### PR TITLE
issue-1751: [Filestore] WriteBackCache::FlushAll should not fail if newer WriteData request is failed to flush

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -298,27 +298,40 @@ EFlushRetryStatus TWriteBackCacheState::FlushFailed(
         "Flush wasn't requested for node %lu",
         nodeId);
 
+    Y_ABORT_UNLESS(
+        nodeState.Cache.HasUnflushedRequests(),
+        "Node %lu has no unflushed requests",
+        nodeId);
+
     Stats->FlushFailed();
 
     const auto now = Timer->Now();
 
-    // Fail Flush and FlushAll requests
+    // Fail all Flush requests
     for (auto& it: nodeState.FlushRequests) {
         Stats->RequestFailed(ERequestType::Flush, now - it->RequestStartTime);
         QueuedOperations.FailFlushOrReleasePromise(
             std::move(it->Promise),
             error);
     }
-
-    for (auto& it: FlushAllRequestQueue) {
-        Stats->RequestFailed(ERequestType::FlushAll, now - it.RequestStartTime);
-        QueuedOperations.FailFlushOrReleasePromise(
-            std::move(it.Promise),
-            error);
-    }
-
     nodeState.FlushRequests.clear();
-    FlushAllRequestQueue.clear();
+
+    // Fail FlushAll requests that were requested after the failed request
+    auto failedRequestSequenceId = nodeState.Cache.GetMinUnflushedSequenceId();
+    while (!FlushAllRequestQueue.empty()) {
+        auto& rq = FlushAllRequestQueue.back();
+        if (rq.SequenceId < failedRequestSequenceId) {
+            // The items in FlushAllRequestQueue are strictly ordered - no need
+            // to check any further requests once we find one that was requested
+            // before the failed request
+            break;
+        }
+        Stats->RequestFailed(ERequestType::FlushAll, now - rq.RequestStartTime);
+        QueuedOperations.FailFlushOrReleasePromise(
+            std::move(rq.Promise),
+            error);
+        FlushAllRequestQueue.pop_back();
+    }
 
     // Fail barrier acquisitions
     while (!nodeState.Barriers.empty()) {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -417,6 +417,33 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
             b.Metrics.WriteDataRequestDroppedCount->Get());
     }
 
+    Y_UNIT_TEST(FlushAllShouldNotFailOnNewerWriteDataRequests)
+    {
+        TBootstrap b;
+
+        UNIT_ASSERT(b.Add(1, 101, 1, "a").GetValue());
+        UNIT_ASSERT(b.Add(2, 102, 2, "b").GetValue());
+
+        auto f1 = b.State->AddFlushAllRequest();
+
+        UNIT_ASSERT(b.Add(3, 103, 3, "c").GetValue());
+
+        auto f2 = b.State->AddFlushAllRequest();
+
+        auto error = MakeError(E_FAIL, "Flush failed");
+
+        b.State->FlushFailed(3, error);
+
+        UNIT_ASSERT(!f1.HasValue());
+        UNIT_ASSERT(f2.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(error, f2.GetValue());
+
+        b.State->FlushFailed(1, error);
+
+        UNIT_ASSERT(f1.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(error, f1.GetValue());
+    }
+
     Y_UNIT_TEST(HandleReleaseFailures)
     {
         TBootstrap b;


### PR DESCRIPTION
### Notes

WriteData requests that were failed to flush should not affect prior FlushAll requests, i.e.:
FlushAll should be affected only by WriteData request with lower SequenceId value.

Actual:
1. Write some data to the first node.
2. Request FlushAll.
3. Write some data to the second node.
4. Flush fails for the second node.
5. FlushAll is failed.

Expected:
5. FlushAll is not failed.

### Issue
Related to https://github.com/ydb-platform/nbs/issues/1751
