### PR TITLE
[Filestore, NBS] Change ssh LogLevel from in SshToGuest to verbose from error.

### DIFF
--- a/cloud/storage/core/tools/testing/qemu/lib/common.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/common.py
@@ -30,7 +30,7 @@ class SshToGuest(object):
             "-i", self.key,
             "-l", self.user,
             "-p", str(self.port),
-            "-o LogLevel=error",
+            "-o", "LogLevel=VERBOSE",
             "127.0.0.1",
             command
         ]


### PR DESCRIPTION
### Notes
Describe your PR - what it does and why this needs to be done.

### Issue

Debugging this failure: https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/Nightly-build/23366452863/1/nebius-x86-64/summary/1/ya-test.html#FAIL

```
2026-03-21 00:14:58,872 - INFO - cloud.storage.core.tools.testing.qemu.lib.common - get_command:
ssh execute command: 'ssh -n -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
  -o ConnectTimeout=10
  -o IdentitiesOnly=yes
  -o ServerAliveInterval=10       
  -o ServerAliveCountMax=10       
  -i …/id_rsa -l qemu -p 37337
  -o LogLevel=error               
  127.0.0.1 sudo /run_test.sh'
00:16:49  recipe_stop: SIGTERM → pid 666300
          qemu-bin.0.err: "terminating on signal 15 from pid 700137"
```

Looks like `ServerAliveInterval * ServerAliveCountMax = 100s` was the timeout that we hit, and the test crashed.