### PR TITLE
Fix flaky TServiceDestroyTest.ShouldDestroyNonreplDiskWhenGracefulShutdownFailedToFindTheVolume

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_destroy.cpp
@@ -480,9 +480,8 @@ Y_UNIT_TEST_SUITE(TServiceDestroyTest)
             );
 
             auto response = service.RecvDestroyVolumeResponse();
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                S_OK,
-                response->GetStatus(),
+            UNIT_ASSERT_C(
+                !HasError(response->GetError()),
                 response->GetError());
         }
     }


### PR DESCRIPTION
### Notes
Describe your PR - what it does and why this needs to be done.

### Issue
Test was added in #5511 
