### PR TITLE
a benchmark for various concurrent queue-like data structures

### DIFF
--- a/cloud/storage/core/libs/common/bench/queues/main.cpp
+++ b/cloud/storage/core/libs/common/bench/queues/main.cpp
@@ -1,0 +1,234 @@
+#include <library/cpp/testing/benchmark/bench.h>
+
+#include <util/generic/deque.h>
+#include <util/generic/vector.h>
+#include <util/random/fast.h>
+#include <util/system/event.h>
+#include <util/system/mutex.h>
+#include <util/system/spinlock.h>
+#include <util/thread/lfstack.h>
+#include <util/thread/lfqueue.h>
+#include <util/thread/factory.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TQueue>
+void RunBench(TQueue& q, ui64 iters, ui32 producers, ui32 consumers)
+{
+    struct TContext
+    {
+        TManualEvent Ev;
+        std::atomic<ui32> Producers;
+        std::atomic<ui32> Consumers;
+    };
+
+    auto context = std::make_shared<TContext>();
+    context->Producers = producers;
+    context->Consumers = consumers;
+
+    for (ui32 i = 0; i < producers; ++i) {
+        SystemThreadFactory()->Run(
+            [&q, iters, producers, context] ()
+            {
+                for (size_t i = 0; i < iters / producers; ++i) {
+                    q.Enqueue(i);
+                }
+
+                context->Producers.fetch_sub(1, std::memory_order_release);
+                context->Ev.Signal();
+            });
+    }
+
+    for (ui32 i = 0; i < consumers; ++i) {
+        SystemThreadFactory()->Run(
+            [&q, context] ()
+            {
+                while (true) {
+                    if (!q.Dequeue()
+                        && !context->Producers.load(std::memory_order_acquire))
+                    {
+                        break;
+                    }
+                }
+
+                context->Consumers.fetch_sub(1, std::memory_order_release);
+                context->Ev.Signal();
+            });
+    }
+
+    while (context->Producers.load(std::memory_order_acquire)
+            || context->Consumers.load(std::memory_order_acquire))
+    {
+        context->Ev.WaitI();
+        context->Ev.Reset();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TLFStackSingleConsumerDequeueAll
+{
+    TLockFreeStack<ui64> Data;
+    TVector<ui64> Dequeued;
+
+    void Enqueue(ui64 x)
+    {
+        Data.Enqueue(x);
+    }
+
+    bool Dequeue()
+    {
+        Data.DequeueAllSingleConsumer(&Dequeued);
+        const bool haveData = Dequeued.size() > 0;
+        Dequeued.clear();
+        return haveData;
+    }
+};
+
+struct TLFStackDequeueAll
+{
+    TLockFreeStack<ui64> Data;
+    TVector<ui64> Dequeued;
+
+    void Enqueue(ui64 x)
+    {
+        Data.Enqueue(x);
+    }
+
+    bool Dequeue()
+    {
+        Data.DequeueAll(&Dequeued);
+        const bool haveData = Dequeued.size() > 0;
+        Dequeued.clear();
+        return haveData;
+    }
+};
+
+struct TLFQueue
+{
+    TLockFreeQueue<ui64> Data;
+
+    void Enqueue(ui64 x)
+    {
+        Data.Enqueue(x);
+    }
+
+    bool Dequeue()
+    {
+        ui64 x;
+        return Data.Dequeue(&x);
+    }
+};
+
+struct TLFQueueDequeueAll
+{
+    TLockFreeQueue<ui64> Data;
+    TVector<ui64> Dequeued;
+
+    void Enqueue(ui64 x)
+    {
+        Data.Enqueue(x);
+    }
+
+    bool Dequeue()
+    {
+        Data.DequeueAll(&Dequeued);
+        const bool haveData = Dequeued.size() > 0;
+        Dequeued.clear();
+        return haveData;
+    }
+};
+
+struct TDequeWithMutex
+{
+    TDeque<ui64> Data;
+    TMutex Lock;
+
+    void Enqueue(ui64 x)
+    {
+        auto g = Guard(Lock);
+        Data.push_back(x);
+    }
+
+    bool Dequeue()
+    {
+        auto g = Guard(Lock);
+        if (Data.size()) {
+            Data.pop_front();
+            return true;
+        }
+
+        return false;
+    }
+};
+
+struct TDequeWithAdaptiveLock
+{
+    TDeque<ui64> Data;
+    TAdaptiveLock Lock;
+
+    void Enqueue(ui64 x)
+    {
+        auto g = Guard(Lock);
+        Data.push_back(x);
+    }
+
+    bool Dequeue()
+    {
+        auto g = Guard(Lock);
+        if (Data.size()) {
+            Data.pop_front();
+            return true;
+        }
+
+        return false;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define Q_BENCH(TQueue, producers, consumers)                                  \
+    Y_CPU_BENCHMARK(TQueue##_##producers##_##consumers, iface)                 \
+    {                                                                          \
+        TQueue q;                                                              \
+        RunBench(q, iface.Iterations(), 1, 1);                                 \
+    }                                                                          \
+// Q_BENCH
+
+#define Q_BENCH_SET(TQueue, consumers)                                         \
+    Q_BENCH(TQueue, 1, consumers)                                              \
+    Q_BENCH(TQueue, 2, consumers)                                              \
+    Q_BENCH(TQueue, 4, consumers)                                              \
+    Q_BENCH(TQueue, 8, consumers)                                              \
+    Q_BENCH(TQueue, 16, consumers)                                             \
+// Q_BENCH_SET
+
+//
+// Non-DequeueAll LFStack versions are not tested because it's not possible to
+// implement queue-like behaviour on top of them.
+//
+// With DequeueAll the supposed logic looks something like this:
+// TVector<TItem> items;
+// q.DequeueAll(items);
+// for (auto it = items.rbegin(); it != items.rend(); ++it) {
+//     ProcessItem(*it);
+// }
+//
+
+Q_BENCH_SET(TLFStackSingleConsumerDequeueAll, 1)
+Q_BENCH_SET(TLFStackDequeueAll, 1)
+Q_BENCH_SET(TLFStackDequeueAll, 16)
+Q_BENCH_SET(TLFQueue, 1)
+Q_BENCH_SET(TLFQueueDequeueAll, 1)
+Q_BENCH_SET(TLFQueue, 16)
+Q_BENCH_SET(TLFQueueDequeueAll, 16)
+Q_BENCH_SET(TDequeWithMutex, 1)
+Q_BENCH_SET(TDequeWithAdaptiveLock, 1)
+Q_BENCH_SET(TDequeWithMutex, 16)
+Q_BENCH_SET(TDequeWithAdaptiveLock, 16)

--- a/cloud/storage/core/libs/common/bench/queues/ya.make
+++ b/cloud/storage/core/libs/common/bench/queues/ya.make
@@ -1,0 +1,15 @@
+Y_BENCHMARK()
+
+IF (SANITIZER_TYPE)
+    TAG(ya:manual)
+ENDIF()
+
+SRCS(
+    main.cpp
+)
+
+PEERDIR(
+    cloud/storage/core/libs/common
+)
+
+END()

--- a/cloud/storage/core/libs/common/bench/ya.make
+++ b/cloud/storage/core/libs/common/bench/ya.make
@@ -1,3 +1,4 @@
 RECURSE(
     compressed_bitmap
+    queues
 )


### PR DESCRIPTION
Results on my laptop:
```
----------- TLFStackSingleConsumerDequeueAll_1_1 ---------------
 samples:       12114
 iterations:    90592530
 iterations hr:    90.6M
 run time:      5.00210555
 per iteration: 164.8290815 cycles
----------- TLFStackSingleConsumerDequeueAll_2_1 ---------------
 samples:       11608
 iterations:    83185651
 iterations hr:    83.2M
 run time:      5.00152862
 per iteration: 165.4612626 cycles
----------- TLFStackSingleConsumerDequeueAll_4_1 ---------------
 samples:       11571
 iterations:    82657653
 iterations hr:    82.7M
 run time:      5.001762843
 per iteration: 160.8808622 cycles
----------- TLFStackSingleConsumerDequeueAll_8_1 ---------------
 samples:       11475
 iterations:    81287625
 iterations hr:    81.3M
 run time:      5.00162496
 per iteration: 167.3046111 cycles
----------- TLFStackSingleConsumerDequeueAll_16_1 ---------------
 samples:       11519
 iterations:    81913600
 iterations hr:    81.9M
 run time:      5.00212796
 per iteration: 165.9961333 cycles
----------- TLFStackDequeueAll_1_1 ---------------
 samples:       11539
 iterations:    82208253
 iterations hr:    82.2M
 run time:      5.0017673
 per iteration: 164.293308 cycles
----------- TLFStackDequeueAll_2_1 ---------------
 samples:       11476
 iterations:    81313128
 iterations hr:    81.3M
 run time:      5.002175068
 per iteration: 166.0124901 cycles
----------- TLFStackDequeueAll_4_1 ---------------
 samples:       11399
 iterations:    80220111
 iterations hr:    80.2M
 run time:      5.001753096
 per iteration: 173.8644772 cycles
----------- TLFStackDequeueAll_8_1 ---------------
 samples:       11634
 iterations:    83560128
 iterations hr:    83.6M
 run time:      5.001577153
 per iteration: 156.8068007 cycles
----------- TLFStackDequeueAll_16_1 ---------------
 samples:       11508
 iterations:    81760078
 iterations hr:    81.8M
 run time:      5.001868206
 per iteration: 170.0401072 cycles
----------- TLFStackDequeueAll_1_16 ---------------
 samples:       11624
 iterations:    83417986
 iterations hr:    83.4M
 run time:      5.00165347
 per iteration: 164.5910856 cycles
----------- TLFStackDequeueAll_2_16 ---------------
 samples:       11485
 iterations:    81440703
 iterations hr:    81.4M
 run time:      5.001258493
 per iteration: 170.6559163 cycles
----------- TLFStackDequeueAll_4_16 ---------------
 samples:       11533
 iterations:    82118520
 iterations hr:    82.1M
 run time:      5.001697874
 per iteration: 168.5888855 cycles
----------- TLFStackDequeueAll_8_16 ---------------
 samples:       11538
 iterations:    82195431
 iterations hr:    82.2M
 run time:      5.001583198
 per iteration: 166.9556779 cycles
----------- TLFStackDequeueAll_16_16 ---------------
 samples:       11465
 iterations:    81147430
 iterations hr:    81.1M
 run time:      5.001698215
 per iteration: 166.9641571 cycles
----------- TLFQueue_1_1 ---------------
 samples:       7237
 iterations:    32340903
 iterations hr:    32.3M
 run time:      5.00096063
 per iteration: 473.1092809 cycles
----------- TLFQueue_2_1 ---------------
 samples:       7101
 iterations:    31129995
 iterations hr:    31.1M
 run time:      5.001113793
 per iteration: 477.023915 cycles
----------- TLFQueue_4_1 ---------------
 samples:       7166
 iterations:    31708666
 iterations hr:    31.7M
 run time:      5.001493441
 per iteration: 457.3212772 cycles
----------- TLFQueue_8_1 ---------------
 samples:       7109
 iterations:    31201050
 iterations hr:    31.2M
 run time:      5.001743922
 per iteration: 473.6586212 cycles
----------- TLFQueue_16_1 ---------------
 samples:       7175
 iterations:    31788351
 iterations hr:    31.8M
 run time:      5.001986251
 per iteration: 452.5574053 cycles
----------- TLFQueueDequeueAll_1_1 ---------------
 samples:       8469
 iterations:    44288166
 iterations hr:    44.3M
 run time:      5.002279255
 per iteration: 342.4143915 cycles
----------- TLFQueueDequeueAll_2_1 ---------------
 samples:       8425
 iterations:    43828203
 iterations hr:    43.8M
 run time:      5.001806975
 per iteration: 341.9378469 cycles
----------- TLFQueueDequeueAll_4_1 ---------------
 samples:       8500
 iterations:    44608735
 iterations hr:    44.6M
 run time:      5.000969312
 per iteration: 339.1770929 cycles
----------- TLFQueueDequeueAll_8_1 ---------------
 samples:       8397
 iterations:    43529115
 iterations hr:    43.5M
 run time:      5.000918293
 per iteration: 341.3132695 cycles
----------- TLFQueueDequeueAll_16_1 ---------------
 samples:       8487
 iterations:    44467165
 iterations hr:    44.5M
 run time:      5.001495379
 per iteration: 328.8631547 cycles
----------- TLFQueue_1_16 ---------------
 samples:       7144
 iterations:    31509891
 iterations hr:    31.5M
 run time:      5.001290939
 per iteration: 465.8285527 cycles
----------- TLFQueue_2_16 ---------------
 samples:       7122
 iterations:    31319655
 iterations hr:    31.3M
 run time:      5.001603567
 per iteration: 460.2016108 cycles
----------- TLFQueue_4_16 ---------------
 samples:       7110
 iterations:    31208950
 iterations hr:    31.2M
 run time:      5.001670915
 per iteration: 468.445761 cycles
----------- TLFQueue_8_16 ---------------
 samples:       7173
 iterations:    31772406
 iterations hr:    31.8M
 run time:      5.001263024
 per iteration: 454.9646522 cycles
----------- TLFQueue_16_16 ---------------
 samples:       7131
 iterations:    31398850
 iterations hr:    31.4M
 run time:      5.000751964
 per iteration: 475.1449963 cycles
----------- TLFQueueDequeueAll_1_16 ---------------
 samples:       8501
 iterations:    44618181
 iterations hr:    44.6M
 run time:      5.00083192
 per iteration: 323.6969532 cycles
----------- TLFQueueDequeueAll_2_16 ---------------
 samples:       8499
 iterations:    44599290
 iterations hr:    44.6M
 run time:      5.001319376
 per iteration: 337.4215934 cycles
----------- TLFQueueDequeueAll_4_16 ---------------
 samples:       8476
 iterations:    44354071
 iterations hr:    44.4M
 run time:      5.001286744
 per iteration: 334.5777232 cycles
----------- TLFQueueDequeueAll_8_16 ---------------
 samples:       8447
 iterations:    44053191
 iterations hr:    44.1M
 run time:      5.001716912
 per iteration: 337.185146 cycles
----------- TLFQueueDequeueAll_16_16 ---------------
 samples:       8463
 iterations:    44222310
 iterations hr:    44.2M
 run time:      5.001563487
 per iteration: 336.9696832 cycles
----------- TDequeWithMutex_1_1 ---------------
 samples:       6361
 iterations:    24981846
 iterations hr:    25M
 run time:      5.00159772
 per iteration: 624.4307701 cycles
----------- TDequeWithMutex_2_1 ---------------
 samples:       6355
 iterations:    24939453
 iterations hr:    24.9M
 run time:      5.001576191
 per iteration: 607.4169571 cycles
----------- TDequeWithMutex_4_1 ---------------
 samples:       6255
 iterations:    24154725
 iterations hr:    24.2M
 run time:      5.001185068
 per iteration: 668.2552149 cycles
----------- TDequeWithMutex_8_1 ---------------
 samples:       6423
 iterations:    25471953
 iterations hr:    25.5M
 run time:      5.001025479
 per iteration: 598.3755054 cycles
----------- TDequeWithMutex_16_1 ---------------
 samples:       6399
 iterations:    25286716
 iterations hr:    25.3M
 run time:      5.002042135
 per iteration: 609.9932041 cycles
----------- TDequeWithAdaptiveLock_1_1 ---------------
 samples:       7551
 iterations:    35208636
 iterations hr:    35.2M
 run time:      5.002085425
 per iteration: 504.6556446 cycles
----------- TDequeWithAdaptiveLock_2_1 ---------------
 samples:       6971
 iterations:    30004131
 iterations hr:    30M
 run time:      5.003527735
 per iteration: 580.3224673 cycles
----------- TDequeWithAdaptiveLock_4_1 ---------------
 samples:       6587
 iterations:    26787540
 iterations hr:    26.8M
 run time:      5.000947431
 per iteration: 632.9189512 cycles
----------- TDequeWithAdaptiveLock_8_1 ---------------
 samples:       6587
 iterations:    26787540
 iterations hr:    26.8M
 run time:      5.001479534
 per iteration: 622.1166837 cycles
----------- TDequeWithAdaptiveLock_16_1 ---------------
 samples:       6633
 iterations:    27169506
 iterations hr:    27.2M
 run time:      5.001894377
 per iteration: 609.872031 cycles
----------- TDequeWithMutex_1_16 ---------------
 samples:       6014
 iterations:    22334586
 iterations hr:    22.3M
 run time:      5.001217955
 per iteration: 710.341298 cycles
----------- TDequeWithMutex_2_16 ---------------
 samples:       6074
 iterations:    22777875
 iterations hr:    22.8M
 run time:      5.001879599
 per iteration: 709.6528671 cycles
----------- TDequeWithMutex_4_16 ---------------
 samples:       6079
 iterations:    22818390
 iterations hr:    22.8M
 run time:      5.001058965
 per iteration: 665.8053035 cycles
----------- TDequeWithMutex_8_16 ---------------
 samples:       5976
 iterations:    22054761
 iterations hr:    22.1M
 run time:      5.001903138
 per iteration: 745.1647133 cycles
----------- TDequeWithMutex_16_16 ---------------
 samples:       6017
 iterations:    22354641
 iterations hr:    22.4M
 run time:      5.001949648
 per iteration: 700.6487766 cycles

----------- TDequeWithAdaptiveLock_1_16 ---------------
 samples:       7290
 iterations:    32809050
 iterations hr:    32.8M
 run time:      5.001420698
 per iteration: 541.5984227 cycles
----------- TDequeWithAdaptiveLock_2_16 ---------------
 samples:       6984
 iterations:    30112680
 iterations hr:    30.1M
 run time:      5.001429866
 per iteration: 596.7423909 cycles
----------- TDequeWithAdaptiveLock_4_16 ---------------
 samples:       6498
 iterations:    26067810
 iterations hr:    26.1M
 run time:      5.005021125
 per iteration: 649.6767219 cycles
----------- TDequeWithAdaptiveLock_8_16 ---------------
 samples:       7099
 iterations:    31114216
 iterations hr:    31.1M
 run time:      5.001260817
 per iteration: 566.0111464 cycles
----------- TDequeWithAdaptiveLock_16_16 ---------------
 samples:       6564
 iterations:    26604865
 iterations hr:    26.6M
 run time:      5.000710401
 per iteration: 605.6272339 cycles
```

```
Architecture:                x86_64
  CPU op-mode(s):            32-bit, 64-bit
  Address sizes:             46 bits physical, 48 bits virtual
  Byte Order:                Little Endian
CPU(s):                      22
  On-line CPU(s) list:       0-21
Vendor ID:                   GenuineIntel
  Model name:                Intel(R) Core(TM) Ultra 7 165H
    CPU family:              6
    Model:                   170
    Thread(s) per core:      2
    Core(s) per socket:      16
    Socket(s):               1
    Stepping:                4
    CPU(s) scaling MHz:      29%
    CPU max MHz:             5000.0000
    CPU min MHz:             400.0000
    BogoMIPS:                6144.00
```