### PR TITLE
disable async rdma response processing

### DIFF
--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -761,29 +761,18 @@ void TRdmaDataEndpoint::HandleResponse(
     ui32 status,
     size_t responseBytes)
 {
-    auto self = shared_from_this();
-    TaskQueue->ExecuteSimple(
-        [
-            responseBytes = responseBytes,
-            status = status,
-            Log = Log,
-            self = std::move(self),
-            req = std::move(req)
-        ] () mutable
-    {
-        auto* handler = static_cast<IRequestHandler*>(req->Context.get());
-        try {
-            auto buffer = req->ResponseBuffer.Head(responseBytes);
-            if (status == 0) {
-                handler->HandleResponse(buffer);
-            } else {
-                auto error = NRdma::ParseError(buffer);
-                handler->HandleError(error.GetCode(), error.GetMessage());
-            }
-        } catch (...) {
-            STORAGE_ERROR("Exception in callback: " << CurrentExceptionMessage());
+    auto* handler = static_cast<IRequestHandler*>(req->Context.get());
+    try {
+        auto buffer = req->ResponseBuffer.Head(responseBytes);
+        if (status == 0) {
+            handler->HandleResponse(buffer);
+        } else {
+            auto error = NRdma::ParseError(buffer);
+            handler->HandleError(error.GetCode(), error.GetMessage());
         }
-    });
+    } catch (...) {
+        STORAGE_ERROR("Exception in callback: " << CurrentExceptionMessage());
+    }
 }
 
 void TRdmaDataEndpoint::DoStopEndpoint()


### PR DESCRIPTION
#5456

Currently during RDMA reconnects we can recreate buffers for endpoint. It is not a problem if we synchronously terminate requests because it is guaranteed that we do this before recreating rdma qp. However we complete requests asynchronously and in this case it is possible to touch already deallocated memory. Discussed that we need to rethink how we perform reconnects, but now just need to remove source of race.