### PR TITLE
issue-5583: support for ResponseLogEntry write/delete/get ops in private api

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -359,6 +359,18 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    NActors::IActorPtr CreateWriteResponseLogEntryActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    NActors::IActorPtr CreateDeleteResponseLogEntryActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    NActors::IActorPtr CreateGetResponseLogEntryActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
     void PerformToggleServiceStateAction(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo,

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -139,7 +139,19 @@ void TStorageServiceActor::HandleExecuteAction(
         {
             "unsafecreatehandle",
             &TStorageServiceActor::CreateUnsafeCreateHandleActor
-        }
+        },
+        {
+            "writeresponselogentry",
+            &TStorageServiceActor::CreateWriteResponseLogEntryActor
+        },
+        {
+            "deleteresponselogentry",
+            &TStorageServiceActor::CreateDeleteResponseLogEntryActor
+        },
+        {
+            "getresponselogentry",
+            &TStorageServiceActor::CreateGetResponseLogEntryActor
+        },
     };
 
     using TInstantAction = void (TStorageServiceActor::*)(

--- a/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
@@ -239,4 +239,43 @@ IActorPtr TStorageServiceActor::CreateMarkNodeRefsExhaustiveActionActor(
         std::move(input));
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// ResponseLog ops
+
+IActorPtr TStorageServiceActor::CreateWriteResponseLogEntryActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TWriteResponseLogEntryActor = TTabletActionActor<
+        TEvIndexTablet::TEvWriteResponseLogEntryRequest,
+        TEvIndexTablet::TEvWriteResponseLogEntryResponse>;
+    return std::make_unique<TWriteResponseLogEntryActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateDeleteResponseLogEntryActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TDeleteResponseLogEntryActor = TTabletActionActor<
+        TEvIndexTablet::TEvDeleteResponseLogEntryRequest,
+        TEvIndexTablet::TEvDeleteResponseLogEntryResponse>;
+    return std::make_unique<TDeleteResponseLogEntryActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateGetResponseLogEntryActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TGetResponseLogEntryActor = TTabletActionActor<
+        TEvIndexTablet::TEvGetResponseLogEntryRequest,
+        TEvIndexTablet::TEvGetResponseLogEntryResponse>;
+    return std::make_unique<TGetResponseLogEntryActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -414,7 +414,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         service.DestroySession(headers);
     }
 
-
     Y_UNIT_TEST(ShouldPerformUnsafeNodeRefManipulations)
     {
         NProto::TStorageConfig config;
@@ -612,6 +611,95 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 shardNodeName2,
                 r.GetNodes(0).GetShardNodeName());
+        }
+
+        service.DestroySession(headers);
+    }
+
+    Y_UNIT_TEST(ShouldPerformResponseLogEntryManipulations)
+    {
+        NProto::TStorageConfig config;
+        // being explicit
+        config.SetMultiTabletForwardingEnabled(false);
+        TTestEnv env{{}, config};
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        const TString fsId = "test";
+        const ui64 clientTabletId = 111;
+        const ui64 requestId = 222;
+        const ui32 responseCode = E_FS_ISDIR;
+        service.CreateFileStore(fsId, 1'000);
+
+        auto headers = service.InitSession("test", "client");
+
+        {
+            NProtoPrivate::TWriteResponseLogEntryRequest request;
+            request.SetFileSystemId(fsId);
+            auto* entry = request.MutableEntry();
+            entry->SetClientTabletId(clientTabletId);
+            entry->SetRequestId(requestId);
+            auto* rr = entry->MutableRenameNodeInDestinationResponse();
+            rr->MutableError()->SetCode(responseCode);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("WriteResponseLogEntry", buf);
+        }
+
+        {
+            NProtoPrivate::TGetResponseLogEntryRequest request;
+            request.SetFileSystemId(fsId);
+            request.SetClientTabletId(clientTabletId);
+            request.SetRequestId(requestId);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("GetResponseLogEntry", buf);
+            auto r = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                r->GetStatus(),
+                FormatError(r->GetError()));
+            NProtoPrivate::TGetResponseLogEntryResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                r->Record.GetOutput(),
+                &response).ok());
+            UNIT_ASSERT(response.HasEntry());
+            UNIT_ASSERT_VALUES_EQUAL(
+                responseCode,
+                response.GetEntry().GetRenameNodeInDestinationResponse()
+                    .GetError().GetCode());
+        }
+
+        {
+            NProtoPrivate::TDeleteResponseLogEntryRequest request;
+            request.SetFileSystemId(fsId);
+            request.SetClientTabletId(clientTabletId);
+            request.SetRequestId(requestId);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("DeleteResponseLogEntry", buf);
+        }
+
+        {
+            NProtoPrivate::TGetResponseLogEntryRequest request;
+            request.SetFileSystemId(fsId);
+            request.SetClientTabletId(clientTabletId);
+            request.SetRequestId(requestId);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("GetResponseLogEntry", buf);
+            auto r = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                r->GetStatus(),
+                FormatError(r->GetError()));
+            NProtoPrivate::TGetResponseLogEntryResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                r->Record.GetOutput(),
+                &response).ok());
+            UNIT_ASSERT(!response.HasEntry());
         }
 
         service.DestroySession(headers);

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -1130,11 +1130,7 @@ message TWriteResponseLogEntryRequest
     // FileSystem (shard) identifier.
     string FileSystemId = 2;
 
-    // Client tablet (the tablet that issued the original request) identifier.
-    uint64 ClientTabletId = 3;
-
-    // Request id of that request.
-    uint64 RequestId = 4;
+    reserved 3, 4;
 
     // The entry.
     TResponseLogEntry Entry = 5;


### PR DESCRIPTION
### Notes
`ResponseLogEntry` manipulation events are already implemented but they weren't avaliable via filestore actions - fixing this

### Issue
https://github.com/ydb-platform/nbs/issues/5583