### PR TITLE
[Filestore] Fix fs_posix_compliance mount-kikimr-test and mount-local-test by handle vhost restart

### DIFF
--- a/cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/mknod/03.t
+++ b/cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/mknod/03.t
@@ -31,4 +31,4 @@ expect char stat ${nx} type
 expect 0 unlink ${nx}
 expect ENAMETOOLONG mknod ${nxx} c 0644 1 2
 
-rm -rf "${nx%%/*}"
+strace -v -T -ttt $(which rm) -rf "${nx%%/*}"


### PR DESCRIPTION
Fix fs_posix_compliance `mount-kikimr-test` and `mount-local-test`

```
strace: Can't stat 'rm': No such file or directory
```

Test error:

```
2026-03-10 15:20:06,998 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2026-03-10 15:20:06,998 - INFO - ya.test - pytest_runtest_setup: test_posix_compliance[mknod]
2026-03-10 15:20:06,999 - INFO - ya.test - pytest_runtest_setup: ####################################################################################################
2026-03-10 15:20:06,999 - INFO - ya.test - pytest_runtest_setup: Test setup
2026-03-10 15:20:07,002 - INFO - ya.test - pytest_runtest_call: Test call (class_name: test.py, test_name: test_posix_compliance[mknod])
2026-03-10 15:20:07,028 - DEBUG - ya.test - get_binary: Binary was found by /storage/d/b/45899b20-6a439698-c05fb646-b1eb6-0/71/test-14114636038890125963-2AC/1274/cloud/filestore/tools/testing/fs_posix_compliance/suite/fstest
2026-03-10 15:20:07,029 - DEBUG - ya.test - get_binary: Binary was found by /storage/d/b/45899b20-6a439698-c05fb646-b1eb6-0/71/test-14114636038890125963-2AC/1274/cloud/filestore/tools/testing/fs_posix_compliance/suite/bin/flock
2026-03-10 15:20:07,030 - INFO - root - __run_test_suite: executing (mknod, 00.t)
2026-03-10 15:20:09,973 - INFO - root - __run_test_suite: executing (mknod, 01.t)
2026-03-10 15:20:11,055 - INFO - root - __run_test_suite: executing (mknod, 02.t)
2026-03-10 15:20:11,574 - INFO - root - __run_test_suite: executing (mknod, 03.t)
2026-03-10 15:20:14,366 - ERROR - root - __run_test_suite: test (mknod, 03.t) failed: b'1..12\nok 1 (line: 19)\nok 2 (line: 20)\nok 3 (line: 21)\nok 4 (line: 22)\nnot ok 5 (line: 24)\nnot ok 6 (line: 25)\nnot ok 7 (line: 26)\nok 8 (line: 27)\nnot ok 9 (line: 29)\nnot ok 10 (line: 30)\nnot ok 11 (line: 31)\nok 12 (line: 32)\n'
2026-03-10 15:20:15,451 - ERROR - ya.test - logreport: cloud/filestore/tests/fs_posix_compliance/mount-kikimr-test/test.py:15: in test_posix_compliance
    out = compliance.run_compliance_suite(get_filestore_mount_path(), suite, __suites[suite])
cloud/filestore/tools/testing/fs_posix_compliance/pylib/test.py:79: in run_compliance_suite
    return __run_test_suite(tmp_dir, suite, tests)
cloud/filestore/tools/testing/fs_posix_compliance/pylib/test.py:65: in __run_test_suite
    p.check_returncode()
contrib/tools/python3/Lib/subprocess.py:502: in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
E   subprocess.CalledProcessError: Command '/storage/d/b/45899b20-6a439698-c05fb646-b1eb6-0/71/test-14114636038890125963-2AC/1274/environment/arcadia/cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/mknod/03.t' returned non-zero exit status 1.
2026-03-10 15:20:15,454 - INFO - ya.test - pytest_runtest_teardown: Test teardown
2026-03-10 15:21:26,935 - DEBUG - ya.test - verify: Test did not pass, will not verify test output with possible canonical one
2026-03-10 15:21:26,935 - DEBUG - ya.test - verify: Test test.test_posix_compliance[mknod] status: fail
2026-03-10 15:21:26,935 - DEBUG - ya.test - verify: 
cloud/filestore/tests/fs_posix_compliance/mount-kikimr-test/test.py:15: in test_posix_compliance
    out = compliance.run_compliance_suite(get_filestore_mount_path(), suite, __suites[suite])
cloud/filestore/tools/testing/fs_posix_compliance/pylib/test.py:79: in run_compliance_suite
    return __run_test_suite(tmp_dir, suite, tests)
cloud/filestore/tools/testing/fs_posix_compliance/pylib/test.py:65: in __run_test_suite
    p.check_returncode()
contrib/tools/python3/Lib/subprocess.py:502: in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
E   subprocess.CalledProcessError: Command '/storage/d/b/45899b20-6a439698-c05fb646-b1eb6-0/71/test-14114636038890125963-2AC/1274/environment/arcadia/cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/mknod/03.t' returned non-zero exit status 1.
```