### PR TITLE
[Filestore] fix server log parsing in tests

### DIFF
--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -820,6 +820,10 @@ def test_io_telemetry():
     with open(common.output_path("filestore-server.err")) as err:
         for line in err.readlines():
             parts = line.rstrip().split(" ", maxsplit=4)
+            if len(parts) < 4:
+                # we expect that line has the following format
+                # <time> <component> <severity> <message>
+                continue
             component = parts[1]
             message = parts[3]
             if component == ":NFS_TRACE":


### PR DESCRIPTION
### Notes
Yet another error observed in ci

> Logsdir: http://proxy.sandbox.yandex-team.ru/11529179254/cloud/filestore/tests/client/test-results/py3test/chunk2/testing_out_stuff
> [fail] test.py::test_io_telemetry [default-linux-x86_64-relwithdebinfo] (3.17s)
> cloud/filestore/tests/client/test.py:824: in test_io_telemetry
>     message = parts[3]
> E   IndexError: list index out of range
> Log: http://proxy.sandbox.yandex-team.ru/11529179254/cloud/filestore/tests/client/test-results/py3test/chunk2/testing_out_stuff/test.py.test_io_telemetry.log
> Logsdir: http://proxy.sandbox.yandex-team.ru/11529179254/cloud/filestore/tests/client/test-results/py3test/chunk2/testing_out_stuff

Seems like it corresponds to the following line in server output

> 2026-03-27T17:19:56.696040Z :GLOBAL NOTICE: run.cpp:2215: Arc info:
>     Branch: trunk
>     Commit: 9d264fa894e1c33715d6a95e42dbb72804b2bb36
>     Author: robot-mail-internal
>     Summary: RELEASE: :package: social-avatars v232.0.0
>     Last Changed Rev: 19162349
>     Last Changed Date: 2026-03-27T16:27:32.000000Z
> Other info:
>     Build by: sandbox
>     Top src dir: /place/sandbox-data/tasks/0/4/3967781940/__FUSE/mount_path_deafa9cf-fcc5-4703-9e36-d46ab184fbd9
>     Top build dir: /tmp/3967781940/tmpnF6b3n
>     Hostname: sandbox7049-20-04-3221010105-0    Host information: 
>         Linux sandbox7049-20-04-3221010105-0 5.4.210-39.4 #1 SMP Thu Feb 29 12:33:04 UTC 2024 x86_64

### Issue
Put links to the related issues here
