### PR TITLE
issue-5715: implemented the ability to enable directories in shards for existing filesystems - with restrictions on some RenameNode ops

### DIFF
--- a/cloud/filestore/apps/client/lib/resize.cpp
+++ b/cloud/filestore/apps/client/lib/resize.cpp
@@ -19,6 +19,7 @@ private:
     ui32 ShardCount = 0;
     bool EnableStrictFileSystemSizeEnforcement = false;
     bool EnableDirectoryCreationInShards = false;
+    bool ForceDirectoryCreationInShards = false;
 
 public:
     TResizeCommand()
@@ -45,6 +46,10 @@ public:
         Opts.AddLongOption("enable-directory-creation-in-shards")
             .StoreTrue(&EnableDirectoryCreationInShards)
             .Help("enable directory creation in shards");
+
+        Opts.AddLongOption("force-directory-creation-in-shards")
+            .StoreTrue(&ForceDirectoryCreationInShards)
+            .Help("force directory creation in shards");
     }
 
     bool Execute() override
@@ -58,7 +63,10 @@ public:
         request->SetShardCount(ShardCount);
         request->SetEnableStrictFileSystemSizeEnforcement(
             EnableStrictFileSystemSizeEnforcement);
-        request->SetEnableDirectoryCreationInShards(EnableDirectoryCreationInShards);
+        request->SetEnableDirectoryCreationInShards(
+            EnableDirectoryCreationInShards);
+        request->SetForceDirectoryCreationInShards(
+            ForceDirectoryCreationInShards);
 
         PerformanceProfileParams.FillRequest(*request);
 

--- a/cloud/filestore/libs/service/error.cpp
+++ b/cloud/filestore/libs/service/error.cpp
@@ -142,6 +142,14 @@ NProto::TError ErrorIsPreparedForUnlink(ui64 nodeId)
         TStringBuilder() << "node #" << nodeId << " is prepared for unlink");
 }
 
+NProto::TError ErrorRenameNotSupported(ui64 parentId, ui64 newParentId)
+{
+    return MakeError(
+        E_FS_XDEV,
+        TStringBuilder() << "cannot move from " << parentId << " to "
+            << newParentId);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 NProto::TError ErrorNameTooLong(const TString& name)

--- a/cloud/filestore/libs/service/error.h
+++ b/cloud/filestore/libs/service/error.h
@@ -32,6 +32,7 @@ NProto::TError ErrorIsDirectory(ui64 nodeId);
 NProto::TError ErrorIsNotDirectory(ui64 nodeId);
 NProto::TError ErrorIsNotEmpty(ui64 nodeId);
 NProto::TError ErrorIsPreparedForUnlink(ui64 nodeId);
+NProto::TError ErrorRenameNotSupported(ui64 parentId, ui64 newParentId);
 
 //
 // Limits.

--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -51,6 +51,10 @@ private:
     const NProto::TFileStorePerformanceProfile PerformanceProfile;
     const bool Alter;
     const bool Force;
+    const bool EnableDirectoryCreationInShards;
+    const bool ForceDirectoryCreationInShards;
+    const bool EnableStrictFileSystemSizeEnforcement;
+
     ui32 ExplicitShardCount;
 
     NKikimrFileStore::TConfig TargetConfig;
@@ -68,11 +72,8 @@ private:
 
     // These flags are set by HandleGetFileSystemTopologyResponse.
     bool DirectoryCreationInShardsEnabled = false;
-    bool EnableDirectoryCreationInShards = false;
-
+    bool DirectoryCreationInShardsForced = false;
     bool StrictFileSystemSizeEnforcementEnabled = false;
-    bool EnableStrictFileSystemSizeEnforcement = false;
-
     bool ShouldConfigureMainFileStore = false;
 
     const ui64 MainFileStoreCookie = Max<ui64>();
@@ -193,6 +194,9 @@ TAlterFileStoreActor::TAlterFileStoreActor(
     , FileSystemId(request.GetFileSystemId())
     , Alter(true)
     , Force(false)
+    , EnableDirectoryCreationInShards(false)
+    , ForceDirectoryCreationInShards(false)
+    , EnableStrictFileSystemSizeEnforcement(false)
     , ExplicitShardCount(0)
 {
     TargetConfig.SetCloudId(request.GetCloudId());
@@ -211,11 +215,13 @@ TAlterFileStoreActor::TAlterFileStoreActor(
     , PerformanceProfile(request.GetPerformanceProfile())
     , Alter(false)
     , Force(request.GetForce())
-    , ExplicitShardCount(request.GetShardCount())
     , EnableDirectoryCreationInShards(
           request.GetEnableDirectoryCreationInShards())
+    , ForceDirectoryCreationInShards(
+        request.GetForceDirectoryCreationInShards())
     , EnableStrictFileSystemSizeEnforcement(
           request.GetEnableStrictFileSystemSizeEnforcement())
+    , ExplicitShardCount(request.GetShardCount())
 {
     TargetConfig.SetBlocksCount(request.GetBlocksCount());
     TargetConfig.SetVersion(request.GetConfigVersion());
@@ -519,6 +525,9 @@ void TAlterFileStoreActor::HandleGetFileSystemTopologyResponse(
     DirectoryCreationInShardsEnabled =
         EnableDirectoryCreationInShards ||
         msg->Record.GetDirectoryCreationInShardsEnabled();
+    DirectoryCreationInShardsForced =
+        ForceDirectoryCreationInShards ||
+        msg->Record.GetForceDirectoryCreationInShards();
     StrictFileSystemSizeEnforcementEnabled =
         EnableStrictFileSystemSizeEnforcement ||
         msg->Record.GetStrictFileSystemSizeEnforcementEnabled();
@@ -735,6 +744,8 @@ void TAlterFileStoreActor::ConfigureShards(const TActorContext& ctx)
         request->Record.SetMainFileSystemId(FileSystemId);
         request->Record.SetDirectoryCreationInShardsEnabled(
             DirectoryCreationInShardsEnabled);
+        request->Record.SetForceDirectoryCreationInShards(
+            DirectoryCreationInShardsForced);
         request->Record.SetStrictFileSystemSizeEnforcementEnabled(
             StrictFileSystemSizeEnforcementEnabled);
 
@@ -816,6 +827,8 @@ void TAlterFileStoreActor::ConfigureMainFileStore(const TActorContext& ctx)
         FileStoreConfig.MainFileSystemConfig.GetFileSystemId());
     request->Record.SetDirectoryCreationInShardsEnabled(
         DirectoryCreationInShardsEnabled);
+    request->Record.SetForceDirectoryCreationInShards(
+        DirectoryCreationInShardsForced);
     request->Record.SetStrictFileSystemSizeEnforcementEnabled(
         StrictFileSystemSizeEnforcementEnabled);
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -7423,5 +7423,221 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                 0),
             nodeIdx);
     }
+
+    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+        ShouldSwitchOnDirectoryCreationInShardsForExistingFilesystem)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+        config.SetDirectoryCreationInShardsEnabled(false);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        //
+        // dir0_1 and dir0_2 - managed by the main tablet.
+        //
+
+        ui64 dir0_1Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir0_1")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(0, ExtractShardNo(dir0_1Id));
+
+        ui64 dir0_2Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir0_2")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(0, ExtractShardNo(dir0_2Id));
+
+        //
+        // file1 - managed by a shard.
+        //
+
+        auto node1Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(
+            dir0_1Id,
+            "file1"))->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(node1Id));
+
+        //
+        // Forcing directory creation in shards.
+        //
+
+        service.ResizeFileStore(
+            fsConfig.FsId,
+            fsConfig.MainFsBlockCount,
+            false /* force */,
+            0 /* shardCount */,
+            true /* enableStrictSizeMode */,
+            true /* directoryCreationInShards */,
+            true /* forceDirectoryCreationInShards */);
+
+        //
+        // dir2 and dir3 - managed by shards.
+        //
+
+        ui64 dir2Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir2")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(dir2Id));
+
+        ui64 dir3Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(dir2Id, "dir3")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(dir3Id));
+
+        //
+        // Trying to move dir0_1 into dir2 - should fail because the
+        // RootNodeId/dir0_1 NodeRef is not external.
+        //
+
+        service.SendRenameNodeRequest(
+            headers,
+            RootNodeId,
+            "dir0_1",
+            dir2Id,
+            "dir0_1",
+            0 /* flags */);
+
+        {
+            auto renameResponse = service.RecvRenameNodeResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FS_XDEV,
+                renameResponse->GetError().GetCode(),
+                renameResponse->GetError().GetMessage());
+        }
+
+        //
+        // Moving file1 to dir2 should be possible.
+        //
+
+        service.SendRenameNodeRequest(
+            headers,
+            dir0_1Id,
+            "file1",
+            dir2Id,
+            "file1",
+            0 /* flags */);
+
+        {
+            auto renameResponse = service.RecvRenameNodeResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                renameResponse->GetError().GetCode(),
+                renameResponse->GetError().GetMessage());
+        }
+
+        //
+        // Moving dir3 into dir0_1 should be possible as well.
+        //
+
+        service.SendRenameNodeRequest(
+            headers,
+            dir2Id,
+            "dir3",
+            dir0_1Id,
+            "dir3",
+            0 /* flags */);
+
+        {
+            auto renameResponse = service.RecvRenameNodeResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                renameResponse->GetError().GetCode(),
+                renameResponse->GetError().GetMessage());
+        }
+
+        //
+        // Moving dir0_1 into dir0_2 should be possible as well because even
+        // though their node refs are local, both of them are managed by the
+        // main tablet.
+        //
+
+        service.SendRenameNodeRequest(
+            headers,
+            RootNodeId,
+            "dir0_1",
+            dir0_2Id,
+            "dir0_1",
+            0 /* flags */);
+
+        {
+            auto renameResponse = service.RecvRenameNodeResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                renameResponse->GetError().GetCode(),
+                renameResponse->GetError().GetMessage());
+        }
+
+        //
+        // Verifying that the resulting directory structure is correct.
+        //
+
+        auto listNodesResponse = service.ListNodes(
+            headers,
+            fsConfig.FsId,
+            RootNodeId)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(2, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("dir0_2", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            dir0_2Id,
+            listNodesResponse.GetNodes(0).GetId());
+        UNIT_ASSERT_VALUES_EQUAL("dir2", listNodesResponse.GetNames(1));
+        UNIT_ASSERT_VALUES_EQUAL(
+            dir2Id,
+            listNodesResponse.GetNodes(1).GetId());
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsConfig.FsId,
+            dir0_2Id)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("dir0_1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            dir0_1Id,
+            listNodesResponse.GetNodes(0).GetId());
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsConfig.FsId,
+            dir0_1Id)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("dir3", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            dir3Id,
+            listNodesResponse.GetNodes(0).GetId());
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsConfig.FsId,
+            dir3Id)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
+
+        listNodesResponse = service.ListNodes(
+            headers,
+            fsConfig.FsId,
+            dir2Id)->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, listNodesResponse.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL("file1", listNodesResponse.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            node1Id,
+            listNodesResponse.GetNodes(0).GetId());
+    }
 }
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -53,6 +53,7 @@ message TFileSystem
     bool DirectoryCreationInShardsEnabled = 18;
     bool StrictFileSystemSizeEnforcementEnabled = 19;
     bool Frozen = 20;
+    bool ForceDirectoryCreationInShards = 21;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -833,6 +833,8 @@ void TIndexTabletActor::HandleGetFileSystemTopology(
     response->Record.SetShardNo(GetFileSystem().GetShardNo());
     response->Record.SetDirectoryCreationInShardsEnabled(
         GetFileSystem().GetDirectoryCreationInShardsEnabled());
+    response->Record.SetForceDirectoryCreationInShards(
+        GetFileSystem().GetForceDirectoryCreationInShards());
     response->Record.SetStrictFileSystemSizeEnforcementEnabled(
         GetFileSystem().GetStrictFileSystemSizeEnforcementEnabled());
     response->Record.SetMaxShardCount(Config->GetMaxShardCount());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -559,7 +559,8 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
                 && !isParentNodeLinkRequest
                 // otherwise there might be some local nodes which breaks
                 // current cross-shard RenameNode implementation
-                && !isMainWithLocalNodes))
+                && (!isMainWithLocalNodes
+                    || GetFileSystem().GetForceDirectoryCreationInShards())))
     {
         args.Error = SelectShard(args.Attrs.GetSize(), &args.ShardId);
         if (HasError(args.Error)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -98,7 +98,10 @@ NProto::TError TIndexTabletActor::HandleCrossShardRenameNodeImpl(
         return MakeError(E_ARGUMENT, std::move(message));
     }
 
-    if (newParentShardNo == 0 && record.GetNewParentId() != RootNodeId) {
+    if (newParentShardNo == 0
+            && record.GetNewParentId() != RootNodeId
+            && !GetFileSystem().GetForceDirectoryCreationInShards())
+    {
         auto message = ReportInvalidShardNo(
             TStringBuilder() << "RenameNode: "
                 << record.ShortDebugString() << " newParentShardNo"
@@ -313,7 +316,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     // read old node
     if (!args.ChildRef) {
-        args.Error = ErrorInvalidTarget(args.ParentNodeId);
+        args.Error = ErrorInvalidTarget(args.ParentNodeId, args.Name);
         return true;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -542,10 +542,17 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
         }
 
         if (!args.NewChildRef->IsExternal()) {
-            auto message = ReportRenameNodeRequestForLocalNode(TStringBuilder()
-                << "RenameNodeInDestination: "
-                << args.Request.ShortDebugString());
-            args.Error = MakeError(E_ARGUMENT, std::move(message));
+            if (GetFileSystem().GetForceDirectoryCreationInShards()) {
+                args.Error = ErrorRenameNotSupported(
+                    args.Request.GetOriginalRequest().GetNodeId(),
+                    args.Request.GetNewParentId());
+            } else {
+                auto message = ReportRenameNodeRequestForLocalNode(
+                    TStringBuilder() << "RenameNodeInDestination: "
+                        << args.Request.ShortDebugString());
+                args.Error = MakeError(E_ARGUMENT, std::move(message));
+            }
+
             return true;
         }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -454,15 +454,22 @@ bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
 
     // read old node
     if (!args.ChildRef) {
-        args.Error = ErrorInvalidTarget(args.ParentNodeId);
+        args.Error = ErrorInvalidTarget(args.ParentNodeId, args.Name);
         return true;
     }
 
     if (!args.ChildRef->IsExternal()) {
-        auto message = ReportRenameNodeRequestForLocalNode(TStringBuilder()
-            << "PrepareRenameNodeInSource: "
-            << args.Request.ShortDebugString());
-        args.Error = MakeError(E_ARGUMENT, std::move(message));
+        if (GetFileSystem().GetForceDirectoryCreationInShards()) {
+            args.Error = ErrorRenameNotSupported(
+                args.ParentNodeId,
+                args.Request.GetNewParentId());
+        } else {
+            auto message = ReportRenameNodeRequestForLocalNode(TStringBuilder()
+                << "PrepareRenameNodeInSource: "
+                << args.Request.ShortDebugString());
+            args.Error = MakeError(E_ARGUMENT, std::move(message));
+        }
+
         return true;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -164,6 +164,8 @@ void TIndexTabletActor::HandleUpdateConfig(
     newConfig.SetShardAllocationUnit(oldConfig.GetShardAllocationUnit());
     newConfig.SetDirectoryCreationInShardsEnabled(
         oldConfig.GetDirectoryCreationInShardsEnabled());
+    newConfig.SetForceDirectoryCreationInShards(
+        oldConfig.GetForceDirectoryCreationInShards());
     newConfig.SetStrictFileSystemSizeEnforcementEnabled(
         oldConfig.GetStrictFileSystemSizeEnforcementEnabled());
 
@@ -363,6 +365,8 @@ void TIndexTabletActor::ExecuteTx_ConfigureShards(
         std::move(*args.Request.MutableShardFileSystemIds());
     config.SetDirectoryCreationInShardsEnabled(
         args.Request.GetDirectoryCreationInShardsEnabled());
+    config.SetForceDirectoryCreationInShards(
+        args.Request.GetForceDirectoryCreationInShards());
     config.SetStrictFileSystemSizeEnforcementEnabled(
         args.Request.GetStrictFileSystemSizeEnforcementEnabled());
 
@@ -464,6 +468,8 @@ void TIndexTabletActor::ExecuteTx_ConfigureAsShard(
         std::move(*args.Request.MutableShardFileSystemIds());
     config.SetDirectoryCreationInShardsEnabled(
         args.Request.GetDirectoryCreationInShardsEnabled());
+    config.SetForceDirectoryCreationInShards(
+        args.Request.GetForceDirectoryCreationInShards());
     config.SetStrictFileSystemSizeEnforcementEnabled(
         args.Request.GetStrictFileSystemSizeEnforcementEnabled());
 

--- a/cloud/filestore/libs/storage/testlib/service_client.h
+++ b/cloud/filestore/libs/storage/testlib/service_client.h
@@ -174,7 +174,8 @@ public:
         bool force = false,
         ui32 shardCount = 0,
         bool enableStrictSizeMode = false,
-        bool directoryCreationInShards = false)
+        bool directoryCreationInShards = false,
+        bool forceDirectoryCreationInShards = false)
     {
         auto request = std::make_unique<TEvService::TEvResizeFileStoreRequest>();
         request->Record.SetFileSystemId(fileSystemId);
@@ -185,6 +186,8 @@ public:
             enableStrictSizeMode);
         request->Record.SetEnableDirectoryCreationInShards(
             directoryCreationInShards);
+        request->Record.SetForceDirectoryCreationInShards(
+            forceDirectoryCreationInShards);
         return request;
     }
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -675,6 +675,10 @@ message TConfigureShardsRequest
     // Allow shards aggregate statistics from all other shards and strictly
     // enforce filesystem size.
     bool StrictFileSystemSizeEnforcementEnabled = 5;
+
+    // If DirectoryCreationInShardsEnabled is true, forces directory creation
+    // in shards even if main tablet has already created some nodes.
+    bool ForceDirectoryCreationInShards = 6;
 }
 
 message TConfigureShardsResponse
@@ -705,6 +709,10 @@ message TConfigureAsShardRequest
     // Allow shards aggregate statistics from all other shards and strictly
     // enforce filesystem size.
     bool StrictFileSystemSizeEnforcementEnabled = 6;
+
+    // If DirectoryCreationInShardsEnabled is true, forces directory creation
+    // in shards even if main tablet has already created some nodes.
+    bool ForceDirectoryCreationInShards = 7;
 }
 
 message TConfigureAsShardResponse
@@ -954,6 +962,8 @@ message TGetFileSystemTopologyResponse
     bool StrictFileSystemSizeEnforcementEnabled = 5;
 
     uint32 MaxShardCount = 6;
+
+    bool ForceDirectoryCreationInShards = 7;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -273,6 +273,10 @@ message TResizeFileStoreRequest
 
     // Turn on directory creation in shards for the whole filesystem.
     bool EnableDirectoryCreationInShards = 9;
+
+    // Force directory creation in shards for the whole filesystem. Overrides
+    // the LastNodeId check in the main tablet.
+    bool ForceDirectoryCreationInShards = 10;
 }
 
 message TResizeFileStoreResponse

--- a/cloud/filestore/tests/client_sharded/canondata/result.json
+++ b/cloud/filestore/tests/client_sharded/canondata/result.json
@@ -8,6 +8,9 @@
     "test.test_explicit_shard_count_addition": {
         "uri": "file://test.test_explicit_shard_count_addition/results.txt"
     },
+    "test.test_force_directory_creation_in_shards": {
+        "uri": "file://test.test_force_directory_creation_in_shards/results.txt"
+    },
     "test.test_shard_autoaddition": {
         "uri": "file://test.test_shard_autoaddition/results.txt"
     }

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_force_directory_creation_in_shards/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_force_directory_creation_in_shards/results.txt
@@ -1,0 +1,125 @@
+[
+    {
+        "ShardFileSystemId": "fs0_s2",
+        "Name": ".something"
+    },
+    {
+        "Type": 2,
+        "Links": 1,
+        "Name": "a0",
+        "Mode": 511,
+        "Id": 2
+    },
+    {
+        "ShardFileSystemId": "fs0_s1",
+        "Name": "a1"
+    },
+    {
+        "ShardFileSystemId": "fs0_s3",
+        "Name": "another.something"
+    },
+    {
+        "ShardFileSystemId": "fs0_s1",
+        "Name": "f18.txt"
+    },
+    {
+        "ShardFileSystemId": "fs0_s1",
+        "Name": "file.txt"
+    }
+][
+    {
+        "Type": 2,
+        "Links": 1,
+        "Name": "b1",
+        "Mode": 511,
+        "Id": 72057594037927950
+    },
+    {
+        "Type": 2,
+        "Links": 1,
+        "Name": "b2",
+        "Mode": 511,
+        "Id": 144115188075855874
+    },
+    {
+        "Type": 2,
+        "Links": 1,
+        "Name": "b3",
+        "Mode": 511,
+        "Id": 216172782113783810
+    },
+    {
+        "Type": 2,
+        "Links": 1,
+        "Name": "b5",
+        "Mode": 511,
+        "Id": 72057594037927960
+    },
+    {
+        "Type": 2,
+        "Links": 1,
+        "Name": "b6",
+        "Mode": 511,
+        "Id": 72057594037927962
+    }
+]dirViewer(1):
+[
+    {
+        "name": ".something",
+        "node": {
+            "shardId": "fs0_s2",
+            "type": 1,
+            "size": 0,
+            "mode": 420
+        }
+    },
+    {
+        "name": "a0",
+        "node": {
+            "shardId": "",
+            "type": 2,
+            "size": 0,
+            "mode": 511
+        }
+    },
+    {
+        "name": "a1",
+        "node": {
+            "shardId": "fs0_s1",
+            "type": 2,
+            "size": 0,
+            "mode": 511
+        }
+    },
+    {
+        "name": "another.something",
+        "node": {
+            "shardId": "fs0_s3",
+            "type": 1,
+            "size": 0,
+            "mode": 420
+        }
+    },
+    {
+        "name": "f18.txt",
+        "node": {
+            "shardId": "fs0_s1",
+            "type": 1,
+            "size": 62,
+            "mode": 0
+        }
+    },
+    {
+        "name": "file.txt",
+        "node": {
+            "shardId": "fs0_s1",
+            "type": 1,
+            "size": 0,
+            "mode": 420
+        }
+    }
+]
+locks():
+{
+    "locks": []
+}

--- a/cloud/filestore/tests/client_sharded/test.py
+++ b/cloud/filestore/tests/client_sharded/test.py
@@ -4,6 +4,15 @@ import os
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.client import FilestoreCliClient
+from cloud.filestore.tests.python.lib.fs import (
+    FsItem,
+    fill_fs,
+    DIR,
+    FILE,
+    SYMLINK,
+    fetch_dir_viewer_entries,
+    fetch_locks,
+)
 
 BLOCK_SIZE = 4 * 1024
 SHARD_SIZE = 1024 * 1024 * 1024
@@ -13,9 +22,14 @@ def __init_test():
     port = os.getenv("NFS_SERVER_PORT")
     binary_path = common.binary_path("cloud/filestore/apps/client/filestore-client")
     client = FilestoreCliClient(binary_path, port, cwd=common.output_path())
+    client_nocheck = FilestoreCliClient(
+        binary_path,
+        port,
+        cwd=common.output_path(),
+        check_exit_code=False)
 
     results_path = common.output_path() + "/results.txt"
-    return client, results_path
+    return client, client_nocheck, results_path
 
 
 def __process_stat(node):
@@ -42,7 +56,7 @@ def __exec_ls(client, *args):
 
 
 def test_shard_autoaddition():
-    client, results_path = __init_test()
+    client, _, results_path = __init_test()
     out = client.create(
         "fs0",
         "test_cloud",
@@ -99,7 +113,7 @@ def test_shard_autoaddition():
 
 
 def test_explicit_shard_count_addition():
-    client, results_path = __init_test()
+    client, _, results_path = __init_test()
     out = client.create(
         "fs0",
         "test_cloud",
@@ -137,7 +151,7 @@ def test_explicit_shard_count_addition():
 
 
 def test_enable_strict():
-    client, results_path = __init_test()
+    client, _, results_path = __init_test()
     out = client.create(
         "fs0",
         "test_cloud",
@@ -174,7 +188,7 @@ def test_enable_strict():
 
 
 def test_enable_directory_creation_in_shards():
-    client, results_path = __init_test()
+    client, _, results_path = __init_test()
     out = client.create(
         "fs0",
         "test_cloud",
@@ -205,6 +219,139 @@ def test_enable_directory_creation_in_shards():
 
     with open(results_path, "wb") as results_file:
         results_file.write(out)
+
+    ret = common.canonical_file(results_path, local=True)
+    return ret
+
+
+def test_force_directory_creation_in_shards():
+    client, client_nocheck, results_path = __init_test()
+    block_count = 3 * int(SHARD_SIZE / BLOCK_SIZE)
+    client.create(
+        "fs0",
+        "test_cloud",
+        "test_folder",
+        BLOCK_SIZE,
+        block_count)
+
+    def _d(path):
+        return FsItem(path, DIR, None)
+
+    def _f(path, data=None):
+        return FsItem(path, FILE, data)
+
+    def _l(path, symlink):
+        return FsItem(path, SYMLINK, symlink)
+
+    items = [
+        _d("/a0"),
+        _f("/a0/f0.txt", "xxx"),
+        _f("/a0/f1.txt", "xxx2"),
+        _f("/a0/f2.txt", "xxx3"),
+        _d("/a0/b0"),
+        _f("/a0/f3.txt", "xxx4"),
+        _f("/a0/f4.txt"),
+        _d("/a0/b0/c0"),
+        _f("/a0/f5.txt"),
+        _f("/a0/f6.txt", "yyyy"),
+        _f("/a0/f7.txt", "yyyy2"),
+        _f("/a0/f8.txt"),
+        _d("/a0/b0/c0/d0"),
+        _f("/a0/b0/c0/d0/f9.txt", "yyyy3"),
+        _f("/a0/b0/c0/d0/f10.txt", "yyyy4"),
+    ]
+
+    fill_fs(client, "fs0", items)
+
+    out = client.resize(
+        "fs0",
+        block_count,
+        enable_directory_creation_in_shards=True,
+        force_directory_creation_in_shards=True)
+    #out = "".encode("utf8")
+
+    items = [
+        _d("/a1"),
+        _d("/a1/b1"),
+        _d("/a1/b2"),
+        _f("/a1/b2/f11.txt", "zzzzz"),
+        _f("/a1/b2/f12.txt", "zzzzz2"),
+        _f("/a1/b2/f13.txt", "zzzzz3"),
+        _f("/a1/b2/f14.txt", "zzzzz4"),
+        _d("/a1/b2/c1"),
+        _f("/a1/b2/f15.txt", "ZZZZZZZZZZZ"),
+        _l("/a1/b2/l1", "/does/not/matter"),
+        _f("/a1/b2/f16.txt", "ZZZZZZZZZZZ2"),
+        _f("/f17.txt", "010101010101010101"),
+        _f("/a1/f18.txt", "xxxxxxxxxxxxxxxxxxxxxxxxxx"),
+        _d("/a1/b3"),
+        _d("/a1/b4"),
+        _f("/a1/b4/f19.txt", "zzz"),
+        _d("/a1/b4/c2"),
+        _d("/a1/b5"),
+        _d("/a1/b6"),
+        _f("/a1/b6/f20.txt", "yyyyy"),
+        _f("/.something"),
+        _f("/another.something"),
+        _f("/file.txt"),
+    ]
+
+    fill_fs(client, "fs0", items)
+
+    # checking that mv, rm and ln work properly
+    client.mv("fs0", "/a0/b0/c0/d0/f9.txt", "/a0/b0/c0/d0/f9_moved.txt")
+    client.rm("fs0", "/a1/b2/f16.txt")
+    client.mv("fs0", "/a1/b4", "/a1/b5")
+    client_nocheck.mv("fs0", "/a1/b5", "/a1/b6")
+    # checking that cross-directory mv works
+    client.mv("fs0", "/f17.txt", "/a0/f17.txt")
+    client.mv("fs0", "/a0/f17.txt", "/a0/b0/f17.txt")
+    client.mv("fs0", "/a0/b0/f17.txt", "/a0/b0/c0/f17.txt")
+    client.mv("fs0", "/a0/b0/c0/f17.txt", "/a0/b0/c0/d0/f17.txt")
+    client.mv("fs0", "/a0/b0/c0/d0/f17.txt", "/a1/f17.txt")
+    client.mv("fs0", "/a1/f17.txt", "/a1/b2/f17.txt")
+    # local-to-external mv shouldn't succeed
+    client_nocheck.mv("fs0", "/a0/b0", "/a1/b0")
+    # checking that cross-directory mv to root works
+    client.mv("fs0", "/a1/f18.txt", "/f18.txt")
+    # checking that readlink works (indirectly - via diff)
+    client.ln("fs0", "/a1/b2/l2", "--symlink", "/does/not/matter/2")
+
+    out += __exec_ls(client, "fs0", "/", "--disable-multitablet-forwarding")
+    out += __exec_ls(client, "fs0", "/a1/")
+
+    with open(results_path, "wb") as results_file:
+        results_file.write(out)
+
+    #
+    # Querying dirViewer for the root node, dumping the result w/o unstable
+    # fields.
+    #
+
+    tablet_id = json.loads(client.describe("fs0"))["FileStore"]["MainTabletId"]
+    root_node_id = 1
+    entries = fetch_dir_viewer_entries(tablet_id, root_node_id)
+    result = json.dumps(entries, indent=4)
+    with open(results_path, 'a') as results:
+        results.write('dirViewer(1):\n')
+        results.write('{}\n'.format(result))
+
+    #
+    # And let's do the same thing for locks viewer - there should be no locks
+    # so this is just a smoke test.
+    #
+
+    locks = fetch_locks(tablet_id)
+    result = json.dumps(locks, indent=4)
+    with open(results_path, 'a') as results:
+        results.write('locks():\n')
+        results.write('{}\n'.format(result))
+
+    #
+    # Destroying the filesystem - important to do it after querying dirViewer.
+    #
+
+    client.destroy("fs0")
 
     ret = common.canonical_file(results_path, local=True)
     return ret

--- a/cloud/filestore/tests/client_sharded/test.py
+++ b/cloud/filestore/tests/client_sharded/test.py
@@ -268,7 +268,6 @@ def test_force_directory_creation_in_shards():
         block_count,
         enable_directory_creation_in_shards=True,
         force_directory_creation_in_shards=True)
-    #out = "".encode("utf8")
 
     items = [
         _d("/a1"),

--- a/cloud/filestore/tests/client_sharded_dir/test.py
+++ b/cloud/filestore/tests/client_sharded_dir/test.py
@@ -1,11 +1,20 @@
 import json
 import os
-import requests
 import time
 
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.client import FilestoreCliClient
+from cloud.filestore.tests.python.lib.fs import (
+    FsItem,
+    fill_fs,
+    DIR,
+    FILE,
+    SYMLINK,
+    fetch_dir_viewer_entries,
+    fetch_locks,
+)
+
 import cloud.filestore.tools.testing.profile_log.common as profile
 
 BLOCK_SIZE = 4 * 1024
@@ -51,63 +60,6 @@ def __exec_ls(client, *args):
     return json.dumps(nodes, indent=4).encode('utf-8')
 
 
-def __write_some_data(client, fs_id, path, data):
-    data_file = os.path.join(common.output_path(), "data.txt")
-    with open(data_file, "w") as f:
-        f.write("data for %s" % path)
-        f.write(":: actual data: %s" % data)
-
-    client.write(fs_id, path, "--data", data_file)
-
-
-_DIR = 1
-_FILE = 2
-_SYMLINK = 3
-
-
-class FsItem:
-
-    def __init__(self, path, node_type, data):
-        self.path = path
-        self.node_type = node_type
-        self.data = data
-
-
-def __fill_fs(client, fs_id, items):
-    for item in items:
-        if item.node_type == _DIR:
-            client.mkdir(fs_id, item.path)
-        elif item.node_type == _FILE:
-            if item.data is not None:
-                __write_some_data(client, fs_id, item.path, item.data)
-            else:
-                client.touch(fs_id, item.path)
-        else:
-            client.ln(fs_id, item.path, "--symlink", item.data)
-
-
-def __fetch_dir_viewer_entries(tablet_id, node_id):
-    mon_port = os.getenv("NFS_MON_PORT")
-    response = requests.get(
-        url=f"http://localhost:{mon_port}/tablets/app?"
-            f"TabletID={tablet_id}&action=dirViewer&nodeId={node_id}")
-    response.raise_for_status()
-    entries = response.json()["entries"]
-    for entry in entries:
-        del entry["node"]["shardNodeName"]
-        del entry["node"]["id"]
-    return entries
-
-
-def __fetch_locks(tablet_id):
-    mon_port = os.getenv("NFS_MON_PORT")
-    response = requests.get(
-        url=f"http://localhost:{mon_port}/tablets/app?"
-            f"TabletID={tablet_id}&action=locks&getContent=1")
-    response.raise_for_status()
-    return response.json()
-
-
 def test_nonsharded_vs_sharded_fs():
     client, client_nocheck, results_path = __init_test()
     client.create(
@@ -124,13 +76,13 @@ def test_nonsharded_vs_sharded_fs():
         3 * int(SHARD_SIZE / BLOCK_SIZE))
 
     def _d(path):
-        return FsItem(path, _DIR, None)
+        return FsItem(path, DIR, None)
 
     def _f(path, data=None):
-        return FsItem(path, _FILE, data)
+        return FsItem(path, FILE, data)
 
     def _l(path, symlink):
-        return FsItem(path, _SYMLINK, symlink)
+        return FsItem(path, SYMLINK, symlink)
 
     items = [
         _d("/a0"),
@@ -173,8 +125,8 @@ def test_nonsharded_vs_sharded_fs():
         _f("/file.txt"),
     ]
 
-    __fill_fs(client, "fs0", items)
-    __fill_fs(client, "fs1", items)
+    fill_fs(client, "fs0", items)
+    fill_fs(client, "fs1", items)
 
     # checking that mv, rm and ln work properly
     client.mv("fs0", "/a0/b0/c0/d0/f9.txt", "/a0/b0/c0/d0/f9_moved.txt")
@@ -238,7 +190,7 @@ def test_nonsharded_vs_sharded_fs():
 
     tablet_id = json.loads(client.describe("fs1"))["FileStore"]["MainTabletId"]
     root_node_id = 1
-    entries = __fetch_dir_viewer_entries(tablet_id, root_node_id)
+    entries = fetch_dir_viewer_entries(tablet_id, root_node_id)
     result = json.dumps(entries, indent=4)
     with open(results_path, 'a') as results:
         results.write('dirViewer(1):\n')
@@ -253,7 +205,7 @@ def test_nonsharded_vs_sharded_fs():
         "fs1",
         {"HideFileNamesInTabletDirectoryViewer": True})
     root_node_id = 1
-    entries = __fetch_dir_viewer_entries(tablet_id, root_node_id)
+    entries = fetch_dir_viewer_entries(tablet_id, root_node_id)
     result = json.dumps(entries, indent=4)
     with open(results_path, 'a') as results:
         results.write('dirViewer(1):\n')
@@ -264,7 +216,7 @@ def test_nonsharded_vs_sharded_fs():
     # so this is just a smoke test.
     #
 
-    locks = __fetch_locks(tablet_id)
+    locks = fetch_locks(tablet_id)
     result = json.dumps(locks, indent=4)
     with open(results_path, 'a') as results:
         results.write('locks():\n')

--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -131,6 +131,7 @@ class FilestoreCliClient:
         shard_count=None,
         enable_strict=False,
         enable_directory_creation_in_shards=False,
+        force_directory_creation_in_shards=False,
     ):
         cmd = [
             self.__binary_path, "resize",
@@ -149,6 +150,9 @@ class FilestoreCliClient:
 
         if enable_directory_creation_in_shards:
             cmd.append("--enable-directory-creation-in-shards")
+
+        if force_directory_creation_in_shards:
+            cmd.append("--force-directory-creation-in-shards")
 
         logger.info("resizing filestore: " + " ".join(cmd))
         return common.execute(cmd, env=self.__env, check_exit_code=self.__check_exit_code).stdout

--- a/cloud/filestore/tests/python/lib/fs.py
+++ b/cloud/filestore/tests/python/lib/fs.py
@@ -1,0 +1,61 @@
+import os
+import requests
+
+import yatest.common as common
+
+
+def __write_some_data(client, fs_id, path, data):
+    data_file = os.path.join(common.output_path(), "data.txt")
+    with open(data_file, "w") as f:
+        f.write("data for %s" % path)
+        f.write(":: actual data: %s" % data)
+
+    client.write(fs_id, path, "--data", data_file)
+
+
+DIR = 1
+FILE = 2
+SYMLINK = 3
+
+
+class FsItem:
+
+    def __init__(self, path, node_type, data):
+        self.path = path
+        self.node_type = node_type
+        self.data = data
+
+
+def fill_fs(client, fs_id, items):
+    for item in items:
+        if item.node_type == DIR:
+            client.mkdir(fs_id, item.path)
+        elif item.node_type == FILE:
+            if item.data is not None:
+                __write_some_data(client, fs_id, item.path, item.data)
+            else:
+                client.touch(fs_id, item.path)
+        else:
+            client.ln(fs_id, item.path, "--symlink", item.data)
+
+
+def fetch_dir_viewer_entries(tablet_id, node_id):
+    mon_port = os.getenv("NFS_MON_PORT")
+    response = requests.get(
+        url=f"http://localhost:{mon_port}/tablets/app?"
+            f"TabletID={tablet_id}&action=dirViewer&nodeId={node_id}")
+    response.raise_for_status()
+    entries = response.json()["entries"]
+    for entry in entries:
+        del entry["node"]["shardNodeName"]
+        del entry["node"]["id"]
+    return entries
+
+
+def fetch_locks(tablet_id):
+    mon_port = os.getenv("NFS_MON_PORT")
+    response = requests.get(
+        url=f"http://localhost:{mon_port}/tablets/app?"
+            f"TabletID={tablet_id}&action=locks&getContent=1")
+    response.raise_for_status()
+    return response.json()

--- a/cloud/filestore/tests/python/lib/ya.make
+++ b/cloud/filestore/tests/python/lib/ya.make
@@ -21,6 +21,7 @@ PY_SRCS(
     common.py
     daemon_config.py
     endpoint.py
+    fs.py
     http_proxy.py
     kikimr.py
     loadtest.py


### PR DESCRIPTION
### Notes
Implemented `TResizeFileStoreRequest::ForceDirectoryCreationInShards` flag - when used together with `EnableDirectoryCreationInShards`, it will override the `LastNodeId > RootNodeId` check in `tablet_actor_createnode.cpp` and allow any filesystem to create directories in shards. `RenameNode` operations that attempt to move a node with a local node-ref to a directory managed by a shard will fail with `EXDEV` errors causing popular libs/tools to fall back to unlink+copy. Added tests for such scenarios.

### Issue
https://github.com/ydb-platform/nbs/issues/5715
