### PR TITLE
fixing node-ref lock leak upon UnlinkNode ops for sharded parentless filesystems

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -586,6 +586,7 @@ void TIndexTabletActor::CompleteTx_UnlinkNode(
     // reject the request. In this case the nodeRef will be unlocked afterwards.
     if (HasError(args.Error) ||
         (args.ChildRef && !args.ChildRef.GetOrElse({}).IsExternal()) ||
+        Config->GetParentlessFilesOnly() ||
         !GetFileSystem().GetDirectoryCreationInShardsEnabled())
     {
         UnlockNodeRef({args.ParentNodeId, args.Name});

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -2071,6 +2071,40 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         UNIT_ASSERT_VALUES_EQUAL(nodeId, responses[0].GetNode().GetId());
         UNIT_ASSERT_VALUES_EQUAL(4_KB, responses[0].GetNode().GetSize());
     }
+
+    TABLET_TEST_4K_ONLY(ShouldUnlockNodeIdUponUnlinkForParentlessFileSystems)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetDirectoryCreationInShardsEnabled(true);
+        storageConfig.SetParentlessFilesOnly(true);
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.ConfigureShards(true);
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        tablet.InitSession("client", "session");
+
+        const ui64 nodeId = 111;
+        tablet.UnsafeCreateNode(nodeId, 4_KB);
+
+        tablet.UnlinkNode(nodeId, "" /* name */, false /* unlinkDirectory */);
+        auto response = tablet.SendAndRecvUnlinkNode(
+            nodeId,
+            "" /* name */,
+            false /* unlinkDirectory */);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_FS_NOENT,
+            response->GetStatus(),
+            FormatError(response->GetError()));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Notes
`UnlockNodeRef()` call was forgotten for this specific case. In the future we should refactor the `Parentless` control flow path into a separate `StateFunc` and a separate set of transactions (or something in this manner). 

### Issue
Related to https://github.com/ydb-platform/nbs/issues/3699