### PR TITLE
issue-4875: support write blocks local requests for Fresh blocks Writer

### DIFF
--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -25,6 +25,8 @@ using namespace NLWTrace;
 
 using namespace NPartition;
 
+using namespace std::chrono_literals;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -369,6 +371,48 @@ public:
             checkpointId);
     }
 
+    std::unique_ptr<TEvService::TEvWriteBlocksLocalRequest>
+    CreateWriteBlocksLocalRequest(
+        const TBlockRange32& writeRange,
+        TGuardedSgList sglist,
+        ui64 blockSize)
+    {
+        auto request =
+            std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
+        request->Record.SetStartIndex(writeRange.Start);
+        request->Record.Sglist = std::move(sglist);
+        request->Record.BlocksCount = writeRange.Size();
+        request->Record.BlockSize = blockSize;
+        return request;
+    }
+
+    std::unique_ptr<TEvService::TEvWriteBlocksLocalRequest>
+    CreateWriteBlocksLocalRequest(
+        const TBlockRange32& writeRange,
+        TStringBuf blockContent)
+    {
+        TSgList sglist;
+        sglist.resize(
+            writeRange.Size(),
+            {blockContent.data(), blockContent.size()});
+
+        return CreateWriteBlocksLocalRequest(
+            writeRange,
+            TGuardedSgList(std::move(sglist)),
+            blockContent.size() / writeRange.Size());
+    }
+
+
+    std::unique_ptr<TEvService::TEvWriteBlocksLocalRequest>
+    CreateWriteBlocksLocalRequest(
+        ui32 blockIndex,
+        TStringBuf blockContent)
+    {
+        return CreateWriteBlocksLocalRequest(
+            TBlockRange32::MakeClosedInterval(blockIndex, blockIndex),
+            std::move(blockContent));
+    }
+
 #define BLOCKSTORE_DECLARE_METHOD(name, ns)                                    \
     template <typename... Args>                                                \
     void Send##name##Request(Args&&... args)                                   \
@@ -691,6 +735,77 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                         << GetBlockContent('D');
 
         UNIT_ASSERT_EQUAL(expectedContent, actualContent);
+    }
+
+    Y_UNIT_TEST(ShouldSupportWriteBlocksLocalRequest)
+    {
+        auto testEnv = PrepareTestActorRuntime();
+        auto& runtime = *testEnv.Runtime;
+
+        std::unique_ptr<IEventHandle> stollenAddFreshBlocksRequest;
+
+        bool writeBlocksCompletedObserved = false;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+
+                // Drop add fresh blocks response to be sure that we don't wait
+                // partition.
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionCommonPrivate::EvAddFreshBlocksRequest)
+                {
+                    stollenAddFreshBlocksRequest.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        TPartitionClient partition(runtime);
+        partition.WaitReady();
+
+        TFreshBlocksWriterClient fbwClient(
+            runtime,
+            testEnv.FreshBlocksWriterActorId);
+        fbwClient.WaitReady();
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto reassignCounter = counters->GetCounter(
+            "AppImpossibleEvents/AddFreshBlocksResultedInError",
+            true);
+
+        {
+            auto content = GetBlockContent('0');
+
+            TSgList sglist;
+            sglist.resize(1, {content.data(), content.size()});
+            TGuardedSgList guardedSglist(std::move(sglist));
+            fbwClient.WriteBlocksLocal(
+                TBlockRange32::WithLength(0, 1),
+                guardedSglist,
+                4_KB);
+            guardedSglist.Close();
+        }
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                writeBlocksCompletedObserved |=
+                    event->GetTypeRewrite() ==
+                    TEvPartitionCommonPrivate::EvWriteFreshBlocksCompleted;
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        runtime.SendAsync(stollenAddFreshBlocksRequest.release());
+
+        runtime.DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(writeBlocksCompletedObserved);
+        UNIT_ASSERT_VALUES_EQUAL(0, reassignCounter->Val());
     }
 }
 

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
@@ -220,6 +220,11 @@ void TFreshBlocksWriterActor::HandleWriteBlocksRequest(
         return;
     }
 
+    if constexpr (std::is_same_v<TMethod, TEvService::TWriteBlocksLocalMethod>)
+    {
+        msg->Record.CopySglistIntoBuffers();
+    }
+
     auto writeHandler = CreateWriteHandler(
         writeRange,
         std::unique_ptr<typename TMethod::TRequest>(ev->Release().Release()),

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -226,6 +226,13 @@ void TPartitionActor::HandleAddFreshBlocks(
                 TBlockStoreComponents::PARTITION,
                 "%s Failed to lock a guardedSgList on AddFreshBlocks",
                 LogTitle.GetWithTime().c_str());
+
+            using TResponse =
+                TEvPartitionCommonPrivate::TEvAddFreshBlocksResponse;
+            auto response = std::make_unique<TResponse>(
+                MakeError(E_ARGUMENT, "Failed to lock a guardedSgList"));
+
+            NCloud::Reply(ctx, *ev, std::move(response));
             Suicide(ctx);
             return;
         }


### PR DESCRIPTION
### Notes
Now, it is possible that the client will receive a response before the Partition actor receives an AddFreshBlocksRequest. In such cases, the sglist will be closed before blocks are added to the cache. This leads to a tablet restart. To avoid this situation, I added copying requests to proto buffers for new requests.

### Issue
#4875