### PR TITLE
added TConcurrentQueue to the queues benchmark

### DIFF
--- a/cloud/storage/core/libs/common/bench/queues/main.cpp
+++ b/cloud/storage/core/libs/common/bench/queues/main.cpp
@@ -1,3 +1,5 @@
+#include <cloud/storage/core/libs/common/concurrent_queue.h>
+
 #include <library/cpp/testing/benchmark/bench.h>
 
 #include <util/generic/deque.h>
@@ -189,6 +191,21 @@ struct TDequeWithAdaptiveLock
     }
 };
 
+struct TConcurrentQueue
+{
+    NCloud::TConcurrentQueue<ui64> Data;
+
+    void Enqueue(ui64 x)
+    {
+        Data.Enqueue(std::make_unique<ui64>(x));
+    }
+
+    bool Dequeue()
+    {
+        return !!Data.Dequeue();
+    }
+};
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -230,3 +247,5 @@ Q_BENCH_SET(TDequeWithMutex, 1)
 Q_BENCH_SET(TDequeWithAdaptiveLock, 1)
 Q_BENCH_SET(TDequeWithMutex, 16)
 Q_BENCH_SET(TDequeWithAdaptiveLock, 16)
+Q_BENCH_SET(TConcurrentQueue, 1)
+Q_BENCH_SET(TConcurrentQueue, 16)


### PR DESCRIPTION
```
----------- TLFStackSingleConsumerDequeueAll_1_1 ---------------
 samples:       13364
 iterations:    110253825
 iterations hr:    110M
 run time:      5.001708774
 per iteration: 138.7477607 cycles
----------- TLFStackSingleConsumerDequeueAll_2_1 ---------------
 samples:       12150
 iterations:    91145251
 iterations hr:    91.1M
 run time:      5.001717899
 per iteration: 148.2766797 cycles
----------- TLFStackSingleConsumerDequeueAll_4_1 ---------------
 samples:       10764
 iterations:    71526780
 iterations hr:    71.5M
 run time:      5.001936234
 per iteration: 197.5469765 cycles
----------- TLFStackSingleConsumerDequeueAll_8_1 ---------------
 samples:       10774
 iterations:    71670378
 iterations hr:    71.7M
 run time:      5.000907531
 per iteration: 175.9381472 cycles
----------- TLFStackSingleConsumerDequeueAll_16_1 ---------------
 samples:       9957
 iterations:    61211580
 iterations hr:    61.2M
 run time:      5.000972113
 per iteration: 173.874596 cycles
----------- TLFStackDequeueAll_1_1 ---------------
 samples:       12151
 iterations:    91158753
 iterations hr:    91.2M
 run time:      5.001448166
 per iteration: 143.326892 cycles
----------- TLFStackDequeueAll_2_1 ---------------
 samples:       12208
 iterations:    92011395
 iterations hr:    92M
 run time:      5.001582638
 per iteration: 145.2147085 cycles
----------- TLFStackDequeueAll_4_1 ---------------
 samples:       11018
 iterations:    74951646
 iterations hr:    75M
 run time:      5.001060116
 per iteration: 189.3814586 cycles
----------- TLFStackDequeueAll_8_1 ---------------
 samples:       10782
 iterations:    71778171
 iterations hr:    71.8M
 run time:      5.000971928
 per iteration: 176.24904 cycles
----------- TLFStackDequeueAll_16_1 ---------------
 samples:       9961
 iterations:    61255846
 iterations hr:    61.3M
 run time:      5.001326363
 per iteration: 176.3517825 cycles
----------- TLFQueue_1_1 ---------------
 samples:       7196
 iterations:    31972006
 iterations hr:    32M
 run time:      5.001456636
 per iteration: 470.1838879 cycles
----------- TLFQueue_2_1 ---------------
 samples:       5579
 iterations:    19216900
 iterations hr:    19.2M
 run time:      5.001718536
 per iteration: 819.1450167 cycles
----------- TLFQueue_4_1 ---------------
 samples:       5571
 iterations:    19161145
 iterations hr:    19.2M
 run time:      5.000375091
 per iteration: 810.3500923 cycles
----------- TLFQueue_8_1 ---------------
 samples:       5102
 iterations:    16071615
 iterations hr:    16.1M
 run time:      5.001667303
 per iteration: 1123.626666 cycles
----------- TLFQueue_16_1 ---------------
 samples:       5209
 iterations:    16753366
 iterations hr:    16.8M
 run time:      5.00159475
 per iteration: 1095.230391 cycles
----------- TLFQueueDequeueAll_1_1 ---------------
 samples:       8380
 iterations:    43361328
 iterations hr:    43.4M
 run time:      5.000785457
 per iteration: 341.7032615 cycles
----------- TLFQueueDequeueAll_2_1 ---------------
 samples:       6759
 iterations:    28211316
 iterations hr:    28.2M
 run time:      5.00120564
 per iteration: 553.1435091 cycles
----------- TLFQueueDequeueAll_4_1 ---------------
 samples:       5829
 iterations:    20979003
 iterations hr:    21M
 run time:      5.001949038
 per iteration: 730.8967177 cycles
----------- TLFQueueDequeueAll_8_1 ---------------
 samples:       5143
 iterations:    16333470
 iterations hr:    16.3M
 run time:      5.000637598
 per iteration: 1114.013348 cycles
----------- TLFQueueDequeueAll_16_1 ---------------
 samples:       5252
 iterations:    17032366
 iterations hr:    17M
 run time:      5.001834439
 per iteration: 1041.718576 cycles
----------- TLFQueue_1_16 ---------------
 samples:       2679
 iterations:    4432753
 iterations hr:    4.43M
 run time:      5.001927245
 per iteration: 4088.875474 cycles
----------- TLFQueue_2_16 ---------------
 samples:       2941
 iterations:    5341546
 iterations hr:    5.34M
 run time:      5.00259803
 per iteration: 2859.152127 cycles
----------- TLFQueue_4_16 ---------------
 samples:       3230
 iterations:    6442255
 iterations hr:    6.44M
 run time:      5.003267424
 per iteration: 2359.170177 cycles
----------- TLFQueue_8_16 ---------------
 samples:       3261
 iterations:    6568500
 iterations hr:    6.57M
 run time:      5.000655349
 per iteration: 2389.507377 cycles
----------- TLFQueue_16_16 ---------------
 samples:       3307
 iterations:    6754650
 iterations hr:    6.75M
 run time:      5.001296292
 per iteration: 2035.17648 cycles
----------- TDequeWithMutex_1_1 ---------------
 samples:       7241
 iterations:    32373081
 iterations hr:    32.4M
 run time:      5.00123369
 per iteration: 477.226626 cycles
----------- TDequeWithMutex_2_1 ---------------
 samples:       7685
 iterations:    36461530
 iterations hr:    36.5M
 run time:      5.001566835
 per iteration: 401.4348572 cycles
----------- TDequeWithMutex_4_1 ---------------
 samples:       6904
 iterations:    29433628
 iterations hr:    29.4M
 run time:      5.001963728
 per iteration: 574.2713918 cycles
----------- TDequeWithMutex_8_1 ---------------
 samples:       7150
 iterations:    31565485
 iterations hr:    31.6M
 run time:      5.001461142
 per iteration: 559.067838 cycles
----------- TDequeWithMutex_16_1 ---------------
 samples:       7656
 iterations:    36188778
 iterations hr:    36.2M
 run time:      5.001313138
 per iteration: 474.8223806 cycles
----------- TDequeWithAdaptiveLock_1_1 ---------------
 samples:       8264
 iterations:    42168336
 iterations hr:    42.2M
 run time:      5.00141394
 per iteration: 336.2454263 cycles
----------- TDequeWithAdaptiveLock_2_1 ---------------
 samples:       8892
 iterations:    48812140
 iterations hr:    48.8M
 run time:      5.001658747
 per iteration: 282.4433521 cycles
----------- TDequeWithAdaptiveLock_4_1 ---------------
 samples:       8795
 iterations:    47760651
 iterations hr:    47.8M
 run time:      5.001526809
 per iteration: 385.3856416 cycles
----------- TDequeWithAdaptiveLock_8_1 ---------------
 samples:       9417
 iterations:    54752880
 iterations hr:    54.8M
 run time:      5.002063733
 per iteration: 231.8965138 cycles
----------- TDequeWithAdaptiveLock_16_1 ---------------
 samples:       9491
 iterations:    55614331
 iterations hr:    55.6M
 run time:      5.001195383
 per iteration: 128.1477382 cycles
----------- TDequeWithMutex_1_16 ---------------
 samples:       2605
 iterations:    4191960
 iterations hr:    4.19M
 run time:      5.002315448
 per iteration: 4642.215959 cycles
----------- TDequeWithMutex_2_16 ---------------
 samples:       3067
 iterations:    5808936
 iterations hr:    5.81M
 run time:      5.001166241
 per iteration: 3087.373347 cycles
----------- TDequeWithMutex_4_16 ---------------
 samples:       3607
 iterations:    8034036
 iterations hr:    8.03M
 run time:      5.001084903
 per iteration: 2232.18761 cycles
----------- TDequeWithMutex_8_16 ---------------
 samples:       4340
 iterations:    11633076
 iterations hr:    11.6M
 run time:      5.002279336
 per iteration: 1485.368954 cycles
----------- TDequeWithMutex_16_16 ---------------
 samples:       4991
 iterations:    15381831
 iterations hr:    15.4M
 run time:      5.001115364
 per iteration: 905.4240087 cycles
----------- TDequeWithAdaptiveLock_1_16 ---------------
 samples:       2488
 iterations:    3823995
 iterations hr:    3.82M
 run time:      5.000801402
 per iteration: 3592.26491 cycles
----------- TDequeWithAdaptiveLock_2_16 ---------------
 samples:       3156
 iterations:    6151278
 iterations hr:    6.15M
 run time:      5.002543929
 per iteration: 1944.055902 cycles
----------- TDequeWithAdaptiveLock_4_16 ---------------
 samples:       3343
 iterations:    6902470
 iterations hr:    6.9M
 run time:      5.001700747
 per iteration: 963.3030342 cycles
----------- TDequeWithAdaptiveLock_8_16 ---------------
 samples:       4210
 iterations:    10944181
 iterations hr:    10.9M
 run time:      5.005776327
 per iteration: 556.1116784 cycles
----------- TDequeWithAdaptiveLock_16_16 ---------------
 samples:       4982
 iterations:    15326416
 iterations hr:    15.3M
 run time:      5.00035946
 per iteration: 529.7577882 cycles
----------- TConcurrentQueue_1_1 ---------------
 samples:       7593
 iterations:    35595703
 iterations hr:    35.6M
 run time:      5.00236512
 per iteration: 377.0583867 cycles
----------- TConcurrentQueue_2_1 ---------------
 samples:       7653
 iterations:    36163260
 iterations hr:    36.2M
 run time:      5.001388891
 per iteration: 417.4439025 cycles
----------- TConcurrentQueue_4_1 ---------------
 samples:       8014
 iterations:    39653965
 iterations hr:    39.7M
 run time:      5.001394468
 per iteration: 374.2728395 cycles
----------- TConcurrentQueue_8_1 ---------------
 samples:       8270
 iterations:    42223455
 iterations hr:    42.2M
 run time:      5.001105951
 per iteration: 322.8688968 cycles
----------- TConcurrentQueue_16_1 ---------------
 samples:       8071
 iterations:    40216996
 iterations hr:    40.2M
 run time:      5.000964141
 per iteration: 295.9128821 cycles
----------- TConcurrentQueue_1_16 ---------------
 samples:       4232
 iterations:    11061456
 iterations hr:    11.1M
 run time:      5.003608923
 per iteration: 889.3356111 cycles
----------- TConcurrentQueue_2_16 ---------------
 samples:       4776
 iterations:    14084778
 iterations hr:    14.1M
 run time:      5.001746194
 per iteration: 882.114135 cycles
----------- TConcurrentQueue_4_16 ---------------
 samples:       4544
 iterations:    12748725
 iterations hr:    12.7M
 run time:      5.001511021
 per iteration: 1027.695597 cycles
----------- TConcurrentQueue_8_16 ---------------
 samples:       4376
 iterations:    11826816
 iterations hr:    11.8M
 run time:      5.001558095
 per iteration: 1127.487418 cycles
----------- TConcurrentQueue_16_16 ---------------
 samples:       4366
 iterations:    11773378
 iterations hr:    11.8M
 run time:      5.00189421
 per iteration: 983.4786814 cycles
```