### PR TITLE
[CSI] Support multiple nfs-vhost

### DIFF
--- a/cloud/blockstore/tools/csi_driver/cmd/nbs-csi-driver/main.go
+++ b/cloud/blockstore/tools/csi_driver/cmd/nbs-csi-driver/main.go
@@ -49,6 +49,7 @@ func main() {
 	flag.BoolVar(&cfg.UseDiscardForYDBBasedDisks, "use-discard-for-ydb-based-disks", false, "Enable discard option for mounted filesystem. Applied only for YDB-based disks.")
 	flag.DurationVar(&cfg.RetriableErrorsDurationThreshold, "retriable-errors-threshold", 15*time.Minute,
 		"Report retriable errors per volume after duration threshold exceeded")
+	flag.UintVar(&cfg.NfsVhostReplicaCount, "nfs-vhost-replica-count", 0, "number of replicas for the NFS vhost")
 	flag.Parse()
 
 	defer klog.Flush()

--- a/cloud/blockstore/tools/csi_driver/internal/driver/driver.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/driver.go
@@ -70,6 +70,7 @@ type Config struct {
 	GrpcRequestTimeout               time.Duration
 	StartEndpointRequestTimeout      time.Duration
 	RetriableErrorsDurationThreshold time.Duration
+	NfsVhostReplicaCount             uint
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -245,7 +246,8 @@ func NewDriver(cfg Config) (*Driver, error) {
 			mounter.NewMounter(),
 			strings.Split(cfg.MountOptions, ","),
 			cfg.UseDiscardForYDBBasedDisks,
-			cfg.StartEndpointRequestTimeout))
+			cfg.StartEndpointRequestTimeout,
+			cfg.NfsVhostReplicaCount))
 
 	return &Driver{
 		grpcServer: grpcServer,

--- a/cloud/blockstore/tools/csi_driver/internal/driver/helper.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/helper.go
@@ -1,6 +1,9 @@
 package driver
 
 import (
+	"hash/fnv"
+	"strconv"
+
 	storagecoreapi "github.com/ydb-platform/nbs/cloud/storage/core/protos"
 )
 
@@ -44,4 +47,20 @@ func isDiskRegistryMediaKind(mediaKind storagecoreapi.EStorageMediaKind) bool {
 	default:
 		return false
 	}
+}
+
+func getNfsSocket(socketKey string, nfsVhostReplicaCount uint) string {
+	if nfsVhostReplicaCount == 0 {
+		return defaultNfsSocketName
+	}
+
+	h := fnv.New64a()
+	h.Write([]byte(socketKey))
+	index := h.Sum64() % uint64(nfsVhostReplicaCount)
+	if index == 0 {
+		// Use the default socket name for the first instance to support scaling
+		// of existing deployments.
+		return defaultNfsSocketName
+	}
+	return "nfs" + strconv.FormatUint(index, 10) + ".sock"
 }

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node.go
@@ -41,7 +41,7 @@ const NodeBlkTargetPathPattern = "/var/lib/kubelet/plugins/kubernetes.io/csi/vol
 const topologyNodeKey = "topology.nbs.csi/node"
 
 const nbsSocketName = "nbs.sock"
-const nfsSocketName = "nfs.sock"
+const defaultNfsSocketName = "nfs.sock"
 
 const vhostIpc = nbsapi.EClientIpcType_IPC_VHOST
 const nbdIpc = nbsapi.EClientIpcType_IPC_NBD
@@ -197,6 +197,8 @@ type nodeService struct {
 
 	useDiscardForYDBBasedDisks  bool
 	startEndpointRequestTimeout time.Duration
+
+	nfsVhostReplicaCount uint
 }
 
 func newNodeService(
@@ -214,7 +216,8 @@ func newNodeService(
 	mounter mounter.Interface,
 	mountOptions []string,
 	useDiscardForYDBBasedDisks bool,
-	startEndpointRequestTimeout time.Duration) csi.NodeServer {
+	startEndpointRequestTimeout time.Duration,
+	nfsVhostReplicaCount uint) csi.NodeServer {
 
 	return &nodeService{
 		nodeId:                      nodeId,
@@ -233,6 +236,7 @@ func newNodeService(
 		mountOptions:                mountOptions,
 		useDiscardForYDBBasedDisks:  useDiscardForYDBBasedDisks,
 		startEndpointRequestTimeout: startEndpointRequestTimeout,
+		nfsVhostReplicaCount:        nfsVhostReplicaCount,
 	}
 }
 
@@ -304,10 +308,12 @@ func (s *nodeService) NodeStageVolume(
 				if nfsBackend {
 					backend = "nfs"
 				}
+				nfsSocketName := getNfsSocket(instanceId, s.nfsVhostReplicaCount)
 				if err = s.writeStageData(stageRecordPath, &StageData{
 					Backend:       backend,
 					InstanceId:    instanceId,
 					RealStagePath: s.getEndpointDir(instanceId, nbsId),
+					NfsSocketName: nfsSocketName,
 				}); err != nil {
 					return nil, s.statusErrorf(codes.Internal,
 						"Failed to write stage record: %v", err)
@@ -318,7 +324,9 @@ func (s *nodeService) NodeStageVolume(
 						ctx,
 						instanceId,
 						nbsId,
-						vhostSettings)
+						vhostSettings,
+						nfsSocketName,
+					)
 				} else {
 					err = s.nodeStageDiskAsVhostSocket(
 						ctx,
@@ -632,6 +640,7 @@ type StageData struct {
 	Backend       string `json:"backend"`
 	InstanceId    string `json:"instanceId"`
 	RealStagePath string `json:"realStagePath"`
+	NfsSocketName string `json:"nfsSocketName"`
 }
 
 func (s *nodeService) writeStageData(path string, data *StageData) error {
@@ -1067,9 +1076,10 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 		return fmt.Errorf("NFS client wasn't created")
 	}
 
+	soketPath := filepath.Join(endpointDir, defaultNfsSocketName)
 	_, err := nfsClient.StartEndpoint(ctx, &nfsapi.TStartEndpointRequest{
 		Endpoint: &nfsapi.TEndpointConfig{
-			SocketPath:       filepath.Join(endpointDir, nfsSocketName),
+			SocketPath:       soketPath,
 			FileSystemId:     filesystemId,
 			ClientId:         fmt.Sprintf("%s-%s", s.clientId, podId),
 			VhostQueuesCount: vhostSettings.queuesCount,
@@ -1079,7 +1089,7 @@ func (s *nodeService) nodePublishFileStoreAsVhostSocket(
 	if err != nil {
 		if s.IsGrpcTimeoutError(err) {
 			nfsClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
-				SocketPath: filepath.Join(endpointDir, nfsSocketName),
+				SocketPath: soketPath,
 			})
 		}
 
@@ -1098,14 +1108,16 @@ func (s *nodeService) nodeStageFileStoreStartEndpoint(
 	instanceId string,
 	filesystemId string,
 	endpointDir string,
-	vhostSettings vhostSettings) error {
+	vhostSettings vhostSettings,
+	nfsSocketName string) error {
 	if s.nfsClient == nil {
 		return fmt.Errorf("NFS client wasn't created")
 	}
 
+	socketPath := filepath.Join(endpointDir, nfsSocketName)
 	_, err := s.nfsClient.StartEndpoint(ctx, &nfsapi.TStartEndpointRequest{
 		Endpoint: &nfsapi.TEndpointConfig{
-			SocketPath:       filepath.Join(endpointDir, nfsSocketName),
+			SocketPath:       socketPath,
 			FileSystemId:     filesystemId,
 			ClientId:         fmt.Sprintf("%s-%s", s.clientId, instanceId),
 			VhostQueuesCount: vhostSettings.queuesCount,
@@ -1115,7 +1127,7 @@ func (s *nodeService) nodeStageFileStoreStartEndpoint(
 	if err != nil {
 		if s.IsGrpcTimeoutError(err) {
 			s.nfsClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
-				SocketPath: filepath.Join(endpointDir, nfsSocketName),
+				SocketPath: socketPath,
 			})
 		}
 
@@ -1191,14 +1203,16 @@ func (s *nodeService) nodeStageLocalFileStoreStartEndpoint(
 		fsConfig,
 		endpointDir)
 
+	socketPath := filepath.Join(endpointDir, defaultNfsSocketName)
 	if fsConfig.SizeGb == 0 {
 		// legacy local filestore config - passthrough StartEndpoint to nfs-local service
 		if s.nfsLocalClient == nil {
 			return fmt.Errorf("nfs local client wasn't created")
 		}
+
 		_, err := s.nfsLocalClient.StartEndpoint(ctx, &nfsapi.TStartEndpointRequest{
 			Endpoint: &nfsapi.TEndpointConfig{
-				SocketPath:       filepath.Join(endpointDir, nfsSocketName),
+				SocketPath:       socketPath,
 				FileSystemId:     fsConfig.Id,
 				ClientId:         fmt.Sprintf("%s-%s", s.clientId, instanceId),
 				VhostQueuesCount: vhostSettings.queuesCount,
@@ -1208,7 +1222,7 @@ func (s *nodeService) nodeStageLocalFileStoreStartEndpoint(
 		if err != nil {
 			if s.IsGrpcTimeoutError(err) {
 				s.nfsLocalClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
-					SocketPath: filepath.Join(endpointDir, nfsSocketName),
+					SocketPath: socketPath,
 				})
 			}
 
@@ -1248,7 +1262,7 @@ func (s *nodeService) nodeStageLocalFileStoreStartEndpoint(
 
 	startReq := &nfsapi.TStartEndpointRequest{
 		Endpoint: &nfsapi.TEndpointConfig{
-			SocketPath:       filepath.Join(endpointDir, nfsSocketName),
+			SocketPath:       socketPath,
 			FileSystemId:     localFsId,
 			ClientId:         fmt.Sprintf("%s-%s", s.clientId, instanceId),
 			VhostQueuesCount: vhostSettings.queuesCount,
@@ -1263,7 +1277,7 @@ func (s *nodeService) nodeStageLocalFileStoreStartEndpoint(
 	if err != nil {
 		if s.IsGrpcTimeoutError(err) {
 			s.nfsLocalClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
-				SocketPath: filepath.Join(endpointDir, nfsSocketName),
+				SocketPath: socketPath,
 			})
 		}
 
@@ -1305,7 +1319,8 @@ func (s *nodeService) nodeStageFileStoreAsVhostSocket(
 	ctx context.Context,
 	instanceId string,
 	filesystemId string,
-	vhostSettings vhostSettings) error {
+	vhostSettings vhostSettings,
+	nfsSocketName string) error {
 
 	log.Printf("csi.nodeStageFileStoreAsVhostSocket: %s %s", instanceId, filesystemId)
 
@@ -1319,7 +1334,7 @@ func (s *nodeService) nodeStageFileStoreAsVhostSocket(
 	if isExternalFs {
 		err = s.nodeStageLocalFileStoreStartEndpoint(ctx, instanceId, externalFsConfig, endpointDir, vhostSettings)
 	} else {
-		err = s.nodeStageFileStoreStartEndpoint(ctx, instanceId, filesystemId, endpointDir, vhostSettings)
+		err = s.nodeStageFileStoreStartEndpoint(ctx, instanceId, filesystemId, endpointDir, vhostSettings, nfsSocketName)
 	}
 	if err != nil {
 		return err
@@ -1428,9 +1443,10 @@ func (s *nodeService) nodeUnpublishVolume(
 		}
 
 		nfsClient := s.getNfsClient(nbsId)
+		socketPath := filepath.Join(endpointDir, defaultNfsSocketName)
 		if nfsClient != nil {
 			_, err := nfsClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
-				SocketPath: filepath.Join(endpointDir, nfsSocketName),
+				SocketPath: socketPath,
 			})
 			if err != nil {
 				return s.statusErrorf(s.GetGrpcErrorCode(err), "failed to stop nfs endpoint (%T)", nfsClient)
@@ -1498,8 +1514,9 @@ func (s *nodeService) nodeUnstageFileStoreStopEndpoint(
 		return fmt.Errorf("NFS client wasn't created")
 	}
 
+	socketPath := filepath.Join(stageData.RealStagePath, stageData.NfsSocketName)
 	_, err := s.nfsClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
-		SocketPath: filepath.Join(stageData.RealStagePath, nfsSocketName),
+		SocketPath: socketPath,
 	})
 
 	if err != nil {
@@ -1516,6 +1533,7 @@ func (s *nodeService) nodeUnstageLocalFileStoreStopEndpoint(
 
 	log.Printf("csi.nodeUnstageLocalFileStoreStopEndpoint: fsConfig=%+v, stageData=%+v", fsConfig, stageData)
 
+	socketPath := filepath.Join(stageData.RealStagePath, defaultNfsSocketName)
 	if fsConfig.SizeGb == 0 {
 		// legacy local filestore config - passthrough StopEndpoint to nfs-local service
 		if s.nfsLocalClient == nil {
@@ -1523,7 +1541,7 @@ func (s *nodeService) nodeUnstageLocalFileStoreStopEndpoint(
 		}
 
 		_, err := s.nfsLocalClient.StopEndpoint(ctx, &nfsapi.TStopEndpointRequest{
-			SocketPath: filepath.Join(stageData.RealStagePath, nfsSocketName),
+			SocketPath: socketPath,
 		})
 		if err != nil {
 			return s.statusErrorf(s.GetGrpcErrorCode(err), "failed to stop local nfs endpoint (%T)", s.nfsClient)
@@ -1539,7 +1557,7 @@ func (s *nodeService) nodeUnstageLocalFileStoreStopEndpoint(
 	localFsId := fmt.Sprintf("%s-%s", fsConfig.Id, stageData.InstanceId)
 
 	stopReq := &nfsapi.TStopEndpointRequest{
-		SocketPath: filepath.Join(stageData.RealStagePath, nfsSocketName),
+		SocketPath: socketPath,
 	}
 
 	log.Printf("local StopEndpoint: %+v", stopReq)

--- a/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
+++ b/cloud/blockstore/tools/csi_driver/internal/driver/node_test.go
@@ -38,6 +38,7 @@ const (
 	defaultPodId                       = "test-pod-id-13"
 	defaultDiskId                      = "test-disk-id-42"
 	defaultInstanceId                  = "testInstanceId"
+	defaultNfsVhostReplicaCount        = 0
 )
 
 type LocalFsOverride int
@@ -103,11 +104,21 @@ func getVolumeId(perInstanceVolumes bool) string {
 	return defaultDiskId
 }
 
-func CreateTestContext(t *testing.T, vmMode bool, legacyMode bool, perInstanceVolumes bool) testContext {
+func CreateTestContext(
+	t *testing.T,
+	vmMode bool,
+	legacyMode bool,
+	perInstanceVolumes bool,
+	nfsVhostReplicaCount uint32,
+) testContext {
 	tempDir := t.TempDir()
 	socketsDir := filepath.Join(tempDir, "sockets")
 	sourcePath := getSourcePath(socketsDir, vmMode, legacyMode)
 
+	socketKey := defaultPodId
+	if perInstanceVolumes {
+		socketKey = defaultInstanceId
+	}
 	return testContext{nbsClient: mocks.NewNbsClientMock(),
 		nfsClient:               mocks.NewNfsEndpointClientMock(),
 		nfsLocalClient:          mocks.NewNfsEndpointClientMock(),
@@ -122,7 +133,7 @@ func CreateTestContext(t *testing.T, vmMode bool, legacyMode bool, perInstanceVo
 		stagingTargetPath:       filepath.Join(tempDir, "testStagingTargetPath"),
 		sourcePath:              sourcePath,
 		nbsSocketPath:           filepath.Join(sourcePath, "nbs.sock"),
-		nfsSocketPath:           filepath.Join(sourcePath, "nfs.sock"),
+		nfsSocketPath:           filepath.Join(sourcePath, getNfsSocket(socketKey, uint(nfsVhostReplicaCount))),
 		targetPathMountMode:     filepath.Join(tempDir, "pods", defaultPodId, "volumes", defaultDiskId, "mount"),
 		targetPathBlockMode:     filepath.Join(tempDir, "volumeDevices", "publish", defaultDiskId, defaultPodId),
 		localFsOverrides:        make(ExternalFsOverrideMap),
@@ -146,7 +157,7 @@ func doTestPublishUnpublishVolumeForKubevirtHelper(
 	requestQueuesCountOpt *uint32,
 ) {
 	t.Helper()
-	testCtx := CreateTestContext(t, true, true, false)
+	testCtx := CreateTestContext(t, true, true, false, defaultNfsVhostReplicaCount)
 
 	ctx := context.Background()
 
@@ -171,6 +182,7 @@ func doTestPublishUnpublishVolumeForKubevirtHelper(
 		[]string{},
 		true, // enable discard
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
@@ -375,9 +387,10 @@ func doTestStagedPublishUnpublishVolumeForKubevirtHelper(
 	perInstanceVolumes bool,
 	localFsOverride LocalFsOverride,
 	requestQueuesCountOpt *uint32,
+	nfsVhostReplicaCount uint32,
 ) {
 	t.Helper()
-	testCtx := CreateTestContext(t, true, false, perInstanceVolumes)
+	testCtx := CreateTestContext(t, true, false, perInstanceVolumes, defaultNfsVhostReplicaCount)
 
 	ctx := context.Background()
 	deviceName := defaultDiskId
@@ -419,6 +432,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirtHelper(
 		[]string{},
 		false, // enableDiscard is false for staged tests
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
@@ -559,7 +573,7 @@ func doTestStagedPublishUnpublishVolumeForKubevirtHelper(
 		}).Return(&nbs.TStopEndpointResponse{}, nil)
 
 		expectedNfsClient.On("StopEndpoint", ctx, &nfs.TStopEndpointRequest{
-			SocketPath: filepath.Join(testCtx.socketsDir, defaultPodId, defaultDiskId, nfsSocketName),
+			SocketPath: filepath.Join(testCtx.socketsDir, defaultPodId, defaultDiskId, defaultNfsSocketName),
 		}).Return(&nfs.TStopEndpointResponse{}, nil)
 	}
 
@@ -614,6 +628,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 		perInstanceVolumes    bool
 		localFsOverride       LocalFsOverride
 		requestQueuesCountOpt *uint32
+		nfsVhostReplicaCount  uint32
 	}{
 		// Legacy tests (perInstanceVolumes = false, requestQueuesCountOpt = nil)
 		{
@@ -623,6 +638,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "DiskForKubevirtSetDeviceNameLegacy",
@@ -631,6 +647,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "FilestoreForKubevirtLegacy",
@@ -639,6 +656,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "LocalFilestoreForKubevirtLegacy",
@@ -647,6 +665,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideLegacyEnabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		// Per-instance volume tests (perInstanceVolumes = true, requestQueuesCountOpt = nil)
 		{
@@ -656,6 +675,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    true,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "DiskForKubevirtSetDeviceName",
@@ -664,6 +684,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    true,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "FilestoreForKubevirt",
@@ -672,6 +693,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    true,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "LocalFilestoreForKubevirt",
@@ -680,6 +702,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    true,
 			localFsOverride:       LocalFsOverrideEnabled,
 			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  0,
 		},
 		// Multiqueue tests (perInstanceVolumes = false, requestQueuesCountOpt = &rqc32)
 		// These correspond to the original "Multiqueue" tests which were legacy style.
@@ -690,6 +713,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: &rqc32,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "DiskForKubevirtSetDeviceNameMultiqueue",
@@ -698,6 +722,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: &rqc32,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "FilestoreForKubevirtMultiqueue",
@@ -706,6 +731,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideDisabled,
 			requestQueuesCountOpt: &rqc32,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "LocalFilestoreForKubevirtMultiqueueLegacy",
@@ -714,6 +740,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideLegacyEnabled,
 			requestQueuesCountOpt: &rqc32,
+			nfsVhostReplicaCount:  0,
 		},
 		{
 			name:                  "LocalFilestoreForKubevirtMultiqueue",
@@ -722,6 +749,16 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 			perInstanceVolumes:    false,
 			localFsOverride:       LocalFsOverrideEnabled,
 			requestQueuesCountOpt: &rqc32,
+			nfsVhostReplicaCount:  0,
+		},
+		{
+			name:                  "FilestoreForKubevirtMultipleNfsVhost",
+			backend:               "nfs",
+			deviceNameOpt:         nil,
+			perInstanceVolumes:    true,
+			localFsOverride:       LocalFsOverrideDisabled,
+			requestQueuesCountOpt: nil,
+			nfsVhostReplicaCount:  3,
 		},
 	}
 
@@ -736,6 +773,7 @@ func TestStagedPublishUnpublishVolumeForKubevirt(t *testing.T) {
 				tc.perInstanceVolumes,
 				tc.localFsOverride,
 				tc.requestQueuesCountOpt,
+				tc.nfsVhostReplicaCount,
 			)
 		})
 	}
@@ -777,7 +815,7 @@ func TestReadVhostSettings(t *testing.T) {
 }
 
 func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
-	testCtx := CreateTestContext(t, false, false, false)
+	testCtx := CreateTestContext(t, false, false, false, defaultNfsVhostReplicaCount)
 
 	groupId := ""
 	currentUser, err := user.Current()
@@ -815,6 +853,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 		[]string{"grpid"},
 		true,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	volumeCapability := csi.VolumeCapability{
@@ -937,7 +976,7 @@ func TestPublishUnpublishDiskForInfrakuber(t *testing.T) {
 }
 
 func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
-	testCtx := CreateTestContext(t, false, false, false)
+	testCtx := CreateTestContext(t, false, false, false, defaultNfsVhostReplicaCount)
 
 	ipcType := nbs.EClientIpcType_IPC_NBD
 	nbdDeviceFile := filepath.Join(testCtx.tempDir, "dev", "nbd3")
@@ -963,6 +1002,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	volumeCapability := csi.VolumeCapability{
@@ -1089,7 +1129,7 @@ func TestPublishUnpublishDeviceForInfrakuber(t *testing.T) {
 }
 
 func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
-	testCtx := CreateTestContext(t, false, false, false)
+	testCtx := CreateTestContext(t, false, false, false, defaultNfsVhostReplicaCount)
 
 	info, err := os.Stat(testCtx.tempDir)
 	require.NoError(t, err)
@@ -1112,6 +1152,7 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	ctx := context.Background()
@@ -1154,7 +1195,7 @@ func TestGetVolumeStatCapabilitiesWithoutVmMode(t *testing.T) {
 }
 
 func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
-	testCtx := CreateTestContext(t, true, true, false)
+	testCtx := CreateTestContext(t, true, true, false, defaultNfsVhostReplicaCount)
 
 	nodeService := newNodeService(
 		defaultNodeId,
@@ -1172,6 +1213,7 @@ func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	ctx := context.Background()
@@ -1202,7 +1244,7 @@ func TestGetVolumeStatCapabilitiesWithVmMode(t *testing.T) {
 }
 
 func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
-	testCtx := CreateTestContext(t, false, false, false)
+	testCtx := CreateTestContext(t, false, false, false, defaultNfsVhostReplicaCount)
 	ctx := context.Background()
 
 	volumeContext := map[string]string{
@@ -1225,6 +1267,7 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	_, err := nodeService.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
@@ -1273,7 +1316,7 @@ func TestPublishDeviceWithReadWriteManyModeIsNotSupportedWithNBS(t *testing.T) {
 }
 
 func TestExternaFs(t *testing.T) {
-	testCtx := CreateTestContext(t, true, false, true)
+	testCtx := CreateTestContext(t, true, false, true, defaultNfsVhostReplicaCount)
 
 	ctx := context.Background()
 	mountFilePath := filepath.Join(testCtx.tempDir, "mountDone")
@@ -1314,6 +1357,7 @@ func TestExternaFs(t *testing.T) {
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		4, // custom NfsVhostReplicaCount value should not affect mounting of external fs
 	)
 
 	accessMode := csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
@@ -1429,7 +1473,7 @@ func TestExternaFs(t *testing.T) {
 }
 
 func TestStopEndpointAfterNodeStageVolumeFailureForInfrakuber(t *testing.T) {
-	testCtx := CreateTestContext(t, false, false, false)
+	testCtx := CreateTestContext(t, false, false, false, defaultNfsVhostReplicaCount)
 
 	ipcType := nbs.EClientIpcType_IPC_NBD
 	nbdDeviceFile := filepath.Join(testCtx.tempDir, "dev", "nbd3")
@@ -1454,6 +1498,7 @@ func TestStopEndpointAfterNodeStageVolumeFailureForInfrakuber(t *testing.T) {
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	volumeCapability := csi.VolumeCapability{
@@ -1509,7 +1554,7 @@ func TestNodeStageVolumeErrorForKubevirt(
 	t *testing.T,
 ) {
 	t.Helper()
-	testCtx := CreateTestContext(t, true, false, true)
+	testCtx := CreateTestContext(t, true, false, true, defaultNfsVhostReplicaCount)
 
 	ctx := context.Background()
 	backend := "nbs"
@@ -1530,6 +1575,7 @@ func TestNodeStageVolumeErrorForKubevirt(
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
@@ -1591,7 +1637,7 @@ func TestNodeUnstageVolumeErrorForKubevirt(
 	t *testing.T,
 ) {
 	t.Helper()
-	testCtx := CreateTestContext(t, true, false, false)
+	testCtx := CreateTestContext(t, true, false, false, defaultNfsVhostReplicaCount)
 
 	ctx := context.Background()
 
@@ -1611,6 +1657,7 @@ func TestNodeUnstageVolumeErrorForKubevirt(
 		[]string{},
 		false,
 		defaultStartEndpointRequestTimeout,
+		defaultNfsVhostReplicaCount,
 	)
 
 	accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER


### PR DESCRIPTION
issue: #5362 

Add support for multiple NFS host processes in the CSI driver.
When handling NodeStageVolume, the CSI driver selects one of the available NFS vhost sockets based on a hash of the Pod ID (or instance ID).