### PR TITLE
Fix flaky ShouldDetectDirtyBufferInLastBlock

### DIFF
--- a/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
+++ b/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
@@ -193,8 +193,8 @@ struct TFixture: public NUnitTest::TBaseFixture
     static constexpr ui64 StorageSize = 93_GB;
     static constexpr ui64 StartIndex = 0;
     static constexpr ui64 BlocksCount = StorageSize / BlockSize;
-    const ui32 ExpectedDeallocations = 93;
-    const ui32 ExpectedReads = BlocksCount / DefaultValidatedBlocksRatio;
+    static constexpr ui32 ExpectedDeallocations = 93;
+    static constexpr ui32 ExpectedReads = BlocksCount / DefaultValidatedBlocksRatio;
 
     const TString Filename = "filename";
 
@@ -398,7 +398,9 @@ Y_UNIT_TEST_SUITE(TSafeDeallocateDeviceTest)
         {
             std::memset(buffer.data(), 0, buffer.size());
 
-            if (offset == StorageSize - BlockSize) {
+            const bool isLastRead =
+                FileIO->ReadRequests.size() == ExpectedReads;
+            if (isLastRead && offset == StorageSize - BlockSize) {
                 buffer[buffer.size() / 2] = 0x42;
             }
 


### PR DESCRIPTION
Random read from the last block could fail the assert for read count. Corrupt the last block only for the last read.
```
[[bad]]assertion failed at cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp:420, virtual void NCloud::NBlockStore::NServer::NTestSuiteTSafeDeallocateDeviceTest::TTestCaseShouldDetectDirtyBufferInLastBlock::Execute_(NUnitTest::TTestContext &): (ExpectedReads == FileIO->ReadRequests.size()) failed: (24379 != 24272) [[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char>> const&, bool)+230 (0x1398C66)
NCloud::NBlockStore::NServer::NTestSuiteTSafeDeallocateDeviceTest::TTestCaseShouldDetectDirtyBufferInLastBlock::Execute_(NUnitTest::TTestContext&)+3494 (0xF93F16)
std::__y1::__function::__func<NCloud::NBlockStore::NServer::NTestSuiteTSafeDeallocateDeviceTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NBlockStore::NServer::NTestSuiteTSafeDeallocateDeviceTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()()+181 (0xF9B965)
TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+128 (0x13B8AC0)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+219 (0x139C8CB)
NCloud::NBlockStore::NServer::NTestSuiteTSafeDeallocateDeviceTest::TCurrentTest::Execute()+732 (0xF9B00C)
NUnitTest::TTestFactory::Execute()+1524 (0x139D6D4)
NUnitTest::RunMain(int, char**)+4189 (0x13B4EAD)
main+33 (0x13B3E21)
??+0 (0x7FB1CAC29D90)
__libc_start_main+128 (0x7FB1CAC29E40)
??+0 (0xF0D029)
[[rst]]
```