### PR TITLE
[NBS] remove DescribeVolume for base disk in case of data plane requests

### DIFF
--- a/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
+++ b/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
@@ -51,6 +51,15 @@ std::unique_ptr<NTabletPipe::IClientCache> CreateTabletPipeClientCache(
         NTabletPipe::CreateUnboundedClientCache(clientConfig));
 }
 
+template <typename TMethod>
+constexpr bool IsDataPlaneMethod =
+    std::is_same_v<TMethod, TEvVolume::TDescribeBlocksMethod> ||
+    std::is_same_v<TMethod, TEvService::TReadBlocksMethod> ||
+    std::is_same_v<TMethod, TEvService::TWriteBlocksMethod> ||
+    std::is_same_v<TMethod, TEvService::TZeroBlocksMethod> ||
+    std::is_same_v<TMethod, TEvService::TReadBlocksLocalMethod> ||
+    std::is_same_v<TMethod, TEvService::TWriteBlocksLocalMethod>;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // VolumeProxy discovers the volume specified in the DiskId field of request,
@@ -771,6 +780,12 @@ void TVolumeProxyActor::HandleRequest(
 
                 conn.TabletId = baseDisk->TabletId;
                 conn.IsConnectionToBaseDisk = true;
+
+                if constexpr (IsDataPlaneMethod<TMethod>) {
+                    PostponeRequest(conn, IEventHandlePtr(ev.Release()));
+                    HandleBaseDiskDescribeResponse(&conn, {}, ctx);
+                    break;
+                }
             }
 
             DescribeVolume(ctx, conn);

--- a/cloud/blockstore/libs/storage/volume_proxy/volume_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_proxy/volume_proxy_ut.cpp
@@ -949,6 +949,63 @@ Y_UNIT_TEST_SUITE(TVolumeProxyTest)
                 statResponse->Record.GetVolume().GetDiskId());
         }
     }
+
+    Y_UNIT_TEST(ShouldNotDescribeVolumeForBaseDiskIfDataPlaneRequest)
+    {
+        TTestEnv env;
+        ui32 nodeIdx = SetupTestEnv(env);
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+
+        service.CreateVolume();
+        service.WaitForVolume();
+
+        ui64 volumeTabletId;
+        runtime.SetEventFilter(
+            [&](auto&, auto& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeVolumeResponse: {
+                        auto* msg = event->template Get<
+                            TEvSSProxy::TEvDescribeVolumeResponse>();
+                        const auto& volumeDescription =
+                            msg->PathDescription
+                                .GetBlockStoreVolumeDescription();
+                        volumeTabletId = volumeDescription.GetVolumeTabletId();
+                        break;
+                    }
+                }
+                return false;
+            });
+        service.DescribeVolume();
+
+        service.SendRequest(
+            MakeVolumeProxyServiceId(),
+            std::make_unique<TEvVolume::TEvMapBaseDiskIdToTabletId>(
+                DefaultDiskId,
+                volumeTabletId));
+        service.StatVolume();
+
+        // adjust time to trigger pipe connection destroy
+        runtime.AdvanceCurrentTime(TDuration::Minutes(1));
+        // give a chance to internal messages to complete
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        runtime.ClearCounters();
+
+        auto request = std::make_unique<TEvVolume::TEvDescribeBlocksRequest>();
+        request->Record.SetDiskId(DefaultDiskId);
+        request->Record.SetStartIndex(0);
+        request->Record.SetBlocksCount(1);
+
+        service.SendRequest(MakeVolumeProxyServiceId(), std::move(request));
+        service.StatVolume();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            runtime.GetCounter(TEvSSProxy::EvDescribeVolumeResponse));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
### Notes
TableId for base disk is cached as variable so no need to do extra DescribeVolume request to SS in case of data plane requests. 

### Issue
This PR is part of task to remove dependence between data plane and control plane.
