### PR TITLE
issue-5590: dont read block masks for mixed blobs if its completely in one range

### DIFF
--- a/cloud/blockstore/libs/storage/partition/model/block.h
+++ b/cloud/blockstore/libs/storage/partition/model/block.h
@@ -102,7 +102,7 @@ struct IMixedBlocksIndexVisitor
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) = 0;
+        ui8 compactionRangeCount) = 0;
 };
 
 struct IExtendedBlocksIndexVisitor

--- a/cloud/blockstore/libs/storage/partition/model/block.h
+++ b/cloud/blockstore/libs/storage/partition/model/block.h
@@ -102,7 +102,7 @@ struct IMixedBlocksIndexVisitor
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) = 0;
+        ui32 enclosingCompactionRangeSize) = 0;
 };
 
 struct IExtendedBlocksIndexVisitor

--- a/cloud/blockstore/libs/storage/partition/model/block.h
+++ b/cloud/blockstore/libs/storage/partition/model/block.h
@@ -102,7 +102,7 @@ struct IMixedBlocksIndexVisitor
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) = 0;
+        ui8 compactionRangeCountOverlaped) = 0;
 };
 
 struct IExtendedBlocksIndexVisitor

--- a/cloud/blockstore/libs/storage/partition/model/block.h
+++ b/cloud/blockstore/libs/storage/partition/model/block.h
@@ -93,6 +93,18 @@ struct IBlocksIndexVisitor
         ui16 blobOffset) = 0;
 };
 
+struct IMixedBlocksIndexVisitor
+{
+    virtual ~IMixedBlocksIndexVisitor() = default;
+
+    virtual bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) = 0;
+};
+
 struct IExtendedBlocksIndexVisitor
 {
     virtual ~IExtendedBlocksIndexVisitor() = default;

--- a/cloud/blockstore/libs/storage/partition/model/block.h
+++ b/cloud/blockstore/libs/storage/partition/model/block.h
@@ -102,7 +102,7 @@ struct IMixedBlocksIndexVisitor
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) = 0;
+        ui8 compactionRangeCountOverlapped) = 0;
 };
 
 struct IExtendedBlocksIndexVisitor

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
@@ -241,7 +241,7 @@ bool TMixedIndexCache::TImpl::VisitBlocksIfHot(
                 b.CommitId,
                 b.BlobId,
                 b.BlobOffset,
-                b.EnclosingCompactionRangeSize))
+                b.CompactionRangeCountOverlaped))
         {
             // interrupted
             return true;

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
@@ -139,7 +139,7 @@ public:
     void InsertBlockIfHot(ui32 rangeIdx, TMixedBlock block);
     void EraseBlockIfHot(ui32 rangeIdx, TBlockKey blockKey);
 
-    bool VisitBlocksIfHot(ui32 rangeIdx, IBlocksIndexVisitor& visitor);
+    bool VisitBlocksIfHot(ui32 rangeIdx, IMixedBlocksIndexVisitor& visitor);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -228,7 +228,7 @@ void TMixedIndexCache::TImpl::EraseBlockIfHot(
 
 bool TMixedIndexCache::TImpl::VisitBlocksIfHot(
     ui32 rangeIdx,
-    IBlocksIndexVisitor& visitor)
+    IMixedBlocksIndexVisitor& visitor)
 {
     auto it = Index.find(rangeIdx);
     if (it == Index.end() || it->second.Temperature != ERangeTemperature::Hot) {
@@ -236,7 +236,13 @@ bool TMixedIndexCache::TImpl::VisitBlocksIfHot(
     }
 
     for (const auto& b: it->second.Blocks) {
-        if (!visitor.Visit(b.BlockIndex, b.CommitId, b.BlobId, b.BlobOffset)) {
+        if (!visitor.VisitBlock(
+                b.BlockIndex,
+                b.CommitId,
+                b.BlobId,
+                b.BlobOffset,
+                b.BlobAlignment))
+        {
             // interrupted
             return true;
         }
@@ -286,7 +292,7 @@ void TMixedIndexCache::EraseBlockIfHot(
 
 bool TMixedIndexCache::VisitBlocksIfHot(
     ui32 rangeIdx,
-    IBlocksIndexVisitor& visitor)
+    IMixedBlocksIndexVisitor& visitor)
 {
     return Impl->VisitBlocksIfHot(rangeIdx, visitor);
 }

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
@@ -241,7 +241,7 @@ bool TMixedIndexCache::TImpl::VisitBlocksIfHot(
                 b.CommitId,
                 b.BlobId,
                 b.BlobOffset,
-                b.CompactionRangeCountOverlaped))
+                b.CompactionRangeCountOverlapped))
         {
             // interrupted
             return true;

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
@@ -241,7 +241,7 @@ bool TMixedIndexCache::TImpl::VisitBlocksIfHot(
                 b.CommitId,
                 b.BlobId,
                 b.BlobOffset,
-                b.BlobAlignment))
+                b.EnclosingCompactionRangeSize))
         {
             // interrupted
             return true;

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.cpp
@@ -241,7 +241,7 @@ bool TMixedIndexCache::TImpl::VisitBlocksIfHot(
                 b.CommitId,
                 b.BlobId,
                 b.BlobOffset,
-                b.CompactionRangeCountOverlapped))
+                b.CompactionRangeCount))
         {
             // interrupted
             return true;

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
@@ -18,38 +18,38 @@ struct TMixedBlock
     ui64 CommitId;
     ui32 BlockIndex;
     ui16 BlobOffset;
-    ui8 CompactionRangeCountOverlapped;
+    ui8 CompactionRangeCount;
 
     TMixedBlock(
             TPartialBlobId blobId,
             ui64 commitId,
             ui32 blockIndex,
             ui16 blobOffset,
-            ui8 compactionRangeCountOverlapped)
+            ui8 compactionRangeCount)
         : BlobId(blobId)
         , CommitId(commitId)
         , BlockIndex(blockIndex)
         , BlobOffset(blobOffset)
-        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
+        , CompactionRangeCount(compactionRangeCount)
     {}
 
     bool operator==(const TMixedBlock& other) const
     {
         return BlockIndex == other.BlockIndex && CommitId == other.CommitId &&
                BlobId == other.BlobId && BlobOffset == other.BlobOffset &&
-               CompactionRangeCountOverlapped ==
-                   other.CompactionRangeCountOverlapped;
+               CompactionRangeCount ==
+                   other.CompactionRangeCount;
     }
 };
 
 static_assert(sizeof(TMixedBlock) == 32);
 
-// BlobOffset and CompactionRangeCountOverlapped are stored in a single 32-bit
+// BlobOffset and CompactionRangeCount are stored in a single 32-bit
 // integer in the local database.
 static_assert(sizeof(TMixedBlock::BlobOffset) == 2);
-static_assert(sizeof(TMixedBlock::CompactionRangeCountOverlapped) == 1);
+static_assert(sizeof(TMixedBlock::CompactionRangeCount) == 1);
 static_assert(
-    sizeof(TMixedBlock::CompactionRangeCountOverlapped) +
+    sizeof(TMixedBlock::CompactionRangeCount) +
         sizeof(TMixedBlock::BlobOffset) <=
     4);
 

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
@@ -18,16 +18,19 @@ struct TMixedBlock
     ui64 CommitId;
     ui32 BlockIndex;
     ui16 BlobOffset;
+    ui32 BlobAlignment;
 
     TMixedBlock(
             TPartialBlobId blobId,
             ui64 commitId,
             ui32 blockIndex,
-            ui16 blobOffset)
-       : BlobId(blobId)
-       , CommitId(commitId)
-       , BlockIndex(blockIndex)
-       , BlobOffset(blobOffset)
+            ui16 blobOffset,
+            ui32 blobAlignment)
+        : BlobId(blobId)
+        , CommitId(commitId)
+        , BlockIndex(blockIndex)
+        , BlobOffset(blobOffset)
+        , BlobAlignment(blobAlignment)
     {}
 
     bool operator==(const TMixedBlock& other) const
@@ -39,7 +42,7 @@ struct TMixedBlock
     }
 };
 
-static_assert(sizeof(TMixedBlock) == 32);
+static_assert(sizeof(TMixedBlock) == 40);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -83,7 +86,7 @@ public:
     void InsertBlockIfHot(ui32 rangeIdx, TMixedBlock block);
     void EraseBlockIfHot(ui32 rangeIndex, TBlockKey key);
 
-    bool VisitBlocksIfHot(ui32 rangeIdx, IBlocksIndexVisitor& visitor);
+    bool VisitBlocksIfHot(ui32 rangeIdx, IMixedBlocksIndexVisitor& visitor);
 };
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
@@ -18,27 +18,27 @@ struct TMixedBlock
     ui64 CommitId;
     ui32 BlockIndex;
     ui16 BlobOffset;
-    ui32 BlobAlignment;
+    ui32 EnclosingCompactionRangeSize;
 
     TMixedBlock(
             TPartialBlobId blobId,
             ui64 commitId,
             ui32 blockIndex,
             ui16 blobOffset,
-            ui32 blobAlignment)
+            ui32 enclosingCompactionRangeSize)
         : BlobId(blobId)
         , CommitId(commitId)
         , BlockIndex(blockIndex)
         , BlobOffset(blobOffset)
-        , BlobAlignment(blobAlignment)
+        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
     {}
 
     bool operator==(const TMixedBlock& other) const
     {
-        return BlockIndex == other.BlockIndex
-            && CommitId == other.CommitId
-            && BlobId == other.BlobId
-            && BlobOffset == other.BlobOffset;
+        return BlockIndex == other.BlockIndex && CommitId == other.CommitId &&
+               BlobId == other.BlobId && BlobOffset == other.BlobOffset &&
+               EnclosingCompactionRangeSize ==
+                   other.EnclosingCompactionRangeSize;
     }
 };
 

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
@@ -44,6 +44,15 @@ struct TMixedBlock
 
 static_assert(sizeof(TMixedBlock) == 32);
 
+// BlobOffset and CompactionRangeCountOverlapped are stored in a single 32-bit
+// integer in the local database.
+static_assert(sizeof(TMixedBlock::BlobOffset) == 2);
+static_assert(sizeof(TMixedBlock::CompactionRangeCountOverlapped) == 1);
+static_assert(
+    sizeof(TMixedBlock::CompactionRangeCountOverlapped) +
+        sizeof(TMixedBlock::BlobOffset) <=
+    4);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TMixedIndexCache

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
@@ -18,31 +18,31 @@ struct TMixedBlock
     ui64 CommitId;
     ui32 BlockIndex;
     ui16 BlobOffset;
-    ui32 EnclosingCompactionRangeSize;
+    ui8 CompactionRangeCountOverlaped;
 
     TMixedBlock(
             TPartialBlobId blobId,
             ui64 commitId,
             ui32 blockIndex,
             ui16 blobOffset,
-            ui32 enclosingCompactionRangeSize)
+            ui8 compactionRangeCountOverlaped)
         : BlobId(blobId)
         , CommitId(commitId)
         , BlockIndex(blockIndex)
         , BlobOffset(blobOffset)
-        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
+        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
     {}
 
     bool operator==(const TMixedBlock& other) const
     {
         return BlockIndex == other.BlockIndex && CommitId == other.CommitId &&
                BlobId == other.BlobId && BlobOffset == other.BlobOffset &&
-               EnclosingCompactionRangeSize ==
-                   other.EnclosingCompactionRangeSize;
+               CompactionRangeCountOverlaped ==
+                   other.CompactionRangeCountOverlaped;
     }
 };
 
-static_assert(sizeof(TMixedBlock) == 40);
+static_assert(sizeof(TMixedBlock) == 32);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
+++ b/cloud/blockstore/libs/storage/partition/model/mixed_index_cache.h
@@ -18,27 +18,27 @@ struct TMixedBlock
     ui64 CommitId;
     ui32 BlockIndex;
     ui16 BlobOffset;
-    ui8 CompactionRangeCountOverlaped;
+    ui8 CompactionRangeCountOverlapped;
 
     TMixedBlock(
             TPartialBlobId blobId,
             ui64 commitId,
             ui32 blockIndex,
             ui16 blobOffset,
-            ui8 compactionRangeCountOverlaped)
+            ui8 compactionRangeCountOverlapped)
         : BlobId(blobId)
         , CommitId(commitId)
         , BlockIndex(blockIndex)
         , BlobOffset(blobOffset)
-        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
+        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
     {}
 
     bool operator==(const TMixedBlock& other) const
     {
         return BlockIndex == other.BlockIndex && CommitId == other.CommitId &&
                BlobId == other.BlobId && BlobOffset == other.BlobOffset &&
-               CompactionRangeCountOverlaped ==
-                   other.CompactionRangeCountOverlaped;
+               CompactionRangeCountOverlapped ==
+                   other.CompactionRangeCountOverlapped;
     }
 };
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -226,7 +226,7 @@ private:
             db,
             blob.BlobId,
             blob.Blocks,
-            blob.CompactionRangeCountOverlapped);
+            blob.CompactionRangeCount);
 
         // update counters
         State.IncrementMixedBlobsCount(1);
@@ -382,7 +382,7 @@ private:
                  block.CommitId,
                  block.BlockIndex,
                  blobOffset++,
-                 blob.CompactionRangeCountOverlapped});
+                 blob.CompactionRangeCount});
 
             if (block.IsStoredInDb) {
                 State.DeleteFreshBlockFromDb(

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -222,7 +222,8 @@ private:
         db.WriteBlockMask(blob.BlobId, blockMask);
 
         // write blocks
-        State.WriteMixedBlocks(db, blob.BlobId, blob.Blocks);
+        State
+            .WriteMixedBlocks(db, blob.BlobId, blob.Blocks, blob.BlobAlignment);
 
         // update counters
         State.IncrementMixedBlobsCount(1);
@@ -372,11 +373,13 @@ private:
         // move blocks from FreshBlocks to MixedBlocks
         blobOffset = 0;
         for (const auto& block: blob.Blocks) {
-            State.WriteMixedBlock(db, {
-                blob.BlobId,
-                block.CommitId,
-                block.BlockIndex,
-                blobOffset++});
+            State.WriteMixedBlock(
+                db,
+                {blob.BlobId,
+                 block.CommitId,
+                 block.BlockIndex,
+                 blobOffset++,
+                 blob.BlobAlignment});
 
             if (block.IsStoredInDb) {
                 State.DeleteFreshBlockFromDb(

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -222,8 +222,11 @@ private:
         db.WriteBlockMask(blob.BlobId, blockMask);
 
         // write blocks
-        State
-            .WriteMixedBlocks(db, blob.BlobId, blob.Blocks, blob.BlobAlignment);
+        State.WriteMixedBlocks(
+            db,
+            blob.BlobId,
+            blob.Blocks,
+            blob.EnclosingCompactionRangeSize);
 
         // update counters
         State.IncrementMixedBlobsCount(1);
@@ -379,7 +382,7 @@ private:
                  block.CommitId,
                  block.BlockIndex,
                  blobOffset++,
-                 blob.BlobAlignment});
+                 blob.EnclosingCompactionRangeSize});
 
             if (block.IsStoredInDb) {
                 State.DeleteFreshBlockFromDb(

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -226,7 +226,7 @@ private:
             db,
             blob.BlobId,
             blob.Blocks,
-            blob.EnclosingCompactionRangeSize);
+            blob.CompactionRangeCountOverlaped);
 
         // update counters
         State.IncrementMixedBlobsCount(1);
@@ -382,7 +382,7 @@ private:
                  block.CommitId,
                  block.BlockIndex,
                  blobOffset++,
-                 blob.EnclosingCompactionRangeSize});
+                 blob.CompactionRangeCountOverlaped});
 
             if (block.IsStoredInDb) {
                 State.DeleteFreshBlockFromDb(

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -226,7 +226,7 @@ private:
             db,
             blob.BlobId,
             blob.Blocks,
-            blob.CompactionRangeCountOverlaped);
+            blob.CompactionRangeCountOverlapped);
 
         // update counters
         State.IncrementMixedBlobsCount(1);
@@ -382,7 +382,7 @@ private:
                  block.CommitId,
                  block.BlockIndex,
                  blobOffset++,
-                 blob.CompactionRangeCountOverlaped});
+                 blob.CompactionRangeCountOverlapped});
 
             if (block.IsStoredInDb) {
                 State.DeleteFreshBlockFromDb(

--- a/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
@@ -292,11 +292,11 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
-        Y_UNUSED(compactionRangeCountOverlapped);
+        Y_UNUSED(compactionRangeCount);
         Args.MarkBlock(blockIndex, commitId);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
@@ -259,6 +259,7 @@ STFUNC(TGetChangedBlocksActor::StateWork)
 class TChangedBlocksVisitor final
     : public IFreshBlocksIndexVisitor
     , public IBlocksIndexVisitor
+    , public IMixedBlocksIndexVisitor
 {
 private:
     TTxPartition::TGetChangedBlocks& Args;
@@ -282,6 +283,20 @@ public:
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
+        Args.MarkBlock(blockIndex, commitId);
+        return true;
+    }
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        Y_UNUSED(blobId);
+        Y_UNUSED(blobOffset);
+        Y_UNUSED(blobAlignment);
         Args.MarkBlock(blockIndex, commitId);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
@@ -292,11 +292,11 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
-        Y_UNUSED(blobAlignment);
+        Y_UNUSED(enclosingCompactionRangeSize);
         Args.MarkBlock(blockIndex, commitId);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
@@ -292,11 +292,11 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
-        Y_UNUSED(compactionRangeCountOverlaped);
+        Y_UNUSED(compactionRangeCountOverlapped);
         Args.MarkBlock(blockIndex, commitId);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_changedblocks.cpp
@@ -292,11 +292,11 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
-        Y_UNUSED(enclosingCompactionRangeSize);
+        Y_UNUSED(compactionRangeCountOverlaped);
         Args.MarkBlock(blockIndex, commitId);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1089,14 +1089,14 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
         if (commitId > MaxCommitId) {
             return true;
         }
 
         auto& ab = Args.AffectedBlobs[blobId];
-        ab.CompactionRangeCountOverlapped = compactionRangeCountOverlapped;
+        ab.CompactionRangeCount = compactionRangeCount;
 
         Args.MarkBlock(
             blockIndex,
@@ -1730,7 +1730,7 @@ void PrepareRangeCompaction(
         const bool compactRangeContainsBlob =
             args.BlockRange.Contains(kv.second.BlobRangeHint);
         const bool blobOnlyInOneCompactRange =
-            kv.second.CompactionRangeCountOverlapped == 1;
+            kv.second.CompactionRangeCount == 1;
 
         if ((!compactRangeContainsBlob && !blobOnlyInOneCompactRange) ||
             !readBlockMaskOnCompactionOptimizationEnabled)

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1089,14 +1089,14 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
         if (commitId > MaxCommitId) {
             return true;
         }
 
         auto& ab = Args.AffectedBlobs[blobId];
-        ab.BlobAlignment = blobAlignment;
+        ab.EnclosingCompactionRangeSize = enclosingCompactionRangeSize;
 
         Args.MarkBlock(
             blockIndex,
@@ -1730,7 +1730,8 @@ void PrepareRangeCompaction(
         const bool compactRangeContainsBlob =
             args.BlockRange.Contains(kv.second.BlobRangeHint);
         const bool blobOnlyInOneCompactRange =
-            state.GetCompactionMap().GetRangeSize() == kv.second.BlobAlignment;
+            state.GetCompactionMap().GetRangeSize() ==
+            kv.second.EnclosingCompactionRangeSize;
 
         if ((!compactRangeContainsBlob && !blobOnlyInOneCompactRange) ||
             !readBlockMaskOnCompactionOptimizationEnabled)

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1089,14 +1089,14 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
         if (commitId > MaxCommitId) {
             return true;
         }
 
         auto& ab = Args.AffectedBlobs[blobId];
-        ab.EnclosingCompactionRangeSize = enclosingCompactionRangeSize;
+        ab.CompactionRangeCountOverlaped = compactionRangeCountOverlaped;
 
         Args.MarkBlock(
             blockIndex,
@@ -1730,13 +1730,12 @@ void PrepareRangeCompaction(
         const bool compactRangeContainsBlob =
             args.BlockRange.Contains(kv.second.BlobRangeHint);
         const bool blobOnlyInOneCompactRange =
-            state.GetCompactionMap().GetRangeSize() ==
-            kv.second.EnclosingCompactionRangeSize;
+            kv.second.CompactionRangeCountOverlaped == 1;
 
         if ((!compactRangeContainsBlob && !blobOnlyInOneCompactRange) ||
             !readBlockMaskOnCompactionOptimizationEnabled)
         {
-            state.IncrementBlockMaskReadedDuringCompaction();
+            state.IncrementBlockMaskReadDuringCompaction();
 
             if (db.ReadBlockMask(kv.first, kv.second.BlockMask)) {
                 STORAGE_VERIFY_C(

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1045,13 +1045,16 @@ class TCompactionBlockVisitor final
 private:
     TTxPartition::TRangeCompaction& Args;
     const ui64 MaxCommitId;
+    const TCompactionMap& CompactionMap;
 
 public:
     TCompactionBlockVisitor(
             TTxPartition::TRangeCompaction& args,
-            ui64 maxCommitId)
+            ui64 maxCommitId,
+            const TCompactionMap& compactionMap)
         : Args(args)
         , MaxCommitId(maxCommitId)
+        , CompactionMap(compactionMap)
     {}
 
     bool Visit(const TFreshBlock& block) override
@@ -1110,7 +1113,8 @@ public:
     bool Visit(TBlockRange32 blockRange, const TPartialBlobId& blobId) override
     {
         auto& ab = Args.AffectedBlobs[blobId];
-        ab.BlobRangeHint = blockRange;
+        ab.CompactionRangeCount = CompactionMap.GetRangeIndex(blockRange.End) -
+            CompactionMap.GetRangeIndex(blockRange.Start) + 1;
         return true;
     }
 };
@@ -1611,7 +1615,7 @@ void PrepareRangeCompaction(
     TTxPartition::TRangeCompaction& args,
     const TString& logTitle)
 {
-    TCompactionBlockVisitor visitor(args, commitId);
+    TCompactionBlockVisitor visitor(args, commitId, state.GetCompactionMap());
     state.FindFreshBlocks(visitor, args.BlockRange, commitId);
     visitor.KeepTrackOfAffectedBlocks = true;
     ready &= state.FindMixedBlocksForCompaction(db, visitor, args.RangeIdx);
@@ -1723,12 +1727,10 @@ void PrepareRangeCompaction(
     for (auto& kv: args.AffectedBlobs) {
         state.IncrementBlobsProcessedDuringCompaction();
 
-        const bool compactRangeContainsBlob =
-            args.BlockRange.Contains(kv.second.BlobRangeHint);
         const bool blobOnlyInOneCompactRange =
             kv.second.CompactionRangeCount == 1;
 
-        if ((!compactRangeContainsBlob && !blobOnlyInOneCompactRange) ||
+        if (!blobOnlyInOneCompactRange ||
             !readBlockMaskOnCompactionOptimizationEnabled)
         {
             state.IncrementBlockMaskReadDuringCompaction();

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1109,10 +1109,6 @@ public:
 
     bool Visit(TBlockRange32 blockRange, const TPartialBlobId& blobId) override
     {
-        if (blobId.CommitId() > MaxCommitId) {
-            return true;
-        }
-
         auto& ab = Args.AffectedBlobs[blobId];
         ab.BlobRangeHint = blockRange;
         return true;

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -642,7 +642,11 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
                     blockIndices.emplace_back(blockIndex);
                 }
             }
-            mixedBlobs.emplace_back(blobId, std::move(blockIndices), blockChecksums);
+            mixedBlobs.emplace_back(
+                blobId,
+                std::move(blockIndices),
+                blockChecksums,
+                0);   // unknown blob alignment
             mixedBlobCompactionInfos.push_back({blobsSkipped, blocksSkipped});
         } else {
             LOG_ERROR(
@@ -1035,6 +1039,7 @@ STFUNC(TCompactionActor::StateWork)
 class TCompactionBlockVisitor final
     : public IFreshBlocksIndexVisitor
     , public IBlocksIndexVisitor
+    , public IMixedBlocksIndexVisitor
     , public IBlobsVisitor
 {
 private:
@@ -1079,8 +1084,35 @@ public:
         return true;
     }
 
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        if (commitId > MaxCommitId) {
+            return true;
+        }
+
+        auto& ab = Args.AffectedBlobs[blobId];
+        ab.BlobAlignment = blobAlignment;
+
+        Args.MarkBlock(
+            blockIndex,
+            commitId,
+            blobId,
+            blobOffset,
+            KeepTrackOfAffectedBlocks);
+        return true;
+    }
+
     bool Visit(TBlockRange32 blockRange, const TPartialBlobId& blobId) override
     {
+        if (blobId.CommitId() > MaxCommitId) {
+            return true;
+        }
+
         auto& ab = Args.AffectedBlobs[blobId];
         ab.BlobRangeHint = blockRange;
         return true;
@@ -1693,12 +1725,18 @@ void PrepareRangeCompaction(
     args.ChecksumsEnabled = args.BlockRange.Start < checksumBoundary;
 
     for (auto& kv: args.AffectedBlobs) {
+        state.IncrementBlobsProcessedDuringCompaction();
+
         const bool compactRangeContainsBlob =
             args.BlockRange.Contains(kv.second.BlobRangeHint);
+        const bool blobOnlyInOneCompactRange =
+            state.GetCompactionMap().GetRangeSize() == kv.second.BlobAlignment;
 
-        if (!compactRangeContainsBlob ||
+        if ((!compactRangeContainsBlob && !blobOnlyInOneCompactRange) ||
             !readBlockMaskOnCompactionOptimizationEnabled)
         {
+            state.IncrementBlockMaskReadedDuringCompaction();
+
             if (db.ReadBlockMask(kv.first, kv.second.BlockMask)) {
                 STORAGE_VERIFY_C(
                     kv.second.BlockMask.Defined(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1089,14 +1089,14 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
         if (commitId > MaxCommitId) {
             return true;
         }
 
         auto& ab = Args.AffectedBlobs[blobId];
-        ab.CompactionRangeCountOverlaped = compactionRangeCountOverlaped;
+        ab.CompactionRangeCountOverlapped = compactionRangeCountOverlapped;
 
         Args.MarkBlock(
             blockIndex,
@@ -1730,7 +1730,7 @@ void PrepareRangeCompaction(
         const bool compactRangeContainsBlob =
             args.BlockRange.Contains(kv.second.BlobRangeHint);
         const bool blobOnlyInOneCompactRange =
-            kv.second.CompactionRangeCountOverlaped == 1;
+            kv.second.CompactionRangeCountOverlapped == 1;
 
         if ((!compactRangeContainsBlob && !blobOnlyInOneCompactRange) ||
             !readBlockMaskOnCompactionOptimizationEnabled)

--- a/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
-        Y_UNUSED(enclosingCompactionRangeSize);
+        Y_UNUSED(compactionRangeCountOverlaped);
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
@@ -27,6 +27,7 @@ namespace {
 class TDescribeBlocksVisitor final
     : public IFreshBlocksIndexVisitor
     , public IBlocksIndexVisitor
+    , public IMixedBlocksIndexVisitor
 {
 private:
     TTxPartition::TDescribeBlocks& Args;
@@ -51,6 +52,18 @@ public:
         const TPartialBlobId& blobId,
         ui16 blobOffset) override
     {
+        Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
+        return true;
+    }
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        Y_UNUSED(blobAlignment);
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
-        Y_UNUSED(compactionRangeCountOverlapped);
+        Y_UNUSED(compactionRangeCount);
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
-        Y_UNUSED(blobAlignment);
+        Y_UNUSED(enclosingCompactionRangeSize);
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_describeblocks.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
-        Y_UNUSED(compactionRangeCountOverlaped);
+        Y_UNUSED(compactionRangeCountOverlapped);
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -37,19 +37,19 @@ public:
         TGuardedBuffer<TBlockBuffer> BlobContent;
         TVector<TBlock> Blocks;
         TVector<ui32> Checksums;
-        ui32 EnclosingCompactionRangeSize = 0;
+        ui8 CompactionRangeCountOverlaped = 0;
 
         TRequest(
                 const TPartialBlobId& blobId,
                 TBlockBuffer blobContent,
                 TVector<TBlock> blocks,
                 TVector<ui32> checksums,
-                ui32 enclosingCompactionRangeSize)
+                ui8 compactionRangeCountOverlaped)
             : BlobId(blobId)
             , BlobContent(std::move(blobContent))
             , Blocks(std::move(blocks))
             , Checksums(std::move(checksums))
-            , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
+            , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
         {}
     };
 
@@ -238,7 +238,7 @@ void TFlushActor::AddBlobs(const TActorContext& ctx)
             req.BlobId,
             std::move(req.Blocks),
             std::move(req.Checksums),
-            req.EnclosingCompactionRangeSize);
+            req.CompactionRangeCountOverlaped);
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(
@@ -404,17 +404,17 @@ struct TBlob
     TBlockBuffer BlobContent;
     TVector<TBlock> Blocks;
     TVector<ui32> Checksums;
-    ui32 EnclosingCompactionRangeSize;
+    ui8 CompactionRangeCountOverlaped;
 
     TBlob(
             TBlockBuffer blobContent,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui32 enclosingCompactionRangeSize)
+            ui8 compactionRangeCountOverlaped)
         : BlobContent(std::move(blobContent))
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
+        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
     {}
 };
 
@@ -540,15 +540,20 @@ private:
         TVector<TBlock> blocks,
         TVector<ui32> checksums)
     {
-        const bool blobOnlyInOneCompactRange =
-            CompactionMap.GetRangeIndex(blocks.front().BlockIndex) ==
-            CompactionMap.GetRangeIndex(blocks.back().BlockIndex);
+        const auto compactionRangeCountOverlaped =
+            CompactionMap.GetRangeIndex(blocks.back().BlockIndex) -
+            CompactionMap.GetRangeIndex(blocks.front().BlockIndex) + 1;
+
+        const ui8 compactionRangeCountOverlapedInOnyByte =
+            compactionRangeCountOverlaped <= Max<ui8>()
+                ? compactionRangeCountOverlaped
+                : 0;
 
         Blobs.emplace_back(
             std::move(blobContent),
             std::move(blocks),
             std::move(checksums),
-            blobOnlyInOneCompactRange ? CompactionMap.GetRangeSize() : 0);
+            compactionRangeCountOverlapedInOnyByte);
     }
 
     static ui32 GetBlobRangeSize(const TVector<TBlock>& blocks, ui32 blockIndex)
@@ -765,7 +770,7 @@ void TPartitionActor::HandleFlush(
             std::move(blob.BlobContent),
             std::move(blob.Blocks),
             std::move(blob.Checksums),
-            blob.EnclosingCompactionRangeSize);
+            blob.CompactionRangeCountOverlaped);
     }
 
     Y_ABORT_UNLESS(requests);

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -37,19 +37,19 @@ public:
         TGuardedBuffer<TBlockBuffer> BlobContent;
         TVector<TBlock> Blocks;
         TVector<ui32> Checksums;
-        ui8 CompactionRangeCountOverlapped = 0;
+        ui8 CompactionRangeCount = 0;
 
         TRequest(
                 const TPartialBlobId& blobId,
                 TBlockBuffer blobContent,
                 TVector<TBlock> blocks,
                 TVector<ui32> checksums,
-                ui8 compactionRangeCountOverlapped)
+                ui8 compactionRangeCount)
             : BlobId(blobId)
             , BlobContent(std::move(blobContent))
             , Blocks(std::move(blocks))
             , Checksums(std::move(checksums))
-            , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
+            , CompactionRangeCount(compactionRangeCount)
         {}
     };
 
@@ -238,7 +238,7 @@ void TFlushActor::AddBlobs(const TActorContext& ctx)
             req.BlobId,
             std::move(req.Blocks),
             std::move(req.Checksums),
-            req.CompactionRangeCountOverlapped);
+            req.CompactionRangeCount);
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(
@@ -404,17 +404,17 @@ struct TBlob
     TBlockBuffer BlobContent;
     TVector<TBlock> Blocks;
     TVector<ui32> Checksums;
-    ui8 CompactionRangeCountOverlapped;
+    ui8 CompactionRangeCount;
 
     TBlob(
             TBlockBuffer blobContent,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui8 compactionRangeCountOverlapped)
+            ui8 compactionRangeCount)
         : BlobContent(std::move(blobContent))
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
+        , CompactionRangeCount(compactionRangeCount)
     {}
 };
 
@@ -540,20 +540,20 @@ private:
         TVector<TBlock> blocks,
         TVector<ui32> checksums)
     {
-        const auto compactionRangeCountOverlapped =
+        const auto compactionRangeCount =
             CompactionMap.GetRangeIndex(blocks.back().BlockIndex) -
             CompactionMap.GetRangeIndex(blocks.front().BlockIndex) + 1;
 
-        const ui8 compactionRangeCountOverlappedInOneByte =
-            compactionRangeCountOverlapped <= Max<ui8>()
-                ? compactionRangeCountOverlapped
+        const ui8 compactionRangeCountInOneByte =
+            compactionRangeCount <= Max<ui8>()
+                ? compactionRangeCount
                 : 0;
 
         Blobs.emplace_back(
             std::move(blobContent),
             std::move(blocks),
             std::move(checksums),
-            compactionRangeCountOverlappedInOneByte);
+            compactionRangeCountInOneByte);
     }
 
     static ui32 GetBlobRangeSize(const TVector<TBlock>& blocks, ui32 blockIndex)
@@ -770,7 +770,7 @@ void TPartitionActor::HandleFlush(
             std::move(blob.BlobContent),
             std::move(blob.Blocks),
             std::move(blob.Checksums),
-            blob.CompactionRangeCountOverlapped);
+            blob.CompactionRangeCount);
     }
 
     Y_ABORT_UNLESS(requests);

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -37,18 +37,19 @@ public:
         TGuardedBuffer<TBlockBuffer> BlobContent;
         TVector<TBlock> Blocks;
         TVector<ui32> Checksums;
-        ui32 BlobAlignment = 0;
+        ui32 EnclosingCompactionRangeSize = 0;
 
-        TRequest(const TPartialBlobId& blobId,
-                 TBlockBuffer blobContent,
-                 TVector<TBlock> blocks,
-                 TVector<ui32> checksums,
-                 ui32 blobAlignment)
+        TRequest(
+                const TPartialBlobId& blobId,
+                TBlockBuffer blobContent,
+                TVector<TBlock> blocks,
+                TVector<ui32> checksums,
+                ui32 enclosingCompactionRangeSize)
             : BlobId(blobId)
             , BlobContent(std::move(blobContent))
             , Blocks(std::move(blocks))
             , Checksums(std::move(checksums))
-            , BlobAlignment(blobAlignment)
+            , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
         {}
     };
 
@@ -237,7 +238,7 @@ void TFlushActor::AddBlobs(const TActorContext& ctx)
             req.BlobId,
             std::move(req.Blocks),
             std::move(req.Checksums),
-            req.BlobAlignment);
+            req.EnclosingCompactionRangeSize);
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(
@@ -403,19 +404,18 @@ struct TBlob
     TBlockBuffer BlobContent;
     TVector<TBlock> Blocks;
     TVector<ui32> Checksums;
-    ui32 BlobAlignment;
+    ui32 EnclosingCompactionRangeSize;
 
     TBlob(
             TBlockBuffer blobContent,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui32 blobAlignment)
+            ui32 enclosingCompactionRangeSize)
         : BlobContent(std::move(blobContent))
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , BlobAlignment(blobAlignment)
-    {
-    }
+        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
+    {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -765,7 +765,7 @@ void TPartitionActor::HandleFlush(
             std::move(blob.BlobContent),
             std::move(blob.Blocks),
             std::move(blob.Checksums),
-            blob.BlobAlignment);
+            blob.EnclosingCompactionRangeSize);
     }
 
     Y_ABORT_UNLESS(requests);

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -431,6 +431,7 @@ private:
     const ui32 MaxBlocksInBlob;
     const ui64 DiskPrefixLengthWithBlockChecksumsInBlobs;
     const TCompactionMap& CompactionMap;
+    const bool ReadBlockMaskOnCompactionOptimizationEnabled;
 
     TBlockBuffer BlobContent { TProfilingAllocator::Instance() };
 
@@ -446,7 +447,8 @@ public:
             ui32 maxBlobRangeSize,
             ui32 maxBlocksInBlob,
             ui64 diskPrefixLengthWithBlockChecksumsInBlobs,
-            const TCompactionMap& compactionMap)
+            const TCompactionMap& compactionMap,
+            bool readBlockMaskOnCompactionOptimizationEnabled)
         : Blobs(blobs)
         , BlockSize(blockSize)
         , FlushBlobSizeThreshold(flushBlobSizeThreshold)
@@ -455,6 +457,8 @@ public:
         , DiskPrefixLengthWithBlockChecksumsInBlobs(
               diskPrefixLengthWithBlockChecksumsInBlobs)
         , CompactionMap(compactionMap)
+        , ReadBlockMaskOnCompactionOptimizationEnabled(
+              readBlockMaskOnCompactionOptimizationEnabled)
     {}
 
     bool Visit(const TFreshBlock& block) override
@@ -540,12 +544,13 @@ private:
         TVector<TBlock> blocks,
         TVector<ui32> checksums)
     {
-        const auto compactionRangeCount =
+        const ui32 compactionRangeCount =
             CompactionMap.GetRangeIndex(blocks.back().BlockIndex) -
             CompactionMap.GetRangeIndex(blocks.front().BlockIndex) + 1;
 
         const ui8 compactionRangeCountInOneByte =
-            compactionRangeCount <= Max<ui8>()
+            compactionRangeCount <= Max<ui8>() &&
+                    ReadBlockMaskOnCompactionOptimizationEnabled
                 ? compactionRangeCount
                 : 0;
 
@@ -733,7 +738,8 @@ void TPartitionActor::HandleFlush(
             Config->GetMaxBlobRangeSize(),
             State->GetMaxBlocksInBlob(),
             Config->GetDiskPrefixLengthWithBlockChecksumsInBlobs(),
-            State->GetCompactionMap());
+            State->GetCompactionMap(),
+            IsReadBlockMaskOnCompactionOptimizationEnabled());
 
         State->FindFreshBlocks(visitor, TBlockRange32::Max(), commitId);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -37,15 +37,18 @@ public:
         TGuardedBuffer<TBlockBuffer> BlobContent;
         TVector<TBlock> Blocks;
         TVector<ui32> Checksums;
+        ui32 BlobAlignment = 0;
 
         TRequest(const TPartialBlobId& blobId,
                  TBlockBuffer blobContent,
                  TVector<TBlock> blocks,
-                 TVector<ui32> checksums)
+                 TVector<ui32> checksums,
+                 ui32 blobAlignment)
             : BlobId(blobId)
             , BlobContent(std::move(blobContent))
             , Blocks(std::move(blocks))
             , Checksums(std::move(checksums))
+            , BlobAlignment(blobAlignment)
         {}
     };
 
@@ -233,7 +236,8 @@ void TFlushActor::AddBlobs(const TActorContext& ctx)
         freshBlobs.emplace_back(
             req.BlobId,
             std::move(req.Blocks),
-            std::move(req.Checksums));
+            std::move(req.Checksums),
+            req.BlobAlignment);
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(
@@ -399,14 +403,17 @@ struct TBlob
     TBlockBuffer BlobContent;
     TVector<TBlock> Blocks;
     TVector<ui32> Checksums;
+    ui32 BlobAlignment;
 
     TBlob(
             TBlockBuffer blobContent,
             TVector<TBlock> blocks,
-            TVector<ui32> checksums)
+            TVector<ui32> checksums,
+            ui32 blobAlignment)
         : BlobContent(std::move(blobContent))
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
+        , BlobAlignment(blobAlignment)
     {
     }
 };
@@ -423,6 +430,7 @@ private:
     const ui32 MaxBlobRangeSize;
     const ui32 MaxBlocksInBlob;
     const ui64 DiskPrefixLengthWithBlockChecksumsInBlobs;
+    const TCompactionMap& CompactionMap;
 
     TBlockBuffer BlobContent { TProfilingAllocator::Instance() };
 
@@ -437,14 +445,16 @@ public:
             ui32 flushBlobSizeThreshold,
             ui32 maxBlobRangeSize,
             ui32 maxBlocksInBlob,
-            ui64 diskPrefixLengthWithBlockChecksumsInBlobs)
+            ui64 diskPrefixLengthWithBlockChecksumsInBlobs,
+            const TCompactionMap& compactionMap)
         : Blobs(blobs)
         , BlockSize(blockSize)
         , FlushBlobSizeThreshold(flushBlobSizeThreshold)
         , MaxBlobRangeSize(maxBlobRangeSize)
         , MaxBlocksInBlob(maxBlocksInBlob)
         , DiskPrefixLengthWithBlockChecksumsInBlobs(
-            diskPrefixLengthWithBlockChecksumsInBlobs)
+              diskPrefixLengthWithBlockChecksumsInBlobs)
+        , CompactionMap(compactionMap)
     {}
 
     bool Visit(const TFreshBlock& block) override
@@ -454,7 +464,7 @@ public:
             if (GetBlobRangeSize(Blocks, block.Meta.BlockIndex)
                     > MaxBlobRangeSize / BlockSize)
             {
-                Blobs.emplace_back(
+                FlushBlob(
                     std::move(BlobContent),
                     std::move(Blocks),
                     std::move(Checksums));
@@ -478,7 +488,7 @@ public:
             }
 
             if (Blocks.size() == MaxBlocksInBlob) {
-                Blobs.emplace_back(
+                FlushBlob(
                     std::move(BlobContent),
                     std::move(Blocks),
                     std::move(Checksums));
@@ -487,7 +497,7 @@ public:
             const auto blobRangeSize =
                 GetBlobRangeSize(ZeroBlocks, block.Meta.BlockIndex);
             if (blobRangeSize > MaxBlobRangeSize / BlockSize) {
-                Blobs.emplace_back(
+                FlushBlob(
                     TBlockBuffer(),
                     std::move(ZeroBlocks),
                     TVector<ui32>() /* checksums */);
@@ -496,7 +506,7 @@ public:
             ZeroBlocks.emplace_back(block.Meta.BlockIndex, block.Meta.CommitId, block.Meta.IsStoredInDb);
 
             if (ZeroBlocks.size() == MaxBlocksInBlob) {
-                Blobs.emplace_back(
+                FlushBlob(
                     TBlockBuffer(),
                     std::move(ZeroBlocks),
                     TVector<ui32>() /* checksums */);
@@ -510,14 +520,14 @@ public:
     {
         const auto dataSize = Blocks.size() * BlockSize;
         if (Blocks && (!Blobs || dataSize >= FlushBlobSizeThreshold)) {
-            Blobs.emplace_back(
+            FlushBlob(
                 std::move(BlobContent),
                 std::move(Blocks),
                 std::move(Checksums));
         }
 
         if (ZeroBlocks && (!Blobs || ZeroBlocks.size() >= FlushBlobSizeThreshold)) {
-            Blobs.emplace_back(
+            FlushBlob(
                 TBlockBuffer(),
                 std::move(ZeroBlocks),
                 TVector<ui32>() /* checksums */);
@@ -525,6 +535,22 @@ public:
     }
 
 private:
+    void FlushBlob(
+        TBlockBuffer blobContent,
+        TVector<TBlock> blocks,
+        TVector<ui32> checksums)
+    {
+        const bool blobOnlyInOneCompactRange =
+            CompactionMap.GetRangeIndex(blocks.front().BlockIndex) ==
+            CompactionMap.GetRangeIndex(blocks.back().BlockIndex);
+
+        Blobs.emplace_back(
+            std::move(blobContent),
+            std::move(blocks),
+            std::move(checksums),
+            blobOnlyInOneCompactRange ? CompactionMap.GetRangeSize() : 0);
+    }
+
     static ui32 GetBlobRangeSize(const TVector<TBlock>& blocks, ui32 blockIndex)
     {
         if (blocks) {
@@ -701,7 +727,8 @@ void TPartitionActor::HandleFlush(
             flushBlobSizeThreshold,
             Config->GetMaxBlobRangeSize(),
             State->GetMaxBlocksInBlob(),
-            Config->GetDiskPrefixLengthWithBlockChecksumsInBlobs());
+            Config->GetDiskPrefixLengthWithBlockChecksumsInBlobs(),
+            State->GetCompactionMap());
 
         State->FindFreshBlocks(visitor, TBlockRange32::Max(), commitId);
 
@@ -737,7 +764,8 @@ void TPartitionActor::HandleFlush(
             blobId,
             std::move(blob.BlobContent),
             std::move(blob.Blocks),
-            std::move(blob.Checksums));
+            std::move(blob.Checksums),
+            blob.BlobAlignment);
     }
 
     Y_ABORT_UNLESS(requests);

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -37,19 +37,19 @@ public:
         TGuardedBuffer<TBlockBuffer> BlobContent;
         TVector<TBlock> Blocks;
         TVector<ui32> Checksums;
-        ui8 CompactionRangeCountOverlaped = 0;
+        ui8 CompactionRangeCountOverlapped = 0;
 
         TRequest(
                 const TPartialBlobId& blobId,
                 TBlockBuffer blobContent,
                 TVector<TBlock> blocks,
                 TVector<ui32> checksums,
-                ui8 compactionRangeCountOverlaped)
+                ui8 compactionRangeCountOverlapped)
             : BlobId(blobId)
             , BlobContent(std::move(blobContent))
             , Blocks(std::move(blocks))
             , Checksums(std::move(checksums))
-            , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
+            , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
         {}
     };
 
@@ -238,7 +238,7 @@ void TFlushActor::AddBlobs(const TActorContext& ctx)
             req.BlobId,
             std::move(req.Blocks),
             std::move(req.Checksums),
-            req.CompactionRangeCountOverlaped);
+            req.CompactionRangeCountOverlapped);
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(
@@ -404,17 +404,17 @@ struct TBlob
     TBlockBuffer BlobContent;
     TVector<TBlock> Blocks;
     TVector<ui32> Checksums;
-    ui8 CompactionRangeCountOverlaped;
+    ui8 CompactionRangeCountOverlapped;
 
     TBlob(
             TBlockBuffer blobContent,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui8 compactionRangeCountOverlaped)
+            ui8 compactionRangeCountOverlapped)
         : BlobContent(std::move(blobContent))
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
+        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
     {}
 };
 
@@ -540,20 +540,20 @@ private:
         TVector<TBlock> blocks,
         TVector<ui32> checksums)
     {
-        const auto compactionRangeCountOverlaped =
+        const auto compactionRangeCountOverlapped =
             CompactionMap.GetRangeIndex(blocks.back().BlockIndex) -
             CompactionMap.GetRangeIndex(blocks.front().BlockIndex) + 1;
 
-        const ui8 compactionRangeCountOverlapedInOnyByte =
-            compactionRangeCountOverlaped <= Max<ui8>()
-                ? compactionRangeCountOverlaped
+        const ui8 compactionRangeCountOverlappedInOneByte =
+            compactionRangeCountOverlapped <= Max<ui8>()
+                ? compactionRangeCountOverlapped
                 : 0;
 
         Blobs.emplace_back(
             std::move(blobContent),
             std::move(blocks),
             std::move(checksums),
-            compactionRangeCountOverlapedInOnyByte);
+            compactionRangeCountOverlappedInOneByte);
     }
 
     static ui32 GetBlobRangeSize(const TVector<TBlock>& blocks, ui32 blockIndex)
@@ -770,7 +770,7 @@ void TPartitionActor::HandleFlush(
             std::move(blob.BlobContent),
             std::move(blob.Blocks),
             std::move(blob.Checksums),
-            blob.CompactionRangeCountOverlaped);
+            blob.CompactionRangeCountOverlapped);
     }
 
     Y_ABORT_UNLESS(requests);

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
@@ -21,6 +21,7 @@ namespace {
 class TMetadataRebuildBlockVisitor final
     : public IFreshBlocksIndexVisitor
     , public IBlocksIndexVisitor
+    , public IMixedBlocksIndexVisitor
 {
 private:
     TTxPartition::TMetadataRebuildUsedBlocks& Args;
@@ -46,6 +47,22 @@ public:
     {
         Y_UNUSED(commitId);
         Y_UNUSED(blobOffset);
+
+        OnBlock(blockIndex, commitId, !IsDeletionMarker(blobId));
+
+        return true;
+    }
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        Y_UNUSED(commitId);
+        Y_UNUSED(blobOffset);
+        Y_UNUSED(blobAlignment);
 
         OnBlock(blockIndex, commitId, !IsDeletionMarker(blobId));
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
@@ -58,11 +58,10 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
-        Y_UNUSED(commitId);
         Y_UNUSED(blobOffset);
-        Y_UNUSED(compactionRangeCountOverlaped);
+        Y_UNUSED(compactionRangeCountOverlapped);
 
         OnBlock(blockIndex, commitId, !IsDeletionMarker(blobId));
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
@@ -58,11 +58,11 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
         Y_UNUSED(commitId);
         Y_UNUSED(blobOffset);
-        Y_UNUSED(blobAlignment);
+        Y_UNUSED(enclosingCompactionRangeSize);
 
         OnBlock(blockIndex, commitId, !IsDeletionMarker(blobId));
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
@@ -58,10 +58,10 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
         Y_UNUSED(blobOffset);
-        Y_UNUSED(compactionRangeCountOverlapped);
+        Y_UNUSED(compactionRangeCount);
 
         OnBlock(blockIndex, commitId, !IsDeletionMarker(blobId));
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_usedblocks.cpp
@@ -58,11 +58,11 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
         Y_UNUSED(commitId);
         Y_UNUSED(blobOffset);
-        Y_UNUSED(enclosingCompactionRangeSize);
+        Y_UNUSED(compactionRangeCountOverlaped);
 
         OnBlock(blockIndex, commitId, !IsDeletionMarker(blobId));
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
@@ -67,9 +67,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
-        Y_UNUSED(enclosingCompactionRangeSize);
+        Y_UNUSED(compactionRangeCountOverlaped);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
@@ -67,9 +67,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
-        Y_UNUSED(compactionRangeCountOverlapped);
+        Y_UNUSED(compactionRangeCount);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
@@ -67,9 +67,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
-        Y_UNUSED(blobAlignment);
+        Y_UNUSED(enclosingCompactionRangeSize);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
@@ -25,6 +25,7 @@ template <bool Index>
 class TCheckIndexVisitor final
     : public IBlocksIndexVisitor
     , public IExtendedBlocksIndexVisitor
+    , public IMixedBlocksIndexVisitor
 {
 private:
     TTxPartition::TCheckIndex& Args;
@@ -57,6 +58,18 @@ public:
         ui32 checksum) override
     {
         Y_UNUSED(checksum);
+
+        return Visit(blockIndex, commitId, blobId, blobOffset);
+    }
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        Y_UNUSED(blobAlignment);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_check.cpp
@@ -67,9 +67,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
-        Y_UNUSED(compactionRangeCountOverlaped);
+        Y_UNUSED(compactionRangeCountOverlapped);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
-        Y_UNUSED(compactionRangeCountOverlapped);
+        Y_UNUSED(compactionRangeCount);
 
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
-        Y_UNUSED(enclosingCompactionRangeSize);
+        Y_UNUSED(compactionRangeCountOverlaped);
 
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
-        Y_UNUSED(blobAlignment);
+        Y_UNUSED(enclosingCompactionRangeSize);
 
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
@@ -24,6 +24,7 @@ namespace {
 class TDescribeRangeVisitor final
     : public IFreshBlocksIndexVisitor
     , public IBlocksIndexVisitor
+    , public IMixedBlocksIndexVisitor
 {
 private:
     TTxPartition::TDescribeRange& Args;
@@ -51,6 +52,19 @@ public:
         const TPartialBlobId& blobId,
         ui16 blobOffset) override
     {
+        Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
+        return true;
+    }
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        Y_UNUSED(blobAlignment);
+
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
@@ -61,9 +61,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
-        Y_UNUSED(compactionRangeCountOverlaped);
+        Y_UNUSED(compactionRangeCountOverlapped);
 
         Args.MarkBlock(blockIndex, commitId, blobId, blobOffset);
         return true;

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -818,9 +818,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
-        Y_UNUSED(blobAlignment);
+        Y_UNUSED(enclosingCompactionRangeSize);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -730,6 +730,7 @@ STFUNC(TReadBlocksActor::StateWork)
 class TReadBlocksVisitor final
     : public IFreshBlocksIndexVisitor
     , public IBlocksIndexVisitor
+    , public IMixedBlocksIndexVisitor
 {
 private:
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
@@ -810,6 +811,18 @@ public:
         }
 
         return true;
+    }
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        Y_UNUSED(blobAlignment);
+
+        return Visit(blockIndex, commitId, blobId, blobOffset);
     }
 };
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -818,9 +818,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
-        Y_UNUSED(enclosingCompactionRangeSize);
+        Y_UNUSED(compactionRangeCountOverlaped);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -818,9 +818,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
-        Y_UNUSED(compactionRangeCountOverlaped);
+        Y_UNUSED(compactionRangeCountOverlapped);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -818,9 +818,9 @@ public:
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
-        Y_UNUSED(compactionRangeCountOverlapped);
+        Y_UNUSED(compactionRangeCount);
 
         return Visit(blockIndex, commitId, blobId, blobOffset);
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
@@ -106,8 +106,8 @@ void TPartitionActor::HandleStatPartition(
     response->Record.MutableStats()->SetBlobsProcessedDuringCompaction(
         State->GetBlobsProcessedDuringCompaction());
 
-    response->Record.MutableStats()->SetBlockMaskReadedDuringCompaction(
-        State->GetBlockMaskReadedDuringCompaction());
+    response->Record.MutableStats()->SetBlockMaskReadDuringCompaction(
+        State->GetBlockMaskReadDuringCompaction());
 
     LWTRACK(
         ResponseSent_Partition,

--- a/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_statpartition.cpp
@@ -103,6 +103,12 @@ void TPartitionActor::HandleStatPartition(
     response->Record.MutableStats()->SetTrimFreshLogToCommitId(
         State->GetTrimFreshLogToCommitId());
 
+    response->Record.MutableStats()->SetBlobsProcessedDuringCompaction(
+        State->GetBlobsProcessedDuringCompaction());
+
+    response->Record.MutableStats()->SetBlockMaskReadedDuringCompaction(
+        State->GetBlockMaskReadedDuringCompaction());
+
     LWTRACK(
         ResponseSent_Partition,
         requestInfo->CallContext->LWOrbit,

--- a/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writemixedblocks.cpp
@@ -285,7 +285,8 @@ void TWriteMixedBlocksActor::AddBlobs(const TActorContext& ctx)
         blobs.emplace_back(
             req.BlobId,
             std::move(blocks),
-            std::move(req.Checksums));
+            std::move(req.Checksums),
+            0);   // unknown blob alignment
     }
 
     auto request = std::make_unique<TEvPartitionPrivate::TEvAddBlobsRequest>(

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -167,8 +167,8 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::CompactionRangeCountOverlaped>(
-                    block.CompactionRangeCountOverlaped));
+                NIceDb::TUpdate<TTable::CompactionRangeCountOverlapped>(
+                    block.CompactionRangeCountOverlapped));
     } else {
         Table<TTable>()
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
@@ -176,15 +176,15 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
                 NIceDb::TUpdate<TTable::BlobCommitId>(block.BlobId.CommitId()),
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::CompactionRangeCountOverlaped>(
-                    block.CompactionRangeCountOverlaped));
+                NIceDb::TUpdate<TTable::CompactionRangeCountOverlapped>(
+                    block.CompactionRangeCountOverlapped));
     }
 }
 
 void TPartitionDatabase::WriteMixedBlocks(
     const TPartialBlobId& blobId,
     const TVector<ui32>& blocks,
-    ui8 compactionRangeCountOverlaped)
+    ui8 compactionRangeCountOverlapped)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
@@ -195,8 +195,8 @@ void TPartitionDatabase::WriteMixedBlocks(
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(blobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(blobOffset),
-                NIceDb::TUpdate<TTable::CompactionRangeCountOverlaped>(
-                    compactionRangeCountOverlaped));
+                NIceDb::TUpdate<TTable::CompactionRangeCountOverlapped>(
+                    compactionRangeCountOverlapped));
         ++blobOffset;
     }
 }
@@ -250,15 +250,15 @@ bool TPartitionDatabase::FindMixedBlocks(
                 it.GetValue<TTable::BlobId>());
 
             ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-            ui8 compactionRangeCountOverlaped =
-                it.GetValue<TTable::CompactionRangeCountOverlaped>();
+            ui8 compactionRangeCountOverlapped =
+                it.GetValue<TTable::CompactionRangeCountOverlapped>();
 
             if (!visitor.VisitBlock(
                     blockIndex,
                     commitId,
                     blobId,
                     blobOffset,
-                    compactionRangeCountOverlaped))
+                    compactionRangeCountOverlapped))
             {
                 return true;   // interrupted
             }
@@ -314,15 +314,15 @@ bool TPartitionDatabase::FindMixedBlocks(
                         it.GetValue<TTable::BlobId>());
 
                     ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-                    ui8 compactionRangeCountOverlaped =
-                        it.GetValue<TTable::CompactionRangeCountOverlaped>();
+                    ui8 compactionRangeCountOverlapped =
+                        it.GetValue<TTable::CompactionRangeCountOverlapped>();
 
                     if (!visitor.VisitBlock(
                             blockIndex,
                             commitId,
                             blobId,
                             blobOffset,
-                            compactionRangeCountOverlaped))
+                            compactionRangeCountOverlapped))
                     {
                         return true;    // interrupted
                     }

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -166,20 +166,23 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
-                NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset));
+                NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
+                NIceDb::TUpdate<TTable::BlobAlignment>(block.BlobAlignment));
     } else {
         Table<TTable>()
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
             .Update(
                 NIceDb::TUpdate<TTable::BlobCommitId>(block.BlobId.CommitId()),
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
-                NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset));
+                NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
+                NIceDb::TUpdate<TTable::BlobAlignment>(block.BlobAlignment));
     }
 }
 
 void TPartitionDatabase::WriteMixedBlocks(
     const TPartialBlobId& blobId,
-    const TVector<ui32>& blocks)
+    const TVector<ui32>& blocks,
+    ui32 blobAlignment)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
@@ -189,7 +192,8 @@ void TPartitionDatabase::WriteMixedBlocks(
             .Key(blockIndex, ReverseCommitId(blobId.CommitId()))
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(blobId.UniqueId()),
-                NIceDb::TUpdate<TTable::BlobOffset>(blobOffset));
+                NIceDb::TUpdate<TTable::BlobOffset>(blobOffset),
+                NIceDb::TUpdate<TTable::BlobAlignment>(blobAlignment));
         ++blobOffset;
     }
 }
@@ -204,7 +208,7 @@ void TPartitionDatabase::DeleteMixedBlock(ui32 blockIndex, ui64 commitId)
 }
 
 bool TPartitionDatabase::FindMixedBlocks(
-    IBlocksIndexVisitor& visitor,
+    IMixedBlocksIndexVisitor& visitor,
     const TBlockRange32& readRange,
     bool precharge,
     ui64 maxCommitId)
@@ -243,8 +247,15 @@ bool TPartitionDatabase::FindMixedBlocks(
                 it.GetValue<TTable::BlobId>());
 
             ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
+            ui32 blobAlignment = it.GetValue<TTable::BlobAlignment>();
 
-            if (!visitor.Visit(blockIndex, commitId, blobId, blobOffset)) {
+            if (!visitor.VisitBlock(
+                    blockIndex,
+                    commitId,
+                    blobId,
+                    blobOffset,
+                    blobAlignment))
+            {
                 return true;    // interrupted
             }
         }
@@ -260,7 +271,7 @@ bool TPartitionDatabase::FindMixedBlocks(
 }
 
 bool TPartitionDatabase::FindMixedBlocks(
-    IBlocksIndexVisitor& visitor,
+    IMixedBlocksIndexVisitor& visitor,
     const TVector<ui32>& blocks,
     ui64 maxCommitId)
 {
@@ -299,8 +310,15 @@ bool TPartitionDatabase::FindMixedBlocks(
                         it.GetValue<TTable::BlobId>());
 
                     ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
+                    ui32 blobAlignment = it.GetValue<TTable::BlobAlignment>();
 
-                    if (!visitor.Visit(blockIndex, commitId, blobId, blobOffset)) {
+                    if (!visitor.VisitBlock(
+                            blockIndex,
+                            commitId,
+                            blobId,
+                            blobOffset,
+                            blobAlignment))
+                    {
                         return true;    // interrupted
                     }
                 }

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -61,6 +61,19 @@ ui16 ProcessCompactionCounter(ui32 value)
     return value > Max<ui16>() ? Max<ui16>() : value;
 }
 
+ui32 UnifyBlobOffsetAndCompactionRangeCountOverlapped(
+    ui16 blobOffset,
+    ui8 compactionRangeCountOverlapped)
+{
+    return ui32{compactionRangeCountOverlapped} << 16 | blobOffset;
+}
+
+std::pair<ui16, ui8> SplitBlobOffsetAndCompactionRangeCountOverlapped(
+    ui32 value)
+{
+    return {value & Max<ui16>(), value >> 16};
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -161,23 +174,28 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
+    const ui32 blobOffsetAndCompactionRangeCountOverlapped =
+        UnifyBlobOffsetAndCompactionRangeCountOverlapped(
+            block.BlobOffset,
+            block.CompactionRangeCountOverlapped);
+
     if (block.CommitId == block.BlobId.CommitId()) {
         Table<TTable>()
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
-                NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::CompactionRangeCountOverlapped>(
-                    block.CompactionRangeCountOverlapped));
+                NIceDb::TUpdate<
+                    TTable::BlobOffsetAndCompactionRangeCountOverlapped>(
+                    blobOffsetAndCompactionRangeCountOverlapped));
     } else {
         Table<TTable>()
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
             .Update(
                 NIceDb::TUpdate<TTable::BlobCommitId>(block.BlobId.CommitId()),
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
-                NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::CompactionRangeCountOverlapped>(
-                    block.CompactionRangeCountOverlapped));
+                NIceDb::TUpdate<
+                    TTable::BlobOffsetAndCompactionRangeCountOverlapped>(
+                    blobOffsetAndCompactionRangeCountOverlapped));
     }
 }
 
@@ -190,13 +208,18 @@ void TPartitionDatabase::WriteMixedBlocks(
 
     ui16 blobOffset = 0;
     for (ui32 blockIndex: blocks) {
+        const ui32 blobOffsetAndCompactionRangeCountOverlapped =
+            UnifyBlobOffsetAndCompactionRangeCountOverlapped(
+                blobOffset,
+                compactionRangeCountOverlapped);
+
         Table<TTable>()
             .Key(blockIndex, ReverseCommitId(blobId.CommitId()))
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(blobId.UniqueId()),
-                NIceDb::TUpdate<TTable::BlobOffset>(blobOffset),
-                NIceDb::TUpdate<TTable::CompactionRangeCountOverlapped>(
-                    compactionRangeCountOverlapped));
+                NIceDb::TUpdate<
+                    TTable::BlobOffsetAndCompactionRangeCountOverlapped>(
+                    blobOffsetAndCompactionRangeCountOverlapped));
         ++blobOffset;
     }
 }
@@ -249,9 +272,11 @@ bool TPartitionDatabase::FindMixedBlocks(
                 blobCommitId ? blobCommitId : commitId,
                 it.GetValue<TTable::BlobId>());
 
-            ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-            ui8 compactionRangeCountOverlapped =
-                it.GetValue<TTable::CompactionRangeCountOverlapped>();
+            ui32 blobOffsetAndCompactionRangeCountOverlapped = it.GetValue<
+                TTable::BlobOffsetAndCompactionRangeCountOverlapped>();
+            auto [blobOffset, compactionRangeCountOverlapped] =
+                SplitBlobOffsetAndCompactionRangeCountOverlapped(
+                    blobOffsetAndCompactionRangeCountOverlapped);
 
             if (!visitor.VisitBlock(
                     blockIndex,
@@ -313,9 +338,13 @@ bool TPartitionDatabase::FindMixedBlocks(
                         blobCommitId ? blobCommitId : commitId,
                         it.GetValue<TTable::BlobId>());
 
-                    ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-                    ui8 compactionRangeCountOverlapped =
-                        it.GetValue<TTable::CompactionRangeCountOverlapped>();
+                    ui32 blobOffsetAndCompactionRangeCountOverlapped =
+                        it.GetValue<
+                            TTable::
+                                BlobOffsetAndCompactionRangeCountOverlapped>();
+                    auto [blobOffset, compactionRangeCountOverlapped] =
+                        SplitBlobOffsetAndCompactionRangeCountOverlapped(
+                            blobOffsetAndCompactionRangeCountOverlapped);
 
                     if (!visitor.VisitBlock(
                             blockIndex,

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -61,14 +61,14 @@ ui16 ProcessCompactionCounter(ui32 value)
     return value > Max<ui16>() ? Max<ui16>() : value;
 }
 
-ui32 UnifyBlobOffsetAndCompactionRangeCountOverlapped(
+ui32 UnifyBlobOffsetAndCompactionRangeCount(
     ui16 blobOffset,
-    ui8 compactionRangeCountOverlapped)
+    ui8 compactionRangeCount)
 {
-    return ui32{compactionRangeCountOverlapped} << 16 | blobOffset;
+    return ui32{compactionRangeCount} << 16 | blobOffset;
 }
 
-std::pair<ui16, ui8> SplitBlobOffsetAndCompactionRangeCountOverlapped(
+std::pair<ui16, ui8> SplitBlobOffsetAndCompactionRangeCount(
     ui32 value)
 {
     return {value & Max<ui16>(), value >> 16};
@@ -174,10 +174,10 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
-    const ui32 blobOffsetAndCompactionRangeCountOverlapped =
-        UnifyBlobOffsetAndCompactionRangeCountOverlapped(
+    const ui32 blobOffsetAndCompactionRangeCount =
+        UnifyBlobOffsetAndCompactionRangeCount(
             block.BlobOffset,
-            block.CompactionRangeCountOverlapped);
+            block.CompactionRangeCount);
 
     if (block.CommitId == block.BlobId.CommitId()) {
         Table<TTable>()
@@ -185,8 +185,8 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<
-                    TTable::BlobOffsetAndCompactionRangeCountOverlapped>(
-                    blobOffsetAndCompactionRangeCountOverlapped));
+                    TTable::BlobOffsetAndCompactionRangeCount>(
+                    blobOffsetAndCompactionRangeCount));
     } else {
         Table<TTable>()
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
@@ -194,32 +194,32 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
                 NIceDb::TUpdate<TTable::BlobCommitId>(block.BlobId.CommitId()),
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<
-                    TTable::BlobOffsetAndCompactionRangeCountOverlapped>(
-                    blobOffsetAndCompactionRangeCountOverlapped));
+                    TTable::BlobOffsetAndCompactionRangeCount>(
+                    blobOffsetAndCompactionRangeCount));
     }
 }
 
 void TPartitionDatabase::WriteMixedBlocks(
     const TPartialBlobId& blobId,
     const TVector<ui32>& blocks,
-    ui8 compactionRangeCountOverlapped)
+    ui8 compactionRangeCount)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
     ui16 blobOffset = 0;
     for (ui32 blockIndex: blocks) {
-        const ui32 blobOffsetAndCompactionRangeCountOverlapped =
-            UnifyBlobOffsetAndCompactionRangeCountOverlapped(
+        const ui32 blobOffsetAndCompactionRangeCount =
+            UnifyBlobOffsetAndCompactionRangeCount(
                 blobOffset,
-                compactionRangeCountOverlapped);
+                compactionRangeCount);
 
         Table<TTable>()
             .Key(blockIndex, ReverseCommitId(blobId.CommitId()))
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(blobId.UniqueId()),
                 NIceDb::TUpdate<
-                    TTable::BlobOffsetAndCompactionRangeCountOverlapped>(
-                    blobOffsetAndCompactionRangeCountOverlapped));
+                    TTable::BlobOffsetAndCompactionRangeCount>(
+                    blobOffsetAndCompactionRangeCount));
         ++blobOffset;
     }
 }
@@ -272,18 +272,18 @@ bool TPartitionDatabase::FindMixedBlocks(
                 blobCommitId ? blobCommitId : commitId,
                 it.GetValue<TTable::BlobId>());
 
-            ui32 blobOffsetAndCompactionRangeCountOverlapped = it.GetValue<
-                TTable::BlobOffsetAndCompactionRangeCountOverlapped>();
-            auto [blobOffset, compactionRangeCountOverlapped] =
-                SplitBlobOffsetAndCompactionRangeCountOverlapped(
-                    blobOffsetAndCompactionRangeCountOverlapped);
+            ui32 blobOffsetAndCompactionRangeCount = it.GetValue<
+                TTable::BlobOffsetAndCompactionRangeCount>();
+            auto [blobOffset, compactionRangeCount] =
+                SplitBlobOffsetAndCompactionRangeCount(
+                    blobOffsetAndCompactionRangeCount);
 
             if (!visitor.VisitBlock(
                     blockIndex,
                     commitId,
                     blobId,
                     blobOffset,
-                    compactionRangeCountOverlapped))
+                    compactionRangeCount))
             {
                 return true;   // interrupted
             }
@@ -338,20 +338,20 @@ bool TPartitionDatabase::FindMixedBlocks(
                         blobCommitId ? blobCommitId : commitId,
                         it.GetValue<TTable::BlobId>());
 
-                    ui32 blobOffsetAndCompactionRangeCountOverlapped =
+                    ui32 blobOffsetAndCompactionRangeCount =
                         it.GetValue<
                             TTable::
-                                BlobOffsetAndCompactionRangeCountOverlapped>();
-                    auto [blobOffset, compactionRangeCountOverlapped] =
-                        SplitBlobOffsetAndCompactionRangeCountOverlapped(
-                            blobOffsetAndCompactionRangeCountOverlapped);
+                                BlobOffsetAndCompactionRangeCount>();
+                    auto [blobOffset, compactionRangeCount] =
+                        SplitBlobOffsetAndCompactionRangeCount(
+                            blobOffsetAndCompactionRangeCount);
 
                     if (!visitor.VisitBlock(
                             blockIndex,
                             commitId,
                             blobId,
                             blobOffset,
-                            compactionRangeCountOverlapped))
+                            compactionRangeCount))
                     {
                         return true;    // interrupted
                     }

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -167,8 +167,8 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::EnclosingCompactionRangeSize>(
-                    block.EnclosingCompactionRangeSize));
+                NIceDb::TUpdate<TTable::CompactionRangeCountOverlaped>(
+                    block.CompactionRangeCountOverlaped));
     } else {
         Table<TTable>()
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
@@ -176,15 +176,15 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
                 NIceDb::TUpdate<TTable::BlobCommitId>(block.BlobId.CommitId()),
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::EnclosingCompactionRangeSize>(
-                    block.EnclosingCompactionRangeSize));
+                NIceDb::TUpdate<TTable::CompactionRangeCountOverlaped>(
+                    block.CompactionRangeCountOverlaped));
     }
 }
 
 void TPartitionDatabase::WriteMixedBlocks(
     const TPartialBlobId& blobId,
     const TVector<ui32>& blocks,
-    ui32 enclosingCompactionRangeSize)
+    ui8 compactionRangeCountOverlaped)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
@@ -195,8 +195,8 @@ void TPartitionDatabase::WriteMixedBlocks(
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(blobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(blobOffset),
-                NIceDb::TUpdate<TTable::EnclosingCompactionRangeSize>(
-                    enclosingCompactionRangeSize));
+                NIceDb::TUpdate<TTable::CompactionRangeCountOverlaped>(
+                    compactionRangeCountOverlaped));
         ++blobOffset;
     }
 }
@@ -250,15 +250,15 @@ bool TPartitionDatabase::FindMixedBlocks(
                 it.GetValue<TTable::BlobId>());
 
             ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-            ui32 enclosingCompactionRangeSize =
-                it.GetValue<TTable::EnclosingCompactionRangeSize>();
+            ui8 compactionRangeCountOverlaped =
+                it.GetValue<TTable::CompactionRangeCountOverlaped>();
 
             if (!visitor.VisitBlock(
                     blockIndex,
                     commitId,
                     blobId,
                     blobOffset,
-                    enclosingCompactionRangeSize))
+                    compactionRangeCountOverlaped))
             {
                 return true;   // interrupted
             }
@@ -314,15 +314,15 @@ bool TPartitionDatabase::FindMixedBlocks(
                         it.GetValue<TTable::BlobId>());
 
                     ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-                    ui32 enclosingCompactionRangeSize =
-                        it.GetValue<TTable::EnclosingCompactionRangeSize>();
+                    ui8 compactionRangeCountOverlaped =
+                        it.GetValue<TTable::CompactionRangeCountOverlaped>();
 
                     if (!visitor.VisitBlock(
                             blockIndex,
                             commitId,
                             blobId,
                             blobOffset,
-                            enclosingCompactionRangeSize))
+                            compactionRangeCountOverlaped))
                     {
                         return true;    // interrupted
                     }

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -167,7 +167,8 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::BlobAlignment>(block.BlobAlignment));
+                NIceDb::TUpdate<TTable::EnclosingCompactionRangeSize>(
+                    block.EnclosingCompactionRangeSize));
     } else {
         Table<TTable>()
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
@@ -175,14 +176,15 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
                 NIceDb::TUpdate<TTable::BlobCommitId>(block.BlobId.CommitId()),
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(block.BlobOffset),
-                NIceDb::TUpdate<TTable::BlobAlignment>(block.BlobAlignment));
+                NIceDb::TUpdate<TTable::EnclosingCompactionRangeSize>(
+                    block.EnclosingCompactionRangeSize));
     }
 }
 
 void TPartitionDatabase::WriteMixedBlocks(
     const TPartialBlobId& blobId,
     const TVector<ui32>& blocks,
-    ui32 blobAlignment)
+    ui32 enclosingCompactionRangeSize)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
@@ -193,7 +195,8 @@ void TPartitionDatabase::WriteMixedBlocks(
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(blobId.UniqueId()),
                 NIceDb::TUpdate<TTable::BlobOffset>(blobOffset),
-                NIceDb::TUpdate<TTable::BlobAlignment>(blobAlignment));
+                NIceDb::TUpdate<TTable::EnclosingCompactionRangeSize>(
+                    enclosingCompactionRangeSize));
         ++blobOffset;
     }
 }
@@ -247,16 +250,17 @@ bool TPartitionDatabase::FindMixedBlocks(
                 it.GetValue<TTable::BlobId>());
 
             ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-            ui32 blobAlignment = it.GetValue<TTable::BlobAlignment>();
+            ui32 enclosingCompactionRangeSize =
+                it.GetValue<TTable::EnclosingCompactionRangeSize>();
 
             if (!visitor.VisitBlock(
                     blockIndex,
                     commitId,
                     blobId,
                     blobOffset,
-                    blobAlignment))
+                    enclosingCompactionRangeSize))
             {
-                return true;    // interrupted
+                return true;   // interrupted
             }
         }
 
@@ -310,14 +314,15 @@ bool TPartitionDatabase::FindMixedBlocks(
                         it.GetValue<TTable::BlobId>());
 
                     ui16 blobOffset = it.GetValue<TTable::BlobOffset>();
-                    ui32 blobAlignment = it.GetValue<TTable::BlobAlignment>();
+                    ui32 enclosingCompactionRangeSize =
+                        it.GetValue<TTable::EnclosingCompactionRangeSize>();
 
                     if (!visitor.VisitBlock(
                             blockIndex,
                             commitId,
                             blobId,
                             blobOffset,
-                            blobAlignment))
+                            enclosingCompactionRangeSize))
                     {
                         return true;    // interrupted
                     }

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -72,7 +72,7 @@ public:
     void WriteMixedBlocks(
         const TPartialBlobId& blobId,
         const TVector<ui32>& blocks,
-        ui32 blobAlignment);
+        ui32 enclosingCompactionRangeSize);
 
     void DeleteMixedBlock(ui32 blockIndex, ui64 commitId);
 

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -72,7 +72,7 @@ public:
     void WriteMixedBlocks(
         const TPartialBlobId& blobId,
         const TVector<ui32>& blocks,
-        ui8 compactionRangeCountOverlapped);
+        ui8 compactionRangeCount);
 
     void DeleteMixedBlock(ui32 blockIndex, ui64 commitId);
 

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -71,18 +71,19 @@ public:
 
     void WriteMixedBlocks(
         const TPartialBlobId& blobId,
-        const TVector<ui32>& blocks);
+        const TVector<ui32>& blocks,
+        ui32 blobAlignment);
 
     void DeleteMixedBlock(ui32 blockIndex, ui64 commitId);
 
     bool FindMixedBlocks(
-        IBlocksIndexVisitor& visitor,
+        IMixedBlocksIndexVisitor& visitor,
         const TBlockRange32& readRange,
         bool precharge,
         ui64 maxCommitId = Max());
 
     bool FindMixedBlocks(
-        IBlocksIndexVisitor& visitor,
+        IMixedBlocksIndexVisitor& visitor,
         const TVector<ui32>& blocks,
         ui64 maxCommitId = Max());
 

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -72,7 +72,7 @@ public:
     void WriteMixedBlocks(
         const TPartialBlobId& blobId,
         const TVector<ui32>& blocks,
-        ui32 enclosingCompactionRangeSize);
+        ui8 compactionRangeCountOverlaped);
 
     void DeleteMixedBlock(ui32 blockIndex, ui64 commitId);
 

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -72,7 +72,7 @@ public:
     void WriteMixedBlocks(
         const TPartialBlobId& blobId,
         const TVector<ui32>& blocks,
-        ui8 compactionRangeCountOverlaped);
+        ui8 compactionRangeCountOverlapped);
 
     void DeleteMixedBlock(ui32 blockIndex, ui64 commitId);
 

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -59,7 +59,7 @@ struct TTestBlockVisitor final
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlaped) override
+        ui8 compactionRangeCountOverlapped) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
@@ -68,7 +68,7 @@ struct TTestBlockVisitor final
             Result << " ";
         }
         Result << "#" << blockIndex << ":" << CommitId2Str(commitId) << ":"
-               << ui32{compactionRangeCountOverlaped};
+               << ui32{compactionRangeCountOverlapped};
         return true;
     }
 };

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -59,7 +59,7 @@ struct TTestBlockVisitor final
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 blobAlignment) override
+        ui32 enclosingCompactionRangeSize) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
@@ -68,7 +68,7 @@ struct TTestBlockVisitor final
             Result << " ";
         }
         Result << "#" << blockIndex << ":" << CommitId2Str(commitId) << ":"
-               << blobAlignment;
+               << enclosingCompactionRangeSize;
         return true;
     }
 };

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -59,7 +59,7 @@ struct TTestBlockVisitor final
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui32 enclosingCompactionRangeSize) override
+        ui8 compactionRangeCountOverlaped) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
@@ -68,7 +68,7 @@ struct TTestBlockVisitor final
             Result << " ";
         }
         Result << "#" << blockIndex << ":" << CommitId2Str(commitId) << ":"
-               << enclosingCompactionRangeSize;
+               << ui32{compactionRangeCountOverlaped};
         return true;
     }
 };

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -26,6 +26,7 @@ TString CommitId2Str(ui64 commitId)
 struct TTestBlockVisitor final
     : public IBlocksIndexVisitor
     , public IBlobsVisitor
+    , public IMixedBlocksIndexVisitor
 {
     TStringBuilder Result;
     THashMap<TPartialBlobId, TBlockRange32, TPartialBlobIdHash> BlobToRange;
@@ -50,6 +51,24 @@ struct TTestBlockVisitor final
             Result << " ";
         }
         Result << "#" << blockIndex << ":" << CommitId2Str(commitId);
+        return true;
+    }
+
+    bool VisitBlock(
+        ui32 blockIndex,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui16 blobOffset,
+        ui32 blobAlignment) override
+    {
+        Y_UNUSED(blobId);
+        Y_UNUSED(blobOffset);
+
+        if (Result) {
+            Result << " ";
+        }
+        Result << "#" << blockIndex << ":" << CommitId2Str(commitId) << ":"
+               << blobAlignment;
         return true;
     }
 };
@@ -179,29 +198,26 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
             db.InitSchema();
         });
 
-        executor.WriteTx([&] (TPartitionDatabase db) {
-            db.WriteMixedBlocks(
-                executor.MakeBlobId(),
-                {0, 1, 2});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            { db.WriteMixedBlocks(executor.MakeBlobId(), {0, 1, 2}, 12); });
 
-        executor.WriteTx([&] (TPartitionDatabase db) {
-            db.WriteMixedBlocks(
-                executor.MakeBlobId(),
-                {4, 5, 6});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            { db.WriteMixedBlocks(executor.MakeBlobId(), {4, 5, 6}, 13); });
 
-        ui64 maxCommitId = executor.WriteTx([&] (TPartitionDatabase db) {
-            db.WriteMixedBlocks(
-                executor.MakeBlobId(),
-                {2, 3, 4});
-        });
+        ui64 maxCommitId = executor.WriteTx(
+            [&](TPartitionDatabase db)
+            { db.WriteMixedBlocks(executor.MakeBlobId(), {2, 3, 4}, 14); });
 
-        executor.WriteTx([&] (TPartitionDatabase db) {
-            db.WriteMixedBlocks(
-                executor.MakeBlobId(),
-                {0, 1, 2, 3, 4, 5, 6});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                db.WriteMixedBlocks(
+                    executor.MakeBlobId(),
+                    {0, 1, 2, 3, 4, 5, 6},
+                    15);
+            });
 
         executor.ReadTx([&] (TPartitionDatabase db) {
             {
@@ -212,7 +228,7 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                     true,   // precharge
                     maxCommitId
                 ));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#0:2 #1:2");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#0:2:12 #1:2:12");
             }
             {
                 TTestBlockVisitor visitor;
@@ -222,7 +238,7 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                     true,   // precharge
                     maxCommitId
                 ));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#5:3 #6:3");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#5:3:13 #6:3:13");
             }
             {
                 TTestBlockVisitor visitor;
@@ -232,7 +248,9 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                     true,   // precharge
                     maxCommitId
                 ));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#2:4 #2:2 #3:4");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    visitor.Result,
+                    "#2:4:14 #2:2:12 #3:4:14");
             }
             {
                 TTestBlockVisitor visitor;
@@ -242,7 +260,9 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                     true,   // precharge
                     maxCommitId
                 ));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#3:4 #4:4 #4:3");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    visitor.Result,
+                    "#3:4:14 #4:4:14 #4:3:13");
             }
             {
                 TTestBlockVisitor visitor;
@@ -252,7 +272,9 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                     true,   // precharge
                     maxCommitId
                 ));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#1:2 #2:4 #2:2 #3:4 #4:4 #4:3 #5:3");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    visitor.Result,
+                    "#1:2:12 #2:4:14 #2:2:12 #3:4:14 #4:4:14 #4:3:13 #5:3:13");
             }
             {
                 TTestBlockVisitor visitor;
@@ -261,7 +283,10 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                     TBlockRange32::MakeClosedInterval(1, 5),
                     true    // precharge
                 ));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#1:5 #1:2 #2:5 #2:4 #2:2 #3:5 #3:4 #4:5 #4:4 #4:3 #5:5 #5:3");
+                UNIT_ASSERT_VALUES_EQUAL(
+                    visitor.Result,
+                    "#1:5:15 #1:2:12 #2:5:15 #2:4:14 #2:2:12 #3:5:15 #3:4:14 #4:5:15 "
+                    "#4:4:14 #4:3:13 #5:5:15 #5:3:13");
             }
         });
     }
@@ -276,57 +301,57 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
         executor.WriteTx([&] (TPartitionDatabase db) {
             db.WriteMixedBlocks(
                 executor.MakeBlobId(),
-                {0, 1, 2});
+                {0, 1, 2}, 12);
         });
 
         executor.WriteTx([&] (TPartitionDatabase db) {
             db.WriteMixedBlocks(
                 executor.MakeBlobId(),
-                {4, 5, 6});
+                {4, 5, 6}, 13);
         });
 
         ui64 maxCommitId = executor.WriteTx([&] (TPartitionDatabase db) {
             db.WriteMixedBlocks(
                 executor.MakeBlobId(),
-                {2, 3, 4});
+                {2, 3, 4}, 14);
         });
 
         executor.WriteTx([&] (TPartitionDatabase db) {
             db.WriteMixedBlocks(
                 executor.MakeBlobId(),
-                {0, 1, 2, 3, 4, 5, 6});
+                {0, 1, 2, 3, 4, 5, 6}, 15);
         });
 
         executor.ReadTx([&] (TPartitionDatabase db) {
             {
                 TTestBlockVisitor visitor;
                 UNIT_ASSERT(db.FindMixedBlocks(visitor, TVector<ui32>{0, 1}, maxCommitId));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#0:2 #1:2");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#0:2:12 #1:2:12");
             }
             {
                 TTestBlockVisitor visitor;
                 UNIT_ASSERT(db.FindMixedBlocks(visitor, TVector<ui32>{5, 6}, maxCommitId));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#5:3 #6:3");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#5:3:13 #6:3:13");
             }
             {
                 TTestBlockVisitor visitor;
                 UNIT_ASSERT(db.FindMixedBlocks(visitor, TVector<ui32>{2, 3}, maxCommitId));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#2:4 #2:2 #3:4");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#2:4:14 #2:2:12 #3:4:14");
             }
             {
                 TTestBlockVisitor visitor;
                 UNIT_ASSERT(db.FindMixedBlocks(visitor, TVector<ui32>{3, 4}, maxCommitId));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#3:4 #4:4 #4:3");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#3:4:14 #4:4:14 #4:3:13");
             }
             {
                 TTestBlockVisitor visitor;
                 UNIT_ASSERT(db.FindMixedBlocks(visitor, TVector<ui32>{1, 3, 5}, maxCommitId));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#1:2 #3:4 #5:3");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#1:2:12 #3:4:14 #5:3:13");
             }
             {
                 TTestBlockVisitor visitor;
                 UNIT_ASSERT(db.FindMixedBlocks(visitor, TVector<ui32>{1, 3, 5}));
-                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#1:5 #1:2 #3:5 #3:4 #5:5 #5:3");
+                UNIT_ASSERT_VALUES_EQUAL(visitor.Result, "#1:5:15 #1:2:12 #3:5:15 #3:4:14 #5:5:15 #5:3:13");
             }
         });
     }

--- a/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database_ut.cpp
@@ -59,7 +59,7 @@ struct TTestBlockVisitor final
         ui64 commitId,
         const TPartialBlobId& blobId,
         ui16 blobOffset,
-        ui8 compactionRangeCountOverlapped) override
+        ui8 compactionRangeCount) override
     {
         Y_UNUSED(blobId);
         Y_UNUSED(blobOffset);
@@ -68,7 +68,7 @@ struct TTestBlockVisitor final
             Result << " ";
         }
         Result << "#" << blockIndex << ":" << CommitId2Str(commitId) << ":"
-               << ui32{compactionRangeCountOverlapped};
+               << ui32{compactionRangeCount};
         return true;
     }
 };

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -51,17 +51,17 @@ struct TAddMixedBlob
     const TPartialBlobId BlobId;
     const TVector<ui32> Blocks;
     const TVector<ui32> Checksums;
-    const ui8 CompactionRangeCountOverlaped = 0;
+    const ui8 CompactionRangeCountOverlapped = 0;
 
     TAddMixedBlob(
             const TPartialBlobId& blobId,
             TVector<ui32> blocks,
             TVector<ui32> checksums,
-            ui8 compactionRangeCountOverlaped)
+            ui8 compactionRangeCountOverlapped)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
+        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
     {}
 };
 
@@ -93,17 +93,17 @@ struct TAddFreshBlob
     const TPartialBlobId BlobId;
     const TVector<TBlock> Blocks;
     const TVector<ui32> Checksums;
-    const ui8 CompactionRangeCountOverlaped = 0;
+    const ui8 CompactionRangeCountOverlapped = 0;
 
     TAddFreshBlob(
             const TPartialBlobId& blobId,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui8 compactionRangeCountOverlaped)
+            ui8 compactionRangeCountOverlapped)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
+        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
     {}
 };
 
@@ -127,7 +127,7 @@ struct TAffectedBlob
     // All blocks in the blob contained in BlobRangeHint. Actual blob range can
     // be smaller.
     TBlockRange32 BlobRangeHint = TBlockRange32::Max();
-    ui8 CompactionRangeCountOverlaped = 0;
+    ui8 CompactionRangeCountOverlapped = 0;
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;
     TVector<ui32> AffectedBlockIndices;

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -51,17 +51,17 @@ struct TAddMixedBlob
     const TPartialBlobId BlobId;
     const TVector<ui32> Blocks;
     const TVector<ui32> Checksums;
-    const ui32 EnclosingCompactionRangeSize = 0;
+    const ui8 CompactionRangeCountOverlaped = 0;
 
     TAddMixedBlob(
             const TPartialBlobId& blobId,
             TVector<ui32> blocks,
             TVector<ui32> checksums,
-            ui32 enclosingCompactionRangeSize)
+            ui8 compactionRangeCountOverlaped)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
+        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
     {}
 };
 
@@ -93,17 +93,17 @@ struct TAddFreshBlob
     const TPartialBlobId BlobId;
     const TVector<TBlock> Blocks;
     const TVector<ui32> Checksums;
-    const ui32 EnclosingCompactionRangeSize = 0;
+    const ui8 CompactionRangeCountOverlaped = 0;
 
     TAddFreshBlob(
             const TPartialBlobId& blobId,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui32 enclosingCompactionRangeSize)
+            ui8 compactionRangeCountOverlaped)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
+        , CompactionRangeCountOverlaped(compactionRangeCountOverlaped)
     {}
 };
 
@@ -127,7 +127,7 @@ struct TAffectedBlob
     // All blocks in the blob contained in BlobRangeHint. Actual blob range can
     // be smaller.
     TBlockRange32 BlobRangeHint = TBlockRange32::Max();
-    ui32 EnclosingCompactionRangeSize = 0;
+    ui8 CompactionRangeCountOverlaped = 0;
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;
     TVector<ui32> AffectedBlockIndices;

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -51,14 +51,17 @@ struct TAddMixedBlob
     const TPartialBlobId BlobId;
     const TVector<ui32> Blocks;
     const TVector<ui32> Checksums;
+    const ui32 BlobAlignment = 0;
 
     TAddMixedBlob(
             const TPartialBlobId& blobId,
             TVector<ui32> blocks,
-            TVector<ui32> checksums)
+            TVector<ui32> checksums,
+            ui32 blobAlignment)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
+        , BlobAlignment(blobAlignment)
     {}
 };
 
@@ -90,14 +93,17 @@ struct TAddFreshBlob
     const TPartialBlobId BlobId;
     const TVector<TBlock> Blocks;
     const TVector<ui32> Checksums;
+    const ui32 BlobAlignment = 0;
 
     TAddFreshBlob(
             const TPartialBlobId& blobId,
             TVector<TBlock> blocks,
-            TVector<ui32> checksums)
+            TVector<ui32> checksums,
+            ui32 blobAlignment)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
+        , BlobAlignment(blobAlignment)
     {}
 };
 
@@ -121,6 +127,7 @@ struct TAffectedBlob
     // All blocks in the blob contained in BlobRangeHint. Actual blob range can
     // be smaller.
     TBlockRange32 BlobRangeHint = TBlockRange32::Max();
+    ui32 BlobAlignment = 0;
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;
     TVector<ui32> AffectedBlockIndices;

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -51,17 +51,17 @@ struct TAddMixedBlob
     const TPartialBlobId BlobId;
     const TVector<ui32> Blocks;
     const TVector<ui32> Checksums;
-    const ui8 CompactionRangeCountOverlapped = 0;
+    const ui8 CompactionRangeCount = 0;
 
     TAddMixedBlob(
             const TPartialBlobId& blobId,
             TVector<ui32> blocks,
             TVector<ui32> checksums,
-            ui8 compactionRangeCountOverlapped)
+            ui8 compactionRangeCount)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
+        , CompactionRangeCount(compactionRangeCount)
     {}
 };
 
@@ -93,17 +93,17 @@ struct TAddFreshBlob
     const TPartialBlobId BlobId;
     const TVector<TBlock> Blocks;
     const TVector<ui32> Checksums;
-    const ui8 CompactionRangeCountOverlapped = 0;
+    const ui8 CompactionRangeCount = 0;
 
     TAddFreshBlob(
             const TPartialBlobId& blobId,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui8 compactionRangeCountOverlapped)
+            ui8 compactionRangeCount)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , CompactionRangeCountOverlapped(compactionRangeCountOverlapped)
+        , CompactionRangeCount(compactionRangeCount)
     {}
 };
 
@@ -127,7 +127,7 @@ struct TAffectedBlob
     // All blocks in the blob contained in BlobRangeHint. Actual blob range can
     // be smaller.
     TBlockRange32 BlobRangeHint = TBlockRange32::Max();
-    ui8 CompactionRangeCountOverlapped = 0;
+    ui8 CompactionRangeCount = 0;
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;
     TVector<ui32> AffectedBlockIndices;

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -124,9 +124,6 @@ struct TWriteFreshBlocksRequest
 
 struct TAffectedBlob
 {
-    // All blocks in the blob contained in BlobRangeHint. Actual blob range can
-    // be smaller.
-    TBlockRange32 BlobRangeHint = TBlockRange32::Max();
     ui8 CompactionRangeCount = 0;
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -51,17 +51,17 @@ struct TAddMixedBlob
     const TPartialBlobId BlobId;
     const TVector<ui32> Blocks;
     const TVector<ui32> Checksums;
-    const ui32 BlobAlignment = 0;
+    const ui32 EnclosingCompactionRangeSize = 0;
 
     TAddMixedBlob(
             const TPartialBlobId& blobId,
             TVector<ui32> blocks,
             TVector<ui32> checksums,
-            ui32 blobAlignment)
+            ui32 enclosingCompactionRangeSize)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , BlobAlignment(blobAlignment)
+        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
     {}
 };
 
@@ -93,17 +93,17 @@ struct TAddFreshBlob
     const TPartialBlobId BlobId;
     const TVector<TBlock> Blocks;
     const TVector<ui32> Checksums;
-    const ui32 BlobAlignment = 0;
+    const ui32 EnclosingCompactionRangeSize = 0;
 
     TAddFreshBlob(
             const TPartialBlobId& blobId,
             TVector<TBlock> blocks,
             TVector<ui32> checksums,
-            ui32 blobAlignment)
+            ui32 enclosingCompactionRangeSize)
         : BlobId(blobId)
         , Blocks(std::move(blocks))
         , Checksums(std::move(checksums))
-        , BlobAlignment(blobAlignment)
+        , EnclosingCompactionRangeSize(enclosingCompactionRangeSize)
     {}
 };
 
@@ -127,7 +127,7 @@ struct TAffectedBlob
     // All blocks in the blob contained in BlobRangeHint. Actual blob range can
     // be smaller.
     TBlockRange32 BlobRangeHint = TBlockRange32::Max();
-    ui32 BlobAlignment = 0;
+    ui32 EnclosingCompactionRangeSize = 0;
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;
     TVector<ui32> AffectedBlockIndices;

--- a/cloud/blockstore/libs/storage/partition/part_schema.h
+++ b/cloud/blockstore/libs/storage/partition/part_schema.h
@@ -111,7 +111,7 @@ struct TPartitionSchema
         {
         };
 
-        struct CompactionRangeCountOverlaped
+        struct CompactionRangeCountOverlapped
             : public Column<6, NKikimr::NScheme::NTypeIds::Uint8>
         {
         };
@@ -123,7 +123,7 @@ struct TPartitionSchema
             BlobCommitId,
             BlobId,
             BlobOffset,
-            CompactionRangeCountOverlaped>;
+            CompactionRangeCountOverlapped>;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
         using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;

--- a/cloud/blockstore/libs/storage/partition/part_schema.h
+++ b/cloud/blockstore/libs/storage/partition/part_schema.h
@@ -106,13 +106,8 @@ struct TPartitionSchema
         {
         };
 
-        struct BlobOffset
+        struct BlobOffsetAndCompactionRangeCountOverlapped
             : public Column<5, NKikimr::NScheme::NTypeIds::Uint32>
-        {
-        };
-
-        struct CompactionRangeCountOverlapped
-            : public Column<6, NKikimr::NScheme::NTypeIds::Uint8>
         {
         };
 
@@ -122,8 +117,7 @@ struct TPartitionSchema
             CommitId,
             BlobCommitId,
             BlobId,
-            BlobOffset,
-            CompactionRangeCountOverlapped>;
+            BlobOffsetAndCompactionRangeCountOverlapped>;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
         using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;

--- a/cloud/blockstore/libs/storage/partition/part_schema.h
+++ b/cloud/blockstore/libs/storage/partition/part_schema.h
@@ -111,8 +111,8 @@ struct TPartitionSchema
         {
         };
 
-        struct EnclosingCompactionRangeSize
-            : public Column<6, NKikimr::NScheme::NTypeIds::Uint32>
+        struct CompactionRangeCountOverlaped
+            : public Column<6, NKikimr::NScheme::NTypeIds::Uint8>
         {
         };
 
@@ -123,7 +123,7 @@ struct TPartitionSchema
             BlobCommitId,
             BlobId,
             BlobOffset,
-            EnclosingCompactionRangeSize>;
+            CompactionRangeCountOverlaped>;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
         using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;

--- a/cloud/blockstore/libs/storage/partition/part_schema.h
+++ b/cloud/blockstore/libs/storage/partition/part_schema.h
@@ -111,11 +111,10 @@ struct TPartitionSchema
         {
         };
 
-        struct BlobAlignment
+        struct EnclosingCompactionRangeSize
             : public Column<6, NKikimr::NScheme::NTypeIds::Uint32>
         {
         };
-
 
         using TKey = TableKey<BlockIndex, CommitId>;
         using TColumns = TableColumns<
@@ -124,7 +123,7 @@ struct TPartitionSchema
             BlobCommitId,
             BlobId,
             BlobOffset,
-            BlobAlignment>;
+            EnclosingCompactionRangeSize>;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
         using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;

--- a/cloud/blockstore/libs/storage/partition/part_schema.h
+++ b/cloud/blockstore/libs/storage/partition/part_schema.h
@@ -111,14 +111,20 @@ struct TPartitionSchema
         {
         };
 
+        struct BlobAlignment
+            : public Column<6, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
+
+
         using TKey = TableKey<BlockIndex, CommitId>;
         using TColumns = TableColumns<
             BlockIndex,
             CommitId,
             BlobCommitId,
             BlobId,
-            BlobOffset
-        >;
+            BlobOffset,
+            BlobAlignment>;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
         using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;

--- a/cloud/blockstore/libs/storage/partition/part_schema.h
+++ b/cloud/blockstore/libs/storage/partition/part_schema.h
@@ -106,7 +106,7 @@ struct TPartitionSchema
         {
         };
 
-        struct BlobOffsetAndCompactionRangeCountOverlapped
+        struct BlobOffsetAndCompactionRangeCount
             : public Column<5, NKikimr::NScheme::NTypeIds::Uint32>
         {
         };
@@ -117,7 +117,7 @@ struct TPartitionSchema
             CommitId,
             BlobCommitId,
             BlobId,
-            BlobOffsetAndCompactionRangeCountOverlapped>;
+            BlobOffsetAndCompactionRangeCount>;
 
         using StoragePolicy = TStoragePolicy<IndexChannel>;
         using CompactionPolicy = TCompactionPolicy<ECompactionPolicy::IndexTable>;

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -425,23 +425,21 @@ void TPartitionState::WriteMixedBlock(
 void TPartitionState::WriteMixedBlocks(
     TPartitionDatabase& db,
     const TPartialBlobId& blobId,
-    const TVector<ui32>& blockIndices)
+    const TVector<ui32>& blockIndices,
+    ui32 blobAlignment)
 {
     const ui64 commitId = blobId.CommitId();
     ui16 blobOffset = 0;
 
     for (const ui32 blockIndex: blockIndices) {
         const ui32 rangeIdx = CompactionMap.GetRangeIndex(blockIndex);
-        MixedIndexCache.InsertBlockIfHot(rangeIdx, {
-            blobId,
-            commitId,
-            blockIndex,
-            blobOffset
-        });
+        MixedIndexCache.InsertBlockIfHot(
+            rangeIdx,
+            {blobId, commitId, blockIndex, blobOffset, blobAlignment});
         ++blobOffset;
     }
 
-    db.WriteMixedBlocks(blobId, blockIndices);
+    db.WriteMixedBlocks(blobId, blockIndices, blobAlignment);
 }
 
 void TPartitionState::DeleteMixedBlock(
@@ -456,7 +454,7 @@ void TPartitionState::DeleteMixedBlock(
 
 bool TPartitionState::FindMixedBlocksForCompaction(
     TPartitionDatabase& db,
-    IBlocksIndexVisitor& visitor,
+    IMixedBlocksIndexVisitor& visitor,
     ui32 rangeIdx)
 {
     if (MixedIndexCache.VisitBlocksIfHot(rangeIdx, visitor)) {
@@ -466,29 +464,35 @@ bool TPartitionState::FindMixedBlocksForCompaction(
 
     auto cacheInserter = MixedIndexCache.GetInserterForRange(rangeIdx);
 
-    struct TVisitorAndCacheInserter final
-        : public IBlocksIndexVisitor
+    struct TVisitorAndCacheInserter final: public IMixedBlocksIndexVisitor
     {
-        IBlocksIndexVisitor& Visitor;
+        IMixedBlocksIndexVisitor& Visitor;
         TMixedIndexCache::TInserterPtr CacheInserter;
 
         TVisitorAndCacheInserter(
-                IBlocksIndexVisitor& visitor,
-                TMixedIndexCache::TInserterPtr cacheInserter)
+            IMixedBlocksIndexVisitor& visitor,
+            TMixedIndexCache::TInserterPtr cacheInserter)
             : Visitor(visitor)
             , CacheInserter(std::move(cacheInserter))
         {}
 
-        bool Visit(
+        bool VisitBlock(
             ui32 blockIndex,
             ui64 commitId,
             const TPartialBlobId& blobId,
-            ui16 blobOffset) override
+            ui16 blobOffset,
+            ui32 blobAlignment) override
         {
-            bool ok = Visitor.Visit(blockIndex, commitId, blobId, blobOffset);
+            bool ok = Visitor.VisitBlock(
+                blockIndex,
+                commitId,
+                blobId,
+                blobOffset,
+                blobAlignment);
             Y_ABORT_UNLESS(ok);
 
-            CacheInserter->Insert({blobId, commitId, blockIndex, blobOffset});
+            CacheInserter->Insert(
+                {blobId, commitId, blockIndex, blobOffset, blobAlignment});
             return true;
         }
 

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -426,7 +426,7 @@ void TPartitionState::WriteMixedBlocks(
     TPartitionDatabase& db,
     const TPartialBlobId& blobId,
     const TVector<ui32>& blockIndices,
-    ui8 compactionRangeCountOverlapped)
+    ui8 compactionRangeCount)
 {
     const ui64 commitId = blobId.CommitId();
     ui16 blobOffset = 0;
@@ -439,11 +439,11 @@ void TPartitionState::WriteMixedBlocks(
              commitId,
              blockIndex,
              blobOffset,
-             compactionRangeCountOverlapped});
+             compactionRangeCount});
         ++blobOffset;
     }
 
-    db.WriteMixedBlocks(blobId, blockIndices, compactionRangeCountOverlapped);
+    db.WriteMixedBlocks(blobId, blockIndices, compactionRangeCount);
 }
 
 void TPartitionState::DeleteMixedBlock(
@@ -485,14 +485,14 @@ bool TPartitionState::FindMixedBlocksForCompaction(
             ui64 commitId,
             const TPartialBlobId& blobId,
             ui16 blobOffset,
-            ui8 compactionRangeCountOverlapped) override
+            ui8 compactionRangeCount) override
         {
             bool ok = Visitor.VisitBlock(
                 blockIndex,
                 commitId,
                 blobId,
                 blobOffset,
-                compactionRangeCountOverlapped);
+                compactionRangeCount);
             Y_ABORT_UNLESS(ok);
 
             CacheInserter->Insert(
@@ -500,7 +500,7 @@ bool TPartitionState::FindMixedBlocksForCompaction(
                  commitId,
                  blockIndex,
                  blobOffset,
-                 compactionRangeCountOverlapped});
+                 compactionRangeCount});
             return true;
         }
 

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -426,7 +426,7 @@ void TPartitionState::WriteMixedBlocks(
     TPartitionDatabase& db,
     const TPartialBlobId& blobId,
     const TVector<ui32>& blockIndices,
-    ui32 enclosingCompactionRangeSize)
+    ui8 compactionRangeCountOverlaped)
 {
     const ui64 commitId = blobId.CommitId();
     ui16 blobOffset = 0;
@@ -439,11 +439,11 @@ void TPartitionState::WriteMixedBlocks(
              commitId,
              blockIndex,
              blobOffset,
-             enclosingCompactionRangeSize});
+             compactionRangeCountOverlaped});
         ++blobOffset;
     }
 
-    db.WriteMixedBlocks(blobId, blockIndices, enclosingCompactionRangeSize);
+    db.WriteMixedBlocks(blobId, blockIndices, compactionRangeCountOverlaped);
 }
 
 void TPartitionState::DeleteMixedBlock(
@@ -485,14 +485,14 @@ bool TPartitionState::FindMixedBlocksForCompaction(
             ui64 commitId,
             const TPartialBlobId& blobId,
             ui16 blobOffset,
-            ui32 enclosingCompactionRangeSize) override
+            ui8 compactionRangeCountOverlaped) override
         {
             bool ok = Visitor.VisitBlock(
                 blockIndex,
                 commitId,
                 blobId,
                 blobOffset,
-                enclosingCompactionRangeSize);
+                compactionRangeCountOverlaped);
             Y_ABORT_UNLESS(ok);
 
             CacheInserter->Insert(
@@ -500,7 +500,7 @@ bool TPartitionState::FindMixedBlocksForCompaction(
                  commitId,
                  blockIndex,
                  blobOffset,
-                 enclosingCompactionRangeSize});
+                 compactionRangeCountOverlaped});
             return true;
         }
 

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -426,7 +426,7 @@ void TPartitionState::WriteMixedBlocks(
     TPartitionDatabase& db,
     const TPartialBlobId& blobId,
     const TVector<ui32>& blockIndices,
-    ui32 blobAlignment)
+    ui32 enclosingCompactionRangeSize)
 {
     const ui64 commitId = blobId.CommitId();
     ui16 blobOffset = 0;
@@ -435,11 +435,15 @@ void TPartitionState::WriteMixedBlocks(
         const ui32 rangeIdx = CompactionMap.GetRangeIndex(blockIndex);
         MixedIndexCache.InsertBlockIfHot(
             rangeIdx,
-            {blobId, commitId, blockIndex, blobOffset, blobAlignment});
+            {blobId,
+             commitId,
+             blockIndex,
+             blobOffset,
+             enclosingCompactionRangeSize});
         ++blobOffset;
     }
 
-    db.WriteMixedBlocks(blobId, blockIndices, blobAlignment);
+    db.WriteMixedBlocks(blobId, blockIndices, enclosingCompactionRangeSize);
 }
 
 void TPartitionState::DeleteMixedBlock(
@@ -481,18 +485,22 @@ bool TPartitionState::FindMixedBlocksForCompaction(
             ui64 commitId,
             const TPartialBlobId& blobId,
             ui16 blobOffset,
-            ui32 blobAlignment) override
+            ui32 enclosingCompactionRangeSize) override
         {
             bool ok = Visitor.VisitBlock(
                 blockIndex,
                 commitId,
                 blobId,
                 blobOffset,
-                blobAlignment);
+                enclosingCompactionRangeSize);
             Y_ABORT_UNLESS(ok);
 
             CacheInserter->Insert(
-                {blobId, commitId, blockIndex, blobOffset, blobAlignment});
+                {blobId,
+                 commitId,
+                 blockIndex,
+                 blobOffset,
+                 enclosingCompactionRangeSize});
             return true;
         }
 

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -426,7 +426,7 @@ void TPartitionState::WriteMixedBlocks(
     TPartitionDatabase& db,
     const TPartialBlobId& blobId,
     const TVector<ui32>& blockIndices,
-    ui8 compactionRangeCountOverlaped)
+    ui8 compactionRangeCountOverlapped)
 {
     const ui64 commitId = blobId.CommitId();
     ui16 blobOffset = 0;
@@ -439,11 +439,11 @@ void TPartitionState::WriteMixedBlocks(
              commitId,
              blockIndex,
              blobOffset,
-             compactionRangeCountOverlaped});
+             compactionRangeCountOverlapped});
         ++blobOffset;
     }
 
-    db.WriteMixedBlocks(blobId, blockIndices, compactionRangeCountOverlaped);
+    db.WriteMixedBlocks(blobId, blockIndices, compactionRangeCountOverlapped);
 }
 
 void TPartitionState::DeleteMixedBlock(
@@ -485,14 +485,14 @@ bool TPartitionState::FindMixedBlocksForCompaction(
             ui64 commitId,
             const TPartialBlobId& blobId,
             ui16 blobOffset,
-            ui8 compactionRangeCountOverlaped) override
+            ui8 compactionRangeCountOverlapped) override
         {
             bool ok = Visitor.VisitBlock(
                 blockIndex,
                 commitId,
                 blobId,
                 blobOffset,
-                compactionRangeCountOverlaped);
+                compactionRangeCountOverlapped);
             Y_ABORT_UNLESS(ok);
 
             CacheInserter->Insert(
@@ -500,7 +500,7 @@ bool TPartitionState::FindMixedBlocksForCompaction(
                  commitId,
                  blockIndex,
                  blobOffset,
-                 compactionRangeCountOverlaped});
+                 compactionRangeCountOverlapped});
             return true;
         }
 

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -561,7 +561,7 @@ public:
         TPartitionDatabase& db,
         const TPartialBlobId& blobId,
         const TVector<ui32>& blockIndices,
-        ui32 blobAlignment);
+        ui32 enclosingCompactionRangeSize);
 
     void DeleteMixedBlock(
         TPartitionDatabase& db,

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -561,7 +561,7 @@ public:
         TPartitionDatabase& db,
         const TPartialBlobId& blobId,
         const TVector<ui32>& blockIndices,
-        ui8 compactionRangeCountOverlaped);
+        ui8 compactionRangeCountOverlapped);
 
     void DeleteMixedBlock(
         TPartitionDatabase& db,

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -561,7 +561,7 @@ public:
         TPartitionDatabase& db,
         const TPartialBlobId& blobId,
         const TVector<ui32>& blockIndices,
-        ui8 compactionRangeCountOverlapped);
+        ui8 compactionRangeCount);
 
     void DeleteMixedBlock(
         TPartitionDatabase& db,

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -386,6 +386,7 @@ public:
     //
     // Commits
     //
+
 public:
 
     ui64 GetLastCommitId() const
@@ -559,7 +560,8 @@ public:
     void WriteMixedBlocks(
         TPartitionDatabase& db,
         const TPartialBlobId& blobId,
-        const TVector<ui32>& blockIndices);
+        const TVector<ui32>& blockIndices,
+        ui32 blobAlignment);
 
     void DeleteMixedBlock(
         TPartitionDatabase& db,
@@ -568,7 +570,7 @@ public:
 
     bool FindMixedBlocksForCompaction(
         TPartitionDatabase& db,
-        IBlocksIndexVisitor& visitor,
+        IMixedBlocksIndexVisitor& visitor,
         ui32 rangeIndex);
 
     void RaiseRangeTemperature(ui32 rangeIndex);
@@ -592,6 +594,8 @@ private:
     const ui32 MaxBlobsPerRange;
     ui32 CompactionRangeCountPerRun;
     TInstant LastCompactionRangeCountPerRunTs;
+    ui64 BlobsProcessedDuringCompaction = 0;
+    ui64 BlockMaskReadedDuringCompaction = 0;
 
 public:
     TOperationState& GetCompactionState(ECompactionType type);
@@ -696,6 +700,26 @@ public:
     void SetUsedBlocks(TPartitionDatabase& db, const TVector<ui32>& blocks);
     void UnsetUsedBlocks(TPartitionDatabase& db, const TBlockRange32& range);
     void UnsetUsedBlocks(TPartitionDatabase& db, const TVector<ui32>& blocks);
+
+    void IncrementBlobsProcessedDuringCompaction()
+    {
+        ++BlobsProcessedDuringCompaction;
+    }
+
+    void IncrementBlockMaskReadedDuringCompaction()
+    {
+        ++BlockMaskReadedDuringCompaction;
+    }
+
+    ui64 GetBlobsProcessedDuringCompaction() const
+    {
+        return BlobsProcessedDuringCompaction;
+    }
+
+    ui64 GetBlockMaskReadedDuringCompaction() const
+    {
+        return BlockMaskReadedDuringCompaction;
+    }
 
 private:
     void WriteUsedBlocksToDB(TPartitionDatabase& db, ui32 begin, ui32 end);

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -561,7 +561,7 @@ public:
         TPartitionDatabase& db,
         const TPartialBlobId& blobId,
         const TVector<ui32>& blockIndices,
-        ui32 enclosingCompactionRangeSize);
+        ui8 compactionRangeCountOverlaped);
 
     void DeleteMixedBlock(
         TPartitionDatabase& db,
@@ -595,7 +595,7 @@ private:
     ui32 CompactionRangeCountPerRun;
     TInstant LastCompactionRangeCountPerRunTs;
     ui64 BlobsProcessedDuringCompaction = 0;
-    ui64 BlockMaskReadedDuringCompaction = 0;
+    ui64 BlockMaskReadDuringCompaction = 0;
 
 public:
     TOperationState& GetCompactionState(ECompactionType type);
@@ -706,9 +706,9 @@ public:
         ++BlobsProcessedDuringCompaction;
     }
 
-    void IncrementBlockMaskReadedDuringCompaction()
+    void IncrementBlockMaskReadDuringCompaction()
     {
-        ++BlockMaskReadedDuringCompaction;
+        ++BlockMaskReadDuringCompaction;
     }
 
     ui64 GetBlobsProcessedDuringCompaction() const
@@ -716,9 +716,9 @@ public:
         return BlobsProcessedDuringCompaction;
     }
 
-    ui64 GetBlockMaskReadedDuringCompaction() const
+    ui64 GetBlockMaskReadDuringCompaction() const
     {
-        return BlockMaskReadedDuringCompaction;
+        return BlockMaskReadDuringCompaction;
     }
 
 private:

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -398,14 +398,14 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
                 ui64 commitId,
                 const TPartialBlobId& blobId,
                 ui16 blobOffset,
-                ui32 enclosingCompactionRangeSize) override
+                ui8 compactionRangeCountOverlaped) override
             {
                 Blocks.emplace_back(
                     blobId,
                     commitId,
                     blockIndex,
                     blobOffset,
-                    enclosingCompactionRangeSize);
+                    compactionRangeCountOverlaped);
                 return true;
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -363,11 +363,11 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
 
         constexpr ui32 rangeIdx = 0;
         TVector<TMixedBlock> blocks = {
-            { {1, 1}, 1, 1, 1 },
-            { {2, 2}, 2, 2, 2 },
-            { {3, 3}, 3, 3, 3 },
-            { {4, 4}, 4, 4, 4 },
-            { {5, 5}, 5, 5, 5 }
+            { {1, 1}, 1, 1, 1, 1},
+            { {2, 2}, 2, 2, 2, 2},
+            { {3, 3}, 3, 3, 3, 3},
+            { {4, 4}, 4, 4, 4, 4},
+            { {5, 5}, 5, 5, 5, 5}
         };
 
         auto mixedBlocksCompatator = [](const auto& lhs, const auto& rhs) {
@@ -385,7 +385,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         TVector<TMixedBlock> actual;
 
         struct TVisitor final
-            : public IBlocksIndexVisitor
+            : public IMixedBlocksIndexVisitor
         {
             TVector<TMixedBlock>& Blocks;
 
@@ -393,13 +393,19 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
                 : Blocks(blocks)
             {}
 
-            bool Visit(
+            bool VisitBlock(
                 ui32 blockIndex,
                 ui64 commitId,
                 const TPartialBlobId& blobId,
-                ui16 blobOffset) override
+                ui16 blobOffset,
+                ui32 blobAlignment) override
             {
-                Blocks.emplace_back(blobId, commitId, blockIndex, blobOffset);
+                Blocks.emplace_back(
+                    blobId,
+                    commitId,
+                    blockIndex,
+                    blobOffset,
+                    blobAlignment);
                 return true;
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -398,14 +398,14 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
                 ui64 commitId,
                 const TPartialBlobId& blobId,
                 ui16 blobOffset,
-                ui8 compactionRangeCountOverlapped) override
+                ui8 compactionRangeCount) override
             {
                 Blocks.emplace_back(
                     blobId,
                     commitId,
                     blockIndex,
                     blobOffset,
-                    compactionRangeCountOverlapped);
+                    compactionRangeCount);
                 return true;
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -398,14 +398,14 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
                 ui64 commitId,
                 const TPartialBlobId& blobId,
                 ui16 blobOffset,
-                ui8 compactionRangeCountOverlaped) override
+                ui8 compactionRangeCountOverlapped) override
             {
                 Blocks.emplace_back(
                     blobId,
                     commitId,
                     blockIndex,
                     blobOffset,
-                    compactionRangeCountOverlaped);
+                    compactionRangeCountOverlapped);
                 return true;
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -398,14 +398,14 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
                 ui64 commitId,
                 const TPartialBlobId& blobId,
                 ui16 blobOffset,
-                ui32 blobAlignment) override
+                ui32 enclosingCompactionRangeSize) override
             {
                 Blocks.emplace_back(
                     blobId,
                     commitId,
                     blockIndex,
                     blobOffset,
-                    blobAlignment);
+                    enclosingCompactionRangeSize);
                 return true;
             }
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -351,8 +351,8 @@ auto InitTestActorRuntime(
 void InitLogSettings(TTestActorRuntime& runtime)
 {
     for (ui32 i = TBlockStoreComponents::START; i < TBlockStoreComponents::END; ++i) {
-        // runtime.SetLogPriority(i, NLog::PRI_INFO);
-        runtime.SetLogPriority(i, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(i, NLog::PRI_INFO);
+        // runtime.SetLogPriority(i, NLog::PRI_DEBUG);
     }
     // runtime.SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
     runtime.SetLogPriority(NKikimrServices::BS_NODE, NLog::PRI_ERROR);

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -351,8 +351,8 @@ auto InitTestActorRuntime(
 void InitLogSettings(TTestActorRuntime& runtime)
 {
     for (ui32 i = TBlockStoreComponents::START; i < TBlockStoreComponents::END; ++i) {
-        runtime.SetLogPriority(i, NLog::PRI_INFO);
-        // runtime.SetLogPriority(i, NLog::PRI_DEBUG);
+        // runtime.SetLogPriority(i, NLog::PRI_INFO);
+        runtime.SetLogPriority(i, NLog::PRI_DEBUG);
     }
     // runtime.SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
     runtime.SetLogPriority(NKikimrServices::BS_NODE, NLog::PRI_ERROR);
@@ -13371,7 +13371,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 partition.ReadBlocks(TBlockRange32::WithLength(0, 2))));
     }
 
-    Y_UNIT_TEST(ShouldCleanupBlobsWithoutReadingBlockMasks)
+    Y_UNIT_TEST(ShouldCleanupMergedBlobsWithoutReadingBlockMasks)
     {
         auto config = DefaultConfig();
         config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
@@ -13425,6 +13425,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetBlockMaskReadedDuringCompaction());
         }
 
         partition.Cleanup();
@@ -13460,6 +13462,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             const auto& stats = response->Record.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetBlockMaskReadedDuringCompaction());
         }
 
         partition.Cleanup();
@@ -13540,6 +13544,133 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(
             GetBlockContent('1'),
             GetBlockContent(partition.ReadBlocks(0, "c1")));
+    }
+
+    Y_UNIT_TEST(ShouldCleanupMixedBlobsWithoutReadingBlockMasks)
+    {
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        for (size_t i = 1019; i < 1024; ++i) {
+            partition.WriteBlocks(i, 'a' + i - 1019);
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.GetBlockMaskReadedDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        for (size_t i = 1019; i < 1024; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent('a' + i - 1019),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        for (size_t i = 1019; i < 1030; ++i) {
+            partition.WriteBlocks(i, 'b' + i - 1019);
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                3,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.GetBlockMaskReadedDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        for (size_t i = 1019; i < 1030; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent('b' + i - 1019),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                4,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                2,
+                stats.GetBlockMaskReadedDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        for (size_t i = 1019; i < 1030; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent('b' + i - 1019),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13426,7 +13426,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(3, stats.GetBlobsProcessedDuringCompaction());
-            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetBlockMaskReadedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetBlockMaskReadDuringCompaction());
         }
 
         partition.Cleanup();
@@ -13463,7 +13463,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
             UNIT_ASSERT_VALUES_EQUAL(5, stats.GetBlobsProcessedDuringCompaction());
-            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetBlockMaskReadedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetBlockMaskReadDuringCompaction());
         }
 
         partition.Cleanup();
@@ -13588,7 +13588,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 stats.GetBlobsProcessedDuringCompaction());
             UNIT_ASSERT_VALUES_EQUAL(
                 0,
-                stats.GetBlockMaskReadedDuringCompaction());
+                stats.GetBlockMaskReadDuringCompaction());
         }
 
         partition.Cleanup();
@@ -13631,7 +13631,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 stats.GetBlobsProcessedDuringCompaction());
             UNIT_ASSERT_VALUES_EQUAL(
                 1,
-                stats.GetBlockMaskReadedDuringCompaction());
+                stats.GetBlockMaskReadDuringCompaction());
         }
 
         partition.Cleanup();
@@ -13654,7 +13654,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 stats.GetBlobsProcessedDuringCompaction());
             UNIT_ASSERT_VALUES_EQUAL(
                 2,
-                stats.GetBlockMaskReadedDuringCompaction());
+                stats.GetBlockMaskReadDuringCompaction());
         }
 
         partition.Cleanup();

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -413,6 +413,12 @@ message TVolumeStats
 
     // Current trim fresh log as commit id
     uint64 TrimFreshLogToCommitId = 29;
+
+    // Number of read block masks during compaction.
+    uint64 BlockMaskReadedDuringCompaction = 30;
+
+    // Number of blobs processed during compaction.
+    uint64 BlobsProcessedDuringCompaction = 31;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -415,7 +415,7 @@ message TVolumeStats
     uint64 TrimFreshLogToCommitId = 29;
 
     // Number of read block masks during compaction.
-    uint64 BlockMaskReadedDuringCompaction = 30;
+    uint64 BlockMaskReadDuringCompaction = 30;
 
     // Number of blobs processed during compaction.
     uint64 BlobsProcessedDuringCompaction = 31;


### PR DESCRIPTION
### Notes

Added `CompactionRangeCount` field to mixed index: number of compaction ranges blob overlaps with.
if `CompactionRangeCount` for blob equals to 1, block masks are not readed

In a local db, it is stored in a single column with the BlobOffset value.
### Issue
#5590
