### PR TITLE
Remove specialization of std::underlying_type

### DIFF
--- a/cloud/filestore/libs/vfs/fsync_queue_ut.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue_ut.cpp
@@ -32,7 +32,7 @@ struct TEnvironment
     TFSyncQueue Queue = TFSyncQueue(FileSystemId, Logging);
 
     TFSyncCache::TRequestId CurrentRequestId = 1ul;
-    std::underlying_type_t<TNodeId> CurrentNodeId = 1ul;
+    TNodeId::TUnderlyingType CurrentNodeId = 1ul;
 
     std::mt19937_64 eng = CreateRandomEngine();
     THashSet<THandle> UsedHandles;
@@ -55,7 +55,7 @@ struct TEnvironment
 
     THandle GetRandomHandle()
     {
-        using H = std::underlying_type_t<THandle>;
+        using H = THandle::TUnderlyingType;
 
         std::uniform_int_distribution<H> dist(1, std::numeric_limits<H>::max());
 

--- a/cloud/filestore/libs/vfs/fsync_queue_ut_stress.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue_ut_stress.cpp
@@ -85,7 +85,7 @@ struct TEnvironment
     TFSyncQueue Queue = TFSyncQueue(FileSystemId, Logging);
 
     std::atomic<TFSyncCache::TRequestId> CurrentRequestId = 1ul;
-    std::atomic<std::underlying_type_t<TNodeId>> CurrentNodeId = 1ul;
+    std::atomic<TNodeId::TUnderlyingType> CurrentNodeId = 1ul;
 
     TMutex HandleMutex;
     std::mt19937_64 eng = CreateRandomEngine();
@@ -109,7 +109,7 @@ struct TEnvironment
 
     THandle GetRandomHandle()
     {
-        using H = std::underlying_type_t<THandle>;
+        using H = THandle::TUnderlyingType;
 
         std::uniform_int_distribution<H> dist(1, std::numeric_limits<H>::max());
 

--- a/cloud/storage/core/libs/common/scoped_handle.h
+++ b/cloud/storage/core/libs/common/scoped_handle.h
@@ -21,6 +21,8 @@ private:
     T Value = InvalidValue;
 
 public:
+    using TUnderlyingType = T;
+
     constexpr TScopedHandle() = default;
 
     constexpr explicit TScopedHandle(T value)
@@ -83,9 +85,3 @@ struct TEqualTo<NCloud::TScopedHandle<T, V, Tag>>
 {};
 
 ////////////////////////////////////////////////////////////////////////////////
-
-template <typename T, T V, typename Tag>
-struct std::underlying_type<NCloud::TScopedHandle<T, V, Tag>>
-{
-    using type = T;
-};


### PR DESCRIPTION
New GCC raise warning. About specialization for std classes
