### PR TITLE
issue-2674: deleting stale ResponseLogEntries in background

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -729,4 +729,11 @@ message TStorageConfig
     // Mode for calculating byte size in ListNodes when applying MaxBytes limit.
     // TODO(#5148): consider other size calculation modes
     optional EListNodesSizeMode ListNodesSizeMode = 484;
+
+    // Tablet ResponseLogEntry TTL in ms before it gets deleted by a regular
+    // tablet operation.
+    optional uint32 ResponseLogEntryTTL = 485;
+
+    // Frequency of tablet regular task runs (e.g. ResponseLogEntry cleanup).
+    optional uint32 TabletRegularTasksSchedulePeriod = 486;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -326,6 +326,9 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(ListNodesSizeMode,                                                     \
         NProto::EListNodesSizeMode,                                            \
         NProto::LNSM_NAME_ONLY                                                )\
+                                                                               \
+    xxx(ResponseLogEntryTTL,                TDuration,  TDuration::Hours(1)   )\
+    xxx(TabletRegularTasksSchedulePeriod,   TDuration,  TDuration::Minutes(1) )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -387,6 +387,9 @@ public:
     bool GetGidPropagationEnabled() const;
 
     bool GetNodeRefsNoAutoPrecharge() const;
+
+    [[nodiscard]] TDuration GetTabletRegularTasksSchedulePeriod() const;
+    [[nodiscard]] TDuration GetResponseLogEntryTTL() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -1170,6 +1170,7 @@ struct TEvIndexTabletPrivate
 
         EvUpdateCounters,
         EvUpdateLeakyBucketCounters,
+        EvRunRegularTasks,
 
         EvReadDataCompleted,
         EvWriteDataCompleted,
@@ -1208,6 +1209,8 @@ struct TEvIndexTabletPrivate
     using TEvUpdateCounters = TRequestEvent<TEmpty, EvUpdateCounters>;
     using TEvUpdateLeakyBucketCounters =
         TRequestEvent<TEmpty, EvUpdateLeakyBucketCounters>;
+
+    using TEvRunRegularTasks = TRequestEvent<TEmpty, EvRunRegularTasks>;
 
     using TEvReleaseCollectBarrier =
         TRequestEvent<TReleaseCollectBarrier, EvReleaseCollectBarrier>;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -251,6 +251,9 @@ private:
         TDuration time);
     void CalculateActorCPUUsage(const NActors::TActorContext& ctx);
 
+    void DeleteOldResponseLogEntries(const NActors::TActorContext& ctx);
+    void RunRegularTasks(const NActors::TActorContext& ctx);
+
     void ScheduleSyncSessions(const NActors::TActorContext& ctx);
     void ScheduleCleanupSessions(const NActors::TActorContext& ctx);
     void CreateSessionsInShards(
@@ -552,6 +555,10 @@ private:
 
     void HandleUpdateLeakyBucketCounters(
         const TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleRunRegularTasks(
+        const TEvIndexTabletPrivate::TEvRunRegularTasks::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleReleaseCollectBarrier(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -594,6 +594,8 @@ void TIndexTabletActor::HandleUpdateCounters(
     CalculateActorCPUUsage(ctx);
     SendMetricsToExecutor(ctx);
 
+    Store(Metrics.ResponseLogEntryCount, GetResponseLogEntryCount());
+
     UpdateCountersScheduled = false;
     ScheduleUpdateCounters(ctx);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -4,6 +4,7 @@
 #include "tablet_schema.h"
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
+#include <cloud/filestore/libs/diagnostics/metrics/operations.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -270,6 +271,8 @@ void TIndexTabletActor::CompleteTx_LoadState(
         config);
     UpdateLogTag();
 
+    NMetrics::Store(Metrics.ResponseLogEntryCount, GetResponseLogEntryCount());
+
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Loading tablet sessions");
     auto idleSessionDeadline = ctx.Now() + Config->GetIdleSessionTimeout();
@@ -386,6 +389,7 @@ void TIndexTabletActor::CompleteTx_LoadState(
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Scheduling OpLog ops");
     ReplayOpLog(ctx, args.OpLog);
+    RunRegularTasks(ctx);
 
     LOG_INFO_S(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -718,6 +718,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
         args.Request.GetHeaders().GetInternal().GetClientTabletId());
     args.ResponseLogEntry.SetRequestId(
         args.Request.GetHeaders().GetRequestId());
+    args.ResponseLogEntry.SetTimestampMs(ctx.Now().MilliSeconds());
     *args.ResponseLogEntry.MutableRenameNodeInDestinationResponse() =
         args.Response;
     WriteResponseLogEntry(db, args.ResponseLogEntry);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -302,21 +302,6 @@ void TDeleteResponseLogEntryActor::HandleDeleteResponseLogEntryResponse(
             return;
         }
 
-        const auto message = Sprintf(
-            "DeleteResponseLogEntry failed for %s, %lu, %lu with error %s"
-            ", will not retry",
-            ShardFileSystemId.c_str(),
-            ClientTabletId,
-            TabletRequestId,
-            FormatError(msg->GetError()).Quote().c_str());
-
-        LOG_ERROR(
-            ctx,
-            TFileStoreComponents::TABLET_WORKER,
-            "%s %s",
-            LogTag.c_str(),
-            message.c_str());
-
         ReplyAndDie(ctx, msg->Record.GetError());
         return;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -366,6 +366,8 @@ void TTabletMetrics::Register(
 
     REGISTER_AGGREGATABLE_SUM(CPUUsageMicros, EMetricType::MT_DERIVATIVE);
 
+    REGISTER_LOCAL(ResponseLogEntryCount, EMetricType::MT_ABSOLUTE);
+
 #undef REGISTER_LOCAL
 #undef REGISTER_AGGREGATABLE_SUM
 #undef REGISTER

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -275,6 +275,8 @@ struct TTabletMetrics
     std::atomic<i64> CPUUsageMicros{0};
     i64 CPUUsageRate = 0;
 
+    std::atomic<i64> ResponseLogEntryCount{0};
+
     const NMetrics::IMetricsRegistryPtr StorageRegistry;
     const NMetrics::IMetricsRegistryPtr StorageFsRegistry;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -319,4 +319,22 @@ void TIndexTabletState::DeleteResponseLogEntry(
     Impl->InternalResponses.erase(reqId);
 }
 
+ui64 TIndexTabletState::GetResponseLogEntryCount() const
+{
+    return Impl->InternalResponses.size();
+}
+
+TVector<TInternalRequestId> TIndexTabletState::ListOldResponseLogEntries(
+    TInstant minTimestamp)
+{
+    TVector<TInternalRequestId> reqIds;
+    for (const auto& [k, e]: Impl->InternalResponses) {
+        if (e.GetTimestampMs() < minTimestamp.MilliSeconds()) {
+            reqIds.push_back(k);
+        }
+    }
+
+    return reqIds;
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -15,6 +15,7 @@
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
 #include <cloud/filestore/libs/storage/tablet/model/channels.h>
 #include <cloud/filestore/libs/storage/tablet/model/compaction_map.h>
+#include <cloud/filestore/libs/storage/tablet/model/internal_request_id.h>
 #include <cloud/filestore/libs/storage/tablet/model/mixed_blocks.h>
 #include <cloud/filestore/libs/storage/tablet/model/node_index_cache.h>
 #include <cloud/filestore/libs/storage/tablet/model/node_session_stat.h>
@@ -869,6 +870,11 @@ public:
         TIndexTabletDatabase& db,
         ui64 clientTabletId,
         ui64 requestId);
+
+    ui64 GetResponseLogEntryCount() const;
+
+    TVector<TInternalRequestId> ListOldResponseLogEntries(
+        TInstant minTimestamp);
 
     //
     // Writes

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -13,6 +13,7 @@
 #include <cloud/filestore/libs/storage/model/public.h>
 #include <cloud/filestore/libs/storage/tablet/events/tablet_private.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
+#include <cloud/filestore/libs/storage/tablet/model/internal_request_id.h>
 #include <cloud/filestore/libs/storage/tablet/model/profile_log_events.h>
 #include <cloud/filestore/libs/storage/tablet/model/range_locks.h>
 #include <cloud/filestore/libs/storage/tablet/model/request_metrics.h>
@@ -112,7 +113,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(PrepareRenameNodeInSource,          __VA_ARGS__)                       \
     xxx(RenameNodeInDestination,            __VA_ARGS__)                       \
     xxx(CommitRenameNodeInSource,           __VA_ARGS__)                       \
-    xxx(DeleteResponseLogEntry,             __VA_ARGS__)                       \
+    xxx(DeleteResponseLogEntries,           __VA_ARGS__)                       \
     xxx(GetResponseLogEntry,                __VA_ARGS__)                       \
     xxx(WriteResponseLogEntry,              __VA_ARGS__)                       \
                                                                                \
@@ -1307,22 +1308,19 @@ struct TTxIndexTablet
     };
 
     //
-    // DeleteResponseLogEntry
+    // DeleteResponseLogEntries
     //
 
-    struct TDeleteResponseLogEntry: TTxIndexTabletBase
+    struct TDeleteResponseLogEntries: TTxIndexTabletBase
     {
         const TRequestInfoPtr RequestInfo;
-        const ui64 ClientTabletId;
-        const ui64 RequestId;
+        const TVector<TInternalRequestId> InternalRequestIds;
 
-        explicit TDeleteResponseLogEntry(
+        explicit TDeleteResponseLogEntries(
                 TRequestInfoPtr requestInfo,
-                ui64 clientTabletId,
-                ui64 requestId)
+                TVector<TInternalRequestId> internalRequestIds)
             : RequestInfo(std::move(requestInfo))
-            , ClientTabletId(clientTabletId)
-            , RequestId(requestId)
+            , InternalRequestIds(std::move(internalRequestIds))
         {}
 
         void Clear() override

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -998,6 +998,9 @@ message TResponseLogEntry
     uint64 ClientTabletId = 1;
     uint64 RequestId = 2;
 
+    // Entry creation timestamp
+    uint64 TimestampMs = 3;
+
     oneof Response {
         TRenameNodeInDestinationResponse RenameNodeInDestinationResponse = 101;
     }


### PR DESCRIPTION
### Notes
Follow-up for https://github.com/ydb-platform/nbs/pull/5249 and https://github.com/ydb-platform/nbs/pull/5269

`ResponseLogEntry` deletion via explicit `TEvDeleteResponseLogEntryRequest`s is implemented as "best-effort" (for simplicity) so we need to have some background op that deletes really old entries from time to time. Introduced `TEvRunRegularTasks` event - planning to add similar rarely firing tablet background tasks there in the future.

The number of `ResponseLogEntr`ies should be tiny so iterating over all of them once a minute should not be a problem at all. I added `ResponseLogEntryCount` sensor to be able to notice its growth (if we introduce a bug which causes the number of these entries to grow). 

Fixes filestore tablet ut build after https://github.com/ydb-platform/nbs/pull/5269 vs https://github.com/ydb-platform/nbs/pull/5272 conflict as well

### Issue
https://github.com/ydb-platform/nbs/issues/2674