### PR TITLE
blockstore: treating checkpoints-in-flight commit ids as actual checkpoint commit ids for the purposes of garbage collection on Cleanup operation

### DIFF
--- a/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
@@ -3,9 +3,6 @@
 #include <library/cpp/json/json_value.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 
-#include <algorithm>
-#include <ranges>
-
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -169,7 +166,6 @@ bool TCheckpointStore::RemoveCommitId(ui64 commitId)
 
 void TCheckpointQueue::Enqueue(const TString& checkpointId, ui64 commitId)
 {
-    Y_ABORT_UNLESS(Queue.empty() || commitId >= Queue.back().first);
     Queue.emplace_back(commitId, checkpointId);
 }
 
@@ -189,21 +185,6 @@ TString TCheckpointQueue::Dequeue(ui64 commitId)
 bool TCheckpointQueue::Empty() const
 {
     return Queue.empty();
-}
-
-void TCheckpointQueue::GetCommitIds(TVector<ui64>& commitIds) const
-{
-    for (const auto& [commitId, _]: Queue) {
-        commitIds.push_back(commitId);
-    }
-}
-
-ui64 TCheckpointQueue::GetMinCommitId() const
-{
-    if (Queue.empty()) {
-        return Max<ui64>();
-    }
-    return Queue.front().first;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -281,12 +262,18 @@ bool TCheckpointsInFlight::HasCheckpoint(const TString& checkpointId) const
 
 void TCheckpointsInFlight::GetCommitIds(TVector<ui64>& commitIds) const
 {
-    CommitIdQueue.GetCommitIds(commitIds);
+    for (const auto& [_, txPair]: PendingTransactions) {
+        const auto& txCommitId = txPair.CommitId;
+        if (!txCommitId) {
+            continue;
+        }
+        commitIds.push_back(txCommitId);
+    }
 }
 
 ui64 TCheckpointsInFlight::GetMinCommitId() const
 {
-    auto minCommitId = CommitIdQueue.GetMinCommitId();
+    auto minCommitId = Max<ui64>();
     for (const auto& [_, txPair]: PendingTransactions) {
         const auto& txCommitId = txPair.CommitId;
         if (!txCommitId) {

--- a/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
@@ -169,6 +169,7 @@ bool TCheckpointStore::RemoveCommitId(ui64 commitId)
 
 void TCheckpointQueue::Enqueue(const TString& checkpointId, ui64 commitId)
 {
+    Y_ABORT_UNLESS(Queue.empty() || commitId >= Queue.back().first);
     Queue.emplace_back(commitId, checkpointId);
 }
 
@@ -202,10 +203,7 @@ ui64 TCheckpointQueue::GetMinCommitId() const
     if (Queue.empty()) {
         return Max();
     }
-    return std::ranges::min_element(
-               Queue,
-               [](const auto& a, const auto& b) { return a.first < b.first; })
-        ->first;
+    return Queue.front().first;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -284,26 +282,17 @@ bool TCheckpointsInFlight::HasCheckpoint(const TString& checkpointId) const
 void TCheckpointsInFlight::GetCommitIds(TVector<ui64>& commitIds) const
 {
     CommitIdQueue.GetCommitIds(commitIds);
-    for (const auto& [_, queue]: PendingTransactions) {
-        for (const auto& [_, commitId]: queue) {
-            if (!commitId) {
-                continue;
-            }
-            commitIds.push_back(commitId);
-        }
-    }
 }
 
 ui64 TCheckpointsInFlight::GetMinCommitId() const
 {
-    ui64 minCommitId = CommitIdQueue.GetMinCommitId();
-    for (const auto& [_, queue]: PendingTransactions) {
-        for (const auto& [_, commitId]: queue) {
-            if (!commitId) {
-                continue;
-            }
-            minCommitId = Min(minCommitId, commitId);
+    auto minCommitId = CommitIdQueue.GetMinCommitId();
+    for (const auto& [_, txPair]: PendingTransactions) {
+        auto& txCommitId = txPair.second;
+        if (!txCommitId) {
+            continue;
         }
+        minCommitId = Min(minCommitId, txCommitId);
     }
     return minCommitId;
 }

--- a/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
@@ -201,7 +201,7 @@ void TCheckpointQueue::GetCommitIds(TVector<ui64>& commitIds) const
 ui64 TCheckpointQueue::GetMinCommitId() const
 {
     if (Queue.empty()) {
-        return Max();
+        return Max<ui64>();
     }
     return Queue.front().first;
 }
@@ -288,7 +288,7 @@ ui64 TCheckpointsInFlight::GetMinCommitId() const
 {
     auto minCommitId = CommitIdQueue.GetMinCommitId();
     for (const auto& [_, txPair]: PendingTransactions) {
-        auto& txCommitId = txPair.second;
+        const auto& txCommitId = txPair.CommitId;
         if (!txCommitId) {
             continue;
         }

--- a/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/checkpoint.cpp
@@ -3,6 +3,9 @@
 #include <library/cpp/json/json_value.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 
+#include <algorithm>
+#include <ranges>
+
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -194,6 +197,17 @@ void TCheckpointQueue::GetCommitIds(TVector<ui64>& commitIds) const
     }
 }
 
+ui64 TCheckpointQueue::GetMinCommitId() const
+{
+    if (Queue.empty()) {
+        return Max();
+    }
+    return std::ranges::min_element(
+               Queue,
+               [](const auto& a, const auto& b) { return a.first < b.first; })
+        ->first;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 bool TCheckpointsInFlight::AddTx(
@@ -270,6 +284,28 @@ bool TCheckpointsInFlight::HasCheckpoint(const TString& checkpointId) const
 void TCheckpointsInFlight::GetCommitIds(TVector<ui64>& commitIds) const
 {
     CommitIdQueue.GetCommitIds(commitIds);
+    for (const auto& [_, queue]: PendingTransactions) {
+        for (const auto& [_, commitId]: queue) {
+            if (!commitId) {
+                continue;
+            }
+            commitIds.push_back(commitId);
+        }
+    }
+}
+
+ui64 TCheckpointsInFlight::GetMinCommitId() const
+{
+    ui64 minCommitId = CommitIdQueue.GetMinCommitId();
+    for (const auto& [_, queue]: PendingTransactions) {
+        for (const auto& [_, commitId]: queue) {
+            if (!commitId) {
+                continue;
+            }
+            minCommitId = Min(minCommitId, commitId);
+        }
+    }
+    return minCommitId;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/partition/model/checkpoint.h
@@ -123,6 +123,8 @@ public:
 
     bool Empty() const;
     void GetCommitIds(TVector<ui64>& commitIds) const;
+
+    [[nodiscard]] ui64 GetMinCommitId() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -154,6 +156,8 @@ public:
     [[nodiscard]] bool HasCheckpoint(const TString& checkpointId) const;
 
     void GetCommitIds(TVector<ui64>& commitIds) const;
+
+    [[nodiscard]] ui64 GetMinCommitId() const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/checkpoint.h
+++ b/cloud/blockstore/libs/storage/partition/model/checkpoint.h
@@ -122,9 +122,6 @@ public:
     TString Dequeue(ui64 commitId);
 
     bool Empty() const;
-    void GetCommitIds(TVector<ui64>& commitIds) const;
-
-    [[nodiscard]] ui64 GetMinCommitId() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_checkpoint.cpp
@@ -244,7 +244,12 @@ void TPartitionActor::DeleteCheckpoint(
         reply,
         deleteOnlyData);
 
-    SharedState->WaitCommitForCheckpoint(ctx, std::move(tx), checkpointId, 0);
+    SharedState->WaitCommitForCheckpoint(
+        ctx,
+        std::move(tx),
+        checkpointId,
+        0 /* commitId */
+    );
 }
 
 bool TPartitionActor::PrepareDeleteCheckpoint(

--- a/cloud/blockstore/libs/storage/partition/part_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_checkpoint.cpp
@@ -244,12 +244,7 @@ void TPartitionActor::DeleteCheckpoint(
         reply,
         deleteOnlyData);
 
-    SharedState->WaitCommitForCheckpoint(
-        ctx,
-        std::move(tx),
-        checkpointId,
-        0 /* commitId */
-    );
+    SharedState->WaitCommitForCheckpoint(ctx, std::move(tx), checkpointId, 0);
 }
 
 bool TPartitionActor::PrepareDeleteCheckpoint(

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -140,6 +140,8 @@ ui64 TPartitionState::GetCleanupCommitId() const
     commitId =
         Min(commitId, GetCheckpoints().GetMinCommitId() - 1);
 
+    commitId = Min(commitId, GetCheckpointsInFlight()->GetMinCommitId() - 1);
+
     return commitId;
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13457,7 +13457,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldNotLoseAnyMixedMergedBlocksWhileWaitingForCheckpointCreation)
+    Y_UNIT_TEST(
+        ShouldNotLoseAnyMixedMergedBlocksWhileWaitingForCheckpointCreation)
     {
         auto config = DefaultConfig();
         config.SetFreshChannelWriteRequestsEnabled(true);
@@ -13476,15 +13477,20 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         bool interceptTransactions = true;
 
         std::unique_ptr<IEventHandle> executeTransactionsEvent;
-        runtime->SetObserverFunc(
-            [&](TAutoPtr<IEventHandle>& event)
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
-                if (event->GetTypeRewrite() == TEvPartitionCommonPrivate::EvExecuteTransactions && interceptTransactions) {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvExecuteTransactions &&
+                    interceptTransactions)
+                {
                     executeTransactionsEvent.reset(event.Release());
                     interceptTransactions = false;
-                    return TTestActorRuntime::EEventAction::DROP;
+
+                    return true;
                 }
-                return TTestActorRuntime::DefaultObserverFunc(event);
+                return false;
             });
 
         auto response = partition.RecvCompactionResponse();
@@ -13493,6 +13499,12 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.Cleanup();
 
         UNIT_ASSERT(executeTransactionsEvent);
+
+        partition.SendReadBlocksRequest(0, "c1");
+        auto readBlocksResponse = partition.RecvReadBlocksResponse();
+
+        // Check that create checkpoint transaction is not executed
+        UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, readBlocksResponse->GetStatus());
 
         runtime->SendAsync(executeTransactionsEvent.release());
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13456,6 +13456,109 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
         }
     }
+
+    Y_UNIT_TEST(ShouldNotLoseAnyBlocksWithMultipleCheckpointsCreationAndDelete)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool interseptEvent = false;
+        bool skipFirstIntercept = false;
+
+        std::unique_ptr<IEventHandle> putEvent;
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvBlobStorage::EvPut) {
+                    auto* msg = event->Get<TEvBlobStorage::TEvPut>();
+
+                    if (msg->Id.Channel() == 0 && interseptEvent &&
+                        !skipFirstIntercept)
+                    {
+                        putEvent.reset(event.Release());
+                        interseptEvent = false;
+                        return TTestActorRuntime::EEventAction::DROP;
+                    } else if (msg->Id.Channel() == 0 && interseptEvent) {
+                        skipFirstIntercept = false;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.WriteBlocks(0, '1');
+        partition.Flush();
+
+        partition.SendCreateCheckpointRequest("c1");
+        partition.SendDeleteCheckpointRequest("c1");
+        partition.SendCreateCheckpointRequest("c1");
+        partition.SendDeleteCheckpointRequest("c1");
+        partition.SendCreateCheckpointRequest("c1");
+        partition.SendCompactionRequest();
+
+        interseptEvent = true;
+
+        runtime->DispatchEvents({}, 10ms);
+        UNIT_ASSERT(putEvent);
+
+        skipFirstIntercept = true;
+        interseptEvent = true;
+
+        // create checkpoint  and compaction transactions executed not completed
+        runtime->SendAsync(putEvent.release());
+
+        runtime->DispatchEvents({}, 10ms);
+
+        // delete checkpoint  and addblobs transactions executed not completed
+        UNIT_ASSERT(putEvent);
+        runtime->SendAsync(putEvent.release());
+
+        skipFirstIntercept = true;
+        interseptEvent = true;
+
+        runtime->DispatchEvents({}, 10ms);
+
+        // create checkpoint transaction executed not completed, compaction
+        // operation completed, old blob in cleanup queue
+
+        UNIT_ASSERT(putEvent);
+        runtime->SendAsync(putEvent.release());
+
+        skipFirstIntercept = true;
+        interseptEvent = true;
+
+        partition.RecvCompactionResponse();
+
+        runtime->DispatchEvents({}, 10ms);
+
+        // Delete checkpoint transaction executed not completed, now there is no
+        // checkpoints, but old blob in cleanup queue. Next checkpoint
+        // transaction should start execution after delete checkpoint
+        // transaction completed.
+
+        partition.SendCleanupRequest();
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(putEvent);
+        runtime->SendAsync(putEvent.release());
+
+        runtime->DispatchEvents({}, 10ms);
+
+        for (size_t i = 0; i < 3; i++) {
+            partition.RecvCreateCheckpointResponse();
+        }
+
+        partition.ReadBlocks(TBlockRange32::WithLength(0, 1));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1'),
+            GetBlockContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 1), "c1")));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13467,7 +13467,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         TPartitionClient partition(*runtime);
         partition.WaitReady();
 
-        bool interseptEvent = false;
+        bool interceptEvent = false;
         bool skipFirstIntercept = false;
 
         std::unique_ptr<IEventHandle> putEvent;
@@ -13477,13 +13477,13 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 if (event->GetTypeRewrite() == TEvBlobStorage::EvPut) {
                     auto* msg = event->Get<TEvBlobStorage::TEvPut>();
 
-                    if (msg->Id.Channel() == 0 && interseptEvent &&
+                    if (msg->Id.Channel() == 0 && interceptEvent &&
                         !skipFirstIntercept)
                     {
                         putEvent.reset(event.Release());
-                        interseptEvent = false;
+                        interceptEvent = false;
                         return TTestActorRuntime::EEventAction::DROP;
-                    } else if (msg->Id.Channel() == 0 && interseptEvent) {
+                    } else if (msg->Id.Channel() == 0 && interceptEvent) {
                         skipFirstIntercept = false;
                     }
                 }
@@ -13501,13 +13501,13 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.SendCreateCheckpointRequest("c1");
         partition.SendCompactionRequest();
 
-        interseptEvent = true;
+        interceptEvent = true;
 
         runtime->DispatchEvents({}, 10ms);
         UNIT_ASSERT(putEvent);
 
         skipFirstIntercept = true;
-        interseptEvent = true;
+        interceptEvent = true;
 
         // create checkpoint  and compaction transactions executed not completed
         runtime->SendAsync(putEvent.release());
@@ -13519,7 +13519,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         runtime->SendAsync(putEvent.release());
 
         skipFirstIntercept = true;
-        interseptEvent = true;
+        interceptEvent = true;
 
         runtime->DispatchEvents({}, 10ms);
 
@@ -13530,16 +13530,16 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         runtime->SendAsync(putEvent.release());
 
         skipFirstIntercept = true;
-        interseptEvent = true;
+        interceptEvent = true;
 
         partition.RecvCompactionResponse();
 
         runtime->DispatchEvents({}, 10ms);
 
-        // Delete checkpoint transaction executed not completed, now there is no
-        // checkpoints, but old blob in cleanup queue. Next checkpoint
-        // transaction should start execution after delete checkpoint
-        // transaction completed.
+        // The delete checkpoint transaction was executed, but it was not
+        // completed, so there are no checkpoints anymore, but there is an old
+        // blob in the cleanup queue. The next checkpoint transaction will start
+        // execution after the delete checkpoint transaction is completed.
 
         partition.SendCleanupRequest();
         runtime->DispatchEvents({}, 10ms);

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13471,9 +13471,6 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         partition.WriteBlocks(0, '1');
         partition.Flush();
 
-        partition.SendCreateCheckpointRequest("c1");
-        partition.SendCompactionRequest();
-
         bool interceptTransactions = true;
 
         std::unique_ptr<IEventHandle> executeTransactionsEvent;
@@ -13493,9 +13490,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
                 return false;
             });
 
-        auto response = partition.RecvCompactionResponse();
-        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
-
+        partition.SendCreateCheckpointRequest("c1");
+        partition.Compaction();
         partition.Cleanup();
 
         UNIT_ASSERT(executeTransactionsEvent);

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13457,7 +13457,7 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldNotLoseAnyBlocksWithMultipleCheckpointsCreationAndDelete)
+    Y_UNIT_TEST(ShouldNotLoseAnyMixedMergedBlocksWhileWaitingForCheckpointCreation)
     {
         auto config = DefaultConfig();
         config.SetFreshChannelWriteRequestsEnabled(true);
@@ -13467,97 +13467,40 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         TPartitionClient partition(*runtime);
         partition.WaitReady();
 
-        bool interceptEvent = false;
-        bool skipFirstIntercept = false;
-
-        std::unique_ptr<IEventHandle> putEvent;
-        runtime->SetObserverFunc(
-            [&](TAutoPtr<IEventHandle>& event)
-            {
-                if (event->GetTypeRewrite() == TEvBlobStorage::EvPut) {
-                    auto* msg = event->Get<TEvBlobStorage::TEvPut>();
-
-                    if (msg->Id.Channel() == 0 && interceptEvent &&
-                        !skipFirstIntercept)
-                    {
-                        putEvent.reset(event.Release());
-                        interceptEvent = false;
-                        return TTestActorRuntime::EEventAction::DROP;
-                    } else if (msg->Id.Channel() == 0 && interceptEvent) {
-                        skipFirstIntercept = false;
-                    }
-                }
-
-                return TTestActorRuntime::DefaultObserverFunc(event);
-            });
-
         partition.WriteBlocks(0, '1');
         partition.Flush();
 
         partition.SendCreateCheckpointRequest("c1");
-        partition.SendDeleteCheckpointRequest("c1");
-        partition.SendCreateCheckpointRequest("c1");
-        partition.SendDeleteCheckpointRequest("c1");
-        partition.SendCreateCheckpointRequest("c1");
         partition.SendCompactionRequest();
 
-        interceptEvent = true;
+        bool interceptTransactions = true;
 
-        runtime->DispatchEvents({}, 10ms);
-        UNIT_ASSERT(putEvent);
+        std::unique_ptr<IEventHandle> executeTransactionsEvent;
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvPartitionCommonPrivate::EvExecuteTransactions && interceptTransactions) {
+                    executeTransactionsEvent.reset(event.Release());
+                    interceptTransactions = false;
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
 
-        skipFirstIntercept = true;
-        interceptEvent = true;
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
 
-        // create checkpoint  and compaction transactions executed not completed
-        runtime->SendAsync(putEvent.release());
+        partition.Cleanup();
 
-        runtime->DispatchEvents({}, 10ms);
+        UNIT_ASSERT(executeTransactionsEvent);
 
-        // delete checkpoint  and addblobs transactions executed not completed
-        UNIT_ASSERT(putEvent);
-        runtime->SendAsync(putEvent.release());
+        runtime->SendAsync(executeTransactionsEvent.release());
 
-        skipFirstIntercept = true;
-        interceptEvent = true;
+        partition.RecvCreateCheckpointResponse();
 
-        runtime->DispatchEvents({}, 10ms);
-
-        // create checkpoint transaction executed not completed, compaction
-        // operation completed, old blob in cleanup queue
-
-        UNIT_ASSERT(putEvent);
-        runtime->SendAsync(putEvent.release());
-
-        skipFirstIntercept = true;
-        interceptEvent = true;
-
-        partition.RecvCompactionResponse();
-
-        runtime->DispatchEvents({}, 10ms);
-
-        // The delete checkpoint transaction was executed, but it was not
-        // completed, so there are no checkpoints anymore, but there is an old
-        // blob in the cleanup queue. The next checkpoint transaction will start
-        // execution after the delete checkpoint transaction is completed.
-
-        partition.SendCleanupRequest();
-        runtime->DispatchEvents({}, 10ms);
-
-        UNIT_ASSERT(putEvent);
-        runtime->SendAsync(putEvent.release());
-
-        runtime->DispatchEvents({}, 10ms);
-
-        for (size_t i = 0; i < 3; i++) {
-            partition.RecvCreateCheckpointResponse();
-        }
-
-        partition.ReadBlocks(TBlockRange32::WithLength(0, 1));
         UNIT_ASSERT_VALUES_EQUAL(
             GetBlockContent('1'),
-            GetBlockContent(
-                partition.ReadBlocks(TBlockRange32::WithLength(0, 1), "c1")));
+            GetBlockContent(partition.ReadBlocks(0, "c1")));
     }
 }
 


### PR DESCRIPTION
### Notes
#5676 continuation

### Issue
#5750 