### PR TITLE
[NBS] Add ERequestSplitterPolicy to TMultiPartitionWrapperActor

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -108,6 +108,20 @@ enum EOverlappingRequestsPolicy
     ORP_DISABLE = 2;
 }
 
+enum ERequestSplitterPolicy
+{
+    // Read/write/zero requests are split by TVolumeActor as usual.
+    RSP_ENABLE = 0;
+
+    // Read/write/zero requests are split by TVolumeActor as usual, but when a
+    // cross-partition request appears, the CritEvent raised.
+    RSP_ENABLE_WITH_CRIT_EVENT = 1;
+
+    // Splitting of read/write/zero requests in TVolumeActor is disabled. It is
+    // assumed that the splitting is implemented on couple layers above volume.
+    RSP_DISABLE = 2;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 message TPoolKindToMediaKindMapping
@@ -1532,4 +1546,9 @@ message TStorageServiceConfig
     // Don't read block masks on compaction if blob is entirely contained
     // in one compaction range.
     optional bool ReadBlockMaskOnCompactionOptimizationEnabled = 491;
+
+    // Policy for splitting read/write/zero requests in TVolumeActor.
+    // It is preferable to enable splitting via EnableRequestSplitter in the
+    // Server config.
+    optional ERequestSplitterPolicy RequestSplitterPolicy = 492;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -86,6 +86,7 @@ using TCritEventParams = TVector<std::pair<TStringBuf, TValue>>;
     xxx(DiskRegistryStateIntegrityBroken)                                      \
     xxx(AddFreshBlocksResultedInError)                                         \
     xxx(OverlappingRequestsDetected)                                           \
+    xxx(CrossPartitionRequestDetected)                                         \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(xxx)                             \

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -685,6 +685,9 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(OverlappingRequestsPolicy,                                             \
         NProto::EOverlappingRequestsPolicy,                                    \
         NProto::EOverlappingRequestsPolicy::ORP_ENABLE                        )\
+    xxx(RequestSplitterPolicy,                                                 \
+        NProto::ERequestSplitterPolicy,                                        \
+        NProto::ERequestSplitterPolicy::RSP_ENABLE                            )\
     xxx(VolumeBalancerMaxInProgress,          ui64,        0                  )\
     xxx(ReadBlockMaskOnCompactionOptimizationEnabled,                          \
         bool,                                                                  \
@@ -845,6 +848,13 @@ IOutputStream& operator<<(
     NProto::EOverlappingRequestsPolicy orp)
 {
     return out << NProto::EOverlappingRequestsPolicy_Name(orp);
+}
+
+IOutputStream& operator<<(
+    IOutputStream& out,
+    NProto::ERequestSplitterPolicy rsp)
+{
+    return out << NProto::ERequestSplitterPolicy_Name(rsp);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -801,6 +801,9 @@ public:
     [[nodiscard]] NProto::EOverlappingRequestsPolicy
     GetOverlappingRequestsPolicy() const;
 
+    [[nodiscard]] NProto::ERequestSplitterPolicy
+    GetRequestSplitterPolicy() const;
+
     [[nodiscard]] TPoolKindToMediaKindMapping
     GetPoolKindToMediaKindMapping() const;
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.cpp
@@ -1,5 +1,6 @@
 #include "multi_partition_wrapper_actor.h"
 
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/kikimr/components.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 
@@ -39,11 +40,13 @@ TMultiPartitionWrapperActor::TMultiPartitionWrapperActor(
     const TString& diskId,
     ui32 blockSize,
     ui32 blocksPerStripe,
+    NProto::ERequestSplitterPolicy splitterPolicy,
     const TVector<NActors::TActorId>& partitionActors)
     : LogTitle(std::move(logTitle))
     , TraceSerializer(std::move(traceSerializer))
     , BlockSize(blockSize)
     , BlocksPerStripe(blocksPerStripe)
+    , SplitterPolicy(splitterPolicy)
     , Partitions(MakePartitions(diskId, blockSize, partitionActors))
 {}
 
@@ -157,7 +160,8 @@ void TMultiPartitionWrapperActor::HandleRequest(
     const bool isCrossPartitionRequest =
         partitionRequests.size() > 1 || IsDescribeBlocksMethod<TMethod>;
 
-    if (!isCrossPartitionRequest) {
+    const auto forwardToSinglePartition = [&]
+    {
         auto newEvent = typename TMethod::TRequest::TPtr(
             static_cast<typename TMethod::TRequest::THandle*>(new IEventHandle(
                 partitionRequests.front().ActorId,
@@ -169,8 +173,26 @@ void TMultiPartitionWrapperActor::HandleRequest(
                 &ev->Sender   // The non-delivery error of the request is also
                               // handled by the volume actor
                 )));
-
         ctx.Send(newEvent.Release());
+    };
+
+    if constexpr (IsReadOrWriteMethod<TMethod>) {
+        if (SplitterPolicy == NProto::ERequestSplitterPolicy::RSP_DISABLE) {
+            forwardToSinglePartition();
+            return;
+        }
+
+        if (SplitterPolicy ==
+                NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT &&
+            isCrossPartitionRequest)
+        {
+            ReportCrossPartitionRequestDetected(
+                {{"disk", Partitions.front().DiskId}, {"range", blockRange}});
+        }
+    }
+
+    if (!isCrossPartitionRequest) {
+        forwardToSinglePartition();
         return;
     }
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/model/log_title.h>
 #include <cloud/blockstore/libs/storage/volume/actors/multi_partition_requests.h>
@@ -25,6 +26,8 @@ private:
     const ITraceSerializerPtr TraceSerializer;
     const ui32 BlockSize = 0;
     const ui32 BlocksPerStripe = 0;
+    const NProto::ERequestSplitterPolicy SplitterPolicy =
+        NProto::ERequestSplitterPolicy::RSP_ENABLE;
     const TBriefPartitionInfoList Partitions;
 
 public:
@@ -34,6 +37,7 @@ public:
         const TString& diskId,
         ui32 blockSize,
         ui32 blocksPerStripe,
+        NProto::ERequestSplitterPolicy splitterPolicy,
         const TVector<NActors::TActorId>& partitionActors);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -160,6 +160,7 @@ void TVolumeActor::OnPartitionStateChanged(
                     GetDiskId(),
                     State->GetMeta().GetVolumeConfig().GetBlockSize(),
                     State->GetMeta().GetVolumeConfig().GetBlocksPerStripe(),
+                    Config->GetRequestSplitterPolicy(),
                     std::move(partitionActors)),
                 TActorsStack::EActorPurpose::MultiPartitionWrapper);
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -9177,6 +9177,98 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(1, overlappingRequestsCounter->Val());
     }
 
+    Y_UNIT_TEST(ShouldReportCrossPartitionRequestDetected)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetRequestSplitterPolicy(
+            NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT);
+
+        auto runtime = PrepareTestActorRuntime(std::move(storageServiceConfig));
+        TVolumeClient volume(*runtime);
+
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD,
+            1024,
+            "vol0",
+            "cloud",
+            "folder",
+            2,
+            1024);
+        volume.WaitReady();
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume.AddClient(clientInfo);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto crossPartitionCounter = counters->GetCounter(
+            "AppCriticalEvents/CrossPartitionRequestDetected",
+            true);
+
+        volume.WriteBlocks(
+            TBlockRange64::WithLength(512, 1024),
+            clientInfo.GetClientId(),
+            1);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, crossPartitionCounter->Val());
+    }
+
+    Y_UNIT_TEST(ShouldNotReportCrossPartitionRequestDetectedForSinglePartition)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetRequestSplitterPolicy(
+            NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT);
+
+        auto runtime = PrepareTestActorRuntime(std::move(storageServiceConfig));
+        TVolumeClient volume(*runtime);
+
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::EStorageMediaKind::STORAGE_MEDIA_HDD,
+            1024,
+            "vol0",
+            "cloud",
+            "folder",
+            2,
+            1024);
+        volume.WaitReady();
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume.AddClient(clientInfo);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto crossPartitionCounter = counters->GetCounter(
+            "AppCriticalEvents/CrossPartitionRequestDetected",
+            true);
+
+        volume.WriteBlocks(
+            TBlockRange64::WithLength(0, 512),
+            clientInfo.GetClientId(),
+            1);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, crossPartitionCounter->Val());
+    }
+
     Y_UNIT_TEST(ShouldDescribeFromBaseDisk)
     {
         NProto::TStorageServiceConfig storageServiceConfig;

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -15,6 +15,7 @@ NonReplicatedMigrationStartAllowed: true
 
 # Volume
 OverlappingRequestsPolicy: ORP_ENABLE_WITH_CRIT_EVENT
+RequestSplitterPolicy: RSP_ENABLE_WITH_CRIT_EVENT
 
 # DiskRegistry-based
 AcquireNonReplicatedDevices: true

--- a/example/nbs/nbs-storage2.txt
+++ b/example/nbs/nbs-storage2.txt
@@ -15,6 +15,7 @@ NonReplicatedMigrationStartAllowed: true
 
 # Volume
 OverlappingRequestsPolicy: ORP_ENABLE_WITH_CRIT_EVENT
+RequestSplitterPolicy: RSP_ENABLE_WITH_CRIT_EVENT
 
 # DiskRegistry-based
 AcquireNonReplicatedDevices: true


### PR DESCRIPTION
Adds ERequestSplitterPolicy config option to TMultiPartitionWrapperActor to support gradual migration from actor-level request splitting to TSplitRequestService.

RSP_ENABLE preserves current behavior, RSP_ENABLE_WITH_CRIT_EVENT fires a critical event on each cross-partition request to verify that TSplitRequestService handles all splits before switching
to RSP_DISABLE, which disables splitting in the actor entirely.