### PR TITLE
[Blockstore] Fix tsan failure on TVolumeInfo::RemoveByInactivityTimeoutEnabled concurrent usage

### DIFF
--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -699,30 +699,16 @@ public:
         return GetVolumeInfoImpl(diskId, clientId);
     }
 
-    void SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+    void DisableRemoveVolumeInfoByInactivityTimeout(
         const TString& diskId,
-        const TString& clientId,
-        bool enabled) override
+        const TString& clientId) override
     {
         TWriteGuard guard(Lock);
 
         auto volumeInfo = GetVolumeInfoImpl(diskId, clientId);
         if (volumeInfo) {
-            volumeInfo->RemoveByInactivityTimeoutEnabled = enabled;
+            volumeInfo->RemoveByInactivityTimeoutEnabled = false;
         }
-    }
-
-    [[nodiscard]] bool GetRemoveVolumeInfoByInactivityTimeoutEnabled(
-        const TString& diskId,
-        const TString& clientId) const override
-    {
-        TReadGuard guard(Lock);
-
-        auto volumeInfo = GetVolumeInfoImpl(diskId, clientId);
-        if (volumeInfo) {
-            return volumeInfo->RemoveByInactivityTimeoutEnabled;
-        }
-        return false;
     }
 
     NProto::EStorageMediaKind GetStorageMediaKind(
@@ -1129,24 +1115,12 @@ struct TVolumeStatsStub final
         return nullptr;
     }
 
-    void SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+    void DisableRemoveVolumeInfoByInactivityTimeout(
         const TString& diskId,
-        const TString& clientId,
-        bool enabled) override
+        const TString& clientId) override
     {
         Y_UNUSED(diskId);
         Y_UNUSED(clientId);
-        Y_UNUSED(enabled);
-    }
-
-    [[nodiscard]] bool GetRemoveVolumeInfoByInactivityTimeoutEnabled(
-        const TString& diskId,
-        const TString& clientId) const override
-    {
-        Y_UNUSED(diskId);
-        Y_UNUSED(clientId);
-
-        return false;
     }
 
     NProto::EStorageMediaKind GetStorageMediaKind(

--- a/cloud/blockstore/libs/diagnostics/volume_stats.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.h
@@ -105,14 +105,9 @@ struct IVolumeStats
         const TString& diskId,
         const TString& clientId) const = 0;
 
-    virtual void SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+    virtual void DisableRemoveVolumeInfoByInactivityTimeout(
         const TString& diskId,
-        const TString& clientId,
-        bool enabled) = 0;
-
-    [[nodiscard]] virtual bool GetRemoveVolumeInfoByInactivityTimeoutEnabled(
-        const TString& diskId,
-        const TString& clientId) const = 0;
+        const TString& clientId) = 0;
 
     virtual NProto::EStorageMediaKind GetStorageMediaKind(
         const TString& diskId) const = 0;

--- a/cloud/blockstore/libs/diagnostics/volume_stats_test.h
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_test.h
@@ -240,24 +240,12 @@ public:
         return TVolumeProcessingPolicy::GetVolumeInfo(diskId, clientId);
     }
 
-    void SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+    void DisableRemoveVolumeInfoByInactivityTimeout(
         const TString& diskId,
-        const TString& clientId,
-        bool enabled) override
+        const TString& clientId) override
     {
         Y_UNUSED(diskId);
         Y_UNUSED(clientId);
-        Y_UNUSED(enabled);
-    }
-
-    [[nodiscard]] bool GetRemoveVolumeInfoByInactivityTimeoutEnabled(
-        const TString& diskId,
-        const TString& clientId) const override
-    {
-        Y_UNUSED(diskId);
-        Y_UNUSED(clientId);
-
-        return false;
     }
 
     NProto::EStorageMediaKind GetStorageMediaKind(

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1367,10 +1367,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
                             ->FindSubgroup("folder", DefaultFolderId));
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-1"));
         }
-        volumeStats->SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+        volumeStats->DisableRemoveVolumeInfoByInactivityTimeout(
             "disk-1",
-            "client-1",
-            false);
+            "client-1");
 
         Timer->AdvanceTime(inactivityTimeout * 0.5);
 
@@ -1396,10 +1395,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
                             ->FindSubgroup("folder", DefaultFolderId));
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-2"));
         }
-        volumeStats->SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+        volumeStats->DisableRemoveVolumeInfoByInactivityTimeout(
             "disk-2",
-            "client-2",
-            false);
+            "client-2");
 
         Timer->AdvanceTime(inactivityTimeout * 0.6);
         volumeStats->TrimVolumes();

--- a/cloud/blockstore/libs/endpoints/session_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/session_manager.cpp
@@ -289,10 +289,9 @@ public:
 
                     // Make volumeInfo stats durable after successful mount
                     self->VolumeStats
-                        ->SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+                        ->DisableRemoveVolumeInfoByInactivityTimeout(
                             response.GetVolume().GetDiskId(),
-                            self->ClientId,
-                            false);
+                            self->ClientId);
                 }
                 return f;
             });

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -150,24 +150,12 @@ struct TVolumeStatsTestMock final: public IVolumeStats
         return nullptr;
     }
 
-    void SetRemoveVolumeInfoByInactivityTimeoutEnabled(
+    void DisableRemoveVolumeInfoByInactivityTimeout(
         const TString& diskId,
-        const TString& clientId,
-        bool enabled) override
+        const TString& clientId) override
     {
         Y_UNUSED(diskId);
         Y_UNUSED(clientId);
-        Y_UNUSED(enabled);
-    }
-
-    [[nodiscard]] bool GetRemoveVolumeInfoByInactivityTimeoutEnabled(
-        const TString& diskId,
-        const TString& clientId) const override
-    {
-        Y_UNUSED(diskId);
-        Y_UNUSED(clientId);
-
-        return false;
     }
 
     NProto::EStorageMediaKind GetStorageMediaKind(


### PR DESCRIPTION
Fix tsan failure originated in PR #5333

TVolumeInfo::RemoveByInactivityTimeoutEnabled flag was concurrently read at TStorageDataClient::MountVolume() (called via mount request future) and and written TVolumeStats::TrimVolumes() (called via Scheduler / TStatsUpdater / TServerStats).
 
TVolumeInfo::RemoveByInactivityTimeoutEnabled setter/getter moved from IVolumeInfo interface into IVolumeStats interface as meant only for internal use by TVolumeInfo owner - TVolumeStats, not by external IVolumeInfo users. All TVolumeInfo::RemoveByInactivityTimeoutEnabled use cases put under TVolumeStats::Lock TRWMutex.