### PR TITLE
issue-4875: added Partition and FBW synchronization on Compaction

### DIFF
--- a/cloud/blockstore/libs/storage/api/fresh_blocks_writer.h
+++ b/cloud/blockstore/libs/storage/api/fresh_blocks_writer.h
@@ -11,6 +11,7 @@ namespace NCloud::NBlockStore::NStorage::NFreshBlocksWriter {
 
 #define BLOCKSTORE_FRESH_BLOCKS_WRITER_REQUESTS(xxx, ...)                      \
     xxx(WaitReady,               __VA_ARGS__)                                  \
+    xxx(WaitCommit,              __VA_ARGS__)                                  \
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -25,6 +26,19 @@ struct TEvFreshBlocksWriter
     };
 
     struct TWaitReadyResponse
+    {
+    };
+
+    //
+    // WaitCommit
+    //
+
+    struct TWaitCommitRequest
+    {
+        ui64 CommitId;
+    };
+
+    struct TWaitCommitResponse
     {
     };
 

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
@@ -361,6 +361,42 @@ void TFreshBlocksWriterActor::HandleWaitReady(
     NCloud::Reply(ctx, *ev, std::move(response));
 }
 
+void TFreshBlocksWriterActor::HandleWaitCommit(
+    const TEvFreshBlocksWriter::TEvWaitCommitRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+    ui64 minCommitId = CommitIdsState->GetCommitQueue().GetMinCommitId();
+
+    if (msg->CommitId <= minCommitId) {
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvFreshBlocksWriter::TEvWaitCommitResponse>());
+
+        return;
+    }
+
+    auto reqInfo = CreateRequestInfo<TEvFreshBlocksWriter::TWaitCommitMethod>(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+
+    auto callback =
+        [reqInfo = std::move(reqInfo)](const NActors::TActorContext& ctx)
+    {
+        NCloud::Reply(
+            ctx,
+            *reqInfo,
+            std::make_unique<TEvFreshBlocksWriter::TEvWaitCommitResponse>());
+    };
+
+    // wait for commits to complete
+    CommitIdsState->AccessCommitQueue().Enqueue(
+        std::move(callback),
+        msg->CommitId);
+}
+
 bool TFreshBlocksWriterActor::HandleRequests(STFUNC_SIG)
 {
     switch (ev->GetTypeRewrite()) {

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -906,7 +906,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                 return event->GetTypeRewrite() ==
                        TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
             });
-
         TPartitionClient partition(runtime);
         partition.WaitReady();
 
@@ -1009,6 +1008,80 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             S_OK,
             response->GetStatus(),
             response->GetErrorReason());
+    }
+
+    Y_UNIT_TEST(ShouldWaitForAddFreshBlocksBeforeCompaction)
+    {
+        auto testEnv = PrepareTestActorRuntime();
+        auto& runtime = *testEnv.Runtime;
+
+        TPartitionClient partition(runtime);
+        partition.WaitReady();
+
+        TFreshBlocksWriterClient fbwClient(
+            runtime,
+            testEnv.FreshBlocksWriterActorId);
+
+        fbwClient.WaitReady();
+
+        fbwClient.WriteBlocks(0, '0');
+
+        partition.Flush();
+
+        std::unique_ptr<IEventHandle> stollenAddFreshBlocksRequest;
+
+        bool wasWaitCommitRequest = false;
+        bool wasWaitCommitResponse = false;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionCommonPrivate::EvAddFreshBlocksRequest)
+                {
+                    stollenAddFreshBlocksRequest.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                wasWaitCommitRequest |=
+                    event->GetTypeRewrite() ==
+                    NFreshBlocksWriter::TEvFreshBlocksWriter::
+                        EvWaitCommitRequest;
+                wasWaitCommitResponse |=
+                    event->GetTypeRewrite() ==
+                    NFreshBlocksWriter::TEvFreshBlocksWriter::
+                        EvWaitCommitResponse;
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        fbwClient.WriteBlocks(1, '1');
+
+        UNIT_ASSERT(stollenAddFreshBlocksRequest);
+
+        UNIT_ASSERT(!wasWaitCommitRequest);
+
+        partition.SendCompactionRequest();
+
+        runtime.DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(wasWaitCommitRequest);
+        UNIT_ASSERT(!wasWaitCommitResponse);
+
+        runtime.Send(stollenAddFreshBlocksRequest.release());
+
+        auto resp = partition.RecvCompactionResponse();
+        UNIT_ASSERT(!HasError(resp->GetError()));
+
+        UNIT_ASSERT(wasWaitCommitResponse);
+
+        auto actualContent = GetBlocksContent(
+            fbwClient.ReadBlocks(TBlockRange32::WithLength(0, 2)));
+
+        TStringBuilder expectedContent;
+        expectedContent << GetBlockContent('0') << GetBlockContent('1');
+
+        UNIT_ASSERT_EQUAL(expectedContent, actualContent);
     }
 }
 

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
@@ -358,6 +358,8 @@ void TFreshBlocksWriterActor::HandleWriteBlocksCompleted(
         LogTitle.GetWithTime().c_str(),
         commitId);
 
+    CommitIdsState->AccessCommitQueue().ReleaseBarrier(commitId);
+
     Actors.Erase(ev->Sender);
 
     Y_DEBUG_ABORT_UNLESS(WriteAndZeroRequestsInProgress >= requestCount);
@@ -365,6 +367,8 @@ void TFreshBlocksWriterActor::HandleWriteBlocksCompleted(
 
     // TODO(issue-4875): process drain requests
     // DrainActorCompanion.ProcessDrainRequests(ctx);
+
+    ProcessCommitQueue(ctx, CommitIdsState->AccessCommitQueue());
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NFreshBlocksWriter

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -68,6 +68,8 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
         return;
     }
 
+    CommitIdsState->AccessCommitQueue().AcquireBarrier(commitId);
+
     const bool freshChannelWriteRequestsEnabled =
         Config->GetFreshChannelWriteRequestsEnabled() ||
         Config->IsFreshChannelWriteRequestsFeatureEnabled(

--- a/cloud/blockstore/libs/storage/partition/model/commit_queue.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/commit_queue.cpp
@@ -4,23 +4,23 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TCommitQueue::Enqueue(TTxPtr tx, ui64 commitId)
+void TCommitQueue::Enqueue(TCallback callback, ui64 commitId)
 {
     if (Items) {
         Y_ABORT_UNLESS(Items.back().CommitId < commitId);
     }
-    Items.emplace_back(commitId, std::move(tx));
+    Items.emplace_back(commitId, std::move(callback));
 }
 
-TCommitQueue::TTxPtr TCommitQueue::Dequeue()
+TCommitQueue::TCallback TCommitQueue::Dequeue()
 {
-    TTxPtr tx;
+    TCallback callback;
     if (Items) {
         auto& item = Items.front();
-        tx = std::move(item.Tx);
+        callback = std::move(item.Callback);
         Items.pop_front();
     }
-    return tx;
+    return callback;
 }
 
 ui64 TCommitQueue::Peek() const
@@ -29,6 +29,26 @@ ui64 TCommitQueue::Peek() const
         return Items.front().CommitId;
     }
     return Max();
+}
+
+void ProcessCommitQueue(
+    const NActors::TActorContext& ctx,
+    TCommitQueue& commitQueue)
+{
+    ui64 minCommitId = commitQueue.GetMinCommitId();
+
+    while (!commitQueue.Empty()) {
+        ui64 commitId = commitQueue.Peek();
+
+        if (minCommitId >= commitId) {
+            // start execution
+            auto callback = commitQueue.Dequeue();
+            callback(ctx);
+        } else {
+            // delay execution until all previous commits completed
+            break;
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/commit_queue.h
+++ b/cloud/blockstore/libs/storage/partition/model/commit_queue.h
@@ -12,19 +12,18 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TCommitQueue
-    : public TBarriers
+class TCommitQueue: public TBarriers
 {
-    using TTxPtr = std::unique_ptr<ITransactionBase>;
+    using TCallback = std::function<void(const NActors::TActorContext& ctx)>;
 
     struct TItem
     {
         const ui64 CommitId;
-        TTxPtr Tx;
+        TCallback Callback;
 
-        TItem(ui64 commitId, TTxPtr tx)
+        TItem(ui64 commitId, TCallback callback)
             : CommitId(commitId)
-            , Tx(std::move(tx))
+            , Callback(std::move(callback))
         {}
     };
 
@@ -32,8 +31,8 @@ private:
     TDeque<TItem> Items;
 
 public:
-    void Enqueue(TTxPtr tx, ui64 commitId);
-    TTxPtr Dequeue();
+    void Enqueue(TCallback callback, ui64 commitId);
+    TCallback Dequeue();
 
     bool Empty() const
     {
@@ -42,5 +41,9 @@ public:
 
     ui64 Peek() const;
 };
+
+void ProcessCommitQueue(
+    const NActors::TActorContext& ctx,
+    TCommitQueue& commitQueue);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/commit_queue_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/commit_queue_ut.cpp
@@ -1,42 +1,142 @@
 #include "commit_queue.h"
+#include "cloud/blockstore/libs/storage/core/request_info.h"
+
+#include <contrib/ydb/core/testlib/actors/test_runtime.h>
+#include <contrib/ydb/core/testlib/tablet_helpers.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
+using namespace NActors;
+
+using namespace std::chrono_literals;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TTransactionStub
-    : public ITransactionBase
+enum ETestEvents
 {
-    const ui64 CommitId;
+    EvBegin = EventSpaceBegin(NKikimr::TEvents::ES_USERSPACE + 10),
 
-    TTransactionStub(ui64 commitId)
-        : CommitId(commitId)
-    {}
+    EvEnqueue,
+    EvDequeue,
+    EvValueDequeued,
+};
 
-    void Init(const NActors::TActorContext&) override
+struct TEnqueue
+{
+    ui64 Value = 0;
+    ui64 CommitId = 0;
+};
+
+struct TValueDequeued
+{
+    ui64 Value = 0;
+};
+
+using TEvEnqueue = TRequestEvent<TEnqueue, EvEnqueue>;
+
+using TEvDequeue = TRequestEvent<TEmpty, EvDequeue>;
+
+using TEvValueDequeued = TRequestEvent<TValueDequeued, EvValueDequeued>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TMyTestEnv final
+{
+public:
+    TActorId Sender;
+
+private:
+    TTestActorRuntime Runtime;
+
+public:
+    TMyTestEnv()
     {
+        NKikimr::SetupTabletServices(Runtime);
+        Sender = Runtime.AllocateEdgeActor();
     }
 
-    bool Execute(
-        NKikimr::NTabletFlatExecutor::TTransactionContext&,
-        const NActors::TActorContext&) override
+    TActorId Register(IActorPtr actor)
     {
-        return false;
+        auto actorId = Runtime.Register(actor.release());
+        Runtime.EnableScheduleForActor(actorId);
+
+        return actorId;
     }
 
-    void Complete(const NActors::TActorContext&) override
+    void Send(const TActorId& recipient, IEventBasePtr event, ui64 cookie = 0)
     {
+        Runtime.Send(
+            new IEventHandle(recipient, Sender, event.release(), 0, cookie));
+    }
+
+    void DispatchEvents(TDuration timeout)
+    {
+        Runtime.DispatchEvents(TDispatchOptions(), timeout);
+    }
+
+    TAutoPtr<IEventHandle> GrabValueDequeued(TDuration timeout)
+    {
+        TAutoPtr<IEventHandle> handle;
+        Runtime.GrabEdgeEventRethrow<TEvValueDequeued>(handle, timeout);
+        return handle;
+    }
+
+    TTestActorRuntimeBase& AccessRuntime()
+    {
+        return Runtime;
     }
 };
 
-ui64 GetCommitId(const ITransactionBase& tx)
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCommitQueueActor: public TActor<TCommitQueueActor>
 {
-    return static_cast<const TTransactionStub&>(tx).CommitId;
-}
+    TCommitQueue Queue;
+
+    TCommitQueueActor()
+        : TActor(&TThis::Main)
+    {}
+
+    void Main(TAutoPtr<IEventHandle>& ev)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvEnqueue, HandleEnqueue);
+            HFunc(TEvDequeue, HandleDequeue);
+        }
+    }
+
+    void HandleEnqueue(const TEvEnqueue::TPtr& ev, const TActorContext& ctx)
+    {
+        Y_UNUSED(ctx);
+
+        auto* msg = ev->Get();
+        auto requestInfo =
+            CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
+
+        auto callback = [requestInfo = std::move(requestInfo),
+                         value = msg->Value](const NActors::TActorContext& ctx)
+        {
+            NCloud::Reply(
+                ctx,
+                *requestInfo,
+                std::make_unique<TEvValueDequeued>(value));
+        };
+
+        Queue.Enqueue(std::move(callback), msg->CommitId);
+    }
+
+    void HandleDequeue(const TEvDequeue::TPtr& ev, const TActorContext& ctx)
+    {
+        Y_UNUSED(ev);
+
+        auto callback = Queue.Dequeue();
+        callback(ctx);
+    }
+};
 
 }   // namespace
 
@@ -46,28 +146,38 @@ Y_UNIT_TEST_SUITE(TCommitQueueTest)
 {
     Y_UNIT_TEST(ShouldKeepTrackOfCommits)
     {
-        TCommitQueue queue;
+        TMyTestEnv testEnv;
 
-        queue.Enqueue(std::make_unique<TTransactionStub>(1), 1);
-        queue.Enqueue(std::make_unique<TTransactionStub>(2), 2);
-        queue.Enqueue(std::make_unique<TTransactionStub>(3), 3);
+        auto actorId = testEnv.Register(std::make_unique<TCommitQueueActor>());
 
-        UNIT_ASSERT(!queue.Empty());
+        testEnv.Send(actorId, std::make_unique<TEvEnqueue>(1, 1), 1);
+        testEnv.Send(actorId, std::make_unique<TEvEnqueue>(2, 2), 2);
+        testEnv.Send(actorId, std::make_unique<TEvEnqueue>(3, 3), 3);
 
-        UNIT_ASSERT_EQUAL(queue.Peek(), 1);
-        auto tx = queue.Dequeue();
-        UNIT_ASSERT_EQUAL(GetCommitId(*tx), 1);
+        testEnv.DispatchEvents(10ms);
 
-        UNIT_ASSERT_EQUAL(queue.Peek(), 2);
-        tx = queue.Dequeue();
-        UNIT_ASSERT_EQUAL(GetCommitId(*tx), 2);
+        auto* actor = dynamic_cast<TCommitQueueActor*>(
+            testEnv.AccessRuntime().FindActor(actorId));
 
-        UNIT_ASSERT_EQUAL(queue.Peek(), 3);
-        tx = queue.Dequeue();
-        UNIT_ASSERT_EQUAL(GetCommitId(*tx), 3);
+        UNIT_ASSERT(!actor->Queue.Empty());
 
-        UNIT_ASSERT(queue.Empty());
+        auto checkQueue = [&](ui64 expectedValue)
+        {
+            UNIT_ASSERT_EQUAL(actor->Queue.Peek(), expectedValue);
+            testEnv.Send(actorId, std::make_unique<TEvDequeue>());
+            auto ev = testEnv.GrabValueDequeued(100ms);
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedValue,
+                ev->Get<TEvValueDequeued>()->Value);
+        };
+
+        checkQueue(1);
+        checkQueue(2);
+        checkQueue(3);
+
+        UNIT_ASSERT(actor->Queue.Empty());
     }
+
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ut/ya.make
@@ -17,7 +17,13 @@ SRCS(
 )
 
 PEERDIR(
-    library/cpp/resource
+    contrib/ydb/library/actors/testlib
+
+    contrib/ydb/core/testlib
+    contrib/ydb/core/testlib/default
+    contrib/ydb/core/testlib/basics
+
+    library/cpp/testing/unittest
 )
 
 RESOURCE(

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1146,6 +1146,10 @@ STFUNC(TPartitionActor::StateWork)
 
         HFunc(TEvHiveProxy::TEvReassignTabletResponse, HandleReassignTabletResponse);
 
+        HFunc(
+            NFreshBlocksWriter::TEvFreshBlocksWriter::TEvWaitCommitResponse,
+            HandleWaitCommitIdsResponse);
+
         IgnoreFunc(TEvPartitionPrivate::TEvCleanupResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCollectGarbageResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCompactionResponse);
@@ -1224,6 +1228,9 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvDeleteUnconfirmedBlobsResponse);
 
         IgnoreFunc(TEvHiveProxy::TEvReassignTabletResponse);
+
+        IgnoreFunc(
+            NFreshBlocksWriter::TEvFreshBlocksWriter::TEvWaitCommitResponse);
 
         // Wakeup function should handle wakeup event taking into account that
         // there is wakeup event scheduled during boot stage with

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -9,6 +9,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -184,6 +185,8 @@ private:
     NActors::TActorId FreshBlocksWriter;
 
     TPartitionSharedStatePtr SharedState;
+    std::unique_ptr<ITransactionBase> CurrentCompactionTransaction;
+    ui64 CurrentCompactionCommitId = 0;
 
     TRequestInfoPtr Poisoner;
 
@@ -513,6 +516,10 @@ private:
     void CreateIOCompanionClient();
 
     bool IsFreshBlocksWriterEnabled() const;
+    void ScheduleCompactionTransaction(
+        const NActors::TActorContext& ctx,
+        ui64 commitId,
+        std::unique_ptr<ITransactionBase> tx);
 
 private:
     STFUNC(StateBoot);
@@ -805,6 +812,11 @@ private:
 
     void HandleUpdateResourceMetrics(
         const TEvPartitionPrivate::TEvUpdateResourceMetrics::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleWaitCommitIdsResponse(
+        const NFreshBlocksWriter::TEvFreshBlocksWriter::TEvWaitCommitResponse::
+            TPtr& ev,
         const NActors::TActorContext& ctx);
 
     BLOCKSTORE_PARTITION_REQUESTS(BLOCKSTORE_IMPLEMENT_REQUEST, TEvPartition)

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -4,6 +4,7 @@
 #include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
+#include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
@@ -23,6 +24,8 @@ using namespace NActors;
 
 using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
+
+using namespace NFreshBlocksWriter;
 
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
@@ -1459,6 +1462,52 @@ void TPartitionActor::HandleCompaction(
         msg->CompactionOptions,
         std::move(ranges));
 
+    if (FreshBlocksWriter) {
+        STORAGE_VERIFY(
+            !CurrentCompactionTransaction && !CurrentCompactionCommitId,
+            TWellKnownEntityTypes::TABLET,
+            TabletID());
+        CurrentCompactionTransaction = std::move(tx);
+        CurrentCompactionCommitId = commitId;
+
+        NCloud::Send(
+            ctx,
+            FreshBlocksWriter,
+            std::make_unique<TEvFreshBlocksWriter::TEvWaitCommitRequest>(
+                commitId));
+        return;
+    }
+
+    ScheduleCompactionTransaction(ctx, commitId, std::move(tx));
+}
+
+void TPartitionActor::HandleWaitCommitIdsResponse(
+    const NFreshBlocksWriter::TEvFreshBlocksWriter::TEvWaitCommitResponse::TPtr&
+        ev,
+    const NActors::TActorContext& ctx)
+{
+    if (HasError(ev->Get()->GetError())) {
+        Suicide(ctx);
+        return;
+    }
+
+    STORAGE_VERIFY(
+        CurrentCompactionCommitId,
+        TWellKnownEntityTypes::TABLET,
+        TabletID());
+
+    ScheduleCompactionTransaction(
+        ctx,
+        CurrentCompactionCommitId,
+        std::move(CurrentCompactionTransaction));
+    CurrentCompactionCommitId = 0;
+}
+
+void TPartitionActor::ScheduleCompactionTransaction(
+    const NActors::TActorContext& ctx,
+    ui64 commitId,
+    std::unique_ptr<ITransactionBase> tx)
+{
     ui64 minCommitId = State->GetCommitQueue().GetMinCommitId();
     Y_ABORT_UNLESS(minCommitId <= commitId);
 
@@ -1467,26 +1516,24 @@ void TPartitionActor::HandleCompaction(
         ExecuteTx(ctx, std::move(tx));
     } else {
         // delay execution until all previous commits completed
-        State->AccessCommitQueue().Enqueue(std::move(tx), commitId);
+        // wrap tx in std::shared_ptr to be able to store it in the
+        // std::function
+        auto sharedTx = std::make_shared<decltype(tx)>(std::move(tx));
+        auto callback = [self = this, sharedTx](
+                            const NActors::TActorContext& ctx) mutable
+        {
+            self->ExecuteTx(ctx, std::move(*sharedTx));
+        };
+
+        State->AccessCommitQueue().Enqueue(std::move(callback), commitId);
     }
 }
 
 void TPartitionActor::ProcessCommitQueue(const TActorContext& ctx)
 {
-    ui64 minCommitId = State->GetCommitQueue().GetMinCommitId();
-
-    while (!State->GetCommitQueue().Empty()) {
-        ui64 commitId = State->GetCommitQueue().Peek();
-        Y_ABORT_UNLESS(minCommitId <= commitId);
-
-        if (minCommitId == commitId) {
-            // start execution
-            ExecuteTx(ctx, State->AccessCommitQueue().Dequeue());
-        } else {
-            // delay execution until all previous commits completed
-            break;
-        }
-    }
+    ::NCloud::NBlockStore::NStorage::NPartition::ProcessCommitQueue(
+        ctx,
+        State->AccessCommitQueue());
 
     // TODO: too many different queues exist
     // Since create checkpoint operation waits for the last commit to complete


### PR DESCRIPTION
### Notes
Needed to not overwrite fresh blocks while compaction.

compaction logic:
```mermaid
sequenceDiagram
      PartitionActor->>PartitionActor: Compaction Request
      Note over PartitionActor: Chose CommitId<br/>Acquire Commit Queue<br/>Acquire Cleanup Queue<br/>Acquire Garbage Queue
      PartitionActor->>FreshBlocksWriter: WaitCommitRequest 
      Note over FreshBlocksWriter: Wait for commits to complete
      FreshBlocksWriter->>PartitionActor: WaitCommitResponse
      Note over PartitionActor: Wait for commits to complete 
      Note over PartitionActor: All Regular Compaction logic

```

how writes work: https://github.com/ydb-platform/nbs/pull/5334#issue-4000891461
### Issue
#4875 