### PR TITLE
issue-5076: [Filestore] fix nfs-features bug by applying features only to a matching tablet as opposed to all the tablets

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -6,6 +6,8 @@
 #include <cloud/filestore/private/api/protos/actions.pb.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
+#include <cloud/storage/core/libs/features/features_config.h>
+
 #include <contrib/libs/protobuf/src/google/protobuf/stubs/stringpiece.h>
 #include <google/protobuf/util/json_util.h>
 
@@ -1138,6 +1140,42 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         UNIT_ASSERT_VALUES_EQUAL(2, listResponse->Record.GetNodes().size());
 
         UNIT_ASSERT_VALUES_EQUAL(1, getCacheHit());
+    }
+
+    Y_UNIT_TEST(ShouldNotLeakFeaturesAcrossFileStoresWithSharedConfig)
+    {
+        // Reproduce the bug: all tablet actors share the same TStorageConfig
+        // passed by shared_ptr. When SetCloudFolderEntity is modifies the
+        // shared ProtoConfig for all tablets, not only the matching one
+        NCloud::NProto::TFeaturesConfig featuresConfigProto;
+        auto* feature = featuresConfigProto.AddFeatures();
+        feature->SetName("ParentlessFilesOnly");
+        feature->MutableWhitelist()->AddEntityIds("with-feature");
+
+        NProto::TStorageConfig config;
+        TTestEnv env{{}, config};
+        env.GetStorageConfig()->SetFeaturesConfig(
+            std::make_shared<NFeatures::TFeaturesConfig>(featuresConfigProto));
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        service.CreateFileStore("with-feature", 1'000);
+        service.CreateFileStore("without-feature", 1'000);
+
+        {
+            auto response = ExecuteGetStorageConfig("with-feature", service);
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                response.GetParentlessFilesOnly());
+        }
+
+        {
+            auto response = ExecuteGetStorageConfig("without-feature", service);
+            UNIT_ASSERT_VALUES_EQUAL(
+                false,
+                response.GetParentlessFilesOnly());
+        }
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -55,7 +55,7 @@ TIndexTabletActor::TIndexTabletActor(
                 time);
         }
     )
-    , Config(std::move(config))
+    , Config(std::make_shared<TStorageConfig>(*config))
     , DiagConfig(std::move(diagConfig))
     , BlobCodec(NBlockCodecs::Codec(Config->GetBlobCompressionCodec()))
 {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -204,7 +204,6 @@ void TIndexTabletActor::CompleteTx_LoadState(
 {
     if (args.StorageConfig.Defined()) {
         StorageConfigOverride = *args.StorageConfig;
-        Config = std::make_shared<TStorageConfig>(*Config);
         Config->Merge(*args.StorageConfig.Get());
         LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
             LogTag << " Merge StorageConfig with config from tablet database");


### PR DESCRIPTION
All index tablet actors were created with a `shared_ptr` to the same `TStorageConfig` instance (passed from the actor system factory). 

SetCloudFolderEntity iterates over all bool fields in ProtoConfig and sets matching ones to true — but never resets them. So when tablet A with feature ran `SetCloudFolderEntity`, it set `ParentlessFilesOnly=true` in the shared `ProtoConfig`. 

When tablet B without-feature was subsequently called `SetCloudFolderEntity`, it did not clear the field, leaving `ParentlessFilesOnly=true` inherited from tablet A.

---

#5076