### PR TITLE
issue-5340: TKikimrFileStore shouldn't std::move the contents of the original request

### DIFF
--- a/cloud/filestore/libs/service_kikimr/service.cpp
+++ b/cloud/filestore/libs/service_kikimr/service.cpp
@@ -161,7 +161,7 @@ public:
     void SendRequest(
         IActorSystem& actorSystem,
         TCallContextPtr callContext,
-        TRequest request,
+        const TRequest& request,
         TPromise<TResponse> promise,
         TActorId actorId)
     {
@@ -176,7 +176,7 @@ public:
             actorId,
             std::make_unique<TRequestEvent>(
                 std::move(callContext),
-                std::move(request)).release(),
+                request).release(),
             0 /* flags */,
             cookie,
             nullptr /* forwardOnNondelivery */);
@@ -494,7 +494,7 @@ private:
             Handler->SendRequest(
                 *ActorSystem,
                 std::move(callContext),
-                std::move(*request),
+                *request,
                 std::move(response));
             return;
         }

--- a/cloud/filestore/libs/service_kikimr/service_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/service_ut.cpp
@@ -89,15 +89,17 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
 
         auto context = MakeIntrusive<TCallContext>();
         auto request = std::make_shared<NProto::TCreateFileStoreRequest>();
+        request->SetFileSystemId("fs");
 
-        auto future = service->CreateFileStore(
-            std::move(context),
-            std::move(request));
+        auto future = service->CreateFileStore(std::move(context), request);
 
         actorSystem->DispatchEvents(WaitTimeout);
 
         const auto& response = future.GetValue(WaitTimeout);
         UNIT_ASSERT(!HasError(response));
+
+        // service shouldn't move/clear request contents
+        UNIT_ASSERT_VALUES_EQUAL("fs", request->GetFileSystemId());
 
         service->Stop();
     }


### PR DESCRIPTION
### Notes
The `UsePermanentActor: true` mode introduced here https://github.com/ydb-platform/nbs/pull/5341 contains a bug - it `std::move`s the contents of the original request. It's a bug because durable-client and write-back-cache keep a shared_ptr to the same request object and can try to access it after the layers below them respond.

### Issue
https://github.com/ydb-platform/nbs/issues/5340