### PR TITLE
issue-2674: directories in shards: 1. UnlinkNode shouldn't rely on UnlinkDirectory flag 2. CreateNode should work as if ShardIdSelectionInLeaderEnabled is true

### DIFF
--- a/cloud/filestore/bin/nfs/nfs-storage.txt
+++ b/cloud/filestore/bin/nfs/nfs-storage.txt
@@ -10,3 +10,5 @@ DirectoryHandlesTableSize: 10000
 TwoStageReadEnabled: true
 TwoStageReadThreshold: 65536
 MaxFuseLoopThreads: 8
+DirectoryCreationInShardsEnabled: true
+ShardIdSelectionInLeaderEnabled: true

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5823,6 +5823,17 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // unlinking the file in subdir
         service.UnlinkNode(headers, subdirId, "file", false);
 
+        // unlinking subdir should fail if UnlinkDirectory==false
+        unlinkResponse = service.SendAndRecvUnlinkNode(
+            headers,
+            dirId,
+            "subdir",
+            false);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_FS_ISDIR,
+            unlinkResponse->GetError().GetCode(),
+            unlinkResponse->GetError().GetMessage());
+
         // unlinking subdir should now succeed
         service.UnlinkNode(headers, dirId, "subdir", true);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1466,8 +1466,11 @@ bool TIndexTabletActor::BehaveAsShard(const NProto::THeaders& headers) const
     // shards)
     //
     // Note that checking both that ShardFileSystemIds is not empty and that the
-    // DirectoryCreationInShardsEnabled flag is set might be excessive, because
-    // they are both supposed to be set at the same time
+    // DirectoryCreationInShardsEnabled flag is true is necessary because:
+    // * ShardFileSystemIds can be empty even if directory creation in shards is
+    //  enabled - e.g. for small filesystems
+    // * DirectoryCreationInShardsEnabled can be false but ShardFileSystemIds
+    //  can be non-empty - e.g. when strict size enforcement is enabled
     if (headers.GetBehaveAsDirectoryTablet() &&
         !GetFileSystem().GetShardFileSystemIds().empty() &&
         GetFileSystem().GetDirectoryCreationInShardsEnabled())

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -580,8 +580,18 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
     const bool isParentNodeLinkRequest =
         args.Request.HasLink() && args.Request.GetLink().GetShardNodeName();
 
+    //
+    // If directory creation in shards is enabled we cannot allow the service
+    // layer to decide where to create the node because we need to perform some
+    // extra checks which the service layer is unable to do.
+    //
+
+    const bool shardIdSelectionEnabled =
+        Config->GetShardIdSelectionInLeaderEnabled()
+        || GetFileSystem().GetDirectoryCreationInShardsEnabled();
+
     if (!BehaveAsShard(args.Request.GetHeaders())
-            && Config->GetShardIdSelectionInLeaderEnabled()
+            && shardIdSelectionEnabled
             && !GetFileSystem().GetShardFileSystemIds().empty()
             && (args.Attrs.GetType() == NProto::E_REGULAR_NODE
                 || GetFileSystem().GetDirectoryCreationInShardsEnabled()

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -72,7 +72,6 @@ void TIndexTabletActor::ReplayOpLog(
             );
         } else if (op.HasUnlinkNodeInShardRequest()) {
             bool shouldUnlockUponCompletion =
-                op.GetUnlinkNodeInShardRequest().GetUnlinkDirectory() &&
                 GetFileSystem().GetDirectoryCreationInShardsEnabled();
             if (shouldUnlockUponCompletion) {
                 // There is a need to unlock the node ref after the operation is

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -488,9 +488,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
         // unlocked and not removed until the confirmation from the shard is
         // received that the node is unlinked.
 
-        if (!args.Request.GetUnlinkDirectory() ||
-            !GetFileSystem().GetDirectoryCreationInShardsEnabled())
-        {
+        if (!GetFileSystem().GetDirectoryCreationInShardsEnabled()) {
             UnlinkExternalNode(
                 db,
                 args.ParentNodeId,
@@ -582,14 +580,12 @@ void TIndexTabletActor::CompleteTx_UnlinkNode(
     }
 
     bool shouldUnlockUponCompletion = true;
-    // If the node is external and it's a directory and creation of
-    // directories is enabled for this filesystem and the request is to be
-    // forwarded to the shard, then the nodeRef is not unlocked here as it
-    // is possible that the shard will reject the request. In this case the
-    // nodeRef will be unlocked afterwards
+    // If the node is external and creation of directories in shards is enabled
+    // for this filesystem and the request is to be forwarded to the shard, then
+    // the nodeRef is not unlocked here as it is possible that the shard will
+    // reject the request. In this case the nodeRef will be unlocked afterwards.
     if (HasError(args.Error) ||
         (args.ChildRef && !args.ChildRef.GetOrElse({}).IsExternal()) ||
-        !args.Request.GetUnlinkDirectory() ||
         !GetFileSystem().GetDirectoryCreationInShardsEnabled())
     {
         UnlockNodeRef({args.ParentNodeId, args.Name});


### PR DESCRIPTION
### Notes
* tablet-level `UnlinkNode` code cannot rely on the `UnlinkDirectory` flag to decide whether the target node is a directory because this flag is set by the client
* legacy `ShardIdSelectionInLeaderEnabled: false` mode doesn't have proper checks that would prevent directory creation in shards in some cases so it's safer to pretend as if `ShardIdSelectionInLeaderEnabled` is true if `DirectoryCreationInShardsEnabled` is true in the `CreateNode` code
* enabling `DirectoryCreationInShardsEnabled: true` and `ShardIdSelectionInLeaderEnabled: true` in local filestore setup

Related to https://github.com/ydb-platform/nbs/pull/3202

### Issue
https://github.com/ydb-platform/nbs/issues/2674
https://github.com/ydb-platform/nbs/issues/5431