### PR TITLE
Fix style lint error S1021 on new test `TestIsDiskNotFoundError `

### DIFF
--- a/cloud/blockstore/public/sdk/go/client/error_test.go
+++ b/cloud/blockstore/public/sdk/go/client/error_test.go
@@ -37,8 +37,7 @@ func TestGetClientError(t *testing.T) {
 
 func TestIsDiskNotFoundError(t *testing.T) {
 	clientErr := &ClientError{}
-	var err error
-	err = clientErr
+	err := clientErr
 
 	clientErr.Code = E_NOT_IMPLEMENTED
 	require.False(t, IsDiskNotFoundError(err))


### PR DESCRIPTION
### Notes

```
$S/cloud/blockstore/public/sdk/go/client/error_test.go:40:2: "S1021: should merge variable declaration with assignment on next line"
$S/cloud/blockstore/public/sdk/go/client/error_test.go:40:2: "S1021: if you believe this report is false positive, please silence it with //nolint:s1021 comment"
```

### Issue
Put links to the related issues here
