### PR TITLE
VolumeBalancer: experimental unlock-based preemption mechanism

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1551,4 +1551,14 @@ message TStorageServiceConfig
     // It is preferable to enable splitting via EnableRequestSplitter in the
     // Server config.
     optional ERequestSplitterPolicy RequestSplitterPolicy = 492;
+
+    // If true, preemption with source == balancer will
+    // use gentle remount mechanism (avoids directly killing tablet)
+    optional bool GentleBalancerPreemptionEnabled = 493;
+
+    // Timeout for gentle preemption (ms)
+    optional uint32 GentleBalancerPreemptionTimeout = 494;
+
+    // Retry delay for gentle preemption (ms)
+    optional uint32 GentleBalancerPreemptionRetryDelay = 495;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1553,12 +1553,12 @@ message TStorageServiceConfig
     optional ERequestSplitterPolicy RequestSplitterPolicy = 492;
 
     // If true, preemption with source == balancer will
-    // use gentle remount mechanism (avoids directly killing tablet)
-    optional bool GentleBalancerPreemptionEnabled = 493;
+    // use gentle remount mechanism, avoiding direct tablet killing.
+    optional bool VolumeBalancerGentlePreemptionEnabled = 493;
 
-    // Timeout for gentle preemption (ms)
-    optional uint32 GentleBalancerPreemptionTimeout = 494;
+    // Timeout for gentle preemption (ms).
+    optional uint32 VolumeBalancerGentlePreemptionTimeout = 494;
 
-    // Retry delay for gentle preemption (ms)
-    optional uint32 GentleBalancerPreemptionRetryDelay = 495;
+    // Retry delay for gentle preemption (ms).
+    optional uint32 VolumeBalancerGentlePreemptionRetryDelay = 495;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -692,9 +692,10 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(ReadBlockMaskOnCompactionOptimizationEnabled,                          \
         bool,                                                                  \
         false                                                                 )\
-    xxx(GentleBalancerPreemptionEnabled,      bool,        false              )\
-    xxx(GentleBalancerPreemptionTimeout,      TDuration,   Hours(24)          )\
-    xxx(GentleBalancerPreemptionRetryDelay,   TDuration,   Seconds(60)        )\
+                                                                               \
+    xxx(VolumeBalancerGentlePreemptionEnabled,      bool,       false         )\
+    xxx(VolumeBalancerGentlePreemptionTimeout,      TDuration,  Hours(24)     )\
+    xxx(VolumeBalancerGentlePreemptionRetryDelay,   TDuration,  Seconds(60)   )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -692,6 +692,9 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(ReadBlockMaskOnCompactionOptimizationEnabled,                          \
         bool,                                                                  \
         false                                                                 )\
+    xxx(GentleBalancerPreemptionEnabled,      bool,        false              )\
+    xxx(GentleBalancerPreemptionTimeout,      TDuration,   Hours(24)          )\
+    xxx(GentleBalancerPreemptionRetryDelay,   TDuration,   Seconds(60)        )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -811,11 +811,11 @@ public:
 
     [[nodiscard]] bool GetReadBlockMaskOnCompactionOptimizationEnabled() const;
 
-    [[nodiscard]] bool GetGentleBalancerPreemptionEnabled() const;
+    [[nodiscard]] bool GetVolumeBalancerGentlePreemptionEnabled() const;
 
-    [[nodiscard]] TDuration GetGentleBalancerPreemptionTimeout() const;
+    [[nodiscard]] TDuration GetVolumeBalancerGentlePreemptionTimeout() const;
 
-    [[nodiscard]] TDuration GetGentleBalancerPreemptionRetryDelay() const;
+    [[nodiscard]] TDuration GetVolumeBalancerGentlePreemptionRetryDelay() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -810,6 +810,12 @@ public:
     [[nodiscard]] ui64 GetVolumeBalancerMaxInProgress() const;
 
     [[nodiscard]] bool GetReadBlockMaskOnCompactionOptimizationEnabled() const;
+
+    [[nodiscard]] bool GetGentleBalancerPreemptionEnabled() const;
+
+    [[nodiscard]] TDuration GetGentleBalancerPreemptionTimeout() const;
+
+    [[nodiscard]] TDuration GetGentleBalancerPreemptionRetryDelay() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/service/service_events_private.h
+++ b/cloud/blockstore/libs/storage/service/service_events_private.h
@@ -263,6 +263,18 @@ struct TEvServicePrivate
     };
 
     //
+    // Gentle volume release
+    //
+
+    struct TGentlyReleaseVolumeRequest
+    {
+    };
+
+    struct TGentlyReleaseVolumeResponse
+    {
+    };
+
+    //
     // UpdateManuallyPreemptedVolume notification
     //
 
@@ -328,6 +340,8 @@ struct TEvServicePrivate
         EvCreateEncryptionKeyResponse,
         EvListMountedVolumesRequest,
         EvListMountedVolumesResponse,
+        EvGentlyReleaseVolumeRequest,
+        EvGentlyReleaseVolumeResponse,
 
         EvEnd
     };
@@ -429,6 +443,14 @@ struct TEvServicePrivate
     using TEvListMountedVolumesResponse = TResponseEvent<
         TListMountedVolumesResponse,
         EvListMountedVolumesResponse>;
+
+    using TEvGentlyReleaseVolumeRequest = TRequestEvent<
+        TGentlyReleaseVolumeRequest,
+        EvGentlyReleaseVolumeRequest>;
+
+    using TEvGentlyReleaseVolumeResponse = TResponseEvent<
+        TGentlyReleaseVolumeResponse,
+        EvGentlyReleaseVolumeResponse>;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -297,7 +297,7 @@ void TVolumeSessionActor::HandleUnlockTabletResponse(
         }
         if (error.GetCode() == S_ALREADY) {
             auto response =
-                std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
+                std::make_unique<TEvServicePrivate::TEvGentlyReleaseVolumeResponse>(
                     msg->Error);
             NCloud::Send(ctx, MountRequestActor, std::move(response));
         }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -264,7 +264,6 @@ void TVolumeSessionActor::HandleGentlyReleaseVolumeRequest(
     const NActors::TActorContext& ctx)
 {
     Y_UNUSED(ev);
-    Y_UNUSED(ctx);
 
     // Request unlock
     CurrentRequest = GENTLY_RELEASE_REQUEST;
@@ -292,7 +291,7 @@ void TVolumeSessionActor::HandleUnlockTabletResponse(
                 FormatError(error).c_str());
 
             ctx.Schedule(
-                Config->GetGentleBalancerPreemptionRetryDelay(),
+                Config->GetVolumeBalancerGentlePreemptionRetryDelay(),
                 new TEvServicePrivate::TEvGentlyReleaseVolumeRequest());
             return;
         }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.cpp
@@ -8,6 +8,7 @@
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/volume_proxy/volume_proxy.h>
 
+#include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/format.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -258,6 +259,64 @@ void TVolumeSessionActor::FailPendingRequestsAndDie(
     NotifyAndDie(ctx);
 }
 
+void TVolumeSessionActor::HandleGentlyReleaseVolumeRequest(
+    const TEvServicePrivate::TEvGentlyReleaseVolumeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    Y_UNUSED(ctx);
+
+    // Request unlock
+    CurrentRequest = GENTLY_RELEASE_REQUEST;
+    NCloud::Send<NCloud::NStorage::TEvHiveProxy::TEvUnlockTabletRequest>(
+        ctx,
+        NCloud::NStorage::MakeHiveProxyServiceId(),
+        0,   // cookie
+        TabletId);
+}
+
+void TVolumeSessionActor::HandleUnlockTabletResponse(
+    const NCloud::NStorage::TEvHiveProxy::TEvUnlockTabletResponse::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    if (MountRequestActor && CurrentRequest == GENTLY_RELEASE_REQUEST) {
+        const auto* msg = ev->Get();
+
+        const auto& error = msg->GetError();
+        if (FAILED(error.GetCode())) {
+            LOG_ERROR(
+                ctx,
+                TBlockStoreComponents::SERVICE,
+                "%s UnlockTablet for gentle release failed: %s",
+                LogTitle.GetWithTime().c_str(),
+                FormatError(error).c_str());
+
+            ctx.Schedule(
+                Config->GetGentleBalancerPreemptionRetryDelay(),
+                new TEvServicePrivate::TEvGentlyReleaseVolumeRequest());
+            return;
+        }
+        if (error.GetCode() == S_ALREADY) {
+            auto response =
+                std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
+                    msg->Error);
+            NCloud::Send(ctx, MountRequestActor, std::move(response));
+        }
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::SERVICE,
+            "%s Unlock for gentle release successful",
+            LogTitle.GetWithTime().c_str());
+        return;
+    }
+    LOG_WARN(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "%s Unexpected UnlockTabletResponse with CurrentRequest = %d",
+        LogTitle.GetWithTime().c_str(),
+        static_cast<int>(CurrentRequest));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 STFUNC(TVolumeSessionActor::StateDescribe)
@@ -330,6 +389,14 @@ STFUNC(TVolumeSessionActor::StateWork)
         HFunc(
             TEvService::TEvChangeVolumeBindingRequest,
             HandleChangeVolumeBindingRequest);
+
+        HFunc(
+            TEvServicePrivate::TEvGentlyReleaseVolumeRequest,
+            HandleGentlyReleaseVolumeRequest);
+
+        HFunc(
+            NCloud::NStorage::TEvHiveProxy::TEvUnlockTabletResponse,
+            HandleUnlockTabletResponse);
 
         IgnoreFunc(TEvService::TEvUnmountVolumeResponse);
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.h
@@ -19,6 +19,8 @@
 #include <cloud/blockstore/libs/storage/model/log_title.h>
 #include <cloud/blockstore/libs/storage/volume_proxy/volume_proxy.h>
 
+#include <cloud/storage/core/libs/api/hive_proxy.h>
+
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <utility>
@@ -35,7 +37,8 @@ private:
     {
         NONE,
         START_REQUEST,
-        STOP_REQUEST
+        STOP_REQUEST,
+        GENTLY_RELEASE_REQUEST
     };
 
     struct TMountRequestProcResult
@@ -217,6 +220,14 @@ private:
 
     void HandleChangeVolumeBindingRequest(
         const TEvService::TEvChangeVolumeBindingRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleGentlyReleaseVolumeRequest(
+        const TEvServicePrivate::TEvGentlyReleaseVolumeRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleUnlockTabletResponse(
+        const NCloud::NStorage::TEvHiveProxy::TEvUnlockTabletResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
 };
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -294,7 +294,7 @@ TMountRequestActor::TMountRequestActor(
     //} else if (Params.BindingType == TVolumeInfo::LOCAL) {
     //    MountMode = NProto::VOLUME_MOUNT_LOCAL;
     }
-    UseGentlePreemption = Config->GetGentleBalancerPreemptionEnabled() &&
+    UseGentlePreemption = Config->GetVolumeBalancerGentlePreemptionEnabled() &&
                           Params.PreemptionSource == NProto::SOURCE_BALANCER;
 }
 
@@ -644,13 +644,12 @@ void TMountRequestActor::GentlyReleaseVolume(const TActorContext& ctx)
         ctx,
         Params.SessionActorId);
 
-    // Now we consider preemption failed
-    // if we didn't get GentlyReleaseVolumeResponse
-    // in GentlePreemptionTimeout,
-    // which means locally mounted volume hasn't been
-    // demoted by new hive-booted tablet
+    // Now we treat preemption as failed if we do not receive
+    // GentlyReleaseVolumeResponse within GentlePreemptionTimeout,
+    // which means the locally mounted volume wasn't demoted by the
+    // new Hive-booted tablet
     ctx.Schedule(
-        Config->GetGentleBalancerPreemptionTimeout(),
+        Config->GetVolumeBalancerGentlePreemptionTimeout(),
         new TEvents::TEvWakeup());
 }
 
@@ -664,12 +663,11 @@ void TMountRequestActor::GentlyPullVolume(const TActorContext& ctx)
 
     RequestVolumeStart(ctx);
 
-    // Now we consider preemption failed
-    // if we didn't get successful StartVolumeResponse
-    // in GentlePreemptionTimeout,
-    // which means volume hasn't been started locally
+    // Now we treat volume pull as failed if we do not receive
+    // StartVolumeResponse within GentlePreemptionTimeout,
+    // which means the volume tablet didn't successfully start locally
     ctx.Schedule(
-        Config->GetGentleBalancerPreemptionTimeout(),
+        Config->GetVolumeBalancerGentlePreemptionTimeout(),
         new TEvents::TEvWakeup());
 
     GentlePullInProgress = true;
@@ -865,11 +863,12 @@ void TMountRequestActor::HandleStartVolumeResponse(
         if (mountMode == NProto::VOLUME_MOUNT_LOCAL) {
             if (GentlePullInProgress) {
                 ctx.Schedule(
-                    Config->GetGentleBalancerPreemptionRetryDelay(),
+                    Config->GetVolumeBalancerGentlePreemptionRetryDelay(),
                     std::make_unique<IEventHandle>(
                         Params.SessionActorId,
                         ctx.SelfID,
-                        new TEvServicePrivate::TEvStartVolumeRequest{VolumeTabletId}));
+                        new TEvServicePrivate::TEvStartVolumeRequest{
+                            VolumeTabletId}));
                 return;
             }
             VolumeSessionRestartRequired = true;

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -912,7 +912,8 @@ void TMountRequestActor::HandleWakeup(
         // Hive didn't boot new tablet in time, consider fail
         Error = MakeError(
             E_TIMEOUT,
-            "Gentle Release timeout waiting for volume release to hive");
+            "Gentle release timed out while waiting for the volume to be "
+            "released to Hive");
         NotifyAndDie(ctx);
         return;
     }
@@ -920,7 +921,7 @@ void TMountRequestActor::HandleWakeup(
         // Tablet didn't start locally in time, consider fail
         Error = MakeError(
             E_TIMEOUT,
-            "Gentle Pull timeout waiting for volume start");
+            "Gentle pull timed out while waiting for the volume to start");
         NotifyAndDie(ctx);
         return;
     }
@@ -935,13 +936,13 @@ void TMountRequestActor::HandleGentlyReleaseVolumeResponse(
     }
     auto msg = ev->Get();
     auto error = msg->GetError();
-    if (SUCCEEDED(error.GetCode())) {
-        GentleReleaseInProgress = false;
-        WaitForVolume(ctx, Config->GetLocalStartAddClientTimeout());
+    if (HasError(error)) {
+        Error = error;
+        NotifyAndDie(ctx);
         return;
     }
-    Error = error;
-    NotifyAndDie(ctx);
+    GentleReleaseInProgress = false;
+    WaitForVolume(ctx, Config->GetLocalStartAddClientTimeout());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -179,6 +179,9 @@ private:
     bool IsTabletAcquired = false;
     bool VolumeSessionRestartRequired = false;
     bool IsVolumeRestarting = false;
+    bool GentleReleaseInProgress = false;
+    bool GentlePullInProgress = false;
+    bool UseGentlePreemption = false;
 
 public:
     TMountRequestActor(
@@ -206,6 +209,9 @@ private:
 
     void LockVolume(const TActorContext& ctx);
     void UnlockVolume(const TActorContext& ctx);
+
+    void GentlyReleaseVolume(const TActorContext& ctx);
+    void GentlyPullVolume(const TActorContext& ctx);
 
 private:
     STFUNC(StateWork);
@@ -253,6 +259,14 @@ private:
     void HandleTabletLockLost(
         const TEvHiveProxy::TEvTabletLockLost::TPtr& ev,
         const TActorContext& ctx);
+
+    void HandleWakeup(
+        const TEvents::TEvWakeup::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleGentlyReleaseVolumeResponse(
+        const TEvServicePrivate::TEvGentlyReleaseVolumeResponse::TPtr& ev,
+        const TActorContext& ctx);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -280,6 +294,8 @@ TMountRequestActor::TMountRequestActor(
     //} else if (Params.BindingType == TVolumeInfo::LOCAL) {
     //    MountMode = NProto::VOLUME_MOUNT_LOCAL;
     }
+    UseGentlePreemption = Config->GetGentleBalancerPreemptionEnabled() &&
+                          Params.PreemptionSource == NProto::SOURCE_BALANCER;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -615,6 +631,50 @@ void TMountRequestActor::UnlockVolume(const TActorContext& ctx)
         VolumeTabletId);
 }
 
+void TMountRequestActor::GentlyReleaseVolume(const TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "%s Gently releasing volume",
+        LogTitle.GetWithTime().c_str());
+    GentleReleaseInProgress = true;
+
+    NCloud::Send<TEvServicePrivate::TEvGentlyReleaseVolumeRequest>(
+        ctx,
+        Params.SessionActorId);
+
+    // Now we consider preemption failed
+    // if we didn't get GentlyReleaseVolumeResponse
+    // in GentlePreemptionTimeout,
+    // which means locally mounted volume hasn't been
+    // demoted by new hive-booted tablet
+    ctx.Schedule(
+        Config->GetGentleBalancerPreemptionTimeout(),
+        new TEvents::TEvWakeup());
+}
+
+void TMountRequestActor::GentlyPullVolume(const TActorContext& ctx)
+{
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::SERVICE,
+        "%s Gently pulling volume",
+        LogTitle.GetWithTime().c_str());
+
+    RequestVolumeStart(ctx);
+
+    // Now we consider preemption failed
+    // if we didn't get successful StartVolumeResponse
+    // in GentlePreemptionTimeout,
+    // which means volume hasn't been started locally
+    ctx.Schedule(
+        Config->GetGentleBalancerPreemptionTimeout(),
+        new TEvents::TEvWakeup());
+
+    GentlePullInProgress = true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TMountRequestActor::NotifyAndDie(const TActorContext& ctx)
@@ -669,7 +729,11 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
         }
 
         if (!VolumeStarted && MountMode == NProto::VOLUME_MOUNT_LOCAL) {
-            RequestVolumeStart(ctx);
+            if (UseGentlePreemption) {
+                GentlyPullVolume(ctx);
+            } else {
+                RequestVolumeStart(ctx);
+            }
             return;
         }
 
@@ -694,7 +758,11 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
         const bool mayStopVolume = Params.IsLocalMounter || VolumeStarted;
 
         if (mayStopVolume && MountMode == NProto::VOLUME_MOUNT_REMOTE) {
-            RequestVolumeStop(ctx);
+            if (UseGentlePreemption) {
+                GentlyReleaseVolume(ctx);
+            } else {
+                RequestVolumeStop(ctx);
+            }
             return;
         }
     } else if (VolumeStarted || error.GetCode() == E_BS_MOUNT_CONFLICT) {
@@ -795,6 +863,15 @@ void TMountRequestActor::HandleStartVolumeResponse(
         }
     } else {
         if (mountMode == NProto::VOLUME_MOUNT_LOCAL) {
+            if (GentlePullInProgress) {
+                ctx.Schedule(
+                    Config->GetGentleBalancerPreemptionRetryDelay(),
+                    std::make_unique<IEventHandle>(
+                        Params.SessionActorId,
+                        ctx.SelfID,
+                        new TEvServicePrivate::TEvStartVolumeRequest{VolumeTabletId}));
+                return;
+            }
             VolumeSessionRestartRequired = true;
             NotifyAndDie(ctx);
             return;
@@ -826,6 +903,48 @@ void TMountRequestActor::HandleStopVolumeResponse(
     NotifyAndDie(ctx);
 }
 
+void TMountRequestActor::HandleWakeup(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    if (GentleReleaseInProgress) {
+        GentleReleaseInProgress = false;
+        // Hive didn't boot new tablet in time, consider fail
+        Error = MakeError(
+            E_TIMEOUT,
+            "Gentle Release timeout waiting for volume release to hive");
+        NotifyAndDie(ctx);
+        return;
+    }
+    if (GentlePullInProgress) {
+        // Tablet didn't start locally in time, consider fail
+        Error = MakeError(
+            E_TIMEOUT,
+            "Gentle Pull timeout waiting for volume start");
+        NotifyAndDie(ctx);
+        return;
+    }
+}
+
+void TMountRequestActor::HandleGentlyReleaseVolumeResponse(
+    const TEvServicePrivate::TEvGentlyReleaseVolumeResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    if (!GentleReleaseInProgress) {
+        return;
+    }
+    auto msg = ev->Get();
+    auto error = msg->GetError();
+    if (SUCCEEDED(error.GetCode())) {
+        GentleReleaseInProgress = false;
+        WaitForVolume(ctx, Config->GetLocalStartAddClientTimeout());
+        return;
+    }
+    Error = error;
+    NotifyAndDie(ctx);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 STFUNC(TMountRequestActor::StateWork)
@@ -842,6 +961,12 @@ STFUNC(TMountRequestActor::StateWork)
 
         HFunc(TEvHiveProxy::TEvUnlockTabletResponse, HandleUnlockTabletResponse);
         HFunc(TEvHiveProxy::TEvLockTabletResponse, HandleLockTabletResponse);
+
+        HFunc(
+            TEvServicePrivate::TEvGentlyReleaseVolumeResponse,
+            HandleGentlyReleaseVolumeResponse);
+
+        HFunc(TEvents::TEvWakeup, HandleWakeup);
 
         IgnoreFunc(TEvHiveProxy::TEvTabletLockLost);
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
@@ -82,10 +82,10 @@ void TVolumeSessionActor::HandleStartVolumeActorStopped(
                     TEvServicePrivate::TEvGentlyReleaseVolumeResponse>();
                 break;
             default:
-                LOG_DEBUG(
+                LOG_ERROR(
                     ctx,
                     TBlockStoreComponents::SERVICE,
-                    "%s TEvStartVolumeActorStopped unhandled",
+                    "%s StartVolumeActor stopped without explicit request",
                     LogTitle.GetWithTime().c_str());
                 break;
         }

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
@@ -66,16 +66,35 @@ void TVolumeSessionActor::HandleStartVolumeActorStopped(
     VolumeInfo->Error.Clear();
 
     if (MountRequestActor) {
-        if (CurrentRequest == START_REQUEST) {
-            auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
-                msg->Error);
-            NCloud::Send(ctx, MountRequestActor, std::move(response));
-        } else {
-            auto response = std::make_unique<TEvServicePrivate::TEvStopVolumeResponse>();
+        IEventBasePtr response;
+        switch (CurrentRequest) {
+            case START_REQUEST:
+                response =
+                    std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
+                        msg->Error);
+                break;
+            case STOP_REQUEST:
+                response = std::make_unique<
+                    TEvServicePrivate::TEvStopVolumeResponse>();
+                break;
+            case GENTLY_RELEASE_REQUEST:
+                response = std::make_unique<
+                    TEvServicePrivate::TEvGentlyReleaseVolumeResponse>();
+                break;
+            default:
+                LOG_DEBUG(
+                    ctx,
+                    TBlockStoreComponents::SERVICE,
+                    "%s TEvStartVolumeActorStopped unhandled",
+                    LogTitle.GetWithTime().c_str());
+                break;
+        }
+        if (response) {
             NCloud::Send(ctx, MountRequestActor, std::move(response));
         }
     } else if (UnmountRequestActor) {
-        auto response = std::make_unique<TEvServicePrivate::TEvStopVolumeResponse>();
+        auto response =
+            std::make_unique<TEvServicePrivate::TEvStopVolumeResponse>();
         NCloud::Send(ctx, UnmountRequestActor, std::move(response));
     }
 }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
@@ -22,8 +22,8 @@ void THiveProxyActor::HandleUnlockTablet(
     auto* states = HiveStates.FindPtr(hive);
     auto* state = states ? states->LockStates.FindPtr(tabletId) : nullptr;
     if (!state) {
-        // Unlock with a paired lock
-        auto error = MakeError(E_ARGUMENT, "Unlock without a matching Lock");
+        // Unlock without a paired lock
+        auto error = MakeError(S_ALREADY, "Unlock without a matching Lock");
         auto response =
             std::make_unique<TEvHiveProxy::TEvUnlockTabletResponse>(error);
         NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
@@ -22,8 +22,9 @@ void THiveProxyActor::HandleUnlockTablet(
     auto* states = HiveStates.FindPtr(hive);
     auto* state = states ? states->LockStates.FindPtr(tabletId) : nullptr;
     if (!state) {
-        // Unlock without a paired lock
-        auto error = MakeError(S_ALREADY, "Unlock without a matching Lock");
+        // Unlock without a corresponding lock
+        auto error =
+            MakeError(S_ALREADY, "Unlock without a corresponding Lock");
         auto response =
             std::make_unique<TEvHiveProxy::TEvUnlockTabletResponse>(error);
         NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
@@ -854,6 +854,26 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
         env.SendLockRequest(sender, FakeTablet2, E_REJECTED);
     }
 
+    Y_UNIT_TEST(UnlockSameTabletTwice)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        auto sender = runtime.AllocateEdgeActor();
+
+        env.SendLockRequest(sender, FakeTablet2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            env.HiveState->LockedTablets[FakeTablet2],
+            env.HiveProxyActorId);
+
+        env.SendUnlockRequest(sender, FakeTablet2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            env.HiveState->LockedTablets[FakeTablet2],
+            TActorId());
+
+        env.SendUnlockRequest(sender, FakeTablet2, S_ALREADY);
+    }
+
     Y_UNIT_TEST(LockMissingTablet) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);


### PR DESCRIPTION
Experimental volume preemption mechanism update:

Instead of explicitly killing volume, now we only release tablet lock so hive can take this tablet. If hive is unavailable, tablet will continue to work

Feature is disabled by default and is currently in research state.