### PR TITLE
issue-5094: [Disk Manager] Add metrics for nfs client

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/metrics/metrics.go
+++ b/cloud/disk_manager/internal/pkg/clients/metrics/metrics.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type Metrics interface {
+	OnError(err error)
+	StatRequest(name string) func(err *error)
+}
+
+func New(
+	registry metrics.Registry,
+	tags map[string]string,
+) Metrics {
+
+	registry = registry.WithTags(tags)
+
+	return &clientMetrics{
+		registry:         registry,
+		underlyingErrors: registry.Counter("underlying_errors"),
+		requestStats:     make(map[string]*requestStats),
+	}
+}

--- a/cloud/disk_manager/internal/pkg/clients/metrics/metrics_impl.go
+++ b/cloud/disk_manager/internal/pkg/clients/metrics/metrics_impl.go
@@ -1,10 +1,9 @@
-package nbs
+package metrics
 
 import (
 	"sync"
 	"time"
 
-	nbs_client "github.com/ydb-platform/nbs/cloud/blockstore/public/sdk/go/client"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 )
 
@@ -73,7 +72,7 @@ func (m *clientMetrics) getOrNewRequestStats(
 	return stats
 }
 
-func (m *clientMetrics) OnError(err nbs_client.ClientError) {
+func (m *clientMetrics) OnError(err error) {
 	// TODO: split metrics into types (retriable, fatal, etc.)
 	m.underlyingErrors.Inc()
 }
@@ -90,22 +89,4 @@ func (m *clientMetrics) StatRequest(name string) func(err *error) {
 			stats.recordDuration(time.Since(start))
 		}
 	}
-}
-
-func newClientMetrics(registry metrics.Registry) *clientMetrics {
-	return &clientMetrics{
-		registry:         registry,
-		underlyingErrors: registry.Counter("underlying_errors"),
-		requestStats:     make(map[string]*requestStats),
-	}
-}
-
-func newSessionMetrics(
-	registry metrics.Registry,
-	host string,
-) *clientMetrics {
-
-	return newClientMetrics(registry.WithTags(map[string]string{
-		"request_host": host,
-	}))
 }

--- a/cloud/disk_manager/internal/pkg/clients/metrics/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/metrics/ya.make
@@ -1,0 +1,8 @@
+GO_LIBRARY()
+
+SRCS(
+    metrics.go
+    metrics_impl.go
+)
+
+END()

--- a/cloud/disk_manager/internal/pkg/clients/nbs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/client.go
@@ -12,6 +12,7 @@ import (
 	private_protos "github.com/ydb-platform/nbs/cloud/blockstore/private/api/protos"
 	"github.com/ydb-platform/nbs/cloud/blockstore/public/api/protos"
 	nbs_client "github.com/ydb-platform/nbs/cloud/blockstore/public/sdk/go/client"
+	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/pkg/client/codes"
@@ -562,7 +563,7 @@ func canBeBaseDisk(volume *protos.TVolume) bool {
 type client struct {
 	nbs                           *nbs_client.DiscoveryClient
 	sessionMetricsRegistry        metrics.Registry
-	metrics                       *clientMetrics
+	metrics                       client_metrics.Metrics
 	enableThrottlingForMediaKinds []core_protos.EStorageMediaKind
 	sessionRediscoverPeriodMin    time.Duration
 	sessionRediscoverPeriodMax    time.Duration

--- a/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
@@ -6,6 +6,7 @@ import (
 
 	nbs_client "github.com/ydb-platform/nbs/cloud/blockstore/public/sdk/go/client"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth"
+	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
 	nbs_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nbs/config"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	coreprotos "github.com/ydb-platform/nbs/cloud/storage/core/protos"
@@ -23,7 +24,7 @@ type factory struct {
 	config                 *nbs_config.ClientConfig
 	credentials            auth.Credentials
 	sessionMetricsRegistry metrics.Registry
-	metrics                *clientMetrics
+	metrics                client_metrics.Metrics
 	clients                map[string]client
 	multiZoneClients       map[[2]string]multiZoneClient
 }
@@ -134,7 +135,7 @@ func (f *factory) initClients(
 							tracing.AttributeError(&err),
 						),
 					)
-					f.metrics.OnError(err)
+					f.metrics.OnError(&err)
 				},
 			},
 			&nbs_client.DiscoveryClientOpts{
@@ -295,7 +296,10 @@ func newFactoryWithCreds(
 		config:                 config,
 		credentials:            creds,
 		sessionMetricsRegistry: sessionMetricsRegistry,
-		metrics:                newClientMetrics(clientMetricsRegistry),
+		metrics:                client_metrics.New(
+			clientMetricsRegistry,
+			map[string]string{},
+		),
 	}
 	err := f.initClients(ctx)
 	if err != nil {

--- a/cloud/disk_manager/internal/pkg/clients/nbs/multi_zone_client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/multi_zone_client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ydb-platform/nbs/cloud/blockstore/public/api/protos"
 	nbs_client "github.com/ydb-platform/nbs/cloud/blockstore/public/sdk/go/client"
+	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 	"github.com/ydb-platform/nbs/cloud/tasks/tracing"
@@ -15,7 +16,7 @@ import (
 type multiZoneClient struct {
 	srcZoneClient *client
 	dstZoneClient *client
-	metrics       *clientMetrics
+	metrics       client_metrics.Metrics
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/clients/nbs/session.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/ydb-platform/nbs/cloud/blockstore/public/api/protos"
 	nbs_client "github.com/ydb-platform/nbs/cloud/blockstore/public/sdk/go/client"
+	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/common"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
@@ -38,7 +39,7 @@ type Session struct {
 	mutex            sync.RWMutex
 	client           *nbs_client.Client
 	session          *nbs_client.Session
-	metrics          *clientMetrics
+	metrics          client_metrics.Metrics
 	volume           *protos.TVolume
 	cancelRediscover func()
 }
@@ -410,7 +411,10 @@ func (s *Session) discoverAndMount(ctx context.Context) (*protos.TVolume, error)
 		*client,
 		logging.GetLogger(ctx),
 	)
-	s.metrics = newSessionMetrics(s.metricsRegistry, host)
+	s.metrics = client_metrics.New(
+		s.metricsRegistry,
+		map[string]string{"request_host": host},
+	)
 
 	err = s.session.MountVolume(
 		s.withClientID(ctx),

--- a/cloud/disk_manager/internal/pkg/clients/nbs/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/ya.make
@@ -9,10 +9,13 @@ SRCS(
     client.go
     factory.go
     interface.go
-    metrics.go
     multi_zone_client.go
     session.go
     testing_client.go
+)
+
+PEERDIR(
+    cloud/disk_manager/internal/pkg/clients/metrics
 )
 
 END()

--- a/cloud/disk_manager/internal/pkg/clients/nfs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/client.go
@@ -3,6 +3,7 @@ package nfs
 import (
 	"context"
 
+	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
 	nfs_client "github.com/ydb-platform/nbs/cloud/filestore/public/sdk/go/client"
@@ -81,22 +82,11 @@ func setupStderrLogger(ctx context.Context) context.Context {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-type clientMetrics struct {
-	registry metrics.Registry
-	errors   metrics.Counter
-}
-
-func (m *clientMetrics) OnError(err nfs_client.ClientError) {
-	// TODO: split metrics into types (retriable, fatal, etc.)
-	m.errors.Inc()
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 type client struct {
-	nfs     *nfs_client.Client
-	metrics clientMetrics
-	zoneID  string
+	nfs             *nfs_client.Client
+	metrics         client_metrics.Metrics
+	metricsRegistry metrics.Registry
+	zoneID          string
 }
 
 func (c *client) ZoneID() string {
@@ -111,7 +101,9 @@ func (c *client) Create(
 	ctx context.Context,
 	filesystemID string,
 	params CreateFilesystemParams,
-) error {
+) (err error) {
+
+	defer c.metrics.StatRequest("Create")(&err)
 
 	mediaKind, err := getStorageMediaKind(params.Kind)
 	if err != nil {
@@ -137,9 +129,11 @@ func (c *client) Delete(
 	ctx context.Context,
 	filesystemID string,
 	force bool,
-) error {
+) (err error) {
 
-	err := c.nfs.DestroyFileStore(ctx, filesystemID, force)
+	defer c.metrics.StatRequest("Delete")(&err)
+
+	err = c.nfs.DestroyFileStore(ctx, filesystemID, force)
 	return wrapError(err)
 }
 
@@ -147,7 +141,9 @@ func (c *client) Resize(
 	ctx context.Context,
 	filesystemID string,
 	size uint64,
-) error {
+) (err error) {
+
+	defer c.metrics.StatRequest("Resize")(&err)
 
 	retries := 0
 	for {
@@ -203,7 +199,9 @@ func (c *client) DescribeModel(
 	blocksCount uint64,
 	blockSize uint32,
 	kind types.FilesystemKind,
-) (FilesystemModel, error) {
+) (_ FilesystemModel, err error) {
+
+	defer c.metrics.StatRequest("DescribeModel")(&err)
 
 	mediaKind, err := getStorageMediaKind(kind)
 	if err != nil {
@@ -238,7 +236,9 @@ func (c *client) DestroyCheckpoint(
 	ctx context.Context,
 	filesystemID string,
 	checkpointID string,
-) error {
+) (err error) {
+
+	defer c.metrics.StatRequest("DestroyCheckpoint")(&err)
 
 	return c.nfs.DestroyCheckpoint(
 		ctx,
@@ -252,7 +252,9 @@ func (c *client) CreateSession(
 	fileSystemID string,
 	checkpointID string,
 	readonly bool,
-) (Session, error) {
+) (_ Session, err error) {
+
+	defer c.metrics.StatRequest("CreateSession")(&err)
 
 	s, err := c.nfs.CreateSession(ctx, fileSystemID, checkpointID, readonly)
 	if err != nil {
@@ -260,7 +262,10 @@ func (c *client) CreateSession(
 	}
 
 	return &session{
-		nfs:     c.nfs,
-		session: s,
+		nfs:             c.nfs,
+		session:         s,
+		metricsRegistry: c.metricsRegistry,
+		filesystemID:    fileSystemID,
+		checkpointID:    checkpointID,
 	}, nil
 }

--- a/cloud/disk_manager/internal/pkg/clients/nfs/factory.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/factory.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth"
+	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
 	nfs_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs/config"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	nfs_client "github.com/ydb-platform/nbs/cloud/filestore/public/sdk/go/client"
@@ -103,7 +104,8 @@ func NewNfsClientLog(level nfs_client.LogLevel) nfs_client.Log {
 type factory struct {
 	config            *nfs_config.ClientConfig
 	clientCredentials *nfs_client.ClientCredentials
-	metrics           clientMetrics
+	metrics           client_metrics.Metrics
+	metricsRegistry   metrics.Registry
 	// map from zone
 	endpointPickers map[string]*endpointPicker
 }
@@ -156,7 +158,7 @@ func (f *factory) NewClient(
 		&nfs_client.DurableClientOpts{
 			Timeout: &durableClientTimeout,
 			OnError: func(err nfs_client.ClientError) {
-				f.metrics.OnError(err)
+				f.metrics.OnError(&err)
 			},
 		},
 		NewNfsClientLog(nfs_client.LOG_DEBUG),
@@ -166,9 +168,10 @@ func (f *factory) NewClient(
 	}
 
 	return &client{
-		nfs:     nfs,
-		metrics: f.metrics,
-		zoneID:  zoneID,
+		nfs:             nfs,
+		metrics:         f.metrics,
+		metricsRegistry: f.metricsRegistry,
+		zoneID:          zoneID,
 	}, nil
 }
 
@@ -196,10 +199,10 @@ func NewFactoryWithCreds(
 	metricsRegistry metrics.Registry,
 ) Factory {
 
-	clientMetrics := clientMetrics{
-		registry: metricsRegistry,
-		errors:   metricsRegistry.Counter("errors"),
-	}
+	clientMetrics := client_metrics.New(
+		metricsRegistry,
+		map[string]string{"client": "nfs"},
+	)
 
 	if config.GetDisableAuthentication() {
 		credentials = nil
@@ -225,6 +228,7 @@ func NewFactoryWithCreds(
 		config:            config,
 		clientCredentials: clientCredentials,
 		metrics:           clientMetrics,
+		metricsRegistry:   metricsRegistry,
 		endpointPickers:   endpointPickers,
 	}
 }

--- a/cloud/disk_manager/internal/pkg/clients/nfs/session.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/session.go
@@ -3,6 +3,8 @@ package nfs
 import (
 	"context"
 
+	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	nfs_protos "github.com/ydb-platform/nbs/cloud/filestore/public/api/protos"
 	nfs_client "github.com/ydb-platform/nbs/cloud/filestore/public/sdk/go/client"
 )
@@ -21,8 +23,27 @@ const (
 ////////////////////////////////////////////////////////////////////////////////
 
 type session struct {
-	nfs     *nfs_client.Client
-	session nfs_client.Session
+	nfs             *nfs_client.Client
+	session         nfs_client.Session
+	metrics         client_metrics.Metrics
+	metricsRegistry metrics.Registry
+	filesystemID    string
+	checkpointID    string
+}
+
+func (s *session) initMetrics() {
+	if s.metrics != nil {
+		return
+	}
+
+	s.metrics = client_metrics.New(
+		s.metricsRegistry,
+		map[string]string{
+			"client":        "nfs",
+			"filesystem_id": s.filesystemID,
+			"checkpoint_id": s.checkpointID,
+		},
+	)
 }
 
 func (s *session) CreateCheckpoint(
@@ -30,7 +51,10 @@ func (s *session) CreateCheckpoint(
 	filesystemID string,
 	checkpointID string,
 	nodeID uint64,
-) error {
+) (err error) {
+
+	s.initMetrics()
+	defer s.metrics.StatRequest("CreateCheckpoint")(&err)
 
 	return wrapError(
 		s.nfs.CreateCheckpoint(
@@ -55,7 +79,10 @@ func (s *session) ListNodes(
 	cookie string,
 	maxBytes uint32,
 	unsafe bool,
-) ([]Node, string, error) {
+) (_ []Node, _ string, err error) {
+
+	s.initMetrics()
+	defer s.metrics.StatRequest("ListNodes")(&err)
 
 	nodes, cookie, err := s.nfs.ListNodes(
 		ctx,
@@ -76,7 +103,10 @@ func (s *session) ListNodes(
 func (s *session) CreateNode(
 	ctx context.Context,
 	node Node,
-) (uint64, error) {
+) (_ uint64, err error) {
+
+	s.initMetrics()
+	defer s.metrics.StatRequest("CreateNode")(&err)
 
 	nodeID, err := s.nfs.CreateNode(
 		ctx,
@@ -89,7 +119,10 @@ func (s *session) CreateNode(
 func (s *session) ReadLink(
 	ctx context.Context,
 	nodeID uint64,
-) ([]byte, error) {
+) (_ []byte, err error) {
+
+	s.initMetrics()
+	defer s.metrics.StatRequest("ReadLink")(&err)
 
 	data, err := s.nfs.ReadLink(ctx, s.session, nodeID)
 	return data, wrapError(err)

--- a/cloud/disk_manager/internal/pkg/clients/nfs/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/ya.make
@@ -13,6 +13,10 @@ SRCS(
     session.go
 )
 
+PEERDIR(
+    cloud/disk_manager/internal/pkg/clients/metrics
+)
+
 END()
 
 RECURSE(

--- a/cloud/disk_manager/internal/pkg/clients/ya.make
+++ b/cloud/disk_manager/internal/pkg/clients/ya.make
@@ -1,4 +1,5 @@
 RECURSE(
+    metrics
     nbs
     nfs
 )

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -1263,3 +1263,93 @@ func TestDiskServiceDeleteNonExistentDisk(t *testing.T) {
 func TestDiskServiceDeleteNonExistentDiskSync(t *testing.T) {
 	testDiskServiceDeleteNonExistentDisk(t, true /* sync */)
 }
+
+func TestNbsClientReportsMetrics(t *testing.T) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	diskSize := uint64(32 * 1024 * 4096)
+	diskID1 := t.Name() + "1"
+
+	reqCtx := testcommon.GetRequestContext(t, ctx)
+	operation, err := client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcEmpty{
+			SrcEmpty: &empty.Empty{},
+		},
+		Size: int64(diskSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: "zone-a",
+			DiskId: diskID1,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	nbsClient := testcommon.NewNbsTestingClient(t, ctx, "zone-a")
+	_, err = nbsClient.FillDisk(ctx, diskID1, diskSize)
+	require.NoError(t, err)
+
+	snapshotID := t.Name()
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateSnapshot(reqCtx, &disk_manager.CreateSnapshotRequest{
+		Src: &disk_manager.DiskId{
+			ZoneId: "zone-a",
+			DiskId: diskID1,
+		},
+		SnapshotId: snapshotID,
+		FolderId:   "folder",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	diskID2 := t.Name() + "2"
+
+	reqCtx = testcommon.GetRequestContext(t, ctx)
+	operation, err = client.CreateDisk(reqCtx, &disk_manager.CreateDiskRequest{
+		Src: &disk_manager.CreateDiskRequest_SrcSnapshotId{
+			SrcSnapshotId: snapshotID,
+		},
+		Size: int64(diskSize),
+		Kind: disk_manager.DiskKind_DISK_KIND_SSD,
+		DiskId: &disk_manager.DiskId{
+			ZoneId: "zone-a",
+			DiskId: diskID2,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+
+	require.Greater(t, testcommon.GetCounterControlplane(
+		t,
+		"count",
+		map[string]string{"client": "nbs", "request": "Create"},
+	), float64(0))
+
+	require.Greater(t, testcommon.GetCounterDataplane(
+		t,
+		"count",
+		map[string]string{"client": "nbs", "request": "Read"},
+	), float64(0))
+
+	require.Greater(t, testcommon.GetCounterDataplane(
+		t,
+		"count",
+		map[string]string{"client": "nbs", "request": "Write"},
+	), float64(0))
+
+	testcommon.DeleteDisk(t, ctx, client, diskID1)
+	testcommon.DeleteDisk(t, ctx, client, diskID2)
+
+	testcommon.CheckConsistency(t, ctx)
+}

--- a/cloud/disk_manager/internal/pkg/facade/facade_test/facade_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/facade_test/facade_test.go
@@ -64,7 +64,7 @@ func TestFacadeShouldSendErrorMetrics(t *testing.T) {
 		&disk_manager.ListPlacementGroupsRequest{ZoneId: "zone-a"},
 	)
 	require.NoError(t, err)
-	errorsCount := testcommon.GetCounter(
+	errorsCount := testcommon.GetCounterControlplane(
 		t,
 		"errors",
 		map[string]string{
@@ -88,7 +88,7 @@ func TestFacadeShouldSendErrorMetrics(t *testing.T) {
 		},
 	})
 	require.Error(t, err)
-	newErrorsCount := testcommon.GetCounter(
+	newErrorsCount := testcommon.GetCounterControlplane(
 		t,
 		"errors",
 		map[string]string{

--- a/cloud/disk_manager/internal/pkg/facade/filesystem_scrubbing_test/filesystem_scrubbing_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_scrubbing_test/filesystem_scrubbing_test.go
@@ -64,3 +64,83 @@ func TestFilesystemScrubbingTraversesFilesystem(t *testing.T) {
 	testcommon.WaitOperationEnded(t, ctx, taskID)
 	testcommon.CheckConsistency(t, ctx)
 }
+
+func TestNfsClientReportsMetrics(t *testing.T) {
+	ctx := testcommon.NewContext()
+
+	client, err := testcommon.NewClient(ctx)
+	require.NoError(t, err)
+	defer client.Close()
+
+	nfsClient := testcommon.NewNfsTestingClient(t, ctx, "zone-a")
+	defer nfsClient.Close()
+
+	filesystemID := t.Name()
+
+	operation, err := client.CreateFilesystem(
+		testcommon.GetRequestContext(t, ctx),
+		&disk_manager.CreateFilesystemRequest{
+			FilesystemId: &disk_manager.FilesystemId{
+				ZoneId:       "zone-a",
+				FilesystemId: filesystemID,
+			},
+			BlockSize: 4096,
+			Size:      1024 * 1024 * 1024,
+			Kind:      disk_manager.FilesystemKind_FILESYSTEM_KIND_SSD,
+			CloudId:   "cloud",
+			FolderId:  "folder",
+		},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, operation)
+	err = internal_client.WaitOperation(ctx, client, operation.Id)
+	require.NoError(t, err)
+	defer func() {
+		err := nfsClient.Delete(ctx, filesystemID, true)
+		require.NoError(t, err)
+	}()
+
+	nfsClient.FillFilesystemWithDefaultTree(
+		ctx,
+		filesystemID,
+		1000,
+		5,
+		3,
+	)
+
+	taskID := testcommon.ScheduleFilesystemScrubbing(
+		t,
+		ctx,
+		"zone-a",
+		filesystemID,
+	)
+
+	testcommon.WaitOperationEnded(t, ctx, taskID)
+
+	require.Greater(t, testcommon.GetCounterControlplane(
+		t,
+		"count",
+		map[string]string{"client": "nfs", "request": "Create"},
+	), float64(0))
+
+	require.Greater(t, testcommon.GetCounterDataplane(
+		t,
+		"count",
+		map[string]string{
+			"client":        "nfs",
+			"request":       "CreateSession",
+		},
+	), float64(0))
+
+	require.Greater(t, testcommon.GetCounterDataplane(
+		t,
+		"count",
+		map[string]string{
+			"client":        "nfs",
+			"request":       "ListNodes",
+			"filesystem_id": filesystemID,
+		},
+	), float64(0))
+
+	testcommon.CheckConsistency(t, ctx)
+}

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -951,11 +951,17 @@ func httpGetWithRetries(url string) (*http.Response, error) {
 	return retryableClient.Get(url)
 }
 
-func GetCounter(t *testing.T, name string, labels map[string]string) float64 {
+func GetCounter(
+	t *testing.T,
+	port string,
+	name string,
+	labels map[string]string,
+) float64 {
+
 	resp, err := httpGetWithRetries(
 		fmt.Sprintf(
 			"http://localhost:%s/metrics/",
-			os.Getenv("DISK_MANAGER_RECIPE_DISK_MANAGER_MON_PORT"),
+			port,
 		),
 	)
 	require.NoError(t, err)
@@ -999,4 +1005,32 @@ func metricMatchesLabel(
 	}
 
 	return true
+}
+
+func GetCounterControlplane(
+	t *testing.T,
+	name string,
+	labels map[string]string,
+) float64 {
+
+	return GetCounter(
+		t,
+		os.Getenv("DISK_MANAGER_RECIPE_DISK_MANAGER_MON_PORT"),
+		name,
+		labels,
+	)
+}
+
+func GetCounterDataplane(
+	t *testing.T,
+	name string,
+	labels map[string]string,
+) float64 {
+
+	return GetCounter(
+		t,
+		os.Getenv("DISK_MANAGER_RECIPE_DATAPLANE_MON_PORT"),
+		name,
+		labels,
+	)
 }

--- a/cloud/disk_manager/test/recipe/__main__.py
+++ b/cloud/disk_manager/test/recipe/__main__.py
@@ -411,6 +411,8 @@ def start(argv):
             ERR_LOG_FILE_NAMES_FILE, disk_manager.disk_manager.stderr_file_name
         )
 
+    set_env("DISK_MANAGER_RECIPE_DATAPLANE_MON_PORT", str(disk_managers[-1].monitoring_port))
+
     # First node is always control plane.
     set_env("DISK_MANAGER_RECIPE_DISK_MANAGER_PORT", str(disk_managers[0].port))
     set_env("DISK_MANAGER_RECIPE_SERVER_CONFIG", disk_managers[0].server_config)


### PR DESCRIPTION
Extract metrics from nbs client to clients/metrics, slightly rename methods.
Add counters for all nfs requests.
Add tests that metrics are correctly reported during disk creation and filesystem traversal.