### PR TITLE
[NBS] volume: persist and restore broken devices, notify DiskRegistry

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1575,4 +1575,9 @@ message TStorageServiceConfig
     // modification requests (AddHost, AddDevice, RemoveHost, RemoveDevice,
     // PurgeHost) are rejected with E_REJECTED. 0 means no limit.
     optional uint32 MaxInFlightCmsRequests = 498;
+
+    // If true, TVolumeActor notifies DiskRegistry about volume health changes
+    // (VOLUME_HEALTH_UNHEALTHY when the first device breaks, VOLUME_HEALTH_HEALTHY
+    // when all recovered) for non-replicated disks.
+    optional bool VolumeHealthNotificationEnabled = 499;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -511,6 +511,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(NonReplicatedVolumeNotificationTimeout,    TDuration, Seconds(30)     )\
                                                                                \
     xxx(CoolDownTimeoutBeforeSecureErase,          TDuration, Seconds(0)      )\
+    xxx(VolumeHealthNotificationEnabled,           bool,      false           )\
     xxx(NonReplicatedSecureEraseTimeout,           TDuration, Minutes(10)     )\
     xxx(MaxDevicesToErasePerDeviceNameForDefaultPoolKind,   ui32,   100       )\
     xxx(MaxDevicesToErasePerDeviceNameForLocalPoolKind,     ui32,   100       )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -473,6 +473,7 @@ public:
     TDuration GetDeletedCheckpointHistoryLifetime() const;
     bool GetNonReplicatedMigrationStartAllowed() const;
     bool GetNonReplicatedVolumeMigrationDisabled() const;
+    [[nodiscard]] bool GetVolumeHealthNotificationEnabled() const;
     ui32 GetMigrationIndexCachingInterval() const;
     ui32 GetMaxMigrationBandwidth() const;
     ui32 GetMaxMigrationIoDepth() const;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_broken.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_broken.cpp
@@ -44,7 +44,8 @@ void TDiskRegistryActor::HandleUpdateVolumeHealth(
         std::move(requestInfo),
         msg->Record.GetDiskId(),
         ctx.Now(),
-        health);
+        health,
+        msg->Record.GetHeaders().GetVolumeRequestId());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -69,7 +70,7 @@ void TDiskRegistryActor::ExecuteUpdateVolumeHealth(
 
     TDiskRegistryDatabase db(tx.DB);
     args.Error =
-        State->UpdateVolumeHealth(db, args.DiskId, args.Now, args.VolumeHealth);
+        State->UpdateVolumeHealth(db, args.DiskId, args.Now, args.VolumeHealth, args.VolumeHealthSeqNo);
 }
 
 void TDiskRegistryActor::CompleteUpdateVolumeHealth(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -491,6 +491,7 @@ void TDiskRegistryState::ProcessDisks(TVector<NProto::TDiskConfig> configs)
         disk.MediaKind = NProto::STORAGE_MEDIA_SSD_NONREPLICATED;
         disk.MigrationStartTs = TInstant::MicroSeconds(config.GetMigrationStartTs());
         disk.VolumeHealth = config.GetVolumeHealth();
+        disk.VolumeHealthSeqNo = config.GetVolumeHealthSeqNo();
 
         for (auto& hi: *config.MutableHistory()) {
             disk.History.push_back(std::move(hi));
@@ -5266,6 +5267,7 @@ NProto::TDiskConfig TDiskRegistryState::BuildDiskConfig(
     config.SetStorageMediaKind(diskState.MediaKind);
     config.SetMigrationStartTs(diskState.MigrationStartTs.MicroSeconds());
     config.SetVolumeHealth(diskState.VolumeHealth);
+    config.SetVolumeHealthSeqNo(diskState.VolumeHealthSeqNo);
 
     for (const auto& [uuid, seqNo, _]: diskState.FinishedMigrations) {
         Y_UNUSED(seqNo);
@@ -8679,7 +8681,8 @@ NProto::TError TDiskRegistryState::UpdateVolumeHealth(
     TDiskRegistryDatabase& db,
     const TDiskId& diskId,
     TInstant now,
-    NProto::EVolumeHealth volumeHealth)
+    NProto::EVolumeHealth volumeHealth,
+    ui64 volumeHealthSeqNo)
 {
     auto* disk = Disks.FindPtr(diskId);
     if (!disk) {
@@ -8687,11 +8690,24 @@ NProto::TError TDiskRegistryState::UpdateVolumeHealth(
             E_NOT_FOUND,
             TStringBuilder() << "disk " << diskId.Quote() << " not found");
     }
-    if (disk->VolumeHealth == volumeHealth) {
+    if (volumeHealthSeqNo < disk->VolumeHealthSeqNo) {
+        return MakeError(
+            E_ABORTED,
+            TStringBuilder() << "Stale volume health update for disk "
+                             << diskId.Quote() << ": incoming seqNo "
+                             << volumeHealthSeqNo << " is older than current "
+                             << disk->VolumeHealthSeqNo << ", dropping");
+    }
+    if (volumeHealthSeqNo == disk->VolumeHealthSeqNo) {
         return MakeError(S_ALREADY);
     }
+    const bool healthUnchanged = disk->VolumeHealth == volumeHealth;
+    disk->VolumeHealthSeqNo = volumeHealthSeqNo;
     disk->VolumeHealth = volumeHealth;
     db.UpdateDisk(BuildDiskConfig(diskId, *disk));
+    if (healthUnchanged) {
+        return MakeError(S_ALREADY);
+    }
     TryUpdateDiskStateImpl(db, diskId, *disk, now);
     return {};
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -277,6 +277,7 @@ class TDiskRegistryState
         TVector<TLaggingDevice> OutdatedLaggingDevices;
 
         NProto::EVolumeHealth VolumeHealth = NProto::VOLUME_HEALTH_HEALTHY;
+        ui64 VolumeHealthSeqNo = 0;
     };
 
     struct TVolumeDeviceOverrides
@@ -795,7 +796,8 @@ public:
         TDiskRegistryDatabase& db,
         const TDiskId& diskId,
         TInstant now,
-        NProto::EVolumeHealth volumeHealth);
+        NProto::EVolumeHealth volumeHealth,
+        ui64 volumeHealthSeqNo);
 
     NProto::TError SuspendDevice(TDiskRegistryDatabase& db, const TDeviceId& id);
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -1539,6 +1539,7 @@ struct TTxDiskRegistry
         const TString DiskId;
         const TInstant Now;
         const NProto::EVolumeHealth VolumeHealth;
+        const ui64 VolumeHealthSeqNo;
 
         NProto::TError Error;
 
@@ -1546,11 +1547,13 @@ struct TTxDiskRegistry
             TRequestInfoPtr requestInfo,
             TString diskId,
             TInstant now,
-            NProto::EVolumeHealth volumeHealth)
+            NProto::EVolumeHealth volumeHealth,
+            ui64 volumeHealthSeqNo)
             : RequestInfo(std::move(requestInfo))
             , DiskId(std::move(diskId))
             , Now(now)
             , VolumeHealth(volumeHealth)
+            , VolumeHealthSeqNo(volumeHealthSeqNo)
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_notify.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_notify.cpp
@@ -536,7 +536,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         diskRegistry.UpdateVolumeHealth(
             "nonrepl-vol",
-            NProto::VOLUME_HEALTH_UNHEALTHY);
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            1);
 
         runtime->AdvanceCurrentTime(5s);
         runtime->DispatchEvents({}, 10ms);
@@ -554,7 +555,8 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
 
         diskRegistry.UpdateVolumeHealth(
             "nonrepl-vol",
-            NProto::VOLUME_HEALTH_HEALTHY);
+            NProto::VOLUME_HEALTH_HEALTHY,
+            2);
 
         runtime->AdvanceCurrentTime(5s);
         runtime->DispatchEvents({}, 10ms);
@@ -565,6 +567,65 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             notifyService->Requests[1].Event,
             TDiskBackOnline,
             DiskId);
+    }
+
+    Y_UNIT_TEST(ShouldEnforceSeqNoOrdering)
+    {
+        auto notifyService = std::make_shared<TFakeNotifyService>();
+
+        const TVector agents{
+            CreateAgentConfig(
+                "agent-1",
+                {
+                    Device("dev-1", "uuid-1", "rack-1", 10_GB),
+                }),
+        };
+
+        auto runtime = TTestRuntimeBuilder()
+                           .WithAgents(agents)
+                           .With(notifyService)
+                           .Build();
+        TDiskRegistryClient diskRegistry(*runtime);
+
+        diskRegistry.WaitReady();
+        diskRegistry.SetWritableState(true);
+        diskRegistry.UpdateConfig(CreateRegistryConfig(0, agents));
+        RegisterAndWaitForAgents(*runtime, agents);
+
+        diskRegistry.AllocateDisk(
+            "nonrepl-vol",
+            10_GB,
+            4_KB,
+            "",
+            0,
+            "yc-nbs",
+            "yc-nbs.folder");
+
+        diskRegistry.UpdateVolumeHealth(
+            "nonrepl-vol",
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            5);
+        runtime->AdvanceCurrentTime(5s);
+        runtime->DispatchEvents({}, 10ms);
+        UNIT_ASSERT_VALUES_EQUAL(1, notifyService->Requests.size());
+
+        diskRegistry.SendUpdateVolumeHealthRequest(
+            "nonrepl-vol",
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            5);
+        auto duplicate = diskRegistry.RecvUpdateVolumeHealthResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, duplicate->GetStatus());
+
+        diskRegistry.SendUpdateVolumeHealthRequest(
+            "nonrepl-vol",
+            NProto::VOLUME_HEALTH_HEALTHY,
+            3);
+        auto stale = diskRegistry.RecvUpdateVolumeHealthResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_ABORTED, stale->GetStatus());
+
+        runtime->AdvanceCurrentTime(5s);
+        runtime->DispatchEvents({}, 10ms);
+        UNIT_ASSERT_VALUES_EQUAL(1, notifyService->Requests.size());
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h
@@ -1214,12 +1214,14 @@ public:
 
     auto CreateUpdateVolumeHealthRequest(
         const TString& diskId,
-        NProto::EVolumeHealth volumeHealth)
+        NProto::EVolumeHealth volumeHealth,
+        ui64 volumeHealthSeqNo)
     {
         auto request =
             std::make_unique<TEvDiskRegistry::TEvUpdateVolumeHealthRequest>();
         request->Record.SetDiskId(diskId);
         request->Record.SetVolumeHealth(volumeHealth);
+        request->Record.MutableHeaders()->SetVolumeRequestId(volumeHealthSeqNo);
         return request;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.cpp
@@ -51,6 +51,7 @@ TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfig(
           Devices,
           [this](const NProto::TDeviceConfig& device)
           { return IsDeviceReadyForReading(device); }))
+    , BrokenAtByDeviceId(std::move(params.BrokenAtByDeviceId))
 
 {
     Y_ABORT_UNLESS(Devices.size());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -72,6 +72,7 @@ public:
         TDuration MaxTimedOutDeviceStateDuration;
         bool MaxTimedOutDeviceStateDurationOverridden = false;
         bool UseSimpleMigrationBandwidthLimiter = true;
+        THashMap<TString, TInstant> BrokenAtByDeviceId;
 
         TNonreplicatedPartitionConfigInitParams(
                 TDevices devices,
@@ -139,6 +140,7 @@ private:
     const bool UseSimpleMigrationBandwidthLimiter;
     const TVector<ui64> BlockIndices;
     const bool CanReadFromAllDevices = false;
+    const THashMap<TString, TInstant> BrokenAtByDeviceId;
 
 public:
     explicit TNonreplicatedPartitionConfig(
@@ -149,6 +151,11 @@ public:
     const auto& GetDevices() const
     {
         return Devices;
+    }
+
+    const THashMap<TString, TInstant>& GetBrokenAtByDeviceId() const
+    {
+        return BrokenAtByDeviceId;
     }
 
     bool IsReadOnly() const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.cpp
@@ -37,6 +37,14 @@ void TDeviceStat::MarkBroken(TInstant now)
     }
     BrokenTransitionTs = now;
     DeviceStatus = EDeviceStatus::Broken;
+}
+
+void TDeviceStat::MarkBrokenAndNotify(TInstant now)
+{
+    if (DeviceStatus == EDeviceStatus::Broken) {
+        return;
+    }
+    MarkBroken(now);
     if (Observer) {
         Observer->OnDeviceBroken(DeviceUUID, now);
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats.h
@@ -59,6 +59,7 @@ public:
 
     void MarkOk(TInstant requestStartTs, TDuration executionTime);
     void MarkBroken(TInstant now);
+    void MarkBrokenAndNotify(TInstant now);
     void MarkUnavailable();
     void MarkBackOnline();
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/model/device_stats_ut.cpp
@@ -75,7 +75,7 @@ Y_UNIT_TEST_SUITE(TDeviceStatTest)
 
         const auto now = TInstant::Seconds(100);
 
-        stat.MarkBroken(now);
+        stat.MarkBrokenAndNotify(now);
         UNIT_ASSERT_VALUES_EQUAL(1, observer.BrokenCount);
 
         stat.MarkOk(now, TDuration::MilliSeconds(5));

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -31,10 +31,14 @@ TVector<TDeviceStat> CreateDeviceStats(
     IDeviceStatObserver* observer)
 {
     const auto& devices = partConfig.GetDevices();
+    const auto& brokenAt = partConfig.GetBrokenAtByDeviceId();
     TVector<TDeviceStat> stats;
     stats.reserve(devices.size());
     for (const auto& device: devices) {
         stats.emplace_back(device.GetDeviceUUID(), observer);
+        if (const TInstant* ts = brokenAt.FindPtr(device.GetDeviceUUID())) {
+            stats.back().MarkBroken(*ts);
+        }
     }
     return stats;
 }
@@ -360,7 +364,7 @@ bool TNonreplicatedPartitionActor::InitRequests(
         TDeviceStat& deviceStat = DeviceStats[dr.DeviceIdx];
         if (dr.Device.GetNodeId() == 0) {
             // Accessing a non-allocated device causes the disk to break.
-            deviceStat.MarkBroken(ctx.Now());
+            deviceStat.MarkBrokenAndNotify(ctx.Now());
 
             reply(
                 ctx,

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -310,6 +310,9 @@ message TDiskConfig
     // Health state reported by TVolumeActor (set to UNHEALTHY when at least
     // one device timed out from the volume's perspective).
     EVolumeHealth VolumeHealth = 19;
+
+    // Last applied SeqNo from TVolumeActor health notification.
+    uint64 VolumeHealthSeqNo = 20;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
+++ b/cloud/blockstore/libs/storage/testlib/disk_registry_proxy_mock.h
@@ -59,6 +59,10 @@ private:
                 TEvDiskRegistry::TEvFinishMigrationRequest,
                 HandleFinishMigration);
 
+            HFunc(
+                TEvDiskRegistry::TEvUpdateVolumeHealthRequest,
+                HandleUpdateVolumeHealth);
+
             // acquire/release
             HFunc(TEvDiskRegistry::TEvAcquireDiskRequest, HandleAcquireDisk);
             HFunc(TEvDiskRegistry::TEvReleaseDiskRequest, HandleReleaseDisk);
@@ -403,6 +407,34 @@ private:
 
         NCloud::Reply(ctx, *ev,
             std::make_unique<TEvDiskRegistry::TEvFinishMigrationResponse>());
+    }
+
+    void HandleUpdateVolumeHealth(
+        const TEvDiskRegistry::TEvUpdateVolumeHealthRequest::TPtr& ev,
+        const NActors::TActorContext& ctx)
+    {
+        ++State->UpdateVolumeHealthRequests;
+        State->LastVolumeHealth = ev->Get()->Record.GetVolumeHealth();
+        State->LastVolumeHealthSeqNo =
+            ev->Get()->Record.GetHeaders().GetVolumeRequestId();
+
+        if (State->DropVolumeHealthResponses) {
+            return;
+        }
+
+        NProto::TError error;
+        if (State->VolumeHealthForcedErrorCount > 0) {
+            --State->VolumeHealthForcedErrorCount;
+            error = MakeError(
+                State->VolumeHealthForcedErrorCode,
+                "test forced error");
+        }
+
+        NCloud::Reply(
+            ctx,
+            *ev,
+            std::make_unique<TEvDiskRegistry::TEvUpdateVolumeHealthResponse>(
+                std::move(error)));
     }
 
     void HandleAcquireDisk(

--- a/cloud/blockstore/libs/storage/testlib/test_env_state.h
+++ b/cloud/blockstore/libs/storage/testlib/test_env_state.h
@@ -58,6 +58,12 @@ struct TDiskRegistryState: TAtomicRefCount<TDiskRegistryState>
     EMigrationMode MigrationMode = EMigrationMode::Disabled;
     ui32 ReplicaCount = 0;
     ui32 FinishMigrationRequests = 0;
+    ui32 UpdateVolumeHealthRequests = 0;
+    NProto::EVolumeHealth LastVolumeHealth = NProto::VOLUME_HEALTH_HEALTHY;
+    ui64 LastVolumeHealthSeqNo = 0;
+    bool DropVolumeHealthResponses = false;
+    ui32 VolumeHealthForcedErrorCount = 0;
+    ui32 VolumeHealthForcedErrorCode = S_OK;
     THashSet<TString> DeviceReplacementUUIDs;
 
     TVector<TString> UnavailableDeviceUUIDs;

--- a/cloud/blockstore/libs/storage/volume/actors/volume_health_sync_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_health_sync_actor.cpp
@@ -1,0 +1,195 @@
+#include "volume_health_sync_actor.h"
+
+#include <cloud/blockstore/libs/kikimr/components.h>
+#include <cloud/blockstore/libs/storage/api/disk_registry_proxy.h>
+#include <cloud/blockstore/libs/storage/core/proto_helpers.h>
+
+#include <cloud/storage/core/libs/actors/helpers.h>
+
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <util/random/random.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVolumeHealthSyncActor::TVolumeHealthSyncActor(
+    TString diskId,
+    ui32 generation,
+    TChildLogTitle logTitle,
+    TBackoffDelayProvider delayProvider)
+    : TActor(&TThis::StateWork)
+    , DiskId(std::move(diskId))
+    , SeqNoGen(TCompositeId::FromGeneration(generation))
+    , LogTitle(std::move(logTitle))
+    , DelayProvider(std::move(delayProvider))
+{}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TInstant TVolumeHealthSyncActor::CalcRequestDeadline(TInstant now) const
+{
+    const auto delay = DelayProvider.GetDelay();
+    const auto jitterMicros = delay.MicroSeconds() / 2
+                                  ? RandomNumber<ui64>(delay.MicroSeconds() / 2)
+                                  : 0;
+    const auto total = delay + TDuration::MicroSeconds(jitterMicros);
+    return total.ToDeadLine(now);
+}
+
+void TVolumeHealthSyncActor::SendUpdate(
+    const TActorContext& ctx,
+    TUpdate update)
+{
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Send UpdateVolumeHealth request: %s seqNo=%" PRIu64,
+        LogTitle.GetWithTime().c_str(),
+        NProto::EVolumeHealth_Name(update.Health).c_str(),
+        update.SeqNo);
+
+    auto request =
+        std::make_unique<TEvDiskRegistry::TEvUpdateVolumeHealthRequest>();
+    request->Record.SetDiskId(DiskId);
+    request->Record.SetVolumeHealth(update.Health);
+    request->Record.MutableHeaders()->SetVolumeRequestId(update.SeqNo);
+
+    NCloud::Send(
+        ctx,
+        MakeDiskRegistryProxyServiceId(),
+        std::move(request),
+        update.SeqNo);
+
+    ctx.Schedule(update.Deadline, new TEvents::TEvWakeup(update.SeqNo));
+}
+
+void TVolumeHealthSyncActor::CompleteUpdate(
+    const TActorContext& ctx,
+    ui64 seqNo,
+    const NProto::TError& error)
+{
+    if (!UpdateInProgress || seqNo != UpdateInProgress->SeqNo) {
+        return;
+    }
+
+    if (GetErrorKind(error) == EErrorKind::ErrorRetriable) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "%s UpdateVolumeHealth retriable error (seqNo=%" PRIu64 "): %s",
+            LogTitle.GetWithTime().c_str(),
+            seqNo,
+            FormatError(error).c_str());
+
+        if (error.GetCode() == E_TIMEOUT) {
+            DelayProvider.IncreaseDelay();
+        }
+
+        UpdateInProgress->Deadline = CalcRequestDeadline(ctx.Now());
+        SendUpdate(ctx, *UpdateInProgress);
+        return;
+    }
+
+    const auto logLevel =
+        HasError(error) ? NActors::NLog::PRI_ERROR : NActors::NLog::PRI_INFO;
+    LOG_LOG(
+        ctx,
+        logLevel,
+        TBlockStoreComponents::VOLUME,
+        "%s UpdateVolumeHealth %s (seqNo=%" PRIu64 "): %s",
+        LogTitle.GetWithTime().c_str(),
+        HasError(error) ? "failed" : "succeeded",
+        seqNo,
+        FormatError(error).c_str());
+
+    UpdateInProgress.reset();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TVolumeHealthSyncActor::HandleUpdateVolumeHealth(
+    const TEvDiskRegistry::TEvUpdateVolumeHealthRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto health = ev->Get()->Record.GetVolumeHealth();
+    const ui64 seqNo = SeqNoGen.GetValue();
+    SeqNoGen.Advance();
+    DelayProvider.Reset();
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Sync volume health with Disk Registry: %s seqNo=%" PRIu64,
+        LogTitle.GetWithTime().c_str(),
+        NProto::EVolumeHealth_Name(health).c_str(),
+        seqNo);
+
+    UpdateInProgress = TUpdate{
+        .Health = health,
+        .SeqNo = seqNo,
+        .Deadline = CalcRequestDeadline(ctx.Now()),
+    };
+    SendUpdate(ctx, *UpdateInProgress);
+}
+
+void TVolumeHealthSyncActor::HandleUpdateVolumeHealthResponse(
+    const TEvDiskRegistry::TEvUpdateVolumeHealthResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    CompleteUpdate(ctx, ev->Cookie, ev->Get()->Record.GetError());
+}
+
+void TVolumeHealthSyncActor::HandleWakeup(
+    const TEvents::TEvWakeup::TPtr& ev,
+    const TActorContext& ctx)
+{
+    if (!UpdateInProgress || ev->Get()->Tag != UpdateInProgress->SeqNo) {
+        return;
+    }
+    if (UpdateInProgress->Deadline > ctx.Now()) {
+        return;
+    }
+
+    CompleteUpdate(
+        ctx,
+        UpdateInProgress->SeqNo,
+        MakeError(E_TIMEOUT, "timed out"));
+}
+
+void TVolumeHealthSyncActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TVolumeHealthSyncActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+        HFunc(TEvents::TEvWakeup, HandleWakeup);
+
+        HFunc(
+            TEvDiskRegistry::TEvUpdateVolumeHealthRequest,
+            HandleUpdateVolumeHealth);
+        HFunc(
+            TEvDiskRegistry::TEvUpdateVolumeHealthResponse,
+            HandleUpdateVolumeHealthResponse);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/actors/volume_health_sync_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_health_sync_actor.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cloud/blockstore/libs/storage/api/disk_registry.h>
+#include <cloud/blockstore/libs/storage/core/public.h>
+#include <cloud/blockstore/libs/storage/model/composite_id.h>
+#include <cloud/blockstore/libs/storage/model/log_title.h>
+#include <cloud/blockstore/libs/storage/protos/volume.pb.h>
+
+#include <cloud/storage/core/libs/common/backoff_delay_provider.h>
+
+#include <contrib/ydb/library/actors/core/actor.h>
+#include <contrib/ydb/library/actors/core/events.h>
+
+#include <util/datetime/base.h>
+
+#include <optional>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TVolumeHealthSyncActor final
+    : public NActors::TActor<TVolumeHealthSyncActor>
+{
+    struct TUpdate
+    {
+        NProto::EVolumeHealth Health = NProto::VOLUME_HEALTH_HEALTHY;
+        ui64 SeqNo = 0;
+        TInstant Deadline;
+    };
+
+private:
+    const TString DiskId;
+    TCompositeId SeqNoGen;
+    TChildLogTitle LogTitle;
+    TBackoffDelayProvider DelayProvider;
+    std::optional<TUpdate> UpdateInProgress;
+
+public:
+    TVolumeHealthSyncActor(
+        TString diskId,
+        ui32 generation,
+        TChildLogTitle logTitle,
+        TBackoffDelayProvider delayProvider);
+
+private:
+    STFUNC(StateWork);
+
+    [[nodiscard]] TInstant CalcRequestDeadline(TInstant now) const;
+    void SendUpdate(const NActors::TActorContext& ctx, TUpdate update);
+    void CompleteUpdate(
+        const NActors::TActorContext& ctx,
+        ui64 seqNo,
+        const NProto::TError& error);
+
+    void HandleUpdateVolumeHealth(
+        const TEvDiskRegistry::TEvUpdateVolumeHealthRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleUpdateVolumeHealthResponse(
+        const TEvDiskRegistry::TEvUpdateVolumeHealthResponse::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleWakeup(
+        const NActors::TEvents::TEvWakeup::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const NActors::TEvents::TEvPoisonPill::TPtr& ev,
+        const NActors::TActorContext& ctx);
+};
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/actors/ya.make
+++ b/cloud/blockstore/libs/storage/volume/actors/ya.make
@@ -16,6 +16,7 @@ SRCS(
     release_devices_actor.cpp
     shadow_disk_actor.cpp
     volume_as_partition_actor.cpp
+    volume_health_sync_actor.cpp
     disk_registry_based_partition_statistics_collector_actor.cpp
 )
 

--- a/cloud/blockstore/libs/storage/volume/ut/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
     volume_state_ut.cpp
     volume_throttling_ut.cpp
     volume_ut.cpp
+    volume_ut_broken_devices.cpp
     volume_ut_checkpoint.cpp
     volume_ut_checksums.cpp
     volume_ut_session.cpp

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -335,6 +335,9 @@ private:
     NProto::TError StorageAllocationResult;
     bool DiskAllocationScheduled = false;
 
+    THashMap<TString, TInstant> DeviceUUIDToBrokenAt;
+    NActors::TActorId VolumeHealthSyncActorId;
+
     TVolumeRequestMap VolumeRequests;
     TRequestsInFlight WriteAndZeroRequestsInFlight;
 
@@ -1276,6 +1279,15 @@ private:
     void HandleCheckRangeResponse(
         const TEvVolume::TEvCheckRangeResponse::TPtr& ev,
         const NActors::TActorContext& ctx);
+
+    void CleanupStaleBrokenDevices(const NActors::TActorContext& ctx);
+
+    void RegisterVolumeHealthSyncActorIfNeeded(
+        const NActors::TActorContext& ctx);
+
+    void SendVolumeHealthNotification(
+        const NActors::TActorContext& ctx,
+        NProto::EVolumeHealth volumeHealth);
 
     void CreateCheckpointLightRequest(
         const NActors::TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -716,6 +716,8 @@ void TVolumeActor::CompleteUpdateDevices(
                 std::move(outdatedDevices)));
     };
 
+    CleanupStaleBrokenDevices(ctx);
+
     StopPartitions(ctx, onPartitionDestroy);
     SendVolumeConfigUpdated(ctx);
     StartPartitionsForUse(ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_broken_devices.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_broken_devices.cpp
@@ -1,10 +1,72 @@
 #include "volume_actor.h"
 
+#include "actors/volume_health_sync_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/disk_registry.h>
 #include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
+#include <cloud/blockstore/libs/storage/volume/model/helpers.h>
+
+#include <cloud/storage/core/libs/common/backoff_delay_provider.h>
+#include <cloud/storage/core/libs/common/media.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TVolumeActor::RegisterVolumeHealthSyncActorIfNeeded(
+    const TActorContext& ctx)
+{
+    if (!Config->GetVolumeHealthNotificationEnabled()) {
+        return;
+    }
+
+    if (VolumeHealthSyncActorId) {
+        return;
+    }
+
+    if (!State) {
+        return;
+    }
+
+    if (!IsNonReplicatedMediaKind(
+            State->GetMeta().GetConfig().GetStorageMediaKind()))
+    {
+        return;
+    }
+
+    VolumeHealthSyncActorId = NCloud::Register<TVolumeHealthSyncActor>(
+        ctx,
+        State->GetDiskId(),
+        Executor()->Generation(),
+        LogTitle.GetChild(GetCycleCount()),
+        TBackoffDelayProvider{TDuration::Seconds(1), TDuration::Seconds(30)});
+    Actors.insert(VolumeHealthSyncActorId);
+
+    if (DeviceUUIDToBrokenAt.empty()) {
+        SendVolumeHealthNotification(ctx, NProto::VOLUME_HEALTH_HEALTHY);
+    } else {
+        SendVolumeHealthNotification(ctx, NProto::VOLUME_HEALTH_UNHEALTHY);
+    }
+}
+
+void TVolumeActor::SendVolumeHealthNotification(
+    const TActorContext& ctx,
+    NProto::EVolumeHealth volumeHealth)
+{
+    if (!VolumeHealthSyncActorId) {
+        return;
+    }
+
+    auto request =
+        std::make_unique<TEvDiskRegistry::TEvUpdateVolumeHealthRequest>();
+    request->Record.SetVolumeHealth(volumeHealth);
+
+    NCloud::Send(ctx, VolumeHealthSyncActorId, std::move(request));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -12,35 +74,161 @@ void TVolumeActor::HandleBrokenDeviceNotification(
     const TEvNonreplPartitionPrivate::TEvBrokenDeviceNotification::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (!VolumeHealthSyncActorId) {
+        return;
+    }
+
     auto* msg = ev->Get();
+    const auto& uuid = msg->DeviceUUID;
+    const auto& ts = msg->BrokenTs;
+
+    if (DeviceUUIDToBrokenAt.contains(uuid)) {
+        return;
+    }
 
     LOG_WARN(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Device %s is broken (broken at %s)",
         LogTitle.GetWithTime().c_str(),
-        msg->DeviceUUID.Quote().c_str(),
-        msg->BrokenTs.ToString().c_str());
+        uuid.Quote().c_str(),
+        ts.ToString().c_str());
 
-    // TODO: save the broken device to the database
+    const bool wasEmpty = DeviceUUIDToBrokenAt.empty();
+    DeviceUUIDToBrokenAt[uuid] = ts;
+    ExecuteTx<TUpdateBrokenDevice>(
+        ctx,
+        TVector<TTxVolume::TUpdateBrokenDevice::TDeviceEntry>{
+            {.DeviceUUID = uuid, .BrokenTs = ts, .Add = true}});
+
+    if (wasEmpty) {
+        SendVolumeHealthNotification(ctx, NProto::VOLUME_HEALTH_UNHEALTHY);
+    }
 }
-
-////////////////////////////////////////////////////////////////////////////////
 
 void TVolumeActor::HandleDeviceRecoveredNotification(
     const TEvNonreplPartitionPrivate::TEvDeviceRecoveredNotification::TPtr& ev,
     const TActorContext& ctx)
 {
+    if (!VolumeHealthSyncActorId) {
+        return;
+    }
+
     auto* msg = ev->Get();
+    const auto& uuid = msg->DeviceUUID;
+
+    if (!DeviceUUIDToBrokenAt.contains(uuid)) {
+        return;
+    }
 
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,
         "%s Device %s has recovered",
         LogTitle.GetWithTime().c_str(),
-        msg->DeviceUUID.Quote().c_str());
+        uuid.Quote().c_str());
 
-    // TODO: remove the device from the list of broken ones in the database
+    DeviceUUIDToBrokenAt.erase(uuid);
+    ExecuteTx<TUpdateBrokenDevice>(
+        ctx,
+        TVector<TTxVolume::TUpdateBrokenDevice::TDeviceEntry>{
+            {.DeviceUUID = uuid, .BrokenTs = TInstant::Zero(), .Add = false}});
+
+    if (DeviceUUIDToBrokenAt.empty()) {
+        SendVolumeHealthNotification(ctx, NProto::VOLUME_HEALTH_HEALTHY);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TVolumeActor::PrepareUpdateBrokenDevice(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxVolume::TUpdateBrokenDevice& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+    return true;
+}
+
+void TVolumeActor::ExecuteUpdateBrokenDevice(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxVolume::TUpdateBrokenDevice& args)
+{
+    Y_UNUSED(ctx);
+
+    TVolumeDatabase db(tx.DB);
+    for (const auto& entry: args.Entries) {
+        if (entry.Add) {
+            db.WriteBrokenDevice(entry.DeviceUUID, entry.BrokenTs);
+        } else {
+            db.DeleteBrokenDevice(entry.DeviceUUID);
+        }
+    }
+}
+
+void TVolumeActor::CompleteUpdateBrokenDevice(
+    const TActorContext& ctx,
+    TTxVolume::TUpdateBrokenDevice& args)
+{
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Updated %zu broken device(s) in DB: [%s]",
+        LogTitle.GetWithTime().c_str(),
+        args.Entries.size(),
+        [&]()
+        {
+            TStringBuilder str;
+            size_t size = args.Entries.size();
+            for (size_t i = 0; i < size; ++i) {
+                str << args.Entries[i].DeviceUUID;
+                if (i + 1 < size) {
+                    str << ", ";
+                }
+            }
+            return str;
+        }()
+            .c_str());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TVolumeActor::CleanupStaleBrokenDevices(const TActorContext& ctx)
+{
+    if (DeviceUUIDToBrokenAt.empty()) {
+        return;
+    }
+
+    THashMap<TString, TInstant> staleDeviceUUIDToBrokenAt;
+    staleDeviceUUIDToBrokenAt.swap(DeviceUUIDToBrokenAt);
+    for (const auto* dev: GetAllDevices(State->GetMeta())) {
+        auto it = staleDeviceUUIDToBrokenAt.find(dev->GetDeviceUUID());
+        if (it != staleDeviceUUIDToBrokenAt.end()) {
+            // Device still belongs to this volume, keep it in broken set
+            DeviceUUIDToBrokenAt.insert(*it);
+            staleDeviceUUIDToBrokenAt.erase(it);
+        }
+    }
+
+    // Remove orphaned entries (device no longer in volume) from DB
+    if (!staleDeviceUUIDToBrokenAt.empty()) {
+        TVector<TTxVolume::TUpdateBrokenDevice::TDeviceEntry> entries;
+        entries.reserve(staleDeviceUUIDToBrokenAt.size());
+        for (const auto& [uuid, _]: staleDeviceUUIDToBrokenAt) {
+            entries.push_back(
+                {.DeviceUUID = uuid,
+                 .BrokenTs = TInstant::Zero(),
+                 .Add = false});
+        }
+        ExecuteTx<TUpdateBrokenDevice>(ctx, std::move(entries));
+    }
+
+    if (DeviceUUIDToBrokenAt.empty()) {
+        SendVolumeHealthNotification(ctx, NProto::VOLUME_HEALTH_HEALTHY);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_loadstate.cpp
@@ -5,7 +5,6 @@
 #include <cloud/blockstore/libs/storage/core/config.h>
 
 #include <cloud/storage/core/libs/common/format.h>
-#include <cloud/storage/core/libs/common/media.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -51,6 +50,7 @@ bool TVolumeActor::PrepareLoadState(
         db.ReadStorageConfig(args.StorageConfig),
         db.ReadFollowers(args.FollowerDisks),
         db.ReadLeaders(args.LeaderDisks),
+        db.ReadBrokenDevices(args.BrokenDevices),
     };
 
     if (args.Meta) {
@@ -162,6 +162,13 @@ void TVolumeActor::CompleteLoadState(
                 CopyCachedStatsToPartCounters(partStats.Stats, *info);
             }
         }
+
+        for (const auto& info: args.BrokenDevices) {
+            DeviceUUIDToBrokenAt[info.DeviceUUID] = info.BrokenTs;
+        }
+
+        CleanupStaleBrokenDevices(ctx);
+        RegisterVolumeHealthSyncActorIfNeeded(ctx);
 
         Y_ABORT_UNLESS(CurrentState == STATE_INIT);
         BecomeAux(ctx, STATE_WORK);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -259,6 +259,7 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
             maxTimedOutDeviceStateDurationOverridden,
             useSimpleMigrationBandwidthLimiter,
         };
+    params.BrokenAtByDeviceId = DeviceUUIDToBrokenAt;
     auto nonreplicatedConfig =
         std::make_shared<TNonreplicatedPartitionConfig>(std::move(params));
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updateconfig.cpp
@@ -391,6 +391,8 @@ void TVolumeActor::CompleteUpdateConfig(
         BecomeAux(ctx, STATE_WORK);
     }
 
+    RegisterVolumeHealthSyncActorIfNeeded(ctx);
+
     LOG_INFO(
         ctx,
         TBlockStoreComponents::VOLUME,

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -47,6 +47,7 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(RemoveFollower,                 __VA_ARGS__)                           \
     xxx(UpdateLeader,                   __VA_ARGS__)                           \
     xxx(RemoveLeader,                   __VA_ARGS__)                           \
+    xxx(UpdateBrokenDevice,             __VA_ARGS__)                           \
 // BLOCKSTORE_VOLUME_TRANSACTIONS
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -850,6 +851,31 @@ struct TTxVolume
         TRemoveLeader(TRequestInfoPtr requestInfo, TLeaderFollowerLink link)
             : RequestInfo(std::move(requestInfo))
             , Link(std::move(link))
+        {}
+
+        void Clear()
+        {
+            // nothing to do
+        }
+    };
+
+    //
+    // UpdateBrokenDevice
+    //
+
+    struct TUpdateBrokenDevice
+    {
+        struct TDeviceEntry
+        {
+            TString DeviceUUID;
+            TInstant BrokenTs;
+            bool Add;
+        };
+
+        TVector<TDeviceEntry> Entries;
+
+        explicit TUpdateBrokenDevice(TVector<TDeviceEntry> entries)
+            : Entries(std::move(entries))
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/volume/volume_ut_broken_devices.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_broken_devices.cpp
@@ -1,0 +1,337 @@
+#include "volume_ut.h"
+
+#include <cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NTestVolume;
+using namespace std::chrono_literals;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const ui64 DefaultBlockCount =
+    DefaultDeviceBlockSize * DefaultDeviceBlockCount / DefaultBlockSize;
+
+NProto::TStorageServiceConfig MakeConfig(bool enableVolumeHealth)
+{
+    NProto::TStorageServiceConfig config;
+    config.SetAcquireNonReplicatedDevices(true);
+    config.SetVolumeHealthNotificationEnabled(enableVolumeHealth);
+    return config;
+}
+
+void SetupVolume(
+    TVolumeClient& volume,
+    NCloud::NProto::EStorageMediaKind mediaKind,
+    ui64 blockCount)
+{
+    volume.UpdateVolumeConfig(0, 0, 0, 0, false, 1, mediaKind, blockCount);
+    volume.WaitReady();
+}
+
+void SetupNrdVolume(TVolumeClient& volume)
+{
+    SetupVolume(
+        volume,
+        NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+        DefaultBlockCount);
+}
+
+void SendBrokenDeviceNotification(TVolumeClient& volume, const TString& uuid)
+{
+    volume.SendToPipe(
+        std::make_unique<
+            TEvNonreplPartitionPrivate::TEvBrokenDeviceNotification>(
+            TEvNonreplPartitionPrivate::TBrokenDeviceNotification(
+                uuid,
+                TInstant::Seconds(100))));
+}
+
+void SendRecoveredDeviceNotification(TVolumeClient& volume, const TString& uuid)
+{
+    volume.SendToPipe(
+        std::make_unique<
+            TEvNonreplPartitionPrivate::TEvDeviceRecoveredNotification>(
+            TEvNonreplPartitionPrivate::TDeviceRecoveredNotification(uuid)));
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TVolumeBrokenDevicesTest)
+{
+    Y_UNIT_TEST(ShouldSendUnhealthyOnFirstBrokenDevice)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+        const ui32 requestsBefore = state->UpdateVolumeHealthRequests;
+
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsBefore + 1,
+            state->UpdateVolumeHealthRequests);
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            state->LastVolumeHealth);
+    }
+
+    Y_UNIT_TEST(ShouldNotSendDuplicateUnhealthy)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+        const ui32 requestsBefore = state->UpdateVolumeHealthRequests;
+
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        SendBrokenDeviceNotification(volume, "uuid-2");
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsBefore + 1,
+            state->UpdateVolumeHealthRequests);
+    }
+
+    Y_UNIT_TEST(ShouldSendHealthyWhenAllDevicesRecover)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        SendBrokenDeviceNotification(volume, "uuid-2");
+        runtime->DispatchEvents({}, 1s);
+
+        SendRecoveredDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+
+        SendRecoveredDeviceNotification(volume, "uuid-2");
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_HEALTHY,
+            state->LastVolumeHealth);
+    }
+
+    Y_UNIT_TEST(ShouldSkipAllWorkWhenFlagDisabled)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/false),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+        const ui32 requestsBefore = state->UpdateVolumeHealthRequests;
+
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsBefore,
+            state->UpdateVolumeHealthRequests);
+    }
+
+    Y_UNIT_TEST(ShouldSkipNotificationsForMirrorVolume)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupVolume(
+            volume,
+            NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2,
+            DefaultBlockCount);
+        const ui32 requestsBefore = state->UpdateVolumeHealthRequests;
+
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsBefore,
+            state->UpdateVolumeHealthRequests);
+    }
+
+    Y_UNIT_TEST(ShouldCleanupStaleDevicesOnUpdateDevices)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            state->LastVolumeHealth);
+
+        volume.ReallocateDisk();
+        volume.ReconnectPipe();
+        volume.WaitReady();
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_HEALTHY,
+            state->LastVolumeHealth);
+    }
+
+    Y_UNIT_TEST(ShouldRetryUntilDelivered)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+
+        state->DropVolumeHealthResponses = true;
+
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            state->LastVolumeHealth);
+        const ui32 requestsAfterFirst = state->UpdateVolumeHealthRequests;
+
+        runtime->AdvanceCurrentTime(30s);
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_GT(state->UpdateVolumeHealthRequests, requestsAfterFirst);
+
+        state->DropVolumeHealthResponses = false;
+        runtime->AdvanceCurrentTime(30s);
+        runtime->DispatchEvents({}, 1s);
+        const ui32 requestsAfterAck = state->UpdateVolumeHealthRequests;
+
+        runtime->AdvanceCurrentTime(60s);
+        runtime->DispatchEvents({}, 1s);
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsAfterAck,
+            state->UpdateVolumeHealthRequests);
+    }
+
+    Y_UNIT_TEST(ShouldStopRetryAfterTerminalResponse)
+    {
+        for (auto code: {E_ABORTED, S_ALREADY}) {
+            auto state = MakeIntrusive<TDiskRegistryState>();
+            auto runtime = PrepareTestActorRuntime(
+                MakeConfig(/*enableVolumeHealth=*/true),
+                state);
+
+            TVolumeClient volume(*runtime);
+            SetupNrdVolume(volume);
+            const ui32 requestsBefore = state->UpdateVolumeHealthRequests;
+
+            state->VolumeHealthForcedErrorCount = 1;
+            state->VolumeHealthForcedErrorCode = code;
+
+            SendBrokenDeviceNotification(volume, "uuid-1");
+            runtime->DispatchEvents({}, 1s);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                requestsBefore + 1,
+                state->UpdateVolumeHealthRequests,
+                code);
+
+            runtime->AdvanceCurrentTime(60s);
+            runtime->DispatchEvents({}, 1s);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                requestsBefore + 1,
+                state->UpdateVolumeHealthRequests,
+                code);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldReplaceInflightOnNewHealthChange)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+        const ui32 requestsBefore = state->UpdateVolumeHealthRequests;
+
+        state->DropVolumeHealthResponses = true;
+        SendBrokenDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsBefore + 1,
+            state->UpdateVolumeHealthRequests);
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            state->LastVolumeHealth);
+
+        state->DropVolumeHealthResponses = false;
+        SendRecoveredDeviceNotification(volume, "uuid-1");
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsBefore + 2,
+            state->UpdateVolumeHealthRequests);
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_HEALTHY,
+            state->LastVolumeHealth);
+
+        runtime->AdvanceCurrentTime(60s);
+        runtime->DispatchEvents({}, 1s);
+        UNIT_ASSERT_VALUES_EQUAL(
+            requestsBefore + 2,
+            state->UpdateVolumeHealthRequests);
+    }
+
+    Y_UNIT_TEST(ShouldPersistBrokenDevicesAcrossTabletRestart)
+    {
+        auto state = MakeIntrusive<TDiskRegistryState>();
+        auto runtime = PrepareTestActorRuntime(
+            MakeConfig(/*enableVolumeHealth=*/true),
+            state);
+
+        TVolumeClient volume(*runtime);
+        SetupNrdVolume(volume);
+
+        SendBrokenDeviceNotification(volume, "uuid0");
+        runtime->DispatchEvents({}, 1s);
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            state->LastVolumeHealth);
+        const ui32 requestsBeforeRestart = state->UpdateVolumeHealthRequests;
+
+        volume.RebootTablet();
+        volume.WaitReady();
+        runtime->DispatchEvents({}, 1s);
+
+        UNIT_ASSERT_GT(
+            state->UpdateVolumeHealthRequests,
+            requestsBeforeRestart);
+        UNIT_ASSERT_EQUAL(
+            NProto::VOLUME_HEALTH_UNHEALTHY,
+            state->LastVolumeHealth);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/storage/core/libs/common/media.cpp
+++ b/cloud/storage/core/libs/common/media.cpp
@@ -46,6 +46,17 @@ bool IsDiskRegistryLocalMediaKind(NProto::EStorageMediaKind mediaKind)
     }
 }
 
+bool IsNonReplicatedMediaKind(NProto::EStorageMediaKind mediaKind)
+{
+    switch (mediaKind) {
+        case NProto::STORAGE_MEDIA_SSD_NONREPLICATED:
+        case NProto::STORAGE_MEDIA_HDD_NONREPLICATED:
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool IsReliableMediaKind(NProto::EStorageMediaKind mediaKind)
 {
     return !IsDiskRegistryMediaKind(mediaKind) ||

--- a/cloud/storage/core/libs/common/media.h
+++ b/cloud/storage/core/libs/common/media.h
@@ -15,6 +15,7 @@ bool IsDiskRegistryMediaKind(NProto::EStorageMediaKind mediaKind);
 bool IsBlobStorageMediaKind(NProto::EStorageMediaKind mediaKind);
 bool IsReliableDiskRegistryMediaKind(NProto::EStorageMediaKind mediaKind);
 bool IsDiskRegistryLocalMediaKind(NProto::EStorageMediaKind mediaKind);
+bool IsNonReplicatedMediaKind(NProto::EStorageMediaKind mediaKind);
 bool IsReliableMediaKind(NProto::EStorageMediaKind mediaKind);
 TString MediaKindToString(NProto::EStorageMediaKind mediaKind);
 TString MediaKindToStatsString(NProto::EStorageMediaKind mediaKind);


### PR DESCRIPTION
[#3727](https://github.com/ydb-platform/nbs/issues/3727)

TVolumeActor persists broken device state to DB and restores it on restart. When the first device breaks, DiskRegistry is notified with VOLUME_HEALTH_UNHEALTHY so users see the disk as  temporarily unavailable without waiting for DR heartbeat detection; once all devices recover or are replaced via reallocate, VOLUME_HEALTH_HEALTHY is sent. Delivery is handled by a dedicated child TVolumeHealthSyncActor that retries with exponential backoff until DR acknowledges. Ordering and idempotency are enforced on the DR side via a monotonic seqNo (TCompositeId carrying the tablet generation), so retries including the re-push on tablet restart cannot be misapplied or lost.