### PR TITLE
[Filestore] Add FileStore type to the togglable types on the Hive monitoring page

### DIFF
--- a/contrib/ydb/core/mind/hive/monitoring.cpp
+++ b/contrib/ydb/core/mind/hive/monitoring.cpp
@@ -1213,9 +1213,7 @@ public:
              TTabletTypes::TestShard,
              TTabletTypes::BlobDepot,
              TTabletTypes::ColumnShard,
-             TTabletTypes::FileStore,
-             TTabletTypes::BlockStoreVolume,
-             TTabletTypes::BlockStorePartition2}) {
+             TTabletTypes::FileStore}) {
             const TVector<i64>& allowedMetrics = Self->GetTabletTypeAllowedMetricIds(tabletType);
             out << "<tr>"
                    "<td>" << GetTabletTypeShortName(tabletType) << "</td>";

--- a/contrib/ydb/core/mind/hive/monitoring.cpp
+++ b/contrib/ydb/core/mind/hive/monitoring.cpp
@@ -1213,7 +1213,8 @@ public:
              TTabletTypes::TestShard,
              TTabletTypes::BlobDepot,
              TTabletTypes::ColumnShard,
-             TTabletTypes::FileStore}) {
+             TTabletTypes::FileStore,
+        }) {
             const TVector<i64>& allowedMetrics = Self->GetTabletTypeAllowedMetricIds(tabletType);
             out << "<tr>"
                    "<td>" << GetTabletTypeShortName(tabletType) << "</td>";

--- a/contrib/ydb/core/mind/hive/monitoring.cpp
+++ b/contrib/ydb/core/mind/hive/monitoring.cpp
@@ -1212,7 +1212,10 @@ public:
              TTabletTypes::NodeBroker,
              TTabletTypes::TestShard,
              TTabletTypes::BlobDepot,
-             TTabletTypes::ColumnShard}) {
+             TTabletTypes::ColumnShard,
+             TTabletTypes::FileStore,
+             TTabletTypes::BlockStoreVolume,
+             TTabletTypes::BlockStorePartition2}) {
             const TVector<i64>& allowedMetrics = Self->GetTabletTypeAllowedMetricIds(tabletType);
             out << "<tr>"
                    "<td>" << GetTabletTypeShortName(tabletType) << "</td>";


### PR DESCRIPTION
### Notes
This is necessary to be able to disable Network metrics consideration and balance filestore tablets just by their count

### Issue
Put links to the related issues here
