### PR TITLE
issue-5250: Fix PCI device binding to vfio-pci driver

### DIFF
--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
@@ -16,7 +16,7 @@ void WriteFile(const TFsPath& path, TStringBuf data)
 {
     TFile file{path, EOpenModeFlag::OpenExisting | EOpenModeFlag::WrOnly};
 
-    TFileOutput(file).Write(data);
+    file.Write(data.data(), data.size());
 }
 
 TString ReadFile(const TFsPath& path)
@@ -62,17 +62,19 @@ public:
         }
 
         const TFsPath basePath = SysFsRoot / "bus/pci";
+        const TFsPath devicePath = basePath / "devices" / pciAddr;
 
         // Unbind from the current driver
         if (currentDriver) {
-            WriteFile(
-                basePath / "devices" / pciAddr / "driver/unbind",
-                pciAddr);
+            WriteFile(devicePath / "driver/unbind", pciAddr);
         }
 
         // Bind to the new driver
         if (driverName) {
+            WriteFile(devicePath / "driver_override", driverName);
             WriteFile(basePath / "drivers" / driverName / "bind", pciAddr);
+        } else {
+            WriteFile(devicePath / "driver_override", {});
         }
     }
 

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
@@ -67,6 +67,8 @@ struct TFixture: public NUnitTest::TBaseFixture
             const TFsPath devicePath = GetPCIDevicePath(device);
             NFs::MakeDirectoryRecursive(devicePath);
 
+            (devicePath / "driver_override").Touch();
+
             WriteFileHex(devicePath / "vendor", device.GetVendorId());
             WriteFileHex(devicePath / "device", device.GetDeviceId());
 
@@ -107,7 +109,7 @@ struct TFixture: public NUnitTest::TBaseFixture
         TFsPath path = SysFsRoot / "bus/pci/drivers/" / name;
 
         NFs::MakeDirectoryRecursive(path);
-        for (const TStringBuf sub: {"bind", "unbind", "new_id"}) {
+        for (const TStringBuf sub: {"bind", "unbind"}) {
             (path / sub).Touch();
         }
 
@@ -205,6 +207,9 @@ Y_UNIT_TEST_SUITE(TSysFsHelpersTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 pciAddr,
                 ReadFile(VFIODriverPath / "bind"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "vfio-pci",
+                ReadFile(GetPCIDevicePath(device) / "driver_override"));
         }
 
         {
@@ -230,6 +235,9 @@ Y_UNIT_TEST_SUITE(TSysFsHelpersTest)
                 pciAddr,
                 ReadFile(VFIODriverPath / "unbind"));
             UNIT_ASSERT_VALUES_EQUAL("", ReadFile(VFIODriverPath / "bind"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                ReadFile(GetPCIDevicePath(device) / "driver_override"));
         }
 
         {
@@ -246,6 +254,9 @@ Y_UNIT_TEST_SUITE(TSysFsHelpersTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 pciAddr,
                 ReadFile(VFIODriverPath / "bind"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "vfio-pci",
+                ReadFile(GetPCIDevicePath(device) / "driver_override"));
         }
     }
 


### PR DESCRIPTION
Set `driver_override` on the PCI device before attempting bind. Without this, binding to vfio-pci silently fails for devices like NVMe whose IDs are not in the vfio-pci ID table.
Previously the device would successfully unbind from nvme but never attach to vfio-pci, leaving it driverless and without /dev/vfio/ entry.

#5250