### PR TITLE
remove flaky test TLowlevelTest::TTestCaseShouldPropagateFsyncErrors

### DIFF
--- a/cloud/filestore/libs/service_local/lowlevel_ut.cpp
+++ b/cloud/filestore/libs/service_local/lowlevel_ut.cpp
@@ -68,19 +68,6 @@ Y_UNIT_TEST_SUITE(TLowlevelTest)
         checkListDirResult(res, 10);
 
     }
-
-    Y_UNIT_TEST(ShouldPropagateFsyncErrors)
-    {
-        TFileHandle invalidHandle;
-        UNIT_ASSERT(!invalidHandle.IsOpen());
-
-        for (auto dataSync: {true, false}) {
-            UNIT_ASSERT_EXCEPTION_SATISFIES(
-                NLowLevel::Fsync(invalidHandle, dataSync),
-                TServiceError,
-                [](auto const& e) { return e.GetCode() == E_FS_BADHANDLE; });
-        }
-    }
 };
 
 }   // namespace NCloud::NFileStore


### PR DESCRIPTION
### Notes
Remove test as it does not work under release-hardening. Seems like in this mode fdatasync returns 0 even if invalid handle was passed

At least I've create debug test

> Y_UNIT_TEST(DebugFsync)
>     {
>         errno = 0;
>         int res = fdatasync(-1);
>         int err = errno;
>         if (res == 0) {
>             UNIT_ASSERT_C(false, "fdatasync(-1) returned 0");
>         }
>         if (res == -1 && err == 0) {
>             UNIT_ASSERT_C(false, "fdatasync(-1) returned -1 but errno is 0");
>         }
>     }

And it failed with

> assertion failed at cloud/filestore/libs/service_local/lowlevel_ut.cpp:91, virtual void NCloud::NFileStore::NTestSuiteTLowlevelTest::TTestCaseDebugFsync::Execute_(NUnitTest::TTestContext &): (false) fdatasync(-1) returned 0
> TBackTrace::Capture() at /-S/util/system/backtrace.cpp:284:9
> GetCurrentTest at /-S/library/cpp/testing/unittest/registar.cpp:70:12
> UnRef at /-S/util/generic/ptr.h:637:13
> ~TScopeGuard at /-S/util/generic/scope.h:26:13
> TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) at /-S/library/cpp/testing/unittest/utmain.cpp:527:13
> ~__value_func at /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:266:16
> UnRef at /-S/util/generic/ptr.h:637:13
> NUnitTest::TTestFactory::Execute() at /-S/library/cpp/testing/unittest/registar.cpp:0:19
> NUnitTest::RunMain(int, char**) at /-S/library/cpp/testing/unittest/utmain.cpp:0:44
> ?? at ??:0:0
> _start at ??:0:0

### Issue
#5617
