### PR TITLE
fixed incorrect GetStorageStats.TimeSumUs metric values

### DIFF
--- a/cloud/filestore/libs/storage/core/request_info.h
+++ b/cloud/filestore/libs/storage/core/request_info.h
@@ -35,7 +35,7 @@ struct TRequestInfo
     const ui64 Started = GetCycleCount();
     ui64 ExecCycles = 0;
 
-    // ActorSystem start ts. Might be empty.
+    // Request processing start ts. Might be empty.
     TInstant StartedTs;
 
     TRequestInfo() = default;

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -3042,6 +3042,19 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                 (data1.size() + 2 * data2.size()) / 4_KB,
                 stats.GetMixedBlocksCount());
         }
+
+        // smoke test for GetStorageStats.TimeSumUs metric - it should not show
+        // unnaturally large values
+
+        env.GetRegistry()->Update(env.GetRuntime().GetCurrentTime());
+        auto tabletCounters = env.GetRuntime().GetAppData().Counters
+            ->FindSubgroup("counters", "filestore")
+            ->FindSubgroup("component", "storage")
+            ->FindSubgroup("type", "hdd");
+        UNIT_ASSERT_LT(
+            tabletCounters->GetCounter("GetStorageStats.TimeSumUs")
+                ->GetAtomic(),
+            10'000'000);
     }
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldRetryUnlinkingInShard)

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -1155,6 +1155,7 @@ struct TEvIndexTabletPrivate
         NProtoPrivate::TStorageStats AggregateStats;
         TVector<TShardStats> ShardStats;
         TInstant StartedTs;
+        bool IsBackgroundRequest = false;
     };
 
     //


### PR DESCRIPTION
### Notes
Here https://github.com/ydb-platform/nbs/pull/5111 I added separate tablet metrics for the `GetStorageStats` request but `TimeSumUs` was broken because for background requests it was calculated using a zero `StartedTs` value. Fixing it here. 