### PR TITLE
[NBS-6929]: Limit max in-progress volumes (push&pull combined) for VolumeBalancer

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1470,4 +1470,8 @@ message TStorageServiceConfig
     // Pool kind to storage media kind mapping.
     // Used for cluster capacity estimation (getclustercapacity private api).
     repeated TPoolKindToMediaKindMapping PoolKindToMediaKindMapping = 487;
+
+    // Maximum number of inflight attach/detach path requests.
+    // VolumeBalancerMaxInProgress == 0 means no limit
+    optional uint64 VolumeBalancerMaxInProgress = 488;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -682,6 +682,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(OverlappingRequestsPolicy,                                             \
         NProto::EOverlappingRequestsPolicy,                                    \
         NProto::EOverlappingRequestsPolicy::ORP_ENABLE                        )\
+    xxx(VolumeBalancerMaxInProgress,          ui64,        0                  )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -784,6 +784,8 @@ public:
 
     [[nodiscard]] TPoolKindToMediaKindMapping
     GetPoolKindToMediaKindMapping() const;
+
+    [[nodiscard]] ui64 GetVolumeBalancerMaxInProgress() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -255,6 +255,14 @@ void TVolumeBalancerActor::SendConfigSubscriptionRequest(
         std::move(req));
 }
 
+bool TVolumeBalancerActor::IsMaxInProgressLimitReached() const
+{
+    return StorageConfig &&
+           StorageConfig->GetVolumeBalancerMaxInProgress() > 0 && State &&
+           State->GetVolumesInProgressCount() >=
+               StorageConfig->GetVolumeBalancerMaxInProgress();
+}
+
 void TVolumeBalancerActor::HandleGetVolumeStatsResponse(
     const TEvService::TEvGetVolumeStatsResponse::TPtr& ev,
     const TActorContext& ctx)
@@ -328,12 +336,22 @@ void TVolumeBalancerActor::HandleGetVolumeStatsResponse(
             *CpuWaitCounter,
             ctx.Now());
 
-        if (IsBalancerEnabled()) {
+        if (IsBalancerEnabled() && !IsMaxInProgressLimitReached()) {
             if (auto vol = State->GetVolumeToPush()) {
                 SendVolumeToHive(ctx, std::move(vol));
             } else if (auto vol = State->GetVolumeToPull()) {
                 PullVolumeFromHive(ctx, std::move(vol));
             }
+        } else if (IsMaxInProgressLimitReached()) {
+            // StorageConfig isn't nullptr as limit wouldn't
+            // be in effect otherwise
+            LOG_INFO_S(
+                ctx,
+                TBlockStoreComponents::VOLUME_BALANCER,
+                "Skipping balancer operation: "
+                    << State->GetVolumesInProgressCount() << "/"
+                    << StorageConfig->GetVolumeBalancerMaxInProgress()
+                    << " volumes already in progress");
         }
 
         ctx.Schedule(Timeout, new TEvents::TEvWakeup());

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
@@ -80,6 +80,8 @@ private:
 
     void SendConfigSubscriptionRequest(const NActors::TActorContext& ctx);
 
+    bool IsMaxInProgressLimitReached() const;
+
     STFUNC(StateWork);
 
     void HandleWakeup(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -113,6 +113,11 @@ public:
         VolumesInProgress.erase(std::move(volume));
     }
 
+    auto GetVolumesInProgressCount() const
+    {
+        return VolumesInProgress.size();
+    }
+
 private:
     void RenderLocalVolumes(TStringStream& out) const;
     void RenderPreemptedVolumes(TStringStream& out, TInstant now) const;

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -96,6 +96,12 @@ public:
         return *this;
     }
 
+    TVolumeBalancerConfigBuilder& WithMaxInProgress(ui64 maxInProgress)
+    {
+        StorageConfig.SetVolumeBalancerMaxInProgress(maxInProgress);
+        return *this;
+    }
+
     NProto::TStorageServiceConfig Build()
     {
         return StorageConfig;
@@ -446,7 +452,7 @@ TString RunState(
         auto ev = testEnv.GrabBindingRequest();
         UNIT_ASSERT(!ev);
 
-        testEnv.GrabVolumesStatsRequest();
+        auto statRequestEvent = testEnv.GrabVolumesStatsRequest();
 
         TVector<NProto::TVolumeBalancerDiskStats> stats;
         for (const auto& v: volumes) {
@@ -463,7 +469,9 @@ TString RunState(
                 : TResultOrError<TDuration>(
                       cpuWait.GetResult() * TDuration::Seconds(15)));
 
-        testEnv.SendVolumesStatsResponse(actorId, stats);
+        if (statRequestEvent.Get() != nullptr) {
+            testEnv.SendVolumesStatsResponse(actorId, stats);
+        }
 
         testEnv.DispatchEvents(TDuration::Seconds(1));
     }
@@ -945,6 +953,118 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
             serverGroup
                 ->GetCounter("AppCriticalEvents/CpuWaitCounterReadError", true)
                 ->Val());
+    }
+
+    Y_UNIT_TEST(ShouldRespectInProgressLimitDisabled)
+    {
+        TVolumeBalancerTestEnv testEnv;
+        TVolumeBalancerConfigBuilder config;
+
+        auto volumeBindingActorID = testEnv.Register(CreateVolumeBalancerActor(
+            config.WithType(NProto::PREEMPTION_MOVE_LEAST_HEAVY)
+                .WithMaxInProgress(0),
+            testEnv.VolumeStats,
+            testEnv.Fetcher,
+            testEnv.GetEdgeActor()));
+
+        testEnv.DispatchEvents();
+
+        auto diskId = RunState(
+            testEnv,
+            volumeBindingActorID,
+            {
+                {"vol0", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol1", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol2", true, NProto::EPreemptionSource::SOURCE_NONE},
+            },
+            {{"vol0", 10}, {"vol1", 1}, {"vol2", 2}},
+            1,
+            EChangeBindingOp::RELEASE_TO_HIVE,
+            TDuration::Seconds(15));
+
+        UNIT_ASSERT_VALUES_EQUAL("vol1", diskId);
+
+        auto diskId2 = RunState(
+            testEnv,
+            volumeBindingActorID,
+            {
+                {"vol0", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol1", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol2", true, NProto::EPreemptionSource::SOURCE_NONE},
+            },
+            {{"vol0", 10}, {"vol1", 1}, {"vol2", 2}},
+            1,
+            EChangeBindingOp::RELEASE_TO_HIVE,
+            TDuration::Seconds(15));
+
+        UNIT_ASSERT_VALUES_EQUAL("vol2", diskId2);
+    }
+
+    Y_UNIT_TEST(ShouldRespectInProgressLimitSetToOne)
+    {
+        TVolumeBalancerTestEnv testEnv;
+        TVolumeBalancerConfigBuilder config;
+
+        auto volumeBindingActorID = testEnv.Register(CreateVolumeBalancerActor(
+            config.WithType(NProto::PREEMPTION_MOVE_LEAST_HEAVY)
+                .WithMaxInProgress(1),
+            testEnv.VolumeStats,
+            testEnv.Fetcher,
+            testEnv.GetEdgeActor()));
+
+        testEnv.DispatchEvents();
+
+        auto diskId = RunState(
+            testEnv,
+            volumeBindingActorID,
+            {
+                {"vol0", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol1", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol2", true, NProto::EPreemptionSource::SOURCE_NONE},
+            },
+            {{"vol0", 10}, {"vol1", 1}, {"vol2", 2}},
+            1,
+            EChangeBindingOp::RELEASE_TO_HIVE,
+            TDuration::Seconds(15));
+
+        UNIT_ASSERT_VALUES_EQUAL("vol1", diskId);
+
+        // Expect to not get any preemption requests while first one
+        // is in progress
+        auto diskId2 = RunState(
+            testEnv,
+            volumeBindingActorID,
+            {
+                {"vol0", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol1", false, NProto::EPreemptionSource::SOURCE_BALANCER},
+                {"vol2", true, NProto::EPreemptionSource::SOURCE_NONE},
+            },
+            {{"vol0", 10}, {"vol1", 1}, {"vol2", 2}},
+            1,
+            {},
+            TDuration::Seconds(15));
+
+        UNIT_ASSERT(diskId2.empty());
+
+        testEnv.SendChangeVolumeBindingResponse(
+            volumeBindingActorID,
+            "vol1",
+            {});
+
+        auto diskId3 = RunState(
+            testEnv,
+            volumeBindingActorID,
+            {
+                {"vol0", true, NProto::EPreemptionSource::SOURCE_NONE},
+                {"vol1", false, NProto::EPreemptionSource::SOURCE_BALANCER},
+                {"vol2", true, NProto::EPreemptionSource::SOURCE_NONE},
+            },
+            {{"vol0", 10}, {"vol1", 1}, {"vol2", 2}},
+            1,
+            EChangeBindingOp::RELEASE_TO_HIVE,
+            TDuration::Seconds(15));
+
+        UNIT_ASSERT_VALUES_EQUAL("vol2", diskId3);
     }
 }
 


### PR DESCRIPTION
Limiting the maximum amount of simultaneous volume pushes & pulls is intended to reduce damage during incidents.
Also, this change is an important part of the new preemption approach #5235 practically stopping preemptions if single request hangs

If `VolumeBalancerMaxInProgress` is set to 0 (default), no limit is applied