### PR TITLE
issue-5356: [Filestore] should not wait for requests completion when NodeBroker lease is expired

### DIFF
--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -40,6 +40,7 @@
 #include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/daemon/mlock.h>
+#include <cloud/storage/core/libs/daemon/public.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/stats_updater.h>
@@ -528,6 +529,16 @@ void TBootstrapVhost::StopComponents()
 
 void TBootstrapVhost::Drain()
 {
+    if (Configs->Options->Service == NDaemon::EServiceKind::Kikimr &&
+        GetShouldContinue().PollState() != TProgramShouldContinue::Continue)
+    {
+        auto code = GetShouldContinue().GetReturnCode();
+        if (code == NodeLeaseExpirationExitCode) {
+            ythrow TAppShouldExitWithoutShutdownException()
+                << "Node lease is expired";
+        }
+    }
+
     if (EndpointManager) {
         EndpointManager->Drain();
     }

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -532,7 +532,7 @@ void TBootstrapVhost::Drain()
     if (Configs->Options->Service == NDaemon::EServiceKind::Kikimr &&
         GetShouldContinue().PollState() != TProgramShouldContinue::Continue)
     {
-        auto code = GetShouldContinue().GetReturnCode();
+        const int code = GetShouldContinue().GetReturnCode();
         if (code == NodeLeaseExpirationExitCode) {
             ythrow TAppShouldExitWithoutShutdownException()
                 << "Node lease is expired";

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.h
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.h
@@ -18,6 +18,11 @@ namespace NCloud::NFileStore::NDaemon {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// NodeBroker lease expiration exit code
+constexpr int NodeLeaseExpirationExitCode = 2;
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TVhostModuleFactories
 {
     std::function<NVFS::IFileSystemLoopFactoryPtr(

--- a/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
@@ -192,14 +192,14 @@ auto MakeSslServerCredentials()
 ////////////////////////////////////////////////////////////////////////////////
 
 // Needed to mock NodeBroker to allow our dynamic node to register
-class FakeYdbDiscoveryService final
+class TFakeYdbDiscoveryService final
     : public Ydb::Discovery::V1::DiscoveryService::Service
 {
 private:
     ui64 DynamicNodeIcPort;
 
 public:
-    FakeYdbDiscoveryService(ui64 dynamicNodeIcPort)
+    explicit TFakeYdbDiscoveryService(ui64 dynamicNodeIcPort)
         : DynamicNodeIcPort(dynamicNodeIcPort)
     {}
 
@@ -232,12 +232,12 @@ public:
     }
 };
 
-// Grpc server for FakeYdbDiscoveryService.
+// Grpc server for TFakeYdbDiscoveryService.
 // Needed to mock NodeBroker to allow our dynamic node to register
 class TestYdbDiscoveryServer
 {
 private:
-    FakeYdbDiscoveryService Service;
+    TFakeYdbDiscoveryService Service;
     std::unique_ptr<grpc::Server> Server;
 
     TPortManager PortManager;

--- a/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
@@ -1,0 +1,436 @@
+#include "bootstrap.h"
+
+#include <cloud/filestore/libs/storage/testlib/test_env.h>
+#include <cloud/filestore/libs/vfs_fuse/loop.h>
+
+#include <cloud/storage/core/libs/daemon/app.h>
+
+#include <contrib/ydb/core/driver_lib/run/factories.h>
+#include <contrib/ydb/core/mind/lease_holder.h>
+#include <contrib/ydb/public/api/protos/ydb_discovery.pb.h>
+#include <contrib/ydb/public/api/grpc/ydb_discovery_v1.grpc.pb.h>
+
+#include <contrib/libs/grpc/include/grpc/grpc.h>
+#include <contrib/libs/grpc/include/grpcpp/security/server_credentials.h>
+
+#include <library/cpp/testing/common/network.h>
+#include <library/cpp/testing/unittest/tests_data.h>
+
+#include <util/folder/tempdir.h>
+#include <util/generic/cast.h>
+#include <util/generic/string.h>
+#include <util/stream/file.h>
+#include <util/string/printf.h>
+
+#include <memory>
+#include <string>
+
+namespace NCloud::NFileStore::NDaemon {
+
+using namespace NActors;
+using namespace NKikimr;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const TString SysConfigStr = R"(
+    Executor {
+        Type: BASIC
+        Threads: 1
+        Name: "System"
+    }
+    Executor {
+        Type: BASIC
+        Threads: 1
+        Name: "User"
+    }
+    Executor {
+        Type: BASIC
+        Threads: 1
+        Name: "Batch"
+    }
+    Executor {
+        Type: IO
+        Threads: 1
+        Name: "IO"
+    }
+    Executor {
+        Type: BASIC
+        Threads: 1
+        Name: "IC"
+    }
+    Scheduler {
+        Resolution: 64
+        SpinThreshold: 0
+        ProgressThreshold: 10000
+    }
+    SysExecutor: 0
+    UserExecutor: 1
+    IoExecutor: 3
+    BatchExecutor: 2
+    ServiceExecutor {
+        ServiceName: "User"
+        ExecutorId: 1
+    }
+    ServiceExecutor {
+        ServiceName: "Batch"
+        ExecutorId: 2
+    }
+    ServiceExecutor {
+        ServiceName: "IO"
+        ExecutorId: 3
+    }
+    ServiceExecutor {
+        ServiceName: "Interconnect"
+        ExecutorId: 4
+    }
+)";
+
+const TString StorageConfigTemplateStr = R"(
+    SchemeShardDir: "local"
+    NodeType: "nfs"
+    NodeRegistrationRootCertsFile: "%s"
+    NodeRegistrationCert {
+        CertFile: "%s"
+        CertPrivateKeyFile: "%s"
+    }
+)";
+
+const TString NamingConfigTemplateStr = R"(
+    Node {
+        NodeId: 1
+        Address: "localhost"
+        Host: "localhost"
+        Port: %d
+        InterconnectHost: "localhost"
+    }
+)";
+
+const TString DomainsConfigStr = R"(
+    Domain {
+        DomainId: 1
+        SchemeRoot: 72057594046678944
+        SSId: 1
+        HiveUid: 1
+        Name: "local"
+        StoragePoolTypes {
+            Kind: "ssd"
+            PoolConfig {
+                BoxId: 1
+                ErasureSpecies: "block-4-2"
+                VDiskKind: "Default"
+                Kind: "ssd"
+                PDiskFilter {
+                    Property {
+                        Type: SSD
+                    }
+                }
+            }
+        }
+        ExplicitMediators: 72057594046382081
+        ExplicitCoordinators: 72057594046316545
+        ExplicitAllocators: 72057594046447617
+    }
+    StateStorage {
+        SSId: 1
+        Ring {
+            NToSelect: 1
+            Node: 1
+        }
+    }
+    HiveConfig {
+        HiveUid: 1
+        Hive: 72057594037968897
+    }
+)";
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString GetTestFilePath(const TString& fileName)
+{
+    return JoinFsPaths(ArcadiaSourceRoot(), "cloud/filestore/tests", fileName);
+}
+
+TString GetCertFile()
+{
+    return GetTestFilePath("certs/server.crt");
+}
+
+TString GetCertKeyFile()
+{
+    return GetTestFilePath("certs/server.key");
+}
+
+TString ReadFile(const TString& fileName)
+{
+    TFileInput in(fileName);
+    return in.ReadAll();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto MakeSslServerCredentials()
+{
+    grpc::SslServerCredentialsOptions opts;
+    opts.client_certificate_request =
+        GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY;
+
+    const auto certFile = GetCertFile();
+    const auto certKeyFile = GetCertKeyFile();
+
+    opts.pem_root_certs = ReadFile(certFile);
+
+    grpc::SslServerCredentialsOptions::PemKeyCertPair keyCert;
+    keyCert.cert_chain = ReadFile(certFile);
+    keyCert.private_key = ReadFile(certKeyFile);
+    opts.pem_key_cert_pairs.push_back(keyCert);
+
+    return grpc::SslServerCredentials(opts);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Needed to mock NodeBroker to allow our dynamic node to register
+class FakeYdbDiscoveryService final
+    : public Ydb::Discovery::V1::DiscoveryService::Service
+{
+private:
+    ui64 DynamicNodeIcPort;
+
+public:
+    FakeYdbDiscoveryService(ui64 dynamicNodeIcPort)
+        : DynamicNodeIcPort(dynamicNodeIcPort)
+    {}
+
+    grpc::Status NodeRegistration(
+        grpc::ServerContext* ctx,
+        const Ydb::Discovery::NodeRegistrationRequest* req,
+        Ydb::Discovery::NodeRegistrationResponse* resp) override
+    {
+        Y_UNUSED(ctx);
+        Y_UNUSED(req);
+
+        auto* operation = resp->mutable_operation();
+        operation->set_ready(true);
+        operation->set_status(Ydb::StatusIds::SUCCESS);
+
+        Ydb::Discovery::NodeRegistrationResult result;
+        result.set_node_id(1);
+        result.set_scope_tablet_id(72057594037968897);
+        result.set_scope_path_id(1);
+
+        auto* node = result.add_nodes();
+        node->set_node_id(2);
+        node->set_address("localhost");
+        node->set_host("localhost");
+        node->set_port(DynamicNodeIcPort);
+
+        operation->mutable_result()->PackFrom(result);
+
+        return grpc::Status::OK;
+    }
+};
+
+// Grpc server for FakeYdbDiscoveryService.
+// Needed to mock NodeBroker to allow our dynamic node to register
+class TestYdbDiscoveryServer
+{
+private:
+    FakeYdbDiscoveryService Service;
+    std::unique_ptr<grpc::Server> Server;
+
+    TPortManager PortManager;
+    ui16 Port = 0;
+
+public:
+    TestYdbDiscoveryServer(ui64 dynamicNodeIcPort)
+        : Service(dynamicNodeIcPort)
+    {}
+
+    ~TestYdbDiscoveryServer()
+    {
+        Stop();
+    }
+
+    void Start()
+    {
+        grpc::ServerBuilder builder;
+        builder.RegisterService(&Service);
+
+        Port = PortManager.GetPort();
+        const auto endpoint = "[::]:" + IntToString<10>(Port);
+        builder.AddListeningPort(endpoint, MakeSslServerCredentials());
+
+        Server = builder.BuildAndStart();
+        UNIT_ASSERT(Server);
+    }
+
+    void Stop()
+    {
+        if (Server) {
+            Server->Shutdown();
+            Server.reset();
+        }
+    }
+
+    ui16 GetPort() const
+    {
+        return Port;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TBootstrapVhostTest)
+{
+    Y_UNIT_TEST(ShouldNotWaitForRequestsWhenNodeLeaseIsExpired)
+    {
+        TPortManager PortManager;
+        const auto staticNodeIcPort = PortManager.GetPort();
+        const auto dynamicNodeIcPort = PortManager.GetPort();
+
+        TestYdbDiscoveryServer ydbDiscoveryServer(dynamicNodeIcPort);
+        ydbDiscoveryServer.Start();
+
+        auto moduleFactories = std::make_shared<NKikimr::TModuleFactories>();
+
+        auto vhostFactories =
+            std::make_shared<NDaemon::TVhostModuleFactories>();
+        vhostFactories->LoopFactory = NFuse::CreateFuseLoopFactory;
+
+        TBootstrapVhost bootstrap(
+            std::move(moduleFactories),
+            std::move(vhostFactories));
+
+        TTempDir dir;
+
+        auto sysConfigPath = dir.Path() / "nfs-sys.txt";
+        TOFStream(sysConfigPath.GetPath()).Write(SysConfigStr);
+
+        auto storageConfigPath = dir.Path() / "nfs-storage.txt";
+        auto storageConfigStr = Sprintf(
+            StorageConfigTemplateStr.c_str(),
+            GetCertFile().c_str(),      // NodeRegistrationRootCertsFile
+            GetCertFile().c_str(),      // NodeRegistrationCert.CertFile
+            GetCertKeyFile().c_str()    // NodeRegistrationCert.CertPrivateKeyFile
+        );
+        TOFStream(storageConfigPath.GetPath()).Write(storageConfigStr);
+
+        auto namingConfigPath = dir.Path() / "nfs-names.txt";
+        auto namingConfigStr = Sprintf(
+            NamingConfigTemplateStr.c_str(),
+            staticNodeIcPort);
+        TOFStream(namingConfigPath.GetPath()).Write(namingConfigStr);
+
+        auto domainsConfigPath = dir.Path() / "nfs-domains.txt";
+        TOFStream(domainsConfigPath.GetPath()).Write(DomainsConfigStr);
+
+        TVector<TString> args = {
+            "./program",
+
+            "--service", "kikimr",
+
+            "--sys-file", sysConfigPath,
+            "--storage-file", storageConfigPath,
+            "--naming-file", namingConfigPath,
+            "--domains-file", domainsConfigPath,
+
+            "--ic-port", IntToString<10>(dynamicNodeIcPort),
+
+            "--domain", "local",
+
+            "--node-broker", "localhost",
+            "--node-broker-port", IntToString<10>(ydbDiscoveryServer.GetPort()),
+
+            "--use-secure-registration",
+        };
+
+        TVector<char*> argv;
+        argv.reserve(args.size());
+
+        for (auto& arg : args) {
+            argv.push_back(arg.begin());
+        }
+
+        bootstrap.ParseOptions(argv.size(), argv.data());
+
+        bootstrap.Init();
+        bootstrap.Start();
+
+        // Emulate NodeBroker lease expiration - it is simpler than creating real
+        // conditions for it
+        //
+        // The correspondence between node lease expiration and
+        // |NodeLeaseExpirationExitCode| is verified in the
+        // ShouldObserveSpecificReturnCodeWhenNodeLeaseIsExpired test
+        bootstrap.GetShouldContinue().ShouldStop(NodeLeaseExpirationExitCode);
+
+        UNIT_ASSERT_EXCEPTION(
+            bootstrap.Stop(),
+            TAppShouldExitWithoutShutdownException);
+
+        // This looks hacky, but we need TBootstrap::Stop to finish without
+        // exceptions. Otherwise, Actor System threads will not be joined and
+        // the test will crash
+        //
+        // In the production binary, the behavior is different: when TApp
+        // receives TAppShouldExitWithoutShutdownException, it calls _exit and
+        // terminates the process immediately
+        bootstrap.GetShouldContinue().ShouldStop(0);
+        bootstrap.Stop();
+    }
+
+    // This test asserts that |NodeLeaseExpirationExitCode| has the expected
+    // value and correctly corresponds to NodeBroker lease expiration
+    Y_UNIT_TEST(ShouldObserveSpecificReturnCodeWhenNodeLeaseIsExpired)
+    {
+        NStorage::TTestEnv env({});
+        auto& runtime = env.GetRuntime();
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        auto& appData = runtime.GetAppData(nodeIdx);
+
+        // If KikimrShouldContinue is not nullptr, this code is not needed and
+        // can be removed
+        UNIT_ASSERT(!appData.KikimrShouldContinue);
+        TProgramShouldContinue shouldContinue;
+        // HACK(svartmetal): KikimrShouldContinue is a const pointer, so
+        // const_cast is needed to modify it
+        const_cast<TProgramShouldContinue*&>(appData.KikimrShouldContinue) =
+            &shouldContinue;
+        Y_DEFER {
+            const_cast<TProgramShouldContinue*&>(appData.KikimrShouldContinue) =
+                nullptr;
+        };
+
+        const TDuration leaseExpirationTimeout = TDuration::Hours(2);
+
+        IActorPtr leaseHolder(NNodeBroker::CreateLeaseHolder(
+            runtime.GetCurrentTime() + leaseExpirationTimeout));
+        auto leaseHolderId = runtime.Register(
+            leaseHolder.release(),
+            nodeIdx,
+            appData.UserPoolId,
+            TMailboxType::Simple,
+            0);
+        runtime.EnableScheduleForActor(leaseHolderId);
+        runtime.RegisterService(TActorId(), leaseHolderId, 0);
+
+        // Advance time to trigger NodeBroker lease expiration
+        runtime.AdvanceCurrentTime(leaseExpirationTimeout);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        // Expect that lease is expired
+        UNIT_ASSERT(
+            TProgramShouldContinue::Stop == shouldContinue.PollState());
+        UNIT_ASSERT_VALUES_EQUAL(
+            NodeLeaseExpirationExitCode,
+            shouldContinue.GetReturnCode());
+    }
+};
+
+}   // namespace NCloud::NFileStore::NDaemon

--- a/cloud/filestore/libs/daemon/vhost/ut/ya.make
+++ b/cloud/filestore/libs/daemon/vhost/ut/ya.make
@@ -3,7 +3,21 @@ UNITTEST_FOR(cloud/filestore/libs/daemon/vhost)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/small.inc)
 
 SRCS(
+    bootstrap_ut.cpp
     config_initializer_ut.cpp
 )
+
+PEERDIR(
+    cloud/filestore/libs/storage/testlib
+
+    contrib/ydb/core/testlib
+)
+
+DATA(
+    arcadia/cloud/filestore/tests/certs/server.crt
+    arcadia/cloud/filestore/tests/certs/server.key
+)
+
+YQL_LAST_ABI_VERSION()
 
 END()

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -315,6 +315,7 @@ void TTestEnv::SetupLogging()
         NKikimrServices::TX_MEDIATOR,
         NKikimrServices::TX_PROXY,
         NKikimrServices::TX_PROXY_SCHEME_CACHE,
+        NKikimrServices::NODE_BROKER,
     };
 
     for (ui32 i: kikimrServices) {

--- a/cloud/filestore/tests/lease_expiration/test.py
+++ b/cloud/filestore/tests/lease_expiration/test.py
@@ -1,0 +1,394 @@
+import logging
+import os
+import pathlib
+import requests
+import tempfile
+import time
+import uuid
+
+from retrying import retry
+
+import library.python.fs as fs
+
+import yatest.common as common
+
+from contrib.ydb.core.protos.node_broker_pb2 import TConfig as TNodeBrokerConfig
+from contrib.ydb.core.protos import msgbus_pb2 as ydb_msgbus
+from contrib.ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds as YdbStatusIds
+from contrib.ydb.tests.library.common.msgbus_types import MessageBusStatus as YdbMessageBusStatus
+from contrib.ydb.tests.library.common.wait_for import wait_for
+from contrib.ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from contrib.ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+
+from cloud.storage.core.protos.endpoints_pb2 import EEndpointStorageType
+from cloud.storage.core.tools.testing.qemu.lib.common import SshToGuest, get_mount_paths, get_qemu_kvm, get_qemu_firmware
+from cloud.storage.core.tools.testing.qemu.lib.qemu import Qemu
+
+from cloud.filestore.config.server_pb2 import TServerAppConfig, TKikimrServiceConfig
+from cloud.filestore.config.vhost_pb2 import \
+    TVhostAppConfig, TVhostServiceConfig, TServiceEndpoint
+from cloud.filestore.tests.python.lib.client import FilestoreCliClient, create_endpoint
+from cloud.filestore.tests.python.lib.daemon_config import FilestoreServerConfigGenerator, FilestoreVhostConfigGenerator
+from cloud.filestore.tests.python.lib.server import FilestoreServer, wait_for_filestore_server
+from cloud.filestore.tests.python.lib.vhost import FilestoreVhost, wait_for_filestore_vhost
+
+logger = logging.getLogger(__name__)
+
+RETRY_COUNT = 100
+WAIT_TIMEOUT_MS = 2000  # 2 sec
+EPOCH_DURATION_US = 30 * 10**6  # 30 sec
+# NodeBroker lease expiration timeout
+#
+# Add 100 seconds to give the system enough time to shut down after lease
+# expiration
+NODE_LEASE_EXPIRATION_TIMEOUT_SECONDS = 2 * EPOCH_DURATION_US / 10**6 + 100
+# NodeBroker lease expiration exit code
+NODE_LEASE_EXPIRATION_EXIT_CODE = 2
+NODE_BROKER_TABLET_ID = 72057594037936129
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def mkdir(ssh: SshToGuest, dir: str):
+    return ssh("sudo mkdir -p {}".format(dir))
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def mount(ssh: SshToGuest, dir: str):
+    return ssh("sudo mount -t virtiofs fs0 {} -o rw".format(dir))
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def create_file(ssh: SshToGuest, dir: str, file_name: str):
+    return ssh(f"sudo touch {dir}/{file_name}")
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def touch_file_in_background(ssh: SshToGuest, dir: str, file_name: str):
+    return ssh(
+        f"tmux new-session -d 'while true; do sudo dd if=/dev/urandom \
+        of={dir}/{file_name} bs=1M count=1 oflag=direct status=none; done'"
+    )
+
+
+class QemuWithWorkload:
+    def __init__(self, vhost_socket):
+        rootfs = common.build_path(
+            "cloud/storage/core/tools/testing/qemu/image/rootfs.img"
+        )
+        self.qemu = Qemu(
+            qemu_kvm=get_qemu_kvm(),
+            qemu_firmware=get_qemu_firmware(),
+            rootfs=rootfs,
+            kernel=None,
+            kcmdline=None,
+            initrd=None,
+            mem="4G",
+            proc=8,
+            virtio='fs',
+            qemu_options=[],
+            vhost_socket=vhost_socket,
+            enable_kvm=True,
+        )
+
+    def start(self):
+        self.qemu.set_mount_paths(get_mount_paths())
+        self.qemu.start()
+
+        ssh_key = common.source_path(
+            "cloud/storage/core/tools/testing/qemu/keys/id_rsa"
+        )
+        new_ssh_key = common.work_path(os.path.basename(ssh_key))
+        fs.copy_file(ssh_key, new_ssh_key)
+        os.chmod(new_ssh_key, 0o0600)
+
+        ssh = SshToGuest(user="qemu",
+                         port=self.qemu.get_ssh_port(),
+                         key=new_ssh_key)
+
+        virtiofs_mount_path = "/mnt/fs0"
+        mkdir(ssh, virtiofs_mount_path)
+        mount(ssh, virtiofs_mount_path)
+        # Sanity check
+        create_file(ssh, virtiofs_mount_path, "file")
+        # Actual workload. We need workload to keep filestore-vhost busy,
+        # otherwise, if no requests are in flight at lease expiration,
+        # the possible hang won’t reproduce
+        for i in range(3):
+            touch_file_in_background(ssh, virtiofs_mount_path, "file")
+
+    def stop(self):
+        self.qemu.stop()
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def update_current_epoch_end(
+    ydb_cluster,
+    current_epoch_end_us,
+):
+    current_epoch_end_key = 5
+
+    req = ydb_msgbus.TLocalMKQL()
+    req.TabletID = NODE_BROKER_TABLET_ID
+    req.Program.Program.Text = \
+        f"""
+        (
+        (let key '('('Key (Uint32 '{current_epoch_end_key}))))
+        (let value '('Value (Uint64 '{current_epoch_end_us})))
+        (let ret (AsList (UpdateRow 'Params key '(value))))
+        (return ret)
+        )
+        """
+
+    response = ydb_cluster.client.invoke(req, "LocalMKQL")
+    # NOTE: the MessageBusStatus is used here for a reason, since LocalMKQL
+    # is a special type of "message bus" call
+    assert YdbMessageBusStatus.MSTATUS_OK == response.Status
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def update_next_epoch_end(
+    ydb_cluster,
+    next_epoch_end_us,
+):
+    next_epoch_end_key = 6
+
+    req = ydb_msgbus.TLocalMKQL()
+    req.TabletID = NODE_BROKER_TABLET_ID
+    req.Program.Program.Text = \
+        f"""
+        (
+        (let key '('('Key (Uint32 '{next_epoch_end_key}))))
+        (let value '('Value (Uint64 '{next_epoch_end_us})))
+        (let ret (AsList (UpdateRow 'Params key '(value))))
+        (return ret)
+        )
+        """
+
+    response = ydb_cluster.client.invoke(req, "LocalMKQL")
+    # NOTE: the MessageBusStatus is used here for a reason, since LocalMKQL
+    # is a special type of "message bus" call
+    assert YdbMessageBusStatus.MSTATUS_OK == response.Status
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def kill_node_broker_tablet(ydb_cluster):
+    response = ydb_cluster.client.tablet_kill(NODE_BROKER_TABLET_ID)
+    # NOTE: the MessageBusStatus is used here for a reason, since
+    # TabletKillRequest is a special type of "message bus" call
+    assert YdbMessageBusStatus.MSTATUS_OK == response.Status
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def update_epoch_duration_via_console(ydb_cluster, epoch_duration_us):
+    node_broker_config = TNodeBrokerConfig()
+    node_broker_config.EpochDuration = epoch_duration_us
+
+    req = ydb_msgbus.TConsoleRequest()
+    action = req.ConfigureRequest.Actions.add()
+    action.AddConfigItem.ConfigItem.Config.NodeBrokerConfig.CopyFrom(
+        node_broker_config
+    )
+
+    response = ydb_cluster.client.invoke(req, "ConsoleRequest")
+    assert YdbStatusIds.SUCCESS == response.Status.Code
+
+
+@retry(stop_max_attempt_number=RETRY_COUNT, wait_fixed=WAIT_TIMEOUT_MS)
+def ensure_epoch_duration_updated(ydb_cluster, epoch_duration_us):
+    def query_monitoring(url, text):
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        return r.text.find(text) != -1
+
+    ydb_mon_port = list(ydb_cluster.nodes.values())[0].mon_port
+    epoch_duration_seconds = epoch_duration_us // 10**6
+
+    assert query_monitoring(
+        f"http://localhost:{ydb_mon_port}/tablets/app?TabletID={NODE_BROKER_TABLET_ID}",
+        f"EpochDuration: {epoch_duration_seconds}.0")
+
+
+def setup_ydb(ydb_binary_path):
+    os.environ["YDB_DEFAULT_LOG_LEVEL"] = "DEBUG"
+
+    configurator = KikimrConfigGenerator(
+        erasure=None,
+        use_in_memory_pdisks=False,
+        binary_path=ydb_binary_path,
+        dynamic_storage_pools=[
+            dict(name="dynamic_storage_pool:1", kind="rot", pdisk_user_kind=0),
+            dict(name="dynamic_storage_pool:2", kind="ssd", pdisk_user_kind=0),
+        ],
+    )
+
+    cluster = kikimr_cluster_factory(configurator=configurator)
+    cluster.start()
+    return configurator, cluster
+
+
+def setup_filestore_server(ydb_binary_path, ydb_port, ydb_configurator):
+    ydb_domain = ydb_configurator.domains_txt.Domain[0].Name
+
+    filestore_server_binary_path = common.binary_path(
+        "cloud/filestore/apps/server/filestore-server"
+    )
+
+    server_config = TServerAppConfig()
+    server_config.KikimrServiceConfig.CopyFrom(TKikimrServiceConfig())
+
+    server_unix_socket_path = str(
+        pathlib.Path(tempfile.mkdtemp(dir="/tmp")) / "filestore.sock"
+    )
+    server_config.ServerConfig.UnixSocketPath = server_unix_socket_path
+
+    filestore_server_configurator = FilestoreServerConfigGenerator(
+        binary_path=filestore_server_binary_path,
+        app_config=server_config,
+        service_type="kikimr",
+        verbose=True,
+        kikimr_port=ydb_port,
+        domain=ydb_domain,
+    )
+    filestore_server_configurator.generate_configs(
+        ydb_configurator.domains_txt,
+        ydb_configurator.names_txt,
+    )
+
+    filestore_server = FilestoreServer(
+        configurator=filestore_server_configurator,
+        kikimr_binary_path=ydb_binary_path,
+        dynamic_storage_pools=ydb_configurator.dynamic_storage_pools,
+    )
+    filestore_server.start()
+    wait_for_filestore_server(
+        filestore_server,
+        filestore_server_configurator.port,
+    )
+
+    return server_config, filestore_server_configurator, filestore_server
+
+
+def setup_filestore_vhost(ydb_port, ydb_configurator, server_config):
+    ydb_domain = ydb_configurator.domains_txt.Domain[0].Name
+
+    filestore_vhost_binary_path = common.binary_path(
+        "cloud/filestore/apps/vhost/filestore-vhost"
+    )
+
+    config = TVhostAppConfig()
+    config.ServerConfig.CopyFrom(server_config.ServerConfig)
+
+    uid = str(uuid.uuid4())
+    endpoint_storage_dir = common.work_path() + '/endpoints-' + uid
+    pathlib.Path(endpoint_storage_dir).mkdir(parents=True, exist_ok=True)
+
+    config.VhostServiceConfig.CopyFrom(TVhostServiceConfig())
+    config.VhostServiceConfig.EndpointStorageType = \
+        EEndpointStorageType.ENDPOINT_STORAGE_FILE
+    config.VhostServiceConfig.EndpointStorageDir = endpoint_storage_dir
+    config.VhostServiceConfig.ServiceEndpoints.append(TServiceEndpoint())
+
+    filestore_vhost_configurator = FilestoreVhostConfigGenerator(
+        binary_path=filestore_vhost_binary_path,
+        app_config=config,
+        service_type="kikimr",
+        verbose=True,
+        kikimr_port=ydb_port,
+        domain=ydb_domain,
+    )
+
+    filestore_vhost = FilestoreVhost(filestore_vhost_configurator)
+    filestore_vhost.start()
+    wait_for_filestore_vhost(
+        filestore_vhost,
+        filestore_vhost_configurator.port,
+    )
+
+    return filestore_vhost_configurator, endpoint_storage_dir, filestore_vhost
+
+
+def create_filesystem_and_start_endpoint(
+    endpoint_storage_dir,
+    filestore_server_port,
+    filestore_vhost_port,
+):
+    filestore_client_path = common.binary_path(
+        "cloud/filestore/apps/client/filestore-client")
+
+    client = FilestoreCliClient(
+        filestore_client_path,
+        filestore_server_port,
+        vhost_port=filestore_vhost_port,
+        verbose=True,
+        cwd=common.output_path(),
+    )
+
+    filesystem_id = "fs0"
+    client.create(filesystem_id, "test_cloud", "test_folder")
+
+    vhost_socket = create_endpoint(
+        client,
+        filesystem_id,
+        "/tmp",
+        "test.vhost",
+        endpoint_storage_dir,
+    )
+
+    return vhost_socket
+
+
+def test_vhost_lease_expiration():
+    ydb_binary_path = common.binary_path("contrib/ydb/apps/ydbd/ydbd")
+    ydb_configurator, ydb_cluster = setup_ydb(ydb_binary_path)
+    ydb_port = list(ydb_cluster.nodes.values())[0].port
+
+    # Update the epoch duration (default is 1 hour), as it is obviously too long
+    # for the test
+    update_epoch_duration_via_console(ydb_cluster, EPOCH_DURATION_US)
+    ensure_epoch_duration_updated(ydb_cluster, EPOCH_DURATION_US)
+
+    # Patch the current and next epoch end times in the NodeBroker local DB to
+    # shorten the current epoch, because the first epoch always lasts an hour
+    # Use current time in us + 100 seconds
+    current_epoch_end_us = time.time_ns() // 1000 + 100 * 10**6
+    update_current_epoch_end(ydb_cluster, current_epoch_end_us)
+    next_epoch_end_us = current_epoch_end_us + EPOCH_DURATION_US
+    update_next_epoch_end(ydb_cluster, next_epoch_end_us)
+
+    # Restart the NodeBroker because it loads the current epoch from the local
+    # DB only at startup
+    kill_node_broker_tablet(ydb_cluster)
+    # Wait until NodeBroker is ready
+    ensure_epoch_duration_updated(ydb_cluster, EPOCH_DURATION_US)
+
+    server_config, filestore_server_configurator, filestore_server = \
+        setup_filestore_server(ydb_binary_path, ydb_port, ydb_configurator)
+
+    filestore_vhost_configurator, endpoint_storage_dir, filestore_vhost = \
+        setup_filestore_vhost(
+            ydb_port,
+            ydb_configurator,
+            server_config,
+        )
+
+    vhost_socket = create_filesystem_and_start_endpoint(
+        endpoint_storage_dir,
+        filestore_server_configurator.port,
+        filestore_vhost_configurator.port,
+    )
+
+    qemu = QemuWithWorkload(vhost_socket)
+    qemu.start()
+
+    # Stop YDB to force subsequent lease expiration
+    ydb_cluster.stop()
+
+    # Wait until the lease expires
+    for service in [filestore_vhost, filestore_server]:
+        assert wait_for(
+            lambda: not service.is_alive(),
+            NODE_LEASE_EXPIRATION_TIMEOUT_SECONDS,
+        )
+        assert NODE_LEASE_EXPIRATION_EXIT_CODE == service.daemon.exit_code
+
+    qemu.stop()

--- a/cloud/filestore/tests/lease_expiration/ya.make
+++ b/cloud/filestore/tests/lease_expiration/ya.make
@@ -1,6 +1,10 @@
 PY3TEST()
 
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+ENDIF()
 
 TEST_SRCS(test.py)
 

--- a/cloud/filestore/tests/lease_expiration/ya.make
+++ b/cloud/filestore/tests/lease_expiration/ya.make
@@ -1,0 +1,35 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+TEST_SRCS(test.py)
+
+PEERDIR(
+    cloud/filestore/config
+    cloud/filestore/tests/python/lib
+
+    cloud/storage/core/tools/testing/qemu/lib
+
+    contrib/ydb/core/protos
+    contrib/ydb/tests/library
+    contrib/python/requests/py3
+
+    library/python/fs
+    library/python/retry
+    library/python/testing/yatest_common
+)
+
+DEPENDS(
+    cloud/filestore/apps/client
+    cloud/filestore/apps/server
+    cloud/filestore/apps/vhost
+
+    cloud/storage/core/tools/testing/qemu/bin
+    cloud/storage/core/tools/testing/qemu/image
+
+    contrib/ydb/apps/ydbd
+)
+
+DATA(arcadia/cloud/storage/core/tools/testing/qemu/keys)
+
+END()

--- a/cloud/filestore/tests/ya.make
+++ b/cloud/filestore/tests/ya.make
@@ -24,6 +24,7 @@ RECURSE_FOR_TESTS(
     fmdtest
     fs_posix_compliance
     guest_cache
+    lease_expiration
     loadtest
     profile_log
     registration

--- a/cloud/storage/core/libs/daemon/app.h
+++ b/cloud/storage/core/libs/daemon/app.h
@@ -45,6 +45,10 @@ int DoMain(TBootstrap& bootstrap, int argc, char** argv)
 
         try {
             bootstrap.Stop();
+        } catch (const TAppShouldExitWithoutShutdownException& ex) {
+            Cerr << "app is calling _exit(" << exitCode << ") immediately: "
+                 << CurrentExceptionMessage() << Endl;
+            _exit(exitCode);
         } catch (...) {
             Cerr << "main bootstrap stop: " << CurrentExceptionMessage() << Endl;
             return 1;

--- a/cloud/storage/core/libs/daemon/public.h
+++ b/cloud/storage/core/libs/daemon/public.h
@@ -1,3 +1,20 @@
 #pragma once
 
+#include <util/generic/yexception.h>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// When this exception is thrown, TApp handles it by calling _exit.
+// Traditional exit handlers and destructors are not invoked, which allows the
+// program to exit even when safe shutdown is impossible or very hard
+class TAppShouldExitWithoutShutdownException
+    : public yexception
+{};
+
+}   // namespace NCloud
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TProgramShouldContinue;

--- a/contrib/ydb/core/mind/node_broker_impl.h
+++ b/contrib/ydb/core/mind/node_broker_impl.h
@@ -56,7 +56,7 @@ public:
         struct TEvUpdateEpoch : public TEventLocal<TEvUpdateEpoch, EvUpdateEpoch> {};
 
         struct TEvResolvedRegistrationRequest : public TEventLocal<TEvResolvedRegistrationRequest, EvResolvedRegistrationRequest> {
-            
+
             TEvResolvedRegistrationRequest(
                     TEvNodeBroker::TEvRegistrationRequest::TPtr request,
                     NActors::TScopeId scopeId,
@@ -75,7 +75,10 @@ public:
 private:
     using TActorBase = TActor<TNodeBroker>;
 
-    static constexpr TDuration MIN_LEASE_DURATION = TDuration::Minutes(5);
+    // See issue #5356 or ask Mikhail Montsev (@svartmetal) for details.
+    // MIN_LEASE_DURATION reduced from 300 to 30 seconds for better testing
+    // (see cloud/filestore/tests/lease_expiration test)
+    static constexpr TDuration MIN_LEASE_DURATION = TDuration::Seconds(30);
 
     enum EConfigKey {
         ConfigKeyConfig = 1,


### PR DESCRIPTION
### Notes
When NodeBroker lease is expired (due to network problems for example) https://github.com/ydb-platform/nbs/blob/5cf58a77d9adcc346425923bb922d6a2c8a4f0b5/contrib/ydb/core/mind/lease_holder.cpp#L233, `EndpointManager::Drain` is called https://github.com/ydb-platform/nbs/blob/5cf58a77d9adcc346425923bb922d6a2c8a4f0b5/cloud/filestore/libs/daemon/vhost/bootstrap.cpp#L524 which waits for in-flight requests to complete and hangs because Interconnect is not working https://github.com/ydb-platform/nbs/blob/5cf58a77d9adcc346425923bb922d6a2c8a4f0b5/cloud/filestore/libs/endpoint/endpoint_manager.cpp#L184

So the safe approach is to call _exit, which skips process shutdown

### Issue
#5356 