### PR TITLE
issue-5293: raising a crit event instead of verifying on node attrs without types

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -50,6 +50,7 @@ namespace NCloud::NFileStore{
     xxx(CounterIsNegative)                                                     \
     xxx(InvalidResponseLogEntry)                                               \
     xxx(InvalidateTimedOutRegionsError)                                        \
+    xxx(NodeCacheInvalidNode)                                                  \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_CRITICAL_EVENTS_WITHOUT_LOGGING(xxx)                         \

--- a/cloud/filestore/libs/vfs_fuse/node_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/node_cache.cpp
@@ -1,8 +1,7 @@
 #include "node_cache.h"
 
+#include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/service/request.h>
-
-#include <cloud/storage/core/libs/common/verify.h>
 
 #include <util/generic/vector.h>
 #include <util/string/builder.h>
@@ -27,13 +26,12 @@ bool TNodeCacheShard::UpdateNode(
         if (version >= node.LastUpdateVersion) {
             node.UpdateAttrs(attrs, version);
 
-            STORAGE_VERIFY_C(
-                node.IsValid(),
-                TWellKnownEntityTypes::FILESYSTEM,
-                FileSystemId,
-                TStringBuilder() << "invalid attrs: "
-                    << attrs.ShortUtf8DebugString()
+            if (!node.IsValid()) {
+                ReportNodeCacheInvalidNode(TStringBuilder()
+                    << "fs: " << FileSystemId
+                    << ", attrs: " << attrs.ShortUtf8DebugString()
                     << ", version: " << version);
+            }
 
             updated = true;
         }


### PR DESCRIPTION
### Notes
This fixes profile log replay test and is overall a bit safer. Profile log replay test needs to be fixed separately - it should not generate node attrs without node types.

### Issue
https://github.com/ydb-platform/nbs/issues/5293