### PR TITLE
issue-5293: NodeCache cleanup

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -174,7 +174,7 @@ bool TFileSystem::UpdateNodeCache(
         Y_ABORT_UNLESS(node);
 
         entry.ino = attrs.GetId();
-        entry.generation = NodeCache.Generation();
+        entry.generation = 0; // TODO
         entry.attr_timeout = Config->GetAttrTimeout().SecondsFloat();
         entry.entry_timeout = GetEntryCacheTimeout(attrs).SecondsFloat();
 

--- a/cloud/filestore/libs/vfs_fuse/node_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/node_cache.cpp
@@ -10,12 +10,11 @@ namespace NCloud::NFileStore::NFuse {
 
 TNode* TNodeCache::AddNode(const NProto::TNodeAttr& attrs)
 {
-    auto [it, inserted] = Nodes.emplace(attrs);
+    auto [it, inserted] = Id2Node.emplace(attrs.GetId(), TNode(attrs));
     Y_ABORT_UNLESS(inserted, "failed to insert %s",
         DumpMessage(attrs).data());
 
-    auto* node = (TNode*)&*it;
-    return node;
+    return &it->second;
 }
 
 TNode* TNodeCache::TryAddNode(const NProto::TNodeAttr& attrs)
@@ -33,8 +32,8 @@ TNode* TNodeCache::TryAddNode(const NProto::TNodeAttr& attrs)
 
 void TNodeCache::ForgetNode(ui64 ino, size_t count)
 {
-    auto it = Nodes.find(ino);
-    if (it == Nodes.end()) {
+    auto it = Id2Node.find(ino);
+    if (it == Id2Node.end()) {
         // we lose our cache after restart, so we should expect forget requests
         // targeting nodes that are absent from our cache
         // see NBS-2102
@@ -42,17 +41,16 @@ void TNodeCache::ForgetNode(ui64 ino, size_t count)
         return;
     }
 
-    count = const_cast<TNode&>(*it).UnRef(count);
+    count = it->second.UnRef(count);
     if (count == 0) {
         // do not pass element itself
-        Nodes.erase(it);
+        Id2Node.erase(it);
     }
 }
 
 TNode* TNodeCache::FindNode(ui64 ino)
 {
-    auto it = Nodes.find(ino);
-    return it != Nodes.end() ? (TNode*)&*it : nullptr;
+    return Id2Node.FindPtr(ino);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,7 +61,7 @@ void TXAttrCache::Add(
     const TString& value,
     ui64 version)
 {
-    auto current = Get(ino, name);
+    const auto* current = Get(ino, name);
     if (!current || current->Version < version) {
         Cache.Update(
             TKey{ino, name},

--- a/cloud/filestore/libs/vfs_fuse/node_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/node_cache.h
@@ -8,7 +8,7 @@
 
 #include <library/cpp/cache/cache.h>
 
-#include <util/generic/hash_set.h>
+#include <util/generic/hash.h>
 #include <util/generic/intrlist.h>
 #include <util/generic/string.h>
 
@@ -17,7 +17,6 @@ namespace NCloud::NFileStore::NFuse {
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TNode
-    : private TNonCopyable
 {
     NProto::TNodeAttr Attrs;
     ui64 RefCount = 1;
@@ -51,74 +50,33 @@ struct TNode
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TNodeOps
-{
-    struct THash
-    {
-        template <typename T>
-        size_t operator ()(const T& value) const
-        {
-            return IntHash(GetNodeId(value));
-        }
-    };
-
-    struct TEqual
-    {
-        template <typename T1, typename T2>
-        bool operator ()(const T1& l, const T2& r) const
-        {
-            return GetNodeId(l) == GetNodeId(r);
-        }
-    };
-
-    static auto GetNodeId(const TNode& node)
-    {
-        return node.Attrs.GetId();
-    }
-
-    template <typename T>
-    static auto GetNodeId(const T& value)
-    {
-        return value;
-    }
-};
-
-using TNodeMap = THashSet<TNode, TNodeOps::THash, TNodeOps::TEqual>;
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TNodeCache
 {
 private:
-    TNodeMap Nodes;
-
-    // TODO: keep track of session re-creation
-    ui64 LastGen = 0;
+    THashMap<ui64, TNode> Id2Node;
 
 public:
-    ui64 Generation() const
-    {
-        return LastGen;
-    }
-
-    TNode* AddNode(const NProto::TNodeAttr& node);
-    TNode* TryAddNode(const NProto::TNodeAttr& node);
+    TNode* AddNode(const NProto::TNodeAttr& attrs);
+    TNode* TryAddNode(const NProto::TNodeAttr& attrs);
     TNode* FindNode(ui64 ino);
     void ForgetNode(ui64 ino, size_t count);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TXAttr {
+struct TXAttr
+{
     TString Name;
     TMaybe<TString> Value;
     ui64 Version;
     TInstant UpdateTime;
 };
 
-class TXAttrCache {
+class TXAttrCache
+{
 private:
-    struct TWeighter {
+    struct TWeighter
+    {
         static TInstant Weight(const TXAttr& value)
         {
             return value.UpdateTime;


### PR DESCRIPTION
### Notes
I will need `NodeCache` to track node attr versions for https://github.com/ydb-platform/nbs/issues/5293. Cleaning it up in this separate PR.

In the future we might need to reimplement this simple cache to eliminate the global (per-fs) lock.

### Issue
https://github.com/ydb-platform/nbs/issues/5293