### PR TITLE
[Filestore] out of order support for index #5349

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/deletion_markers.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/deletion_markers.cpp
@@ -73,6 +73,8 @@ private:
 
     IAllocator* Alloc;
 
+    void AddOutOfOrder(TDeletionMarker deletionMarker, TDisjointRangeMap& map);
+
 public:
     TImpl(IAllocator* alloc)
         : DisjointRangeMapByNodeId{alloc}
@@ -102,7 +104,10 @@ void TDeletionMarkers::TImpl::Add(
     TDisjointRangeMapByNodeId::insert_ctx ctx;
     auto it = DisjointRangeMapByNodeId.find(deletionMarker.NodeId, ctx);
     if (it == DisjointRangeMapByNodeId.end()) {
-        it = DisjointRangeMapByNodeId.emplace_direct(ctx, deletionMarker.NodeId, Alloc);
+        it = DisjointRangeMapByNodeId.emplace_direct(
+            ctx,
+            deletionMarker.NodeId,
+            Alloc);
     }
 
     auto& map = it->second;
@@ -111,107 +116,134 @@ void TDeletionMarkers::TImpl::Add(
     const ui32 end = deletionMarker.BlockIndex + deletionMarker.BlockCount;
     Y_ABORT_UNLESS(start < end);
 
-    if (isLatestCommit) {
-        auto lo = map.upper_bound(start);
-        auto hi = map.upper_bound(end);
+    if (!isLatestCommit) {
+        AddOutOfOrder(deletionMarker, map);
+        return;
+    }
 
-        if (lo != map.end() && lo->Start < start) {
-            // cutting lo from the right side
-            map.emplace(lo->Start, start, lo->CommitId);
+    auto lo = map.upper_bound(start);
+    auto hi = map.upper_bound(end);
+
+    if (lo != map.end() && lo->Start < start) {
+        // cutting lo from the right side
+        map.emplace(lo->Start, start, lo->CommitId);
+    }
+
+    if (hi != map.end() && hi->Start < end) {
+        // cutting hi from the left side
+        const_cast<TDeletedRange&>(*hi).Start = end;
+    }
+
+    while (lo != hi) {
+        map.erase(lo++);
+    }
+
+    map.emplace(start, end, deletionMarker.CommitId);
+
+    Y_IF_DEBUG({
+        // check that ranges are disjoint
+        ui32 prevEnd = 0;
+
+        for (const auto deletedRange: map) {
+            Y_ABORT_UNLESS(deletedRange.Start >= prevEnd);
+            prevEnd = deletedRange.End;
+        }
+    });
+
+    DeletionMarkers.push_back(deletionMarker);
+}
+
+void TDeletionMarkers::TImpl::AddOutOfOrder(
+    TDeletionMarker deletionMarker,
+    TDisjointRangeMap& map)
+{
+    const ui32 start = deletionMarker.BlockIndex;
+    const ui32 end = deletionMarker.BlockIndex + deletionMarker.BlockCount;
+    Y_ABORT_UNLESS(start < end);
+
+    // Out-of-order insert:
+    //   We insert [start, end) with commit Cnew into a map of disjoint
+    //   ranges. Existing ranges with commit >= Cnew "block" insertion.
+    //   Existing ranges with commit <  Cnew are replaced in overlap parts.
+    //
+    // Example:
+    //   new:         [--------------- Cnew=100 ------------)
+    //   existing:    [-- C=50 --) [---- C=120 ----) [-- C=80 --)
+    //                    lower          blocks              lower
+    //
+    // Pass 1 over overlaps:
+    //   - blocking overlaps (commit >= Cnew) -> blockedSegments
+    //   - lower-commit overlaps              -> erase range, keep
+    //   non-overlap
+    //                                          tails in tailRanges
+    //
+    // Pass 2:
+    //   - reinsert tailRanges (preserve unaffected pieces of erased ranges)
+    //   - fill gaps between blockedSegments with Cnew:
+    //       start .... blocked .... blocked .... end
+    //       ^insertionStart advances to blocked.End each step
+    //
+    // Complexity of interval bookkeeping in this branch:
+    //   O(K), where K is number of overlapping ranges. Total O(K*logN) due
+    //   to map insertions/erasures.
+    struct TSegment
+    {
+        ui32 Start;
+        ui32 End;
+    };
+
+    TVector<TSegment> blockedSegments;
+    TVector<TDeletedRange> tailRanges;
+
+    auto current = map.upper_bound(start);
+    while (current != map.end() && current->Start < end) {
+        auto it = current++;
+        const TDeletedRange deletedRange = *it;
+
+        const ui32 overlapStart = Max(start, deletedRange.Start);
+        const ui32 overlapEnd = Min(end, deletedRange.End);
+
+        Y_ABORT_UNLESS(overlapStart < overlapEnd);
+
+        if (deletedRange.CommitId >= deletionMarker.CommitId) {
+            blockedSegments.push_back({overlapStart, overlapEnd});
+            continue;
         }
 
-        if (hi != map.end() && hi->Start < end) {
-            // cutting hi from the left side
-            const_cast<TDeletedRange&>(*hi).Start = end;
+        map.erase(it);
+
+        if (deletedRange.Start < overlapStart) {
+            tailRanges.emplace_back(
+                deletedRange.Start,
+                overlapStart,
+                deletedRange.CommitId);
         }
 
-        while (lo != hi) {
-            map.erase(lo++);
+        if (overlapEnd < deletedRange.End) {
+            tailRanges.emplace_back(
+                overlapEnd,
+                deletedRange.End,
+                deletedRange.CommitId);
         }
+    }
 
-        map.emplace(start, end, deletionMarker.CommitId);
-    } else {
-        // Out-of-order insert:
-        //   We insert [start, end) with commit Cnew into a map of disjoint
-        //   ranges. Existing ranges with commit >= Cnew "block" insertion.
-        //   Existing ranges with commit <  Cnew are replaced in overlap parts.
-        //
-        // Example:
-        //   new:         [--------------- Cnew=100 ------------)
-        //   existing:    [-- C=50 --) [---- C=120 ----) [-- C=80 --)
-        //                    lower          blocks              lower
-        //
-        // Pass 1 over overlaps:
-        //   - blocking overlaps (commit >= Cnew) -> blockedSegments
-        //   - lower-commit overlaps              -> erase range, keep
-        //   non-overlap
-        //                                          tails in tailRanges
-        //
-        // Pass 2:
-        //   - reinsert tailRanges (preserve unaffected pieces of erased ranges)
-        //   - fill gaps between blockedSegments with Cnew:
-        //       start .... blocked .... blocked .... end
-        //       ^insertionStart advances to blocked.End each step
-        //
-        // Complexity of interval bookkeeping in this branch:
-        //   O(K), where K is number of overlapping ranges. Total O(K*logN) due
-        //   to map insertions/erasures.
-        struct TSegment
-        {
-            ui32 Start;
-            ui32 End;
-        };
+    for (const auto& deletedRange: tailRanges) {
+        map.emplace(
+            deletedRange.Start,
+            deletedRange.End,
+            deletedRange.CommitId);
+    }
 
-        TVector<TSegment> blockedSegments;
-        TVector<TDeletedRange> tailRanges;
-
-        auto current = map.upper_bound(start);
-        while (current != map.end() && current->Start < end) {
-            auto it = current++;
-            const TDeletedRange deletedRange = *it;
-
-            const ui32 overlapStart = Max(start, deletedRange.Start);
-            const ui32 overlapEnd = Min(end, deletedRange.End);
-
-            Y_ABORT_UNLESS(overlapStart < overlapEnd);
-
-            if (deletedRange.CommitId >= deletionMarker.CommitId) {
-                blockedSegments.push_back({overlapStart, overlapEnd});
-                continue;
-            }
-
-            map.erase(it);
-
-            if (deletedRange.Start < overlapStart) {
-                tailRanges.emplace_back(
-                    deletedRange.Start,
-                    overlapStart,
-                    deletedRange.CommitId);
-            }
-
-            if (overlapEnd < deletedRange.End) {
-                tailRanges.emplace_back(
-                    overlapEnd,
-                    deletedRange.End,
-                    deletedRange.CommitId);
-            }
+    ui32 insertionStart = start;
+    for (const auto& blocked: blockedSegments) {
+        if (insertionStart < blocked.Start) {
+            map.emplace(insertionStart, blocked.Start, deletionMarker.CommitId);
         }
+        insertionStart = Max(insertionStart, blocked.End);
+    }
 
-        for (const auto& deletedRange: tailRanges) {
-            map.emplace(deletedRange.Start, deletedRange.End, deletedRange.CommitId);
-        }
-
-        ui32 insertionStart = start;
-        for (const auto& blocked: blockedSegments) {
-            if (insertionStart < blocked.Start) {
-                map.emplace(insertionStart, blocked.Start, deletionMarker.CommitId);
-            }
-            insertionStart = Max(insertionStart, blocked.End);
-        }
-
-        if (insertionStart < end) {
-            map.emplace(insertionStart, end, deletionMarker.CommitId);
-        }
+    if (insertionStart < end) {
+        map.emplace(insertionStart, end, deletionMarker.CommitId);
     }
 
     Y_IF_DEBUG({

--- a/cloud/filestore/libs/storage/tablet/model/deletion_markers.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/deletion_markers.cpp
@@ -81,7 +81,7 @@ public:
 
     bool Empty() const;
 
-    void Add(TDeletionMarker deletionMarker);
+    void Add(TDeletionMarker deletionMarker, bool isLatestCommit);
 
     ui32 Apply(TArrayRef<TBlock> blocks) const;
 
@@ -95,7 +95,9 @@ bool TDeletionMarkers::TImpl::Empty() const
     return DeletionMarkers.empty();
 }
 
-void TDeletionMarkers::TImpl::Add(TDeletionMarker deletionMarker)
+void TDeletionMarkers::TImpl::Add(
+    TDeletionMarker deletionMarker,
+    bool isLatestCommit)
 {
     TDisjointRangeMapByNodeId::insert_ctx ctx;
     auto it = DisjointRangeMapByNodeId.find(deletionMarker.NodeId, ctx);
@@ -107,25 +109,110 @@ void TDeletionMarkers::TImpl::Add(TDeletionMarker deletionMarker)
 
     const ui32 start = deletionMarker.BlockIndex;
     const ui32 end = deletionMarker.BlockIndex + deletionMarker.BlockCount;
+    Y_ABORT_UNLESS(start < end);
 
-    auto lo = map.upper_bound(start);
-    auto hi = map.upper_bound(end);
+    if (isLatestCommit) {
+        auto lo = map.upper_bound(start);
+        auto hi = map.upper_bound(end);
 
-    if (lo != map.end() && lo->Start < start) {
-        // cutting lo from the right side
-        map.emplace(lo->Start, start, lo->CommitId);
+        if (lo != map.end() && lo->Start < start) {
+            // cutting lo from the right side
+            map.emplace(lo->Start, start, lo->CommitId);
+        }
+
+        if (hi != map.end() && hi->Start < end) {
+            // cutting hi from the left side
+            const_cast<TDeletedRange&>(*hi).Start = end;
+        }
+
+        while (lo != hi) {
+            map.erase(lo++);
+        }
+
+        map.emplace(start, end, deletionMarker.CommitId);
+    } else {
+        // Out-of-order insert:
+        //   We insert [start, end) with commit Cnew into a map of disjoint
+        //   ranges. Existing ranges with commit >= Cnew "block" insertion.
+        //   Existing ranges with commit <  Cnew are replaced in overlap parts.
+        //
+        // Example:
+        //   new:         [--------------- Cnew=100 ------------)
+        //   existing:    [-- C=50 --) [---- C=120 ----) [-- C=80 --)
+        //                    lower          blocks              lower
+        //
+        // Pass 1 over overlaps:
+        //   - blocking overlaps (commit >= Cnew) -> blockedSegments
+        //   - lower-commit overlaps              -> erase range, keep
+        //   non-overlap
+        //                                          tails in tailRanges
+        //
+        // Pass 2:
+        //   - reinsert tailRanges (preserve unaffected pieces of erased ranges)
+        //   - fill gaps between blockedSegments with Cnew:
+        //       start .... blocked .... blocked .... end
+        //       ^insertionStart advances to blocked.End each step
+        //
+        // Complexity of interval bookkeeping in this branch:
+        //   O(K), where K is number of overlapping ranges. Total O(K*logN) due
+        //   to map insertions/erasures.
+        struct TSegment
+        {
+            ui32 Start;
+            ui32 End;
+        };
+
+        TVector<TSegment> blockedSegments;
+        TVector<TDeletedRange> tailRanges;
+
+        auto current = map.upper_bound(start);
+        while (current != map.end() && current->Start < end) {
+            auto it = current++;
+            const TDeletedRange deletedRange = *it;
+
+            const ui32 overlapStart = Max(start, deletedRange.Start);
+            const ui32 overlapEnd = Min(end, deletedRange.End);
+
+            Y_ABORT_UNLESS(overlapStart < overlapEnd);
+
+            if (deletedRange.CommitId >= deletionMarker.CommitId) {
+                blockedSegments.push_back({overlapStart, overlapEnd});
+                continue;
+            }
+
+            map.erase(it);
+
+            if (deletedRange.Start < overlapStart) {
+                tailRanges.emplace_back(
+                    deletedRange.Start,
+                    overlapStart,
+                    deletedRange.CommitId);
+            }
+
+            if (overlapEnd < deletedRange.End) {
+                tailRanges.emplace_back(
+                    overlapEnd,
+                    deletedRange.End,
+                    deletedRange.CommitId);
+            }
+        }
+
+        for (const auto& deletedRange: tailRanges) {
+            map.emplace(deletedRange.Start, deletedRange.End, deletedRange.CommitId);
+        }
+
+        ui32 insertionStart = start;
+        for (const auto& blocked: blockedSegments) {
+            if (insertionStart < blocked.Start) {
+                map.emplace(insertionStart, blocked.Start, deletionMarker.CommitId);
+            }
+            insertionStart = Max(insertionStart, blocked.End);
+        }
+
+        if (insertionStart < end) {
+            map.emplace(insertionStart, end, deletionMarker.CommitId);
+        }
     }
-
-    if (hi != map.end() && hi->Start < end) {
-        // cutting hi from the left side
-        const_cast<TDeletedRange&>(*hi).Start = end;
-    }
-
-    while (lo != hi) {
-        map.erase(lo++);
-    }
-
-    map.emplace(start, end, deletionMarker.CommitId);
 
     Y_IF_DEBUG({
         // check that ranges are disjoint
@@ -195,7 +282,12 @@ bool TDeletionMarkers::Empty() const
 
 void TDeletionMarkers::Add(TDeletionMarker deletionMarker)
 {
-    return Impl->Add(deletionMarker);
+    return Impl->Add(deletionMarker, true);
+}
+
+void TDeletionMarkers::AddOutOfOrder(TDeletionMarker deletionMarker)
+{
+    return Impl->Add(deletionMarker, false);
 }
 
 ui32 TDeletionMarkers::Apply(TBlock& block) const

--- a/cloud/filestore/libs/storage/tablet/model/deletion_markers.h
+++ b/cloud/filestore/libs/storage/tablet/model/deletion_markers.h
@@ -59,6 +59,7 @@ public:
     bool Empty() const;
 
     void Add(TDeletionMarker deletionMarker);
+    void AddOutOfOrder(TDeletionMarker deletionMarker);
     ui32 Apply(TBlock& block) const;
     ui32 Apply(TArrayRef<TBlock> blocks) const;
     TVector<TDeletionMarker> Extract();

--- a/cloud/filestore/libs/storage/tablet/model/deletion_markers_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/deletion_markers_ut.cpp
@@ -4,6 +4,9 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <algorithm>
+#include <random>
+
 #include <util/random/fast.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -254,6 +257,110 @@ Y_UNIT_TEST_SUITE(TDeletionMarkersTest)
             m.Add({ DefaultNodeId, commitId++, left, right - left + 1 });
             CHECK_DELETION_MARKERS(maxN, m, DefaultNodeId);
         }
+    }
+
+    Y_UNIT_TEST(ShouldBeOrderIndependent)
+    {
+        constexpr ui64 nodeId = 1;
+
+        const TVector<TDeletionMarker> deletionMarkers = {
+            {nodeId, 10, 5, 4},    // [5, 9)
+            {nodeId, 20, 2, 6},    // [2, 8)
+            {nodeId, 25, 7, 2},    // [7, 9)
+            {nodeId, 30, 0, 3},    // [0, 3) latest
+        };
+
+        TDeletionMarkers inOrder(TDefaultAllocator::Instance());
+        TDeletionMarkers outOfOrder1(TDefaultAllocator::Instance());
+        TDeletionMarkers outOfOrder2(TDefaultAllocator::Instance());
+
+        // in-order insertion: every next marker has the latest commit id.
+        inOrder.Add(deletionMarkers[0]);
+        inOrder.Add(deletionMarkers[1]);
+        inOrder.Add(deletionMarkers[2]);
+        inOrder.Add(deletionMarkers[3]);
+
+        // out-of-order insertion: mark only running-max commit ids as latest.
+        outOfOrder1.Add(deletionMarkers[1]);
+        outOfOrder1.Add(deletionMarkers[2]);
+        outOfOrder1.AddOutOfOrder(deletionMarkers[0]);
+        outOfOrder1.Add(deletionMarkers[3]);
+
+        outOfOrder2.Add(deletionMarkers[2]);
+        outOfOrder2.AddOutOfOrder(deletionMarkers[0]);
+        outOfOrder2.AddOutOfOrder(deletionMarkers[1]);
+        outOfOrder2.Add(deletionMarkers[3]);
+
+        auto blocksInOrder = GenerateBlocks(10, nodeId);
+        auto blocksOutOfOrder1 = GenerateBlocks(10, nodeId);
+        auto blocksOutOfOrder2 = GenerateBlocks(10, nodeId);
+
+        inOrder.Apply(MakeArrayRef(blocksInOrder));
+        outOfOrder1.Apply(MakeArrayRef(blocksOutOfOrder1));
+        outOfOrder2.Apply(MakeArrayRef(blocksOutOfOrder2));
+
+        ASSERT_VECTORS_EQUAL(blocksInOrder, blocksOutOfOrder1);
+        ASSERT_VECTORS_EQUAL(blocksInOrder, blocksOutOfOrder2);
+
+        UNIT_ASSERT_VALUES_EQUAL(30, blocksInOrder[0].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(30, blocksInOrder[1].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(30, blocksInOrder[2].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(20, blocksInOrder[3].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(20, blocksInOrder[4].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(20, blocksInOrder[5].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(20, blocksInOrder[6].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(25, blocksInOrder[7].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(25, blocksInOrder[8].MaxCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, blocksInOrder[9].MaxCommitId);
+    }
+
+    Y_UNIT_TEST(ShouldBeOrderIndependentWithRandomlyDistributedDeletionMarkers)
+    {
+        const ui32 markerCount = 32 * 1024;
+
+        TVector<TDeletionMarker> deletionMarkers;
+        deletionMarkers.reserve(markerCount);
+
+        ui64 commitId = 1;
+        TFastRng<ui32> gen(12345);
+
+        for (ui32 step = 0; step < markerCount; ++step) {
+            ui32 left = gen.GenRand64() % 1024;
+            ui32 right = gen.GenRand64() % 1024;
+            if (left > right) {
+                std::swap(left, right);
+            }
+
+            deletionMarkers.push_back({
+                DefaultNodeId,
+                commitId++,
+                left,
+                right - left + 1
+            });
+        }
+
+        TDeletionMarkers inOrder(TDefaultAllocator::Instance());
+        TDeletionMarkers outOfOrder(TDefaultAllocator::Instance());
+
+        for (const auto& marker: deletionMarkers) {
+            inOrder.Add(marker);
+        }
+
+        std::mt19937_64 shuffleGen(12345);
+        std::shuffle(deletionMarkers.begin(), deletionMarkers.end(), shuffleGen);
+
+        for (const auto& marker: deletionMarkers) {
+            outOfOrder.AddOutOfOrder(marker);
+        }
+
+        auto blocksInOrder = GenerateBlocks(1024, DefaultNodeId);
+        auto blocksOutOfOrder = GenerateBlocks(1024, DefaultNodeId);
+
+        const ui32 updateCountInOrder = inOrder.Apply(MakeArrayRef(blocksInOrder));
+        const ui32 updateCountOutOfOrder = outOfOrder.Apply(MakeArrayRef(blocksOutOfOrder));
+
+        UNIT_ASSERT_VALUES_EQUAL(updateCountInOrder, updateCountOutOfOrder);
+        ASSERT_VECTORS_EQUAL(blocksInOrder, blocksOutOfOrder);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/model/fresh_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_blocks.cpp
@@ -75,24 +75,6 @@ bool TFreshBlocks::AddBlock(
     return true;
 }
 
-ui64 TFreshBlocks::MarkBlockDeleted(ui64 nodeId, ui32 blockIndex, ui64 commitId)
-{
-    auto it = Blocks.lower_bound(BlockKey(nodeId, blockIndex, commitId));
-    if (it != Blocks.end()) {
-        auto& block = const_cast<TBlock&>(it->first);
-
-        if (block.NodeId == nodeId && block.BlockIndex == blockIndex) {
-            Y_ABORT_UNLESS(block.MinCommitId <= commitId);
-            if (block.MaxCommitId == InvalidCommitId) {
-                block.MaxCommitId = commitId;
-                return block.MinCommitId;
-            }
-        }
-    }
-
-    return InvalidCommitId;
-}
-
 TVector<TFreshBlocks::TVersionedBlock> TFreshBlocks::MarkBlocksDeleted(
     ui64 nodeId,
     ui32 blockIndex,
@@ -107,9 +89,7 @@ TVector<TFreshBlocks::TVersionedBlock> TFreshBlocks::MarkBlocksDeleted(
     for (auto it = start; it != end; ++it) {
         auto& block = const_cast<TBlock&>(it->first);
 
-        if (block.MinCommitId <= commitId &&
-            block.MaxCommitId == InvalidCommitId)
-        {
+        if (block.MinCommitId <= commitId && commitId < block.MaxCommitId) {
             block.MaxCommitId = commitId;
             result.emplace_back(block.BlockIndex, block.MinCommitId);
         }

--- a/cloud/filestore/libs/storage/tablet/model/fresh_blocks_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_blocks_ut.cpp
@@ -83,7 +83,13 @@ Y_UNIT_TEST_SUITE(TFreshBlocksTest)
         TFreshBlocks freshBlocks(TDefaultAllocator::Instance());
         freshBlocks.AddBlock(nodeId, blockIndex, "x", 1, 1);
 
-        ui64 minCommitId = freshBlocks.MarkBlockDeleted(nodeId, blockIndex, 2);
+        auto deleted = freshBlocks.MarkBlocksDeleted(
+            nodeId,
+            blockIndex,
+            1,
+            2);
+        UNIT_ASSERT_VALUES_EQUAL(deleted.size(), 1);
+        ui64 minCommitId = deleted[0].second;
         UNIT_ASSERT_VALUES_EQUAL(minCommitId, 1);
 
         freshBlocks.AddBlock(nodeId, blockIndex, "y", 1, 2);
@@ -105,6 +111,82 @@ Y_UNIT_TEST_SUITE(TFreshBlocksTest)
         UNIT_ASSERT_VALUES_EQUAL(block->MinCommitId, 2);
         UNIT_ASSERT_VALUES_EQUAL(block->MaxCommitId, InvalidCommitId);
         UNIT_ASSERT_VALUES_EQUAL(block->BlockData, "y");
+    }
+
+    Y_UNIT_TEST(ShouldOverwriteBlocksOutOfOrder)
+    {
+        ui64 nodeId = 1;
+        ui32 blockIndex = 123;
+
+        TFreshBlocks freshBlocks(TDefaultAllocator::Instance());
+
+        freshBlocks.AddBlock(nodeId, blockIndex + 0, "a", 1, 1);
+        freshBlocks.AddBlock(nodeId, blockIndex + 1, "b", 1, 1);
+        freshBlocks.AddBlock(nodeId, blockIndex + 2, "c", 1, 1);
+
+        auto deleted = freshBlocks.MarkBlocksDeleted(
+            nodeId,
+            blockIndex,
+            3,
+            10);
+        UNIT_ASSERT_VALUES_EQUAL(deleted.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[0].first, blockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[0].second, 1);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[1].first, blockIndex + 1);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[1].second, 1);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[2].first, blockIndex + 2);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[2].second, 1);
+
+        freshBlocks.AddBlock(nodeId, blockIndex + 0, "A", 1, 10);
+        freshBlocks.AddBlock(nodeId, blockIndex + 1, "B", 1, 10);
+        freshBlocks.AddBlock(nodeId, blockIndex + 2, "C", 1, 10);
+
+        deleted = freshBlocks.MarkBlocksDeleted(
+            nodeId,
+            blockIndex + 1,
+            2,
+            5);
+        UNIT_ASSERT_VALUES_EQUAL(deleted.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[0].first, blockIndex + 1);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[0].second, 1);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[1].first, blockIndex + 2);
+        UNIT_ASSERT_VALUES_EQUAL(deleted[1].second, 1);
+
+        auto block = freshBlocks.FindBlock(nodeId, blockIndex + 0, 6);
+        UNIT_ASSERT(block);
+        UNIT_ASSERT_VALUES_EQUAL(block->MinCommitId, 1);
+        UNIT_ASSERT_VALUES_EQUAL(block->MaxCommitId, 10);
+        UNIT_ASSERT_VALUES_EQUAL(block->BlockData, "a");
+
+        block = freshBlocks.FindBlock(nodeId, blockIndex + 1, 4);
+        UNIT_ASSERT(block);
+        UNIT_ASSERT_VALUES_EQUAL(block->MinCommitId, 1);
+        UNIT_ASSERT_VALUES_EQUAL(block->MaxCommitId, 5);
+        UNIT_ASSERT_VALUES_EQUAL(block->BlockData, "b");
+
+        block = freshBlocks.FindBlock(nodeId, blockIndex + 1, 6);
+        UNIT_ASSERT(!block);
+
+        block = freshBlocks.FindBlock(nodeId, blockIndex + 2, 6);
+        UNIT_ASSERT(!block);
+
+        block = freshBlocks.FindBlock(nodeId, blockIndex + 0, 10);
+        UNIT_ASSERT(block);
+        UNIT_ASSERT_VALUES_EQUAL(block->MinCommitId, 10);
+        UNIT_ASSERT_VALUES_EQUAL(block->MaxCommitId, InvalidCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(block->BlockData, "A");
+
+        block = freshBlocks.FindBlock(nodeId, blockIndex + 1, 10);
+        UNIT_ASSERT(block);
+        UNIT_ASSERT_VALUES_EQUAL(block->MinCommitId, 10);
+        UNIT_ASSERT_VALUES_EQUAL(block->MaxCommitId, InvalidCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(block->BlockData, "B");
+
+        block = freshBlocks.FindBlock(nodeId, blockIndex + 2, 10);
+        UNIT_ASSERT(block);
+        UNIT_ASSERT_VALUES_EQUAL(block->MinCommitId, 10);
+        UNIT_ASSERT_VALUES_EQUAL(block->MaxCommitId, InvalidCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(block->BlockData, "C");
     }
 
     Y_UNIT_TEST(ShouldFindBlocks)

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.cpp
@@ -330,6 +330,16 @@ void TMixedBlocks::AddDeletionMarker(
     range->DeletionMarkers.Add(deletionMarker);
 }
 
+void TMixedBlocks::AddDeletionMarkerOutOfOrder(
+    ui32 rangeId,
+    TDeletionMarker deletionMarker)
+{
+    auto* range = Impl->FindRange(rangeId);
+    Y_ABORT_UNLESS(range);
+
+    range->DeletionMarkers.AddOutOfOrder(deletionMarker);
+}
+
 TVector<TDeletionMarker> TMixedBlocks::ExtractDeletionMarkers(ui32 rangeId)
 {
     auto* range = Impl->FindRange(rangeId);

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
@@ -58,7 +58,13 @@ public:
         ui32 blockIndex,
         ui32 blocksCount) const;
 
-    void AddDeletionMarker(ui32 rangeId, TDeletionMarker deletionMarker);
+    void AddDeletionMarker(
+        ui32 rangeId,
+        TDeletionMarker deletionMarker);
+
+    void AddDeletionMarkerOutOfOrder(
+        ui32 rangeId,
+        TDeletionMarker deletionMarker);
 
     TVector<TDeletionMarker> ExtractDeletionMarkers(ui32 rangeId);
 

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks_ut.cpp
@@ -190,6 +190,177 @@ Y_UNIT_TEST_SUITE(TMixedBlocksTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldApplyDeletionMarkersForOutOfOrderBlockInsertion)
+    {
+        constexpr ui32 rangeId = 0;
+        constexpr ui64 nodeId = 1;
+        constexpr ui32 blockIndex = 123456;
+        constexpr ui32 blocksCount = 3;
+
+        TMixedBlocks mixedBlocks(TDefaultAllocator::Instance());
+        mixedBlocks.RefRange(rangeId);
+
+        // Existing index state: a newer write is already present.
+        mixedBlocks.AddDeletionMarker(
+            rangeId,
+            TDeletionMarker(nodeId, 20, blockIndex, blocksCount));
+
+        {
+            const TBlock block(nodeId, blockIndex, 20, InvalidCommitId);
+            auto list = TBlockList::EncodeBlocks(
+                block,
+                blocksCount,
+                TDefaultAllocator::Instance());
+            UNIT_ASSERT(mixedBlocks.AddBlocks(
+                rangeId,
+                TPartialBlobId(20, 1),
+                std::move(list)));
+        }
+
+        // Out-of-order insertion path for older write.
+        // Older marker must not downgrade already known newer commit ids.
+        mixedBlocks.AddDeletionMarkerOutOfOrder(
+            rangeId,
+            TDeletionMarker(nodeId, 10, blockIndex, blocksCount));
+
+        {
+            const TBlock block(nodeId, blockIndex, 10, InvalidCommitId);
+            auto list = TBlockList::EncodeBlocks(
+                block,
+                blocksCount,
+                TDefaultAllocator::Instance());
+            UNIT_ASSERT(mixedBlocks.AddBlocks(
+                rangeId,
+                TPartialBlobId(10, 1),
+                std::move(list)));
+        }
+
+        {
+            TMixedBlockVisitor visitor;
+            mixedBlocks.FindBlocks(
+                visitor,
+                rangeId,
+                nodeId,
+                17,
+                blockIndex,
+                blocksCount);
+
+            auto blocks = visitor.Finish();
+            UNIT_ASSERT_VALUES_EQUAL(blocks.size(), blocksCount);
+
+            for (ui32 i = 0; i < blocksCount; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(blocks[i].NodeId, nodeId);
+                UNIT_ASSERT_VALUES_EQUAL(blocks[i].BlockIndex, blockIndex + i);
+                UNIT_ASSERT_VALUES_EQUAL(blocks[i].MinCommitId, 10);
+                UNIT_ASSERT_VALUES_EQUAL(blocks[i].MaxCommitId, 20);
+            }
+        }
+
+        {
+            TMixedBlockVisitor visitor;
+            mixedBlocks.FindBlocks(
+                visitor,
+                rangeId,
+                nodeId,
+                20,
+                blockIndex,
+                blocksCount);
+
+            auto blocks = visitor.Finish();
+            UNIT_ASSERT_VALUES_EQUAL(blocks.size(), blocksCount);
+
+            for (ui32 i = 0; i < blocksCount; ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(blocks[i].NodeId, nodeId);
+                UNIT_ASSERT_VALUES_EQUAL(blocks[i].BlockIndex, blockIndex + i);
+                UNIT_ASSERT_VALUES_EQUAL(blocks[i].MinCommitId, 20);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    blocks[i].MaxCommitId,
+                    InvalidCommitId);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ShouldKeepNonOverlappedPartVisibleForOutOfOrderInsertion)
+    {
+        constexpr ui32 rangeId = 0;
+        constexpr ui64 nodeId = 1;
+        constexpr ui32 blockIndex = 123456;
+        constexpr ui32 blocksCount = 4;
+
+        TMixedBlocks mixedBlocks(TDefaultAllocator::Instance());
+        mixedBlocks.RefRange(rangeId);
+
+        // Existing newer write covers only middle sub-range [1, 3).
+        mixedBlocks.AddDeletionMarker(
+            rangeId,
+            TDeletionMarker(nodeId, 20, blockIndex + 1, 2));
+
+        {
+            const TBlock block(nodeId, blockIndex + 1, 20, InvalidCommitId);
+            auto list = TBlockList::EncodeBlocks(
+                block,
+                2,
+                TDefaultAllocator::Instance());
+            UNIT_ASSERT(mixedBlocks.AddBlocks(
+                rangeId,
+                TPartialBlobId(20, 2),
+                std::move(list)));
+        }
+
+        // Older write is inserted after newer state is already in the index.
+        mixedBlocks.AddDeletionMarkerOutOfOrder(
+            rangeId,
+            TDeletionMarker(nodeId, 10, blockIndex, blocksCount));
+
+        {
+            const TBlock block(nodeId, blockIndex, 10, InvalidCommitId);
+            auto list = TBlockList::EncodeBlocks(
+                block,
+                blocksCount,
+                TDefaultAllocator::Instance());
+            UNIT_ASSERT(mixedBlocks.AddBlocks(
+                rangeId,
+                TPartialBlobId(10, 2),
+                std::move(list)));
+        }
+
+        TMixedBlockVisitor visitor;
+        mixedBlocks
+            .FindBlocks(visitor, rangeId, nodeId, 20, blockIndex, blocksCount);
+
+        auto blocks = visitor.Finish();
+        UNIT_ASSERT_VALUES_EQUAL(blocks.size(), blocksCount);
+
+        bool seen[blocksCount] = {};
+        ui64 minCommitId[blocksCount] = {};
+        ui64 maxCommitId[blocksCount] = {};
+
+        for (const auto& block: blocks) {
+            UNIT_ASSERT_VALUES_EQUAL(block.NodeId, nodeId);
+            UNIT_ASSERT(block.BlockIndex >= blockIndex);
+            UNIT_ASSERT(block.BlockIndex < blockIndex + blocksCount);
+
+            const ui32 idx = block.BlockIndex - blockIndex;
+            UNIT_ASSERT(!seen[idx]);
+            seen[idx] = true;
+            minCommitId[idx] = block.MinCommitId;
+            maxCommitId[idx] = block.MaxCommitId;
+        }
+
+        for (ui32 i = 0; i < blocksCount; ++i) {
+            UNIT_ASSERT(seen[i]);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(minCommitId[0], 10);
+        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[0], InvalidCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(minCommitId[1], 20);
+        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[1], InvalidCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(minCommitId[2], 20);
+        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[2], InvalidCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(minCommitId[3], 10);
+        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[3], InvalidCommitId);
+    }
+
     Y_UNIT_TEST(ShouldRefCountRanges)
     {
         constexpr ui32 rangeId = 0;

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks_ut.cpp
@@ -246,13 +246,13 @@ Y_UNIT_TEST_SUITE(TMixedBlocksTest)
                 blocksCount);
 
             auto blocks = visitor.Finish();
-            UNIT_ASSERT_VALUES_EQUAL(blocks.size(), blocksCount);
+            UNIT_ASSERT_VALUES_EQUAL(blocksCount, blocks.size());
 
             for (ui32 i = 0; i < blocksCount; ++i) {
-                UNIT_ASSERT_VALUES_EQUAL(blocks[i].NodeId, nodeId);
-                UNIT_ASSERT_VALUES_EQUAL(blocks[i].BlockIndex, blockIndex + i);
-                UNIT_ASSERT_VALUES_EQUAL(blocks[i].MinCommitId, 10);
-                UNIT_ASSERT_VALUES_EQUAL(blocks[i].MaxCommitId, 20);
+                UNIT_ASSERT_VALUES_EQUAL(nodeId, blocks[i].NodeId);
+                UNIT_ASSERT_VALUES_EQUAL(blockIndex + i, blocks[i].BlockIndex);
+                UNIT_ASSERT_VALUES_EQUAL(10, blocks[i].MinCommitId);
+                UNIT_ASSERT_VALUES_EQUAL(20, blocks[i].MaxCommitId);
             }
         }
 
@@ -267,15 +267,15 @@ Y_UNIT_TEST_SUITE(TMixedBlocksTest)
                 blocksCount);
 
             auto blocks = visitor.Finish();
-            UNIT_ASSERT_VALUES_EQUAL(blocks.size(), blocksCount);
+            UNIT_ASSERT_VALUES_EQUAL(blocksCount, blocks.size());
 
             for (ui32 i = 0; i < blocksCount; ++i) {
-                UNIT_ASSERT_VALUES_EQUAL(blocks[i].NodeId, nodeId);
-                UNIT_ASSERT_VALUES_EQUAL(blocks[i].BlockIndex, blockIndex + i);
-                UNIT_ASSERT_VALUES_EQUAL(blocks[i].MinCommitId, 20);
+                UNIT_ASSERT_VALUES_EQUAL(nodeId, blocks[i].NodeId);
+                UNIT_ASSERT_VALUES_EQUAL(blockIndex + i, blocks[i].BlockIndex);
+                UNIT_ASSERT_VALUES_EQUAL(20, blocks[i].MinCommitId);
                 UNIT_ASSERT_VALUES_EQUAL(
-                    blocks[i].MaxCommitId,
-                    InvalidCommitId);
+                    InvalidCommitId,
+                    blocks[i].MaxCommitId);
             }
         }
     }
@@ -329,16 +329,16 @@ Y_UNIT_TEST_SUITE(TMixedBlocksTest)
             .FindBlocks(visitor, rangeId, nodeId, 20, blockIndex, blocksCount);
 
         auto blocks = visitor.Finish();
-        UNIT_ASSERT_VALUES_EQUAL(blocks.size(), blocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(blocksCount, blocks.size());
 
         bool seen[blocksCount] = {};
         ui64 minCommitId[blocksCount] = {};
         ui64 maxCommitId[blocksCount] = {};
 
         for (const auto& block: blocks) {
-            UNIT_ASSERT_VALUES_EQUAL(block.NodeId, nodeId);
-            UNIT_ASSERT(block.BlockIndex >= blockIndex);
-            UNIT_ASSERT(block.BlockIndex < blockIndex + blocksCount);
+            UNIT_ASSERT_VALUES_EQUAL(nodeId, block.NodeId);
+            UNIT_ASSERT_GE(block.BlockIndex, blockIndex);
+            UNIT_ASSERT_LT(block.BlockIndex, blockIndex + blocksCount);
 
             const ui32 idx = block.BlockIndex - blockIndex;
             UNIT_ASSERT(!seen[idx]);
@@ -348,17 +348,17 @@ Y_UNIT_TEST_SUITE(TMixedBlocksTest)
         }
 
         for (ui32 i = 0; i < blocksCount; ++i) {
-            UNIT_ASSERT(seen[i]);
+            UNIT_ASSERT_VALUES_EQUAL(true, seen[i]);
         }
 
-        UNIT_ASSERT_VALUES_EQUAL(minCommitId[0], 10);
-        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[0], InvalidCommitId);
-        UNIT_ASSERT_VALUES_EQUAL(minCommitId[1], 20);
-        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[1], InvalidCommitId);
-        UNIT_ASSERT_VALUES_EQUAL(minCommitId[2], 20);
-        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[2], InvalidCommitId);
-        UNIT_ASSERT_VALUES_EQUAL(minCommitId[3], 10);
-        UNIT_ASSERT_VALUES_EQUAL(maxCommitId[3], InvalidCommitId);
+        UNIT_ASSERT_VALUES_EQUAL(10, minCommitId[0]);
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, maxCommitId[0]);
+        UNIT_ASSERT_VALUES_EQUAL(20, minCommitId[1]);
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, maxCommitId[1]);
+        UNIT_ASSERT_VALUES_EQUAL(20, minCommitId[2]);
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, maxCommitId[2]);
+        UNIT_ASSERT_VALUES_EQUAL(10, minCommitId[3]);
+        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, maxCommitId[3]);
     }
 
     Y_UNIT_TEST(ShouldRefCountRanges)

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1027,6 +1027,12 @@ public:
         const TBlock& block,
         ui32 blocksCount);
 
+    TWriteMixedBlocksResult WriteMixedBlocksCommitOrderAware(
+        TIndexTabletDatabase& db,
+        const TPartialBlobId& blobId,
+        const TBlock& block,
+        ui32 blocksCount);
+
     TWriteMixedBlocksResult WriteMixedBlocks(
         TIndexTabletDatabase& db,
         const TPartialBlobId& blobId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -683,6 +683,36 @@ void TIndexTabletState::WriteMixedBlocks(
     InvalidateReadAheadCache(block.NodeId);
 }
 
+TWriteMixedBlocksResult TIndexTabletState::WriteMixedBlocksCommitOrderAware(
+    TIndexTabletDatabase& db,
+    const TPartialBlobId& blobId,
+    const TBlock& block,
+    ui32 blocksCount)
+{
+    if (block.MinCommitId == GetCurrentCommitId()) {
+        WriteMixedBlocks(db, blobId, block, blocksCount);
+        return {.GarbageBlocksCount = 0, .NewBlob = true};
+    }
+
+    ui32 rangeId = GetMixedRangeIndex(block.NodeId, block.BlockIndex, blocksCount);
+
+    TVector<TBlock> blocks;
+    blocks.reserve(blocksCount);
+    for (ui32 i = 0; i < blocksCount; ++i) {
+        blocks.emplace_back(
+            block.NodeId,
+            block.BlockIndex + i,
+            block.MinCommitId,
+            block.MaxCommitId);
+    }
+
+    auto result = WriteMixedBlocks(db, rangeId, blobId, blocks);
+    if (result.NewBlob) {
+        AddNewBlob(db, blobId);
+    }
+    return result;
+}
+
 TWriteMixedBlocksResult TIndexTabletState::WriteMixedBlocks(
     TIndexTabletDatabase& db,
     const TPartialBlobId& blobId,
@@ -854,9 +884,17 @@ void TIndexTabletState::MarkMixedBlocksDeleted(
     IncrementDeletionMarkersCount(db, blocksCount);
 
     if (Impl->MixedBlocks.IsLoaded(rangeId)) {
-        Impl->MixedBlocks.AddDeletionMarker(
-            rangeId, {nodeId, commitId, blockIndex, blocksCount}
-        );
+        if (commitId == GetCurrentCommitId()) {
+            Impl->MixedBlocks.AddDeletionMarker(
+                rangeId,
+                {nodeId, commitId, blockIndex, blocksCount}
+            );
+        } else {
+            Impl->MixedBlocks.AddDeletionMarkerOutOfOrder(
+                rangeId,
+                {nodeId, commitId, blockIndex, blocksCount}
+            );
+        }
     }
 
     const auto stats = GetCompactionStats(rangeId);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -890,6 +890,7 @@ void TIndexTabletState::MarkMixedBlocksDeleted(
                 {nodeId, commitId, blockIndex, blocksCount}
             );
         } else {
+            TABLET_VERIFY(commitId < GetCurrentCommitId());
             Impl->MixedBlocks.AddDeletionMarkerOutOfOrder(
                 rangeId,
                 {nodeId, commitId, blockIndex, blocksCount}


### PR DESCRIPTION
Currently we have possibility to only apply index updates in commit order. Deletion markers and block lifetimes are built assuming newer commits always arrive later, which breaks replay and rebuild flows where older writes are inserted after newer state is already present.

What was done in this commit:
- Added out-of-order insertion path for TDeletionMarkers (AddOutOfOrder) with interval handling that keeps newer commits authoritative.
- Added TMixedBlocks::AddDeletionMarkerOutOfOrder and used it from tablet state when marker commit is not the current commit.
- Added TIndexTabletState::WriteMixedBlocksCommitOrderAware for mixed block writes from older commits.
- Updated fresh block deletion condition to handle out-of-order deletes (MinCommitId <= commitId < MaxCommitId).
- Added deterministic and randomized unit tests for order-independent behavior in deletion markers, fresh blocks, and mixed blocks.