### PR TITLE
issue-1751: [Filestore] WriteBackCache: ReleaseHandle should trigger Flush

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
@@ -139,6 +139,10 @@ struct TNodeState
                        : ENodeFlushStatus::NothingToFlush;
         }
 
+        if (HandleToReleaseCount > 0) {
+            return ENodeFlushStatus::FlushRequested;
+        }
+
         if (!FlushRequests.empty() ||
             minUnflushedSequenceId <= flushAllSequenceId)
         {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
@@ -140,6 +140,10 @@ struct TNodeState
         }
 
         if (HandleToReleaseCount > 0) {
+            // Non-zero value of HandleToReleaseCount indicates that there are
+            // handles that are requested for release but cannot be released
+            // because there are pending or unflushed WriteData requests
+            // associated with them. We need to flush these requests first.
             return ENodeFlushStatus::FlushRequested;
         }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -352,6 +352,22 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         UNIT_ASSERT_VALUES_EQUAL("2", b.DumpEvents());
     }
 
+    Y_UNIT_TEST(ReleaseHandleShouldTriggerFlush)
+    {
+        TBootstrap b;
+
+        UNIT_ASSERT(b.Add(1, 101, 1, "a").GetValue());
+        UNIT_ASSERT_VALUES_EQUAL("", b.DumpEvents());
+
+        auto releaseHandle = b.State->AddReleaseHandleRequest(1, 101);
+        UNIT_ASSERT(!releaseHandle.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL("1", b.DumpEvents());
+
+        b.FlushCache(1);
+        UNIT_ASSERT(!HasError(releaseHandle.GetValue()));
+        UNIT_ASSERT_VALUES_EQUAL("", b.DumpEvents());
+    }
+
     Y_UNIT_TEST(HandleFlushFailures)
     {
         TBootstrap b;


### PR DESCRIPTION
### Notes
Previously, `Flush` was called explicitly before `ReleaseHandle`:
https://github.com/ydb-platform/nbs/blob/4014969e2906c84018dc372b99c23e28e85a4429/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp#L237-L346

Then the logic has changed and `WriteBackCache` is now responsible for waiting until the data is flushed:
https://github.com/ydb-platform/nbs/blob/dda5a9502049437a112179101929522b2e425968/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp#L269-L284

It was forgotten to add flush trigger condition.

### Issue
Related to https://github.com/ydb-platform/nbs/issues/1751
