### PR TITLE
issue-2674: fixing false positive NodeNotFoundInShard crit event in case of listing + unlink/rename race

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -79,10 +79,6 @@ private:
         const TEvIndexTablet::TEvGetNodeAttrBatchResponse::TPtr& ev,
         const TActorContext& ctx);
 
-    void HandleGetNodeAttrResponse(
-        const TEvService::TEvGetNodeAttrResponse::TPtr& ev,
-        const TActorContext& ctx);
-
     void CheckNodeAttrs(const TActorContext& ctx);
 
     void HandleGetNodeAttrResponseCheck(
@@ -339,50 +335,6 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
     }
 }
 
-void TListNodesActor::HandleGetNodeAttrResponse(
-    const TEvService::TEvGetNodeAttrResponse::TPtr& ev,
-    const TActorContext& ctx)
-{
-    auto* msg = ev->Get();
-
-    LOG_DEBUG(
-        ctx,
-        TFileStoreComponents::SERVICE,
-        "GetNodeAttrResponse from shard: %s",
-        msg->Record.GetNode().DebugString().Quote().c_str());
-
-    if (HasError(msg->GetError())) {
-        if (msg->GetError().GetCode() == NoEnt) {
-            MissingNodeIndices.push_back(ev->Cookie);
-
-            LOG_WARN(
-                ctx,
-                TFileStoreComponents::SERVICE,
-                "Node not found in shard: %s, %s",
-                FormatError(msg->GetError()).Quote().c_str(),
-                Response.GetNames(ev->Cookie).c_str());
-        } else {
-            LOG_WARN(
-                ctx,
-                TFileStoreComponents::SERVICE,
-                "Failed to GetNodeAttr from shard: %s",
-                FormatError(msg->GetError()).Quote().c_str());
-
-            HandleError(ctx, std::move(*msg->Record.MutableError()));
-            return;
-        }
-    } else {
-        TABLET_VERIFY(ev->Cookie < Response.NodesSize());
-        auto* node = Response.MutableNodes(ev->Cookie);
-        *node = std::move(*msg->Record.MutableNode());
-    }
-
-    if (++GetNodeAttrResponses == Response.NodesSize()) {
-        CheckResponseAndReply(ctx);
-        return;
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void TListNodesActor::CheckNodeAttrs(const TActorContext& ctx)
@@ -427,6 +379,7 @@ void TListNodesActor::HandleGetNodeAttrResponseCheck(
     const auto& name = Response.GetNames(ev->Cookie);
 
     bool exists = true;
+    bool locked = false;
     if (HasError(msg->GetError())) {
         if (msg->GetError().GetCode() == NoEnt) {
             exists = false;
@@ -448,22 +401,44 @@ void TListNodesActor::HandleGetNodeAttrResponseCheck(
     } else {
         const auto& attr = msg->Record.GetNode();
         exists = attr.GetShardNodeName() == node.GetShardNodeName();
+        locked = msg->Record.GetIsNodeRefLocked();
     }
 
     if (exists) {
-        ++LostNodeCount;
-        LOG_WARN(
-            ctx,
-            TFileStoreComponents::SERVICE,
-            "Node found in leader but missing in shard. Node observed in "
-            "leader: (name: %s, node proto: %s). Listing request proto: %s. "
-            "Validation response proto: %s",
-            name.Quote().c_str(),
-            node.ShortDebugString().Quote().c_str(),
-            ListNodesRequest.ShortDebugString().Quote().c_str(),
-            msg->Record.ShortDebugString().Quote().c_str());
+        if (locked) {
+            //
+            // NodeRef is being processed by a concurrent write operation - e.g.
+            // UnlinkNode or RenameNode. It's ok to temporarily have internal
+            // inconsistency between the directory tablet and the shard in
+            // charge of this node in this case.
+            //
 
-        ReportNodeNotFoundInShard();
+            LOG_DEBUG(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "Node found in leader but missing in shard. Node observed in "
+                "leader: (name: %s, node proto: %s). Listing request: %s. "
+                "Validation response: %s",
+                name.Quote().c_str(),
+                node.ShortDebugString().Quote().c_str(),
+                ListNodesRequest.ShortDebugString().Quote().c_str(),
+                msg->Record.ShortDebugString().Quote().c_str());
+        } else {
+            ++LostNodeCount;
+
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "Node found in leader but missing in shard. Node observed in "
+                "leader: (name: %s, node proto: %s). Listing request: %s. "
+                "Validation response: %s",
+                name.Quote().c_str(),
+                node.ShortDebugString().Quote().c_str(),
+                ListNodesRequest.ShortDebugString().Quote().c_str(),
+                msg->Record.ShortDebugString().Quote().c_str());
+
+            ReportNodeNotFoundInShard();
+        }
     }
 
     if (++CheckedNodeCount == MissingNodeIndices.size()) {
@@ -567,9 +542,6 @@ STFUNC(TListNodesActor::StateWork)
         HFunc(
             TEvService::TEvListNodesResponse,
             HandleListNodesResponse);
-        HFunc(
-            TEvService::TEvGetNodeAttrResponse,
-            HandleGetNodeAttrResponse);
         HFunc(
             TEvIndexTablet::TEvGetNodeAttrBatchResponse,
             HandleGetNodeAttrBatchResponse);

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5857,6 +5857,104 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     }
 
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+        ShouldHandleUnlinkedNodeUponListingWithDirectoriesInShards)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+        config.SetDirectoryCreationInShardsEnabled(true);
+
+        TShardedFileSystemConfig fsConfig{
+            .DirectoryCreationInShardsEnabled = true};
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        auto dirId = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir")
+        )->Record.GetNode().GetId();
+
+        auto subdir1Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(dirId, "subdir1")
+        )->Record.GetNode().GetId();
+        Y_UNUSED(subdir1Id);
+
+        auto subdir2Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(dirId, "subdir2")
+        )->Record.GetNode().GetId();
+
+        IEventHandlePtr unlinkNodeResponse;
+        bool shouldIntercept = true;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+
+                if (event->GetTypeRewrite() == TEvService::EvUnlinkNodeResponse
+                        && shouldIntercept)
+                {
+                    unlinkNodeResponse.reset(event.Release());
+                    return true;
+                }
+
+                return false;
+            });
+
+        service.SendUnlinkNodeRequest(headers, dirId, "subdir1", true);
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+        UNIT_ASSERT(unlinkNodeResponse);
+
+        auto listing = service.ListNodes(headers, fsConfig.FsId, dirId)->Record;
+        UNIT_ASSERT_VALUES_EQUAL(1, listing.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listing.NamesSize());
+
+        UNIT_ASSERT_VALUES_EQUAL(subdir2Id, listing.GetNodes(0).GetId());
+        UNIT_ASSERT_VALUES_EQUAL("subdir2", listing.GetNames(0));
+
+        shouldIntercept = false;
+        env.GetRuntime().Send(unlinkNodeResponse.release());
+        auto unlinkResponse = service.RecvUnlinkNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            unlinkResponse->GetStatus(),
+            FormatError(unlinkResponse->GetError()));
+
+        shouldIntercept = true;
+        service.SendUnlinkNodeRequest(headers, dirId, "subdir2", true);
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+        UNIT_ASSERT(unlinkNodeResponse);
+
+        service.SendListNodesRequest(headers, fsConfig.FsId, dirId);
+        auto listingResponse = service.RecvListNodesResponse();
+        // all the listed node refs point to the nodes that are being unlinked
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            listingResponse->GetStatus(),
+            FormatError(listingResponse->GetError()));
+
+        shouldIntercept = false;
+        env.GetRuntime().Send(unlinkNodeResponse.release());
+        unlinkResponse = service.RecvUnlinkNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            unlinkResponse->GetStatus(),
+            FormatError(unlinkResponse->GetError()));
+
+        listing = service.ListNodes(headers, fsConfig.FsId, dirId)->Record;
+        UNIT_ASSERT_VALUES_EQUAL(0, listing.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listing.NamesSize());
+
+        const auto counters =
+            env.GetCounters()->FindSubgroup("component", "service");
+        UNIT_ASSERT(counters);
+        const auto counter = counters->GetCounter(
+            "AppCriticalEvents/NodeNotFoundInShard");
+
+        UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
+    }
+
+    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldHandleRenameNodeInDestinationError)
     {
         config.SetMultiTabletForwardingEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
@@ -143,6 +143,7 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttr(
         args.TargetNodeId = ref->ChildNodeId;
         args.ShardId = ref->ShardId;
         args.ShardNodeName = ref->ShardNodeName;
+        args.IsNodeRefLocked = IsNodeRefLocked({args.NodeId, args.Name});
     } else {
         args.TargetNodeId = args.NodeId;
     }
@@ -185,6 +186,7 @@ void TIndexTabletActor::CompleteTx_GetNodeAttr(
                 args.TargetNodeId,
                 args.TargetNode->Attrs);
         }
+        response->Record.SetIsNodeRefLocked(args.IsNodeRefLocked);
 
         args.RequestMetrics.Update(
             1,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -708,6 +708,7 @@ public:
 
     bool TryLockNodeRef(TNodeRefKey key);
     void UnlockNodeRef(const TNodeRefKey& key);
+    bool IsNodeRefLocked(const TNodeRefKey& key) const;
 
     //
     // Sessions

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -595,6 +595,11 @@ void TIndexTabletState::UnlockNodeRef(const TNodeRefKey& key)
     Impl->LockedNodeRefs.erase(key);
 }
 
+bool TIndexTabletState::IsNodeRefLocked(const TNodeRefKey& key) const
+{
+    return Impl->LockedNodeRefs.contains(key);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 IIndexTabletDatabase& TIndexTabletState::AccessInMemoryIndexState()

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1578,6 +1578,8 @@ struct TTxIndexTablet
         TString ShardId;
         TString ShardNodeName;
 
+        bool IsNodeRefLocked = false;
+
         TGetNodeAttr(
                 TRequestInfoPtr requestInfo,
                 const NProto::TGetNodeAttrRequest& request,
@@ -1601,6 +1603,8 @@ struct TTxIndexTablet
             TargetNode.Clear();
             ShardId.clear();
             ShardNodeName.clear();
+
+            IsNodeRefLocked = false;
         }
     };
 

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -478,6 +478,11 @@ message TGetNodeAttrResponse
     // Node attributes.
     TNodeAttr Node = 2;
 
+    // Whether the requested node-ref is locked by a running write operation
+    // (e.g. UnlinkNode or RenameNode). Valid only for the requests with
+    // parent-id + name pair.
+    bool IsNodeRefLocked = 3;
+
     // Optional response headers.
     TResponseHeaders Headers = 1000;
 }


### PR DESCRIPTION
### Notes
Without directories in shards there's a guarantee that `UnlinkNode` succeeds in shard (i.e. we'll get either `S_OK`/`S_ALREADY`/`S_FALSE` or a retriable error) so we can delete `NodeRef` first and then proceed with `UnlinkNode` in shard.

With directories in shards the `UnlinkNode` operation in shard can fail - e.g. if the target node is a non-empty directory. That's why in this case we have to do it the other way around - we attempt `UnlinkNode` in shard first and then, if it succeeds, we delete the corresponding `NodeRef`. We lock `NodeRef` first, in the beginning of this whole operation.

This opposite order introduces a race in the lost-node check in the storage service layer's listing logic. The logic works as follows:
1. list nodes in the tablet in charge of the directory
2. fetch the attributes of the nodes fetched on step 2
3. if we got `ENOENT` for some of the nodes on step 2, then do `GetNodeAttr(parentId, name)` in the tablet in charge of the directory for such nodes
4. if any of the node refs requested on step 3 still exist in the directory tablet, then raise the `NodeNotFoundInShard` crit event

If we unlink the node in shard first, then there is a race between step 3 and `NodeRef` deletion so false-positive `NodeNotFoundInShard` crit events can be triggered. Fixing this here in the following way:
* returning `IsNodeRefLocked` flag in `TGetNodeAttrResponse`
* not reporting the `NodeNotFoundInShard` crit event for the locked node refs

There's also a small chance of returning `E_IO` upon the listing request - this happens if all the listed nodes are being unlinked. This issue is also fixed here - we just return `E_REJECTED` now in this case. This fix happened automatically - by not incrementing `LostNodeCount` for locked node-refs.

Deleted the unneeded legacy `HandleGetNodeAttrResponse()` handler from the listing code as well.

### Issue
https://github.com/ydb-platform/nbs/issues/2674