### PR TITLE
issue- [Filestore] use commitId as opposed to mtime in the guest cache invalidation policy

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -65,8 +65,7 @@ message TFileSystemConfig
     // Enable write-back cache on FUSE server
     optional bool ServerWriteBackCacheEnabled = 19;
 
-    // Allow to set keep_cache flag on file open if allowed by tablet
-    optional bool GuestKeepCacheAllowed = 20;
+    optional bool GuestKeepCacheAllowed = 20 [deprecated = true];
 
     // Create parentless files only. Meaning that files will be created
     // without any reference to parent directory.

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -23,14 +23,11 @@ enum EGuestCachingType
     // No caching is allowed, every CreateHandle forces a guest page cache
     // invalidation
     GCT_NONE = 0;
-    // The second RDONLY open call will be allowed not to invalidate the guest
-    // page cache if there are no other write handles and mtime of the file
-    // has not been changed since the last cache invalidation within a given
-    // session
-    GCT_SECOND_READ = 1;
-    // Same as GCT_SECOND_READ but the first RDONLY open call is also allowed
-    // to use the cache if the conditions regarding the write handles and
-    // mtime are met
+    // Treated the same way as GCT_ANY_READ
+    GCT_SECOND_READ = 1 [deprecated = true];
+    // Any open call is allowed not to invalidate the guest page cache if the
+    // commit id of the file has not changed since the last observed commit id
+    // within a given session
     GCT_ANY_READ = 2;
 }
 
@@ -560,9 +557,7 @@ message TStorageConfig
 
     // If set to true, in some cases the client is allowed not to invalidate the
     // guest page cache associated with the inode. It is allowed only for
-    // handles to nodes that are not being edited and are already opened
-    // within a given session
-    optional bool GuestKeepCacheAllowed = 423;
+    optional bool GuestKeepCacheAllowed = 423 [deprecated = true];
 
     optional EGuestCachingType GuestCachingType = 424;
 

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -44,32 +44,22 @@ struct TPerNodeHandleStats
 private:
     // Number of all handles to this node open in this session
     i64 OpenHandles = 0;
-    // Number of write (both O_RDWR and O_WRONLY) handles to this node open in
-    // this session
-    i64 OpenWriteHandles = 0;
-    // Among all opens, what was the last visible mtime of the node when the
-    // guest-side invalidation occurred
-    ui64 LastGuestCacheInvalidationMtime = 0;
+    // Among all opens, what was the last observed commit id of the node
+    ui64 ObservedCommitId = 0;
 
-    void RegisterHandle(const NProto::TSessionHandle& handle)
+    void RegisterHandle()
     {
         ++OpenHandles;
-        if (HasFlag(handle.GetFlags(), NProto::TCreateHandleRequest::E_WRITE)) {
-            ++OpenWriteHandles;
-        }
     }
 
-    void UnregisterHandle(const NProto::TSessionHandle& handle)
+    void UnregisterHandle()
     {
         --OpenHandles;
-        if (HasFlag(handle.GetFlags(), NProto::TCreateHandleRequest::E_WRITE)) {
-            --OpenWriteHandles;
-        }
     }
 
-    void OnGuestCacheInvalidated(ui64 mtime)
+    void UpdateObservedCommitId(ui64 commitId)
     {
-        LastGuestCacheInvalidationMtime = mtime;
+        ObservedCommitId = commitId;
     }
 
     [[nodiscard]] bool Empty() const
@@ -99,14 +89,14 @@ public:
             OffloadedStats.Erase(it);
         }
         auto& nodeStats = Stats[handle.GetNodeId()];
-        nodeStats.RegisterHandle(handle);
+        nodeStats.RegisterHandle();
     }
 
     void UnregisterHandle(const NProto::TSessionHandle& handle)
     {
         auto it = Stats.find(handle.GetNodeId());
         if (it != Stats.end()) {
-            it->second.UnregisterHandle(handle);
+            it->second.UnregisterHandle();
             if (it->second.Empty()) {
                 OffloadedStats.Insert(it->first, it->second);
                 Stats.erase(it);
@@ -114,34 +104,19 @@ public:
         }
     }
 
-    void OnGuestCacheInvalidated(const NProto::TNodeAttr& node)
+    void UpdateObservedCommitId(ui64 nodeId, ui64 commitId)
     {
-        auto mtime = node.GetMTime();
-        if (mtime == 0) {
-            return;
-        }
-
-        auto it = Stats.find(node.GetId());
+        auto it = Stats.find(nodeId);
         if (it != Stats.end()) {
-            it->second.OnGuestCacheInvalidated(mtime);
+            it->second.UpdateObservedCommitId(commitId);
         }
     }
 
-    [[nodiscard]] bool IsAllowedToKeepCache(
-        const NProto::TNodeAttr& node,
-        bool isFirstReadAllowed) const
+    [[nodiscard]] bool IsAllowedToKeepCache(ui64 nodeId, ui64 commitId) const
     {
-        auto it = Stats.find(node.GetId());
+        auto it = Stats.find(nodeId);
         if (it != Stats.end()) {
-            // We can allow ourselves not to invalidate the cache if it is not
-            // opened for writing and the last time that the cache was
-            // invalidated was after the node was modified. Also sometimes we
-            // can require this read handle to be not the first one opened, see
-            // isFirstReadAllowed variable
-            if (it->second.OpenWriteHandles == 0 &&
-                it->second.OpenHandles > (isFirstReadAllowed ? 0 : 1) &&
-                it->second.LastGuestCacheInvalidationMtime >= node.GetMTime())
-            {
+            if (it->second.ObservedCommitId >= commitId) {
                 return true;
             }
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -429,25 +429,13 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         auto* node = args.Response.MutableNodeAttr();
         ConvertNodeFromAttrs(*node, args.TargetNodeId, args.TargetNode->Attrs);
 
-        if ((Config->GetGuestKeepCacheAllowed() ||
-             Config->GetGuestCachingType() != NProto::GCT_NONE) &&
-            !HasFlag(args.Flags, NProto::TCreateHandleRequest::E_WRITE))
-        {
-            // We set the GuestKeepCache to tell the client not to bother
-            // invalidating the caches upon opening a read-only handle
-            args.Response.SetGuestKeepCache(
-                session->HandleStatsByNode.IsAllowedToKeepCache(
-                    *node,
-                    // isFirstReadAllowed
-                    Config->GetGuestCachingType() == NProto::GCT_ANY_READ));
-        }
+        // We set the GuestKeepCache to tell the client not to bother
+        // invalidating the caches upon opening this handle
+        args.Response.SetGuestKeepCache(
+            session->HandleStatsByNode.IsAllowedToKeepCache(
+                args.TargetNodeId,
+                args.TargetNode->MinCommitId));
 
-        // We can remember the last time that the cache was invalidated by a
-        // user of a given session in order not to invalidate the cache the next
-        // time if the file was not modified
-        if (!args.Response.GetGuestKeepCache()) {
-            session->HandleStatsByNode.OnGuestCacheInvalidated(*node);
-        }
     } else {
         args.Response.SetShardFileSystemId(args.ShardId);
         args.Response.SetShardNodeName(args.ShardNodeName);
@@ -530,6 +518,13 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
         std::make_unique<TEvService::TEvCreateHandleResponse>(args.Error);
 
     if (!HasError(args.Error)) {
+        if (args.TargetNode) {
+            if (auto* session = FindSession(args.SessionId)) {
+                session->HandleStatsByNode.UpdateObservedCommitId(
+                    args.TargetNodeId,
+                    args.TargetNode->MinCommitId);
+            }
+        }
         CommitDupCacheEntry(args.SessionId, args.RequestId);
         response->Record = std::move(args.Response);
     }

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -147,9 +147,7 @@ void TFileSystem::Open(
                 if (self->Config->GetGuestPageCacheDisabled()) {
                     fi.direct_io = 1;
                 }
-                if (response.GetGuestKeepCache() &&
-                    self->Config->GetGuestKeepCacheAllowed())
-                {
+                if (response.GetGuestKeepCache()) {
                     fi.keep_cache = 1;
                 }
 

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1225,7 +1225,6 @@ private:
         config.SetExtendedAttributesDisabled(
             features.GetExtendedAttributesDisabled());
 
-        config.SetGuestKeepCacheAllowed(features.GetGuestKeepCacheAllowed());
         config.SetMaxBackground(features.GetMaxBackground());
         config.SetMaxFuseLoopThreads(features.GetMaxFuseLoopThreads());
 

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -32,7 +32,7 @@ message TFileStoreFeatures
     bool ExtendedAttributesDisabled = 17;
     bool ServerWriteBackCacheEnabled = 18;
     bool DirectoryCreationInShardsEnabled = 19;
-    bool GuestKeepCacheAllowed = 20;
+    bool GuestKeepCacheAllowed = 20 [deprecated = true];
     bool ParentlessFilesOnly = 21;
     bool AllowHandlelessIO = 22;
     bool HasXAttrs = 23;


### PR DESCRIPTION
### Notes
Using the node CommitId protects us from the time drift that the mtime is prone to

### Issue

Slight follow-up cleanup for #3295