### PR TITLE
[Disk Manager] use in-memory pdisks for test recipe

### DIFF
--- a/cloud/disk_manager/test/recipe/ydb_launcher.py
+++ b/cloud/disk_manager/test/recipe/ydb_launcher.py
@@ -19,6 +19,7 @@ class YDBLauncher:
             erasure=None,
             static_pdisk_size=64 * 2**30,
             dynamic_storage_pools=dynamic_storage_pools,
+            use_in_memory_pdisks=True,
             enable_public_api_external_blobs=True)
 
         self.__cluster = kikimr_cluster_factory(configurator=self.__configurator)


### PR DESCRIPTION
Testing the YDB service is not our intention, so we prefer to use in-memory PDisks to speed up the tests