### PR TITLE
issue-5588: [Disk Manager] deletion tasks created directly by API calls from Compute should be non-cancellable

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/disks/service.go
+++ b/cloud/disk_manager/internal/pkg/services/disks/service.go
@@ -441,10 +441,11 @@ func (s *service) DeleteDisk(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
+	return s.taskScheduler.ScheduleNonCancellableTask(
 		ctx,
 		"disks.DeleteDisk",
-		"",
+		"", // description
+		"", // zoneID
 		&protos.DeleteDiskRequest{
 			Disk: &types.Disk{
 				ZoneId: req.DiskId.ZoneId,

--- a/cloud/disk_manager/internal/pkg/services/filesystem/service.go
+++ b/cloud/disk_manager/internal/pkg/services/filesystem/service.go
@@ -141,10 +141,11 @@ func (s *service) DeleteFilesystem(
 		)
 	}
 
-	return s.scheduler.ScheduleTask(
+	return s.scheduler.ScheduleNonCancellableTask(
 		ctx,
 		"filesystem.DeleteFilesystem",
-		"",
+		"", // description
+		"", // zoneID
 		&protos.DeleteFilesystemRequest{
 			Filesystem: &protos.FilesystemId{
 				ZoneId:       req.FilesystemId.ZoneId,

--- a/cloud/disk_manager/internal/pkg/services/filesystem_snapshot/service.go
+++ b/cloud/disk_manager/internal/pkg/services/filesystem_snapshot/service.go
@@ -50,10 +50,11 @@ func (s *service) DeleteFilesystemSnapshot(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
+	return s.taskScheduler.ScheduleNonCancellableTask(
 		ctx,
 		"filesystem_snapshot.DeleteFilesystemSnapshot",
-		"",
+		"", // description
+		"", // zoneID
 		&empty.Empty{},
 	)
 }

--- a/cloud/disk_manager/internal/pkg/services/images/service.go
+++ b/cloud/disk_manager/internal/pkg/services/images/service.go
@@ -144,10 +144,11 @@ func (s *service) DeleteImage(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
+	return s.taskScheduler.ScheduleNonCancellableTask(
 		ctx,
 		"images.DeleteImage",
-		"",
+		"", // description
+		"", // zoneID
 		&protos.DeleteImageRequest{
 			ImageId: req.ImageId,
 		},

--- a/cloud/disk_manager/internal/pkg/services/placementgroup/service.go
+++ b/cloud/disk_manager/internal/pkg/services/placementgroup/service.go
@@ -99,10 +99,11 @@ func (s *service) DeletePlacementGroup(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
+	return s.taskScheduler.ScheduleNonCancellableTask(
 		ctx,
 		"placement_group.DeletePlacementGroup",
-		"",
+		"", // description
+		"", // zoneID
 		&protos.DeletePlacementGroupRequest{
 			ZoneId:  req.GroupId.ZoneId,
 			GroupId: req.GroupId.GroupId,

--- a/cloud/disk_manager/internal/pkg/services/snapshots/service.go
+++ b/cloud/disk_manager/internal/pkg/services/snapshots/service.go
@@ -69,10 +69,11 @@ func (s *service) DeleteSnapshot(
 		)
 	}
 
-	return s.taskScheduler.ScheduleTask(
+	return s.taskScheduler.ScheduleNonCancellableTask(
 		ctx,
 		"snapshots.DeleteSnapshot",
-		"",
+		"", // description
+		"", // zoneID
 		&protos.DeleteSnapshotRequest{
 			SnapshotId: req.SnapshotId,
 		},


### PR DESCRIPTION
### Notes
Task list:
```
disks.DeleteDisk
filesystem.DeleteFilesystem
filesystem_snapshot.DeleteFilesystemSnapshot
images.DeleteImage
placement_group.DeletePlacementGroup
snapshots.DeleteSnapshot
```
### Issue
#5588 
