### PR TITLE
added MainTabletId to GetFileStoreInfo output

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_getfsinfo.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getfsinfo.cpp
@@ -95,6 +95,7 @@ void TGetFileStoreInfoActor::HandleDescribeFileStoreResponse(
     auto* fs = response->Record.MutableFileStore();
     Convert(config, *fs);
     Convert(config, *fs->MutablePerformanceProfile());
+    fs->SetMainTabletId(fileStore.GetIndexTabletId());
 
     ReplyAndDie(ctx, std::move(response));
 }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -202,6 +202,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(1'000, response.GetBlocksCount());
         UNIT_ASSERT_VALUES_EQUAL(DefaultBlockSize, response.GetBlockSize());
         UNIT_ASSERT_VALUES_EQUAL(1, response.GetConfigVersion());
+        UNIT_ASSERT(response.GetMainTabletId() != 0);
 
         const auto& profile = response.GetPerformanceProfile();
         UNIT_ASSERT(!profile.GetThrottlingEnabled());

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -79,6 +79,9 @@ message TFileStore
 
     // Zero for main fs, non-zero for shards.
     uint32 ShardNo = 13;
+
+    // The id of the main filestore tablet.
+    uint64 MainTabletId = 14;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
It's useful to have it there - this way we can get the fs id <-> tablet id mapping even for offline tablets.