### PR TITLE
[Filestore] Fix race in TFileSystemTest::ShouldNotReportEnormousMaxTimeWhenCancellingRequest

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -4560,7 +4560,21 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         NProto::TFileStoreFeatures features;
 
-        // Use WriteBackCache in order to stop when CompletionQueue is stopped
+        // StopAsync and GetAttrRequest are executed concurrently:
+        // - if StopAsync is completed before GetAttrRequest, it will not be
+        //   processed at all;
+        // - if GetAttrRequest is completed before StopAsync, it will not be
+        //   canceled and will return with success.
+        //
+        // We use WriteBackCache in order to prevent race and enforce strict
+        // ordering between StopAsync and GetAttrRequest execution.
+        //
+        // WriteBackCache::FlushAll is executed after CompletionQueue is stopped
+        // (new requests will be canceled) and before FUSE loop is unmounted.
+        //
+        // We catch the moment when FlushAll is called by listening to
+        // WriteData requests.
+
         features.SetServerWriteBackCacheEnabled(true);
 
         const ui64 NodeId = 123;


### PR DESCRIPTION
### Notes

The execution order of `StopAsync` and sending `GetAttr` request was undefined.

PR fixes execution order by listening to WriteData call from FlushAll from WriteBackCache at Stop.

```
2026-03-24T14:57:57.761721Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: CreateSession #18070239999656056418 [f:fs1] REQUEST
2026-03-24T14:57:57.761743Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:439: [f:""][c:""][s:""][n:0] initiating session f: 3
2026-03-24T14:57:57.761767Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:482: [f:""][c:""][s:"4b2e5b75-6d7d7f7-5c2f59b0-10d79d5f"][n:0] session established 0
2026-03-24T14:57:57.761794Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: CreateSession #18070239999656056418 [f:fs1][c:] RESPONSE request completed(total_time: 68us, execution_time: 68us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2026-03-24T14:57:57.761885Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1131: [f:"fs1"][c:""] starting new session
2026-03-24T14:57:57.761911Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1147: [f:"fs1"][c:""] new session (1 threads) filestore config: "FileSystemId: fs1\nBlockSize: 4096\nLockRetryTimeout: 1.000000s\nEntryTimeout: 15.000000s\nRegularFileEntryTimeout: 0.000000s\nNegativeEntryTimeout: 0.000000s\nAttrTimeout: 15.000000s\nXAttrCacheLimit: 512\nXAttrCacheTimeout: 15.000000s\nMaxBufferSize: 1048576\nPreferredBlockSize: 4096\nAsyncDestroyHandleEnabled: 0\nAsyncHandleOperationPeriod: 0.000000s\nDirectIoEnabled: 0\nDirectIoAlign: 0\nGuestWriteBackCacheEnabled: 0\nZeroCopyEnabled: 0\nGuestPageCacheDisabled: 0\nExtendedAttributesDisabled: 0\nServerWriteBackCacheEnabled: 0\nDirectoryHandlesStorageEnabled: 0\nDirectoryHandlesTableSize: 0\nGuestKeepCacheAllowed: 0\nMaxBackground: 0\nMaxFuseLoopThreads: 0\nZeroCopyWriteEnabled: 0\nFSyncQueueDisabled: 0\nGuestHandleKillPrivV2Enabled: 0\nZeroCopyReadEnabled: 0\n"
2026-03-24T14:57:57.761929Z :NFS_VHOST INFO: : virtio_session_mount:442: starting device /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129, num_frontend_queues=2, num_backend_queues=1
2026-03-24T14:57:57.762238Z :NFS_VHOST INFO: : server_read:2210: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: Connection established, sock = 10
2026-03-24T14:57:57.762262Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: GET_FEATURES (1)
2026-03-24T14:57:57.762273Z :NFS_VHOST INFO: : vhost_get_features:807: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: GET_FEATURES: reply with supported_features 0x154000000
2026-03-24T14:57:57.762330Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_FEATURES (2)
2026-03-24T14:57:57.762339Z :NFS_VHOST INFO: : vhost_set_features:847: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_FEATURES: features 0x100000000
2026-03-24T14:57:57.762362Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: GET_PROTOCOL_FEATURES (15)
2026-03-24T14:57:57.762426Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_PROTOCOL_FEATURES (16)
2026-03-24T14:57:57.762453Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_OWNER (3)
2026-03-24T14:57:57.762479Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: GET_QUEUE_NUM (17)
2026-03-24T14:57:57.762557Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_MEM_TABLE (5)
2026-03-24T14:57:57.762657Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_NUM (8)
2026-03-24T14:57:57.762677Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_BASE (10)
2026-03-24T14:57:57.762689Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_ADDR (9)
2026-03-24T14:57:57.762712Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_ERR (14)
2026-03-24T14:57:57.762735Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_KICK (12)
2026-03-24T14:57:57.762814Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_CALL (13)
2026-03-24T14:57:57.762889Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_NUM (8)
2026-03-24T14:57:57.762904Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_BASE (10)
2026-03-24T14:57:57.762930Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_ADDR (9)
2026-03-24T14:57:57.762957Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_ERR (14)
2026-03-24T14:57:57.762978Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_KICK (12)
2026-03-24T14:57:57.763058Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: SET_VRING_CALL (13)
2026-03-24T14:57:57.763355Z :NFS_VHOST DEBUG: : virtq_dequeue_many:472: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129[0]: resubmit inflight requests, if any
2026-03-24T14:57:57.763382Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 104 and 2 OUT desc of length 80
2026-03-24T14:57:57.763389Z :NFS_FUSE DEBUG: : unique: 1, opcode: INIT (26), nodeid: 0, insize: 104, pid: 0
2026-03-24T14:57:57.763398Z :NFS_FUSE INFO: : INIT REQ: 7.38
2026-03-24T14:57:57.763408Z :NFS_FUSE INFO: : flags=0x03fffffb
2026-03-24T14:57:57.763413Z :NFS_FUSE INFO: : max_readahead=0x00000000
2026-03-24T14:57:57.763426Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1440: [f:"fs1"][c:""][l:17] resetting session state
2026-03-24T14:57:57.763460Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1460: [f:"fs1"][c:""] session reset completed: S_OK
2026-03-24T14:57:57.763466Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:94: resetting filesystem cache
2026-03-24T14:57:57.763469Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:97: clear directory cache of size 0
2026-03-24T14:57:57.763472Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:88: scheduling destroy handle queue processing
2026-03-24T14:57:57.763476Z :NFS_FUSE INFO: :    INIT RSP: 7.31
2026-03-24T14:57:57.763479Z :NFS_FUSE INFO: :    flags=0x0044b42b
2026-03-24T14:57:57.763481Z :NFS_FUSE INFO: :    max_readahead=0x00000000
2026-03-24T14:57:57.763483Z :NFS_FUSE INFO: :    max_write=0x00100000
2026-03-24T14:57:57.763485Z :NFS_FUSE INFO: :    max_background=16384
2026-03-24T14:57:57.763487Z :NFS_FUSE INFO: :    congestion_threshold=12288
2026-03-24T14:57:57.763489Z :NFS_FUSE INFO: :    time_gran=1
2026-03-24T14:57:57.763491Z :NFS_FUSE DEBUG: :    unique: 1, success, outsize: 80
2026-03-24T14:57:57.763494Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 2 desc of length 80
2026-03-24T14:57:57.763518Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129[0]: head = 0
2026-03-24T14:57:57.763619Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:226: [f:fs1] StopAsync: completing left: 0, requests left: 0, fuse cancellation code: 0
2026-03-24T14:57:57.763728Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:653: stopping FUSE loop
2026-03-24T14:57:57.763739Z :NFS_VHOST INFO: : virtio_session_exit:517: unregister device /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129
2026-03-24T14:57:57.763773Z :NFS_VHOST INFO: : vdev_disconnect:2087: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129: Close connection with client, sock = 10
2026-03-24T14:57:57.763822Z :NFS_VHOST INFO: : vring_mark_stopped:287: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129[0]: stopped vring with 0 in-flight requests
2026-03-24T14:57:57.763835Z :NFS_VHOST INFO: : vring_mark_stopped:287: /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129[1]: stopped vring with 0 in-flight requests
2026-03-24T14:57:57.763930Z :NFS_VHOST INFO: : unregister_complete:332: stopping device /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129
2026-03-24T14:57:57.763942Z :NFS_VHOST INFO: : unregister_complete:336: finished stopping device /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129
2026-03-24T14:57:57.763954Z :NFS_VHOST INFO: : virtio_session_exit:526: finished unregister device
2026-03-24T14:57:57.763965Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:583: stopping FUSE loop thread 10.0
2026-03-24T14:57:57.764000Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:590: stopped FUSE loop thread 10.0
2026-03-24T14:57:57.764006Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:665: stopped FUSE loop
2026-03-24T14:57:57.764012Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:677: unmounting FUSE session
2026-03-24T14:57:57.764026Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1430: [f:"fs1"][c:""] got destroy request
2026-03-24T14:57:57.764033Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1440: [f:"fs1"][c:""][l:0] resetting session state
2026-03-24T14:57:57.764069Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1460: [f:"fs1"][c:""] session reset completed: S_OK
2026-03-24T14:57:57.764081Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:94: resetting filesystem cache
2026-03-24T14:57:57.764088Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:97: clear directory cache of size 0
2026-03-24T14:57:57.764093Z :NFS_VHOST INFO: : virtio_session_close:496: destroying device /home/github/.ya/build/build_root/j2ck/000a73/r3tmp/vhost.socket_544721726141697129
2026-03-24T14:57:57.764108Z :NFS_VHOST INFO: : virtio_session_close:505: finished destroying device
2026-03-24T14:57:57.764135Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: DestroySession #112482255151183442 [f:fs1] REQUEST
2026-03-24T14:57:57.764151Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:557: [f:""][c:""][s:"4b2e5b75-6d7d7f7-5c2f59b0-10d79d5f"][n:0] destroying session
2026-03-24T14:57:57.764167Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:580: [f:""][c:""][s:"4b2e5b75-6d7d7f7-5c2f59b0-10d79d5f"][n:0] session destroyed
2026-03-24T14:57:57.764189Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: DestroySession #112482255151183442 [f:fs1][c:] RESPONSE request completed(total_time: 42us, execution_time: 42us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
/actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:4585:15: runtime error: member call on null pointer of type 'NMonitoring::TDynamicCounters'
```

**Issues**

#5548