### PR TITLE
issue-1559: [Disk Manager]  Add lister to node storage

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/lister.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/lister.go
@@ -1,0 +1,66 @@
+package nodes
+
+import (
+	"context"
+
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/listers"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type nodeStorageLister struct {
+	storage    Storage
+	snapshotID string
+	limit      int
+}
+
+func (l *nodeStorageLister) ListNodes(
+	ctx context.Context,
+	nodeID uint64,
+	cookie string,
+) ([]nfs.Node, string, error) {
+
+	return l.storage.ListNodes(
+		ctx,
+		l.snapshotID,
+		nodeID,
+		cookie,
+		l.limit,
+	)
+}
+
+func (l *nodeStorageLister) Close(ctx context.Context) error {
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type nodeStorageListerFactory struct {
+	storage Storage
+	limit   int
+}
+
+func NewNodeStorageListerFactory(
+	storage Storage,
+	limit int,
+) listers.FilesystemListerFactory {
+
+	return &nodeStorageListerFactory{
+		storage: storage,
+		limit:   limit,
+	}
+}
+
+func (f *nodeStorageListerFactory) CreateLister(
+	ctx context.Context,
+	_ string,
+	checkpointID string,
+) (listers.FilesystemLister, error) {
+
+	return &nodeStorageLister{
+		storage:    f.storage,
+		snapshotID: checkpointID,
+		limit:      f.limit,
+	}, nil
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/storage_ydb.go
@@ -14,10 +14,15 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
+const defaultUpsertBatchSize = 1000
+
+////////////////////////////////////////////////////////////////////////////////
+
 type storageYDB struct {
-	db          *persistence.YDBClient
-	tablesPath  string
-	deleteLimit int
+	db              *persistence.YDBClient
+	tablesPath      string
+	deleteLimit     int
+	upsertBatchSize int
 }
 
 func NewStorage(
@@ -27,9 +32,10 @@ func NewStorage(
 ) Storage {
 
 	return &storageYDB{
-		db:          db,
-		tablesPath:  db.AbsolutePath(tablesPath),
-		deleteLimit: deleteLimit,
+		db:              db,
+		tablesPath:      db.AbsolutePath(tablesPath),
+		deleteLimit:     deleteLimit,
+		upsertBatchSize: defaultUpsertBatchSize,
 	}
 }
 
@@ -224,6 +230,25 @@ func scanNodes(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+func (s *storageYDB) upsertInBatches(
+	values []persistence.Value,
+	upsert func(batch []persistence.Value) error,
+) error {
+
+	for i := 0; i < len(values); i += s.upsertBatchSize {
+		end := i + s.upsertBatchSize
+		if end > len(values) {
+			end = len(values)
+		}
+
+		if err := upsert(values[i:end]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *storageYDB) saveNodeRefs(
 	ctx context.Context,
 	session *persistence.Session,
@@ -236,18 +261,20 @@ func (s *storageYDB) saveNodeRefs(
 		values = append(values, nodeRefStructValue(snapshotID, node))
 	}
 
-	_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
-		--!syntax_v1
-		pragma TablePathPrefix = "%v";
-		declare $node_refs as List<%v>;
+	return s.upsertInBatches(values, func(batch []persistence.Value) error {
+		_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
+			--!syntax_v1
+			pragma TablePathPrefix = "%v";
+			declare $node_refs as List<%v>;
 
-		upsert into node_refs
-		select *
-		from AS_TABLE($node_refs)
-	`, s.tablesPath, nodeRefStructTypeString()),
-		persistence.ValueParam("$node_refs", persistence.ListValue(values...)),
-	)
-	return err
+			upsert into node_refs
+			select *
+			from AS_TABLE($node_refs)
+		`, s.tablesPath, nodeRefStructTypeString()),
+			persistence.ValueParam("$node_refs", persistence.ListValue(batch...)),
+		)
+		return err
+	})
 }
 
 func (s *storageYDB) saveNodes(
@@ -262,18 +289,20 @@ func (s *storageYDB) saveNodes(
 		values = append(values, nodeStructValue(snapshotID, node))
 	}
 
-	_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
-		--!syntax_v1
-		pragma TablePathPrefix = "%v";
-		declare $nodes as List<%v>;
+	return s.upsertInBatches(values, func(batch []persistence.Value) error {
+		_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
+			--!syntax_v1
+			pragma TablePathPrefix = "%v";
+			declare $nodes as List<%v>;
 
-		upsert into nodes
-		select *
-		from AS_TABLE($nodes)
-	`, s.tablesPath, nodeStructTypeString()),
-		persistence.ValueParam("$nodes", persistence.ListValue(values...)),
-	)
-	return err
+			upsert into nodes
+			select *
+			from AS_TABLE($nodes)
+		`, s.tablesPath, nodeStructTypeString()),
+			persistence.ValueParam("$nodes", persistence.ListValue(batch...)),
+		)
+		return err
+	})
 }
 
 func (s *storageYDB) saveHardlinks(
@@ -290,22 +319,20 @@ func (s *storageYDB) saveHardlinks(
 		}
 	}
 
-	if len(values) == 0 {
-		return nil
-	}
+	return s.upsertInBatches(values, func(batch []persistence.Value) error {
+		_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
+			--!syntax_v1
+			pragma TablePathPrefix = "%v";
+			declare $hardlinks as List<%v>;
 
-	_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
-		--!syntax_v1
-		pragma TablePathPrefix = "%v";
-		declare $hardlinks as List<%v>;
-
-		upsert into hardlinks
-		select *
-		from AS_TABLE($hardlinks)
-	`, s.tablesPath, hardlinkStructTypeString()),
-		persistence.ValueParam("$hardlinks", persistence.ListValue(values...)),
-	)
-	return err
+			upsert into hardlinks
+			select *
+			from AS_TABLE($hardlinks)
+		`, s.tablesPath, hardlinkStructTypeString()),
+			persistence.ValueParam("$hardlinks", persistence.ListValue(batch...)),
+		)
+		return err
+	})
 }
 
 func (s *storageYDB) listNodeRefs(
@@ -322,7 +349,7 @@ func (s *storageYDB) listNodeRefs(
 		lastChildName = cookie
 	}
 
-	res, err := session.ExecuteRO(ctx, fmt.Sprintf(`
+	res, err := session.StreamExecuteRO(ctx, fmt.Sprintf(`
 		--!syntax_v1
 		pragma TablePathPrefix = "%v";
 		declare $snapshot_id as Utf8;
@@ -382,7 +409,7 @@ func (s *storageYDB) fetchNodeAttrs(
 		nodeIDValues = append(nodeIDValues, persistence.Uint64Value(id))
 	}
 
-	res, err := session.ExecuteRO(ctx, fmt.Sprintf(`
+	res, err := session.StreamExecuteRO(ctx, fmt.Sprintf(`
 		--!syntax_v1
 		pragma TablePathPrefix = "%v";
 		declare $snapshot_id as Utf8;
@@ -569,18 +596,20 @@ func (s *storageYDB) updateRestorationNodeIDMapping(
 		))
 	}
 
-	_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
-		--!syntax_v1
-		pragma TablePathPrefix = "%v";
-		declare $mappings as List<%v>;
+	return upsertInBatches(values, func(batch []persistence.Value) error {
+		_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
+			--!syntax_v1
+			pragma TablePathPrefix = "%v";
+			declare $mappings as List<%v>;
 
-		upsert into restoration_node_ids_mapping
-		select *
-		from AS_TABLE($mappings)
-	`, s.tablesPath, restoreMappingStructTypeString()),
-		persistence.ValueParam("$mappings", persistence.ListValue(values...)),
-	)
-	return err
+			upsert into restoration_node_ids_mapping
+			select *
+			from AS_TABLE($mappings)
+		`, s.tablesPath, restoreMappingStructTypeString()),
+			persistence.ValueParam("$mappings", persistence.ListValue(batch...)),
+		)
+		return err
+	})
 }
 
 func (s *storageYDB) getDestinationNodeIDs(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/storage_ydb.go
@@ -596,7 +596,7 @@ func (s *storageYDB) updateRestorationNodeIDMapping(
 		))
 	}
 
-	return upsertInBatches(values, func(batch []persistence.Value) error {
+	return s.upsertInBatches(values, func(batch []persistence.Value) error {
 		_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
 			--!syntax_v1
 			pragma TablePathPrefix = "%v";

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/storage_ydb_test.go
@@ -442,3 +442,56 @@ func TestListHardLinks(t *testing.T) {
 
 	compareNodes(t, expected, collected)
 }
+
+func TestLister(t *testing.T) {
+	const totalNodes = 10000
+	const nodesPerListing = 2000
+
+	f := createFixture(t, 100)
+	defer f.teardown()
+
+	snapshotID := "snapshot-lister"
+	parentNodeID := uint64(1)
+
+	var nodes []nfs.Node
+	for nodeID := uint64(0); nodeID < totalNodes; nodeID++ {
+		node := makeNode(
+			parentNodeID,
+			nodeID,
+			fmt.Sprintf("node-%05d", nodeID),
+			nfs_client.NODE_KIND_FILE,
+		)
+		nodes = append(nodes, node)
+	}
+
+	err := f.storage.SaveNodes(f.ctx, snapshotID, nodes)
+	require.NoError(t, err)
+
+	factory := NewNodeStorageListerFactory(f.storage, nodesPerListing)
+
+	lister, err := factory.CreateLister(f.ctx, "", snapshotID)
+	require.NoError(t, err)
+
+	var collected []nfs.Node
+	cookie := ""
+	iterations := 0
+	for {
+		nodes, nextCookie, err := lister.ListNodes(f.ctx, parentNodeID, cookie)
+		require.NoError(t, err)
+		collected = append(collected, nodes...)
+		iterations++
+
+		if len(nextCookie) == 0 {
+			break
+		}
+		cookie = nextCookie
+	}
+
+	require.Equal(t, totalNodes/nodesPerListing, iterations)
+	require.Len(t, collected, totalNodes)
+	for i, node := range collected {
+		expectedNodeID := uint64(i)
+		require.Equal(t, expectedNodeID, node.NodeID)
+		require.Equal(t, fmt.Sprintf("node-%05d", expectedNodeID), node.Name)
+	}
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/nodes/ya.make
@@ -1,6 +1,7 @@
 GO_LIBRARY()
 
 SRCS(
+    lister.go
     storage.go
     storage_ydb.go
 )


### PR DESCRIPTION

### Notes
Implement lister, so we can use traversal mechanism for filesystem snapshots restore. Make nodes storage more reselient to missconfigurations (attempt to fetch too many nodes, attempt to upsert too many nodes, yielding transaction limits in ydb).


### Issue
#1559