### PR TITLE
Use LogTitle in mirror partition logs

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -193,8 +193,8 @@ void TMirrorPartitionActor::CompareChecksums(const TActorContext& ctx)
             LOG_INFO(
                 ctx,
                 TBlockStoreComponents::PARTITION,
-                "[%s] Reschedule scrubbing for range %s due to inflight write",
-                DiskId.c_str(),
+                "%s Reschedule scrubbing for range %s due to inflight write",
+                LogTitle.GetWithTime().c_str(),
                 DescribeRange(GetScrubbingRange()).c_str());
         }
         StartScrubbingRange(ctx, ScrubbingRangeId);
@@ -217,8 +217,8 @@ void TMirrorPartitionActor::CompareChecksums(const TActorContext& ctx)
                 LOG_WARN(
                     ctx,
                     TBlockStoreComponents::PARTITION,
-                    "[%s] Checksum mismatch for range %s, reschedule scrubbing",
-                    DiskId.c_str(),
+                    "%s Checksum mismatch for range %s, reschedule scrubbing",
+                    LogTitle.GetWithTime().c_str(),
                     DescribeRange(GetScrubbingRange()).c_str());
             }
 
@@ -229,8 +229,8 @@ void TMirrorPartitionActor::CompareChecksums(const TActorContext& ctx)
         LOG_ERROR(
             ctx,
             TBlockStoreComponents::PARTITION,
-            "[%s] Checksum mismatch for range %s",
-            DiskId.c_str(),
+            "%s Checksum mismatch for range %s",
+            LogTitle.GetWithTime().c_str(),
             DescribeRange(GetScrubbingRange()).c_str());
 
         if (Config
@@ -245,8 +245,8 @@ void TMirrorPartitionActor::CompareChecksums(const TActorContext& ctx)
             LOG_ERROR(
                 ctx,
                 TBlockStoreComponents::PARTITION,
-                "[%s] Replica %lu range %s checksum %lu",
-                DiskId.c_str(),
+                "%s Replica %lu range %s checksum %lu",
+                LogTitle.GetWithTime().c_str(),
                 i,
                 DescribeRange(GetScrubbingRange()).c_str(),
                 checksums[i]);
@@ -279,8 +279,8 @@ void TMirrorPartitionActor::StartResyncRange(
     LOG_WARN(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Resyncing range %s",
-        DiskId.c_str(),
+        "%s Resyncing range %s",
+        LogTitle.GetWithTime().c_str(),
         DescribeRange(GetScrubbingRange()).c_str());
     ResyncRangeStarted = true;
 
@@ -462,8 +462,8 @@ void TMirrorPartitionActor::HandleScrubbingNextRange(
         LOG_DEBUG(
             ctx,
             TBlockStoreComponents::PARTITION,
-            "[%s] Reschedule scrubbing for range %s due to inflight write",
-            DiskId.c_str(),
+            "%s Reschedule scrubbing for range %s due to inflight write",
+            LogTitle.GetWithTime().c_str(),
             DescribeRange(scrubbingRange).c_str());
 
         StartScrubbingRange(ctx, ScrubbingRangeId);
@@ -483,8 +483,8 @@ void TMirrorPartitionActor::HandleScrubbingNextRange(
         LOG_DEBUG(
             ctx,
             TBlockStoreComponents::PARTITION,
-            "[%s] Skipping scrubbing for range %s, devices not ready for reading",
-            DiskId.c_str(),
+            "%s Skipping scrubbing for range %s, devices not ready for reading",
+            LogTitle.GetWithTime().c_str(),
             DescribeRange(scrubbingRange).c_str());
 
         StartScrubbingRange(ctx, ScrubbingRangeId + 1);
@@ -494,8 +494,8 @@ void TMirrorPartitionActor::HandleScrubbingNextRange(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Scrubbing range %s",
-        DiskId.c_str(),
+        "%s Scrubbing range %s",
+        LogTitle.GetWithTime().c_str(),
         DescribeRange(scrubbingRange).c_str());
 
     ScrubbingThroughput += scrubbingRange.Size() * State.GetBlockSize();
@@ -515,8 +515,8 @@ void TMirrorPartitionActor::HandleChecksumUndelivery(
         LOG_DEBUG(
             ctx,
             TBlockStoreComponents::PARTITION,
-            "[%s] Reschedule scrubbing for range %s due to checksum error %s",
-            DiskId.c_str(),
+            "%s Reschedule scrubbing for range %s due to checksum error %s",
+            LogTitle.GetWithTime().c_str(),
             DescribeRange(GetScrubbingRange()).c_str(),
             FormatError(ChecksumRangeActorCompanion.GetError()).c_str());
         ScheduleScrubbingNextRange(ctx);
@@ -537,8 +537,8 @@ void TMirrorPartitionActor::HandleChecksumResponse(
         LOG_DEBUG(
             ctx,
             TBlockStoreComponents::PARTITION,
-            "[%s] Reschedule scrubbing for range %s due to checksum error %s",
-            DiskId.c_str(),
+            "%s Reschedule scrubbing for range %s due to checksum error %s",
+            LogTitle.GetWithTime().c_str(),
             DescribeRange(GetScrubbingRange()).c_str(),
             FormatError(ChecksumRangeActorCompanion.GetError()).c_str());
         StartScrubbingRange(ctx, ScrubbingRangeId);
@@ -565,8 +565,8 @@ void TMirrorPartitionActor::HandleRangeResynced(
     }
 
     LOG_WARN(ctx, TBlockStoreComponents::PARTITION,
-        "[%s] Range %s resync finished: %s %s",
-        DiskId.c_str(),
+        "%s Range %s resync finished: %s %s",
+        LogTitle.GetWithTime().c_str(),
         DescribeRange(msg->Range).c_str(),
         FormatError(msg->GetError()).c_str(),
         ToString(msg->Status).c_str());
@@ -605,8 +605,8 @@ void TMirrorPartitionActor::HandleAddLaggingAgent(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Adding lagging agent: %s, replica index: %u",
-        DiskId.c_str(),
+        "%s Adding lagging agent: %s, replica index: %u",
+        LogTitle.GetWithTime().c_str(),
         msg->LaggingAgent.GetAgentId().c_str(),
         replicaIndex);
 
@@ -648,8 +648,8 @@ void TMirrorPartitionActor::HandleRemoveLaggingAgent(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Removing lagging agent: %s, replica index: %u",
-        DiskId.c_str(),
+        "%s Removing lagging agent: %s, replica index: %u",
+        LogTitle.GetWithTime().c_str(),
         msg->LaggingAgent.GetAgentId().Quote().c_str(),
         msg->LaggingAgent.GetReplicaIndex());
 
@@ -674,8 +674,8 @@ void TMirrorPartitionActor::HandleInconsistentDiskAgent(
     LOG_WARN(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Disable multi-agent writes due to bad response from %s.",
-        DiskId.c_str(),
+        "%s Disable multi-agent writes due to bad response from %s.",
+        LogTitle.GetWithTime().c_str(),
         msg->AgentId.Quote().c_str());
 
     ReportDiskAgentInconsistentMultiWriteResponse(
@@ -718,8 +718,8 @@ void TMirrorPartitionActor::HandleAddTagsResponse(
     LOG_WARN(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] %s tag added for disk",
-        DiskId.c_str(),
+        "%s %s tag added for disk",
+        LogTitle.GetWithTime().c_str(),
         IntermediateWriteBufferTagName);
 }
 
@@ -752,8 +752,8 @@ void TMirrorPartitionActor::HandleLockAndDrainRange(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Range %s is locked for writing requests",
-        DiskId.c_str(),
+        "%s Range %s is locked for writing requests",
+        LogTitle.GetWithTime().c_str(),
         DescribeRange(msg->Range).c_str());
 }
 
@@ -768,8 +768,8 @@ void TMirrorPartitionActor::HandleReleaseRange(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,
-        "[%s] Range %s unlocked for writing requests",
-        DiskId.c_str(),
+        "%s Range %s unlocked for writing requests",
+        LogTitle.GetWithTime().c_str(),
         DescribeRange(msg->Range).c_str());
 }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_readblocks.cpp
@@ -605,7 +605,8 @@ void TMirrorPartitionActor::ReadBlocks(
                 splitError.GetCode() == E_ARGUMENT ? NLog::PRI_ERROR
                                                    : NLog::PRI_DEBUG,
                 TBlockStoreComponents::PARTITION,
-                "Can't split read request: %s",
+                "%s Can't split read request: %s",
+                LogTitle.GetWithTime().c_str(),
                 FormatError(splitError).c_str());
 
             NCloud::Reply(
@@ -623,8 +624,8 @@ void TMirrorPartitionActor::ReadBlocks(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] Will read %s from %u replicas",
-        DiskId.c_str(),
+        "%s Will read %s from %u replicas",
+        LogTitle.GetWithTime().c_str(),
         DescribeRange(blockRange).c_str(),
         replicaActorIds.size());
 
@@ -679,9 +680,9 @@ NProto::TError TMirrorPartitionActor::SplitReadBlocks(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION_WORKER,
-        "[%s] Split original range %s by device borders. Will try to read "
+        "%s Split original range %s by device borders. Will try to read "
         "with few requests",
-        DiskId.c_str(),
+        LogTitle.GetWithTime().c_str(),
         DescribeRange(blockRange).c_str());
 
     const ui64 requestIdentityKey = RegisterNewReadBlocksRequest(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_stats.cpp
@@ -25,7 +25,8 @@ void TMirrorPartitionActor::UpdateCounters(
         LOG_INFO(
             ctx,
             TBlockStoreComponents::PARTITION,
-            "Partition %s for disk %s counters not found",
+            "%s Partition %s for disk %s counters not found",
+            LogTitle.GetWithTime().c_str(),
             ToString(sender).c_str(),
             State.GetReplicaInfos()[0].Config->GetName().Quote().c_str());
 
@@ -186,9 +187,9 @@ void TMirrorPartitionActor::HandleDiskRegistryBasedPartCountersCombined(
         LOG_ERROR(
             ctx,
             TBlockStoreComponents::PARTITION_NONREPL,
-            "[%s] Failed to send mirror actor statistics due to empty "
+            "%s Failed to send mirror actor statistics due to empty "
             "StatisticRequestInfo.",
-            DiskId.Quote().c_str());
+            LogTitle.GetWithTime().c_str());
         return;
     }
 
@@ -198,7 +199,7 @@ void TMirrorPartitionActor::HandleDiskRegistryBasedPartCountersCombined(
         LOG_WARN(
             ctx,
             TBlockStoreComponents::PARTITION_NONREPL,
-            "[%s] Failed to send mirror actor statistics due to error: %s",
+            "%s Failed to send mirror actor statistics due to error: %s",
             LogTitle.GetWithTime().c_str(),
             FormatError(msg->Error).c_str());
     }


### PR DESCRIPTION
Using the LogTitle instead of DIskId in mirror partition logs.