### PR TITLE
Fix flaky TMirrorPartitionResyncTest::ShouldFallbackToSlowPathWhenFastPathDataReadFails

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp
@@ -535,7 +535,7 @@ struct TTestEnv
 
     void TestNoEvent(ui32 eventType)
     {
-        Runtime.DispatchEvents({}, TInstant::Zero());
+        Runtime.DispatchEvents({}, TInstant::MilliSeconds(10));
         auto evList = Runtime.CaptureEvents();
         for (auto& ev: evList) {
             UNIT_ASSERT(ev->GetTypeRewrite() != eventType);
@@ -2459,7 +2459,10 @@ Y_UNIT_TEST_SUITE(TMirrorPartitionResyncTest)
                 return false;
             });
 
+        // Wait for resync to do one range
         env.ResyncController.SetStopAfterResyncedRangeCount(1);
+        env.ResyncController.WaitForResyncedRangeCount(1);
+
         TPartitionClient client(runtime, env.ActorId);
         // Send read request - this should trigger fast path
         client.SendReadBlocksRequest(readRange);


### PR DESCRIPTION
```
2026-02-12T08:41:44.302109Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Resyncing range [0..1023]
2026-02-12T08:41:44.738485Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Resync read fast path [2100..2199]
2026-02-12T08:41:44.751626Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Resync read slow path [2100..2199]
2026-02-12T08:41:44.751647Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Resyncing range [2048..3071]
resynced range [0..1023]
2026-02-12T08:41:44.752732Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Range [0..1023] resync finished: S_OK
2026-02-12T08:41:44.752739Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Range [0..1023] resynced
resynced range [2048..3071]
2026-02-12T08:41:44.754294Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Range [2048..3071] resync finished: S_OK
2026-02-12T08:41:44.754299Z node 33 :BLOCKSTORE_PARTITION DEBUG: [test] Range [2048..3071] resynced
2026-02-12T08:41:44.754315Z node 33 :BLOCKSTORE_PARTITION_WORKER DEBUG: [test] Will read [2100..2199] from 1 replicas
[[bad]]assertion failed at cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_ut.cpp:541, void NCloud::NBlockStore::NStorage::(anonymous namespace)::TTestEnv::TestNoEvent(ui32): (ev->GetTypeRewrite() != eventType) [[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char>> const&, bool)+136 (0xC1F9588)
??+0 (0xBDCC7CF)
NCloud::NBlockStore::NStorage::NTestSuiteTMirrorPartitionResyncTest::TTestCaseShouldFallbackToSlowPathWhenFastPathDataReadFails::Execute_(NUnitTest::TTestContext&)+2720 (0xBDF1FB0)
NCloud::NBlockStore::NStorage::NTestSuiteTMirrorPartitionResyncTest::TCurrentTest::Execute()::'lambda'()::operator()() const+71 (0xBDF7807)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+127 (0xC1FB53F)
NCloud::NBlockStore::NStorage::NTestSuiteTMirrorPartitionResyncTest::TCurrentTest::Execute()+481 (0xBDF71A1)
NUnitTest::TTestFactory::Execute()+780 (0xC1FBC9C)
NUnitTest::RunMain(int, char**)+3005 (0xC20AC4D)
??+0 (0x7EFFD74B0D90)
__libc_start_main+128 (0x7EFFD74B0E40)
??+0 (0xB1BA029)
[[rst]]
```