### PR TITLE
issue-2718: [Blockstore] [Go SDK] IsDiskNotFoundError should handle E_NOT_FOUND error

### DIFF
--- a/cloud/blockstore/public/sdk/go/client/client.go
+++ b/cloud/blockstore/public/sdk/go/client/client.go
@@ -1,9 +1,6 @@
 package client
 
 import (
-	"errors"
-	"strings"
-
 	protos "github.com/ydb-platform/nbs/cloud/blockstore/public/api/protos"
 	"golang.org/x/net/context"
 )
@@ -275,27 +272,6 @@ func (client *Client) ReleaseNVMeDevice(
 
 	_, err := client.Impl.ReleaseNVMeDevice(ctx, req)
 	return err
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-func IsDiskNotFoundError(e error) bool {
-	var clientErr *ClientError
-	if errors.As(e, &clientErr) {
-		if clientErr.Facility() == FACILITY_SCHEMESHARD {
-			// TODO: remove support for PathDoesNotExist.
-			if clientErr.Status() == 2 {
-				return true
-			}
-
-			// Hack for NBS-3162.
-			if strings.Contains(clientErr.Error(), "Another drop in progress") {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/public/sdk/go/client/error.go
+++ b/cloud/blockstore/public/sdk/go/client/error.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -139,4 +140,27 @@ func GetClientError(err error) ClientError {
 	}
 
 	return ClientError{E_FAIL, err.Error()}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func IsDiskNotFoundError(e error) bool {
+	var clientErr *ClientError
+	if errors.As(e, &clientErr) {
+		if clientErr.Facility() == FACILITY_SCHEMESHARD {
+			// TODO(svartmetal): remove support for PathDoesNotExist (see #2718)
+			if clientErr.Status() == 2 {
+				return true
+			}
+
+			// Hack for NBS-3162.
+			if strings.Contains(clientErr.Error(), "Another drop in progress") {
+				return true
+			}
+		}
+
+		return clientErr.Code == E_NOT_FOUND
+	}
+
+	return false
 }

--- a/cloud/blockstore/public/sdk/go/client/error_test.go
+++ b/cloud/blockstore/public/sdk/go/client/error_test.go
@@ -34,3 +34,15 @@ func TestGetClientError(t *testing.T) {
 	require.Equal(t, code, e.Code)
 	require.Equal(t, message, e.Message)
 }
+
+func TestIsDiskNotFoundError(t *testing.T) {
+	clientErr := &ClientError{}
+	var err error
+	err = clientErr
+
+	clientErr.Code = E_NOT_IMPLEMENTED
+	require.False(t, IsDiskNotFoundError(err))
+
+	clientErr.Code = E_NOT_FOUND
+	require.True(t, IsDiskNotFoundError(err))
+}


### PR DESCRIPTION
### Notes
NBS should return E_NOT_FOUND instead of StatusPathDoesNotExist for 'not found' or deleted disks. 
This change teaches clients (Disk Manager, CSI driver) to handle E_NOT_FOUND. 
After client rollout, we will translate StatusPathDoesNotExist to E_NOT_FOUND in Blockstore code

### Issue
#2718
