### PR TITLE
Add shaping throttler config; allow to persist shaping throttler state in volume's DB

### DIFF
--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -42,19 +42,10 @@ message TVolumePerfThreshold
 ////////////////////////////////////////////////////////////////////////////////
 // Volume performance measurements settings
 
-message TOperationCoefficients
-{
-    optional uint32 Iops = 1;
-    optional uint64 Bandwidth = 2;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-// Volume performance measurements settings
-
 message TVolumePerfSettings
 {
-    optional TOperationCoefficients Write = 1;
-    optional TOperationCoefficients Read = 2;
+    optional NCloud.NProto.TPerformanceProfile Write = 1;
+    optional NCloud.NProto.TPerformanceProfile Read = 2;
     optional uint32 CriticalFactor = 3;
 };
 

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -5,6 +5,7 @@ package NCloud.NBlockStore.NProto;
 import "cloud/storage/core/protos/authorization_mode.proto";
 import "cloud/storage/core/protos/certificate.proto";
 import "cloud/storage/core/protos/config_dispatcher_settings.proto";
+import "cloud/storage/core/protos/diagnostics.proto";
 import "cloud/storage/core/protos/media.proto";
 
 option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/config";
@@ -116,6 +117,52 @@ message TPoolKindToMediaKindMapping
 
     // Corresponding NBS storage media kind
     optional NCloud.NProto.EStorageMediaKind MediaKind = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TShapingThrottlerQuota
+{
+    // Performance profile for write requests.
+    optional NCloud.NProto.TPerformanceProfile Write = 1;
+
+    // Performance profile for read requests.
+    optional NCloud.NProto.TPerformanceProfile Read = 2;
+
+    // Number of IOs that are expected to be processed in parallel.
+    optional uint32 ExpectedIoParallelism = 3;
+
+    // The maximum amount of "budget" that can accumulate in the bucket
+    // (in milliseconds).
+    optional uint32 MaxBudget = 4;
+
+    // The time it takes to fully refill the bucket from empty
+    // (in milliseconds).
+    optional uint32 BudgetRefillTime = 5;
+
+    // The speed of budget consumption. All unspent budget will become shaping
+    // wait time (1.0 - no budget consumption, 2.0 - consume budget at 2x rate).
+    optional double BudgetSpendRate = 6;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TShapingThrottlerConfig
+{
+    // Performance measurements coefficients for SSD.
+    optional TShapingThrottlerQuota SsdQuota = 1;
+
+    // Performance measurements coefficients for HDD.
+    optional TShapingThrottlerQuota HddQuota = 2;
+
+    // Performance measurements coefficients for NRD.
+    optional TShapingThrottlerQuota NonreplQuota = 3;
+
+    // Performance measurements coefficients for mirror2 disks.
+    optional TShapingThrottlerQuota Mirror2Quota = 4;
+
+    // Performance measurements coefficients for mirror3 disks.
+    optional TShapingThrottlerQuota Mirror3Quota = 5;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1478,4 +1525,7 @@ message TStorageServiceConfig
     // If true, the VhostDiscardEnabled flag is enabled on volume restart.
     // Applies to network-ssd and network-hdd disks.
     optional bool EnableVhostDiscardOnVolumeRestart = 489;
+
+    // Shaping throttler configuration.
+    optional TShapingThrottlerConfig ShapingThrottlerConfig = 490;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -175,6 +175,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
             {"ssd", NCloud::NProto::STORAGE_MEDIA_SSD},                        \
             {"ssdmirror", NCloud::NProto::STORAGE_MEDIA_SSD},                  \
         }})                                                                   )\
+    xxx(ShapingThrottlerConfig,           NProto::TShapingThrottlerConfig, {} )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RO
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -787,6 +787,8 @@ public:
 
     [[nodiscard]] bool GetSendErrorOnAddClientConflict() const;
 
+    [[nodiscard]] NProto::TShapingThrottlerConfig GetShapingThrottlerConfig() const;
+
     [[nodiscard]] bool GetFreshBlocksWriterEnabled() const;
 
     [[nodiscard]] ui64 GetMaxInflightAttachDetachPathRequestsProcessing() const;

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -40,7 +40,31 @@ using namespace NCloud::NStorage;
 
 namespace {
 
+////////////////////////////////////////////////////////////////////////////////
+
 constexpr TInstant DRTabletIdRequestRetryInterval = TInstant::Seconds(3);
+
+bool ShapingThrottlerEnabled(
+    const TStorageConfigPtr& config,
+    NProto::EStorageMediaKind mediaKind)
+{
+    switch (mediaKind) {
+        case NProto::STORAGE_MEDIA_HDD:
+        case NProto::STORAGE_MEDIA_HYBRID:
+            return config->GetShapingThrottlerConfig().HasHddQuota();
+        case NProto::STORAGE_MEDIA_SSD:
+            return config->GetShapingThrottlerConfig().HasSsdQuota();
+        case NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
+            return config->GetShapingThrottlerConfig().HasNonreplQuota();
+        case NProto::STORAGE_MEDIA_SSD_MIRROR2:
+            return config->GetShapingThrottlerConfig().HasMirror2Quota();
+        case NProto::STORAGE_MEDIA_SSD_MIRROR3:
+            return config->GetShapingThrottlerConfig().HasMirror3Quota();
+        default:
+            return false;
+    }
+    return false;
+}
 
 }   // namespace
 
@@ -656,21 +680,26 @@ void TVolumeActor::HandleUpdateThrottlerState(
 
     const auto mediaKind = static_cast<NCloud::NProto::EStorageMediaKind>(
         GetNewestConfig().GetStorageMediaKind());
-    if ((mediaKind == NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD
-            || mediaKind == NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HYBRID)
-            && ctx.Now() - Config->GetThrottlerStateWriteInterval() >= LastThrottlerStateWrite)
+    const bool isHdd =
+        mediaKind == NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD ||
+        mediaKind == NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HYBRID;
+
+    if ((isHdd || ShapingThrottlerEnabled(Config, mediaKind)) &&
+        ctx.Now() - Config->GetThrottlerStateWriteInterval() >=
+            LastThrottlerStateWrite)
     {
-        auto requestInfo = CreateRequestInfo(
-            ev->Sender,
-            ev->Cookie,
-            ev->Get()->CallContext);
+        auto requestInfo =
+            CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext);
 
         ExecuteTx<TWriteThrottlerState>(
             ctx,
             std::move(requestInfo),
             TVolumeDatabase::TThrottlerStateInfo{
-                State->GetThrottlingPolicy().GetCurrentBoostBudget().MilliSeconds()
-            });
+                .BoostBudget = State->GetThrottlingPolicy()
+                                   .GetCurrentBoostBudget()
+                                   .MilliSeconds(),
+                // TODO(#5095): Fill this field.
+                .SpentShapingBudgetShare = 0.0});
     }
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
@@ -113,14 +113,18 @@ void TVolumeActor::CompleteLoadState(
     }
 
     if (args.Meta.Defined()) {
+        const auto throttlerInfo = args.ThrottlerStateInfo.GetOrElse(
+            TVolumeDatabase::TThrottlerStateInfo{
+                .BoostBudget =
+                    CalculateBoostTime(
+                        args.Meta->GetConfig().GetPerformanceProfile())
+                        .MilliSeconds(),
+                .SpentShapingBudgetShare = 0.0});
         TThrottlerConfig throttlerConfig(
             Config->GetMaxThrottlerDelay(),
             Config->GetMaxWriteCostMultiplier(),
             Config->GetDefaultPostponedRequestWeight(),
-            args.ThrottlerStateInfo.Defined()
-                ? TDuration::MilliSeconds(args.ThrottlerStateInfo->Budget)
-                : CalculateBoostTime(
-                    args.Meta->GetConfig().GetPerformanceProfile()),
+            TDuration::MilliSeconds(throttlerInfo.BoostBudget),
             Config->GetDiskSpaceScoreThrottlingEnabled());
 
         bool startPartitionsNeeded = args.StartPartitionsNeeded.GetOrElse(false);

--- a/cloud/blockstore/libs/storage/volume/volume_database.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database.cpp
@@ -621,7 +621,10 @@ void TVolumeDatabase::WriteThrottlerState(const TThrottlerStateInfo& stateInfo)
 
     Table<TTable>()
         .Key(THROTTLER_STATE_KEY)
-        .Update(NIceDb::TUpdate<TTable::Budget>(stateInfo.Budget));
+        .Update(
+            NIceDb::TUpdate<TTable::Budget>(stateInfo.BoostBudget),
+            NIceDb::TUpdate<TTable::SpentShapingBudgetShare>(
+                stateInfo.SpentShapingBudgetShare));
 }
 
 bool TVolumeDatabase::ReadThrottlerState(TMaybe<TThrottlerStateInfo>& stateInfo)
@@ -638,8 +641,9 @@ bool TVolumeDatabase::ReadThrottlerState(TMaybe<TThrottlerStateInfo>& stateInfo)
 
     if (it.IsValid()) {
         stateInfo = {
-            it.GetValue<TTable::Budget>()
-        };
+            .BoostBudget = it.GetValue<TTable::Budget>(),
+            .SpentShapingBudgetShare =
+                it.GetValue<TTable::SpentShapingBudgetShare>()};
     }
 
     return true;

--- a/cloud/blockstore/libs/storage/volume/volume_database.h
+++ b/cloud/blockstore/libs/storage/volume/volume_database.h
@@ -133,7 +133,8 @@ public:
 
     struct TThrottlerStateInfo
     {
-        ui64 Budget = 0;
+        ui64 BoostBudget = 0;
+        double SpentShapingBudgetShare = 0;
     };
 
     void WriteThrottlerState(const TThrottlerStateInfo& stateInfo);

--- a/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_database_ut.cpp
@@ -1082,7 +1082,8 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
 
         executor.WriteTx([&] (TVolumeDatabase db) {
             TVolumeDatabase::TThrottlerStateInfo info;
-            info.Budget = 31415;
+            info.BoostBudget = 31415;
+            info.SpentShapingBudgetShare = 0.1;
             db.WriteThrottlerState(info);
         });
 
@@ -1090,7 +1091,8 @@ Y_UNIT_TEST_SUITE(TVolumeDatabaseTest)
             UNIT_ASSERT(db.ReadThrottlerState(stateInfo));
 
             UNIT_ASSERT(stateInfo.Defined());
-            UNIT_ASSERT_VALUES_EQUAL(31415, stateInfo->Budget);
+            UNIT_ASSERT_VALUES_EQUAL(31415, stateInfo->BoostBudget);
+            UNIT_ASSERT_DOUBLES_EQUAL(0.1, stateInfo->SpentShapingBudgetShare, 1e-9);
         });
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_schema.h
+++ b/cloud/blockstore/libs/storage/volume/volume_schema.h
@@ -224,8 +224,13 @@ struct TVolumeSchema
         {
         };
 
+        struct SpentShapingBudgetShare
+            : public Column<3, NKikimr::NScheme::NTypeIds::Double>
+        {
+        };
+
         using TKey = TableKey<Id>;
-        using TColumns = TableColumns<Id, Budget>;
+        using TColumns = TableColumns<Id, Budget, SpentShapingBudgetShare>;
     };
 
     struct MetaHistory

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -3505,12 +3505,15 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             ui32 throttlerStateWriteIntervalMilliseconds,
             ui32 boostTimeMilliseconds,
             ui32 boostPercentage,
-            NCloud::NProto::EStorageMediaKind mediaKind)
+            NCloud::NProto::EStorageMediaKind mediaKind,
+            NProto::TShapingThrottlerConfig shapingThrottlerConfig)
         {
             NProto::TStorageServiceConfig config;
             config.SetThrottlingEnabled(true);
+            config.SetThrottlingEnabledSSD(true);
             config.SetThrottlerStateWriteInterval(throttlerStateWriteIntervalMilliseconds);
             config.SetMaxThrottlerDelay(TDuration::Seconds(25).MilliSeconds());
+            *config.MutableShapingThrottlerConfig() = std::move(shapingThrottlerConfig);
             Runtime = PrepareTestActorRuntime(config);
 
             Volume = std::make_unique<TVolumeClient>(*Runtime);
@@ -4073,7 +4076,8 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             30'000,   // throttlerStateWriteIntervalMilliseconds
             10'000,   // boostTimeMilliseconds
             200,      // boostPercentage
-            mediaKind);
+            mediaKind,
+            NProto::TShapingThrottlerConfig());
         auto& runtime = env.Runtime;
         auto& volume = *env.Volume;
 
@@ -4118,7 +4122,8 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             30'000,   // throttlerStateWriteIntervalMilliseconds
             10'000,   // boostTimeMilliseconds
             200,      // boostPercentage
-            mediaKind);
+            mediaKind,
+            NProto::TShapingThrottlerConfig());
         auto& runtime = env.Runtime;
         auto& volume = *env.Volume;
 
@@ -4157,13 +4162,83 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         DoTestShouldSaveThrottlerState(NProto::EStorageMediaKind::STORAGE_MEDIA_HDD);
     }
 
+    void DoTestShouldSaveThrottlerStateWhenShapingThrottlerEnabled(const NProto::EStorageMediaKind mediaKind)
+    {
+        NProto::TShapingThrottlerConfig shapingThrottlerConfig;
+        NProto::TShapingThrottlerQuota shapingThrottlerQuota;
+        NProto::TPerformanceProfile performanceProfile;
+        performanceProfile.SetIops(1000);
+        performanceProfile.SetBandwidth(100_MB);
+        shapingThrottlerQuota.MutableWrite()->CopyFrom(performanceProfile);
+        shapingThrottlerQuota.MutableRead()->CopyFrom(performanceProfile);
+        shapingThrottlerQuota.SetExpectedIoParallelism(1);
+        shapingThrottlerQuota.SetMaxBudget(100000);
+        shapingThrottlerQuota.SetBudgetRefillTime(100000);
+        shapingThrottlerQuota.SetBudgetSpendRate(1.0);
+
+        shapingThrottlerConfig.MutableSsdQuota()->CopyFrom(shapingThrottlerQuota);
+        shapingThrottlerConfig.MutableHddQuota()->CopyFrom(shapingThrottlerQuota);
+        shapingThrottlerConfig.MutableNonreplQuota()->CopyFrom(shapingThrottlerQuota);
+        shapingThrottlerConfig.MutableMirror2Quota()->CopyFrom(shapingThrottlerQuota);
+        shapingThrottlerConfig.MutableMirror3Quota()->CopyFrom(shapingThrottlerQuota);
+
+        TThrottledVolumeTestEnv env(
+            30'000,   // throttlerStateWriteIntervalMilliseconds
+            10'000,   // boostTimeMilliseconds
+            200,      // boostPercentage
+            mediaKind,
+            std::move(shapingThrottlerConfig));
+        auto& runtime = env.Runtime;
+        auto& volume = *env.Volume;
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0
+        );
+        volume.AddClient(clientInfo);
+        UNIT_ASSERT_VALUES_EQUAL(10'000, volume.StatVolume()->Record.GetStats().GetBoostBudget());
+
+        const auto fiveBlocks = TBlockRange64::WithLength(0, 5);
+
+        volume.SendReadBlocksRequest(fiveBlocks, clientInfo.GetClientId());
+        TEST_RESPONSE(volume, ReadBlocks, S_OK, WaitTimeout);   // boost = 9'000
+
+        runtime->AdvanceCurrentTime(TDuration::MilliSeconds(30'000));
+
+        const auto thirtyThreeBlocks = TBlockRange64::WithLength(0, 33);
+
+        volume.SendReadBlocksRequest(thirtyThreeBlocks, clientInfo.GetClientId());
+        TEST_RESPONSE(volume, ReadBlocks, S_OK, WaitTimeout);   // boost = 7'250
+
+        volume.RebootTablet();
+        volume.WaitReady();
+        UNIT_ASSERT_VALUES_EQUAL(7'250, volume.StatVolume()->Record.GetStats().GetBoostBudget());
+    }
+
+    Y_UNIT_TEST(ShouldSaveThrottlerStateWhenShapingThrottlerEnabledOnHDD)
+    {
+        DoTestShouldSaveThrottlerStateWhenShapingThrottlerEnabled(NProto::EStorageMediaKind::STORAGE_MEDIA_HDD);
+    }
+
+    Y_UNIT_TEST(ShouldSaveThrottlerStateWhenShapingThrottlerEnabledOnSSD)
+    {
+        DoTestShouldSaveThrottlerStateWhenShapingThrottlerEnabled(NProto::EStorageMediaKind::STORAGE_MEDIA_SSD);
+    }
+
+    Y_UNIT_TEST(ShouldSaveThrottlerStateWhenShapingThrottlerEnabledOnSSDNonreplicated)
+    {
+        DoTestShouldSaveThrottlerStateWhenShapingThrottlerEnabled(NProto::EStorageMediaKind::STORAGE_MEDIA_SSD_NONREPLICATED);
+    }
+
     Y_UNIT_TEST(ShouldNotSaveThrottlerStateBeforeTimeout)
     {
         TThrottledVolumeTestEnv env(
             30'000,   // throttlerStateWriteIntervalMilliseconds
             10'000,   // boostTimeMilliseconds
             200,      // boostPercentage
-            NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD);
+            NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD,
+            NProto::TShapingThrottlerConfig());
         auto& runtime = env.Runtime;
         auto& volume = *env.Volume;
 

--- a/cloud/storage/core/protos/diagnostics.proto
+++ b/cloud/storage/core/protos/diagnostics.proto
@@ -12,3 +12,12 @@ enum EStatsFetcherType
     CGROUP = 0;
     TASKSTATS = 1;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// Performance profile
+
+message TPerformanceProfile
+{
+    optional uint32 Iops = 1;
+    optional uint64 Bandwidth = 2;
+};


### PR DESCRIPTION
#5095

This change introduces `TShapingThrottlerConfig` / `TShapingThrottlerQuota` in blockstore storage config. Volume throttler state is now persisted when shaping throttler is enabled for that kind.