### PR TITLE
[Disk Manager] fix style

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task_test.go
@@ -350,8 +350,9 @@ func TestScrubFilesystemTaskCancel(t *testing.T) {
 		map[uint64]struct{}{}, // nodesToExclude
 		100,                   // limit
 	)
-
+	require.NoError(t, err)
 	require.NotEmpty(t, entries)
+
 	err = task.Cancel(f.ctx, execCtx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
```
$S/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task_test.go:347:2: "SA4006: this value of err is never used"
```