### PR TITLE
Smooth UnspentCostBucket budget spending

### DIFF
--- a/cloud/storage/.gitignore
+++ b/cloud/storage/.gitignore
@@ -11,6 +11,7 @@ core/libs/keyring/ut/bin/cloud-storage-core-libs-keyring-ut-bin
 core/libs/keyring/ut/cloud-storage-core-libs-keyring-ut
 core/libs/tablet/model/ut/cloud-storage-core-libs-tablet-model-ut
 core/libs/tablet/ut/cloud-storage-core-libs-tablet-ut
+core/libs/throttling/bench/smootherstep-bench
 core/libs/throttling/ut/cloud-storage-core-libs-throttling-ut
 core/libs/version/ut/cloud-storage-core-libs-version-ut
 core/tests/recipes/qemu/qemu-recipe

--- a/cloud/storage/core/libs/throttling/bench/main.cpp
+++ b/cloud/storage/core/libs/throttling/bench/main.cpp
@@ -1,0 +1,89 @@
+#include <library/cpp/testing/benchmark/bench.h>
+
+#include <util/generic/vector.h>
+#include <util/random/random.h>
+#include <util/system/compiler.h>
+#include <util/system/yassert.h>
+
+#include <cmath>
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+double Sigmoid(double x)
+{
+    constexpr double Steepness = -8.0;
+    constexpr double Offset = 0.5;
+    return 1.0 / (1.0 + std::exp(Steepness * (x - Offset)));
+}
+
+double Smoothstep(double x)
+{
+    const double x2 = x * x;
+    return 3 * x2 - 2 * x2 * x;
+}
+
+double Smootherstep1(double x)
+{
+    const double x3 = x * x * x;
+    return ((6 * x - 15) * x + 10) * x3;
+}
+
+double Smootherstep2(double x)
+{
+    const double x2 = x * x;
+    const double x4 = x2 * x2;
+    return (((-20 * x + 70) * x - 84) * x + 35) * x4;
+}
+
+double Smootherstep3(double x)
+{
+    const double x2 = x * x;
+    const double x5 = x2 * x2 * x;
+    return ((((70 * x - 315) * x + 540) * x - 420) * x + 126) * x5;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+thread_local TVector<double> RandomNumbers;
+
+#define SMOOTHER_BENCH(SmoothFunc)                                        \
+    Y_CPU_BENCHMARK(SmoothFunc##_Benchmark, iface)                        \
+    {                                                                     \
+        constexpr int RandomNumbersSize = 1024 * 1024;                    \
+        if (RandomNumbers.empty()) {                                      \
+            RandomNumbers.reserve(RandomNumbersSize);                     \
+            for (int i = 0; i < RandomNumbersSize; i++) {                 \
+                RandomNumbers.push_back(RandomNumber<double>());          \
+            }                                                             \
+        }                                                                 \
+                                                                          \
+        for (i64 i = 0; i < static_cast<i64>(iface.Iterations()); ++i) {  \
+            const double x = RandomNumbers[i % RandomNumbersSize];        \
+            double result = SmoothFunc(x);                                \
+            NBench::DoNotOptimize(result);                                \
+            Y_DEBUG_ABORT_UNLESS(                                         \
+                result >= 0.0,                                            \
+                "SmoothFunc(%f) = %f",                                    \
+                x,                                                        \
+                result);                                                  \
+            constexpr double Eps = 1e-9;                                  \
+            Y_DEBUG_ABORT_UNLESS(                                         \
+                result <= 1.0 + Eps,                                      \
+                "SmoothFunc(%f) = %f",                                    \
+                x,                                                        \
+                result);                                                  \
+        }                                                                 \
+    }                                                                     \
+    // SMOOTHER_BENCH
+
+////////////////////////////////////////////////////////////////////////////////
+
+SMOOTHER_BENCH(Sigmoid)
+SMOOTHER_BENCH(Smoothstep)
+SMOOTHER_BENCH(Smootherstep1)
+SMOOTHER_BENCH(Smootherstep2)
+SMOOTHER_BENCH(Smootherstep3)

--- a/cloud/storage/core/libs/throttling/bench/ya.make
+++ b/cloud/storage/core/libs/throttling/bench/ya.make
@@ -1,0 +1,13 @@
+Y_BENCHMARK(smootherstep-bench)
+
+IF (SANITIZER_TYPE)
+    TAG(ya:manual)
+ENDIF()
+
+ALLOCATOR(TCMALLOC_TC)
+
+SRCS(
+    main.cpp
+)
+
+END()

--- a/cloud/storage/core/libs/throttling/unspent_cost_bucket.cpp
+++ b/cloud/storage/core/libs/throttling/unspent_cost_bucket.cpp
@@ -2,6 +2,7 @@
 
 #include <util/generic/utility.h>
 
+#include <algorithm>
 #include <cmath>
 
 namespace NCloud {
@@ -13,6 +14,15 @@ TDuration MultiplyWithRounding(TDuration duration, double multiplier)
 {
     return TDuration::MicroSeconds(
         std::round(duration.MicroSeconds() * multiplier));
+}
+
+TDuration CalculateDesiredBudgetSpend(
+    TDuration minSpend,
+    TDuration maxSpend,
+    double discountFactor)
+{
+    return minSpend +
+           MultiplyWithRounding((maxSpend - minSpend), discountFactor);
 }
 
 }   // namespace
@@ -34,6 +44,12 @@ TUnspentCostBucket::TUnspentCostBucket(
     , CurrentBudget(MaxBudget * (1.0 - spentBudgetShare))
 {}
 
+double TUnspentCostBucket::Smootherstep(double x)
+{
+    const double x3 = x * x * x;
+    return ((6 * x - 15) * x + 10) * x3;
+}
+
 TDuration
 TUnspentCostBucket::Register(TInstant now, TDuration cost, TDuration spent)
 {
@@ -44,11 +60,20 @@ TUnspentCostBucket::Register(TInstant now, TDuration cost, TDuration spent)
         return TDuration::Zero();
     }
 
+    const double budgetRatio = CurrentBudget / MaxBudget;
+    const double discountFactor =
+        // clamp just in case of precision issues
+        Smootherstep(std::clamp(budgetRatio, 0.0, 1.0));
+
     const TDuration maxBudgetSpend = cost - spent;
     const TDuration minBudgetSpend =
         MultiplyWithRounding(cost, BudgetSpendRate) - spent;
-    const TDuration neededBudgetSpend = maxBudgetSpend - minBudgetSpend;
-    const TDuration coveredByBudget = Min(neededBudgetSpend, CurrentBudget);
+    // The speed of budget consumption is higher when the budget is more full.
+    const TDuration desiredBudgetSpend = CalculateDesiredBudgetSpend(
+        minBudgetSpend,
+        maxBudgetSpend,
+        discountFactor);
+    const TDuration coveredByBudget = Min(desiredBudgetSpend, CurrentBudget);
 
     CurrentBudget -= coveredByBudget;
 

--- a/cloud/storage/core/libs/throttling/unspent_cost_bucket.h
+++ b/cloud/storage/core/libs/throttling/unspent_cost_bucket.h
@@ -36,6 +36,11 @@ public:
 
     ~TUnspentCostBucket() = default;
 
+    // https://en.wikipedia.org/wiki/Smoothstep
+    // Similar to sigmoid function but faster. Proof:
+    // cloud/storage/core/libs/throttling/bench.
+    static double Smootherstep(double x);
+
     TDuration Register(TInstant now, TDuration cost, TDuration spentCost);
 
     [[nodiscard]] double CalculateCurrentSpentBudgetShare(TInstant now) const;

--- a/cloud/storage/core/libs/throttling/unspent_cost_bucket_ut.cpp
+++ b/cloud/storage/core/libs/throttling/unspent_cost_bucket_ut.cpp
@@ -2,6 +2,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/random/random.h>
+
 namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -25,7 +27,8 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
     // GET_SHARE_AND_CHECK
 
     // maxBudget=100ms, refillTime=1s (rate=0.1), spendRate=2 (factor=0.5),
-    // spentShapingBudgetShare=0.0 (full budget)
+    // spentShapingBudgetShare=0.0 (full budget). Coverage scales with
+    // Smootherstep(CurrentBudget / MaxBudget).
     Y_UNIT_TEST(ShouldRegister)
     {
         TUnspentCostBucket bucket(
@@ -34,23 +37,20 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
             2.0,
             0.0);
 
-        // budget=100k, cost*0.5=20k, need=20k, covered=20k => budget=80k
-        REG_AND_CHECK(20'000, 100'000, 40'000, 0);
-        // budget=80k+10k=90k, cost*0.5=20k, need=20k, covered=20k => budget=70k
-        REG_AND_CHECK(20'000, 200'000, 40'000, 0);
-        // budget=70k+10k=80k, maxSpend=20k, minSpend=0, need=20k => budget=60k
-        REG_AND_CHECK(0, 300'000, 40'000, 20'000);
+        // Full budget => discount=1 => cover full gap (40k), return 0
+        REG_AND_CHECK(0, 100'000, 40'000, 0);
+        // 70k budget, partial discount => covered 36738, return 3262
+        REG_AND_CHECK(3262, 200'000, 40'000, 0);
+        // +10k refill, partial spend with spent=20k
+        REG_AND_CHECK(12'496, 300'000, 40'000, 20'000);
         // spent >= cost => 0
         REG_AND_CHECK(0, 400'000, 40'000, 40'000);
-        // budget=70k+10k=80k, maxSpend=200k, minSpend=100k, need=100k,
-        // covered=80k => budget=0
-        REG_AND_CHECK(120'000, 500'000, 200'000, 0);
-        // budget=0+10k=10k, maxSpend=50k, minSpend=25k, need=25k,
-        // covered=10k => budget=0
+        // +40k refill to cap, large cost, partial coverage
+        REG_AND_CHECK(144'242, 500'000, 200'000, 0);
+        // nearly empty budget => small covered portion
         REG_AND_CHECK(40'000, 600'000, 50'000, 0);
-        // budget=0+100k=100k (full refill), maxSpend=50k, minSpend=25k,
-        // need=25k, covered=25k => budget=75k
-        REG_AND_CHECK(25'000, 1'600'000, 50'000, 0);
+        // full refill then full coverage of 50k gap
+        REG_AND_CHECK(0, 1'600'000, 50'000, 0);
         // spent >= cost => 0
         REG_AND_CHECK(0, 1'700'000, 50'000, 50'000);
     }
@@ -67,11 +67,10 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
 
         // budget=0, no coverage => full cost returned
         REG_AND_CHECK(40'000, 100'000, 40'000, 0);
-        // budget=0+40k=40k, need=20k, covered=20k => budget=20k
-        REG_AND_CHECK(20'000, 500'000, 40'000, 0);
-        // budget=20k+10k=30k, maxSpend=60k, minSpend=30k, need=30k,
-        // covered=30k => budget=0
-        REG_AND_CHECK(30'000, 600'000, 60'000, 0);
+        // budget=0+40k=40k, Smootherstep scales desired spend
+        REG_AND_CHECK(13'651, 500'000, 40'000, 0);
+        // refill + scaled coverage for cost=60k
+        REG_AND_CHECK(36'349, 600'000, 60'000, 0);
         // budget=0+100k=100k (full refill), maxSpend=25k, minSpend=0,
         // need=25k, covered=25k => budget=75k
         REG_AND_CHECK(0, 1'600'000, 50'000, 25'000);
@@ -87,21 +86,20 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
             2.0,
             0.0);
 
-        // budget=100k, need=20k, covered=20k => budget=80k
-        REG_AND_CHECK(20'000, 100'000, 40'000, 0);
-        // no refill: budget=80k, need=20k, covered=20k => budget=60k
-        REG_AND_CHECK(20'000, 500'000, 40'000, 0);
-        // budget=60k, maxSpend=200k, minSpend=100k, need=100k,
-        // covered=60k => budget=0
-        REG_AND_CHECK(140'000, 600'000, 200'000, 0);
-        // no refill: budget=0, no coverage => full cost
+        // full budget => full gap covered
+        REG_AND_CHECK(0, 100'000, 40'000, 0);
+        // no refill: Smootherstep from 60k budget
+        REG_AND_CHECK(6349, 500'000, 40'000, 0);
+        // no refill: remainder after partial coverage
+        REG_AND_CHECK(173'651, 600'000, 200'000, 0);
+        // no refill: budget depleted, no coverage
         REG_AND_CHECK(40'000, 1'600'000, 40'000, 0);
         // still empty
         REG_AND_CHECK(40'000, 10'000'000, 40'000, 0);
     }
 
     // spendRate=1.0 makes BudgetSpendRate=1.0, so minBudgetSpend equals
-    // maxBudgetSpend and budget is never consumed
+    // maxBudgetSpend; the whole gap is the "minimum" spend from budget.
     Y_UNIT_TEST(ShouldRegisterWithDisabledSpendRate)
     {
         TUnspentCostBucket bucket(
@@ -110,9 +108,9 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
             1.0,
             0.0);
 
-        // minBudgetSpend = cost*1.0 = cost, neededBudgetSpend = 0
-        REG_AND_CHECK(40'000, 100'000, 40'000, 0);
-        REG_AND_CHECK(40'000, 200'000, 40'000, 0);
+        // min=max=gap => desired always equals gap; budget covers it => 0 delay
+        REG_AND_CHECK(0, 100'000, 40'000, 0);
+        REG_AND_CHECK(0, 200'000, 40'000, 0);
         // spent >= cost => 0
         REG_AND_CHECK(0, 300'000, 40'000, 40'000);
     }
@@ -126,12 +124,12 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
             10.0,
             0.0);
 
-        // budget=100k, minSpend=10k, need=90k, covered=90k => budget=10k
-        REG_AND_CHECK(10'000, 100'000, 100'000, 0);
-        // budget=10k+10k=20k, need=90k, covered=20k => budget=0
-        REG_AND_CHECK(80'000, 200'000, 100'000, 0);
-        // budget=0+100k=100k (full refill), need=90k, covered=90k => budget=10k
-        REG_AND_CHECK(10'000, 1'200'000, 100'000, 0);
+        // full budget => cover up to min(200k desired, 100k budget)
+        REG_AND_CHECK(0, 100'000, 100'000, 0);
+        // 10k budget, low discount => covered 10k of 90k need
+        REG_AND_CHECK(90'000, 200'000, 100'000, 0);
+        // full refill => full coverage of 90k need
+        REG_AND_CHECK(0, 1'200'000, 100'000, 0);
     }
 
     Y_UNIT_TEST(ShouldSpentBudgetShare)
@@ -145,15 +143,14 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
         // budget=100k (no LastUpdateTs yet), spent share=1-100k/100k=0
         GET_SHARE_AND_CHECK(0.0, 50'000);
 
-        REG_AND_CHECK(20'000, 100'000, 40'000, 0);   // budget=80k
+        REG_AND_CHECK(0, 100'000, 40'000, 0);   // budget=60k after
 
-        // budget=80k+10k=90k, spent share=1-0.9=0.1
-        GET_SHARE_AND_CHECK(0.1, 200'000);
-        // budget=80k+15k=95k, spent share=1-0.95=0.05
-        GET_SHARE_AND_CHECK(0.05, 250'000);
+        // 60k+10k refill => 70k budget, spent share=0.3
+        GET_SHARE_AND_CHECK(0.3, 200'000);
+        // +15k refill => 75k budget
+        GET_SHARE_AND_CHECK(0.25, 250'000);
 
-        // budget=80k+40k=100k (capped), maxSpend=200k, minSpend=100k,
-        // need=100k, covered=100k => budget=0
+        // +25k refill to cap, large cost, return 100k of 200k gap
         REG_AND_CHECK(100'000, 500'000, 200'000, 0);
 
         // budget=0, spent share=1-0=1.0
@@ -188,6 +185,45 @@ Y_UNIT_TEST_SUITE(TUnspentCostBucketTest)
 
 #undef REG_AND_CHECK
 #undef GET_SHARE_AND_CHECK
+
+    Y_UNIT_TEST(Smootherstep)
+    {
+        constexpr double Eps = 1e-10;
+        UNIT_ASSERT_DOUBLES_EQUAL(
+            0.0,
+            TUnspentCostBucket::Smootherstep(0.0),
+            Eps);
+        UNIT_ASSERT_DOUBLES_EQUAL(
+            1.0,
+            TUnspentCostBucket::Smootherstep(1.0),
+            Eps);
+
+        for (int i = 0; i < 100'000'000; i++) {
+            const double x = RandomNumber<double>();
+            const double result = TUnspentCostBucket::Smootherstep(x);
+
+            UNIT_ASSERT_LE_C(
+                result,
+                1.0 + Eps,
+                Sprintf("Smootherstep(%f) = %f", x, result).c_str());
+            UNIT_ASSERT_GE_C(
+                result,
+                0.0,
+                Sprintf("Smootherstep(%f) = %f", x, result).c_str());
+
+            if (x <= 0.5) {
+                UNIT_ASSERT_LE_C(
+                    result,
+                    0.5 + Eps,
+                    Sprintf("Smootherstep(%f) = %f", x, result).c_str());
+            } else {
+                UNIT_ASSERT_GE_C(
+                    result,
+                    0.5 - Eps,
+                    Sprintf("Smootherstep(%f) = %f", x, result).c_str());
+            }
+        }
+    }
 }
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/throttling/ya.make
+++ b/cloud/storage/core/libs/throttling/ya.make
@@ -17,4 +17,7 @@ PEERDIR(
 
 END()
 
-RECURSE_FOR_TESTS(ut)
+RECURSE_FOR_TESTS(
+    bench
+    ut
+)


### PR DESCRIPTION
#5095
`Register()` no longer consumes budget in a single fixed way for the gap between the minimum and maximum budget spend. It now picks a desired spend by interpolating between `minBudgetSpend` and `maxBudgetSpend` using Smootherstep(CurrentBudget / MaxBudget). Consumption should be higher when the budget is fuller.

For interpolation i chose the [smootherstep](https://en.wikipedia.org/wiki/Smoothstep). It is slightly faster than sigmoid and simpler to use, as it is conveniently positioned relative to the y-axis (unlike sigmoid).

Added a benchmark that compares sigmoid to smoothstep functions. Results are:
```
----------- Sigmoid_Benchmark ---------------
 samples:       39338
 iterations:    955260195
 iterations hr:    955M
 run time:      5.003712421
 per iteration: 12.32858252 cycles
----------- Smoothstep_Benchmark ---------------
 samples:       99311
 iterations:    6088175031
 iterations hr:    6.09G
 run time:      5.009607195
 per iteration: 1.947897513 cycles
----------- Smootherstep1_Benchmark ---------------
 samples:       96192
 iterations:    5711827521
 iterations hr:    5.71G
 run time:      5.008432135
 per iteration: 2.079131814 cycles
----------- Smootherstep2_Benchmark ---------------
 samples:       93695
 iterations:    5419081671
 iterations hr:    5.42G
 run time:      5.00840317
 per iteration: 2.190996133 cycles
----------- Smootherstep3_Benchmark ---------------
 samples:       79463
 iterations:    3897871071
 iterations hr:    3.9G
 run time:      5.007022594
 per iteration: 3.047205232 cycles
 ```