### PR TITLE
issue-1559: [Disk Manager]  Add rootNodeID as a parameter for traversal

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task.go
@@ -71,6 +71,7 @@ func (t *scrubFilesystemTask) Run(
 		t.config.GetTraversalConfig(),
 		rootNodeAlreadyScheduled,
 		t.config.GetListNodesMaxBytes(),
+		nfs.RootNodeID,
 	)
 
 	return traverser.Traverse(ctx, func(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks/storage_mock.go
@@ -14,9 +14,10 @@ type StorageMock struct {
 	mock.Mock
 }
 
-func (s *StorageMock) ScheduleRootNodeForListing(
+func (s *StorageMock) SchedulerDirectoryForTraversal(
 	ctx context.Context,
 	snapshotID string,
+	nodeID uint64,
 ) error {
 
 	args := s.Called(ctx, snapshotID)

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage.go
@@ -17,10 +17,11 @@ type NodeQueueEntry struct {
 ////////////////////////////////////////////////////////////////////////////////
 
 type Storage interface {
-	// Saves the root node to the directory listing queue.
-	ScheduleRootNodeForListing(
+	// Saves the subtree root directory to the directory listing queue.
+	SchedulerDirectoryForTraversal(
 		ctx context.Context,
 		snapshotID string,
+		nodeID uint64,
 	) error
 
 	// Selects nodes to be listed from the directory listing queue.

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb.go
@@ -28,10 +28,11 @@ func NewStorage(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func (s *storageYDB) scheduleRootNodeForListing(
+func (s *storageYDB) schedulerDirectoryForTraversal(
 	ctx context.Context,
 	session *persistence.Session,
 	snapshotID string,
+	nodeID uint64,
 ) error {
 
 	tx, err := session.BeginRWTransaction(ctx)
@@ -44,15 +45,15 @@ func (s *storageYDB) scheduleRootNodeForListing(
 		--!syntax_v1
 		pragma TablePathPrefix = "%v";
 		declare $snapshot_id as Utf8;
-		declare $root_node_id as Uint64;
+		declare $node_id as Uint64;
 		declare $cookie as String;
 		declare $depth as Uint64;
 
 		upsert into directory_listing_queue (filesystem_snapshot_id, node_id, cookie, depth)
-		values ($snapshot_id, $root_node_id, $cookie, $depth)
+		values ($snapshot_id, $node_id, $cookie, $depth)
 	`, s.tablesPath),
 		persistence.ValueParam("$snapshot_id", persistence.UTF8Value(snapshotID)),
-		persistence.ValueParam("$root_node_id", persistence.Uint64Value(nfs.RootNodeID)),
+		persistence.ValueParam("$node_id", persistence.Uint64Value(nodeID)),
 		persistence.ValueParam("$cookie", persistence.StringValue([]byte(""))),
 		persistence.ValueParam("$depth", persistence.Uint64Value(0)),
 	)
@@ -219,15 +220,21 @@ func (s *storageYDB) scheduleChildNodesForListing(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func (s *storageYDB) ScheduleRootNodeForListing(
+func (s *storageYDB) SchedulerDirectoryForTraversal(
 	ctx context.Context,
 	snapshotID string,
+	nodeID uint64,
 ) (err error) {
 
 	err = s.db.Execute(
 		ctx,
 		func(ctx context.Context, session *persistence.Session) error {
-			err = s.scheduleRootNodeForListing(ctx, session, snapshotID)
+			err = s.schedulerDirectoryForTraversal(
+				ctx,
+				session,
+				snapshotID,
+				nodeID,
+			)
 			return err
 		},
 	)

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb_test.go
@@ -111,9 +111,10 @@ func TestNodesScheduling(t *testing.T) {
 	defer f.teardown()
 
 	filesystemSnapshotID := "snapshot"
-	err := f.storage.ScheduleRootNodeForListing(
+	err := f.storage.SchedulerDirectoryForTraversal(
 		f.ctx,
 		filesystemSnapshotID,
+		nfs.RootNodeID,
 	)
 	require.NoError(t, err)
 
@@ -148,7 +149,11 @@ func TestNodesScheduling(t *testing.T) {
 	)
 
 	otherSnapshot := "other"
-	err = f.storage.ScheduleRootNodeForListing(f.ctx, otherSnapshot)
+	err = f.storage.SchedulerDirectoryForTraversal(
+		f.ctx,
+		otherSnapshot,
+		nfs.RootNodeID,
+	)
 	require.NoError(t, err)
 	require.NoError(
 		t,

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal.go
@@ -36,6 +36,7 @@ type FilesystemTraverser struct {
 	config                   *traversal_config.FilesystemTraversalConfig
 	rootNodeAlreadyScheduled bool
 	listNodesMaxBytes        uint32
+	rootNodeID               uint64
 }
 
 // FilesystemTravers performs parallel traversal of a filesystem.
@@ -66,6 +67,7 @@ func NewFilesystemTraverser(
 	config *traversal_config.FilesystemTraversalConfig,
 	rootNodeAlreadyScheduled bool,
 	listNodesMaxBytes uint32,
+	rootNodeID uint64,
 ) *FilesystemTraverser {
 
 	return &FilesystemTraverser{
@@ -80,6 +82,7 @@ func NewFilesystemTraverser(
 		config:                   config,
 		rootNodeAlreadyScheduled: rootNodeAlreadyScheduled,
 		listNodesMaxBytes:        listNodesMaxBytes,
+		rootNodeID:               rootNodeID,
 	}
 }
 
@@ -99,7 +102,11 @@ func (t *FilesystemTraverser) Traverse(
 
 	if !t.rootNodeAlreadyScheduled {
 		logging.Info(ctx, "Scheduling root node for listing.")
-		err := t.storage.ScheduleRootNodeForListing(ctx, t.filesystemSnapshotID)
+		err := t.storage.SchedulerDirectoryForTraversal(
+			ctx,
+			t.filesystemSnapshotID,
+			t.rootNodeID,
+		)
 		if err != nil {
 			return err
 		}

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
@@ -150,6 +150,7 @@ func (f *fixture) getFilesAfterTraversal(
 		},
 		false,
 		0,
+		nfs.RootNodeID,
 	)
 
 	actualNodeNames := []string{}
@@ -287,6 +288,7 @@ func TestTraversalShouldCloseSessionOnError(t *testing.T) {
 		},
 		false,
 		0,
+		nfs.RootNodeID,
 	)
 
 	expectedError := fmt.Errorf("some error")


### PR DESCRIPTION
Rename: ScheduleRootNodeForListing -> SchedulerDirectoryForTraversal.
Add nodeID parameter to SchedulerDirectoryForTraversal.
Add passing rootNodeID to traversal.
#1559 