### PR TITLE
issue-1559: [Disk Manager]  Return shard id and node name in shard from filestore go sdk

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nfs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/client.go
@@ -6,6 +6,7 @@ import (
 	client_metrics "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	"github.com/ydb-platform/nbs/cloud/filestore/public/api/protos"
 	nfs_client "github.com/ydb-platform/nbs/cloud/filestore/public/sdk/go/client"
 	coreprotos "github.com/ydb-platform/nbs/cloud/storage/core/protos"
 	"github.com/ydb-platform/nbs/cloud/tasks/errors"
@@ -126,6 +127,49 @@ func NewClient(
 	}
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+func (c *client) updateFilestore(
+	ctx context.Context,
+	filesystemID string,
+	updateFunc func(
+		filestore *protos.TFileStore,
+	) error,
+) error {
+
+	retries := 0
+	for {
+		filestore, err := c.nfs.GetFileStoreInfo(ctx, filesystemID)
+		if err != nil {
+			return wrapError(err)
+		}
+
+		if filestore.BlockSize == 0 {
+			return errors.NewNonRetriableErrorf(
+				"invalid filestore config %v",
+				filestore,
+			)
+		}
+
+		err = updateFunc(filestore)
+
+		if err != nil {
+			if !isAbortedError(err) {
+				return wrapError(err)
+			}
+
+			if retries == maxConsecutiveRetries {
+				return errors.NewRetriableError(err)
+			}
+
+			retries++
+			continue
+		}
+
+		return nil
+	}
+}
+
 func (c *client) ZoneID() string {
 	return c.zoneID
 }
@@ -183,20 +227,7 @@ func (c *client) Resize(
 
 	defer c.metrics.StatRequest("ResizeFileStore")(&err)
 
-	retries := 0
-	for {
-		filestore, err := c.nfs.GetFileStoreInfo(ctx, filesystemID)
-		if err != nil {
-			return wrapError(err)
-		}
-
-		if filestore.BlockSize == 0 {
-			return errors.NewNonRetriableErrorf(
-				"invalid filestore config %v",
-				filestore,
-			)
-		}
-
+	updateFunc := func(filestore *protos.TFileStore) error {
 		if size%uint64(filestore.BlockSize) != 0 {
 			return errors.NewNonRetriableErrorf(
 				"size %v should be divisible by filestore.BlockSize %v",
@@ -208,28 +239,35 @@ func (c *client) Resize(
 		newBlocksCount := size / uint64(filestore.BlockSize)
 
 		// so far no need in checkpoint; resize is race safe as we cannot reduce space
-		err = c.nfs.ResizeFileStore(
+		return c.nfs.ResizeFileStore(
 			ctx,
 			filesystemID,
 			newBlocksCount,
 			filestore.ConfigVersion,
 		)
-
-		if err != nil {
-			if !isAbortedError(err) {
-				return wrapError(err)
-			}
-
-			if retries == maxConsecutiveRetries {
-				return errors.NewRetriableError(err)
-			}
-
-			retries++
-			continue
-		}
-
-		return nil
 	}
+
+	return c.updateFilestore(ctx, filesystemID, updateFunc)
+}
+
+func (c *client) EnableDirectoryCreationInShards(
+	ctx context.Context,
+	filesystemID string,
+	shardCount uint32,
+) (err error) {
+
+	defer c.metrics.StatRequest("EnableDirectoryCreationInShards")(&err)
+	updateFunc := func(filestore *protos.TFileStore) error {
+		return c.nfs.EnableDirectoryCreationInShards(
+			ctx,
+			filesystemID,
+			filestore.BlocksCount,
+			filestore.ConfigVersion,
+			shardCount,
+		)
+	}
+
+	return c.updateFilestore(ctx, filesystemID, updateFunc)
 }
 
 func (c *client) DescribeModel(
@@ -285,51 +323,6 @@ func (c *client) DestroyCheckpoint(
 			checkpointID,
 		),
 	)
-}
-
-func (c *client) EnableDirectoryCreationInShards(
-	ctx context.Context,
-	filesystemID string,
-	shardCount uint32,
-) (err error) {
-	defer c.metrics.StatRequest("EnableDirectoryCreationInShards")(&err)
-
-	retries := 0
-	for {
-		filestore, err := c.nfs.GetFileStoreInfo(ctx, filesystemID)
-		if err != nil {
-			return wrapError(err)
-		}
-
-		if filestore.BlockSize == 0 {
-			return errors.NewNonRetriableErrorf(
-				"invalid filestore config %v",
-				filestore,
-			)
-		}
-
-		err = c.nfs.EnableDirectoryCreationInShards(
-			ctx,
-			filesystemID,
-			filestore.BlocksCount,
-			filestore.ConfigVersion,
-			shardCount,
-		)
-		if err != nil {
-			if !isAbortedError(err) {
-				return wrapError(err)
-			}
-
-			if retries == maxConsecutiveRetries {
-				return errors.NewRetriableError(err)
-			}
-
-			retries++
-			continue
-		}
-
-		return nil
-	}
 }
 
 func (c *client) CreateSession(

--- a/cloud/disk_manager/internal/pkg/clients/nfs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/client.go
@@ -156,6 +156,7 @@ func (c *client) Create(
 			BlockSize:        params.BlockSize,
 			BlocksCount:      params.BlocksCount,
 			StorageMediaKind: mediaKind,
+			ShardCount:       params.ShardCount,
 		},
 	)
 
@@ -284,6 +285,49 @@ func (c *client) DestroyCheckpoint(
 			checkpointID,
 		),
 	)
+}
+
+func (c *client) EnableDirectoryCreationInShards(
+	ctx context.Context,
+	filesystemID string,
+) (err error) {
+	defer c.metrics.StatRequest("EnableDirectoryCreationInShards")(&err)
+
+	retries := 0
+	for {
+		filestore, err := c.nfs.GetFileStoreInfo(ctx, filesystemID)
+		if err != nil {
+			return wrapError(err)
+		}
+
+		if filestore.BlockSize == 0 {
+			return errors.NewNonRetriableErrorf(
+				"invalid filestore config %v",
+				filestore,
+			)
+		}
+
+		err = c.nfs.EnableDirectoryCreationInShards(
+			ctx,
+			filesystemID,
+			filestore.BlocksCount,
+			filestore.ConfigVersion,
+		)
+		if err != nil {
+			if !isAbortedError(err) {
+				return wrapError(err)
+			}
+
+			if retries == maxConsecutiveRetries {
+				return errors.NewRetriableError(err)
+			}
+
+			retries++
+			continue
+		}
+
+		return nil
+	}
 }
 
 func (c *client) CreateSession(

--- a/cloud/disk_manager/internal/pkg/clients/nfs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/client.go
@@ -290,6 +290,7 @@ func (c *client) DestroyCheckpoint(
 func (c *client) EnableDirectoryCreationInShards(
 	ctx context.Context,
 	filesystemID string,
+	shardCount uint32,
 ) (err error) {
 	defer c.metrics.StatRequest("EnableDirectoryCreationInShards")(&err)
 
@@ -312,6 +313,7 @@ func (c *client) EnableDirectoryCreationInShards(
 			filesystemID,
 			filestore.BlocksCount,
 			filestore.ConfigVersion,
+			shardCount,
 		)
 		if err != nil {
 			if !isAbortedError(err) {

--- a/cloud/disk_manager/internal/pkg/clients/nfs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/interface.go
@@ -14,6 +14,7 @@ type CreateFilesystemParams struct {
 	BlockSize   uint32
 	BlocksCount uint64
 	Kind        types.FilesystemKind
+	ShardCount  uint32
 }
 
 type FilesystemPerformanceProfile struct {
@@ -96,6 +97,11 @@ type Client interface {
 	Delete(ctx context.Context, filesystemID string, force bool) error
 
 	Resize(ctx context.Context, filesystemID string, size uint64) error
+
+	EnableDirectoryCreationInShards(
+		ctx context.Context,
+		filesystemID string,
+	) error
 
 	DescribeModel(
 		ctx context.Context,

--- a/cloud/disk_manager/internal/pkg/clients/nfs/interface.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/interface.go
@@ -101,6 +101,7 @@ type Client interface {
 	EnableDirectoryCreationInShards(
 		ctx context.Context,
 		filesystemID string,
+		shardCount uint32,
 	) error
 
 	DescribeModel(

--- a/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
@@ -54,6 +54,14 @@ func (c *ClientMock) Resize(
 	return args.Error(0)
 }
 
+func (c *ClientMock) EnableDirectoryCreationInShards(
+	ctx context.Context,
+	filesystemID string,
+) error {
+	args := c.Called(ctx, filesystemID)
+	return args.Error(0)
+}
+
 func (c *ClientMock) DescribeModel(
 	ctx context.Context,
 	blocksCount uint64,

--- a/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
@@ -57,6 +57,7 @@ func (c *ClientMock) Resize(
 func (c *ClientMock) EnableDirectoryCreationInShards(
 	ctx context.Context,
 	filesystemID string,
+	shardCount uint32,
 ) error {
 	args := c.Called(ctx, filesystemID)
 	return args.Error(0)

--- a/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/mocks/client_mock.go
@@ -59,7 +59,7 @@ func (c *ClientMock) EnableDirectoryCreationInShards(
 	filesystemID string,
 	shardCount uint32,
 ) error {
-	args := c.Called(ctx, filesystemID)
+	args := c.Called(ctx, filesystemID, shardCount)
 	return args.Error(0)
 }
 

--- a/cloud/disk_manager/internal/pkg/clients/nfs/testing/filesystem_model.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/testing/filesystem_model.go
@@ -264,7 +264,11 @@ func (f *FileSystemModel) CreateAllNodesRecursively() {
 	}
 }
 
-func (f *FileSystemModel) ListAllNodes(parentNodeID uint64) []nfs.Node {
+func (f *FileSystemModel) ListAllNodes(
+	parentNodeID uint64,
+	unsafe bool,
+) []nfs.Node {
+
 	var (
 		nodes  []nfs.Node
 		cookie string
@@ -275,8 +279,8 @@ func (f *FileSystemModel) ListAllNodes(parentNodeID uint64) []nfs.Node {
 			f.ctx,
 			parentNodeID,
 			cookie,
-			0,     // maxBytes
-			false, // unsafe
+			0, // maxBytes
+			unsafe,
 		)
 		require.NoError(f.t, err)
 		for index := range batch {
@@ -307,8 +311,12 @@ func (f *FileSystemModel) ListAllNodes(parentNodeID uint64) []nfs.Node {
 	return nodes
 }
 
-func (f *FileSystemModel) ListNodesRecursively(parentNodeID uint64) []nfs.Node {
-	nodes := f.ListAllNodes(parentNodeID)
+func (f *FileSystemModel) ListNodesRecursively(
+	parentNodeID uint64,
+	unsafe bool,
+) []nfs.Node {
+
+	nodes := f.ListAllNodes(parentNodeID, unsafe)
 	// Sort nodes by name to have a deterministic order
 	slices.SortFunc(
 		nodes,
@@ -323,15 +331,35 @@ func (f *FileSystemModel) ListNodesRecursively(parentNodeID uint64) []nfs.Node {
 			continue
 		}
 
-		children := f.ListNodesRecursively(node.NodeID)
+		children := f.ListNodesRecursively(node.NodeID, unsafe)
 		result = append(result, children...)
 	}
 
 	return result
 }
 
-func (f *FileSystemModel) ListAllNodesRecursively() []nfs.Node {
-	return f.ListNodesRecursively(nfs.RootNodeID)
+func (f *FileSystemModel) ListAllNodesRecursively(unsafe bool) []nfs.Node {
+	return f.ListNodesRecursively(nfs.RootNodeID, unsafe)
+}
+
+func (f *FileSystemModel) RequireNodesEqual(
+	nodes []nfs.Node,
+) {
+
+	require.Equal(f.t, len(f.ExpectedNodes), len(nodes))
+	for index, node := range nodes {
+		expectedNode := f.ExpectedNodes[index]
+		require.Equal(f.t, expectedNode.ParentID, node.ParentID)
+		require.Equal(f.t, expectedNode.Name, node.Name)
+		require.Equal(f.t, expectedNode.Type, node.Type)
+		if !expectedNode.Type.IsSymlink() {
+			require.Equal(f.t, expectedNode.Mode, node.Mode)
+		}
+
+		require.Equal(f.t, expectedNode.UID, node.UID)
+		require.Equal(f.t, expectedNode.GID, node.GID)
+		require.Equal(f.t, expectedNode.LinkTarget, node.LinkTarget)
+	}
 }
 
 func (f *FileSystemModel) SetSession(session nfs.Session) {

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_metrics_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_metrics_test.go
@@ -369,11 +369,12 @@ func TestClientEnableDirectoryCreationInShardsSuccess(t *testing.T) {
 		"fs-1",
 		uint64(100),
 		uint32(1),
+		uint32(1),
 	).Return(nil)
 
 	c := newTestClient(nfsMock, registryMock)
 
-	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1", 1)
 	require.NoError(t, err)
 
 	nfsMock.AssertExpectations(t)
@@ -398,11 +399,12 @@ func TestClientEnableDirectoryCreationInShardsError(t *testing.T) {
 		"fs-1",
 		uint64(100),
 		uint32(1),
+		uint32(1),
 	).Return(testError)
 
 	c := newTestClient(nfsMock, registryMock)
 
-	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1", 1)
 	require.Error(t, err)
 	require.ErrorIs(t, err, testError)
 
@@ -901,11 +903,12 @@ func TestClientEnableDirectoryCreationInShardsWrappedError(t *testing.T) {
 		"fs-1",
 		uint64(100),
 		uint32(1),
+		uint32(1),
 	).Return(testNfsClientError)
 
 	c := newTestClientWithMetricsMock(nfsMock, metricsMock)
 
-	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1", 1)
 	require.Error(t, err)
 	var clientErr *nfs_client.ClientError
 	require.ErrorAs(t, err, &clientErr)
@@ -1303,11 +1306,12 @@ func TestClientEnableDirectoryCreationInShardsNonRetriableError(t *testing.T) {
 		"fs-1",
 		uint64(100),
 		uint32(1),
+		uint32(1),
 	).Return(testNfsClientNonRetriableError)
 
 	c := newTestClientWithMetricsMock(nfsMock, metricsMock)
 
-	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1", 1)
 	require.Error(t, err)
 	var clientErr *nfs_client.ClientError
 	require.ErrorAs(t, err, &clientErr)

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_metrics_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_metrics_test.go
@@ -349,6 +349,67 @@ func TestClientDestroyCheckpointError(t *testing.T) {
 	registryMock.AssertAllExpectations(t)
 }
 
+func TestClientEnableDirectoryCreationInShardsSuccess(t *testing.T) {
+	ctx := context.Background()
+	registryMock := metrics_mocks.NewRegistryMock()
+	setupRequestMocks(registryMock, "EnableDirectoryCreationInShards", true)
+
+	nfsMock := nfs_client_mocks.NewClientInterfaceMock()
+	nfsMock.On("GetFileStoreInfo", mock.Anything, "fs-1").Return(
+		&protos.TFileStore{
+			BlockSize:     4096,
+			BlocksCount:   100,
+			ConfigVersion: 1,
+		},
+		nil,
+	)
+	nfsMock.On(
+		"EnableDirectoryCreationInShards",
+		mock.Anything,
+		"fs-1",
+		uint64(100),
+		uint32(1),
+	).Return(nil)
+
+	c := newTestClient(nfsMock, registryMock)
+
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
+	require.NoError(t, err)
+
+	nfsMock.AssertExpectations(t)
+	registryMock.AssertAllExpectations(t)
+}
+
+func TestClientEnableDirectoryCreationInShardsError(t *testing.T) {
+	ctx := context.Background()
+	registryMock := metrics_mocks.NewRegistryMock()
+	setupRequestMocks(registryMock, "EnableDirectoryCreationInShards", false)
+
+	nfsMock := nfs_client_mocks.NewClientInterfaceMock()
+	nfsMock.On("GetFileStoreInfo", mock.Anything, "fs-1").
+		Return(&protos.TFileStore{
+			BlockSize:     4096,
+			BlocksCount:   100,
+			ConfigVersion: 1,
+		}, nil)
+	nfsMock.On(
+		"EnableDirectoryCreationInShards",
+		mock.Anything,
+		"fs-1",
+		uint64(100),
+		uint32(1),
+	).Return(testError)
+
+	c := newTestClient(nfsMock, registryMock)
+
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, testError)
+
+	nfsMock.AssertExpectations(t)
+	registryMock.AssertAllExpectations(t)
+}
+
 func TestClientCreateSessionSuccess(t *testing.T) {
 	ctx := context.Background()
 	registryMock := metrics_mocks.NewRegistryMock()
@@ -811,6 +872,49 @@ func TestClientDestroyCheckpointWrappedError(t *testing.T) {
 	metricsMock.AssertExpectations(t)
 }
 
+func TestClientEnableDirectoryCreationInShardsWrappedError(t *testing.T) {
+	ctx := context.Background()
+
+	metricsMock := client_metrics_mocks.NewMetricsMock()
+	metricsMock.On(
+		"StatRequest",
+		"EnableDirectoryCreationInShards",
+	).Return(
+		func(err *error) {
+			require.Error(t, *err)
+			var clientErr *nfs_client.ClientError
+			require.ErrorAs(t, *err, &clientErr)
+			require.ErrorIs(t, *err, retriableError)
+		},
+	).Once()
+
+	nfsMock := nfs_client_mocks.NewClientInterfaceMock()
+	nfsMock.On("GetFileStoreInfo", mock.Anything, "fs-1").
+		Return(&protos.TFileStore{
+			BlockSize:     4096,
+			BlocksCount:   100,
+			ConfigVersion: 1,
+		}, nil)
+	nfsMock.On(
+		"EnableDirectoryCreationInShards",
+		mock.Anything,
+		"fs-1",
+		uint64(100),
+		uint32(1),
+	).Return(testNfsClientError)
+
+	c := newTestClientWithMetricsMock(nfsMock, metricsMock)
+
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
+	require.Error(t, err)
+	var clientErr *nfs_client.ClientError
+	require.ErrorAs(t, err, &clientErr)
+	require.ErrorIs(t, err, retriableError)
+
+	nfsMock.AssertExpectations(t)
+	metricsMock.AssertExpectations(t)
+}
+
 func TestClientCreateSessionWrappedError(t *testing.T) {
 	ctx := context.Background()
 
@@ -1160,6 +1264,50 @@ func TestClientDestroyCheckpointNonRetriableError(t *testing.T) {
 	c := newTestClientWithMetricsMock(nfsMock, metricsMock)
 
 	err := c.DestroyCheckpoint(ctx, "fs-1", "cp-1")
+	require.Error(t, err)
+	var clientErr *nfs_client.ClientError
+	require.ErrorAs(t, err, &clientErr)
+	require.NotErrorIs(t, err, retriableError)
+	require.ErrorIs(t, err, testNfsClientNonRetriableError)
+
+	nfsMock.AssertExpectations(t)
+	metricsMock.AssertExpectations(t)
+}
+
+func TestClientEnableDirectoryCreationInShardsNonRetriableError(t *testing.T) {
+	ctx := context.Background()
+
+	metricsMock := client_metrics_mocks.NewMetricsMock()
+	metricsMock.On(
+		"StatRequest",
+		"EnableDirectoryCreationInShards",
+	).Return(
+		func(err *error) {
+			require.Error(t, *err)
+			var clientErr *nfs_client.ClientError
+			require.ErrorAs(t, *err, &clientErr)
+			require.NotErrorIs(t, *err, retriableError)
+		},
+	).Once()
+
+	nfsMock := nfs_client_mocks.NewClientInterfaceMock()
+	nfsMock.On("GetFileStoreInfo", mock.Anything, "fs-1").
+		Return(&protos.TFileStore{
+			BlockSize:     4096,
+			BlocksCount:   100,
+			ConfigVersion: 1,
+		}, nil)
+	nfsMock.On(
+		"EnableDirectoryCreationInShards",
+		mock.Anything,
+		"fs-1",
+		uint64(100),
+		uint32(1),
+	).Return(testNfsClientNonRetriableError)
+
+	c := newTestClientWithMetricsMock(nfsMock, metricsMock)
+
+	err := c.EnableDirectoryCreationInShards(ctx, "fs-1")
 	require.Error(t, err)
 	var clientErr *nfs_client.ClientError
 	require.ErrorAs(t, err, &clientErr)

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -369,8 +369,6 @@ func TestGetNodeAttr(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Delete(ctx, filesystemID, false)
 
-	require.NoError(t, err)
-
 	session, err := client.CreateSession(ctx, filesystemID, "", false)
 	require.NoError(t, err)
 	defer session.Close(ctx)

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -115,7 +115,7 @@ func TestListNodesFileSystem(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Delete(ctx, filesystemID, false)
 
-	err = client.EnableDirectoryCreationInShards(ctx, filesystemID)
+	err = client.EnableDirectoryCreationInShards(ctx, filesystemID, 5)
 	require.NoError(t, err)
 
 	session, err := client.CreateSession(ctx, filesystemID, "", false)
@@ -319,12 +319,10 @@ func TestGetNodeAttr(t *testing.T) {
 		BlocksCount: 1024,
 		BlockSize:   4096,
 		Kind:        types.FilesystemKind_FILESYSTEM_KIND_SSD,
-		ShardCount:  5,
 	})
 	require.NoError(t, err)
 	defer client.Delete(ctx, filesystemID, false)
 
-	err = client.EnableDirectoryCreationInShards(ctx, filesystemID)
 	require.NoError(t, err)
 
 	session, err := client.CreateSession(ctx, filesystemID, "", false)
@@ -343,16 +341,12 @@ func TestGetNodeAttr(t *testing.T) {
 	require.Equal(t, "testfile", fileNode.Name)
 	require.False(t, fileNode.Type.IsDirectory())
 	require.NotZero(t, fileNode.NodeID)
-	require.NotEmpty(t, fileNode.ShardNodeName)
-	require.NotEqual(t, fileNode.ShardFileSystemID, filesystemID)
 
 	dirNode, err := session.GetNodeAttr(ctx, nfs.RootNodeID, "testdir")
 	require.NoError(t, err)
 	require.Equal(t, "testdir", dirNode.Name)
 	require.True(t, dirNode.Type.IsDirectory())
 	require.NotZero(t, dirNode.NodeID)
-	require.NotEmpty(t, dirNode.ShardNodeName)
-	require.NotEqual(t, dirNode.ShardFileSystemID, filesystemID)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -110,9 +110,13 @@ func TestListNodesFileSystem(t *testing.T) {
 		BlocksCount: 1024,
 		BlockSize:   4096,
 		Kind:        types.FilesystemKind_FILESYSTEM_KIND_SSD,
+		ShardCount:  5,
 	})
 	require.NoError(t, err)
 	defer client.Delete(ctx, filesystemID, false)
+
+	err = client.EnableDirectoryCreationInShards(ctx, filesystemID)
+	require.NoError(t, err)
 
 	session, err := client.CreateSession(ctx, filesystemID, "", false)
 	require.NoError(t, err)
@@ -152,6 +156,8 @@ func TestListNodesFileSystem(t *testing.T) {
 		// require.Equal(t, expectedNode.UID, node.UID)
 		// require.Equal(t, expectedNode.GID, node.GID)
 		require.Equal(t, expectedNode.LinkTarget, node.LinkTarget)
+		require.NotEmpty(t, node.ShardNodeName)
+		require.NotEqual(t, node.ShardFileSystemID, filesystemID)
 	}
 
 	expectedNames := []string{
@@ -313,9 +319,13 @@ func TestGetNodeAttr(t *testing.T) {
 		BlocksCount: 1024,
 		BlockSize:   4096,
 		Kind:        types.FilesystemKind_FILESYSTEM_KIND_SSD,
+		ShardCount:  5,
 	})
 	require.NoError(t, err)
 	defer client.Delete(ctx, filesystemID, false)
+
+	err = client.EnableDirectoryCreationInShards(ctx, filesystemID)
+	require.NoError(t, err)
 
 	session, err := client.CreateSession(ctx, filesystemID, "", false)
 	require.NoError(t, err)
@@ -333,12 +343,16 @@ func TestGetNodeAttr(t *testing.T) {
 	require.Equal(t, "testfile", fileNode.Name)
 	require.False(t, fileNode.Type.IsDirectory())
 	require.NotZero(t, fileNode.NodeID)
+	require.NotEmpty(t, fileNode.ShardNodeName)
+	require.NotEqual(t, fileNode.ShardFileSystemID, filesystemID)
 
 	dirNode, err := session.GetNodeAttr(ctx, nfs.RootNodeID, "testdir")
 	require.NoError(t, err)
 	require.Equal(t, "testdir", dirNode.Name)
 	require.True(t, dirNode.Type.IsDirectory())
 	require.NotZero(t, dirNode.NodeID)
+	require.NotEmpty(t, dirNode.ShardNodeName)
+	require.NotEqual(t, dirNode.ShardFileSystemID, filesystemID)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,6 +9,41 @@ import (
 	nfs_testing "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/clients/nfs/testing"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
 )
+
+////////////////////////////////////////////////////////////////////////////////
+
+var listNodesRootDir = nfs_testing.Root(
+	nfs_testing.Dir("etc",
+		nfs_testing.File("passwd"),
+		nfs_testing.File("hosts"),
+	),
+	nfs_testing.Dir(
+		"var",
+		nfs_testing.Dir(
+			"log",
+		),
+	),
+	nfs_testing.Symlink("bin", "/usr/bin"),
+	nfs_testing.Dir("usr",
+		nfs_testing.Dir("bin", nfs_testing.File("bash"), nfs_testing.File("ls")),
+		nfs_testing.Dir("lib", nfs_testing.File("libc.so")),
+	),
+)
+
+var listNodesExpectedNames = []string{
+	"bin",
+	"etc",
+	"hosts",
+	"passwd",
+	"usr",
+	"bin",
+	"bash",
+	"ls",
+	"lib",
+	"libc.so",
+	"var",
+	"log",
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -110,71 +146,81 @@ func TestListNodesFileSystem(t *testing.T) {
 		BlocksCount: 1024,
 		BlockSize:   4096,
 		Kind:        types.FilesystemKind_FILESYSTEM_KIND_SSD,
-		ShardCount:  5,
 	})
 	require.NoError(t, err)
 	defer client.Delete(ctx, filesystemID, false)
 
-	err = client.EnableDirectoryCreationInShards(ctx, filesystemID, 5)
+	session, err := client.CreateSession(ctx, filesystemID, "", false)
+	require.NoError(t, err)
+	defer session.Close(ctx)
+
+	model := nfs_testing.NewFileSystemModel(t, ctx, session, listNodesRootDir)
+	model.CreateAllNodesRecursively()
+
+	nodes := model.ListAllNodesRecursively(false)
+	model.RequireNodesEqual(nodes)
+	require.Equal(t, listNodesExpectedNames, nfs_testing.NodeNames(nodes))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestListNodesFileSystemUnsafe(t *testing.T) {
+	ctx := nfs_testing.NewContext()
+	client := nfs_testing.NewClient(t, ctx)
+
+	filesystemID := t.Name()
+	shardCount := uint32(5)
+	err := client.Create(ctx, filesystemID, nfs.CreateFilesystemParams{
+		FolderID:    "folder",
+		CloudID:     "cloud",
+		BlocksCount: 1024,
+		BlockSize:   4096,
+		Kind:        types.FilesystemKind_FILESYSTEM_KIND_SSD,
+		ShardCount:  shardCount,
+	})
+	require.NoError(t, err)
+	defer client.Delete(ctx, filesystemID, false)
+
+	err = client.EnableDirectoryCreationInShards(ctx, filesystemID, shardCount)
 	require.NoError(t, err)
 
 	session, err := client.CreateSession(ctx, filesystemID, "", false)
 	require.NoError(t, err)
 	defer session.Close(ctx)
 
-	rootDir := nfs_testing.Root(
-		nfs_testing.Dir("etc",
-			nfs_testing.File("passwd"),
-			nfs_testing.File("hosts"),
-		),
-		nfs_testing.Dir(
-			"var",
-			nfs_testing.Dir(
-				"log",
-			),
-		),
-		nfs_testing.Symlink("bin", "/usr/bin"),
-		nfs_testing.Dir("usr",
-			nfs_testing.Dir("bin", nfs_testing.File("bash"), nfs_testing.File("ls")),
-			nfs_testing.Dir("lib", nfs_testing.File("libc.so")),
-		),
-	)
-	model := nfs_testing.NewFileSystemModel(t, ctx, session, rootDir)
+	model := nfs_testing.NewFileSystemModel(t, ctx, session, listNodesRootDir)
 	model.CreateAllNodesRecursively()
 
-	nodes := model.ListAllNodesRecursively()
-	require.Equal(t, len(model.ExpectedNodes), len(nodes))
-	for index, node := range nodes {
-		expectedNode := model.ExpectedNodes[index]
-		require.Equal(t, expectedNode.ParentID, node.ParentID)
-		require.Equal(t, expectedNode.Name, node.Name)
-		require.Equal(t, expectedNode.Type, node.Type)
-		// TODO: enable when ydb based nfs server is supported in the recipe.
-		// Local filestore service also does not support proper uid/gid.
-		// See: https://github.com/ydb-platform/nbs/issues/4302
-		// require.Equal(t, expectedNode.Mode, node.Mode)
-		// require.Equal(t, expectedNode.UID, node.UID)
-		// require.Equal(t, expectedNode.GID, node.GID)
-		require.Equal(t, expectedNode.LinkTarget, node.LinkTarget)
-		require.NotEmpty(t, node.ShardNodeName)
-		require.NotEqual(t, node.ShardFileSystemID, filesystemID)
+	nodes := model.ListAllNodesRecursively(true)
+	model.RequireNodesEqual(nodes)
+	require.Equal(t, listNodesExpectedNames, nfs_testing.NodeNames(nodes))
+
+	// Open sessions to shard filesystems for GetNodeAttr verification.
+	shardSessions := make(map[string]nfs.Session, shardCount)
+	for i := uint32(1); i <= shardCount; i++ {
+		shardFsID := fmt.Sprintf("%s_s%d", filesystemID, i)
+		shardSession, err := client.CreateSession(ctx, shardFsID, "", true)
+		require.NoError(t, err)
+		defer shardSession.Close(ctx)
+		shardSessions[shardFsID] = shardSession
 	}
 
-	expectedNames := []string{
-		"bin",
-		"etc",
-		"hosts",
-		"passwd",
-		"usr",
-		"bin",
-		"bash",
-		"ls",
-		"lib",
-		"libc.so",
-		"var",
-		"log",
+	for _, node := range nodes {
+		require.NotEmpty(t, node.ShardNodeName)
+		require.NotEmpty(t, node.ShardFileSystemID)
+		require.NotEqual(t, filesystemID, node.ShardFileSystemID)
+
+		shardSession, ok := shardSessions[node.ShardFileSystemID]
+		require.True(t, ok, "shard session not found for %s", node.ShardFileSystemID)
+
+		shardNode, err := shardSession.GetNodeAttr(
+			ctx,
+			nfs.RootNodeID,
+			node.ShardNodeName,
+		)
+		require.NoError(t, err)
+		require.Equal(t, node.NodeID, shardNode.NodeID)
 	}
-	require.Equal(t, expectedNames, nfs_testing.NodeNames(nodes))
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -280,7 +326,7 @@ func TestListNodesFromCheckpoint(t *testing.T) {
 	)
 
 	model.CreateNodesRecursively(nfs.RootNodeID, nfs_testing.Dir("after_checkpoint"))
-	nodes := model.ListAllNodesRecursively()
+	nodes := model.ListAllNodesRecursively(false)
 	require.Equal(t, []string{
 		"after_checkpoint",
 		"first",
@@ -299,7 +345,7 @@ func TestListNodesFromCheckpoint(t *testing.T) {
 	model.SetSession(checkpointSession)
 
 	// Verify that only files created before the checkpoint are visible
-	nodes = model.ListAllNodesRecursively()
+	nodes = model.ListAllNodesRecursively(false)
 	require.Equal(t, []string{
 		"first",
 		"second",

--- a/cloud/disk_manager/test/recipe/nfs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nfs_launcher.py
@@ -34,8 +34,6 @@ class NfsLauncher:
         storage_config = TStorageConfig()
         storage_config.AllowFileStoreForceDestroy = allow_filestore_force_destroy
         storage_config.MultiTabletForwardingEnabled = True
-        storage_config.AutomaticallyCreatedShardSize = 1073741824
-        storage_config.StrictFileSystemSizeEnforcementEnabled = True
         storage_config.AutomaticShardCreationEnabled = True
         storage_config.ShardIdSelectionInLeaderEnabled = True
         self.__nfs_configurator = FilestoreServerConfigGenerator(

--- a/cloud/disk_manager/test/recipe/nfs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nfs_launcher.py
@@ -34,6 +34,7 @@ class NfsLauncher:
         storage_config = TStorageConfig()
         storage_config.AllowFileStoreForceDestroy = allow_filestore_force_destroy
         storage_config.MultiTabletForwardingEnabled = True
+        storage_config.AutomaticallyCreatedShardSize = 1073741824
         self.__nfs_configurator = FilestoreServerConfigGenerator(
             binary_path=nfs_binary_path,
             app_config=server_config,

--- a/cloud/disk_manager/test/recipe/nfs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nfs_launcher.py
@@ -33,6 +33,7 @@ class NfsLauncher:
         )
         storage_config = TStorageConfig()
         storage_config.AllowFileStoreForceDestroy = allow_filestore_force_destroy
+        storage_config.MultiTabletForwardingEnabled = True
         self.__nfs_configurator = FilestoreServerConfigGenerator(
             binary_path=nfs_binary_path,
             app_config=server_config,

--- a/cloud/disk_manager/test/recipe/nfs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nfs_launcher.py
@@ -35,6 +35,9 @@ class NfsLauncher:
         storage_config.AllowFileStoreForceDestroy = allow_filestore_force_destroy
         storage_config.MultiTabletForwardingEnabled = True
         storage_config.AutomaticallyCreatedShardSize = 1073741824
+        storage_config.StrictFileSystemSizeEnforcementEnabled = True
+        storage_config.AutomaticShardCreationEnabled = True
+        storage_config.ShardIdSelectionInLeaderEnabled = True
         self.__nfs_configurator = FilestoreServerConfigGenerator(
             binary_path=nfs_binary_path,
             app_config=server_config,

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -330,6 +330,7 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
             node->SetShardFileSystemId(std::move(shardFileSystemId));
             node->SetShardNodeName(std::move(shardNodeName));
         }
+
         ++responseIter;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -326,9 +326,10 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
         auto shardFileSystemId = node->GetShardFileSystemId();
         auto shardNodeName = node->GetShardNodeName();
         *node = std::move(*responseIter->MutableNode());
-        node->SetShardFileSystemId(std::move(shardFileSystemId));
-        node->SetShardNodeName(std::move(shardNodeName));
-
+        if (Unsafe) {
+            node->SetShardFileSystemId(std::move(shardFileSystemId));
+            node->SetShardNodeName(std::move(shardNodeName));
+        }
         ++responseIter;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -323,7 +323,11 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
         }
 
         auto* node = Response.MutableNodes(i);
+        auto shardFileSystemId = node->GetShardFileSystemId();
+        auto shardNodeName = node->GetShardNodeName();
         *node = std::move(*responseIter->MutableNode());
+        node->SetShardFileSystemId(std::move(shardFileSystemId));
+        node->SetShardNodeName(std::move(shardNodeName));
 
         ++responseIter;
     }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -818,9 +818,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         UNIT_ASSERT_VALUES_UNEQUAL("", expectedShardId);
         UNIT_ASSERT_VALUES_UNEQUAL("", expectedShardNodeName);
-        UNIT_ASSERT(
-            expectedShardId == fsConfig.Shard1Id
-            || expectedShardId == fsConfig.Shard2Id);
+        UNIT_ASSERT(expectedShardId == fsConfig.Shard1Id);
 
         auto listNodesResponse = service.ListNodes(
             headers,

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -789,7 +789,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             listNodesResponse.GetNodes(0).GetShardNodeName());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldReturnShardInfoFromListNodes)
+    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldReturnShardInfoFromUnsafeListNodes)
     {
         config.SetMultiTabletForwardingEnabled(true);
 
@@ -7221,36 +7221,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const auto response = GetStorageStats(service, fsId);
         const auto& stats = response.GetStats();
         UNIT_ASSERT_EQUAL(MaxOneByteShardCount, stats.GetShardStats().size());
-    }
-
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldReturnShardInfoInListNodesWithMultiTabletForwarding)
-    {
-        config.SetMultiTabletForwardingEnabled(true);
-
-        TShardedFileSystemConfig fsConfig;
-        CREATE_ENV_AND_SHARDED_FILESYSTEM();
-
-        auto headers = service.InitSession(fsConfig.FsId, "client");
-
-        service.CreateNode(
-            headers,
-            TCreateNodeArgs::File(RootNodeId, "file1"));
-
-        auto listNodesResponse = service.ListNodes(
-            headers,
-            fsConfig.FsId,
-            RootNodeId)->Record;
-
-        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
-        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
-        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
-        UNIT_ASSERT_VALUES_EQUAL(
-            expectedShardId,
-            listNodesResponse.GetNodes(0).GetShardFileSystemId());
-        UNIT_ASSERT_VALUES_EQUAL(
-            expectedShardNodeName,
-            listNodesResponse.GetNodes(0).GetShardNodeName());
     }
 
     SERVICE_TEST_SIMPLE(ShouldReturnListNodesMissingFromShardsWithUnsafeFlag)

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -826,8 +826,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             headers,
             fsConfig.FsId,
             RootNodeId,
-            true, /* unsafe */
-            )->Record;
+            true)->Record;
 
         UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -789,6 +789,56 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             listNodesResponse.GetNodes(0).GetShardNodeName());
     }
 
+    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldReturnShardInfoFromListNodes)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"));
+
+        auto noForwardHeaders = headers;
+        noForwardHeaders.DisableMultiTabletForwarding = true;
+
+        auto getAttrResponse = service.GetNodeAttr(
+            noForwardHeaders,
+            fsConfig.FsId,
+            RootNodeId,
+            "file1")->Record;
+
+        const auto expectedShardId =
+            getAttrResponse.GetNode().GetShardFileSystemId();
+        const auto expectedShardNodeName =
+            getAttrResponse.GetNode().GetShardNodeName();
+
+        UNIT_ASSERT_VALUES_UNEQUAL("", expectedShardId);
+        UNIT_ASSERT_VALUES_UNEQUAL("", expectedShardNodeName);
+        UNIT_ASSERT(
+            expectedShardId == fsConfig.Shard1Id
+            || expectedShardId == fsConfig.Shard2Id);
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsConfig.FsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedShardId,
+            listNodesResponse.GetNodes(0).GetShardFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedShardNodeName,
+            listNodesResponse.GetNodes(0).GetShardNodeName());
+    }
+
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldForwardRequestsToShard)
     {
         config.SetLazyXAttrsEnabled(false);
@@ -7173,7 +7223,37 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_EQUAL(MaxOneByteShardCount, stats.GetShardStats().size());
     }
 
-    SERVICE_TEST_SIMPLE(ShouldListNodesMissingFromShardsWithUnsafeFlag)
+    SERVICE_TEST_SID_SELECT_IN_LEADER(
+        ShouldReturnShardInfoInListNodesWithMultiTabletForwarding)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"));
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsConfig.FsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedShardId,
+            listNodesResponse.GetNodes(0).GetShardFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedShardNodeName,
+            listNodesResponse.GetNodes(0).GetShardNodeName());
+    }
+
+    SERVICE_TEST_SIMPLE(ShouldReturnListNodesMissingFromShardsWithUnsafeFlag)
     {
         config.SetMultiTabletForwardingEnabled(true);
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -825,7 +825,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         auto listNodesResponse = service.ListNodes(
             headers,
             fsConfig.FsId,
-            RootNodeId)->Record;
+            RootNodeId,
+            true, /* unsafe */
+            )->Record;
 
         UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
         UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));

--- a/cloud/filestore/public/sdk/go/client/client.go
+++ b/cloud/filestore/public/sdk/go/client/client.go
@@ -497,9 +497,6 @@ func (client *Client) GetNodeAttr(
 		GID:               uint64(attr.GetGid()),
 		Links:             attr.GetLinks(),
 		Type:              NodeType(attr.GetType()),
-		ShardFileSystemID: attr.GetShardFileSystemId(),
-		ShardNodeName:     attr.GetShardNodeName(),
-		DevID:             attr.GetDevId(),
 	}, nil
 }
 

--- a/cloud/filestore/public/sdk/go/client/client.go
+++ b/cloud/filestore/public/sdk/go/client/client.go
@@ -183,7 +183,7 @@ func (client *Client) EnableDirectoryCreationInShards(
 		BlocksCount:                     blocksCount,
 		ConfigVersion:                   configVersion,
 		EnableDirectoryCreationInShards: true,
-		ShardCount: shardCount,
+		ShardCount:                      shardCount,
 	}
 
 	_, err := client.Impl.ResizeFileStore(ctx, req)
@@ -485,18 +485,18 @@ func (client *Client) GetNodeAttr(
 
 	attr := resp.GetNode()
 	return Node{
-		ParentID:          parentNodeID,
-		NodeID:            attr.GetId(),
-		Name:              name,
-		Atime:             attr.GetATime(),
-		Mtime:             attr.GetMTime(),
-		Ctime:             attr.GetCTime(),
-		Size:              attr.GetSize(),
-		Mode:              attr.GetMode(),
-		UID:               uint64(attr.GetUid()),
-		GID:               uint64(attr.GetGid()),
-		Links:             attr.GetLinks(),
-		Type:              NodeType(attr.GetType()),
+		ParentID: parentNodeID,
+		NodeID:   attr.GetId(),
+		Name:     name,
+		Atime:    attr.GetATime(),
+		Mtime:    attr.GetMTime(),
+		Ctime:    attr.GetCTime(),
+		Size:     attr.GetSize(),
+		Mode:     attr.GetMode(),
+		UID:      uint64(attr.GetUid()),
+		GID:      uint64(attr.GetGid()),
+		Links:    attr.GetLinks(),
+		Type:     NodeType(attr.GetType()),
 	}, nil
 }
 

--- a/cloud/filestore/public/sdk/go/client/client.go
+++ b/cloud/filestore/public/sdk/go/client/client.go
@@ -175,6 +175,7 @@ func (client *Client) EnableDirectoryCreationInShards(
 	filesystemID string,
 	blocksCount uint64,
 	configVersion uint32,
+	shardCount uint32,
 ) error {
 
 	req := &protos.TResizeFileStoreRequest{
@@ -182,6 +183,7 @@ func (client *Client) EnableDirectoryCreationInShards(
 		BlocksCount:                     blocksCount,
 		ConfigVersion:                   configVersion,
 		EnableDirectoryCreationInShards: true,
+		ShardCount: shardCount,
 	}
 
 	_, err := client.Impl.ResizeFileStore(ctx, req)

--- a/cloud/filestore/public/sdk/go/client/client.go
+++ b/cloud/filestore/public/sdk/go/client/client.go
@@ -18,6 +18,7 @@ type CreateFileStoreOpts struct {
 	BlockSize        uint32
 	BlocksCount      uint64
 	StorageMediaKind coreprotos.EStorageMediaKind
+	ShardCount       uint32
 }
 
 type AlterFileStoreOpts struct {
@@ -64,19 +65,22 @@ const (
 ////////////////////////////////////////////////////////////////////////////////
 
 type Node struct {
-	ParentID   uint64
-	NodeID     uint64
-	Name       string
-	Atime      uint64
-	Mtime      uint64
-	Ctime      uint64
-	Size       uint64
-	Mode       uint32
-	UID        uint64
-	GID        uint64
-	Links      uint32
-	Type       NodeType
-	LinkTarget string
+	ParentID          uint64
+	NodeID            uint64
+	Name              string
+	Atime             uint64
+	Mtime             uint64
+	Ctime             uint64
+	Size              uint64
+	Mode              uint32
+	UID               uint64
+	GID               uint64
+	Links             uint32
+	Type              NodeType
+	LinkTarget        string
+	ShardFileSystemID string
+	ShardNodeName     string
+	DevID             uint64
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -113,6 +117,9 @@ func (client *Client) CreateFileStore(
 		req.BlockSize = opts.BlockSize
 		req.BlocksCount = opts.BlocksCount
 		req.StorageMediaKind = opts.StorageMediaKind
+		if opts.ShardCount > 0 {
+			req.ShardCount = opts.ShardCount
+		}
 	}
 
 	resp, err := client.Impl.CreateFileStore(ctx, req)
@@ -157,6 +164,24 @@ func (client *Client) ResizeFileStore(
 		FileSystemId:  fileSystemID,
 		BlocksCount:   blocksCount,
 		ConfigVersion: configVersion,
+	}
+
+	_, err := client.Impl.ResizeFileStore(ctx, req)
+	return err
+}
+
+func (client *Client) EnableDirectoryCreationInShards(
+	ctx context.Context,
+	filesystemID string,
+	blocksCount uint64,
+	configVersion uint32,
+) error {
+
+	req := &protos.TResizeFileStoreRequest{
+		FileSystemId:                    filesystemID,
+		BlocksCount:                     blocksCount,
+		ConfigVersion:                   configVersion,
+		EnableDirectoryCreationInShards: true,
 	}
 
 	_, err := client.Impl.ResizeFileStore(ctx, req)
@@ -331,18 +356,21 @@ func (client *Client) ListNodes(
 	result := make([]Node, len(nodes))
 	for idx, name := range resp.GetNames() {
 		result[idx] = Node{
-			ParentID: nodeID,
-			NodeID:   nodes[idx].GetId(),
-			Name:     string(name),
-			Atime:    nodes[idx].GetATime(),
-			Mtime:    nodes[idx].GetMTime(),
-			Ctime:    nodes[idx].GetCTime(),
-			Size:     nodes[idx].GetSize(),
-			Mode:     nodes[idx].GetMode(),
-			UID:      uint64(nodes[idx].GetUid()),
-			GID:      uint64(nodes[idx].GetGid()),
-			Links:    nodes[idx].GetLinks(),
-			Type:     NodeType(nodes[idx].GetType()),
+			ParentID:          nodeID,
+			NodeID:            nodes[idx].GetId(),
+			Name:              string(name),
+			Atime:             nodes[idx].GetATime(),
+			Mtime:             nodes[idx].GetMTime(),
+			Ctime:             nodes[idx].GetCTime(),
+			Size:              nodes[idx].GetSize(),
+			Mode:              nodes[idx].GetMode(),
+			UID:               uint64(nodes[idx].GetUid()),
+			GID:               uint64(nodes[idx].GetGid()),
+			Links:             nodes[idx].GetLinks(),
+			Type:              NodeType(nodes[idx].GetType()),
+			ShardFileSystemID: nodes[idx].GetShardFileSystemId(),
+			ShardNodeName:     nodes[idx].GetShardNodeName(),
+			DevID:             nodes[idx].GetDevId(),
 		}
 	}
 
@@ -455,18 +483,21 @@ func (client *Client) GetNodeAttr(
 
 	attr := resp.GetNode()
 	return Node{
-		ParentID: parentNodeID,
-		NodeID:   attr.GetId(),
-		Name:     name,
-		Atime:    attr.GetATime(),
-		Mtime:    attr.GetMTime(),
-		Ctime:    attr.GetCTime(),
-		Size:     attr.GetSize(),
-		Mode:     attr.GetMode(),
-		UID:      uint64(attr.GetUid()),
-		GID:      uint64(attr.GetGid()),
-		Links:    attr.GetLinks(),
-		Type:     NodeType(attr.GetType()),
+		ParentID:          parentNodeID,
+		NodeID:            attr.GetId(),
+		Name:              name,
+		Atime:             attr.GetATime(),
+		Mtime:             attr.GetMTime(),
+		Ctime:             attr.GetCTime(),
+		Size:              attr.GetSize(),
+		Mode:              attr.GetMode(),
+		UID:               uint64(attr.GetUid()),
+		GID:               uint64(attr.GetGid()),
+		Links:             attr.GetLinks(),
+		Type:              NodeType(attr.GetType()),
+		ShardFileSystemID: attr.GetShardFileSystemId(),
+		ShardNodeName:     attr.GetShardNodeName(),
+		DevID:             attr.GetDevId(),
 	}, nil
 }
 

--- a/cloud/filestore/public/sdk/go/client/client_interface.go
+++ b/cloud/filestore/public/sdk/go/client/client_interface.go
@@ -33,6 +33,13 @@ type ClientInterface interface {
 		configVersion uint32,
 	) error
 
+	EnableDirectoryCreationInShards(
+		ctx context.Context,
+		filesystemID string,
+		blocksCount uint64,
+		configVersion uint32,
+	) error
+
 	DestroyFileStore(
 		ctx context.Context,
 		fileSystemID string,

--- a/cloud/filestore/public/sdk/go/client/client_interface.go
+++ b/cloud/filestore/public/sdk/go/client/client_interface.go
@@ -38,6 +38,7 @@ type ClientInterface interface {
 		filesystemID string,
 		blocksCount uint64,
 		configVersion uint32,
+		shardCount uint32,
 	) error
 
 	DestroyFileStore(

--- a/cloud/filestore/public/sdk/go/client/mocks/client_mock.go
+++ b/cloud/filestore/public/sdk/go/client/mocks/client_mock.go
@@ -63,9 +63,10 @@ func (m *ClientInterfaceMock) EnableDirectoryCreationInShards(
 	filesystemID string,
 	blocksCount uint64,
 	configVersion uint32,
+	shardCount uint32,
 ) error {
 
-	args := m.Called(ctx, filesystemID, blocksCount, configVersion)
+	args := m.Called(ctx, filesystemID, blocksCount, configVersion, shardCount)
 	return args.Error(0)
 }
 

--- a/cloud/filestore/public/sdk/go/client/mocks/client_mock.go
+++ b/cloud/filestore/public/sdk/go/client/mocks/client_mock.go
@@ -58,6 +58,17 @@ func (m *ClientInterfaceMock) ResizeFileStore(
 	return args.Error(0)
 }
 
+func (m *ClientInterfaceMock) EnableDirectoryCreationInShards(
+	ctx context.Context,
+	filesystemID string,
+	blocksCount uint64,
+	configVersion uint32,
+) error {
+
+	args := m.Called(ctx, filesystemID, blocksCount, configVersion)
+	return args.Error(0)
+}
+
 func (m *ClientInterfaceMock) DestroyFileStore(
 	ctx context.Context,
 	fileSystemID string,


### PR DESCRIPTION
### Notes
Return shard id and node name in shard from ListNodes. 
Add EnableDirectoryCreationInShards method to disk-manager nfs go client and filestore go sdk client.
Enabled multi tablet forwarding in tests. 
Added shard count to filesystem Create.

### Issue
#1559