### PR TITLE
issue-5583: NodeRef locks viewer

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/simple_template.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/simple_template.cpp
@@ -1,0 +1,41 @@
+#include "simple_template.h"
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void OutputTemplate(
+    const TString& templateData,
+    const THashMap<TString, TString>& vars,
+    IOutputStream& out)
+{
+    TStringBuf contentRef(templateData);
+    const TStringBuf b = "{{ ";
+    const TStringBuf e = " }}";
+    ui64 prevIdx = 0;
+    while (true) {
+        const ui64 idx = contentRef.find(b, prevIdx);
+        if (idx == TString::npos) {
+            out << contentRef.substr(prevIdx);
+            break;
+        }
+
+        out << contentRef.substr(prevIdx, idx - prevIdx);
+        const ui64 nextIdx = contentRef.find(e, idx + b.size());
+        if (nextIdx == TString::npos) {
+            out << contentRef.substr(idx);
+            break;
+        }
+
+        auto varName = contentRef.substr(
+            idx + b.size(),
+            nextIdx - idx - b.size());
+        if (const auto* varValue = vars.FindPtr(varName)) {
+            out << *varValue;
+        }
+
+        prevIdx = nextIdx + e.size();
+    }
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/storage/tablet/model/simple_template.h
+++ b/cloud/filestore/libs/storage/tablet/model/simple_template.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/stream/output.h>
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void OutputTemplate(
+    const TString& templateData,
+    const THashMap<TString, TString>& vars,
+    IOutputStream& out);
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -34,6 +34,7 @@ SRCS(
     read_ahead.cpp
     request_metrics.cpp
     shard_balancer.cpp
+    simple_template.cpp
     sparse_segment.cpp
     split_range.cpp
     throttler_logger.cpp

--- a/cloud/filestore/libs/storage/tablet/resources/css/locks.css
+++ b/cloud/filestore/libs/storage/tablet/resources/css/locks.css
@@ -1,0 +1,31 @@
+#locks-container {
+    font-family: monospace;
+    font-size: 13px;
+    padding: 10px;
+}
+#locks-container ul {
+    list-style: none;
+    padding-left: 18px;
+    margin: 0;
+}
+#locks-container li {
+    margin: 2px 0;
+    white-space: nowrap;
+}
+.lock-entry {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    cursor: default;
+    padding: 1px 4px;
+    border-radius: 3px;
+}
+.lock-entry:hover {
+    background: #f0f0f0;
+}
+.lock-icon {
+    font-size: 14px;
+}
+.lock-name {
+    color: #222;
+}

--- a/cloud/filestore/libs/storage/tablet/resources/html/locks-main.html
+++ b/cloud/filestore/libs/storage/tablet/resources/html/locks-main.html
@@ -1,0 +1,13 @@
+<meta charset="UTF-8"/>
+
+<style>{{ STYLE }}</style>
+<script>{{ JS }}</script>
+
+<h3>Locks</h3>
+
+<div id='locks-container'>
+</div>
+
+<script>
+    locksInit("{{ TABLET_ID }}");
+</script>

--- a/cloud/filestore/libs/storage/tablet/resources/js/dir-viewer.js
+++ b/cloud/filestore/libs/storage/tablet/resources/js/dir-viewer.js
@@ -1,5 +1,5 @@
 function render() {
-    // Palette for shard coloring - up to 10 distinct shards
+    // Palette for shard coloring - up to 10 distinct shard colors
     var SHARD_COLORS = [
         '#e74c3c', '#2980b9', '#27ae60', '#8e44ad',
         '#e67e22', '#16a085', '#c0392b', '#2471a3',
@@ -20,7 +20,9 @@ function render() {
 
     function updateLegend() {
         var legend = document.getElementById('dv-legend');
-        if (!legend) return;
+        if (!legend) {
+            return;
+        }
         legend.innerHTML =
             '<span style="font-weight:bold;margin-right:6px">Shards:</span>';
         for (var sid in shardColorMap) {
@@ -95,7 +97,9 @@ function render() {
         var meta = document.createElement('span');
         meta.className = 'dv-meta';
         var parts = ['#' + node.id];
-        if (node.size) parts.push(formatSize(node.size));
+        if (node.size) {
+            parts.push(formatSize(node.size));
+        }
         meta.textContent = '(' + parts.join(', ') + ')';
         entry.appendChild(meta);
 
@@ -218,7 +222,9 @@ function render() {
 
     window.dvInit = function(tabletId, rootNodeId) {
         var container = document.getElementById('dv-root');
-        if (!container) return;
+        if (!container) {
+            return;
+        }
         var ul = document.createElement('ul');
         container.appendChild(ul);
 

--- a/cloud/filestore/libs/storage/tablet/resources/js/locks.js
+++ b/cloud/filestore/libs/storage/tablet/resources/js/locks.js
@@ -1,0 +1,66 @@
+function render() {
+    function buildEntry(tabletId, parentNodeId, name) {
+        var li = document.createElement('li');
+        var entry = document.createElement('span');
+        entry.className = 'lock-entry';
+
+        var icon = document.createElement('span');
+        icon.className = 'lock-icon';
+        icon.textContent = '🔒';
+        entry.appendChild(icon);
+
+        var nameEl = document.createElement('span');
+        nameEl.className = 'lock-name';
+        nameEl.textContent = parentNodeId + "/" + name;
+        entry.appendChild(nameEl);
+
+        li.appendChild(entry);
+
+        return li;
+    }
+
+    function loadLocks(tabletId, ul) {
+        var url = window.location.pathname + '?&TabletID=' + tabletId
+            + '&action=locks&getContent=1';
+        fetch(url)
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.error) {
+                    var errLi = document.createElement('li');
+                    errLi.className = 'locks-error';
+                    errLi.textContent = 'Error: ' + data.error;
+                    ul.appendChild(errLi);
+                    return;
+                }
+                if (!data.locks || data.locks.length === 0) {
+                    var emptyLi = document.createElement('li');
+                    emptyLi.textContent = '(empty)';
+                    ul.appendChild(emptyLi);
+                    return;
+                }
+                data.locks.forEach(function(e) {
+                    ul.appendChild(
+                        buildEntry(tabletId, e.parentNodeId, e.name));
+                });
+            })
+            .catch(function(err) {
+                var errLi = document.createElement('li');
+                errLi.className = 'locks-error';
+                errLi.textContent = 'Fetch error: ' + err;
+                ul.appendChild(errLi);
+            });
+    }
+
+    window.locksInit = function(tabletId) {
+        var container = document.getElementById('locks-container');
+        if (!container) {
+            return;
+        }
+        var ul = document.createElement('ul');
+        container.appendChild(ul);
+
+        loadLocks(tabletId, ul);
+    };
+}
+
+render();

--- a/cloud/filestore/libs/storage/tablet/resources/ya.make
+++ b/cloud/filestore/libs/storage/tablet/resources/ya.make
@@ -2,8 +2,13 @@ LIBRARY()
 
 RESOURCE(
     css/dir-viewer.css css/dir-viewer.css
+    css/locks.css css/locks.css
+
     html/dir-viewer-main.html html/dir-viewer-main.html
+    html/locks-main.html html/locks-main.html
+
     js/dir-viewer.js js/dir-viewer.js
+    js/locks.js js/locks.js
 )
 
 END()

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -579,6 +579,10 @@ private:
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
+    void HandleHttpInfo_Locks(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        TRequestInfoPtr requestInfo);
 
     void HandleSessionDisconnected(
         const NKikimr::TEvTabletPipe::TEvServerDisconnected::TPtr& ev,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -989,6 +989,7 @@ void TIndexTabletActor::HandleHttpInfo(
     static const THttpHandlers getActions {{
         {"dumpRange",       &TIndexTabletActor::HandleHttpInfo_DumpCompactionRange },
         {"dirViewer",       &TIndexTabletActor::HandleHttpInfo_DirViewer },
+        {"locks",           &TIndexTabletActor::HandleHttpInfo_Locks },
     }};
 
     const auto* msg = ev->Get();
@@ -1067,6 +1068,11 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         TAG(TH3) {
             out << "<a href='?TabletID=" << TabletID()
                 << "&action=dirViewer'>Directory Viewer</a>";
+        }
+
+        TAG(TH3) {
+            out << "<a href='?TabletID=" << TabletID()
+                << "&action=locks'>Locks</a>";
         }
 
         const auto& shardIds = GetFileSystem().GetShardFileSystemIds();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_directory_viewer.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_directory_viewer.cpp
@@ -2,17 +2,14 @@
 
 #include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/tablet/model/simple_template.h>
 #include <cloud/filestore/libs/storage/tablet/tablet_state.h>
 
-#include <cloud/storage/core/libs/viewer/tablet_monitoring.h>
-
 #include <library/cpp/json/writer/json.h>
-#include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/resource/resource.h>
 
 #include <util/stream/str.h>
 #include <util/string/builder.h>
-#include <util/system/hostname.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -20,44 +17,6 @@ using namespace NActors;
 using namespace NActors::NMon;
 
 namespace {
-
-////////////////////////////////////////////////////////////////////////////////
-
-void OutputTemplate(
-    const TString& templateName,
-    const THashMap<TString, TString>& vars,
-    IOutputStream& out)
-{
-    TString content = NResource::Find(
-        TStringBuilder() << "html/" << templateName << ".html");
-    TStringBuf contentRef(content);
-    const TStringBuf b = "{{ ";
-    const TStringBuf e = " }}";
-    ui64 prevIdx = 0;
-    while (true) {
-        const ui64 idx = contentRef.find(b, prevIdx);
-        if (idx == TString::npos) {
-            out << contentRef.substr(prevIdx);
-            break;
-        }
-
-        out << contentRef.substr(prevIdx, idx - prevIdx);
-        const ui64 nextIdx = contentRef.find(e, idx + b.size());
-        if (nextIdx == TString::npos) {
-            out << contentRef.substr(idx);
-            break;
-        }
-
-        auto varName = contentRef.substr(
-            idx + b.size(),
-            nextIdx - idx - b.size());
-        if (const auto* varValue = vars.FindPtr(varName)) {
-            out << *varValue;
-        }
-
-        prevIdx = nextIdx + e.size();
-    }
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -130,7 +89,7 @@ void DumpDirViewerJson(
 
 void DumpDirViewerPage(IOutputStream& out, ui64 tabletId, ui32 nodeId)
 {
-    OutputTemplate("dir-viewer-main", {
+    OutputTemplate(NResource::Find("html/dir-viewer-main.html"), {
         {"STYLE", NResource::Find("css/dir-viewer.css")},
         {"JS", NResource::Find("js/dir-viewer.js")},
         {"TABLET_ID", ToString(tabletId)},

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_locks.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring_locks.cpp
@@ -1,0 +1,71 @@
+#include "tablet_actor.h"
+
+#include <cloud/filestore/libs/storage/tablet/model/simple_template.h>
+#include <cloud/filestore/libs/storage/tablet/tablet_state.h>
+
+#include <library/cpp/json/writer/json.h>
+#include <library/cpp/resource/resource.h>
+
+#include <util/stream/str.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+using namespace NActors::NMon;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void DumpLocksPage(IOutputStream& out, ui64 tabletId)
+{
+    OutputTemplate(NResource::Find("html/locks-main.html"), {
+        {"STYLE", NResource::Find("css/locks.css")},
+        {"JS", NResource::Find("js/locks.js")},
+        {"TABLET_ID", ToString(tabletId)}}, out);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleHttpInfo_Locks(
+    const NActors::TActorContext& ctx,
+    const TCgiParameters& params,
+    TRequestInfoPtr requestInfo)
+{
+    if (params.Get("getContent") != "1") {
+        TStringStream out;
+        DumpLocksPage(out, TabletID());
+
+        NCloud::Reply(
+            ctx,
+            *requestInfo,
+            std::make_unique<NMon::TEvRemoteHttpInfoRes>(std::move(out.Str())));
+        return;
+    }
+
+    TStringStream out;
+    NJsonWriter::TBuf writer(NJsonWriter::HEM_DONT_ESCAPE_HTML, &out);
+    writer.BeginObject();
+    writer.WriteKey("locks");
+    writer.BeginList();
+    VisitNodeRefLocks([&] (const TNodeRefKey& x) {
+        writer.BeginObject();
+        writer.WriteKey("parentNodeId");
+        writer.WriteString(ToString(x.ParentNodeId));
+        writer.WriteKey("name");
+        writer.WriteString(x.Name);
+        writer.EndObject();
+    });
+    writer.EndList();
+    writer.EndObject();
+
+    NCloud::Reply(
+        ctx,
+        *requestInfo,
+        std::make_unique<NMon::TEvRemoteJsonInfoRes>(std::move(out.Str())));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -42,6 +42,8 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
+#include <functional>
+
 namespace NCloud::NFileStore::NProto {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -709,6 +711,8 @@ public:
     bool TryLockNodeRef(TNodeRefKey key);
     void UnlockNodeRef(const TNodeRefKey& key);
     bool IsNodeRefLocked(const TNodeRefKey& key) const;
+    using TNodeRefLockVisitor = std::function<void(const TNodeRefKey&)>;
+    void VisitNodeRefLocks(const TNodeRefLockVisitor& visitor) const;
 
     //
     // Sessions

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -600,6 +600,14 @@ bool TIndexTabletState::IsNodeRefLocked(const TNodeRefKey& key) const
     return Impl->LockedNodeRefs.contains(key);
 }
 
+void TIndexTabletState::VisitNodeRefLocks(
+    const TNodeRefLockVisitor& visitor) const
+{
+    for (const auto& x: Impl->LockedNodeRefs) {
+        visitor(x);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 IIndexTabletDatabase& TIndexTabletState::AccessInMemoryIndexState()

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -54,6 +54,7 @@ SRCS(
     tablet_actor_loadstate_nodes.cpp
     tablet_actor_monitoring.cpp
     tablet_actor_monitoring_directory_viewer.cpp
+    tablet_actor_monitoring_locks.cpp
     tablet_actor_oplog.cpp
     tablet_actor_readblob.cpp
     tablet_actor_readdata.cpp


### PR DESCRIPTION
### Notes
* implemented simple NodeRef locks viewer monpage
* moved `OutputTemplate()` to `tablet/model` to reuse it in locks viewer
* did minor cleanup in dir viewer code

<img width="239" height="217" alt="Screenshot from 2026-03-25 17-51-49" src="https://github.com/user-attachments/assets/67d2f78d-3115-4f3c-bc88-53ebb1dbbb47" />

### Issue
https://github.com/ydb-platform/nbs/issues/5583
