### PR TITLE
issue-2674: fix - setting BehaveAsDirectoryTablet for service->tablet UnlinkNode requests (and some other requests, but for them it's not really important)

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -154,6 +154,7 @@ private:
     void ForwardRequestToShard(
         const NActors::TActorContext& ctx,
         const typename TMethod::TRequest::TPtr& ev,
+        bool forceBehaveAsShard,
         ui64 entityId);
 
     template <typename TMethod>

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -264,6 +264,7 @@ void TStorageServiceActor::HandleCreateHandle(
         ForwardRequestToShard<TEvService::TCreateHandleMethod>(
             ctx,
             ev,
+            true /* forceBehaveAsShard */,
             msg->Record.GetNodeId());
         return;
     }

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -240,6 +240,7 @@ void TStorageServiceActor::HandleGetNodeAttr(
         ForwardRequestToShard<TEvService::TGetNodeAttrMethod>(
             ctx,
             ev,
+            false /* forceBehaveAsShard */,
             msg->Record.GetNodeId());
         return;
     }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5146,14 +5146,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(
             1,
             counters->GetCounter("GetNodeAttrInShard.Count")->GetAtomic());
-
-        // TODO(#2674) - fix, UnlinkNode.Count and UnlinkNodeInShard.Count
-        // should be both equal to 1
         UNIT_ASSERT_VALUES_EQUAL(
-            0,
+            1,
             counters->GetCounter("UnlinkNode.Count")->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
-            2,
+            1,
             counters->GetCounter("UnlinkNodeInShard.Count")->GetAtomic());
     }
 


### PR DESCRIPTION
### Notes
Fixes the following issues:
* `DupCache` doesn't work for `UnlinkNode` in shards
* `UnlinkNode[InShard]` tablet counters work incorrectly

### Issue
https://github.com/ydb-platform/nbs/issues/2674