### PR TITLE
issue-4875: added Partition and FBW synchronization on trim fresh log

### DIFF
--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
@@ -361,6 +361,18 @@ void TFreshBlocksWriterActor::HandleWaitReady(
     NCloud::Reply(ctx, *ev, std::move(response));
 }
 
+void TFreshBlocksWriterActor::HandleGetTrimFreshLogToCommitId(
+    const TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdRequest::TPtr&
+        ev,
+    const NActors::TActorContext& ctx)
+{
+    auto response = std::make_unique<
+        TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdResponse>(
+        TrimFreshLogState->GetTrimFreshLogToCommitId());
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
 bool TFreshBlocksWriterActor::HandleRequests(STFUNC_SIG)
 {
     switch (ev->GetTypeRewrite()) {
@@ -453,6 +465,10 @@ STFUNC(TFreshBlocksWriterActor::StateWork)
         HFunc(
             TEvPartitionCommonPrivate::TEvZeroFreshBlocksCompleted,
             HandleZeroBlocksCompleted);
+
+        HFunc(
+            TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdRequest,
+            HandleGetTrimFreshLogToCommitId);
 
         default:
             if (!IOCompanion->HandleRequests(ev, this->ActorContext()) &&

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
@@ -187,6 +187,11 @@ private:
         const TEvPartitionCommonPrivate::TEvZeroFreshBlocksCompleted::TPtr& ev,
         const NActors::TActorContext& ctx);
 
+    void HandleGetTrimFreshLogToCommitId(
+        const TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdRequest::
+            TPtr& ev,
+        const NActors::TActorContext& ctx);
+
     void HandleProcessWriteQueue(
         const NPartition::TEvPartitionPrivate::TEvProcessWriteQueue::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -596,19 +596,17 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
         auto testEnv = PrepareTestActorRuntime();
         auto& runtime = *testEnv.Runtime;
 
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
         runtime.SetEventFilter(
             [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
                 Y_UNUSED(runtime);
-                if (event->GetTypeRewrite() == TEvService::EvWriteBlocksRequest) {
-                    UNIT_ASSERT_VALUES_UNEQUAL(testEnv.PartitionActorId, event->GetRecipientRewrite());
-
-                    return false;
+                if (event->GetTypeRewrite() == TEvService::EvWriteBlocksRequest)
+                {
+                    UNIT_ASSERT_VALUES_UNEQUAL(
+                        testEnv.PartitionActorId,
+                        event->GetRecipientRewrite());
                 }
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
+                return false;
             });
 
         TPartitionClient partition(runtime);
@@ -653,8 +651,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
         auto testEnv = PrepareTestActorRuntime(config);
         auto& runtime = *testEnv.Runtime;
 
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
         runtime.SetEventFilter(
             [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
@@ -665,11 +661,8 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                     UNIT_ASSERT_VALUES_UNEQUAL(
                         testEnv.FreshBlocksWriterActorId,
                         event->GetRecipientRewrite());
-
-                    return false;
                 }
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
+                return false;
             });
 
         TPartitionClient partition(runtime);
@@ -700,16 +693,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
     {
         auto testEnv = PrepareTestActorRuntime(DefaultConfig(), 2048);
         auto& runtime = *testEnv.Runtime;
-
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
-        runtime.SetEventFilter(
-            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
-            {
-                Y_UNUSED(runtime);
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
-            });
 
         TPartitionClient partition(runtime);
         partition.WaitReady();
@@ -1009,6 +992,100 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             S_OK,
             response->GetStatus(),
             response->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldNotTrimInProgressWrites)
+    {
+        auto testEnv = PrepareTestActorRuntime();
+        auto& runtime = *testEnv.Runtime;
+
+        TPartitionClient partition(runtime);
+        partition.WaitReady();
+
+        TFreshBlocksWriterClient fbwClient(
+            runtime,
+            testEnv.FreshBlocksWriterActorId);
+
+        fbwClient.WaitReady();
+
+        fbwClient.WriteBlocks(0, '0');
+
+        ui64 addFreshBlocksCommitId = 0;
+        std::unique_ptr<IEventHandle> stollenAddFreshBlocksRequest;
+
+        bool seenFlushCompleted = false;
+        bool seenTrimCompleted = false;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionCommonPrivate::EvAddFreshBlocksRequest)
+                {
+                    auto* ev = event->Get<TEvPartitionCommonPrivate::TEvAddFreshBlocksRequest>();
+                    addFreshBlocksCommitId = ev->CommitId;
+
+                    stollenAddFreshBlocksRequest.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                if (event->GetTypeRewrite() == TEvBlobStorage::EvCollectGarbage)
+                {
+                    auto* ev = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+
+                    auto trimFreshLogToCommitId =
+                        MakeCommitId(ev->CollectGeneration, ev->CollectStep);
+                    UNIT_ASSERT(
+                        trimFreshLogToCommitId < addFreshBlocksCommitId);
+                }
+
+                seenFlushCompleted |= event->GetTypeRewrite() ==
+                                      TEvPartitionPrivate::EvFlushCompleted;
+
+                seenTrimCompleted |=
+                    event->GetTypeRewrite() ==
+                    TEvPartitionCommonPrivate::EvTrimFreshLogCompleted;
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        fbwClient.WriteBlocks(1, '1');
+
+        UNIT_ASSERT(stollenAddFreshBlocksRequest);
+
+        {
+            partition.SendFlushRequest();
+
+            TDispatchOptions dispatchOptions;
+            dispatchOptions.CustomFinalCondition = [&]()
+            {
+                return seenFlushCompleted;
+            };
+
+            runtime.DispatchEvents(dispatchOptions, 10ms);
+        }
+
+        {
+            partition.SendTrimFreshLogRequest();
+
+            TDispatchOptions dispatchOptions;
+            dispatchOptions.CustomFinalCondition = [&]()
+            {
+                return seenTrimCompleted;
+            };
+
+            runtime.DispatchEvents(dispatchOptions, 10ms);
+        }
+
+        runtime.Send(stollenAddFreshBlocksRequest.release());
+
+        auto actualContent = GetBlocksContent(
+            fbwClient.ReadBlocks(TBlockRange32::WithLength(0, 2)));
+
+        TStringBuilder expectedContent;
+        expectedContent << GetBlockContent('0') << GetBlockContent('1');
+
+        UNIT_ASSERT_EQUAL(expectedContent, actualContent);
     }
 }
 

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
@@ -363,6 +363,10 @@ void TFreshBlocksWriterActor::HandleWriteBlocksCompleted(
     Y_DEBUG_ABORT_UNLESS(WriteAndZeroRequestsInProgress >= requestCount);
     WriteAndZeroRequestsInProgress -= requestCount;
 
+    TrimFreshLogState->AccessTrimFreshLogBarriers().ReleaseBarrierN(
+        commitId,
+        blocksCount);
+
     // TODO(issue-4875): process drain requests
     // DrainActorCompanion.ProcessDrainRequests(ctx);
 }

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -111,6 +111,8 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
         writeHandlers.push_back(r.Data.Handler);
     }
 
+    TrimFreshLogState->AccessTrimFreshLogBarriers().AcquireBarrierN(commitId, blockCount);
+
     const ui32 channel = ChannelsState->PickNextChannel(
         EChannelDataKind::Fresh,
         EChannelPermission::UserWritesAllowed);

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1362,6 +1362,8 @@ void TPartitionActor::HandleGetFreshChannelsInfo(
     FreshBlocksWriter = ev->Sender;
 
     NCloud::Reply(ctx, *ev, std::move(response));
+
+    EnqueueTrimFreshLogIfNeeded(ctx);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
@@ -23,6 +23,11 @@ void TPartitionActor::EnqueueTrimFreshLogIfNeeded(const TActorContext& ctx)
         return;
     }
 
+    if (Config->GetFreshBlocksWriterEnabled() && !FreshBlocksWriter) {
+        // wait for fbw startup
+        return;
+    }
+
     ui64 trimFreshLogToCommitId = State->GetTrimFreshLogToCommitId();
 
     if (trimFreshLogToCommitId == State->GetLastTrimFreshLogToCommitId()) {
@@ -109,7 +114,14 @@ void TPartitionActor::HandleTrimFreshLog(
         return;
     }
 
-    ui64 trimFreshLogToCommitId = State->GetTrimFreshLogToCommitId();
+    if (Config->GetFreshBlocksWriterEnabled() && !FreshBlocksWriter) {
+        replyError(
+            ctx,
+            *requestInfo,
+            E_TRY_AGAIN,
+            "wait for fresh blocks writer start");
+        return;
+    }
 
     auto nextPerGenerationCounter = State->NextCollectPerGenerationCounter();
     if (nextPerGenerationCounter == InvalidCollectPerGenerationCounter) {
@@ -120,9 +132,8 @@ void TPartitionActor::HandleTrimFreshLog(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "%s Start TrimFreshLog @%lu @%lu",
+        "%s Start TrimFreshLog @%lu",
         LogTitle.GetWithTime().c_str(),
-        trimFreshLogToCommitId,
         nextPerGenerationCounter);
 
     State->AccessTrimFreshLogState().SetStatus(EOperationStatus::Started);
@@ -131,17 +142,24 @@ void TPartitionActor::HandleTrimFreshLog(
         return kind == EChannelDataKind::Fresh;
     });
 
+    TVector<NActors::TActorId> actorsToGetTrimFreshLog;
+    if (FreshBlocksWriter) {
+        actorsToGetTrimFreshLog.emplace_back(FreshBlocksWriter);
+    }
+    actorsToGetTrimFreshLog.push_back(ctx.SelfID);
+
     auto actor = NCloud::Register<TTrimFreshLogActor>(
         ctx,
         requestInfo,
         SelfId(),
         Info(),
-        trimFreshLogToCommitId,
         Executor()->Generation(),
         nextPerGenerationCounter,
         std::move(freshChannels),
         PartitionConfig.GetDiskId(),
-        Config->GetTrimFreshLogTimeout());
+        Config->GetTrimFreshLogTimeout(),
+        actorsToGetTrimFreshLog,
+        State->GetLastTrimFreshLogToCommitId());
 
     Actors.Insert(actor);
 }
@@ -184,6 +202,18 @@ void TPartitionActor::HandleTrimFreshLogCompleted(
 
     auto time = CyclesToDurationSafe(msg->TotalCycles).MicroSeconds();
     PartCounters->RequestCounters.TrimFreshLog.AddRequest(time);
+}
+
+void TPartitionActor::HandleGetTrimFreshLogToCommitId(
+    const TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdRequest::TPtr&
+        ev,
+    const TActorContext& ctx)
+{
+    auto response = std::make_unique<
+        TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdResponse>(
+        State->GetTrimFreshLogToCommitId());
+
+    NCloud::Reply(ctx, *ev, std::move(response));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
@@ -102,8 +102,6 @@ void TPartitionActor::HandleTrimFreshLog(
         return;
     }
 
-    const ui64 trimFreshLogToCommitId = State->GetTrimFreshLogToCommitId();
-
     auto nextPerGenerationCounter = State->NextCollectPerGenerationCounter();
     if (nextPerGenerationCounter == InvalidCollectPerGenerationCounter) {
         RebootPartitionOnCollectCounterOverflow(ctx, "TrimFreshLog");
@@ -111,9 +109,8 @@ void TPartitionActor::HandleTrimFreshLog(
     }
 
     LOG_DEBUG(ctx, TBlockStoreComponents::PARTITION,
-        "[%lu] Start TrimFreshLog @%lu @%lu",
+        "[%lu] Start TrimFreshLog @%lu",
         TabletID(),
-        trimFreshLogToCommitId,
         nextPerGenerationCounter);
 
     State->GetTrimFreshLogState().SetStatus(EOperationStatus::Started);
@@ -127,12 +124,13 @@ void TPartitionActor::HandleTrimFreshLog(
         requestInfo,
         SelfId(),
         Info(),
-        trimFreshLogToCommitId,
         ParseCommitId(State->GetLastCommitId()).first,
         nextPerGenerationCounter,
         std::move(freshChannels),
         "",
-        Config->GetTrimFreshLogTimeout());
+        Config->GetTrimFreshLogTimeout(),
+        TVector{ctx.SelfID},
+        State->GetLastTrimFreshLogToCommitId());
 
     Actors.insert(actor);
 }
@@ -169,6 +167,18 @@ void TPartitionActor::HandleTrimFreshLogCompleted(
 
     auto time = CyclesToDurationSafe(msg->TotalCycles).MicroSeconds();
     PartCounters->RequestCounters.TrimFreshLog.AddRequest(time);
+}
+
+void TPartitionActor::HandleGetTrimFreshLogToCommitId(
+    const TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdRequest::TPtr&
+        ev,
+    const TActorContext& ctx)
+{
+    auto response = std::make_unique<
+        TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdResponse>(
+        State->GetTrimFreshLogToCommitId());
+
+    NCloud::Reply(ctx, *ev, std::move(response));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition2

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
@@ -6,6 +6,8 @@
 #include <cloud/storage/core/libs/tablet/gc_logic.h>
 #include <cloud/storage/core/libs/tablet/model/commit.h>
 
+#include <algorithm>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -22,28 +24,33 @@ TTrimFreshLogActor::TTrimFreshLogActor(
         TRequestInfoPtr requestInfo,
         const TActorId& partitionActorId,
         TTabletStorageInfoPtr tabletInfo,
-        ui64 trimFreshLogToCommitId,
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
         TString diskId,
-        TDuration timeout)
+        TDuration timeout,
+        const TVector<NActors::TActorId>& actorsToGetTrimFreshLogToCommitId,
+        ui64 lastTrimFreshLogToCommitId)
     : RequestInfo(std::move(requestInfo))
     , PartitionActorId(partitionActorId)
     , TabletInfo(std::move(tabletInfo))
-    , TrimFreshLogToCommitId(trimFreshLogToCommitId)
     , RecordGeneration(recordGeneration)
     , PerGenerationCounter(perGenerationCounter)
     , FreshChannels(std::move(freshChannels))
     , DiskId(std::move(diskId))
     , Timeout(timeout)
-{}
+    , LastTrimFreshLogToCommitId(lastTrimFreshLogToCommitId)
+{
+    for (const auto& actorId : actorsToGetTrimFreshLogToCommitId) {
+        ActorToTrimFreshLogToCommitId.push_back({.ActorId=actorId});
+    }
+}
 
 void TTrimFreshLogActor::Bootstrap(const TActorContext& ctx)
 {
     TRequestScope timer(*RequestInfo);
 
-    Become(&TThis::StateWork);
+    Become(&TThis::StateWaitTrimFreshLogToCommitId);
 
     LWTRACK(
         RequestReceived_PartitionWorker,
@@ -51,7 +58,15 @@ void TTrimFreshLogActor::Bootstrap(const TActorContext& ctx)
         "TrimFreshLog",
         RequestInfo->CallContext->RequestId);
 
-    TrimFreshLog(ctx);
+    GetTrimFreshLogToCommitId(ctx);
+}
+
+void TTrimFreshLogActor::GetTrimFreshLogToCommitId(const TActorContext& ctx)
+{
+    auto& actorId = ActorToTrimFreshLogToCommitId[ActorIdx].ActorId;
+
+    auto request = std::make_unique<TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdRequest>();
+    NCloud::Send(ctx, actorId, std::move(request));
 }
 
 void TTrimFreshLogActor::TrimFreshLog(const TActorContext& ctx)
@@ -61,8 +76,8 @@ void TTrimFreshLogActor::TrimFreshLog(const TActorContext& ctx)
     auto barriers = BuildGCBarriers(
         *TabletInfo,
         FreshChannels,
-        TVector<TPartialBlobId>(),  // knownBlobIds
-        TrimFreshLogToCommitId);
+        TVector<TPartialBlobId>(),   // knownBlobIds
+        *TrimFreshLogToCommitId);
 
     for (auto channelId: FreshChannels) {
         for (const auto& [bsProxyId, barrier]: barriers.GetRequests(channelId)) {
@@ -104,7 +119,7 @@ void TTrimFreshLogActor::NotifyCompleted(const TActorContext& ctx)
     using TEvent = TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted;
     auto ev = std::make_unique<TEvent>(Error);
 
-    ev->CommitId = TrimFreshLogToCommitId;
+    ev->CommitId = *TrimFreshLogToCommitId;
     ev->ExecCycles = RequestInfo->GetExecCycles();
     ev->TotalCycles = RequestInfo->GetTotalCycles();
 
@@ -127,6 +142,72 @@ void TTrimFreshLogActor::ReplyAndDie(const TActorContext& ctx)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TTrimFreshLogActor::HandleGetTrimFreshLogToCommitIdResponse(
+    const TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdResponse::TPtr&
+        ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    if (HasError(msg->GetError())) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::PARTITION_WORKER,
+            "[%lu] Got error while waiting TrimFreshLogToCommitId: %s",
+            TabletInfo->TabletID,
+            FormatError(msg->GetError()).c_str());
+        Error = std::move(msg->GetError());
+        ReplyAndDie(ctx);
+        return;
+    }
+
+    STORAGE_VERIFY(
+        ActorIdx < ActorToTrimFreshLogToCommitId.size(),
+        TWellKnownEntityTypes::DISK,
+        DiskId);
+
+    ui64 trimFreshLogToCommitId = msg->TrimFreshLogToCommitId;
+
+    ActorToTrimFreshLogToCommitId[ActorIdx].CommitId =
+        trimFreshLogToCommitId;
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%lu] Got TrimFreshLog @%lu from actor %s",
+        TabletInfo->TabletID,
+        trimFreshLogToCommitId,
+        ToString(ActorToTrimFreshLogToCommitId[ActorIdx].ActorId).c_str());
+
+    ++ActorIdx;
+
+    if (ActorIdx < ActorToTrimFreshLogToCommitId.size()) {
+        GetTrimFreshLogToCommitId(ctx);
+        return;
+    }
+
+    TrimFreshLogToCommitId = std::ranges::min_element(
+                                 ActorToTrimFreshLogToCommitId,
+                                 [](const auto& lhs, const auto& rhs)
+                                 { return lhs.CommitId < rhs.CommitId; })
+                                 ->CommitId;
+
+    if (*TrimFreshLogToCommitId == LastTrimFreshLogToCommitId) {
+        NotifyCompleted(ctx);
+        ReplyAndDie(ctx);
+        return;
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::PARTITION_WORKER,
+        "[%lu] Start trimming @%lu",
+        TabletInfo->TabletID,
+        TrimFreshLogToCommitId);
+
+    Become(&TThis::StateWork);
+    TrimFreshLog(ctx);
+}
 
 void TTrimFreshLogActor::HandleCollectGarbageResult(
     const TEvBlobStorage::TEvCollectGarbageResult::TPtr& ev,
@@ -163,6 +244,27 @@ void TTrimFreshLogActor::HandlePoisonPill(
     Y_UNUSED(ev);
 
     Die(ctx);
+}
+
+STFUNC(TTrimFreshLogActor::StateWaitTrimFreshLogToCommitId)
+{
+    TRequestScope timer(*RequestInfo);
+
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdResponse,
+            HandleGetTrimFreshLogToCommitIdResponse);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::PARTITION_WORKER,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+
 }
 
 STFUNC(TTrimFreshLogActor::StateWork)

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
@@ -17,17 +17,29 @@ namespace NCloud::NBlockStore::NStorage {
 class TTrimFreshLogActor final
     : public NActors::TActorBootstrapped<TTrimFreshLogActor>
 {
+
+    struct TActorToTrimFreshLogToCommitId {
+        NActors::TActorId ActorId;
+        ui64 CommitId = 0;
+    };
+
 private:
     const TRequestInfoPtr RequestInfo;
 
     const NActors::TActorId PartitionActorId;
     const NKikimr::TTabletStorageInfoPtr TabletInfo;
-    const ui64 TrimFreshLogToCommitId;
     const ui32 RecordGeneration;
     const ui32 PerGenerationCounter;
     const TVector<ui32> FreshChannels;
     const TString DiskId;
     const TDuration Timeout;
+    const ui64 LastTrimFreshLogToCommitId;
+
+    TVector<TActorToTrimFreshLogToCommitId> ActorToTrimFreshLogToCommitId;
+
+    ui64 ActorIdx = 0;
+
+    std::optional<ui64> TrimFreshLogToCommitId;
 
     ui32 RequestsInFlight = 0;
     NProto::TError Error;
@@ -37,23 +49,32 @@ public:
         TRequestInfoPtr requestInfo,
         const NActors::TActorId& partitionActorId,
         NKikimr::TTabletStorageInfoPtr tabletInfo,
-        ui64 trimFreshLogToCommitId,
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
         TString diskId,
-        TDuration timeout);
+        TDuration timeout,
+        const TVector<NActors::TActorId>& actorsToGetTrimFreshLogToCommitId,
+        ui64 lastTrimFreshLogToCommitId);
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
 private:
+    void GetTrimFreshLogToCommitId(const NActors::TActorContext& ctx);
+
     void TrimFreshLog(const NActors::TActorContext& ctx);
 
     void NotifyCompleted(const NActors::TActorContext& ctx);
     void ReplyAndDie(const NActors::TActorContext& ctx);
 
 private:
+    STFUNC(StateWaitTrimFreshLogToCommitId);
     STFUNC(StateWork);
+
+    void HandleGetTrimFreshLogToCommitIdResponse(
+        const TEvPartitionCommonPrivate::TEvGetTrimFreshLogToCommitIdResponse::
+            TPtr& ev,
+        const NActors::TActorContext& ctx);
 
     void HandleCollectGarbageResult(
         const NKikimr::TEvBlobStorage::TEvCollectGarbageResult::TPtr& ev,

--- a/cloud/blockstore/libs/storage/partition_common/events_private.h
+++ b/cloud/blockstore/libs/storage/partition_common/events_private.h
@@ -63,6 +63,7 @@ using TPartitionSharedStatePtr = std::shared_ptr<TPartitionSharedState>;
     xxx(PatchBlob,                 __VA_ARGS__)                                \
     xxx(GetFreshChannelsInfo,      __VA_ARGS__)                                \
     xxx(AddFreshBlocks,            __VA_ARGS__)                                \
+    xxx(GetTrimFreshLogToCommitId, __VA_ARGS__)                                \
 // BLOCKSTORE_PARTITION_COMMON_REQUESTS_PRIVATE
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -455,7 +456,20 @@ struct TEvPartitionCommonPrivate
     {
     };
 
+    //
+    // GetTrimFreshLogToCommitId
+    //
 
+    struct TGetTrimFreshLogToCommitIdRequest
+    {
+    };
+
+    struct TGetTrimFreshLogToCommitIdResponse
+    {
+        ui64 TrimFreshLogToCommitId;
+    };
+
+    //
     // Events declaration
     //
 


### PR DESCRIPTION
#4875 

trim logic:
```mermaid
sequenceDiagram
      PartitionActor->>PartitionActor: TrimFreshLog
      Note over PartitionActor: Chose NextCollectPerGenerationCounter
      create participant TrimFreshLogActor
      PartitionActor->>TrimFreshLogActor: Register
      TrimFreshLogActor->>+FreshBlocksWriter: GetTrimFreshLogToCommitIdRequest
      FreshBlocksWriter->>-TrimFreshLogActor: GetTrimFreshLogToCommitIdResponse
      TrimFreshLogActor->>+PartitionActor: GetTrimFreshLogToCommitIdRequest
      PartitionActor->>-TrimFreshLogActor: GetTrimFreshLogToCommitIdResponse

      Note over TrimFreshLogActor: Trim Fresh Log with min TrimFreshLogToCommitId
      TrimFreshLogActor->>PartitionActor:TrimFreshBlocksCompleted
```

how writes work: https://github.com/ydb-platform/nbs/pull/5334#issue-4000891461