### PR TITLE
[Blockstore] DestroyVolume should be idempotent when the disk is not found during graceful shutdown of a non-replicated (DiskRegistry-based) disk

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
@@ -486,7 +486,7 @@ void TDestroyVolumeActor::HandleGracefulShutdownResponse(
             FormatError(error).data());
 
         if (IsNotFoundSchemeShardError(error)) {
-            ReplyAndDie(ctx, MakeError(S_ALREADY, "volume not found"));
+            DestroyVolume(ctx);
         } else {
             ReplyAndDie(ctx, std::move(error));
         }

--- a/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
@@ -409,7 +409,7 @@ Y_UNIT_TEST_SUITE(TServiceDestroyTest)
 
     // Reproduces a race condition: StatVolume finds the volume, which is then
     // deleted during graceful shutdown
-    Y_UNIT_TEST(DestroyNonreplDiskWhenGracefulShutdownFailedToFindTheVolume)
+    Y_UNIT_TEST(ShouldDestroyNonreplDiskWhenGracefulShutdownFailedToFindTheVolume)
     {
         TTestEnv env;
         NProto::TStorageServiceConfig config;
@@ -481,7 +481,7 @@ Y_UNIT_TEST_SUITE(TServiceDestroyTest)
 
             auto response = service.RecvDestroyVolumeResponse();
             UNIT_ASSERT_VALUES_EQUAL_C(
-                S_ALREADY,
+                S_OK,
                 response->GetStatus(),
                 response->GetError());
         }


### PR DESCRIPTION
### Notes
Fixes a race condition where a disk found by StatVolume could be deleted before GracefulShutdownRequest, causing `disks.DeleteDisk` Disk Manager task to fail with a non-retriable error and the Compute API operation to get stuck

```
2026-03-10T22:55:35.812626Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:317: [d:xxx] [c:69b0a162-354d-081b-eed0-a5d9-d7037488] DestroyVolume #1636853003130062538 REQUEST { Headers { ClientId: "69b0a162-354d-081b-eed0-a5d9-d7037488" Timestamp: 1773183335812549 RequestId: 1636853003130062538 RequestTimeout: 20000 } DiskId: "xxx" }
...
2026-03-10T22:55:35.995844Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:565: [d:xxx] [c:69b0a162-354d-081b-eed0-a5d9-d7037488] DestroyVolume #1636853003130062538 RESPONSE request completed (execution: 183.179ms, postponed: 0, predicted: 0, backoff: 0, size: 0 B, unaligned: 0, error: SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path not found, path="/xxx/NBS/xxx/xxx-copy" f@silent)
...
2026-03-10T22:55:35.812686Z :BLOCKSTORE_SERVICE INFO: Deleting volume: diskId = "xxx", destroyIfBroken = 0, sync = 0, fillGeneration = 0
...
2026-03-10T22:55:35.988903Z :BLOCKSTORE_VOLUME_PROXY WARN: [vp:72075186244428604 d:xxx pg:1 t:20.195s] Connection to volume failed
...
2026-03-10T22:55:35.995716Z :BLOCKSTORE_VOLUME_PROXY ERROR: [vp:72075186244428604 d:xxx pg:1 t:20.202s] Could not resolve path for volume. Error: SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path not found, path="/xxx/NBS/_1E9/xxx-copy" f@silent
...
2026-03-10T22:55:35.995742Z :BLOCKSTORE_SERVICE ERROR: Volume "xxx": unable to gracefully stop volume: SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path not found, path="/xxx/NBS/xxx/xxx-copy" f@silent
```
### Issue
Put links to the related issues here
