### PR TITLE
issue-5094: [Disk Manager] Add scrubbing invalid node id ut

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
@@ -67,18 +67,6 @@ func (c *ClientMock) DescribeModel(
 	return res, args.Error(1)
 }
 
-func (c *ClientMock) CreateCheckpoint(
-	ctx context.Context,
-	session nfs.Session,
-	filesystemID string,
-	checkpointID string,
-	nodeID uint64,
-) error {
-
-	args := c.Called(ctx, session, filesystemID, checkpointID, nodeID)
-	return args.Error(0)
-}
-
 func (c *ClientMock) DestroyCheckpoint(
 	ctx context.Context,
 	filesystemID string,
@@ -99,49 +87,6 @@ func (c *ClientMock) CreateSession(
 	args := c.Called(ctx, fileSystemID, checkpointID, readonly)
 	res, _ := args.Get(0).(nfs.Session)
 	return res, args.Error(1)
-}
-
-func (c *ClientMock) DestroySession(
-	ctx context.Context,
-	session nfs.Session,
-) error {
-
-	args := c.Called(ctx, session)
-	return args.Error(0)
-}
-
-func (c *ClientMock) ListNodes(
-	ctx context.Context,
-	session nfs.Session,
-	parentNodeID uint64,
-	cookie string,
-	maxBytes uint32,
-	unsafe bool,
-) ([]nfs.Node, string, error) {
-
-	args := c.Called(ctx, session, parentNodeID, cookie, maxBytes, unsafe)
-	res, _ := args.Get(0).([]nfs.Node)
-	return res, args.Get(1).(string), args.Error(2)
-}
-
-func (c *ClientMock) CreateNode(
-	ctx context.Context,
-	session nfs.Session,
-	node nfs.Node,
-) (uint64, error) {
-
-	args := c.Called(ctx, session, node)
-	return args.Get(0).(uint64), args.Error(1)
-}
-
-func (c *ClientMock) ReadLink(
-	ctx context.Context,
-	session nfs.Session,
-	nodeID uint64,
-) ([]byte, error) {
-
-	args := c.Called(ctx, session, nodeID)
-	return args.Get(0).([]byte), args.Error(1)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/clients/nfs/mocks/session_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/mocks/session_mock.go
@@ -1,0 +1,75 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type SessionMock struct {
+	mock.Mock
+}
+
+func (s *SessionMock) ListNodes(
+	ctx context.Context,
+	parentNodeID uint64,
+	cookie string,
+	maxBytes uint32,
+	unsafe bool,
+) ([]nfs.Node, string, error) {
+
+	args := s.Called(ctx, parentNodeID, cookie, maxBytes, unsafe)
+	res, _ := args.Get(0).([]nfs.Node)
+	return res, args.String(1), args.Error(2)
+}
+
+func (s *SessionMock) CreateCheckpoint(
+	ctx context.Context,
+	filesystemID string,
+	checkpointID string,
+	nodeID uint64,
+) error {
+
+	args := s.Called(ctx, filesystemID, checkpointID, nodeID)
+	return args.Error(0)
+}
+
+func (s *SessionMock) CreateNode(
+	ctx context.Context,
+	node nfs.Node,
+) (uint64, error) {
+
+	args := s.Called(ctx, node)
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+func (s *SessionMock) ReadLink(
+	ctx context.Context,
+	nodeID uint64,
+) ([]byte, error) {
+
+	args := s.Called(ctx, nodeID)
+	res, _ := args.Get(0).([]byte)
+	return res, args.Error(1)
+}
+
+func (s *SessionMock) Close(ctx context.Context) error {
+	args := s.Called(ctx)
+	return args.Error(0)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func NewSessionMock() *SessionMock {
+	return &SessionMock{}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Ensure that SessionMock implements nfs.Session.
+func assertSessionMockIsSession(arg *SessionMock) nfs.Session {
+	return arg
+}

--- a/cloud/disk_manager/internal/pkg/clients/nfs/mocks/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/mocks/ya.make
@@ -3,6 +3,7 @@ GO_LIBRARY()
 SRCS(
     client_mock.go
     factory_mock.go
+    session_mock.go
 )
 
 END()

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks/storage_mock.go
@@ -20,7 +20,7 @@ func (s *StorageMock) SchedulerDirectoryForTraversal(
 	nodeID uint64,
 ) error {
 
-	args := s.Called(ctx, snapshotID)
+	args := s.Called(ctx, snapshotID, nodeID)
 	return args.Error(0)
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/tests/ya.make
@@ -6,6 +6,12 @@ REQUIREMENTS(
     ram:16
 )
 
+PEERDIR(
+    cloud/disk_manager/internal/pkg/clients/nfs/mocks
+    cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks
+    cloud/filestore/public/sdk/go/client
+)
+
 IF (RACE)
     SIZE(LARGE)
     TAG(ya:fat ya:force_sandbox ya:sandbox_coverage)

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
@@ -7,14 +7,18 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs"
+	nfs_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs/mocks"
 	nfs_testing "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs/testing"
 	traversal_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/config"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage"
+	storage_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/schema"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	nfs_client "github.com/ydb-platform/nbs/cloud/filestore/public/sdk/go/client"
 	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
 	persistence_config "github.com/ydb-platform/nbs/cloud/tasks/persistence/config"
 )
@@ -300,4 +304,176 @@ func TestTraversalShouldCloseSessionOnError(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, expectedError)
+}
+
+func TestTraversalFiltersInvalidNodeIDs(t *testing.T) {
+	ctx := nfs_testing.NewContext()
+
+	storageMock := storage_mocks.NewStorageMock()
+	clientMock := nfs_mocks.NewClientMock()
+	sessionMock := nfs_mocks.NewSessionMock()
+
+	snapshotID := "test-snapshot"
+	filesystemID := "test-filesystem"
+	checkpointID := "test-checkpoint"
+	workersCount := uint32(1)
+	selectLimit := uint64(1000)
+
+	config := &traversal_config.FilesystemTraversalConfig{
+		TraversalWorkersCount:  &workersCount,
+		SelectNodesToListLimit: &selectLimit,
+	}
+
+	validDirNodeID := uint64(100)
+	validFileNodeID := uint64(200)
+
+	children := []nfs.Node{
+		nfs.Node(nfs_client.Node{
+			NodeID: validFileNodeID,
+			Name:   "file.txt",
+			Type:   nfs_client.NODE_KIND_FILE,
+		}),
+		nfs.Node(nfs_client.Node{
+			NodeID: validDirNodeID,
+			Name:   "subdir",
+			Type:   nfs_client.NODE_KIND_DIR,
+		}),
+		nfs.Node(nfs_client.Node{
+			NodeID: nfs.InvalidNodeID,
+			Name:   "corrupted_dir_1",
+			Type:   nfs_client.NODE_KIND_DIR,
+		}),
+		nfs.Node(nfs_client.Node{
+			NodeID: nfs.InvalidNodeID,
+			Name:   "corrupted_dir_2",
+			Type:   nfs_client.NODE_KIND_DIR,
+		}),
+	}
+
+	// Schedule root node for traversal.
+	storageMock.On(
+		"SchedulerDirectoryForTraversal",
+		mock.Anything,
+		snapshotID,
+		nfs.RootNodeID,
+	).Return(nil)
+
+	// First SelectNodesToList returns root node.
+	storageMock.On(
+		"SelectNodesToList",
+		mock.Anything,
+		snapshotID,
+		mock.Anything, // nodesToExclude
+		selectLimit,
+	).Return(
+		[]storage.NodeQueueEntry{{NodeID: nfs.RootNodeID, Cookie: ""}},
+		nil,
+	).Once()
+
+	// Second SelectNodesToList returns subdir.
+	storageMock.On(
+		"SelectNodesToList",
+		mock.Anything,
+		snapshotID,
+		mock.Anything, // nodesToExclude
+		selectLimit,
+	).Return(
+		[]storage.NodeQueueEntry{{NodeID: validDirNodeID, Cookie: ""}},
+		nil,
+	).Once()
+
+	// Third SelectNodesToList returns empty, traversal done.
+	storageMock.On(
+		"SelectNodesToList",
+		mock.Anything,
+		snapshotID,
+		mock.Anything, // nodesToExclude
+		selectLimit,
+	).Return([]storage.NodeQueueEntry{}, nil)
+
+	// Create session.
+	clientMock.On(
+		"CreateSession",
+		mock.Anything,
+		filesystemID,
+		checkpointID,
+		true, // readonly
+	).Return(sessionMock, nil)
+
+	// ListNodes for root returns children with some invalid node IDs.
+	sessionMock.On(
+		"ListNodes",
+		mock.Anything,
+		nfs.RootNodeID,
+		"",        // cookie
+		uint32(0), // maxBytes
+		false,     // unsafe
+	).Return(children, "", nil)
+
+	// ListNodes for subdir returns empty.
+	sessionMock.On(
+		"ListNodes",
+		mock.Anything,
+		validDirNodeID,
+		"",        // cookie
+		uint32(0), // maxBytes
+		false,     // unsafe
+	).Return([]nfs.Node{}, "", nil)
+
+	// ScheduleChildNodesForListing for root — only valid dir expected.
+	storageMock.On(
+		"ScheduleChildNodesForListing",
+		mock.Anything,
+		snapshotID,
+		nfs.RootNodeID,
+		"", // nextCookie
+		[]nfs.Node{nfs.Node(nfs_client.Node{
+			NodeID: validDirNodeID,
+			Name:   "subdir",
+			Type:   nfs_client.NODE_KIND_DIR,
+		})},
+	).Return(nil)
+
+	// ScheduleChildNodesForListing for subdir — no children.
+	storageMock.On(
+		"ScheduleChildNodesForListing",
+		mock.Anything,
+		snapshotID,
+		validDirNodeID,
+		"", // nextCookie
+		[]nfs.Node(nil),
+	).Return(nil)
+
+	sessionMock.On("Close", mock.Anything).Return(nil)
+
+	traverser := NewFilesystemTraverser(
+		snapshotID,
+		filesystemID,
+		checkpointID,
+		clientMock,
+		storageMock,
+		func(ctx context.Context) error {
+			return nil
+		},
+		config,
+		false, // rootNodeAlreadyScheduled
+		0,     // listNodesMaxBytes
+		nfs.RootNodeID,
+	)
+
+	err := traverser.Traverse(
+		ctx,
+		func(
+			ctx context.Context,
+			nodes []nfs.Node,
+			session nfs.Session,
+		) error {
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	storageMock.AssertExpectations(t)
+	clientMock.AssertExpectations(t)
+	sessionMock.AssertExpectations(t)
 }


### PR DESCRIPTION
Add unit test to check that we do not fail on scrubbing when nfs client with unsafe option returns invalid node ids for corrupt node refs  in shard.
#5094