### PR TITLE
improve rdma client logging

### DIFF
--- a/cloud/blockstore/libs/rdma/impl/client.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client.cpp
@@ -588,14 +588,18 @@ TClientEndpoint::TClientEndpoint(
         return TStringBuilder() << "[" << Id << "] " << msg;
     });
 
-    RDMA_INFO("start endpoint " << Host
-        << " [send_magic=" << Hex(SendMagic, HF_FULL)
+    RDMA_INFO(
+        "start endpoint [host="
+        << Host << " send_magic=" << Hex(SendMagic, HF_FULL)
         << " recv_magic=" << Hex(RecvMagic, HF_FULL) << "]");
 }
 
 TClientEndpoint::~TClientEndpoint()
 {
     // release any leftover resources if endpoint hasn't been properly stopped
+    if (Connection) {
+        RDMA_INFO("release resources");
+    }
     DestroyQP();
     RDMA_INFO("stop endpoint");
 }
@@ -1036,9 +1040,7 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
         }
         if (wc->status != IBV_WC_SUCCESS) {
             RDMA_ERROR(
-                "SEND " << id << " " << NVerbs::PrintCompletion(wc)
-                        << " failed with "
-                        << NVerbs::GetStatusString(wc->status));
+                "SEND " << id << " " << NVerbs::GetStatusString(wc->status));
             Counters->Error();
             Counters->SendRequestCompleted();
             SendQueue.Push(&SendWrs[id.Index]);
@@ -1046,8 +1048,8 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
         }
         if (wc->opcode != IBV_WC_SEND) {
             RDMA_ERROR(
-                "SEND " << id << " " << NVerbs::PrintCompletion(wc)
-                        << " unexpected opcode");
+                "SEND " << id << " unexpected opcode "
+                        << NVerbs::GetOpcodeName(wc->opcode));
             Counters->Error();
             Counters->SendRequestCompleted();
             SendQueue.Push(&SendWrs[id.Index]);
@@ -1064,9 +1066,7 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
         }
         if (wc->status != IBV_WC_SUCCESS) {
             RDMA_ERROR(
-                "RECV " << id << " " << NVerbs::PrintCompletion(wc)
-                        << " failed with "
-                        << NVerbs::GetStatusString(wc->status));
+                "RECV " << id << " " << NVerbs::GetStatusString(wc->status));
             Counters->Error();
             Counters->RecvResponseCompleted();
             RecvQueue.Push(&RecvWrs[id.Index]);
@@ -1074,8 +1074,8 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
         }
         if (wc->opcode != IBV_WC_RECV) {
             RDMA_ERROR(
-                "RECV " << id << " " << NVerbs::PrintCompletion(wc)
-                        << " unexpected opcode");
+                "RECV " << id << " unexpected opcode "
+                        << NVerbs::GetOpcodeName(wc->opcode));
             Counters->Error();
             Counters->RecvResponseCompleted();
             RecvQueue.Push(&RecvWrs[id.Index]);
@@ -1094,10 +1094,7 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc)
 {
     auto id = TWorkRequestId(wc->wr_id);
 
-    RDMA_TRACE(
-        NVerbs::GetOpcodeName(wc->opcode)
-        << " " << id << " completed with "
-        << NVerbs::GetStatusString(wc->status));
+    RDMA_TRACE(NVerbs::GetOpcodeName(wc->opcode) << " " << id << " completed");
 
     if (ValidateCompletion(wc)) {
         Disconnect();
@@ -1122,6 +1119,7 @@ void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send)
 {
     req->ReqId = ActiveRequests.CreateId();
 
+    auto id = TWorkRequestId(send->wr.wr_id);
     auto* requestMsg = send->Message<TRequestMessage>();
     Zero(*requestMsg);
 
@@ -1131,16 +1129,12 @@ void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send)
     requestMsg->In = req->InBuffer;
     requestMsg->Out = req->OutBuffer;
 
-    RDMA_TRACE(
-        "SEND " << TWorkRequestId(send->wr.wr_id) << " posted " << req->ReqId);
-
     try {
         Verbs->PostSend(Connection->qp, &send->wr);
+        RDMA_TRACE("SEND " << id << " posted request " << req->ReqId);
 
     } catch (const TServiceError& e) {
-        RDMA_ERROR(
-            "SEND " << TWorkRequestId(send->wr.wr_id) << " " << e.what());
-
+        RDMA_ERROR("SEND " << id << " " << e.what());
         SendQueue.Push(send);
         Counters->Error();
         Counters->RequestEnqueued();
@@ -1168,17 +1162,20 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
     Counters->SendRequestCompleted();
     SendQueue.Push(send);
 
-    if (auto* req = ActiveRequests.Get(reqId)) {
-        LWTRACK(
-            SendRequestCompleted,
-            req->CallContext->LWOrbit,
-            req->CallContext->RequestId);
-    } else {
-        RDMA_ERROR(
-            "SEND " << wrId << " request not found. Current wrId "
+    auto* req = ActiveRequests.Get(reqId);
+    if (!req) {
+        RDMA_WARN(
+            "SEND " << wrId << " request " << reqId
+                    << " not found, last active request id "
                     << ActiveRequests.GetCurrentId());
         Counters->Error();
+        return;
     }
+
+    LWTRACK(
+        SendRequestCompleted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
 }
 
 void TClientEndpoint::RecvResponse(TRecvWr* recv)
@@ -1187,10 +1184,9 @@ void TClientEndpoint::RecvResponse(TRecvWr* recv)
     auto* responseMsg = recv->Message<TResponseMessage>();
     Zero(*responseMsg);
 
-    RDMA_TRACE("RECV " << id << " posted");
-
     try {
         Verbs->PostRecv(Connection->qp, &recv->wr);
+        RDMA_TRACE("RECV " << id << " posted");
 
     } catch (const TServiceError& e) {
         RDMA_ERROR("RECV " << id << " " << e.what());
@@ -1212,8 +1208,7 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv)
     if (version != RDMA_PROTO_VERSION) {
         RDMA_ERROR(
             "RECV " << wrId << " incompatible protocol version " << version
-                    << ", expected " << int(RDMA_PROTO_VERSION));
-
+                    << ", expected " << static_cast<int>(RDMA_PROTO_VERSION));
         Counters->RecvResponseCompleted();
         Counters->Error();
         Disconnect();
@@ -1229,7 +1224,10 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv)
 
     auto req = ActiveRequests.Pop(reqId);
     if (!req) {
-        RDMA_ERROR("RECV " << wrId << " request " << reqId << " not found");
+        RDMA_WARN(
+            "RECV " << wrId << " request " << reqId
+                    << " not found, last active request id "
+                    << ActiveRequests.GetCurrentId());
         Counters->Error();
         return;
     }
@@ -1746,6 +1744,8 @@ private:
             endpoint->ChangeState(
                 EEndpointState::Disconnecting,
                 EEndpointState::Disconnected);
+
+            RDMA_INFO(endpoint->Log, "disconnected");
         }
     }
 
@@ -1859,7 +1859,7 @@ void TClient::Start() noexcept
 {
     Log = Logging->CreateLog("BLOCKSTORE_RDMA");
 
-    RDMA_DEBUG("start client");
+    RDMA_INFO("start client");
 
     auto counters = Monitoring->GetCounters();
     auto rootGroup = counters->GetSubgroup("counters", "blockstore");
@@ -1896,7 +1896,7 @@ void TClient::Stop() noexcept
     }
     CompletionPollers.clear();
 
-    RDMA_DEBUG("stop client");
+    RDMA_INFO("stop client");
 }
 
 // implements IClient
@@ -1943,7 +1943,7 @@ void TClient::HandleConnectionEvent(NVerbs::TConnectionEventPtr event) noexcept
 {
     TClientEndpoint* endpoint = TClientEndpoint::FromEvent(event.get());
 
-    RDMA_DEBUG(endpoint->Log, "received " << NVerbs::GetEventName(event->event));
+    RDMA_INFO(endpoint->Log, NVerbs::GetEventName(event->event) << " received");
 
     switch (event->event) {
         case RDMA_CM_EVENT_CONNECT_REQUEST:
@@ -1996,8 +1996,7 @@ void TClient::HandleConnectionEvent(NVerbs::TConnectionEventPtr event) noexcept
 
 void TClient::StopEndpoint(TClientEndpoint* endpoint) noexcept
 {
-    RDMA_INFO(endpoint->Log, "detach endpoint and close connection");
-
+    RDMA_INFO(endpoint->Log, "release resources");
     ConnectionPoller->Detach(endpoint);
     if (endpoint->CompletionChannel) {
         endpoint->Poller->Detach(endpoint);
@@ -2035,7 +2034,6 @@ void TClient::Reconnect(TClientEndpoint* endpoint) noexcept
             return;
         }
         // otherwise keep trying
-        RDMA_WARN(endpoint->Log, "connection is hanging");
     }
 
     auto state = endpoint->State.load();
@@ -2082,6 +2080,7 @@ void TClient::Reconnect(TClientEndpoint* endpoint) noexcept
             return;
     }
 
+    RDMA_WARN("unable to connect, try again");
     BeginResolveAddress(endpoint);
 }
 
@@ -2094,11 +2093,11 @@ void TClient::Disconnect(TClientEndpoint* endpoint) noexcept
         return;
     }
 
+    RDMA_INFO(endpoint->Log, "disconnect from " << endpoint->Host);
+
     endpoint->ChangeState(
         EEndpointState::Connected,
         EEndpointState::Disconnecting);
-
-    RDMA_INFO(endpoint->Log, "disconnect");
 
     endpoint->FlushQueues();
     endpoint->Reconnect.Schedule();
@@ -2140,7 +2139,7 @@ void TClient::BeginResolveAddress(TClientEndpoint* endpoint) noexcept
         auto addrinfo = Verbs->GetAddressInfo(
             endpoint->Host, endpoint->Port, &hints);
 
-        RDMA_DEBUG(endpoint->Log, "resolve server address");
+        RDMA_DEBUG(endpoint->Log, "resolve address");
 
         Verbs->ResolveAddress(endpoint->Connection.get(), addrinfo->ai_src_addr,
             addrinfo->ai_dst_addr, RESOLVE_TIMEOUT);
@@ -2173,6 +2172,8 @@ void TClient::BeginConnect(TClientEndpoint* endpoint) noexcept
     Y_ABORT_UNLESS(endpoint);
 
     try {
+        RDMA_INFO(endpoint->Log, "connect to " << endpoint->Host);
+
         endpoint->ChangeState(
             EEndpointState::ResolvingRoute,
             EEndpointState::Connecting);
@@ -2197,9 +2198,6 @@ void TClient::BeginConnect(TClientEndpoint* endpoint) noexcept
             .rnr_retry_count = 7,
         };
 
-        RDMA_INFO(endpoint->Log, "connect "
-            << NVerbs::PrintConnectionParams(&param));
-
         Verbs->Connect(endpoint->Connection.get(), &param);
 
     } catch (const TServiceError& e) {
@@ -2214,8 +2212,7 @@ void TClient::HandleConnected(
 {
     const rdma_conn_param* param = &event->param.conn;
 
-    RDMA_DEBUG(endpoint->Log, "validate "
-        << NVerbs::PrintConnectionParams(param));
+    RDMA_DEBUG(endpoint->Log, "validate");
 
     if (param->private_data == nullptr ||
         param->private_data_len < sizeof(TAcceptMessage) ||
@@ -2240,6 +2237,8 @@ void TClient::HandleConnected(
         endpoint->Disconnect();
         return;
     }
+
+    RDMA_INFO(endpoint->Log, "connected");
 
     if (endpoint->StartResult.Initialized()) {
         auto startResult = std::move(endpoint->StartResult);


### PR DESCRIPTION
- explicitly log the point when endpoint switches to the connected/disconnected state
- log connection events with info level (this is also useful in the context of #5195)
- explicitly log reconnect attempts
- decrease verbosity of completion errors