### PR TITLE
[Filestore] Remove unused handle from SetNodeAttr and GetNodeAttr api

### DIFF
--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -521,7 +521,6 @@ void InitProfileLogRequestInfo(
 {
     auto* nodeInfo = profileLogRequest.MutableNodeInfo();
     nodeInfo->SetParentNodeId(request.GetNodeId());
-    nodeInfo->SetHandle(request.GetHandle());
     nodeInfo->SetFlags(request.GetFlags());
     nodeInfo->SetMode(request.GetUpdate().GetMode());
 }
@@ -534,7 +533,6 @@ void InitProfileLogRequestInfo(
     auto* nodeInfo = profileLogRequest.MutableNodeInfo();
     nodeInfo->SetParentNodeId(request.GetNodeId());
     nodeInfo->SetNodeName(request.GetName());
-    nodeInfo->SetHandle(request.GetHandle());
     nodeInfo->SetFlags(request.GetFlags());
 }
 

--- a/cloud/filestore/libs/diagnostics/profile_log_events_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events_ut.cpp
@@ -511,7 +511,6 @@ Y_UNIT_TEST_SUITE(TProfileLogEventsTest)
 
         NProto::TSetNodeAttrRequest req;
         req.SetNodeId(nodeId);
-        req.SetHandle(handle);
         req.MutableUpdate()->SetMode(mode);
         req.SetFlags(flags);
 

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_attr.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_attr.cpp
@@ -21,18 +21,15 @@ void TFileSystem::SetAttr(
     fuse_ino_t ino,
     struct stat* attr,
     int to_set,
-    fuse_file_info* fi)
+    fuse_file_info*)
 {
-    ui64 handle = fi ? fi->fh : 0;
-    STORAGE_DEBUG("SetAttr #" << ino << " @" << handle
-        << " mask:" << to_set);
+    STORAGE_DEBUG("SetAttr #" << ino << " mask:" << to_set);
 
     if (!ValidateNodeId(*callContext, req, ino)) {
         return;
     }
 
     auto request = StartRequest<NProto::TSetNodeAttrRequest>(ino);
-    request->SetHandle(handle);
 
     auto* update = request->MutableUpdate();
     int flags = 0;
@@ -148,18 +145,15 @@ void TFileSystem::GetAttr(
     TCallContextPtr callContext,
     fuse_req_t req,
     fuse_ino_t ino,
-    fuse_file_info* fi)
+    fuse_file_info*)
 {
-    ui64 handle = fi ? fi->fh : 0;
-    STORAGE_DEBUG("GetAttr #" << ino << " @" << handle);
+    STORAGE_DEBUG("GetAttr #" << ino);
 
     if (!ValidateNodeId(*callContext, req, ino)) {
         return;
     }
 
     auto request = StartRequest<NProto::TGetNodeAttrRequest>(ino);
-    // XXX handle seems to be unneeded
-    request->SetHandle(handle);
 
     // Take into account cached WriteData requests
     const auto cachedNodeSize =

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -389,6 +389,8 @@ message TReadLinkResponse
 
 message TSetNodeAttrRequest
 {
+    reserved 4;
+
     enum EFlags
     {
         F_NONE = 0;
@@ -421,10 +423,6 @@ message TSetNodeAttrRequest
     // Node.
     uint64 NodeId = 3;
 
-    // IO handle.
-    // XXX seems to be unneeded
-    uint64 Handle = 4;
-
     // Update.
     TUpdate Update = 5;
 
@@ -449,6 +447,8 @@ message TSetNodeAttrResponse
 
 message TGetNodeAttrRequest
 {
+    reserved 5;
+
     enum EFlags
     {
         F_NONE = 0;
@@ -465,10 +465,6 @@ message TGetNodeAttrRequest
 
     // Node.
     bytes Name = 4;
-
-    // IO handle.
-    // XXX seems to be unneeded
-    uint64 Handle = 5;
 
     // Specifies information to get.
     uint32 Flags = 6;

--- a/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
@@ -286,7 +286,6 @@ private:
                     ProtoFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
 
                 auto request = CreateRequest<NProto::TSetNodeAttrRequest>();
-                request->SetHandle(handle);
                 request->SetNodeId(response.GetNodeAttr().GetId());
                 request->SetFlags(flags);
                 request->MutableUpdate()->SetSize(InitialFileSize);

--- a/cloud/filestore/tools/testing/loadtest/lib/request_replay_grpc.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_replay_grpc.cpp
@@ -311,7 +311,6 @@ private:
                     ProtoFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
 
                 auto request = CreateRequest<NProto::TSetNodeAttrRequest>();
-                request->SetHandle(handle);
                 request->SetNodeId(response.GetNodeAttr().GetId());
                 request->SetFlags(Flags);
                 request->MutableUpdate()->SetSize(InitialFileSize);


### PR DESCRIPTION
### Notes
Clearing up this unused parameter. Accidentally stumbled upon it while patching the load test binary

### Issue
No issue...
