### PR TITLE
Disable local service if is_tight_service_memory_platform is set in infra throttling config file

### DIFF
--- a/cloud/blockstore/libs/client/throttling.h
+++ b/cloud/blockstore/libs/client/throttling.h
@@ -15,6 +15,7 @@ struct THostPerformanceProfile
 {
     ui32 CpuCount = 0;
     ui32 NetworkMbitThroughput = 0;
+    bool IsTightServiceMemoryPlatform = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/daemon/common/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/common/config_initializer.cpp
@@ -183,6 +183,7 @@ void TConfigInitializerCommon::InitHostPerformanceProfile()
     const auto& tc = EndpointConfig->GetClientConfig().GetThrottlingConfig();
     ui32 networkThroughput = tc.GetDefaultNetworkMbitThroughput();
     ui32 hostCpuCount = tc.GetDefaultHostCpuCount();
+    bool isTightServiceMemoryPlatform = false;
 
     if (auto json = ReadJsonFile(tc.GetInfraThrottlingConfigPath())) {
         try {
@@ -202,11 +203,24 @@ void TConfigInitializerCommon::InitHostPerformanceProfile()
             STORAGE_ERROR("Failed to read HostCpuCount. Error: "
                 << CurrentExceptionMessage().c_str());
         }
+
+        try {
+            if (auto* value =
+                    json->GetValueByPath("is_tight_service_memory_platform"))
+            {
+                isTightServiceMemoryPlatform = value->GetBooleanSafe();
+            }
+        } catch (...) {
+            STORAGE_ERROR(
+                "Failed to read IsTightServiceMemoryPlatform. Error: "
+                << CurrentExceptionMessage().c_str());
+        }
     }
 
     HostPerformanceProfile = {
         .CpuCount = hostCpuCount,
         .NetworkMbitThroughput = networkThroughput,
+        .IsTightServiceMemoryPlatform = isTightServiceMemoryPlatform
     };
 }
 

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -846,6 +846,10 @@ void TBootstrapYdb::InitKikimrService()
 
     STORAGE_INFO("Local NVMe service initialized");
 
+    const bool isHiveLocalServiceEnabled =
+        !Configs->StorageConfig->GetDisableLocalService() &&
+        !Configs->HostPerformanceProfile.IsTightServiceMemoryPlatform;
+
     NStorage::TServerActorSystemArgs args;
     args.ModuleFactories = ModuleFactories;
     args.NodeId = nodeId;
@@ -877,7 +881,7 @@ void TBootstrapYdb::InitKikimrService()
     args.NvmeManager = NvmeManager;
     args.UserCounterProviders = {VolumeStats->GetUserCounters()};
     args.IsDiskRegistrySpareNode = [&] {
-            if (!Configs->StorageConfig->GetDisableLocalService()) {
+            if (isHiveLocalServiceEnabled) {
                 return false;
             }
 
@@ -894,6 +898,7 @@ void TBootstrapYdb::InitKikimrService()
     args.BackgroundThreadPool = BackgroundThreadPool;
     args.PartitionBudgetManager = PartitionBudgetManager;
     args.LocalNVMeService = LocalNVMeService;
+    args.IsHiveLocalServiceEnabled = isHiveLocalServiceEnabled;
 
     ActorSystem = NStorage::CreateActorSystem(args);
 

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
@@ -302,15 +302,20 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         NClient::THostPerformanceProfile expected = {
             .CpuCount = 60,
             .NetworkMbitThroughput = 20'000,
+            .IsTightServiceMemoryPlatform = true,
         };
 
         TTempDir dir;
 
-        auto throttlingConfigStr = Sprintf(R"(
-            {"interfaces": [{"eth0": {"speed": "%d"}}], "compute_cores_num": %d}
-            )",
+        auto throttlingConfigStr = Sprintf(
+            R"({
+              "interfaces": [{"eth0": {"speed": "%d"}}],
+              "compute_cores_num": %d,
+              "is_tight_service_memory_platform": %s
+            })",
             expected.NetworkMbitThroughput,
-            expected.CpuCount);
+            expected.CpuCount,
+            expected.IsTightServiceMemoryPlatform ? "true" : "false");
 
         auto throttlingConfigPath = dir.Path() / "nbs-throttling.txt";
         TOFStream(throttlingConfigPath.GetPath()).Write(throttlingConfigStr);
@@ -338,6 +343,9 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
             expected.CpuCount, actual.CpuCount);
         UNIT_ASSERT_VALUES_EQUAL(
             expected.NetworkMbitThroughput, actual.NetworkMbitThroughput);
+        UNIT_ASSERT_VALUES_EQUAL(
+            expected.IsTightServiceMemoryPlatform,
+            actual.IsTightServiceMemoryPlatform);
     }
 
     Y_UNIT_TEST(ShouldInitHostPerformanceProfileWithoutThrottlingConfigFile)
@@ -367,13 +375,14 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         auto& actual = ci.HostPerformanceProfile;
         UNIT_ASSERT_VALUES_EQUAL(42, actual.CpuCount);
         UNIT_ASSERT_VALUES_EQUAL(325, actual.NetworkMbitThroughput);
+        UNIT_ASSERT_VALUES_EQUAL(false, actual.IsTightServiceMemoryPlatform);
     }
 
     Y_UNIT_TEST(ShouldInitHostPerformanceProfileWithInvalidThrottlingConfigFile)
     {
         TTempDir dir;
         auto throttlingConfigStr = R"(
-            {"interfaces": [{"eth0": {"speed": "-1"}}], "compute_cores_num": -42}
+            {"interfaces": [{"eth0": {"speed": "-1"}}], "compute_cores_num": -42, "is_tight_service_memory_platform": 11}
         )";
 
         auto throttlingConfigPath = dir.Path() / "nbs-throttling.txt";
@@ -402,6 +411,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         auto& actual = ci.HostPerformanceProfile;
         UNIT_ASSERT_VALUES_EQUAL(42, actual.CpuCount);
         UNIT_ASSERT_VALUES_EQUAL(325, actual.NetworkMbitThroughput);
+        UNIT_ASSERT_VALUES_EQUAL(false, actual.IsTightServiceMemoryPlatform);
     }
 
     Y_UNIT_TEST(ShouldInitKikimrFeatures)

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -391,6 +391,7 @@ private:
     const NServer::IEndpointEventHandlerPtr EndpointEventHandler;
     const TPartitionBudgetManagerPtr PartitionBudgetManager;
     const bool IsDiskRegistrySpareNode;
+    const bool IsHiveLocalServiceEnabled;
 
 public:
     TCustomLocalServiceInitializer(
@@ -406,7 +407,8 @@ public:
             NRdma::IClientPtr rdmaClient,
             NServer::IEndpointEventHandlerPtr endpointEventHandler,
             TPartitionBudgetManagerPtr partitionBudgetManager,
-            bool isDiskRegistrySpareNode)
+            bool isDiskRegistrySpareNode,
+            bool isHiveLocalServiceEnabled)
         : AppConfig(appConfig)
         , Logging(std::move(logging))
         , StorageConfig(std::move(storageConfig))
@@ -420,6 +422,7 @@ public:
         , EndpointEventHandler(std::move(endpointEventHandler))
         , PartitionBudgetManager(std::move(partitionBudgetManager))
         , IsDiskRegistrySpareNode(isDiskRegistrySpareNode)
+        , IsHiveLocalServiceEnabled(isHiveLocalServiceEnabled)
     {}
 
     void InitializeServices(
@@ -472,12 +475,10 @@ public:
             return tablet.release();
         };
 
-        const bool enableLocal = !StorageConfig->GetDisableLocalService();
-
-        if (enableLocal || IsDiskRegistrySpareNode) {
+        if (IsHiveLocalServiceEnabled || IsDiskRegistrySpareNode) {
             auto localConfig = MakeIntrusive<TLocalConfig>();
 
-            if (enableLocal) {
+            if (IsHiveLocalServiceEnabled) {
                 localConfig->TabletClassInfo[TTabletTypes::BlockStoreVolume] =
                     TLocalConfig::TTabletClassInfo(
                         MakeIntrusive<TTabletSetupInfo>(
@@ -586,7 +587,8 @@ IActorSystemPtr CreateActorSystem(const TServerActorSystemArgs& sArgs)
             sArgs.RdmaClient,
             sArgs.EndpointEventHandler,
             sArgs.PartitionBudgetManager,
-            sArgs.IsDiskRegistrySpareNode));
+            sArgs.IsDiskRegistrySpareNode,
+            sArgs.IsHiveLocalServiceEnabled));
     };
 
     auto storageConfig = sArgs.StorageConfig;
@@ -618,7 +620,7 @@ IActorSystemPtr CreateActorSystem(const TServerActorSystemArgs& sArgs)
 
     auto nodeId = sArgs.NodeId;
     auto onStart = [=] (IActorSystem& actorSystem) {
-        if (storageConfig->GetDisableLocalService()) {
+        if (!sArgs.IsHiveLocalServiceEnabled) {
             using namespace NNodeWhiteboard;
             const TActorId wb(MakeNodeWhiteboardServiceId(nodeId));
             actorSystem.Send(

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.h
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.h
@@ -78,6 +78,8 @@ struct TServerActorSystemArgs
 
     bool IsDiskRegistrySpareNode = false;
     bool TemporaryServer = false;
+
+    bool IsHiveLocalServiceEnabled = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Support for `ClientConfig::ThrottlingConfig::InfraThrottlingConfigPath`s `is_tight_service_memory_platform` flag
This flag denotes that the host has more constrained less RAM capacity than usual
Supporting this flag allows NBS to prevent enabling Local service on such nodes to avoid undesired memory consumption by brought-in hive's tablets