### PR TITLE
[NBS] send reassign HTTP requests with post method and added wait=0 parameter

### DIFF
--- a/cloud/blockstore/libs/storage/core/resources/actions.js
+++ b/cloud/blockstore/libs/storage/core/resources/actions.js
@@ -11,14 +11,16 @@ function reassignChannels(hiveId, tabletId) {
     var url = 'app?TabletID=' + hiveId;
     url += '&page=ReassignTablet';
     url += '&tablet=' + tabletId;
-    $.ajax({ url: url });
+    url += '&wait=0';
+    $.ajax({ type: 'POST', url: url });
 }
 function reassignChannel(hiveId, tabletId, channel) {
     var url = 'app?TabletID=' + hiveId;
     url += '&page=ReassignTablet';
     url += '&tablet=' + tabletId;
     url += '&channel=' + channel;
-    $.ajax({ url: url });
+    url += '&wait=0';
+    $.ajax({ type: 'POST', url: url });
 }
 function forceCompactionAll() {
     document.forms['ForceCompaction'].submit();


### PR DESCRIPTION
### Notes
In new YDB versions, all modified HTTP requests should be sent using the POST method. Also, the wait = 0 parameter has been added, so Hive does not need to wait for a partition restart while processing a request.

Pr in which reassign requests with Get method was prohibited https://github.com/ydb-platform/ydb/pull/30038
