### PR TITLE
Fix reference implementation for TFileRingBufferTest::RandomizedPushPopRestore

### DIFF
--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -411,9 +411,30 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldNotWriteBeyondBufferWhenEmpty)
+    {
+        const auto f = TTempFileHandle();
+        auto ri = TReferenceImplementation(64);
+        auto rb = TFileRingBuffer(f.GetName(), 64);
+
+        TString data(36, 'a');
+
+        UNIT_ASSERT(rb.PushBack(data));
+        UNIT_ASSERT(ri.PushBack(data));
+
+        rb.PopFront();
+        ri.PopFront();
+
+        UNIT_ASSERT(rb.PushBack(data));
+        UNIT_ASSERT(ri.PushBack(data));
+
+        UNIT_ASSERT(!rb.PushBack(data));
+        UNIT_ASSERT(!ri.PushBack(data));
+    }
+
     Y_UNIT_TEST(RandomizedPushPopRestore)
     {
-        DoRandomizedPushPopRestore(1_MB, 256_MB, 5_KB, 0);
+        DoRandomizedPushPopRestore(1_MB, 16_MB, 5_KB, 0);
     }
 
     Y_UNIT_TEST(RandomizedPushPopRestoreSmall)


### PR DESCRIPTION
In the reference implementation of `TFileRingBuffer`, the pointers were not set to a correct position for an empty buffer.

```
###subtest-started:TFileRingBufferTest::RandomizedPushPopRestoreWithMetadata
[[bad]]assertion failed at cloud/storage/core/libs/common/file_ring_buffer_ut.cpp:366, void NCloud::NTestSuiteTFileRingBufferTest::DoRandomizedPushPopRestore(ui32, ui32, ui32, ui32): (pushed == rb->PushBack(data)) failed: (1 != 0) [[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char>> const&, bool)+136 (0x8CEF58)
NCloud::NTestSuiteTFileRingBufferTest::DoRandomizedPushPopRestore(unsigned int, unsigned int, unsigned int, unsigned int)+8221 (0x67603D)
NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()::'lambda'()::operator()() const+71 (0x695CB7)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+127 (0x8D0F0F)
NCloud::NTestSuiteTFileRingBufferTest::TCurrentTest::Execute()+426 (0x69566A)
NUnitTest::TTestFactory::Execute()+780 (0x8D166C)
NUnitTest::RunMain(int, char**)+3005 (0x8E0B2D)
??+0 (0x7F33F547FD90)
__libc_start_main+128 (0x7F33F547FE40)
??+0 (0x5DA0A9)
[[rst]]
```

Also added amount of data written to increase the probability of the test failing close to 100% without fix.