### PR TITLE
[Filestore] use TAdaptiveLock instead of TMutex in TSession

### DIFF
--- a/cloud/filestore/libs/client/session.cpp
+++ b/cloud/filestore/libs/client/session.cpp
@@ -14,7 +14,9 @@
 
 #include <util/generic/ptr.h>
 #include <util/system/hostname.h>
-#include <util/system/mutex.h>
+#include <util/system/spinlock.h>
+
+#include <mutex>
 
 namespace NCloud::NFileStore::NClient {
 
@@ -214,7 +216,7 @@ private:
     const TString FsTag;
     TLog Log;
 
-    TMutex SessionLock;
+    TAdaptiveLock SessionLock;
     ESessionState SessionState = Idle;
     TPromise<NProto::TCreateSessionResponse> CreateSessionResponse;
     TPromise<NProto::TDestroySessionResponse> DestroySessionResponse;
@@ -373,8 +375,13 @@ private:
     void ExecuteRequest(
         TRequestStatePtr<TCreateSessionMethod> state)
     {
-        with_lock(SessionLock) {
+        {
+            std::unique_lock<TAdaptiveLock> sessionLock{SessionLock};
+
             if (SessionState == SessionDestroying) {
+                // Avoid calling callbacks under a lock
+                sessionLock.unlock();
+
                 state->Response.SetValue(
                     TErrorResponse(
                         E_INVALID_STATE,
@@ -383,6 +390,9 @@ private:
             }
 
             if (SessionState == SessionBroken) {
+                // Avoid calling callbacks under a lock
+                sessionLock.unlock();
+
                 state->Response.SetValue(
                     TErrorResponse(
                         E_INVALID_STATE,
@@ -405,8 +415,12 @@ private:
                             "Session is destroyed"));
                 };
 
-                CreateSessionResponse.GetFuture().Subscribe(postpone);
+                auto future = CreateSessionResponse.GetFuture();
 
+                // Avoid calling callbacks under a lock
+                sessionLock.unlock();
+
+                future.Subscribe(postpone);
                 return;
             }
 
@@ -486,17 +500,25 @@ private:
 
     void ExecuteRequest(TRequestStatePtr<TDestroySessionMethod> state)
     {
-        with_lock (SessionLock) {
+        {
+            std::unique_lock<TAdaptiveLock> sessionLock{SessionLock};
+
             if (SessionState == Idle) {
+                // Avoid calling callbacks under a lock
+                sessionLock.unlock();
+
                 state->Response.SetValue(
                     TErrorResponse(S_ALREADY, "Session is not created"));
                 return;
             }
 
             if (SessionState == SessionBroken) {
+                // Avoid calling callbacks under a lock
+                sessionLock.unlock();
+
                 state->Response.SetValue(
                     TErrorResponse(E_INVALID_STATE, "Session is not broken"));
-                    return;
+                return;
             }
 
             if (SessionState == SessionDestroying) {
@@ -521,7 +543,12 @@ private:
                             "Session is destroyed"));
                 };
 
-                CreateSessionResponse.GetFuture().Subscribe(postpone);
+                auto future = CreateSessionResponse.GetFuture();
+
+                // Avoid calling callbacks under a lock
+                sessionLock.unlock();
+
+                future.Subscribe(postpone);
                 return;
             }
 


### PR DESCRIPTION
### Notes

Without change:
```
svartmetal@svartmetal-ivm:~/nbs-github2/cloud/filestore/libs/client/bench$ ./bench -b 200
----------- TSession_ReadData_1_Durable_false ---------------
 samples:       7931
 iterations:    38838891
 iterations hr:    38.8M
 run time:      10.00218803
 per iteration: 574.2088544 cycles
----------- TSession_ReadData_2_Durable_false ---------------
 samples:       4411
 iterations:    12017253
 iterations hr:    12M
 run time:      10.00240745
 per iteration: 1473.262142 cycles
----------- TSession_ReadData_4_Durable_false ---------------
 samples:       2525
 iterations:    3938221
 iterations hr:    3.94M
 run time:      10.00051665
 per iteration: 5828.803783 cycles
----------- TSession_ReadData_8_Durable_false ---------------
 samples:       1373
 iterations:    1165101
 iterations hr:    1.17M
 run time:      10.00503266
 per iteration: 19332.78928 (19.3K) cycles
----------- TSession_ReadData_16_Durable_false ---------------
 samples:       868
 iterations:    466095
 iterations hr:    466K
 run time:      10.01515344
 per iteration: 47415.77429 (47.4K) cycles
----------- TSession_ReadData_1_Durable_true ---------------
 samples:       7930
 iterations:    38830078
 iterations hr:    38.8M
 run time:      10.00182936
 per iteration: 574.9985236 cycles
----------- TSession_ReadData_2_Durable_true ---------------
 samples:       5437
 iterations:    18255903
 iterations hr:    18.3M
 run time:      10.00267045
 per iteration: 977.8843703 cycles
----------- TSession_ReadData_4_Durable_true ---------------
 samples:       2666
 iterations:    4391166
 iterations hr:    4.39M
 run time:      10.00363621
 per iteration: 5151.217916 cycles
----------- TSession_ReadData_8_Durable_true ---------------
 samples:       1421
 iterations:    1247410
 iterations hr:    1.25M
 run time:      10.00140787
 per iteration: 17617.79996 (17.6K) cycles
----------- TSession_ReadData_16_Durable_true ---------------
 samples:       854
 iterations:    450775
 iterations hr:    451K
 run time:      10.01421921
 per iteration: 48802.16155 (48.8K) cycles
----------- TSession_WriteData_1_Durable_false ---------------
 samples:       7956
 iterations:    39077220
 iterations hr:    39.1M
 run time:      10.00102392
 per iteration: 561.3552444 cycles
----------- TSession_WriteData_2_Durable_false ---------------
 samples:       4695
 iterations:    13611153
 iterations hr:    13.6M
 run time:      10.00463026
 per iteration: 1497.454147 cycles
----------- TSession_WriteData_4_Durable_false ---------------
 samples:       2649
 iterations:    4335040
 iterations hr:    4.34M
 run time:      10.00614055
 per iteration: 5249.783832 cycles
----------- TSession_WriteData_8_Durable_false ---------------
 samples:       1418
 iterations:    1242676
 iterations hr:    1.24M
 run time:      10.00028332
 per iteration: 18188.48816 (18.2K) cycles
----------- TSession_WriteData_16_Durable_false ---------------
 samples:       878
 iterations:    476776
 iterations hr:    477K
 run time:      10.00402143
 per iteration: 45743.1031 (45.7K) cycles
----------- TSession_WriteData_1_Durable_true ---------------
 samples:       7883
 iterations:    38364420
 iterations hr:    38.4M
 run time:      10.00283015
 per iteration: 582.3998892 cycles
----------- TSession_WriteData_2_Durable_true ---------------
 samples:       4977
 iterations:    15293215
 iterations hr:    15.3M
 run time:      10.00348339
 per iteration: 1303.838551 cycles
----------- TSession_WriteData_4_Durable_true ---------------
 samples:       2664
 iterations:    4385241
 iterations hr:    4.39M
 run time:      10.00420612
 per iteration: 5256.569217 cycles
----------- TSession_WriteData_8_Durable_true ---------------
 samples:       1412
 iterations:    1231665
 iterations hr:    1.23M
 run time:      10.00337204
 per iteration: 18279.84862 (18.3K) cycles
----------- TSession_WriteData_16_Durable_true ---------------
 samples:       855
 iterations:    452676
 iterations hr:    453K
 run time:      10.01728416
 per iteration: 48938.57603 (48.9K) cycles
```

With change:
```
svartmetal@svartmetal-ivm:~/nbs-github2/cloud/filestore/libs/client/bench$ ./bench -b 200
----------- TSession_ReadData_1_Durable_false ---------------
 samples:       8061
 iterations:    40118403
 iterations hr:    40.1M
 run time:      10.00268973
 per iteration: 554.5012407 cycles
----------- TSession_ReadData_2_Durable_false ---------------
 samples:       4912
 iterations:    14897611
 iterations hr:    14.9M
 run time:      10.00320483
 per iteration: 1146.576248 cycles
----------- TSession_ReadData_4_Durable_false ---------------
 samples:       3412
 iterations:    7191528
 iterations hr:    7.19M
 run time:      10.00071416
 per iteration: 2998.64744 cycles
----------- TSession_ReadData_8_Durable_false ---------------
 samples:       2262
 iterations:    3161355
 iterations hr:    3.16M
 run time:      10.00293277
 per iteration: 6392.98752 cycles
----------- TSession_ReadData_16_Durable_false ---------------
 samples:       1548
 iterations:    1480060
 iterations hr:    1.48M
 run time:      10.00995325
 per iteration: 12756.38215 (12.8K) cycles
----------- TSession_ReadData_1_Durable_true ---------------
 samples:       8098
 iterations:    40486501
 iterations hr:    40.5M
 run time:      10.0020503
 per iteration: 552.2002122 cycles
----------- TSession_ReadData_2_Durable_true ---------------
 samples:       5526
 iterations:    18852870
 iterations hr:    18.9M
 run time:      10.00138521
 per iteration: 841.1791007 cycles
----------- TSession_ReadData_4_Durable_true ---------------
 samples:       3816
 iterations:    8995161
 iterations hr:    9M
 run time:      10.00249703
 per iteration: 2349.799762 cycles
----------- TSession_ReadData_8_Durable_true ---------------
 samples:       2385
 iterations:    3512575
 iterations hr:    3.51M
 run time:      10.00476367
 per iteration: 5343.909863 cycles
----------- TSession_ReadData_16_Durable_true ---------------
 samples:       1568
 iterations:    1519896
 iterations hr:    1.52M
 run time:      10.00355196
 per iteration: 11969.73306 (12K) cycles
----------- TSession_WriteData_1_Durable_false ---------------
 samples:       8064
 iterations:    40154241
 iterations hr:    40.2M
 run time:      10.00159338
 per iteration: 540.449467 cycles
----------- TSession_WriteData_2_Durable_false ---------------
 samples:       5737
 iterations:    20323500
 iterations hr:    20.3M
 run time:      10.0017695
 per iteration: 978.5948794 cycles
----------- TSession_WriteData_4_Durable_false ---------------
 samples:       3644
 iterations:    8199225
 iterations hr:    8.2M
 run time:      10.00335407
 per iteration: 2658.924903 cycles
----------- TSession_WriteData_8_Durable_false ---------------
 samples:       2349
 iterations:    3409966
 iterations hr:    3.41M
 run time:      10.00327008
 per iteration: 5902.912616 cycles
----------- TSession_WriteData_16_Durable_false ---------------
 samples:       1541
 iterations:    1468041
 iterations hr:    1.47M
 run time:      10.00238675
 per iteration: 12970.12061 (13K) cycles
----------- TSession_WriteData_1_Durable_true ---------------
 samples:       8048
 iterations:    39993096
 iterations hr:    40M
 run time:      10.0018201
 per iteration: 559.6778107 cycles
----------- TSession_WriteData_2_Durable_true ---------------
 samples:       6020
 iterations:    22374705
 iterations hr:    22.4M
 run time:      10.0031761
 per iteration: 847.9256371 cycles
----------- TSession_WriteData_4_Durable_true ---------------
 samples:       4061
 iterations:    10185841
 iterations hr:    10.2M
 run time:      10.00085526
 per iteration: 1892.253779 cycles
----------- TSession_WriteData_8_Durable_true ---------------
 samples:       2344
 iterations:    3394315
 iterations hr:    3.39M
 run time:      10.00425715
 per iteration: 5654.945006 cycles
----------- TSession_WriteData_16_Durable_true ---------------
 samples:       1506
 iterations:    1401975
 iterations hr:    1.4M
 run time:      10.00250305
 per iteration: 13819.45606 (13.8K) cycles
```

### Issue
Put links to the related issues here
