### PR TITLE
issue-2718: [Blockstore] reduce the use of NKikimrScheme::StatusPathDoesNotExist across the code base; use IsDiskNotFoundError instead of IsNotFoundSchemeShardError, IsDiskNotFoundError also checks for E_NOT_FOUND

### DIFF
--- a/cloud/blockstore/libs/cells/impl/describe_volume.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume.cpp
@@ -10,6 +10,7 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/service.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
@@ -327,12 +328,7 @@ void TDescribeResponseHandler::HandleResponse(const auto& future)
                          << HostInfo.Fqdn);
 
     if (EErrorKind::ErrorRetriable != GetErrorKind(response.GetError())) {
-        auto code = response.GetError().GetCode();
-        const bool volumeNotFoundError =
-            code == E_NOT_FOUND ||
-            code ==
-                MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist);
-        Y_DEBUG_ABORT_UNLESS(volumeNotFoundError);
+        Y_DEBUG_ABORT_UNLESS(IsDiskNotFoundError(response.GetError()));
     }
     Cell.DescribeResults[CellResultIndex] = std::move(response.GetError());
 

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -17,6 +17,7 @@
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/blockstore/libs/service/service_method.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/model/log_prefix.h>
 
 #include <cloud/storage/core/libs/common/backoff_delay_provider.h>
@@ -1150,10 +1151,7 @@ NProto::TStopEndpointResponse TEndpointManager::StopEndpointFallback(
     const auto& removeClientResponse = Executor->WaitFor(removeClientFuture);
     const auto& error = removeClientResponse.GetError();
 
-    if (HasError(error) &&
-        error.GetCode() !=
-            MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
-    {
+    if (IsDiskNotFoundError(error)) {
         return TErrorResponse(removeClientResponse.GetError());
     }
 
@@ -1907,9 +1905,7 @@ void TEndpointManager::HandleRestoredEndpoint(
     if (HasError(error)) {
         STORAGE_ERROR("Failed to start endpoint " << socketPath.Quote()
             << ", error:" << FormatError(error));
-        if (error.GetCode() ==
-            MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
-        {
+        if (IsDiskNotFoundError(error)) {
             STORAGE_INFO(
                 "Remove endpoint for non-existing volume. endpoint id: "
                 << endpointId.Quote());

--- a/cloud/blockstore/libs/storage/core/proto_helpers.cpp
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.cpp
@@ -575,4 +575,14 @@ bool IsNotFoundSchemeShardError(const NProto::TError& error)
                error.GetCode())) == NKikimrScheme::StatusPathDoesNotExist;
 }
 
+bool IsDiskNotFoundError(const NProto::TError& error)
+{
+    if (error.GetCode() == E_NOT_FOUND) {
+        return true;
+    }
+
+    // TODO(svartmetal): get rid of this in #2718
+    return IsNotFoundSchemeShardError(error);
+}
+
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/proto_helpers.h
+++ b/cloud/blockstore/libs/storage/core/proto_helpers.h
@@ -255,5 +255,6 @@ NProto::TVolumePerformanceProfile VolumeConfigToVolumePerformanceProfile(
 TString PoolKindToString(const NProto::EDevicePoolKind poolKind);
 
 bool IsNotFoundSchemeShardError(const NProto::TError& error);
+bool IsDiskNotFoundError(const NProto::TError& error);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cleanup.cpp
@@ -1,6 +1,7 @@
 #include "disk_registry_actor.h"
 
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/model/volume_label.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -125,9 +126,7 @@ void TCleanupActor::HandleDescribeVolumeResponse(
     const auto* msg = ev->Get();
     const auto index = ev->Cookie;
 
-    if (msg->GetStatus() ==
-        MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
-    {
+    if (IsDiskNotFoundError(msg->GetError())) {
         DeallocateDisk(ctx, index);
     } else {
         const auto& id = DiskIds[index];

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
@@ -1,6 +1,7 @@
 #include "disk_registry_actor.h"
 
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -290,13 +291,9 @@ void TDiskRegistryActor::HandleUpdateVolumeConfigResponse(
         return;
     }
 
-    auto code = error.GetCode();
-    const auto statusPathDoesNotExist =
-        MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist);
-
     if (kind == EErrorKind::ErrorRetriable
-            || code == E_ABORTED
-            || code == statusPathDoesNotExist)
+            || error.GetCode() == E_ABORTED
+            || IsDiskNotFoundError(error))
     {
         auto* request = new TEvDiskRegistryPrivate::TEvUpdateVolumeConfigRequest(diskId);
 

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_get_link_status.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_get_link_status.cpp
@@ -207,7 +207,7 @@ void TGetLinkStatusActionActor::HandleGetLinkStatusResponse(
     const auto* msg = ev->Get();
     const auto& error = msg->GetError();
 
-    if (ev->Cookie == QueryLeader && IsNotFoundSchemeShardError(error)) {
+    if (ev->Cookie == QueryLeader && IsDiskNotFoundError(error)) {
         SendRequestToFollower(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/service/service_actor_check_liveness.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_check_liveness.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 
 #include <cloud/storage/core/libs/common/alloc.h>
 
@@ -99,17 +100,7 @@ void TVolumeLivenessCheckActor::HandleDescribeResponse(
     const auto* msg = ev->Get();
     const auto& error = msg->GetError();
 
-    bool deleted = false;
-
-    if (FAILED(error.GetCode()) &&
-        FACILITY_FROM_CODE(error.GetCode()) == FACILITY_SCHEMESHARD)
-    {
-        const auto status =
-            static_cast<NKikimrScheme::EStatus>(STATUS_FROM_CODE(error.GetCode()));
-        deleted = status == NKikimrScheme::StatusPathDoesNotExist;
-    }
-
-    if (deleted) {
+    if (IsDiskNotFoundError(error)) {
         DeletedVolumes.emplace_back(VolumesToCheck[ev->Cookie]);
     } else {
         LiveVolumes.emplace_back(VolumesToCheck[ev->Cookie]);

--- a/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy.cpp
@@ -367,7 +367,7 @@ void TDestroyVolumeActor::HandleStatVolumeResponse(
 
     const auto* msg = ev->Get();
 
-    if (IsNotFoundSchemeShardError(msg->GetError())) {
+    if (IsDiskNotFoundError(msg->GetError())) {
         if (Sync) {
             VolumeNotFoundInSS = true;
             DeallocateDisk(ctx);
@@ -485,7 +485,7 @@ void TDestroyVolumeActor::HandleGracefulShutdownResponse(
             DiskId.Quote().data(),
             FormatError(error).data());
 
-        if (IsNotFoundSchemeShardError(error)) {
+        if (IsDiskNotFoundError(error)) {
             DestroyVolume(ctx);
         } else {
             ReplyAndDie(ctx, std::move(error));

--- a/cloud/blockstore/libs/storage/service/service_actor_destroy_volume_link.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_destroy_volume_link.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 
@@ -114,15 +115,10 @@ void TDestroyVolumeLinkActor::HandleUnlinkLeaderVolumeFromFollowerResponse(
             LeaderDiskId.Quote().data(),
             FormatError(error).data());
 
-        if (FACILITY_FROM_CODE(error.GetCode()) == FACILITY_SCHEMESHARD) {
-            auto status = static_cast<NKikimrScheme::EStatus>(
-                STATUS_FROM_CODE(error.GetCode()));
-            // TODO: return E_NOT_FOUND instead of StatusPathDoesNotExist
-            if (status == NKikimrScheme::StatusPathDoesNotExist) {
-                // Leader disk not found. Try to remove on follower.
-                RemoveLinkOnFollower(ctx);
-                return;
-            }
+        if (IsDiskNotFoundError(error)) {
+            // Leader disk not found. Try to remove on follower.
+            RemoveLinkOnFollower(ctx);
+            return;
         }
     }
 

--- a/cloud/blockstore/libs/storage/service/service_ut_describe.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_describe.cpp
@@ -262,7 +262,7 @@ Y_UNIT_TEST_SUITE(TServiceDescribeVolumeTest)
             service.SendDescribeVolumeRequest(DefaultDiskId, true);
             auto response = service.RecvDescribeVolumeResponse();
             UNIT_ASSERT_C(
-                IsNotFoundSchemeShardError(response->GetError()),
+                IsDiskNotFoundError(response->GetError()),
                 FormatError(response->GetError()));
         }
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -347,9 +347,7 @@ void TStartVolumeActor::HandleDescribeVolumeResponse(
 {
     const auto* msg = ev->Get();
 
-    if (msg->GetStatus() ==
-        MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
-    {
+    if (IsDiskNotFoundError(msg->GetError())) {
         LOG_WARN(
             ctx,
             TBlockStoreComponents::SERVICE,
@@ -360,7 +358,7 @@ void TStartVolumeActor::HandleDescribeVolumeResponse(
         return;
     }
 
-    if (msg->GetStatus() == NKikimrScheme::StatusSuccess) {
+    if (!HasError(msg->GetError())) {
         auto volumeTabletId = msg->
             PathDescription.
             GetBlockStoreVolumeDescription().

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_unmount.cpp
@@ -211,9 +211,7 @@ void TUnmountRequestActor::HandleDescribeVolumeResponse(
 {
     const auto* msg = ev->Get();
 
-    if (msg->GetStatus() ==
-        MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist))
-    {
+    if (IsDiskNotFoundError(msg->GetError())) {
         LOG_INFO(
             ctx,
             TBlockStoreComponents::SERVICE,
@@ -222,7 +220,7 @@ void TUnmountRequestActor::HandleDescribeVolumeResponse(
             ClientId.Quote().data());
 
         Error = MakeError(S_ALREADY, "Volume is already destroyed");
-    } else if (msg->GetStatus() == NKikimrScheme::StatusSuccess) {
+    } else if (!HasError(msg->GetError())) {
         auto volumeTabletId = msg->
             PathDescription.
             GetBlockStoreVolumeDescription().

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_createvolume.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_createvolume.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/model/volume_label.h>
 
 #include <cloud/storage/core/libs/common/helpers.h>
@@ -352,15 +353,10 @@ void TCreateVolumeActor::HandleDescribeVolumeBeforeCreateResponse(
 
     const auto& error = msg->GetError();
 
-    // TODO: use E_NOT_FOUND instead of StatusPathDoesNotExist
     if (FAILED(error.GetCode())) {
-        if (FACILITY_FROM_CODE(error.GetCode()) == FACILITY_SCHEMESHARD) {
-           auto status =
-                static_cast<NKikimrScheme::EStatus>(STATUS_FROM_CODE(error.GetCode()));
-            if (status == NKikimrScheme::StatusPathDoesNotExist) {
-                CreateVolume(ctx);
-                return;
-            }
+        if (IsNotFoundSchemeShardError(error)) {
+            CreateVolume(ctx);
+            return;
         }
 
         LOG_ERROR(ctx, TBlockStoreComponents::SS_PROXY,
@@ -421,18 +417,14 @@ void TCreateVolumeActor::HandleCreateVolumeResponse(
     const auto& diskId = VolumeConfig.GetDiskId();
 
     if (FAILED(error.GetCode())) {
-        if (FACILITY_FROM_CODE(error.GetCode()) == FACILITY_SCHEMESHARD) {
-            auto status =
-                static_cast<NKikimrScheme::EStatus>(STATUS_FROM_CODE(error.GetCode()));
-            if (FirstCreationAttempt &&
-                ParentDirs &&
-                status == NKikimrScheme::StatusPathDoesNotExist)
-            {
-                // Try creating intermediate directories
-                FirstCreationAttempt = false;
-                EnsureDirs(ctx);
-                return;
-            }
+        if (FirstCreationAttempt &&
+            ParentDirs &&
+            IsNotFoundSchemeShardError(error))
+        {
+            // Try creating intermediate directories
+            FirstCreationAttempt = false;
+            EnsureDirs(ctx);
+            return;
         }
 
         LOG_ERROR(ctx, TBlockStoreComponents::SS_PROXY,

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describevolume.cpp
@@ -1,6 +1,7 @@
 #include "ss_proxy_actor.h"
 
 #include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/model/volume_label.h>
 #include <cloud/blockstore/libs/storage/ss_proxy/ss_proxy_events_private.h>
 
@@ -174,37 +175,31 @@ void TDescribeVolumeActor::HandleDescribeSchemeResponse(
     const auto& error = msg->GetError();
 
     if (HasError(error)) {
-        if (FACILITY_FROM_CODE(error.GetCode()) == FACILITY_SCHEMESHARD) {
-            auto status =
-                static_cast<NKikimrScheme::EStatus>(STATUS_FROM_CODE(error.GetCode()));
-            // TODO: return E_NOT_FOUND instead of StatusPathDoesNotExist
+        LOG_TRACE(
+            ctx,
+            TBlockStoreComponents::SS_PROXY,
+            "Describe request error for volume %s %s %s",
+            DiskId.c_str(),
+            GetFullPath().Quote().data(),
+            FormatError(error).c_str());
 
-            LOG_TRACE(
-                ctx,
-                TBlockStoreComponents::SS_PROXY,
-                "Describe request error for volume %s %s %s",
-                DiskId.c_str(),
-                GetFullPath().Quote().data(),
-                FormatError(error).c_str());
-
-            if (status == NKikimrScheme::StatusPathDoesNotExist) {
-                switch (State) {
-                    case EState::DescribePrimaryDeprecated: {
-                        State = EState::DescribePrimary;
-                        DescribeVolume(ctx);
-                        return;
-                    }
-                    case EState::DescribePrimary: {
-                        if (ExactDiskIdMatch || IsSecondaryDiskId(DiskId)) {
-                            break;
-                        }
-                        State = EState::DescribeSecondary;
-                        DescribeVolume(ctx);
-                        return;
-                    }
-                    case EState::DescribeSecondary:
-                        break;
+        if (IsNotFoundSchemeShardError(error)) {
+            switch (State) {
+                case EState::DescribePrimaryDeprecated: {
+                    State = EState::DescribePrimary;
+                    DescribeVolume(ctx);
+                    return;
                 }
+                case EState::DescribePrimary: {
+                    if (ExactDiskIdMatch || IsSecondaryDiskId(DiskId)) {
+                        break;
+                    }
+                    State = EState::DescribeSecondary;
+                    DescribeVolume(ctx);
+                    return;
+                }
+                case EState::DescribeSecondary:
+                    break;
             }
         }
 

--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
@@ -398,7 +398,7 @@ void TFollowerDiskActor::HandlePropagateLeadershipToFollowerResponse(
             LogTitle.GetWithTime().c_str(),
             FormatError(msg->GetError()).c_str());
 
-        if (IsNotFoundSchemeShardError(error)) {
+        if (IsDiskNotFoundError(error)) {
             // If it is not possible to transfer leadership because there is no
             // follower disk, then we should go into an error state.
             auto newFollowerInfo = FollowerDiskInfo;

--- a/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
+++ b/cloud/blockstore/libs/storage/volume_proxy/volume_proxy.cpp
@@ -662,7 +662,7 @@ void TVolumeProxyActor::HandleBaseDiskDescribeResponse(
     const NProto::TError& error,
     const TActorContext& ctx)
 {
-    if (error.GetCode() == MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist)) {
+    if (IsDiskNotFoundError(error)) {
         LOG_ERROR(
             ctx,
             TBlockStoreComponents::VOLUME_PROXY,


### PR DESCRIPTION
### Notes
Describe your PR - what it does and why this needs to be done.

### Issue
#2718
