### PR TITLE
issue-4961: add ForceDestroySizeThreshold to allow force destroying small filesystems with stale active sessions

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -736,4 +736,8 @@ message TStorageConfig
 
     // Frequency of tablet regular task runs (e.g. ResponseLogEntry cleanup).
     optional uint32 TabletRegularTasksSchedulePeriod = 486;
+
+    // Allow to destroy filestore with active sessions
+    // with size less than threshold(in bytes)
+    optional uint32 ForceDestroySizeThreshold = 487;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -329,6 +329,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
                                                                                \
     xxx(ResponseLogEntryTTL,                TDuration,  TDuration::Hours(1)   )\
     xxx(TabletRegularTasksSchedulePeriod,   TDuration,  TDuration::Minutes(1) )\
+                                                                               \
+    xxx(ForceDestroySizeThreshold,          ui32,       0                      )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -390,6 +390,8 @@ public:
 
     [[nodiscard]] TDuration GetTabletRegularTasksSchedulePeriod() const;
     [[nodiscard]] TDuration GetResponseLogEntryTTL() const;
+
+    ui32 GetForceDestroySizeThreshold() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -1,5 +1,7 @@
 #include "service_actor.h"
 
+#include "helpers.h"
+
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/storage/api/ss_proxy.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
@@ -28,23 +30,31 @@ private:
     const bool AllowFileStoreDestroyWithOrphanSessions;
     TVector<TString> ShardIds;
     ui32 DestroyedShardCount = 0;
+    ui32 ForceDestroySizeThreshold = 0;
+    NProto::TFileStore FileStore;
 
 public:
     TDestroyFileStoreActor(
         TRequestInfoPtr requestInfo,
         TString fileSystemId,
         bool forceDestroy,
-        bool allowFileStoreDestroyWithOrphanSessions);
+        bool allowFileStoreDestroyWithOrphanSessions,
+        ui32 forceDestroySizeThreshold);
 
     void Bootstrap(const TActorContext& ctx);
 
 private:
     STFUNC(StateWork);
 
+    void DescribeFileStore(const TActorContext& ctx);
     void DescribeSessions(const TActorContext& ctx);
     void GetFileSystemTopology(const TActorContext& ctx);
     void DestroyShards(const TActorContext& ctx);
     void DestroyFileStore(const TActorContext& ctx);
+
+    void HandleDescribeFileStoreResponse(
+        const TEvSSProxy::TEvDescribeFileStoreResponse::TPtr& ev,
+        const TActorContext& ctx);
 
     void HandleDescribeSessionsResponse(
         const TEvIndexTablet::TEvDescribeSessionsResponse::TPtr& ev,
@@ -73,25 +83,76 @@ TDestroyFileStoreActor::TDestroyFileStoreActor(
         TRequestInfoPtr requestInfo,
         TString fileSystemId,
         bool forceDestroy,
-        bool allowFileStoreDestroyWithOrphanSessions)
+        bool allowFileStoreDestroyWithOrphanSessions,
+        ui32 forceDestroySizeThreshold)
     : RequestInfo(std::move(requestInfo))
     , FileSystemId(std::move(fileSystemId))
     , ForceDestroy(forceDestroy)
     , AllowFileStoreDestroyWithOrphanSessions(
         allowFileStoreDestroyWithOrphanSessions)
+    , ForceDestroySizeThreshold(forceDestroySizeThreshold)
 {}
 
 void TDestroyFileStoreActor::Bootstrap(const TActorContext& ctx)
 {
-    if (ForceDestroy) {
-        GetFileSystemTopology(ctx);
-    } else {
-        DescribeSessions(ctx);
-    }
+    DescribeFileStore(ctx);
     Become(&TThis::StateWork);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TDestroyFileStoreActor::DescribeFileStore(const TActorContext& ctx)
+{
+    auto request = std::make_unique<TEvSSProxy::TEvDescribeFileStoreRequest>(
+        FileSystemId);
+
+    NCloud::Send(ctx, MakeSSProxyServiceId(), std::move(request));
+}
+
+void TDestroyFileStoreActor::HandleDescribeFileStoreResponse(
+    const TEvSSProxy::TEvDescribeFileStoreResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    if (HasError(msg->GetError())) {
+        if (msg->GetStatus() ==
+            MAKE_SCHEMESHARD_ERROR(
+                NKikimrScheme::EStatus::StatusPathDoesNotExist))
+        {
+            ReplyAndDie(
+                ctx,
+                MakeError(S_FALSE, FileSystemId.Quote() + " does not exist"));
+            return;
+        }
+
+        ReplyAndDie(ctx, msg->GetError());
+        return;
+    }
+
+    const auto& fileStore = msg->PathDescription.GetFileStoreDescription();
+    const auto& config = fileStore.GetConfig();
+
+    Convert(config, FileStore);
+
+    auto bytesSize = FileStore.GetBlockSize() * FileStore.GetBlocksCount();
+    bool isBelowForceDestroyThreshold = bytesSize <= ForceDestroySizeThreshold;
+    if (isBelowForceDestroyThreshold) {
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "[%s] filestore size(%u bytes) less than "
+            "ForceDestroySizeThreshold(%u bytes), force destroying",
+            FileSystemId.c_str(),
+            bytesSize,
+            ForceDestroySizeThreshold);
+    }
+
+    if (ForceDestroy || isBelowForceDestroyThreshold) {
+        GetFileSystemTopology(ctx);
+    } else {
+        DescribeSessions(ctx);
+    }
+}
 
 void TDestroyFileStoreActor::DescribeSessions(const TActorContext& ctx)
 {
@@ -298,6 +359,10 @@ STFUNC(TDestroyFileStoreActor::StateWork)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         HFunc(
+            TEvSSProxy::TEvDescribeFileStoreResponse,
+            HandleDescribeFileStoreResponse);
+
+        HFunc(
             TEvIndexTablet::TEvDescribeSessionsResponse,
             HandleDescribeSessionsResponse);
 
@@ -366,7 +431,8 @@ void TStorageServiceActor::HandleDestroyFileStore(
         std::move(requestInfo),
         msg->Record.GetFileSystemId(),
         forceDestroy,
-        StorageConfig->GetAllowFileStoreDestroyWithOrphanSessions());
+        StorageConfig->GetAllowFileStoreDestroyWithOrphanSessions(),
+        StorageConfig->GetForceDestroySizeThreshold());
 
     NCloud::Register(ctx, std::move(actor));
 }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3616,6 +3616,73 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             destroyFileStoreResponse->GetErrorReason());
     }
 
+    Y_UNIT_TEST(ShouldDestroyFileStoreWithActiveSessionWithForceDestroySizeThreshold)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetForceDestroySizeThreshold(1_GB);
+
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        const TString fsId = "test";
+        // Size less than ForceDestroySizeThreshold
+        const auto initialBlockCount = 80_MB / DefaultBlockSize;
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, initialBlockCount);
+
+        auto headers = THeaders{fsId, "client", ""};
+        auto createSessionResponse = service.CreateSession(headers);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createSessionResponse->GetStatus(),
+            createSessionResponse->GetErrorReason());
+
+        auto destroyFileStoreResponse = service.DestroyFileStore(fsId);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            destroyFileStoreResponse->GetStatus(),
+            destroyFileStoreResponse->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldNotDestroyFileStoreWithActiveSessionWithForceDestroySizeThreshold)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetForceDestroySizeThreshold(1_GB);
+
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        const TString fsId = "test";
+        // Size more than ForceDestroySizeThreshold
+        const auto initialBlockCount = 2_GB / DefaultBlockSize;
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsId, initialBlockCount);
+
+        auto headers = THeaders{fsId, "client", ""};
+        auto createSessionResponse = service.CreateSession(headers);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createSessionResponse->GetStatus(),
+            createSessionResponse->GetErrorReason());
+        service.AssertDestroyFileStoreFailed(fsId);
+
+        headers.SessionId =
+            createSessionResponse->Record.GetSession().GetSessionId();
+        auto destroySessionResponse = service.DestroySession(headers);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            destroySessionResponse->GetStatus(),
+            destroySessionResponse->GetErrorReason());
+
+        auto destroyFileStoreResponse = service.DestroyFileStore(fsId);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            destroyFileStoreResponse->GetStatus(),
+            destroyFileStoreResponse->GetErrorReason());
+    }
+
     Y_UNIT_TEST(DestroyDestroyedFileStoreShouldNotFail)
     {
         TTestEnv env;


### PR DESCRIPTION
#4961 
Temporary fix for hanging filesystem deletions caused by stale active sessions: force-destroy filesystems smaller than `ForceDestroySizeThreshold`, as most hanging requests involve small acceptance test filesystems.