### PR TITLE
issue-5340: support for multiple THandlerActors + rr request distribution

### DIFF
--- a/cloud/filestore/bin/nfs/nfs-vhost.txt
+++ b/cloud/filestore/bin/nfs/nfs-vhost.txt
@@ -12,6 +12,6 @@ VhostServiceConfig {
   WriteBackCachePath: "/run/qemu/filestore-vhost"
   DirectoryHandlesStoragePath: "/run/qemu/filestore-vhost"
   DirectoryHandlesInitialDataSize: 10485760
-  UsePermanentActor: true
+  PermanentActorCount: 4
 }
 

--- a/cloud/filestore/config/vhost.proto
+++ b/cloud/filestore/config/vhost.proto
@@ -84,10 +84,9 @@ message TVhostServiceConfig
     // Initial data area size for DirectoryHandles persistent table.
     optional uint64 DirectoryHandlesInitialDataSize = 20;
 
-    // If true, a permanent THandler actor will be used instead of one
-    // TRequestActor per each request.
-    optional bool UsePermanentActor = 21;
-    optional uint32 PermanentActorCount = 22;
+    // If nonzero, multiple permanent THandler actors will be used instead of
+    // one TRequestActor per each request.
+    optional uint32 PermanentActorCount = 21;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/config/vhost.proto
+++ b/cloud/filestore/config/vhost.proto
@@ -87,6 +87,7 @@ message TVhostServiceConfig
     // If true, a permanent THandler actor will be used instead of one
     // TRequestActor per each request.
     optional bool UsePermanentActor = 21;
+    optional uint32 PermanentActorCount = 22;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -149,7 +149,10 @@ void TBootstrapServer::InitLWTrace()
 void TBootstrapServer::InitKikimrService()
 {
     Y_ABORT_UNLESS(ActorSystem, "Actor system MUST be initialized to create kikimr filestore");
-    Service = CreateKikimrFileStore(ActorSystem, false /* usePermanentActor */);
+    Service = CreateKikimrFileStore(
+        ActorSystem,
+        false /* usePermanentActor */,
+        0 /* permanentActorCount */);
 
     Service = CreateAuthService(
         std::move(Service),

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -149,10 +149,7 @@ void TBootstrapServer::InitLWTrace()
 void TBootstrapServer::InitKikimrService()
 {
     Y_ABORT_UNLESS(ActorSystem, "Actor system MUST be initialized to create kikimr filestore");
-    Service = CreateKikimrFileStore(
-        ActorSystem,
-        false /* usePermanentActor */,
-        0 /* permanentActorCount */);
+    Service = CreateKikimrFileStore(ActorSystem, 0 /* permanentActorCount */);
 
     Service = CreateAuthService(
         std::move(Service),

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -131,7 +131,8 @@ public:
         const TString& name,
         const NProto::TClientConfig& config,
         NDaemon::EServiceKind kind,
-        bool usePermanentActor)
+        bool usePermanentActor,
+        ui32 permanentActorCount)
     {
         auto clientConfig = std::make_shared<NClient::TClientConfig>(config);
         IFileStoreServicePtr fileStore;
@@ -142,8 +143,10 @@ public:
             }
 
             case NDaemon::EServiceKind::Kikimr: {
-                fileStore =
-                    CreateKikimrFileStore(ActorSystem, usePermanentActor);
+                fileStore = CreateKikimrFileStore(
+                    ActorSystem,
+                    usePermanentActor,
+                    permanentActorCount);
                 break;
             }
 
@@ -394,12 +397,14 @@ void TBootstrapVhost::InitEndpoints()
         LocalService,
         ActorSystem);
 
-    for (const auto& endpoint: Configs->VhostServiceConfig->GetServiceEndpoints()) {
+    const auto& serviceConfig = *Configs->VhostServiceConfig;
+    for (const auto& endpoint: serviceConfig.GetServiceEndpoints()) {
         bool inserted = endpoints->AddEndpoint(
             endpoint.GetName(),
             endpoint.GetClientConfig(),
             Configs->Options->Service,
-            Configs->AppConfig.GetVhostServiceConfig().GetUsePermanentActor());
+            serviceConfig.GetUsePermanentActor(),
+            serviceConfig.GetPermanentActorCount());
 
         if (inserted) {
             STORAGE_INFO("configured endpoint type %s -> %s",

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -131,7 +131,6 @@ public:
         const TString& name,
         const NProto::TClientConfig& config,
         NDaemon::EServiceKind kind,
-        bool usePermanentActor,
         ui32 permanentActorCount)
     {
         auto clientConfig = std::make_shared<NClient::TClientConfig>(config);
@@ -143,10 +142,8 @@ public:
             }
 
             case NDaemon::EServiceKind::Kikimr: {
-                fileStore = CreateKikimrFileStore(
-                    ActorSystem,
-                    usePermanentActor,
-                    permanentActorCount);
+                fileStore =
+                    CreateKikimrFileStore(ActorSystem, permanentActorCount);
                 break;
             }
 
@@ -403,7 +400,6 @@ void TBootstrapVhost::InitEndpoints()
             endpoint.GetName(),
             endpoint.GetClientConfig(),
             Configs->Options->Service,
-            serviceConfig.GetUsePermanentActor(),
             serviceConfig.GetPermanentActorCount());
 
         if (inserted) {

--- a/cloud/filestore/libs/endpoint_vhost/config.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/config.cpp
@@ -44,6 +44,8 @@ static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
     xxx(WriteBackCacheFlushMaxSumWriteRequestsSize, ui32,       32_MB         )\
     xxx(DirectoryHandlesStoragePath,                TString,    ""            )\
     xxx(DirectoryHandlesInitialDataSize,            ui64,       1_GB          )\
+    xxx(UsePermanentActor,                          bool,       false         )\
+    xxx(PermanentActorCount,                        ui32,       4             )\
 // VHOST_SERVICE_CONFIG
 
 #define VHOST_SERVICE_DECLARE_CONFIG(name, type, value)                        \

--- a/cloud/filestore/libs/endpoint_vhost/config.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/config.cpp
@@ -44,8 +44,7 @@ static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
     xxx(WriteBackCacheFlushMaxSumWriteRequestsSize, ui32,       32_MB         )\
     xxx(DirectoryHandlesStoragePath,                TString,    ""            )\
     xxx(DirectoryHandlesInitialDataSize,            ui64,       1_GB          )\
-    xxx(UsePermanentActor,                          bool,       false         )\
-    xxx(PermanentActorCount,                        ui32,       4             )\
+    xxx(PermanentActorCount,                        ui32,       0             )\
 // VHOST_SERVICE_CONFIG
 
 #define VHOST_SERVICE_DECLARE_CONFIG(name, type, value)                        \

--- a/cloud/filestore/libs/endpoint_vhost/config.h
+++ b/cloud/filestore/libs/endpoint_vhost/config.h
@@ -45,7 +45,6 @@ public:
     TString GetDirectoryHandlesStoragePath() const;
     ui64 GetDirectoryHandlesInitialDataSize() const;
 
-    bool GetUsePermanentActor() const;
     ui32 GetPermanentActorCount() const;
 
     void Dump(IOutputStream& out) const;

--- a/cloud/filestore/libs/endpoint_vhost/config.h
+++ b/cloud/filestore/libs/endpoint_vhost/config.h
@@ -45,6 +45,9 @@ public:
     TString GetDirectoryHandlesStoragePath() const;
     ui64 GetDirectoryHandlesInitialDataSize() const;
 
+    bool GetUsePermanentActor() const;
+    ui32 GetPermanentActorCount() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/filestore/libs/service_kikimr/service.cpp
+++ b/cloud/filestore/libs/service_kikimr/service.cpp
@@ -403,22 +403,33 @@ class TKikimrFileStore final
 {
 private:
     const IActorSystemPtr ActorSystem;
-    std::shared_ptr<THandler> Handler;
-    bool UsePermanentActor;
+    const bool UsePermanentActor;
+    const ui32 PermanentActorCount;
+
+    using THandlerPtr = std::shared_ptr<THandler>;
+    TVector<THandlerPtr> Handlers;
+    std::atomic<ui32> Selector{0};
 
 public:
-    TKikimrFileStore(IActorSystemPtr actorSystem, bool usePermanentActor)
+    TKikimrFileStore(
+            IActorSystemPtr actorSystem,
+            bool usePermanentActor,
+            ui32 permanentActorCount)
         : ActorSystem(std::move(actorSystem))
         , UsePermanentActor(usePermanentActor)
+        , PermanentActorCount(permanentActorCount)
     {}
 
     void Start() override
     {
-        if (UsePermanentActor) {
-            Handler = std::make_shared<THandler>();
-            auto actorId = ActorSystem->Register(
-                std::make_unique<THandlerActor>(Handler));
-            Handler->SelfId = actorId;
+        if (UsePermanentActor && PermanentActorCount) {
+            Handlers.resize(PermanentActorCount);
+            for (auto& handler: Handlers) {
+                handler = std::make_shared<THandler>();
+                auto actorId = ActorSystem->Register(
+                    std::make_unique<THandlerActor>(handler));
+                handler->SelfId = actorId;
+            }
         }
     }
 
@@ -491,7 +502,10 @@ private:
         TPromise<typename T::TResponse> response)
     {
         if (UsePermanentActor) {
-            Handler->SendRequest(
+            const ui32 handlerIdx =
+                Selector.fetch_add(1, std::memory_order_relaxed);
+            auto& handler = Handlers[handlerIdx % Handlers.size()];
+            handler->SendRequest(
                 *ActorSystem,
                 std::move(callContext),
                 *request,
@@ -550,11 +564,13 @@ private:
 
 IFileStoreServicePtr CreateKikimrFileStore(
     IActorSystemPtr actorSystem,
-    bool usePermanentActor)
+    bool usePermanentActor,
+    ui32 permanentActorCount)
 {
     return std::make_shared<TKikimrFileStore>(
         std::move(actorSystem),
-        usePermanentActor);
+        usePermanentActor,
+        permanentActorCount);
 }
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/service.cpp
+++ b/cloud/filestore/libs/service_kikimr/service.cpp
@@ -403,8 +403,7 @@ class TKikimrFileStore final
 {
 private:
     const IActorSystemPtr ActorSystem;
-    const bool UsePermanentActor;
-    const ui32 PermanentActorCount;
+    TLog Log;
 
     using THandlerPtr = std::shared_ptr<THandler>;
     TVector<THandlerPtr> Handlers;
@@ -413,23 +412,24 @@ private:
 public:
     TKikimrFileStore(
             IActorSystemPtr actorSystem,
-            bool usePermanentActor,
             ui32 permanentActorCount)
         : ActorSystem(std::move(actorSystem))
-        , UsePermanentActor(usePermanentActor)
-        , PermanentActorCount(permanentActorCount)
-    {}
+        , Log(ActorSystem->CreateLog("KIKIMR_SERVICE"))
+    {
+        Handlers.resize(permanentActorCount);
+    }
 
     void Start() override
     {
-        if (UsePermanentActor && PermanentActorCount) {
-            Handlers.resize(PermanentActorCount);
-            for (auto& handler: Handlers) {
-                handler = std::make_shared<THandler>();
-                auto actorId = ActorSystem->Register(
-                    std::make_unique<THandlerActor>(handler));
-                handler->SelfId = actorId;
-            }
+        for (auto& handler: Handlers) {
+            handler = std::make_shared<THandler>();
+            auto actorId = ActorSystem->Register(
+                std::make_unique<THandlerActor>(handler));
+            handler->SelfId = actorId;
+
+            // we'll switch prio to INFO after the scheme with permanent actors
+            // gets widely adopted
+            STORAGE_WARN("created THandlerActor: " << actorId);
         }
     }
 
@@ -501,7 +501,7 @@ private:
         std::shared_ptr<typename T::TRequest> request,
         TPromise<typename T::TResponse> response)
     {
-        if (UsePermanentActor) {
+        if (Handlers.size()) {
             const ui32 handlerIdx =
                 Selector.fetch_add(1, std::memory_order_relaxed);
             auto& handler = Handlers[handlerIdx % Handlers.size()];
@@ -564,12 +564,10 @@ private:
 
 IFileStoreServicePtr CreateKikimrFileStore(
     IActorSystemPtr actorSystem,
-    bool usePermanentActor,
     ui32 permanentActorCount)
 {
     return std::make_shared<TKikimrFileStore>(
         std::move(actorSystem),
-        usePermanentActor,
         permanentActorCount);
 }
 

--- a/cloud/filestore/libs/service_kikimr/service.h
+++ b/cloud/filestore/libs/service_kikimr/service.h
@@ -12,7 +12,6 @@ namespace NCloud::NFileStore {
 
 IFileStoreServicePtr CreateKikimrFileStore(
     IActorSystemPtr actorSystem,
-    bool usePermanentActor,
     ui32 permanentActorCount);
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/service.h
+++ b/cloud/filestore/libs/service_kikimr/service.h
@@ -12,6 +12,7 @@ namespace NCloud::NFileStore {
 
 IFileStoreServicePtr CreateKikimrFileStore(
     IActorSystemPtr actorSystem,
-    bool usePermanentActor);
+    bool usePermanentActor,
+    ui32 permanentActorCount);
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/service_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/service_ut.cpp
@@ -25,6 +25,7 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr TDuration WaitTimeout = TDuration::Seconds(5);
+constexpr ui32 PermanentActorCount = 4;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -84,7 +85,10 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrFileStore(actorSystem, usePermanentActor);
+        auto service = CreateKikimrFileStore(
+            actorSystem,
+            usePermanentActor,
+            PermanentActorCount);
         service->Start();
 
         auto context = MakeIntrusive<TCallContext>();
@@ -121,7 +125,10 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrFileStore(actorSystem, false);
+        auto service = CreateKikimrFileStore(
+            actorSystem,
+            false,
+            PermanentActorCount);
         service->Start();
 
         {
@@ -176,7 +183,10 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrFileStore(actorSystem, false);
+        auto service = CreateKikimrFileStore(
+            actorSystem,
+            false,
+            PermanentActorCount);
         service->Start();
 
         auto context = MakeIntrusive<TCallContext>();

--- a/cloud/filestore/libs/service_kikimr/service_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/service_ut.cpp
@@ -25,7 +25,6 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr TDuration WaitTimeout = TDuration::Seconds(5);
-constexpr ui32 PermanentActorCount = 4;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -72,7 +71,7 @@ struct TTestServiceActor final
 
 Y_UNIT_TEST_SUITE(TKikimrFileStore)
 {
-    void DoTestShouldHandleRequests(bool usePermanentActor)
+    void DoTestShouldHandleRequests(ui32 permanentActorCount)
     {
         auto serviceActor = std::make_unique<TTestServiceActor>();
         serviceActor->CreateFileStoreHandler =
@@ -87,8 +86,7 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
 
         auto service = CreateKikimrFileStore(
             actorSystem,
-            usePermanentActor,
-            PermanentActorCount);
+            permanentActorCount);
         service->Start();
 
         auto context = MakeIntrusive<TCallContext>();
@@ -110,12 +108,12 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
 
     Y_UNIT_TEST(ShouldHandleRequests)
     {
-        DoTestShouldHandleRequests(false);
+        DoTestShouldHandleRequests(0 /* permanentActorCount */);
     }
 
     Y_UNIT_TEST(ShouldHandleRequestsWithPermanentActor)
     {
-        DoTestShouldHandleRequests(true);
+        DoTestShouldHandleRequests(4 /* permanentActorCount */);
     }
 
     Y_UNIT_TEST(ShouldHandleFsyncRequestsOutsideActorSystem)
@@ -125,10 +123,8 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrFileStore(
-            actorSystem,
-            false,
-            PermanentActorCount);
+        auto service =
+            CreateKikimrFileStore(actorSystem, 0 /* permanentActorCount */);
         service->Start();
 
         {
@@ -183,10 +179,8 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service = CreateKikimrFileStore(
-            actorSystem,
-            false,
-            PermanentActorCount);
+        auto service =
+            CreateKikimrFileStore(actorSystem, 0 /* permanentActorCount */);
         service->Start();
 
         auto context = MakeIntrusive<TCallContext>();

--- a/cloud/filestore/tests/common_configs/nfs-vhost-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-vhost-newfeatures-patch.txt
@@ -1,1 +1,1 @@
-UsePermanentActor: true
+PermanentActorCount: 4


### PR DESCRIPTION
### Notes
Turns out that in some cases a single `THandlerActor` can be a bottleneck - for example, for randread x 4KiB with high parallelism it becomes a bottleneck at around 100-150k IOPS on some CPUs. Making a simple optimization - maintaining multiple `THandlerActor`s and distributing the requests in a round-robin manner among them.

Generally the scheme with permanent actors performs better than the scheme with `TRequestActor`s that are created per-request. This bottleneck in randread tests seems to be the only real remaining issue. 

Replaced `UsePermanentActor` config param with `PermanentActorCount`. `UsePermanentActor` is not used anywhere yet so it's safe to replace.

### Issue
https://github.com/ydb-platform/nbs/issues/5340
