### PR TITLE
issue-2674: there's no point in checking for error before sending DeleteResponseLogEntryRequest

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -781,25 +781,21 @@ void TIndexTabletActor::CompleteTx_CommitRenameNodeInSource(
 
     RemoveInFlightRequest(*args.RequestInfo);
 
-    if (!HasError(args.Error)
-            || GetErrorKind(args.Error) != EErrorKind::ErrorRetriable)
-    {
-        //
-        // Best-effort response log entry deletion attempt. The entries that
-        // don't get deleted because of this request not reaching the shard will
-        // be deleted in background when they become too old.
-        //
+    //
+    // Best-effort response log entry deletion attempt. The entries that don't
+    // get deleted because of this request not reaching the shard will be
+    // deleted in background when they become too old.
+    //
 
-        auto actor = std::make_unique<TDeleteResponseLogEntryActor>(
-            LogTag,
-            ctx.SelfID,
-            std::move(args.ShardFileSystemId),
-            TabletID(),
-            args.TabletRequestId);
+    auto actor = std::make_unique<TDeleteResponseLogEntryActor>(
+        LogTag,
+        ctx.SelfID,
+        std::move(args.ShardFileSystemId),
+        TabletID(),
+        args.TabletRequestId);
 
-        auto actorId = NCloud::Register(ctx, std::move(actor));
-        WorkerActors.insert(actorId);
-    }
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
 
     if (args.IsExplicitRequest) {
         using TResponse =


### PR DESCRIPTION
### Notes
There's no point in checking for error because at this point the relevant `RenameNodeInDestinationRequest` is already deleted from the localdb and so it won't be retried. Only the higher-level operation (`RenameNode`) can be retried - as a whole.

### Issue
https://github.com/ydb-platform/nbs/issues/2674