### PR TITLE
issue-2674: sending DeleteResponseLogEntryRequest upon CommitRenameNodeInSource completion

### DIFF
--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -186,8 +186,8 @@ struct TEvIndexTablet
         EvWriteResponseLogEntryResponse,
 
         // After the TABLET sub-namespace we have TABLET_WORKER and TABLET_PROXY
-        // sub-namespaces which don't have any non-local events so we if we run
-        // out of event ids in the TABLET sub-namespace we can extend it by
+        // sub-namespaces which don't have any non-local events so if we run out
+        // of event ids in the TABLET sub-namespace we can extend it by
         // moving TABLET_WORKER and TABLET_PROXY after SS_PROXY
 
         EvEnd

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -776,6 +776,8 @@ struct TEvIndexTabletPrivate
         const TString SessionId;
         const ui64 RequestId;
         const ui64 OpLogEntryId;
+        TString ShardFileSystemId;
+        const ui64 TabletRequestId;
         NProto::TRenameNodeRequest Request;
         NProto::TProfileLogRequestInfo ProfileLogRequest;
         NProtoPrivate::TRenameNodeInDestinationResponse Response;
@@ -785,6 +787,8 @@ struct TEvIndexTabletPrivate
                 TString sessionId,
                 ui64 requestId,
                 ui64 opLogEntryId,
+                TString shardFileSystemId,
+                ui64 tabletRequestId,
                 NProto::TRenameNodeRequest request,
                 NProto::TProfileLogRequestInfo profileLogRequest,
                 NProtoPrivate::TRenameNodeInDestinationResponse response)
@@ -792,12 +796,16 @@ struct TEvIndexTabletPrivate
             , SessionId(std::move(sessionId))
             , RequestId(requestId)
             , OpLogEntryId(opLogEntryId)
+            , ShardFileSystemId(std::move(shardFileSystemId))
+            , TabletRequestId(tabletRequestId)
             , Request(std::move(request))
             , ProfileLogRequest(std::move(profileLogRequest))
             , Response(std::move(response))
         {
         }
     };
+
+    using TResponseLogEntryDeleted = TEmpty;
 
     //
     // PrepareRenameNodeInSource
@@ -835,14 +843,20 @@ struct TEvIndexTabletPrivate
         NProto::TRenameNodeRequest Request;
         NProtoPrivate::TRenameNodeInDestinationResponse Response;
         const ui64 OpLogEntryId;
+        TString ShardFileSystemId;
+        const ui64 TabletRequestId;
 
         TCommitRenameNodeInSourceRequest(
                 NProto::TRenameNodeRequest request,
                 NProtoPrivate::TRenameNodeInDestinationResponse response,
-                ui64 opLogEntryId)
+                ui64 opLogEntryId,
+                TString shardFileSystemId,
+                ui64 tabletRequestId)
             : Request(std::move(request))
             , Response(std::move(response))
             , OpLogEntryId(opLogEntryId)
+            , ShardFileSystemId(std::move(shardFileSystemId))
+            , TabletRequestId(tabletRequestId)
         {
         }
     };
@@ -1171,6 +1185,7 @@ struct TEvIndexTabletPrivate
         EvDoRenameNode,
         EvUnlinkDirectoryNodeAbortedInShard,
         EvNodeRenamedInDestination,
+        EvResponseLogEntryDeleted,
 
         EvAggregateStatsCompleted,
 
@@ -1226,6 +1241,9 @@ struct TEvIndexTabletPrivate
 
     using TEvNodeRenamedInDestination =
         TRequestEvent<TNodeRenamedInDestination, EvNodeRenamedInDestination>;
+
+    using TEvResponseLogEntryDeleted =
+        TRequestEvent<TResponseLogEntryDeleted, EvResponseLogEntryDeleted>;
 
     using TEvAggregateStatsCompleted =
         TResponseEvent<TAggregateStatsCompleted, EvAggregateStatsCompleted>;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1061,6 +1061,9 @@ STFUNC(TIndexTabletActor::StateInit)
             TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
             HandleNodeRenamedInDestination);
         HFunc(
+            TEvIndexTabletPrivate::TEvResponseLogEntryDeleted,
+            HandleResponseLogEntryDeleted);
+        HFunc(
             TEvIndexTabletPrivate::TEvAggregateStatsCompleted,
             HandleAggregateStatsCompleted);
         HFunc(
@@ -1129,6 +1132,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(
             TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
             HandleNodeRenamedInDestination);
+        HFunc(
+            TEvIndexTabletPrivate::TEvResponseLogEntryDeleted,
+            HandleResponseLogEntryDeleted);
         HFunc(
             TEvIndexTabletPrivate::TEvAggregateStatsCompleted,
             HandleAggregateStatsCompleted);
@@ -1231,6 +1237,9 @@ STFUNC(TIndexTabletActor::StateZombie)
             TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
             HandleNodeRenamedInDestination);
         HFunc(
+            TEvIndexTabletPrivate::TEvResponseLogEntryDeleted,
+            HandleResponseLogEntryDeleted);
+        HFunc(
             TEvIndexTabletPrivate::TEvShardRequestCompleted,
             HandleShardRequestCompleted);
 
@@ -1291,6 +1300,9 @@ STFUNC(TIndexTabletActor::StateBroken)
         HFunc(
             TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
             HandleNodeRenamedInDestination);
+        HFunc(
+            TEvIndexTabletPrivate::TEvResponseLogEntryDeleted,
+            HandleResponseLogEntryDeleted);
         HFunc(
             TEvIndexTabletPrivate::TEvAggregateStatsCompleted,
             HandleAggregateStatsCompleted);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -612,6 +612,10 @@ private:
         const TEvIndexTabletPrivate::TEvNodeRenamedInDestination::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleResponseLogEntryDeleted(
+        const TEvIndexTabletPrivate::TEvResponseLogEntryDeleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleAggregateStatsCompleted(
         const TEvIndexTabletPrivate::TEvAggregateStatsCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_responselog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_responselog.cpp
@@ -209,7 +209,6 @@ void TIndexTabletActor::CompleteTx_WriteResponseLogEntry(
     CommitResponseLogEntry(std::move(args.Entry));
 
     using TResponse = TEvIndexTablet::TEvWriteResponseLogEntryResponse;
-
     auto response = std::make_unique<TResponse>(std::move(args.Error));
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1267,6 +1267,8 @@ struct TTxIndexTablet
         const NProto::TRenameNodeRequest Request;
         const NProtoPrivate::TRenameNodeInDestinationResponse Response;
         const ui64 OpLogEntryId;
+        /* const */ TString ShardFileSystemId;
+        const ui64 TabletRequestId;
         const bool IsExplicitRequest;
 
         ui64 CommitId = InvalidCommitId;
@@ -1278,6 +1280,8 @@ struct TTxIndexTablet
                 NProto::TProfileLogRequestInfo profileLogRequest,
                 NProtoPrivate::TRenameNodeInDestinationResponse response,
                 ui64 opLogEntryId,
+                TString shardFileSystemId,
+                ui64 tabletRequestId,
                 bool isExplicitRequest)
             : TSessionAware(request)
             , TProfileAware(std::move(profileLogRequest))
@@ -1285,6 +1289,8 @@ struct TTxIndexTablet
             , Request(std::move(request))
             , Response(std::move(response))
             , OpLogEntryId(opLogEntryId)
+            , ShardFileSystemId(std::move(shardFileSystemId))
+            , TabletRequestId(tabletRequestId)
             , IsExplicitRequest(isExplicitRequest)
         {}
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -1338,6 +1338,225 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         }
     }
 
+    TABLET_TEST_4K_ONLY(
+        ShouldDeleteResponseLogEntryUponCommitRenameNodeInSource)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        const ui32 nodeIdx = env.CreateNode("nfs");
+
+        TTabletRebootTracker rebootTracker;
+        env.GetRuntime().SetEventFilter(rebootTracker.GetEventFilter());
+
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto dir =
+            CreateNode(tablet, TCreateNodeArgs::Directory(RootNodeId, "dir"));
+
+        const ui64 dstDir = 11111;
+
+        const TString shardId = "shard";
+        const TString shardNodeName = CreateGuidAsString();
+        const ui64 opLogEntryId = Max<ui64>();
+
+        //
+        // Pre-creating a fake node-ref and a fake rename-node-in-destination
+        // response.
+        //
+
+        const TString fileName = "file";
+        tablet.UnsafeCreateNodeRef(
+            dir,
+            fileName,
+            0 /* childId */,
+            shardId,
+            shardNodeName);
+
+        const ui64 tabletRequestId = 10;
+        {
+            NProtoPrivate::TResponseLogEntry entry;
+            entry.SetClientTabletId(tabletId);
+            entry.SetRequestId(tabletRequestId);
+            auto& r = *entry.MutableRenameNodeInDestinationResponse();
+            r.SetOldTargetNodeShardId(shardId);
+            r.SetOldTargetNodeShardNodeName(shardNodeName);
+            tablet.WriteResponseLogEntry(entry);
+        }
+
+        //
+        // Calling CommitRenameNodeInSource for this node-ref and checking that
+        // the response-log-entry gets deleted.
+        //
+
+        {
+            auto renameNodeRequest = tablet.CreateRenameNodeRequest(
+                dir,
+                fileName,
+                dstDir,
+                fileName + ".new");
+
+            NProtoPrivate::TRenameNodeInDestinationResponse subResponse;
+
+            tablet.CommitRenameNodeInSource(
+                renameNodeRequest->Record,
+                subResponse,
+                opLogEntryId,
+                shardId,
+                tabletRequestId);
+        }
+
+        {
+            auto response = tablet.GetResponseLogEntry(tabletId, 10);
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                response->Record.GetEntry().ByteSizeLong());
+        }
+    }
+
+    TABLET_TEST_4K_ONLY(
+        ShouldNotDeleteResponseLogEntryUponCommitRenameNodeInSourceWithError)
+    {
+        TTestEnv env;
+        env.CreateSubDomain("nfs");
+
+        const ui32 nodeIdx = env.CreateNode("nfs");
+
+        TTabletRebootTracker rebootTracker;
+        env.GetRuntime().SetEventFilter(rebootTracker.GetEventFilter());
+
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto dir =
+            CreateNode(tablet, TCreateNodeArgs::Directory(RootNodeId, "dir"));
+
+        const ui64 dstDir = 11111;
+
+        const TString shardId = "shard";
+        const TString shardNodeName = CreateGuidAsString();
+        const ui64 opLogEntryId = Max<ui64>();
+
+        //
+        // Pre-creating a fake node-ref and a fake rename-node-in-destination
+        // response.
+        //
+
+        const TString fileName = "file";
+        tablet.UnsafeCreateNodeRef(
+            dir,
+            fileName,
+            0 /* childId */,
+            shardId,
+            shardNodeName);
+
+        const ui64 tabletRequestId = 10;
+        {
+            NProtoPrivate::TResponseLogEntry entry;
+            entry.SetClientTabletId(tabletId);
+            entry.SetRequestId(tabletRequestId);
+            auto& r = *entry.MutableRenameNodeInDestinationResponse();
+            r.SetOldTargetNodeShardId(shardId);
+            r.SetOldTargetNodeShardNodeName(shardNodeName);
+            tablet.WriteResponseLogEntry(entry);
+        }
+
+        //
+        // Calling CommitRenameNodeInSource for this node-ref and checking that
+        // the response-log-entry is not deleted for retriable errors.
+        //
+
+        {
+            auto renameNodeRequest = tablet.CreateRenameNodeRequest(
+                dir,
+                fileName,
+                dstDir,
+                fileName + ".new");
+
+            NProtoPrivate::TRenameNodeInDestinationResponse subResponse;
+            *subResponse.MutableError() =
+                MakeError(E_REJECTED, "tablet is dead");
+
+            tablet.SendCommitRenameNodeInSourceRequest(
+                renameNodeRequest->Record,
+                subResponse,
+                opLogEntryId,
+                shardId,
+                tabletRequestId);
+
+            auto response = tablet.RecvCommitRenameNodeInSourceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                FormatError(subResponse.GetError()),
+                FormatError(response->GetError()));
+        }
+
+        {
+            auto response = tablet.GetResponseLogEntry(tabletId, 10);
+            UNIT_ASSERT_VALUES_EQUAL(
+                tabletId,
+                response->Record.GetEntry().GetClientTabletId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                10,
+                response->Record.GetEntry().GetRequestId());
+            const auto& r = response->Record.GetEntry()
+                .GetRenameNodeInDestinationResponse();
+            UNIT_ASSERT_VALUES_EQUAL(shardId, r.GetOldTargetNodeShardId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardNodeName,
+                r.GetOldTargetNodeShardNodeName());
+        }
+
+        //
+        // Calling CommitRenameNodeInSource for this node-ref and checking that
+        // the response-log-entry gets deleted for non-retriable errors.
+        //
+
+        {
+            auto renameNodeRequest = tablet.CreateRenameNodeRequest(
+                dir,
+                fileName,
+                dstDir,
+                fileName + ".new");
+
+            NProtoPrivate::TRenameNodeInDestinationResponse subResponse;
+            *subResponse.MutableError() = MakeError(E_ARGUMENT);
+
+            tablet.SendCommitRenameNodeInSourceRequest(
+                renameNodeRequest->Record,
+                subResponse,
+                opLogEntryId,
+                shardId,
+                tabletRequestId);
+
+            auto response = tablet.RecvCommitRenameNodeInSourceResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                FormatError(subResponse.GetError()),
+                FormatError(response->GetError()));
+        }
+
+        {
+            auto response = tablet.GetResponseLogEntry(tabletId, 10);
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                response->Record.GetEntry().ByteSizeLong());
+        }
+    }
+
     Y_UNIT_TEST(ShouldHandleCommitIdOverflowInUnsafeNodeOperations)
     {
         const ui32 maxTabletStep = 4;
@@ -1461,6 +1680,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         env.GetRuntime().SetEventFilter(rebootTracker.GetEventFilter());
 
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        //OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
 
         TIndexTabletClient tablet(
             env.GetRuntime(),
@@ -1536,7 +1756,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
             tablet.SendCommitRenameNodeInSourceRequest(
                 renameNodeRequest->Record,
                 subResponse,
-                opLogEntryId);
+                opLogEntryId,
+                dstShardId,
+                0 // tabletRequestId, doesn't matter for this test
+            );
             auto response = tablet.RecvCommitRenameNodeInSourceResponse();
             reconnectIfNeeded();
 

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -581,14 +581,18 @@ public:
     auto CreateCommitRenameNodeInSourceRequest(
         NProto::TRenameNodeRequest subRequest,
         NProtoPrivate::TRenameNodeInDestinationResponse subResponse,
-        ui64 opLogEntryId)
+        ui64 opLogEntryId,
+        TString shardFileSystemId,
+        ui64 tabletRequestId)
     {
         using TRequestEvent =
             TEvIndexTabletPrivate::TEvCommitRenameNodeInSourceRequest;
         return std::make_unique<TRequestEvent>(
             std::move(subRequest),
             std::move(subResponse),
-            opLogEntryId);
+            opLogEntryId,
+            std::move(shardFileSystemId),
+            tabletRequestId);
     }
 
     auto CreateDeleteResponseLogEntryRequest(


### PR DESCRIPTION
### Notes
Follow-up for https://github.com/ydb-platform/nbs/pull/5249
`DeleteResponseLogEntryRequest` is now sent upon `CommitRenameNodeInSource` completion (except for completion with a retriable error)

Remaining TODO (separate PR): clean up the responses left in `ResponseLog` because of the occasional `DeleteResponseLogEntryRequest` failures - we'll have a TTL for `ResponseLog` entries but it will be big enough to be confident that no one's going to retry a `RenameNodeInDestination` request for which we'll delete the response - e.g. 1 hour or so 

### Issue
https://github.com/ydb-platform/nbs/issues/2674