### PR TITLE
fix filestore ShouldSendBSGroupFlagsToTabletViaAddDataRequests test

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3490,6 +3490,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         TServiceClient service(env.GetRuntime(), nodeIdx);
         const TString fs = "test";
         service.CreateFileStore(fs, 1000);
+        ui64 tabletId = service.GetFileStoreInfo(fs)
+            ->Record.GetFileStore()
+            .GetMainTabletId();
 
         {
             NProto::TStorageConfig newConfig;
@@ -3523,6 +3526,10 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                     case TEvBlobStorage::EvPutResult: {
                         auto* msg =
                             event->template Get<TEvBlobStorage::TEvPutResult>();
+                        if (msg->Id.TabletID() != tabletId || msg->Id.Channel() < 3) {
+                            // skip if not a data channel or not fs tablet
+                            break;
+                        }
                         const_cast<TFlags&>(msg->StatusFlags).Raw |=
                             ui32(yellowFlag);
                         const_cast<float&>(msg->ApproximateFreeSpaceShare) =


### PR DESCRIPTION
### Notes
The problem seems to be in code where we alter every EvPutResult response. We set yellow flag in a response, but Tablet executor seems to have different logic for flags handling. So decided to alter responses for only test fs tablet and channels greater that 2(System, Index, Fresh)

### Issue
#5608
