### PR TITLE
issue-2674: fmdtest now reports an unlinked-file-still-exists error only if that file can still be opened

### DIFF
--- a/cloud/filestore/tests/fmdtest/canondata/test.test/results.txt
+++ b/cloud/filestore/tests/fmdtest/canondata/test.test/results.txt
@@ -9,5 +9,5 @@
     "stat-lat-us": true,
     "list": true,
     "list-lat-us": true,
-    "errors": true
+    "errors": false
 }

--- a/cloud/filestore/tests/fmdtest/test.py
+++ b/cloud/filestore/tests/fmdtest/test.py
@@ -23,7 +23,7 @@ def test():
     report_file = "report.json"
 
     ssh(f"{fmdtest_bin} --test-dir {working_dir} --report-path {report_file}"
-        " --duration 30 --stealer-threads 1 || true")
+        " --duration 30 --stealer-threads 1")
 
     ret = ssh(f"sudo cat {report_file}")
     report = json.loads(ret.stdout.decode("utf8"))

--- a/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
+++ b/cloud/filestore/tools/testing/fmdtest/bin/app.cpp
@@ -171,8 +171,17 @@ public:
             TFsPath filePath = DirPath / fileName;
 
             if (NFs::Exists(filePath)) {
-                STORAGE_ERROR("Unlinked file still exists: " << filePath);
-                ++errors;
+                static constexpr EOpenMode OpenMode =
+                    OpenExisting | RdOnly | Seq;
+                TFileHandle f(filePath, OpenMode);
+                if (f.IsOpen()) {
+                    STORAGE_ERROR("Unlinked file still exists: " << filePath);
+                    ++errors;
+                    f.Close();
+                } else {
+                    STORAGE_WARN("Unlinked file still exists: " << filePath
+                        << ", but can't be opened (stale dentry?)");
+                }
             }
         }
 
@@ -235,9 +244,9 @@ private:
         TFsPath filePath = DirPath / fileName;
 
         TString content(Options.FileSize, 'a' + (ThreadId % ('z' - 'a' + 1)));
-        static constexpr EOpenMode OPEN_MODE = CreateAlways | WrOnly | Seq;
+        static constexpr EOpenMode OpenMode = CreateAlways | WrOnly | Seq;
         THPTimer timer;
-        TFile f(filePath, OPEN_MODE);
+        TFile f(filePath, OpenMode);
         Stats.Create.Register(timer.Passed());
 
         TOFStream os(f);


### PR DESCRIPTION
### Notes
* `fmdtest` now reports errors about still existing unlinked files only if `open()` succeeds for them - otherwise it reports a warning (otherwise the test would fail due to stale dentries in the guest cache - this should be fixed separately)
* removed `|| true` from the `fmdtest` binary call in `tests/fmdtest`

### Issue
https://github.com/ydb-platform/nbs/issues/2674
