### PR TITLE
Increase 'wait for BS Controller to start' timeout from 120 to 240 seconds to mitigate frequent Github CI failures

### DIFF
--- a/contrib/ydb/tests/library/harness/kikimr_runner.py
+++ b/contrib/ydb/tests/library/harness/kikimr_runner.py
@@ -529,7 +529,7 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         self._bs_config_invoke(request)
 
     def _bs_config_invoke(self, request):
-        timeout = yatest_common.plain_or_under_sanitizer(120, 240)
+        timeout = yatest_common.plain_or_under_sanitizer(240, 480)
         sleep = 5
         retries, success = timeout / sleep, False
         while retries > 0 and not success:


### PR DESCRIPTION
Temporary fix for:
```
Traceback (most recent call last):
  File "contrib/ydb/tests/library/harness/kikimr_runner.py", line 311, in start
    self.__run()
  File "contrib/ydb/tests/library/harness/kikimr_runner.py", line 339, in __run
    self.__wait_for_bs_controller_to_start()
  File "contrib/ydb/tests/library/harness/kikimr_runner.py", line 589, in __wait_for_bs_controller_to_start
    assert bs_controller_started
           ^^^^^^^^^^^^^^^^^^^^^
AssertionError
2026-02-16 00:43:04,571 - INFO - contrib.ydb.tests.library.harness.kikimr_runner - stop: Stopped node localhost:64608/1
...
2026-02-16 00:43:04,758 - ERROR - ya.test - logreport: cloud/blockstore/tests/csi_driver/e2e_tests_nfs/test.py:15: in test_volume_lifecycle_local_fs_legacy
    env, run = csi.init(vm_mode=True, external_fs_configs=[fs_config])
cloud/blockstore/tests/csi_driver/lib/csi_runner.py:329: in init
    env = CsiLoadTest(
cloud/blockstore/tests/csi_driver/lib/csi_runner.py:47: in __init__
    super(CsiLoadTest, self).__init__(*args, **kwargs)
cloud/blockstore/tests/python/lib/loadtest_env.py:78: in __init__
    self.kikimr_cluster.start()
contrib/ydb/tests/library/harness/kikimr_runner.py:311: in start
    self.__run()
contrib/ydb/tests/library/harness/kikimr_runner.py:339: in __run
    self.__wait_for_bs_controller_to_start()
contrib/ydb/tests/library/harness/kikimr_runner.py:589: in __wait_for_bs_controller_to_start
    assert bs_controller_started
E   AssertionError
```