### PR TITLE
Fix reading from encrypted local disk with multiple buffers

### DIFF
--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -49,10 +49,11 @@ void CompleteRequest(
 
     if (req->BufferAllocated || encryptor) {
         if (bio->type == VHD_BDEV_READ && status == VHD_BDEV_SUCCESS) {
-            NSan::Unpoison(req->Data[0].iov_base, req->Data[0].iov_len);
+            TBlockDataRef data = req->GetData();
+            NSan::Unpoison(data.data(), data.size());
             const bool success = SgListCopyWithOptionalDecryption(
                 log,
-                static_cast<const char*>(req->Data[0].iov_base),
+                data,
                 bio->sglist,
                 encryptor,
                 bio->first_sector);
@@ -96,10 +97,11 @@ void CompleteCompoundRequest(
         }
 
         if (bio->type == VHD_BDEV_READ && status == VHD_BDEV_SUCCESS) {
-            NSan::Unpoison(req->Buffer.get(), bytes);
+            TBlockDataRef data = req->GetData();
+            NSan::Unpoison(data.data(), data.size());
             const bool success = SgListCopyWithOptionalDecryption(
                 log,
-                req->Buffer.get(),
+                data,
                 bio->sglist,
                 encryptor,
                 bio->first_sector);

--- a/cloud/blockstore/vhost-server/request_aio.cpp
+++ b/cloud/blockstore/vhost-server/request_aio.cpp
@@ -36,6 +36,14 @@ void DiscardRequest(vhd_io* io, TSimpleStats& queueStats)
     vhd_complete_bio(io, VHD_BDEV_IOERR);
 }
 
+size_t TotalVhdBuffersSize(const std::span<vhd_buffer>& buffers)
+{
+    return Accumulate(
+        buffers,
+        0,
+        [](size_t sum, const vhd_buffer& buffer) { return sum + buffer.len; });
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template <bool DoDecrypt>
@@ -147,7 +155,7 @@ void PrepareCompoundIO(
         const bool success = SgListCopyWithOptionalEncryption(
             Log,
             bio->sglist,
-            req->Buffer.get(),
+            req->GetData(),
             encryptor,
             bio->first_sector);
         if (!success) {
@@ -205,23 +213,32 @@ void PrepareCompoundIO(
 
 bool SgListCopyWithOptionalDecryption(
     TLog& Log,
-    const char* src,
+    TBlockDataRef src,
     const vhd_sglist& dst,
     IEncryptor* encryptor,
     ui64 startSector)
 {
     auto buffers = std::span<vhd_buffer>{dst.buffers, dst.nbuffers};
+    const char* srcData = src.data();
+
+    const size_t totalBuffersSize = TotalVhdBuffersSize(buffers);
+    if (src.size() < totalBuffersSize) {
+        STORAGE_ERROR(
+            "Source buffer size less then destination: " << src.size() << " < "
+                                                         << totalBuffersSize);
+        return false;
+    }
 
     if (!encryptor) {
         for (auto& buffer: buffers) {
-            std::memcpy(buffer.base, src, buffer.len);
-            src += buffer.len;
+            std::memcpy(buffer.base, srcData, buffer.len);
+            srcData += buffer.len;
         }
         return true;
     }
 
     for (auto& buffer: buffers) {
-        TBlockDataRef srcRef{src, buffer.len};
+        TBlockDataRef srcRef{srcData, buffer.len};
         TBlockDataRef dstRef{static_cast<const char*>(buffer.base), buffer.len};
         auto err =
             DoCryptoOperation<true>(*encryptor, srcRef, dstRef, startSector);
@@ -233,7 +250,7 @@ bool SgListCopyWithOptionalDecryption(
             return false;
         }
         startSector += buffer.len / VHD_SECTOR_SIZE;
-        src += buffer.len;
+        srcData += buffer.len;
     }
     return true;
 }
@@ -241,23 +258,32 @@ bool SgListCopyWithOptionalDecryption(
 bool SgListCopyWithOptionalEncryption(
     TLog& Log,
     const vhd_sglist& src,
-    char* dst,
+    TBlockDataRef dst,
     IEncryptor* encryptor,
     ui64 startSector)
 {
     auto buffers = std::span<vhd_buffer>{src.buffers, src.nbuffers};
+    const char* dstData = dst.data();
+
+    const size_t totalBuffersSize = TotalVhdBuffersSize(buffers);
+    if (dst.size() < totalBuffersSize) {
+        STORAGE_ERROR(
+            "Destination buffer size less then source: " << dst.size() << " < "
+                                                         << totalBuffersSize);
+        return false;
+    }
 
     if (!encryptor) {
         for (auto& buffer: buffers) {
-            std::memcpy(dst, buffer.base, buffer.len);
-            dst += buffer.len;
+            std::memcpy(const_cast<char*>(dstData), buffer.base, buffer.len);
+            dstData += buffer.len;
         }
         return true;
     }
 
     for (auto& buffer: buffers) {
         TBlockDataRef srcRef{static_cast<const char*>(buffer.base), buffer.len};
-        TBlockDataRef dstRef{dst, buffer.len};
+        TBlockDataRef dstRef{dstData, buffer.len};
         auto err =
             DoCryptoOperation<false>(*encryptor, srcRef, dstRef, startSector);
         if (HasError(err)) {
@@ -268,7 +294,7 @@ bool SgListCopyWithOptionalEncryption(
             return false;
         }
         startSector += buffer.len / VHD_SECTOR_SIZE;
-        dst += buffer.len;
+        dstData += buffer.len;
     }
     return true;
 }
@@ -340,7 +366,7 @@ void PrepareIO(
         });
 
     const bool needToAllocateBuffer =
-        !isAllBuffersAligned || (encryptor && bio->type == VHD_BDEV_WRITE);
+        !isAllBuffersAligned || encryptor != nullptr;
 
     auto req = TAioRequest::CreateNew(
         needToAllocateBuffer ? 1 : buffers.size(),
@@ -355,7 +381,7 @@ void PrepareIO(
             const bool success = SgListCopyWithOptionalEncryption(
                 Log,
                 bio->sglist,
-                static_cast<char*>(req->Data[0].iov_base),
+                req->GetData(),
                 encryptor,
                 bio->first_sector);
             if (!success) {
@@ -414,12 +440,14 @@ void TAioRequestDeleter::operator()(TAioRequest* obj)
 TAioRequest::TAioRequest(
         size_t allocatedBufferSize,
         ui32 blockSize,
+        ui32 bufferCount,
         vhd_io* io,
         TCpuCycles submitTs)
     : iocb()
     , Io(io)
     , SubmitTs(submitTs)
     , BufferAllocated(allocatedBufferSize != 0)
+    , BufferCount(bufferCount)
 {
     if (allocatedBufferSize) {
         Data[0].iov_len = allocatedBufferSize;
@@ -436,9 +464,12 @@ TAioRequestHolder TAioRequest::CreateNew(
     TCpuCycles submitTs)
 {
     const size_t totalSize = sizeof(TAioRequest) + sizeof(iovec) * bufferCount;
-    return TAioRequestHolder{
-        new (std::calloc(1, totalSize))
-            TAioRequest(allocatedBufferSize, blockSize, io, submitTs)};
+    return TAioRequestHolder{new (std::calloc(1, totalSize)) TAioRequest(
+        allocatedBufferSize,
+        blockSize,
+        bufferCount,
+        io,
+        submitTs)};
 }
 
 // static
@@ -447,6 +478,15 @@ TAioRequestHolder TAioRequest::FromIocb(iocb* cb)
     NSan::Acquire(cb);
     Y_ABORT_UNLESS(cb->data == nullptr);
     return TAioRequestHolder{static_cast<TAioRequest*>(cb)};
+}
+
+TBlockDataRef TAioRequest::GetData() const
+{
+    Y_DEBUG_ABORT_UNLESS(BufferCount == 1);
+
+    return TBlockDataRef{
+        static_cast<const char*>(Data[0].iov_base),
+        Data[0].iov_len};
 }
 
 // static
@@ -491,6 +531,7 @@ TAioCompoundRequest::TAioCompoundRequest(
     : Inflight(inflight)
     , Io(io)
     , SubmitTs(submitTs)
+    , BufferSize(bufferSize)
     , Buffer{
           static_cast<char*>(std::aligned_alloc(blockSize, bufferSize)),
       }
@@ -510,6 +551,11 @@ std::unique_ptr<TAioCompoundRequest> TAioCompoundRequest::CreateNew(
         io,
         bufferSize,
         submitTs);
+}
+
+TBlockDataRef TAioCompoundRequest::GetData() const
+{
+    return TBlockDataRef{Buffer.get(), BufferSize};
 }
 
 }   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/vhost-server/request_aio.h
+++ b/cloud/blockstore/vhost-server/request_aio.h
@@ -65,7 +65,10 @@ struct TAioRequest
     TCpuCycles SubmitTs;
     bool BufferAllocated = false;
     bool Unaligned = false;
-    iovec Data[ /* Bio->sglist.nbuffers */ ];
+    ui32 BufferCount = 0;
+
+    // Should be last field in the struct.
+    iovec Data[/* Bio->sglist.nbuffers */];
 
     static TAioRequestHolder CreateNew(
         size_t bufferCount,
@@ -75,10 +78,15 @@ struct TAioRequest
         TCpuCycles submitTs);
     static TAioRequestHolder FromIocb(iocb* cb);
 
+    // If the data contains a single buffer, then the data can be accessed using
+    // this method.
+    [[nodiscard]] TBlockDataRef GetData() const;
+
 private:
     TAioRequest(
         size_t allocatedBufferSize,
         ui32 blockSize,
+        ui32 bufferCount,
         vhd_io* io,
         TCpuCycles submitTs);
 };
@@ -104,6 +112,7 @@ struct TAioCompoundRequest
     std::atomic<ui32> Errors;
     vhd_io* Io;
     TCpuCycles SubmitTs;
+    size_t BufferSize;
     std::unique_ptr<char, TFreeDeleter> Buffer;
 
     TAioCompoundRequest(
@@ -119,6 +128,8 @@ struct TAioCompoundRequest
         vhd_io* io,
         size_t bufferSize,
         TCpuCycles submitTs);
+
+    [[nodiscard]] TBlockDataRef GetData() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -137,7 +148,7 @@ void PrepareIO(
 [[nodiscard]] bool SgListCopyWithOptionalEncryption(
     TLog& Log,
     const vhd_sglist& src,
-    char* dst,
+    TBlockDataRef dst,
     IEncryptor* encryptor,
     ui64 startSector);
 
@@ -145,7 +156,7 @@ void PrepareIO(
 // if successful.
 [[nodiscard]] bool SgListCopyWithOptionalDecryption(
     TLog& Log,
-    const char* src,
+    TBlockDataRef src,
     const vhd_sglist& dst,
     IEncryptor* encryptor,
     ui64 startSector);

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -936,6 +936,67 @@ TEST_P(TServerTest, ShouldStoreEncryptedZeroes)
     }
 }
 
+TEST_P(TServerTest, ShouldReadAndWriteMultipleBuffers)
+{
+    StartServer();
+
+    std::span hdr_w = Hdr(Memory, {.type = VIRTIO_BLK_T_OUT});
+    std::span writeBuffer1 =
+        Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize);
+    std::span writeBuffer2 =
+        Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize);
+    std::span writeStatus = Memory.Allocate(1);
+
+    std::span hdr_r = Hdr(Memory, {.type = VIRTIO_BLK_T_IN});
+    std::span readBuffer1 =
+        Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize);
+    std::span readBuffer2 =
+        Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize);
+    std::span readStatus = Memory.Allocate(1);
+
+
+    for (ui64 i = 0; i <= TotalBlockCount - BlocksPerRequest * 2; ++i) {
+        const TString pattern1 = MakeRandomPattern(RequestSize);
+        const TString pattern2 = MakeRandomPattern(RequestSize);
+
+        // check writes
+        {
+            memcpy(writeBuffer1.data(), pattern1.data(), writeBuffer1.size_bytes());
+            memcpy(writeBuffer2.data(), pattern2.data(), writeBuffer2.size_bytes());
+
+            reinterpret_cast<virtio_blk_req_hdr*>(hdr_w.data())->sector =
+                i * SectorsPerBlock;
+            auto writeOp = Client.WriteAsync(
+                QueueIndex,
+                {hdr_w, writeBuffer1, writeBuffer2},
+                {writeStatus});
+            const ui32 len = writeOp.GetValueSync();
+            EXPECT_EQ(1u, len);
+            EXPECT_EQ(VIRTIO_BLK_S_OK, writeStatus[0]);
+        }
+
+        // check reads
+        {
+            reinterpret_cast<virtio_blk_req_hdr*>(hdr_r.data())->sector =
+                i * SectorsPerBlock;
+            auto readOp = Client.WriteAsync(
+                QueueIndex,
+                {hdr_r},
+                {readBuffer1, readBuffer2, readStatus});
+            const ui32 len = readOp.GetValueSync();
+            EXPECT_EQ(
+                readStatus.size() + readBuffer1.size() + readBuffer2.size(),
+                len);
+            EXPECT_EQ(VIRTIO_BLK_S_OK, readStatus[0]);
+
+            TString readData1(readBuffer1.data(), readBuffer1.size());
+            EXPECT_EQ(pattern1, readData1);
+            TString readData2(readBuffer2.data(), readBuffer2.size());
+            EXPECT_EQ(pattern2, readData2);
+        }
+    }
+}
+
 TEST_P(TServerTest, ShouldStatEncryptorErrors)
 {
     if (EncryptionMode != NProto::EEncryptionMode::ENCRYPTION_AES_XTS) {

--- a/example/nbs/nbs-server.txt
+++ b/example/nbs/nbs-server.txt
@@ -19,7 +19,7 @@ ServerConfig {
   NodeType: "nbs"
   NbdEnabled: true
   VhostEnabled: true
-  VhostServerPath: "../cloud/blockstore/vhost-server/blockstore-vhost-server"
+  VhostServerPath: "../cloud/blockstore/buildall/cloud/blockstore/vhost-server/blockstore-vhost-server"
   ChecksumFlags {
     EnableDataIntegrityClient: true
   }


### PR DESCRIPTION
Fixed a bug where for encrypted local disks, reading from the last 512 bytes for such requests occurred from uninitialized memory.
```
sudo dd if=/dev/vdb bs=4608 iflag=direct count=1 iflag=skip_bytes skip=0 |  hexdump -C
```