### PR TITLE
Added TVolumeShapingThrottler that throttles responses

### DIFF
--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -560,6 +560,10 @@ struct TVolumeSelfSimpleCounters
         EPublishingPolicy::All,
         TCumulativeCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
+    TCounter ShapingThrottlerBudgetSpent{
+        EPublishingPolicy::All,
+        TCumulativeCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
 
     // BlobStorage-based
     TCounter RealMaxWriteBandwidth{
@@ -642,6 +646,7 @@ struct TVolumeSelfSimpleCounters
         MakeMeta<&TVolumeSelfSimpleCounters::LongRunningWriteBlob>(),
         MakeMeta<&TVolumeSelfSimpleCounters::UseFastPath>(),
         MakeMeta<&TVolumeSelfSimpleCounters::HasPerformanceProfileModifications>(),
+        MakeMeta<&TVolumeSelfSimpleCounters::ShapingThrottlerBudgetSpent>(),
 
         MakeMeta<&TVolumeSelfSimpleCounters::RealMaxWriteBandwidth>(),
         MakeMeta<&TVolumeSelfSimpleCounters::PostponedQueueWeight>(),

--- a/cloud/blockstore/libs/storage/partition_common/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition_common/model/ya.make
@@ -18,7 +18,3 @@ PEERDIR(
 )
 
 END()
-
-RECURSE_FOR_TESTS(
-    ut
-)

--- a/cloud/blockstore/libs/storage/volume/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/volume/model/ut/ya.make
@@ -12,6 +12,7 @@ SRCS(
     retry_policy_ut.cpp
     stripe_ut.cpp
     volume_params_ut.cpp
+    volume_shaping_throttler_ut.cpp
     volume_throttling_policy_ut.cpp
 )
 

--- a/cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler.cpp
@@ -1,0 +1,97 @@
+#include "volume_shaping_throttler.h"
+
+#include <cloud/storage/core/libs/throttling/helpers.h>
+#include <cloud/storage/core/protos/diagnostics.pb.h>
+
+namespace NCloud::NBlockStore::NStorage {
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TPerformanceProfile = NCloud::NProto::TPerformanceProfile;
+
+const NProto::TShapingThrottlerQuota& GetShapingThrottlerQuota(
+    const NProto::TShapingThrottlerConfig& shapingThrottlerConfig,
+    NCloud::NProto::EStorageMediaKind storageMediaKind)
+{
+    switch (storageMediaKind) {
+        case NCloud::NProto::STORAGE_MEDIA_SSD:
+            return shapingThrottlerConfig.GetSsdQuota();
+        case NCloud::NProto::STORAGE_MEDIA_HDD:
+        case NCloud::NProto::STORAGE_MEDIA_HYBRID:
+            return shapingThrottlerConfig.GetHddQuota();
+        case NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
+            return shapingThrottlerConfig.GetNonreplQuota();
+        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2:
+            return shapingThrottlerConfig.GetMirror2Quota();
+        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3:
+            return shapingThrottlerConfig.GetMirror3Quota();
+        default:
+            return shapingThrottlerConfig.GetHddQuota();
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVolumeShapingThrottler::TVolumeShapingThrottler(
+    const NProto::TShapingThrottlerConfig& shapingThrottlerConfig,
+    NCloud::NProto::EStorageMediaKind storageMediaKind,
+    double spentShapingBudgetShare)
+    : ShapingThrottlerQuota(
+          GetShapingThrottlerQuota(shapingThrottlerConfig, storageMediaKind))
+    , UnspentCostBucket(
+          TDuration::MilliSeconds(ShapingThrottlerQuota.GetMaxBudget()),
+          TDuration::MilliSeconds(ShapingThrottlerQuota.GetBudgetRefillTime()),
+          ShapingThrottlerQuota.GetBudgetSpendRate(),
+          spentShapingBudgetShare)
+    , ReadPerformanceProfile(
+          ShapingThrottlerQuota.HasRead() ? &ShapingThrottlerQuota.GetRead()
+                                          : nullptr)
+    , WritePerformanceProfile(
+          ShapingThrottlerQuota.HasWrite() ? &ShapingThrottlerQuota.GetWrite()
+                                           : nullptr)
+{}
+
+TDuration TVolumeShapingThrottler::SuggestDelay(
+    TInstant ts,
+    ui64 byteCount,
+    EVolumeThrottlingOpType opType,
+    TDuration executionTime)
+{
+    const TPerformanceProfile* performanceProfile = nullptr;
+    switch (opType) {
+        case EVolumeThrottlingOpType::Read:
+            performanceProfile = ReadPerformanceProfile;
+            break;
+        case EVolumeThrottlingOpType::Write:
+            performanceProfile = WritePerformanceProfile;
+            break;
+        case EVolumeThrottlingOpType::Zero:
+        case EVolumeThrottlingOpType::Describe:
+            return TDuration::Zero();
+    }
+    if (!performanceProfile) {
+        return TDuration::Zero();
+    }
+    const TDuration cost = ShapingThrottlerQuota.GetExpectedIoParallelism() *
+                           CostPerIO(
+                               performanceProfile->GetIops(),
+                               performanceProfile->GetBandwidth(),
+                               byteCount);
+    return UnspentCostBucket.Register(ts, cost, executionTime);
+}
+
+double TVolumeShapingThrottler::CalculateCurrentSpentBudgetShare(
+    TInstant now) const
+{
+    return UnspentCostBucket.CalculateCurrentSpentBudgetShare(now);
+}
+
+TDuration TVolumeShapingThrottler::GetCurrentBudget() const
+{
+    return UnspentCostBucket.GetCurrentBudget();
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler.h
+++ b/cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/blockstore/config/storage.pb.h>
+#include <cloud/blockstore/libs/storage/api/public.h>
+#include <cloud/blockstore/public/api/protos/volume_throttling.pb.h>
+
+#include <cloud/storage/core/libs/throttling/unspent_cost_bucket.h>
+#include <cloud/storage/core/protos/media.pb.h>
+
+#include <util/datetime/base.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Per-volume "shaping" throttler based on media-specific quotas.
+// Converts an IO request (op type + size) into an expected cost derived from
+// the configured performance profile (IOPS/BW) and uses a budget bucket to
+// suggest an additional delay. Designed to be used after the request has
+// completed (pass the measured `executionTime` to account for time already
+// spent).
+// Note: only Read/Write ops are shaped; Zero/Describe are not delayed.
+class TVolumeShapingThrottler
+{
+private:
+    NProto::TShapingThrottlerQuota ShapingThrottlerQuota;
+    TUnspentCostBucket UnspentCostBucket;
+
+    const NCloud::NProto::TPerformanceProfile* const ReadPerformanceProfile;
+    const NCloud::NProto::TPerformanceProfile* const WritePerformanceProfile;
+
+public:
+    TVolumeShapingThrottler(
+        const NProto::TShapingThrottlerConfig& shapingThrottlerConfig,
+        NCloud::NProto::EStorageMediaKind storageMediaKind,
+        double spentShapingBudgetShare);
+
+    TDuration SuggestDelay(
+        TInstant ts,
+        ui64 byteCount,
+        EVolumeThrottlingOpType opType,
+        TDuration executionTime);
+
+    [[nodiscard]] TDuration GetCurrentBudget() const;
+    [[nodiscard]] double CalculateCurrentSpentBudgetShare(TInstant now) const;
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler_ut.cpp
@@ -1,0 +1,402 @@
+#include "volume_shaping_throttler.h"
+
+#include <cloud/blockstore/config/storage.pb.h>
+
+#include <cloud/storage/core/libs/throttling/helpers.h>
+#include <cloud/storage/core/protos/media.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using EOpType = EVolumeThrottlingOpType;
+
+NProto::TShapingThrottlerQuota MakeQuota(
+    ui32 readIops,
+    ui64 readBandwidth,
+    ui32 writeIops,
+    ui64 writeBandwidth,
+    ui32 expectedIoParallelism,
+    ui32 maxBudgetMs,
+    ui32 budgetRefillTimeMs,
+    double budgetSpendRate)
+{
+    NProto::TShapingThrottlerQuota quota;
+    if (readIops || readBandwidth) {
+        auto* read = quota.MutableRead();
+        read->SetIops(readIops);
+        read->SetBandwidth(readBandwidth);
+    }
+    if (writeIops || writeBandwidth) {
+        auto* write = quota.MutableWrite();
+        write->SetIops(writeIops);
+        write->SetBandwidth(writeBandwidth);
+    }
+    quota.SetExpectedIoParallelism(expectedIoParallelism);
+    quota.SetMaxBudget(maxBudgetMs);
+    quota.SetBudgetRefillTime(budgetRefillTimeMs);
+    quota.SetBudgetSpendRate(budgetSpendRate);
+    return quota;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TVolumeShapingThrottlerTest)
+{
+    Y_UNIT_TEST(ShouldDisableThrottlingWithEmptyConfig)
+    {
+        NProto::TShapingThrottlerConfig config;
+        TVolumeShapingThrottler throttler(
+            config,
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            /*spentShapingBudgetShare=*/0.0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            throttler.SuggestDelay(
+                TInstant::Seconds(1),
+                4_KB,
+                EOpType::Read,
+                TDuration::Zero()));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            throttler.SuggestDelay(
+                TInstant::Seconds(2),
+                4_KB,
+                EOpType::Write,
+                TDuration::Zero()));
+    }
+
+    void ShouldSelectCorrectQuotaByMediaKind(
+        NCloud::NProto::EStorageMediaKind mediaKind)
+    {
+        auto makeConfig = [mediaKind]()
+        {
+            constexpr ui32 WriteIops = 100;
+            constexpr ui64 WriteBandwidth = 10_MB;
+            NProto::TShapingThrottlerConfig config;
+
+            auto quota = MakeQuota(
+                0,                // readIops
+                0,                // readBandwidth
+                WriteIops,        // writeIops
+                WriteBandwidth,   // writeBandwidth
+                1,                // expectedIoParallelism
+                100,              // maxBudgetMs
+                0,                // budgetRefillTimeMs
+                2.0);             // budgetSpendRate
+
+            switch (mediaKind) {
+                case NCloud::NProto::STORAGE_MEDIA_SSD:
+                    *config.MutableSsdQuota() = quota;
+                    break;
+                case NCloud::NProto::STORAGE_MEDIA_HDD:
+                case NCloud::NProto::STORAGE_MEDIA_HYBRID:
+                    *config.MutableHddQuota() = quota;
+                    break;
+                case NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
+                    *config.MutableNonreplQuota() = quota;
+                    break;
+                case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2:
+                    *config.MutableMirror2Quota() = quota;
+                    break;
+                case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3:
+                    *config.MutableMirror3Quota() = quota;
+                    break;
+                default:
+                    break;
+            }
+            return config;
+        };
+
+        auto config = makeConfig();
+
+        TVolumeShapingThrottler throttler(
+            config,
+            mediaKind,
+            /*spentShapingBudgetShare=*/0.0);
+        auto delay = throttler.SuggestDelay(
+            TInstant::Seconds(1),   // ts
+            1_MB,                   // byteCount
+            EOpType::Write,
+            TDuration::Zero());   // executionTime
+        UNIT_ASSERT_VALUES_UNEQUAL(TDuration::Zero(), delay);
+    }
+
+    Y_UNIT_TEST(ShouldSelectCorrectQuotaByMediaKind_SSD)
+    {
+        ShouldSelectCorrectQuotaByMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
+    }
+
+    Y_UNIT_TEST(ShouldSelectCorrectQuotaByMediaKind_HDD)
+    {
+        ShouldSelectCorrectQuotaByMediaKind(NCloud::NProto::STORAGE_MEDIA_HDD);
+    }
+
+    Y_UNIT_TEST(ShouldSelectCorrectQuotaByMediaKind_HYBRID)
+    {
+        ShouldSelectCorrectQuotaByMediaKind(
+            NCloud::NProto::STORAGE_MEDIA_HYBRID);
+    }
+
+    Y_UNIT_TEST(ShouldSelectCorrectQuotaByMediaKind_SSD_NONREPLICATED)
+    {
+        ShouldSelectCorrectQuotaByMediaKind(
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
+    }
+
+    Y_UNIT_TEST(ShouldSelectCorrectQuotaByMediaKind_SSD_MIRROR2)
+    {
+        ShouldSelectCorrectQuotaByMediaKind(
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2);
+    }
+
+    Y_UNIT_TEST(ShouldSelectCorrectQuotaByMediaKind_SSD_MIRROR3)
+    {
+        ShouldSelectCorrectQuotaByMediaKind(
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3);
+    }
+
+    Y_UNIT_TEST(ShouldUseSsdQuotaForSsd)
+    {
+        NProto::TShapingThrottlerConfig config;
+        *config.MutableSsdQuota() = MakeQuota(
+            90,     // readIops
+            0,      // readBandwidth
+            0,      // writeIops
+            0,      // writeBandwidth
+            1,      // expectedIoParallelism
+            10,     // maxBudgetMs
+            0,      // budgetRefillTimeMs (no refill)
+            2.0);   // budgetSpendRate
+        *config.MutableHddQuota() = MakeQuota(
+            50,     // readIops
+            0,      // readBandwidth
+            0,      // writeIops
+            0,      // writeBandwidth
+            1,      // expectedIoParallelism
+            10,     // maxBudgetMs
+            0,      // budgetRefillTimeMs (no refill)
+            2.0);   // budgetSpendRate
+
+        TVolumeShapingThrottler ssdThrottler(
+            config,
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            0.0);
+        TVolumeShapingThrottler hddThrottler(
+            config,
+            NCloud::NProto::STORAGE_MEDIA_HDD,
+            0.0);
+
+        const TDuration ssdDelay = ssdThrottler.SuggestDelay(
+            TInstant::Seconds(1),   // ts
+            0,                      // byteCount
+            EOpType::Read,
+            TDuration::Zero());
+        const TDuration hddDelay = hddThrottler.SuggestDelay(
+            TInstant::Seconds(1),   // ts
+            0,                      // byteCount
+            EOpType::Read,
+            TDuration::Zero());
+
+        UNIT_ASSERT_GT(ssdDelay, TDuration::Zero());
+        UNIT_ASSERT_GT(hddDelay, TDuration::Zero());
+        UNIT_ASSERT_GT(hddDelay, ssdDelay);
+    }
+
+    Y_UNIT_TEST(ShouldUseHddQuotaForHybridMedia)
+    {
+        NProto::TShapingThrottlerConfig config;
+        *config.MutableHddQuota() = MakeQuota(
+            100,
+            0,   // read: 100 iops
+            0,
+            0,       // no write profile
+            1,       // expectedIoParallelism
+            1000,    // maxBudgetMs
+            10000,   // budgetRefillTimeMs
+            2.0);    // budgetSpendRate
+
+        TVolumeShapingThrottler hddThrottler(
+            config,
+            NCloud::NProto::STORAGE_MEDIA_HDD,
+            0.0);
+        TVolumeShapingThrottler hybridThrottler(
+            config,
+            NCloud::NProto::STORAGE_MEDIA_HYBRID,
+            0.0);
+
+        auto hddDelay = hddThrottler.SuggestDelay(
+            TInstant::Seconds(1),
+            0,
+            EOpType::Read,
+            TDuration::Zero());
+        auto hybridDelay = hybridThrottler.SuggestDelay(
+            TInstant::Seconds(1),
+            0,
+            EOpType::Read,
+            TDuration::Zero());
+
+        UNIT_ASSERT_VALUES_EQUAL(hddDelay, hybridDelay);
+    }
+
+    Y_UNIT_TEST(ShouldReturnZeroDelayForZeroAndDescribeOps)
+    {
+        NProto::TShapingThrottlerConfig config;
+        *config.MutableSsdQuota() = MakeQuota(
+            100,
+            0,   // read: 100 iops
+            100,
+            0,       // write: 100 iops
+            1,       // expectedIoParallelism
+            1000,    // maxBudgetMs
+            10000,   // budgetRefillTimeMs
+            2.0);    // budgetSpendRate
+
+        TVolumeShapingThrottler throttler(
+            config,
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            /*spentShapingBudgetShare=*/0.0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            throttler.SuggestDelay(
+                TInstant::Seconds(1),
+                4_KB,
+                EOpType::Zero,
+                TDuration::Zero()));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            throttler.SuggestDelay(
+                TInstant::Seconds(2),
+                4_KB,
+                EOpType::Describe,
+                TDuration::Zero()));
+    }
+
+    Y_UNIT_TEST(ShouldReturnZeroDelayIfPerformanceProfileMissing)
+    {
+        NProto::TShapingThrottlerConfig config;
+        // Only set write profile, no read profile.
+        *config.MutableSsdQuota() = MakeQuota(
+            0,       // readIops
+            0,       // readBandwidth
+            100,     // writeIops
+            10_MB,   // writeBandwidth
+            1,       // expectedIoParallelism
+            100,     // maxBudgetMs
+            0,       // budgetRefillTimeMs (no refill)
+            2.0);    // budgetSpendRate
+
+        TVolumeShapingThrottler throttler(
+            config,
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            /*spentShapingBudgetShare=*/0.0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::Zero(),
+            throttler.SuggestDelay(
+                TInstant::Seconds(1),
+                4_MB,
+                EOpType::Read,
+                TDuration::Zero()));
+
+        // Write should produce a non-zero delay.
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            TDuration::Zero(),
+            throttler.SuggestDelay(
+                TInstant::Seconds(2),
+                4_MB,
+                EOpType::Write,
+                TDuration::Zero()));
+    }
+
+    Y_UNIT_TEST(ShouldScaleCostByExpectedIoParallelism)
+    {
+        auto makeThrottler = [](ui32 parallelism)
+        {
+            NProto::TShapingThrottlerConfig config;
+            *config.MutableSsdQuota() = MakeQuota(
+                1000,          // readIops
+                10_MB,         // readBandwidth
+                0,             // writeIops
+                0,             // writeBandwidth
+                parallelism,   // expectedIoParallelism
+                100,           // maxBudgetMs
+                0,             // budgetRefillTimeMs (no refill)
+                2.0);          // budgetSpendRate
+
+            return TVolumeShapingThrottler(
+                config,
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                /*spentShapingBudgetShare=*/0.0);
+        };
+
+        auto throttler1 = makeThrottler(1);
+        auto throttler2 = makeThrottler(3);
+
+        const TDuration delay1 = throttler1.SuggestDelay(
+            TInstant::Seconds(1),   // ts
+            4_MB,                   // byteCount
+            EOpType::Read,
+            TDuration::Zero());
+        const TDuration delay2 = throttler2.SuggestDelay(
+            TInstant::Seconds(1),   // ts
+            4_MB,                   // byteCount
+            EOpType::Read,
+            TDuration::Zero());
+
+        UNIT_ASSERT_GT(delay2, delay1);
+    }
+
+    Y_UNIT_TEST(ShouldAccountForByteCountInCost)
+    {
+        auto makeThrottler = []()
+        {
+            NProto::TShapingThrottlerConfig config;
+            *config.MutableSsdQuota() = MakeQuota(
+                100,     // readIops
+                10_MB,   // readBandwidth
+                0,       // writeIops
+                0,       // writeBandwidth
+                1,       // expectedIoParallelism
+                20,      // maxBudgetMs
+                0,       // budgetRefillTimeMs (no refill)
+                2.0);    // budgetSpendRate
+
+            return TVolumeShapingThrottler(
+                config,
+                NCloud::NProto::STORAGE_MEDIA_SSD,
+                /*spentShapingBudgetShare=*/0.0);
+        };
+
+        auto throttler1 = makeThrottler();
+        auto throttler2 = makeThrottler();
+
+        // Small IO should produce smaller delay than large IO.
+        auto delaySmall = throttler1.SuggestDelay(
+            TInstant::Seconds(1),
+            4_KB,
+            EOpType::Read,
+            TDuration::Zero());
+        auto delayLarge = throttler2.SuggestDelay(
+            TInstant::Seconds(2),
+            4_MB,
+            EOpType::Read,
+            TDuration::Zero());
+
+        UNIT_ASSERT(delayLarge > delaySmall);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/model/ya.make
+++ b/cloud/blockstore/libs/storage/volume/model/ya.make
@@ -20,6 +20,7 @@ SRCS(
     stripe.cpp
     tracing.cpp
     volume_params.cpp
+    volume_shaping_throttler.cpp
     volume_throttling_policy.cpp
 )
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -698,8 +698,9 @@ void TVolumeActor::HandleUpdateThrottlerState(
                 .BoostBudget = State->GetThrottlingPolicy()
                                    .GetCurrentBoostBudget()
                                    .MilliSeconds(),
-                // TODO(#5095): Fill this field.
-                .SpentShapingBudgetShare = 0.0});
+                .SpentShapingBudgetShare =
+                    State->GetShapingThrottler()
+                        .CalculateCurrentSpentBudgetShare(ctx.Now())});
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -152,6 +152,8 @@ class TVolumeActor final
         const TCallContextPtr CallContext;
         const TCallContextPtr ForkedContext;
         const ui64 ReceiveTime;
+        const ui64 ExecutionStartTime;
+        TThrottlingRequestInfo ThrottlingRequestInfo;
         TCancelRoutine* const CancelRoutine;
         const bool IsMultipartitionWriteOrZero;
 
@@ -161,6 +163,8 @@ class TVolumeActor final
                 TCallContextPtr callContext,
                 TCallContextPtr forkedContext,
                 ui64 receiveTime,
+                ui64 executionStartTime,
+                TThrottlingRequestInfo throttlingRequestInfo,
                 TCancelRoutine cancelRoutine,
                 bool isMultipartitionWriteOrZero)
             : Caller(caller)
@@ -168,6 +172,8 @@ class TVolumeActor final
             , CallContext(std::move(callContext))
             , ForkedContext(std::move(forkedContext))
             , ReceiveTime(receiveTime)
+            , ExecutionStartTime(executionStartTime)
+            , ThrottlingRequestInfo(std::move(throttlingRequestInfo))
             , CancelRoutine(cancelRoutine)
             , IsMultipartitionWriteOrZero(isMultipartitionWriteOrZero)
         {}
@@ -1129,6 +1135,7 @@ private:
         ui64 volumeRequestId,
         TBlockRange64 blockRange,
         ui64 traceTime,
+        TThrottlingRequestInfo throttlingRequestInfo,
         bool forkTraces,
         bool isMultipartition);
 
@@ -1138,7 +1145,8 @@ private:
         const typename TMethod::TRequest::TPtr& ev,
         ui64 volumeRequestId,
         TBlockRange64 blockRange,
-        ui64 traceTs);
+        ui64 traceTs,
+        TThrottlingRequestInfo throttlingRequestInfo);
 
     template <typename TMethod>
     NProto::TError ProcessAndValidateReadFromCheckpoint(
@@ -1167,7 +1175,8 @@ private:
     NProto::TError Throttle(
         const NActors::TActorContext& ctx,
         const typename TMethod::TRequest::TPtr& ev,
-        bool throttlingDisabled);
+        bool throttlingDisabled,
+        TThrottlingRequestInfo* throttlingRequestInfo);
 
     template <typename TMethod>
     void ForwardResponse(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -140,6 +140,7 @@ typename TMethod::TRequest::TPtr TVolumeActor::WrapRequest(
     ui64 volumeRequestId,
     TBlockRange64 blockRange,
     ui64 traceTime,
+    TThrottlingRequestInfo throttlingRequestInfo,
     bool forkTraces,
     bool isMultipartitionWriteOrZero)
 {
@@ -183,6 +184,8 @@ typename TMethod::TRequest::TPtr TVolumeActor::WrapRequest(
             std::move(originalContext),
             forkTraces ? msg->CallContext : nullptr,
             traceTime,
+            GetCycleCount(),
+            throttlingRequestInfo,
             &RejectVolumeRequest<TMethod>,
             isMultipartitionWriteOrZero));
 
@@ -225,7 +228,8 @@ void TVolumeActor::SendRequestToPartition(
     const typename TMethod::TRequest::TPtr& ev,
     ui64 volumeRequestId,
     TBlockRange64 blockRange,
-    ui64 traceTime)
+    ui64 traceTime,
+    TThrottlingRequestInfo throttlingRequestInfo)
 {
     STORAGE_VERIFY_C(
         State->IsDiskRegistryMediaKind() || State->GetPartitions(),
@@ -278,6 +282,7 @@ void TVolumeActor::SendRequestToPartition(
         volumeRequestId,
         blockRange,
         traceTime,
+        throttlingRequestInfo,
         forkTraces,
         isMultipartitionWriteOrZero);
 
@@ -439,6 +444,23 @@ bool TVolumeActor::ReplyToOriginalRequest(
             volumeRequest.ForkedContext->LWOrbit);
     }
 
+    TDuration shapingDelay;
+    if (success && volumeRequest.ThrottlingRequestInfo.ByteCount > 0) {
+        const ui64 now = GetCycleCount();
+        const TDuration executionTime =
+            CyclesToDurationSafe(now - volumeRequest.ExecutionStartTime);
+        shapingDelay = State->AccessShapingThrottler().SuggestDelay(
+            ctx.Now(),
+            volumeRequest.ThrottlingRequestInfo.ByteCount,
+            static_cast<EVolumeThrottlingOpType>(
+                volumeRequest.ThrottlingRequestInfo.OpType),
+            executionTime);
+
+        volumeRequest.CallContext->AddTime(
+            EProcessingStage::Shaping,
+            shapingDelay);
+    }
+
     FillResponse<TMethod>(
         *response,
         *volumeRequest.CallContext,
@@ -451,7 +473,11 @@ bool TVolumeActor::ReplyToOriginalRequest(
         response.release(),
         flags,
         volumeRequest.CallerCookie);
-    ctx.Send(std::move(event));
+    if (shapingDelay.GetValue() > 0) {
+        ctx.Schedule(shapingDelay, std::move(event), /*cookie=*/nullptr);
+    } else {
+        ctx.Send(std::move(event));
+    }
 
     if (volumeRequest.IsMultipartitionWriteOrZero) {
         Y_DEBUG_ABORT_UNLESS(MultipartitionWriteAndZeroRequestsInProgress > 0);
@@ -580,7 +606,7 @@ void TVolumeActor::ForwardRequest(
     }
 
     auto* msg = ev->Get();
-    auto now = GetCycleCount();
+    ui64 now = GetCycleCount();
 
     // Fill block range.
     TBlockRange64 blockRange;
@@ -847,8 +873,13 @@ void TVolumeActor::ForwardRequest(
         return;
     }
 
+    TThrottlingRequestInfo throttlingRequestInfo;
     {
-        auto error = Throttle<TMethod>(ctx, ev, throttlingDisabled);
+        auto error = Throttle<TMethod>(
+            ctx,
+            ev,
+            throttlingDisabled,
+            &throttlingRequestInfo);
         if (HasError(error)) {
             replyError(std::move(error));
             return;
@@ -1013,7 +1044,13 @@ void TVolumeActor::ForwardRequest(
     // prepared by the WrapRequest<TMethod>() method, which replaces the sender
     // and receiver.
 
-    SendRequestToPartition<TMethod>(ctx, ev, volumeRequestId, blockRange, now);
+    SendRequestToPartition<TMethod>(
+        ctx,
+        ev,
+        volumeRequestId,
+        blockRange,
+        now,
+        throttlingRequestInfo);
 }
 
 #define BLOCKSTORE_FORWARD_REQUEST(name, ns)                                   \

--- a/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
@@ -140,6 +140,7 @@ void TVolumeActor::CompleteLoadState(
             std::move(args.MetaHistory),
             std::move(args.VolumeParams),
             throttlerConfig,
+            throttlerInfo.SpentShapingBudgetShare,
             std::move(args.Clients),
             std::move(volumeHistory),
             std::move(args.CheckpointRequests),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -788,6 +788,10 @@ TEvStatsService::TVolumeSelfCounters TVolumeActor::GetVolumeSelfCounters(
         State->GetMeta().GetMigrations().size() == 0);
     simple.HasPerformanceProfileModifications.Set(
         HasPerformanceProfileModifications);
+    simple.ShapingThrottlerBudgetSpent.Set(
+        std::round(
+            100 * State->GetShapingThrottler().CalculateCurrentSpentBudgetShare(
+                      ctx.Now())));
 
     THashSet<ui32> allAgents;
     for (const NProto::TDeviceConfig* device: GetAllDevices(State->GetMeta())) {

--- a/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_throttling.cpp
@@ -177,7 +177,8 @@ template <typename TMethod>
 NProto::TError TVolumeActor::Throttle(
     const TActorContext& ctx,
     const typename TMethod::TRequest::TPtr& ev,
-    bool throttlingDisabled)
+    bool throttlingDisabled,
+    TThrottlingRequestInfo* throttlingRequestInfo)
 {
     static const auto ok = MakeError(S_OK);
     static const auto err = MakeError(E_BS_THROTTLED, "Throttled");
@@ -192,15 +193,15 @@ NProto::TError TVolumeActor::Throttle(
     auto* msg = ev->Get();
 
     const auto& tp = State->GetThrottlingPolicy();
-    const auto requestInfo = BuildThrottlingRequestInfo(
+    *throttlingRequestInfo = BuildThrottlingRequestInfo(
         State->GetConfig().GetBlockSize(),
         *msg,
         tp.GetVersion()
     );
 
-    if (static_cast<EVolumeThrottlingOpType>(requestInfo.OpType) ==
+    if (static_cast<EVolumeThrottlingOpType>(throttlingRequestInfo->OpType) ==
             EVolumeThrottlingOpType::Describe &&
-        requestInfo.ByteCount == 0)
+        throttlingRequestInfo->ByteCount == 0)
     {
         // DescribeBlocks with zero weight should not be affected by
         // throttling limits.
@@ -210,7 +211,7 @@ NProto::TError TVolumeActor::Throttle(
     const auto status = Throttler->Throttle(
         ctx,
         msg->CallContext,
-        requestInfo,
+        *throttlingRequestInfo,
         [&ev]() { return NActors::IEventHandlePtr(ev.Release()); },
         TMethod::Name);
 
@@ -237,7 +238,8 @@ template NProto::TError TVolumeActor::Throttle<                                \
     ns::T##name##Method>(                                                      \
         const TActorContext& ctx,                                              \
         const ns::TEv##name##Request::TPtr& ev,                                \
-        bool throttlingDisabled);                                              \
+        bool throttlingDisabled,                                               \
+        TThrottlingRequestInfo* throttlingRequestInfo);                        \
 // GENERATE_IMPL
 
 GENERATE_IMPL(ReadBlocks,            TEvService)

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
@@ -368,6 +368,7 @@ void TVolumeActor::CompleteUpdateConfig(
             // TODO: will it get updated later?
             {},   // volume params
             throttlerConfig,
+            0.0,                           // spentShapingBudgetShare
             {},                            // clients
             TCachedVolumeMountHistory{},   // history
             {},                            // checkpoint requests

--- a/cloud/blockstore/libs/storage/volume/volume_state.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state.cpp
@@ -118,6 +118,7 @@ TVolumeState::TVolumeState(
         TVector<TVolumeMetaHistoryItem> metaHistory,
         TVector<TRuntimeVolumeParamsValue> volumeParams,
         TThrottlerConfig throttlerConfig,
+        double spentShapingBudgetShare,
         THashMap<TString, TVolumeClientState> infos,
         TCachedVolumeMountHistory mountHistory,
         TVector<TCheckpointRequest> checkpointRequests,
@@ -133,6 +134,10 @@ TVolumeState::TVolumeState(
     , ClientInfosByClientId(std::move(infos))
     , ThrottlerConfig(std::move(throttlerConfig))
     , ThrottlingPolicy(Config->GetPerformanceProfile(), ThrottlerConfig)
+    , ShapingThrottler(
+        StorageConfig->GetShapingThrottlerConfig(),
+        Config->GetStorageMediaKind(),
+        spentShapingBudgetShare)
     , MountHistory(std::move(mountHistory))
     , CheckpointStore(std::move(checkpointRequests), Config->GetDiskId())
     , StartPartitionsNeeded(startPartitionsNeeded)

--- a/cloud/blockstore/libs/storage/volume/volume_state.h
+++ b/cloud/blockstore/libs/storage/volume/volume_state.h
@@ -14,7 +14,6 @@
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/public.h>
-#include <cloud/blockstore/libs/storage/volume_throttling_manager/volume_throttling_manager.h>
 #include <cloud/blockstore/libs/storage/protos_ydb/volume.pb.h>
 #include <cloud/blockstore/libs/storage/volume/model/checkpoint.h>
 #include <cloud/blockstore/libs/storage/volume/model/checkpoint_light.h>
@@ -22,7 +21,9 @@
 #include <cloud/blockstore/libs/storage/volume/model/follower_disk.h>
 #include <cloud/blockstore/libs/storage/volume/model/meta.h>
 #include <cloud/blockstore/libs/storage/volume/model/volume_params.h>
+#include <cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler.h>
 #include <cloud/blockstore/libs/storage/volume/model/volume_throttling_policy.h>
+#include <cloud/blockstore/libs/storage/volume_throttling_manager/volume_throttling_manager.h>
 
 #include <cloud/storage/core/libs/common/compressed_bitmap.h>
 #include <cloud/storage/core/libs/common/error.h>
@@ -235,6 +236,7 @@ private:
 
     TThrottlerConfig ThrottlerConfig;
     TVolumeThrottlingPolicy ThrottlingPolicy;
+    TVolumeShapingThrottler ShapingThrottler;
 
     TCachedVolumeMountHistory MountHistory;
 
@@ -294,6 +296,7 @@ public:
         TVector<TVolumeMetaHistoryItem> metaHistory,
         TVector<TRuntimeVolumeParamsValue> volumeParams,
         TThrottlerConfig throttlerConfig,
+        double spentShapingBudgetShare,
         THashMap<TString, TVolumeClientState> infos,
         TCachedVolumeMountHistory mountHistory,
         TVector<TCheckpointRequest> checkpointRequests,
@@ -685,6 +688,16 @@ public:
     const TVolumeThrottlingPolicy& GetThrottlingPolicy() const
     {
         return ThrottlingPolicy;
+    }
+
+    TVolumeShapingThrottler& AccessShapingThrottler()
+    {
+        return ShapingThrottler;
+    }
+
+    const TVolumeShapingThrottler& GetShapingThrottler() const
+    {
+        return ShapingThrottler;
     }
 
     //

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -91,6 +91,7 @@ TVolumeState CreateVolumeState(
         {{TInstant::Seconds(100), CreateVolumeMeta(pp)}},   // metaHistory
         {},                                                 // volumeParams
         throttlerConfig,
+        0.0,   // spentShapingBudgetShare
         std::move(clientInfos),
         {},   // mountHistory
         std::move(checkpointRequests),
@@ -113,6 +114,7 @@ TVolumeState CreateVolumeState(
         {{TInstant::Seconds(100), CreateVolumeMeta(pp)}},   // metaHistory
         {},                                                 // volumeParams
         CreateThrottlerConfig(),
+        0.0,   // spentShapingBudgetShare
         std::move(clientInfos),
         TCachedVolumeMountHistory{VolumeHistoryCacheSize, {}},
         std::move(checkpointRequests),
@@ -135,6 +137,7 @@ TVolumeState CreateVolumeState(
         {},   // metaHistory
         {},   // volumeParams
         CreateThrottlerConfig(),
+        0.0,   // spentShapingBudgetShare
         {},   // clientInfos
         TCachedVolumeMountHistory{
             config.GetVolumeHistoryCacheSize(),
@@ -1995,6 +1998,7 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
                 {},     // metaHistory
                 {},     // volumeParams
                 CreateThrottlerConfig(),
+                0.0,    // spentShapingBudgetShare
                 {},     // infos
                 {},     // mountHistory
                 {},     // checkpointRequests

--- a/cloud/blockstore/libs/storage/volume/volume_throttling_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_throttling_ut.cpp
@@ -341,4 +341,276 @@ Y_UNIT_TEST_SUITE(TVolumeActorUpdateThrottlingConfigTest)
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TVolumeActorShapingThrottlingTest)
+{
+    Y_UNIT_TEST(ShouldAddShapingDelayAndScheduleResponseOnSuccess)
+    {
+        NProto::TStorageServiceConfig storageConfig;
+        storageConfig.SetThrottlingEnabled(true);
+        {
+            auto* quota = storageConfig.MutableShapingThrottlerConfig()
+                              ->MutableHddQuota();
+            quota->MutableWrite()->SetIops(1);
+            quota->MutableWrite()->SetBandwidth(1_MB);
+            quota->SetExpectedIoParallelism(1);
+            quota->SetMaxBudget(1);
+            quota->SetBudgetRefillTime(1000);
+            quota->SetBudgetSpendRate(1.0);
+        }
+
+        auto runtime = PrepareTestActorRuntime(storageConfig);
+        TVolumeClient volume = CreateVolume(*runtime);
+        volume.UpdateVolumeConfig(
+            1_GB,      // maxBandwidth
+            100'000,   // maxIops
+            100,       // burstPercentage
+            1000_MB,   // maxPostponedWeight
+            true,      // throttlingEnabled
+            2,         // version
+            NProto::STORAGE_MEDIA_HDD,
+            2048,       // block count per partition
+            diskId,     // diskId
+            cloudId,    // cloudId
+            folderId,   // folderId
+            2,          // partitions count
+            2           // blocksPerStripe
+        );
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume.AddClient(clientInfo);
+
+        bool firstWriteRequest = true;
+        TDuration scheduledDelay;
+        TAutoPtr<IEventHandle> scheduledResponse;
+
+        runtime->SetScheduledEventFilter(
+            [&](TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event,
+                TDuration delay,
+                TInstant& deadline)
+            {
+                Y_UNUSED(runtime);
+
+                if (event->GetTypeRewrite() ==
+                        TEvService::EvWriteBlocksResponse &&
+                    delay != TDuration::Zero())
+                {
+                    scheduledDelay = delay;
+                    scheduledResponse = event.Release();
+                    deadline = runtime.GetCurrentTime();
+                    return true;
+                }
+
+                return false;
+            });
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvService::EvWriteBlocksRequest) {
+                    if (firstWriteRequest) {
+                        firstWriteRequest = false;
+                        return false;
+                    }
+
+                    runtime.SendAsync(new IEventHandle(
+                        /*recipient=*/event->Sender,   // volume actor
+                        /*sender=*/event->Recipient,   // partition actor
+                        new TEvService::TEvWriteBlocksResponse(MakeError(S_OK)),
+                        0,   // flags
+                        event->Cookie,
+                        nullptr));
+                    return true;
+                }
+
+                return false;
+            });
+
+        volume.SendWriteBlocksRequest(
+            TBlockRange64::WithLength(0, 1000),
+            clientInfo.GetClientId(),
+            1);
+
+        runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+        UNIT_ASSERT(scheduledResponse);
+        UNIT_ASSERT_UNEQUAL(TDuration::Zero(), scheduledDelay);
+
+        runtime->Send(scheduledResponse.Release());
+        auto response = volume.RecvWriteBlocksResponse();
+        UNIT_ASSERT(response);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+        const auto& throttler = response->Record.GetHeaders().GetThrottler();
+        UNIT_ASSERT_VALUES_EQUAL(
+            scheduledDelay.MicroSeconds(),
+            throttler.GetShapingDelay());
+    }
+
+    Y_UNIT_TEST(ShouldNotApplyShapingDelayOnFailure)
+    {
+        NProto::TStorageServiceConfig storageConfig;
+        storageConfig.SetThrottlingEnabled(true);
+        {
+            auto* quota = storageConfig.MutableShapingThrottlerConfig()
+                              ->MutableHddQuota();
+            quota->MutableWrite()->SetIops(10);
+            quota->MutableWrite()->SetBandwidth(10_MB);
+            quota->SetExpectedIoParallelism(1);
+            quota->SetMaxBudget(1);
+            quota->SetBudgetRefillTime(1000);
+            quota->SetBudgetSpendRate(1.0);
+        }
+
+        auto runtime = PrepareTestActorRuntime(storageConfig);
+        TVolumeClient volume = CreateVolume(*runtime);
+        volume.UpdateVolumeConfig(
+            1_GB,      // maxBandwidth
+            100'000,   // maxIops
+            100,       // burstPercentage
+            1000_MB,   // maxPostponedWeight
+            true,      // throttlingEnabled
+            2,         // version
+            NProto::STORAGE_MEDIA_HDD,
+            2048,       // block count per partition
+            diskId,     // diskId
+            cloudId,    // cloudId
+            folderId,   // folderId
+            2,          // partitions count
+            2           // blocksPerStripe
+        );
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume.AddClient(clientInfo);
+
+        bool firstWriteResponse = true;
+        bool scheduled = false;
+
+        runtime->SetScheduledEventFilter(
+            [&](TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event,
+                TDuration delay,
+                TInstant& deadline)
+            {
+                Y_UNUSED(runtime);
+                Y_UNUSED(delay);
+                Y_UNUSED(deadline);
+
+                if (event->GetTypeRewrite() ==
+                    TEvService::TEvWriteBlocksResponse::EventType)
+                {
+                    scheduled = true;
+                }
+                return false;
+            });
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) -> bool
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvService::EvWriteBlocksResponse) {
+                    if (firstWriteResponse) {
+                        auto* response =
+                            event->Get<TEvService::TEvWriteBlocksResponse>();
+                        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+                        *response->Record.MutableError() =
+                            MakeError(E_REJECTED);
+                        firstWriteResponse = false;
+                    }
+                }
+
+                return false;
+            });
+
+        volume.SendWriteBlocksRequest(
+            TBlockRange64::WithLength(0, 1000),
+            clientInfo.GetClientId(),
+            1);
+
+        auto response = volume.RecvWriteBlocksResponse();
+        UNIT_ASSERT(response);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        UNIT_ASSERT_C(!scheduled, "Failure response should not be scheduled");
+
+        const auto& throttler = response->Record.GetHeaders().GetThrottler();
+        UNIT_ASSERT_VALUES_EQUAL(0, throttler.GetShapingDelay());
+    }
+
+    Y_UNIT_TEST(ShouldNotApplyShapingDelayWhenThrottlingIsDisabled)
+    {
+        NProto::TStorageServiceConfig storageConfig;
+        storageConfig.SetThrottlingEnabled(false);
+        {
+            auto* quota = storageConfig.MutableShapingThrottlerConfig()
+                              ->MutableHddQuota();
+            quota->MutableWrite()->SetIops(10);
+            quota->MutableWrite()->SetBandwidth(10_MB);
+            quota->SetExpectedIoParallelism(1);
+            quota->SetMaxBudget(1);
+            quota->SetBudgetRefillTime(1000);
+            quota->SetBudgetSpendRate(1.0);
+        }
+
+        auto runtime = PrepareTestActorRuntime(storageConfig);
+        TVolumeClient volume = CreateVolume(*runtime);
+        volume.UpdateVolumeConfig(
+            1_GB,      // maxBandwidth
+            100'000,   // maxIops
+            100,       // burstPercentage
+            1000_MB,   // maxPostponedWeight
+            true,      // throttlingEnabled
+            2,         // version
+            NProto::STORAGE_MEDIA_HDD,
+            2048,       // block count per partition
+            diskId,     // diskId
+            cloudId,    // cloudId
+            folderId,   // folderId
+            2,          // partitions count
+            2           // blocksPerStripe
+        );
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume.AddClient(clientInfo);
+
+        bool scheduled = false;
+        runtime->SetScheduledEventFilter(
+            [&](TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event,
+                TDuration delay,
+                TInstant& deadline)
+            {
+                Y_UNUSED(runtime);
+                Y_UNUSED(delay);
+                Y_UNUSED(deadline);
+
+                if (event->GetTypeRewrite() ==
+                    TEvService::TEvWriteBlocksResponse::EventType)
+                {
+                    scheduled = true;
+                }
+                return false;
+            });
+
+        auto response = volume.WriteBlocks(
+            TBlockRange64::WithLength(0, 1000),
+            clientInfo.GetClientId(),
+            1);
+
+        UNIT_ASSERT_C(!scheduled, "Failure response should not be scheduled");
+        const auto& throttler = response->Record.GetHeaders().GetThrottler();
+        UNIT_ASSERT_VALUES_EQUAL(0, throttler.GetShapingDelay());
+    }
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/doc/blockstore/storage/volume_shaping_throttler.md
+++ b/doc/blockstore/storage/volume_shaping_throttler.md
@@ -1,0 +1,112 @@
+# Volume shaping throttler (`TVolumeShapingThrottler`)
+
+## General information
+
+`TVolumeShapingThrottler` is a per-volume shaping mechanism that can introduce an extra delay after an IO request completes, so that the observable request completion rate matches a configured media-specific performance profile (IOPS/BW).
+
+Like the regular volume throttler, shaping works on the volume tablet level, but unlike it shaping is intentionally **post-request**:
+- the volume calculates the actual `executionTime` of the already executed request and passes it to the shaper,
+- computes an expected “cost” for that request from the configured quota,
+- returns the remaining delay that should still be applied.
+
+Shaping is implemented in:
+- `cloud/blockstore/libs/storage/volume/model/volume_shaping_throttler.{h,cpp}`
+and is backed by a reusable bucket:
+- `cloud/storage/core/libs/throttling/unspent_cost_bucket.{h,cpp}`
+
+If the selected quota does not contain a corresponding performance profile (`Read` or `Write`), shaping for that op is also effectively disabled (returns zero delay).
+
+Also, **small important note**: volume actor relies on the fact that if the shaping throttler is enabled then the traditional volume throttler is also enabled. The shaping throttler just would not work otherwise.
+
+## Configuration and quota selection
+
+Configuration is provided via `TShapingThrottlerConfig` / `TShapingThrottlerQuota` in:
+- `cloud/blockstore/config/storage.proto`
+
+`TVolumeShapingThrottler` selects the quota by media kind:
+- `STORAGE_MEDIA_SSD` → `SsdQuota`
+- `STORAGE_MEDIA_HDD`, `STORAGE_MEDIA_HYBRID` → `HddQuota`
+- `STORAGE_MEDIA_SSD_NONREPLICATED` → `NonreplQuota`
+- `STORAGE_MEDIA_SSD_MIRROR2` → `Mirror2Quota`
+- `STORAGE_MEDIA_SSD_MIRROR3` → `Mirror3Quota`
+- default → `HddQuota`
+
+If the selected quota (`TShapingThrottlerQuota`) does not contain a corresponding performance profile (`Read` or `Write`), shaping for that op is also effectively disabled (returns zero delay).
+
+## Expected cost model (`CostPerIO`)
+
+For shaped requests, `SuggestDelay` computes an expected duration `cost` and passes it to the bucket along with the actual `executionTime`.
+
+The per-IO “cost” is computed by formula:
+
+$$ CostPerIO = ExpectedIoParallelism\left(\frac{1}{maxIops} + (\frac{byteCount}{maxBandwidth})\right) \text{seconds} $$
+
+- `ExpectedIoParallelism` – is a config parameter.
+
+## `TUnspentCostBucket`: how delay is derived from budget
+
+`TUnspentCostBucket` is a generic helper for turning “unspent” execution time into a delay while smoothing behavior over time.
+
+### Inputs
+
+`Register(now, cost, spentCost)` receives:
+- **`cost`**: expected duration of the operation
+- **`spentCost`**: actual time already spent executing the operation
+
+If `spentCost >= cost`, the request already took long enough and **no additional delay is needed** (`0` is returned).
+
+Otherwise define the gap:
+$ gap = cost - spentCost $
+
+The bucket can cover part of this gap from its accumulated budget and returns the remainder.
+
+### Budget spending and “smootherstep”
+
+Spending aggressiveness depends on how full the bucket is:
+- budget ratio $ r = CurrentBudget/MaxBudget $ is a number in \([0,1]\)
+- a smooth curve is applied:
+- about the function see https://en.wikipedia.org/wiki/Smoothstep
+
+$ discountFactor = Smootherstep(r) = 6r^5 - 15r^4 + 10r^3 $
+
+The bucket chooses how much of the gap it *wants* to cover between:
+
+$ minBudgetSpend = cost * internalFactor - spentCost $
+$ maxBudgetSpend = gap $
+
+and interpolates between them with `discountFactor`. The actual covered amount is limited by the currently available budget.
+
+### Budget refill
+
+Bucket budget refills linearly with wall time and is capped:
+- `MaxBudget`: capacity (clamped to at least 1ms internally)
+- `BudgetRefillTime`: time to refill from 0 to `MaxBudget`
+
+Refill rate is:
+
+$
+BudgetRefillRate = \frac{MaxBudget}{BudgetRefillTime}
+$
+
+If `BudgetRefillTime == 0`, refill rate is 0 (budget never refills).
+
+## Persistence of shaping throttler state
+
+The volume persists shaping state so that the bucket “fullness” survives tablet restarts.
+
+### Periodic write
+
+In `TVolumeActor::HandleUpdateThrottlerState`, the volume periodically writes current spent budget share into localdb as a part of `TVolumeDatabase::TThrottlerStateInfo`.
+
+### Restore on volume tablet load
+
+On startup, `TVolumeActor::CompleteLoadState` loads `SpentShapingBudgetShare` from localdb and passes it into `TVolumeState`, which constructs `TVolumeShapingThrottler(..., spentShapingBudgetShare)`.
+
+## Observability
+
+### Volume shaping quota
+The shaping bucket “spent share” is exported as a percentage in volume self-counters:
+- `simple.ShapingThrottlerBudgetSpent = round(100 * SpentShapingBudgetShare)`
+
+### ShapingTime metrics
+The `server` includes histogram for `ShapingTime`. The `server_volume` includes percentiles of `ShapingTime`. Both metrics together allow to monitor the effectiveness of shapers per-host and per-volume.


### PR DESCRIPTION
### Notes

Introduce `TVolumeShapingThrottler` along with its documentation.
TL;DR:
Allow to throttle the response from the volume to the client. Throttler parameters are set in the storage config. The shaper takes the real `executionTime` of the completed request and calculates the `cost` of a request based on config parameters. If `cost > executionTime`  then some part of the difference (from 0% to 100%) becomes shaping throttler delay.

### Issue
#5095
