### PR TITLE
Increase 'wait for BS Controller to start' timeout from 240 to 480 seconds to mitigate frequent Github CI failures

### DIFF
--- a/contrib/ydb/tests/library/harness/kikimr_runner.py
+++ b/contrib/ydb/tests/library/harness/kikimr_runner.py
@@ -529,7 +529,7 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         self._bs_config_invoke(request)
 
     def _bs_config_invoke(self, request):
-        timeout = yatest_common.plain_or_under_sanitizer(240, 480)
+        timeout = yatest_common.plain_or_under_sanitizer(480, 960)
         sleep = 5
         retries, success = timeout / sleep, False
         while retries > 0 and not success:


### PR DESCRIPTION
Previous PR #5253 