### PR TITLE
EVolumeThrottlingOpType moved out from TVolumeThrottlingPolicy

### DIFF
--- a/cloud/blockstore/libs/storage/volume/model/public.h
+++ b/cloud/blockstore/libs/storage/volume/model/public.h
@@ -10,4 +10,16 @@ class TVolumePerformanceProfile;
 
 }   // namespace NProto
 
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EVolumeThrottlingOpType
+{
+    Read,
+    Write,
+    Zero,
+    Describe,
+
+    Last = Describe,
+};
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/storage/volume/model/volume_throttling_policy.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/volume_throttling_policy.cpp
@@ -13,6 +13,8 @@ namespace NCloud::NBlockStore::NStorage {
 
 namespace {
 
+using EOpType = EVolumeThrottlingOpType;
+
 ////////////////////////////////////////////////////////////////////////////////
 // IOPS throttle
 //
@@ -320,8 +322,7 @@ struct TVolumeThrottlingPolicy::TImpl
             ts,
             PostponedRequestWeight(
                 static_cast<EOpType>(requestInfo.OpType),
-                requestInfo.ByteCount)
-        );
+                requestInfo.ByteCount));
     }
 
     ui64 GetMaxIops(EOpType opType) const
@@ -409,8 +410,7 @@ struct TVolumeThrottlingPolicy::TImpl
             ts,
             PostponedRequestWeight(
                 static_cast<EOpType>(requestInfo.OpType),
-                requestInfo.ByteCount)
-        );
+                requestInfo.ByteCount));
 
         return postponed ? d : TMaybe<TDuration>();
     }

--- a/cloud/blockstore/libs/storage/volume/model/volume_throttling_policy.h
+++ b/cloud/blockstore/libs/storage/volume/model/volume_throttling_policy.h
@@ -46,15 +46,6 @@ class TVolumeThrottlingPolicy final
     : public ITabletThrottlerPolicy
 {
 public:
-    enum class EOpType
-    {
-        Read,
-        Write,
-        Zero,
-        Describe,
-        Last = Describe,
-    };
-
     struct TSplittedUsedQuota {
         double Iops = 0;
         double Bandwidth = 0;
@@ -124,8 +115,8 @@ public:
     NProto::TVolumePerformanceProfile GetCurrentPerformanceProfile() const;
 
     // the following funcs were made public to display the results on monpages
-    ui64 C1(EOpType opType) const;
-    ui64 C2(EOpType opType) const;
+    ui64 C1(EVolumeThrottlingOpType opType) const;
+    ui64 C2(EVolumeThrottlingOpType opType) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/volume_throttling_policy_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/volume_throttling_policy_ut.cpp
@@ -67,7 +67,7 @@ NProto::TVolumePerformanceProfile MakeSimpleConfig(
 
 Y_UNIT_TEST_SUITE(TVolumeThrottlingPolicyTest)
 {
-    using EOpType = TVolumeThrottlingPolicy::EOpType;
+    using EOpType = EVolumeThrottlingOpType;
 
 #define DO_TEST_V(tp, expectedDelayMcs, nowMcs, byteCount, opType, cv)      \
     UNIT_ASSERT_VALUES_EQUAL(                                               \

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -92,12 +92,8 @@ TVolumeActor::TVolumeActor(
               .DiskId = std::move(diskId)})
     , ThrottlerLogger(
           TabletID(),
-          [this](ui32 opType, TDuration time)
-          {
-              UpdateDelayCounter(
-                  static_cast<TVolumeThrottlingPolicy::EOpType>(opType),
-                  time);
-          })
+          [this](EVolumeThrottlingOpType opType, TDuration time)
+          { UpdateDelayCounter(opType, time); })
     , TransactionTimeTracker(VolumeTransactions)
 {}
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -629,9 +629,7 @@ private:
     void ProcessNextAcquireReleaseDiskRequest(const NActors::TActorContext& ctx);
     void OnClientListUpdate(const NActors::TActorContext& ctx);
 
-    void UpdateDelayCounter(
-        TVolumeThrottlingPolicy::EOpType opType,
-        TDuration time);
+    void UpdateDelayCounter(EVolumeThrottlingOpType opType, TDuration time);
 
     void ResetServicePipes(const NActors::TActorContext& ctx);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_monitoring.cpp
@@ -2045,27 +2045,27 @@ void TVolumeActor::RenderConfig(IOutputStream& out) const
                                             TABLEBODY() {
                                                 TABLER() {
                                                     TABLED() { out << "ReadC1"; }
-                                                    TABLED() { out << tp.C1(TVolumeThrottlingPolicy::EOpType::Read); }
+                                                    TABLED() { out << tp.C1(EVolumeThrottlingOpType::Read); }
                                                 }
                                                 TABLER() {
                                                     TABLED() { out << "ReadC2"; }
-                                                    TABLED() { out << FormatByteSize(tp.C2(TVolumeThrottlingPolicy::EOpType::Read)); }
+                                                    TABLED() { out << FormatByteSize(tp.C2(EVolumeThrottlingOpType::Read)); }
                                                 }
                                                 TABLER() {
                                                     TABLED() { out << "WriteC1"; }
-                                                    TABLED() { out << tp.C1(TVolumeThrottlingPolicy::EOpType::Write); }
+                                                    TABLED() { out << tp.C1(EVolumeThrottlingOpType::Write); }
                                                 }
                                                 TABLER() {
                                                     TABLED() { out << "WriteC2"; }
-                                                    TABLED() { out << FormatByteSize(tp.C2(TVolumeThrottlingPolicy::EOpType::Write)); }
+                                                    TABLED() { out << FormatByteSize(tp.C2(EVolumeThrottlingOpType::Write)); }
                                                 }
                                                 TABLER() {
                                                     TABLED() { out << "DescribeC1"; }
-                                                    TABLED() { out << tp.C1(TVolumeThrottlingPolicy::EOpType::Describe); }
+                                                    TABLED() { out << tp.C1(EVolumeThrottlingOpType::Describe); }
                                                 }
                                                 TABLER() {
                                                     TABLED() { out << "DescribeC2"; }
-                                                    TABLED() { out << FormatByteSize(tp.C2(TVolumeThrottlingPolicy::EOpType::Describe)); }
+                                                    TABLED() { out << FormatByteSize(tp.C2(EVolumeThrottlingOpType::Describe)); }
                                                 }
                                             }
                                         }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -33,7 +33,7 @@ TThrottlingRequestInfo BuildThrottlingRequestInfo(
 {
     return {
         IntegerCast<ui32>(CalculateBytesCount(request.Record, blockSize)),
-        static_cast<ui32>(TVolumeThrottlingPolicy::EOpType::Read),
+        static_cast<ui32>(EVolumeThrottlingOpType::Read),
         policyVersion,
     };
 }
@@ -45,7 +45,7 @@ TThrottlingRequestInfo BuildThrottlingRequestInfo(
 {
     return {
         IntegerCast<ui32>(CalculateBytesCount(request.Record, blockSize)),
-        static_cast<ui32>(TVolumeThrottlingPolicy::EOpType::Write),
+        static_cast<ui32>(EVolumeThrottlingOpType::Write),
         policyVersion,
     };
 }
@@ -57,7 +57,7 @@ TThrottlingRequestInfo BuildThrottlingRequestInfo(
 {
     return {
         IntegerCast<ui32>(CalculateBytesCount(request.Record, blockSize)),
-        static_cast<ui32>(TVolumeThrottlingPolicy::EOpType::Zero),
+        static_cast<ui32>(EVolumeThrottlingOpType::Zero),
         policyVersion,
     };
 }
@@ -69,7 +69,7 @@ TThrottlingRequestInfo BuildThrottlingRequestInfo(
 {
     return {
         blockSize * request.Record.GetBlocksCount(),
-        static_cast<ui32>(TVolumeThrottlingPolicy::EOpType::Read),
+        static_cast<ui32>(EVolumeThrottlingOpType::Read),
         policyVersion,
     };
 }
@@ -81,7 +81,7 @@ TThrottlingRequestInfo BuildThrottlingRequestInfo(
 {
     return {
         blockSize * request.Record.BlocksCount,
-        static_cast<ui32>(TVolumeThrottlingPolicy::EOpType::Write),
+        static_cast<ui32>(EVolumeThrottlingOpType::Write),
         policyVersion,
     };
 }
@@ -93,7 +93,7 @@ TThrottlingRequestInfo BuildThrottlingRequestInfo(
 {
     return {
         blockSize * request.Record.GetBlocksCountToRead(),
-        static_cast<ui32>(TVolumeThrottlingPolicy::EOpType::Describe),
+        static_cast<ui32>(EVolumeThrottlingOpType::Describe),
         policyVersion,
     };
 }
@@ -115,26 +115,26 @@ bool GetThrottlingEnabled(
 ////////////////////////////////////////////////////////////////////////////////
 
 void TVolumeActor::UpdateDelayCounter(
-    TVolumeThrottlingPolicy::EOpType opType,
+    EVolumeThrottlingOpType opType,
     TDuration time)
 {
     if (!VolumeSelfCounters) {
         return;
     }
     switch (opType) {
-        case TVolumeThrottlingPolicy::EOpType::Read:
+        case EVolumeThrottlingOpType::Read:
             VolumeSelfCounters->ThrottlerDelayRequestCounters.ReadBlocks
                 .Increment(time.MicroSeconds());
             return;
-        case TVolumeThrottlingPolicy::EOpType::Write:
+        case EVolumeThrottlingOpType::Write:
             VolumeSelfCounters->ThrottlerDelayRequestCounters.WriteBlocks
                 .Increment(time.MicroSeconds());
             return;
-        case TVolumeThrottlingPolicy::EOpType::Zero:
+        case EVolumeThrottlingOpType::Zero:
             VolumeSelfCounters->ThrottlerDelayRequestCounters.ZeroBlocks
                 .Increment(time.MicroSeconds());
             return;
-        case TVolumeThrottlingPolicy::EOpType::Describe:
+        case EVolumeThrottlingOpType::Describe:
             VolumeSelfCounters->ThrottlerDelayRequestCounters.DescribeBlocks
                 .Increment(time.MicroSeconds());
             return;
@@ -198,8 +198,8 @@ NProto::TError TVolumeActor::Throttle(
         tp.GetVersion()
     );
 
-    if (static_cast<TVolumeThrottlingPolicy::EOpType>(requestInfo.OpType) ==
-            TVolumeThrottlingPolicy::EOpType::Describe &&
+    if (static_cast<EVolumeThrottlingOpType>(requestInfo.OpType) ==
+            EVolumeThrottlingOpType::Describe &&
         requestInfo.ByteCount == 0)
     {
         // DescribeBlocks with zero weight should not be affected by

--- a/cloud/blockstore/libs/storage/volume/volume_throttler_logger.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_throttler_logger.cpp
@@ -18,12 +18,14 @@ struct TVolumeThrottlerLogger::TImpl
 {
 private:
     ui64 TabletId;
-    std::function<void(ui32, TDuration)> UpdateDelayCounterFunc;
+    std::function<void(EVolumeThrottlingOpType, TDuration)>
+        UpdateDelayCounterFunc;
 
 public:
     TImpl(
-            ui64 tabletId,
-            std::function<void(ui32, TDuration)> updateDelayCounter)
+        ui64 tabletId,
+        std::function<void(EVolumeThrottlingOpType, TDuration)>
+            updateDelayCounter)
         : TabletId(tabletId)
         , UpdateDelayCounterFunc(std::move(updateDelayCounter))
     {}
@@ -69,7 +71,7 @@ public:
         const NActors::TActorContext& ctx,
         TCallContextBase& callContext,
         const char* methodName,
-        ui32 opType,
+        EVolumeThrottlingOpType opType,
         TDuration delay) const
     {
         TrackAdvancedRequest(callContext, methodName);
@@ -111,7 +113,7 @@ private:
 
 TVolumeThrottlerLogger::TVolumeThrottlerLogger(
         ui64 tabletId,
-        std::function<void(ui32, TDuration)> updateDelayCounter)
+        std::function<void(EVolumeThrottlingOpType, TDuration)> updateDelayCounter)
     : Impl(std::make_unique<TImpl>(tabletId, std::move(updateDelayCounter)))
 {}
 
@@ -155,7 +157,12 @@ void TVolumeThrottlerLogger::LogRequestAdvanced(
     ui32 opType,
     TDuration delay) const
 {
-    Impl->LogRequestAdvanced(ctx, callContext, methodName, opType, delay);
+    Impl->LogRequestAdvanced(
+        ctx,
+        callContext,
+        methodName,
+        static_cast<EVolumeThrottlingOpType>(opType),
+        delay);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_throttler_logger.h
+++ b/cloud/blockstore/libs/storage/volume/volume_throttler_logger.h
@@ -8,8 +8,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TVolumeThrottlerLogger final
-    : public ITabletThrottlerLogger
+class TVolumeThrottlerLogger final: public ITabletThrottlerLogger
 {
 private:
     struct TImpl;
@@ -18,7 +17,8 @@ private:
 public:
     explicit TVolumeThrottlerLogger(
         ui64 tabletId,
-        std::function<void(ui32, TDuration)> updateDelayCounter);
+        std::function<void(EVolumeThrottlingOpType, TDuration)>
+            updateDelayCounter);
 
     ~TVolumeThrottlerLogger();
 


### PR DESCRIPTION
#5095
No behaviour changes are expected. Moved out "EOpType" enum out of class for reuse in the shaping throttlerNo behaviour changes 