### PR TITLE
issue-4875: Fix data loss on fresh blobs data loading with Fresh Blocks Writer Feature

### DIFF
--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -1010,6 +1010,75 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
             response->GetStatus(),
             response->GetErrorReason());
     }
+
+    Y_UNIT_TEST(ShouldNotLooseInFlightWritesOnReboot)
+    {
+        auto testEnv = PrepareTestActorRuntime();
+        auto& runtime = *testEnv.Runtime;
+
+        TPartitionClient partition(runtime);
+        partition.WaitReady();
+
+        TFreshBlocksWriterClient fbwClient(
+            runtime,
+            testEnv.FreshBlocksWriterActorId);
+        fbwClient.WaitReady();
+
+        std::unique_ptr<IEventHandle> stollenPutRequest;
+        bool steelPutRequest = true;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvBlobStorage::EvPut &&
+                    !stollenPutRequest && steelPutRequest)
+                {
+                    Cerr << "Stollen put request" << Endl;
+                    stollenPutRequest.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                if (event->GetTypeRewrite() == TEvPartitionCommonPrivate::EvTrimFreshLogRequest)
+                {
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        fbwClient.SendWriteBlocksRequest(0, '1');
+        runtime.DispatchEvents({}, 10ms);
+
+        fbwClient.WriteBlocks(1, '2');
+
+        partition.Flush();
+
+        fbwClient.WriteBlocks(2, '3');
+
+        partition.Flush();
+
+        steelPutRequest = false;
+        runtime.SendAsync(stollenPutRequest.release());
+
+        auto response = fbwClient.RecvWriteBlocksResponse();
+        UNIT_ASSERT(!HasError(response->GetError()));
+
+        partition.KillTablet();
+        partition.ReconnectPipe();
+        partition.WaitReady();
+
+        TFreshBlocksWriterClient newFbwClient(
+            runtime,
+            testEnv.FreshBlocksWriterActorId);
+        newFbwClient.WaitReady();
+
+        auto actualContent = GetBlocksContent(
+            newFbwClient.ReadBlocks(TBlockRange32::WithLength(0, 3)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuilder() << GetBlockContent('1') << GetBlockContent('2')
+                             << GetBlockContent('3'),
+            actualContent);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -97,6 +97,7 @@ TPartitionState::TPartitionState(
     , CleanupScoreHistory(cleanupScoreHistorySize)
 {
     InitChannels();
+    SetLastTrimFreshLogToCommitId(Meta.GetTrimFreshLogToCommitId());
 }
 
 bool TPartitionState::CheckBlockRange(const TBlockRange64& range) const

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -950,7 +950,7 @@ public:
 
     void UpdateTrimFreshLogToCommitIdInMeta()
     {
-        Meta.SetTrimFreshLogToCommitId(GetTrimFreshLogToCommitId());
+        Meta.SetTrimFreshLogToCommitId(GetLastTrimFreshLogToCommitId());
     }
 
     //

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -12802,6 +12802,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
         }
 
+        bool stopTrimming = false;
         bool saveBlobs = false;
         TSet<ui64> expectedBlobs;
 
@@ -12812,7 +12813,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                     case TEvBlobStorage::EvCollectGarbage: {
                         auto* msg = ev->Get<TEvBlobStorage::TEvCollectGarbage>();
                         if (msg->Channel == FreshChannelId) {
-                            return true;
+                            return stopTrimming;
                         }
                         break;
                     }
@@ -12856,10 +12857,12 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         // update TrimFreshLogToCommitId in meta to gen:step = 0:0
         partition.Flush();
+        partition.TrimFreshLog();
 
         runtime->DispatchEvents(TDispatchOptions{}, TDuration::Seconds(1));
 
         saveBlobs = true;
+        stopTrimming = true;
 
         partition.WriteBlocks(4, 4);
         partition.WriteBlocks(5, 5);


### PR DESCRIPTION
### Notes
We persist the current TrimFreshLogToCommitId for every AddBlobs transaction in the local database. On partition start, we load all the blobs starting from that persisted TrimFreshLogCommitId. So, if at the time of AddBlob transaction execution, there are some inflight requests with a commit id less than the TrimFreshLog to CommitId in the partition and a reboot occurs after the transaction completes, we will not load fresh blobs with a commit id less than the TrimFreshLog from the FBW , though response was already sent.

In this PR i persist Last TrimFreshLogToCommitId, which takes into account commits from FBW

### Issue
#4875
