### PR TITLE
ignore json decode errors while processing traces

### DIFF
--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -823,7 +823,13 @@ def test_io_telemetry():
             component = parts[1]
             message = parts[3]
             if component == ":NFS_TRACE":
-                track = json.loads(message)
+                track = ""
+                try:
+                    track = json.loads(message)
+                except json.JSONDecodeError:
+                    logging.warning(
+                        "failed to deserialize message to JSON: %s" % message)
+                    continue
                 for probe in track:
                     if len(probe) < 3:
                         continue


### PR DESCRIPTION
### Notes
Observed the following error in filestore tests 

> [fail] test.py::test_io_telemetry [default-linux-x86_64-relwithdebinfo] (3.57s)
> cloud/filestore/tests/client/test.py:826: in test_io_telemetry
>     track = json.loads(message)
> contrib/tools/python3/Lib/json/__init__.py:346: in loads
>     return _default_decoder.decode(s)
> contrib/tools/python3/Lib/json/decoder.py:338: in decode
>     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
> contrib/tools/python3/Lib/json/decoder.py:356: in raw_decode
>     raise JSONDecodeError("Expecting value", s, err.value) from None
> E   json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Looking at the https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/tests/client/test.py#L820 and 

> 2026-03-26T18:00:05.115998Z :NFS_TRACE DEBUG: Filter: st_slow_requests_filter stats
> 2026-03-26T18:00:05.216162Z :NFS_TRACE DEBUG: Filter: st_slow_requests_filter stats
> 2026-03-26T18:00:05.316303Z :NFS_TRACE DEBUG: Filter: st_slow_requests_filter stats
> 2026-03-26T18:00:05.416463Z :NFS_TRACE DEBUG: Filter: st_slow_requests_filter stats
> 2026-03-26T18:00:05.516625Z :NFS_TRACE DEBUG: Filter: st_slow_requests_filter stats
> 2026-03-26T18:00:05.616802Z :NFS_TRACE DEBUG: Filter: st_slow_requests_filter stats
> 2026-03-26T18:00:05.716949Z :NFS_TRACE DEBUG: Filter: st_slow_requests_filter stats

it seems like we try to deserialize to json strings that should not be tryed. So far it seems like we should just ignore such strings 

### Issue
Put links to the related issues here
