### PR TITLE
issue-5306: fixed crash in lwtrace upon ExtractItems in an empty TCyclicDepot

### DIFF
--- a/library/cpp/lwtrace/log.h
+++ b/library/cpp/lwtrace/log.h
@@ -44,6 +44,8 @@ namespace NLWTrace {
     public:
         explicit TCyclicBuffer(size_t capacity)
             : Data(capacity)
+            , Front(nullptr)
+            , Back(nullptr)
             , Size(0)
         {
         }
@@ -448,10 +450,12 @@ namespace NLWTrace {
             template <class TReader>
             void ExtractItems(TReader& r) {
                 ReadItems(r);
-                for (TItem *i = OldBuffer->GetFront(), *e = OldBuffer->GetBack();; OldBuffer->Inc(i)) {
-                    i->Clear();
-                    if (i == e) {
-                        break;
+                if (OldBuffer->GetSize() > 0) {
+                    for (TItem *i = OldBuffer->GetFront(), *e = OldBuffer->GetBack();; OldBuffer->Inc(i)) {
+                        i->Clear();
+                        if (i == e) {
+                            break;
+                        }
                     }
                 }
                 OldBuffer->Clear();

--- a/library/cpp/lwtrace/log_ut.cpp
+++ b/library/cpp/lwtrace/log_ut.cpp
@@ -12,6 +12,7 @@ namespace
 
         void Clear()
         {
+            Val = 0;
         }
     };
 
@@ -67,6 +68,18 @@ Y_UNIT_TEST_SUITE(LWTraceLog) {
         log.ReadItems(reader);
 
         UNIT_ASSERT_VALUES_EQUAL(6, reader.NumSeen);
+    }
+
+    Y_UNIT_TEST(ShouldNotCrashOnEmptyCyclicLog) {
+        TCyclicLogImpl<TData> log(100);
+        {
+            TCyclicLogImpl<TData>::TAccessor acc1(log);
+        }
+
+        TReader reader;
+
+        log.ExtractItems(reader);
+        UNIT_ASSERT_VALUES_EQUAL(0, reader.NumSeen);
    }
 
     Y_UNIT_TEST(ShouldNotReturnProcessedItemsViaMoveItems) {


### PR DESCRIPTION
### Notes
`ReadItems()` contains a check for 0 `Size` but `ExtractItems()` doesn't - adding it. Zero-initializing `Front` and `Back` as well to get an immediate `SIGSEGV` instead of possible memory corruption if there's some other code path that tries to access `TCyclicBuffer` items w/o `Size` checks. Fixed lwtrace unittests to actually do something upon `TItem::Clear()` - otherwise there's no memory access and no crash upon null item access.

### Issue
https://github.com/ydb-platform/nbs/issues/5306