### PR TITLE
Fix data race in test TFileSystemTest::ShouldSupportZeroCopyWriteByWriteBackCache

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -3042,9 +3042,11 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         reqWrite->In->Body.flags |= O_WRONLY;
         auto write = bootstrap.Fuse->SendRequest<TWriteRequest>(reqWrite);
 
-        while (writeDataCalled.load() == 0) {
-            bootstrap.Timer->Sleep(TDuration::MilliSeconds(1));
-        }
+        auto reqFlush =
+            bootstrap.Fuse->SendRequest<TFlushRequest>(nodeId, handleId);
+
+        UNIT_ASSERT(reqFlush.Wait(WaitTimeout));
+        UNIT_ASSERT_VALUES_EQUAL(1, writeDataCalled.load());
     }
 
     Y_UNIT_TEST(ShouldSupportZeroCopyWriteByWriteBackCache)


### PR DESCRIPTION
Replace count poller with explicit flush.

```
Uncaught exception: (TSystemError) (Error 35: Resource deadlock avoided) util/system/thread.cpp:198: can not join thread
??+0 (0x16AA421)
std::terminate()+41 (0x1827DB9)
??+0 (0x16A419E)
NCloud::NFileStore::NFuse::NWriteBackCache::TWriteBackCacheState::FlushSucceeded(unsigned long, unsigned long)+976 (0x36DCA20)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::CompleteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)+70 (0x36D9846)
auto NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)::'lambda'(auto const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse>>(auto const&)+148 (0x36D9184)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)+368 (0x36D8800)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ScheduleFlushNode(unsigned long)+203 (0x36D770B)
NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::Release()+129 (0x36DFD11)
NCloud::NFileStore::NFuse::NWriteBackCache::TWriteBackCacheState::TriggerPeriodicFlushAll()+51 (0x36DBA93)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::RequestAutomaticFlush()+26 (0x36D4A2A)
std::__y1::__function::__func<NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ScheduleAutomaticFlushIfNeeded()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ScheduleAutomaticFlushIfNeeded()::'lambda'()>, void ()>::operator()()+46 (0x36D497E)
```