### PR TITLE
[Local Filestore] issue-4983: enable setting ExtendedAttributesDisabled, SnapshotsDirEnabled, and GuestHandleKillPrivV2Enabled using features config

### DIFF
--- a/cloud/filestore/libs/service_local/config.cpp
+++ b/cloud/filestore/libs/service_local/config.cpp
@@ -139,6 +139,9 @@ FILESTORE_SERVICE_CONFIG(FILESTORE_CONFIG_GETTER)
 
 #define FILESTORE_BINARY_FEATURES(xxx)                                         \
     xxx(DirectoryHandlesStorageEnabled)                                        \
+    xxx(ExtendedAttributesDisabled)                                            \
+    xxx(SnapshotsDirEnabled)                                                   \
+    xxx(GuestHandleKillPrivV2Enabled)                                          \
 
 // FILESTORE_BINARY_FEATURES
 
@@ -160,11 +163,13 @@ bool TLocalFileStoreConfig::Get##name(                                         \
         return Get##name();                                                    \
     }                                                                          \
                                                                                \
-    return FeaturesConfig->IsFeatureEnabled(                                   \
-        cloudId,                                                               \
-        folderId,                                                              \
-        fsId,                                                                  \
-        #name);                                                                \
+    if (!FeaturesConfig->IsFeatureEnabled(cloudId, folderId, fsId, #name)) {   \
+        return Get##name();                                                    \
+    }                                                                          \
+                                                                               \
+    auto val = FeaturesConfig->GetFeatureValue(cloudId, folderId, fsId, #name);\
+    val.to_lower();                                                            \
+    return val != "false";                                                     \
 }                                                                              \
 
 // FILESTORE_BINARY_FEATURE_GETTER

--- a/cloud/filestore/libs/service_local/config.h
+++ b/cloud/filestore/libs/service_local/config.h
@@ -95,6 +95,10 @@ public:
     bool GetZeroCopyEnabled() const;
     bool GetGuestPageCacheDisabled() const;
     bool GetExtendedAttributesDisabled() const;
+    bool GetExtendedAttributesDisabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& fsId) const;
 
     void Dump(IOutputStream& out) const;
     TString DumpStr() const;
@@ -154,8 +158,16 @@ public:
     ui64 GetDirectoryHandlesTableSize() const;
 
     bool GetGuestHandleKillPrivV2Enabled() const;
+    bool GetGuestHandleKillPrivV2Enabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& fsId) const;
 
     bool GetSnapshotsDirEnabled() const;
+    bool GetSnapshotsDirEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& fsId) const;
 
     TDuration GetSnapshotsDirRefreshInterval() const;
 };

--- a/cloud/filestore/libs/service_local/config_ut.cpp
+++ b/cloud/filestore/libs/service_local/config_ut.cpp
@@ -4,10 +4,178 @@
 
 namespace NCloud::NFileStore {
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TProtoSetter = void (NProto::TLocalServiceConfig::*)(bool);
+using TPlainGetter = bool (TLocalFileStoreConfig::*)() const;
+using TFeatureGetter = bool (TLocalFileStoreConfig::*)(
+    const TString&,
+    const TString&,
+    const TString&) const;
+
+struct TBinaryFeatureCase
+{
+    TString Name;
+    TProtoSetter ProtoSetter;
+    TPlainGetter PlainGetter;
+    TFeatureGetter FeatureGetter;
+};
+
+void ShouldUseBinaryFeatureFromProtoConfig(const TBinaryFeatureCase& test)
+{
+    NProto::TLocalServiceConfig proto;
+    (proto.*test.ProtoSetter)(true);
+
+    TLocalFileStoreConfig config(proto);
+
+    UNIT_ASSERT((config.*test.PlainGetter)());
+}
+
+void ShouldOverrideBinaryFeatureUsingFeaturesConfig(
+    const TBinaryFeatureCase& test)
+{
+    const TString fsId = "fs-id";
+    const TString anotherFsId = "another-fs-id";
+
+    // no feature match, use proto config
+    {
+        NProto::TLocalServiceConfig proto;
+        (proto.*test.ProtoSetter)(false);
+
+        TLocalFileStoreConfig config(proto);
+
+        NCloud::NProto::TFeaturesConfig featuresProto;
+        auto* feature = featuresProto.AddFeatures();
+        feature->SetName(test.Name);
+        *feature->MutableWhitelist()->AddEntityIds() = anotherFsId;
+
+        config.SetFeaturesConfig(
+            std::make_shared<NFeatures::TFeaturesConfig>(featuresProto));
+
+        UNIT_ASSERT(!(config.*test.FeatureGetter)({}, {}, fsId));
+    }
+
+    // feature enabled in whitelist without explicit value
+    {
+        NProto::TLocalServiceConfig proto;
+        (proto.*test.ProtoSetter)(false);
+
+        TLocalFileStoreConfig config(proto);
+
+        NCloud::NProto::TFeaturesConfig featuresProto;
+        auto* feature = featuresProto.AddFeatures();
+        feature->SetName(test.Name);
+        *feature->MutableWhitelist()->AddEntityIds() = fsId;
+
+        config.SetFeaturesConfig(
+            std::make_shared<NFeatures::TFeaturesConfig>(featuresProto));
+
+        UNIT_ASSERT((config.*test.FeatureGetter)({}, {}, fsId));
+    }
+
+    // feature enabled in whitelist with true value
+    {
+        NProto::TLocalServiceConfig proto;
+        (proto.*test.ProtoSetter)(false);
+
+        TLocalFileStoreConfig config(proto);
+
+        NCloud::NProto::TFeaturesConfig featuresProto;
+        auto* feature = featuresProto.AddFeatures();
+        feature->SetName(test.Name);
+        feature->SetValue("true");
+        *feature->MutableWhitelist()->AddEntityIds() = fsId;
+
+        config.SetFeaturesConfig(
+            std::make_shared<NFeatures::TFeaturesConfig>(featuresProto));
+
+        UNIT_ASSERT((config.*test.FeatureGetter)({}, {}, fsId));
+    }
+
+    // feature disabled in whitelist with false value
+    {
+        NProto::TLocalServiceConfig proto;
+        (proto.*test.ProtoSetter)(true);
+
+        TLocalFileStoreConfig config(proto);
+
+        NCloud::NProto::TFeaturesConfig featuresProto;
+        auto* feature = featuresProto.AddFeatures();
+        feature->SetName(test.Name);
+        feature->SetValue("false");
+        *feature->MutableWhitelist()->AddEntityIds() = fsId;
+
+        config.SetFeaturesConfig(
+            std::make_shared<NFeatures::TFeaturesConfig>(featuresProto));
+
+        UNIT_ASSERT(!(config.*test.FeatureGetter)({}, {}, fsId));
+    }
+}
+
+}   // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TConfigTest)
 {
+    Y_UNIT_TEST(ShouldUseBinaryFeaturesFromProtoConfig)
+    {
+        const TBinaryFeatureCase tests[] = {
+            {
+                "ExtendedAttributesDisabled",
+                &NProto::TLocalServiceConfig::SetExtendedAttributesDisabled,
+                &TLocalFileStoreConfig::GetExtendedAttributesDisabled,
+                &TLocalFileStoreConfig::GetExtendedAttributesDisabled,
+            },
+            {
+                "SnapshotsDirEnabled",
+                &NProto::TLocalServiceConfig::SetSnapshotsDirEnabled,
+                &TLocalFileStoreConfig::GetSnapshotsDirEnabled,
+                &TLocalFileStoreConfig::GetSnapshotsDirEnabled,
+            },
+            {
+                "GuestHandleKillPrivV2Enabled",
+                &NProto::TLocalServiceConfig::SetGuestHandleKillPrivV2Enabled,
+                &TLocalFileStoreConfig::GetGuestHandleKillPrivV2Enabled,
+                &TLocalFileStoreConfig::GetGuestHandleKillPrivV2Enabled,
+            },
+        };
+
+        for (const auto& test: tests) {
+            ShouldUseBinaryFeatureFromProtoConfig(test);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldOverrideBinaryFeaturesUsingFeaturesConfig)
+    {
+        const TBinaryFeatureCase tests[] = {
+            {
+                "ExtendedAttributesDisabled",
+                &NProto::TLocalServiceConfig::SetExtendedAttributesDisabled,
+                &TLocalFileStoreConfig::GetExtendedAttributesDisabled,
+                &TLocalFileStoreConfig::GetExtendedAttributesDisabled,
+            },
+            {
+                "SnapshotsDirEnabled",
+                &NProto::TLocalServiceConfig::SetSnapshotsDirEnabled,
+                &TLocalFileStoreConfig::GetSnapshotsDirEnabled,
+                &TLocalFileStoreConfig::GetSnapshotsDirEnabled,
+            },
+            {
+                "GuestHandleKillPrivV2Enabled",
+                &NProto::TLocalServiceConfig::SetGuestHandleKillPrivV2Enabled,
+                &TLocalFileStoreConfig::GetGuestHandleKillPrivV2Enabled,
+                &TLocalFileStoreConfig::GetGuestHandleKillPrivV2Enabled,
+            },
+        };
+
+        for (const auto& test: tests) {
+            ShouldOverrideBinaryFeatureUsingFeaturesConfig(test);
+        }
+    }
+
     Y_UNIT_TEST(ShouldUseAioAsDefault)
     {
         TLocalFileStoreConfig config;

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -20,16 +20,17 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
 
     auto session = FindSession(clientId, sessionId, sessionSeqNo);
 
-    const auto makeResponse = [&sessionSeqNo, this](const TSessionPtr& session)
+    const auto& cloudId = Store.GetCloudId();
+    const auto& folderId = Store.GetFolderId();
+    const auto& fsId = Store.GetFileSystemId();
+
+    const auto makeResponse = [&sessionSeqNo, &cloudId, &folderId, &fsId, this](
+                                  const TSessionPtr& session)
     {
         NProto::TCreateSessionResponse response;
         session->GetInfo(*response.MutableSession(), sessionSeqNo);
 
         *response.MutableFileStore() = Store;
-
-        const auto& cloudId = Store.GetCloudId();
-        const auto& folderId = Store.GetFolderId();
-        const auto& fsId = Store.GetFileSystemId();
 
         auto* features = response.MutableFileStore()->MutableFeatures();
         features->SetDirectIoEnabled(Config->GetDirectIoEnabled());
@@ -44,7 +45,7 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         features->SetGuestPageCacheDisabled(
             Config->GetGuestPageCacheDisabled());
         features->SetExtendedAttributesDisabled(
-            Config->GetExtendedAttributesDisabled());
+            Config->GetExtendedAttributesDisabled(cloudId, folderId, fsId));
         features->SetServerWriteBackCacheEnabled(
             Config->GetServerWriteBackCacheEnabled());
         features->SetMaxBackground(Config->GetMaxBackground());
@@ -69,7 +70,7 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
                 Config->GetDirectoryHandlesTableSize());
         }
         features->SetGuestHandleKillPrivV2Enabled(
-            Config->GetGuestHandleKillPrivV2Enabled());
+            Config->GetGuestHandleKillPrivV2Enabled(cloudId, folderId, fsId));
         return response;
     };
 
@@ -108,7 +109,7 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         Config->GetMaxHandlePerSessionCount(),
         Config->GetOpenNodeByHandleEnabled(),
         Config->GetNodeCleanupBatchSize(),
-        Config->GetSnapshotsDirEnabled(),
+        Config->GetSnapshotsDirEnabled(cloudId, folderId, fsId),
         Config->GetSnapshotsDirRefreshInterval(),
         Logging);
 


### PR DESCRIPTION
Add the three flags to FILESTORE_BINARY_FEATURES so they can be controlled per
filesystem via features config. For a matching filesystem rule, Value="false"
disables the flag, while any other value, including an unset Value, enables
it. If no rule matches, the proto config remains in effect.
