### PR TITLE
[Filestore] Eliminate race in test TFileSystemTest::ShouldFlushAutomaticallyWithServerWriteBackCacheEnabled

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -292,7 +292,15 @@ struct TBootstrap
     {
         auto stop = StopAsync();
         StopTriggered.TrySetValue();
-        stop.Wait();
+        UNIT_ASSERT(stop.Wait(WaitTimeout));
+
+        if (Scheduler) {
+            // It is not allowed to stop Scheduler in the subscriber of
+            // Loop->StopAsync() because the callback may be called from
+            // a Scheduler thread
+            Scheduler->Stop();
+        }
+
         Fuse->DeInit();
         Loop = nullptr;
         std::remove(SocketPath.c_str());
@@ -300,22 +308,7 @@ struct TBootstrap
 
     TFuture<void> StopAsync()
     {
-        auto f = MakeFuture();
-        if (Loop) {
-            f = Loop->StopAsync();
-        }
-
-        if (!Scheduler) {
-            return f;
-        }
-
-        auto p = NewPromise<void>();
-        f.Subscribe([=] (auto f) mutable {
-            f.GetValue();
-            Scheduler->Stop();
-            p.SetValue();
-        });
-        return p;
+        return Loop ? Loop->StopAsync() : MakeFuture();
     }
 
     void InterruptNextRequest()
@@ -4703,6 +4696,77 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT(!bootstrap.Counters
             ->FindSubgroup("component", "fs_ut")
             ->FindSubgroup("module", "WriteBackCache"));
+    }
+
+    Y_UNIT_TEST(ShouldNotDeadlockWhenFlushCompletionFiredInScheduler)
+    {
+        NProto::TFileStoreFeatures features;
+        features.SetServerWriteBackCacheEnabled(true);
+
+        ui32 automaticFlushPeriodMs = 1;
+        TBootstrap bootstrap(
+            CreateWallClockTimer(),
+            CreateScheduler(),
+            features,
+            0,
+            automaticFlushPeriodMs);
+
+        const ui64 nodeId = 123;
+        const ui64 handleId = 456;
+
+        auto writeDataCalled = NewPromise();
+
+        bootstrap.Service->WriteDataHandler = [&] (auto callContext, auto) {
+            // The callback is expected to be called in the scheduler thread
+            UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+            writeDataCalled.SetValue();
+
+            auto counter = bootstrap.Counters
+                ->FindSubgroup("component", "fs_ut_fs")
+                ->FindSubgroup("host", "cluster")
+                ->FindSubgroup("filesystem", FileSystemId)
+                ->FindSubgroup("client", "")
+                ->FindSubgroup("cloud", "")
+                ->FindSubgroup("folder", "")
+                ->FindSubgroup("module", "WriteBackCache")
+                ->GetCounter("FlushAllRequests_InProgressCount");
+
+            // Automatic flush does not create a request internally
+            UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
+
+            // Wait until Stop is called and FlushAll is triggered
+            // because of cache non-emptiness at session destroy
+            UNIT_ASSERT(WaitForCondition(
+                WaitTimeout,
+                [&]
+                {
+                    // We block scheduler thread so counters will not be updated
+                    // automatically - need to call UpdateStats manually
+                    bootstrap.ModuleStatsRegistry->UpdateStats(true);
+                    return counter->GetAtomic() > 0;
+                }));
+
+            return MakeFuture<NProto::TWriteDataResponse>({});
+        };
+
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        // write request without O_DIRECT should go to write cache
+        auto reqWrite = std::make_shared<TWriteRequest>(
+            nodeId,
+            handleId,
+            0,
+            CreateBuffer(4096, 'a'));
+        reqWrite->In->Body.flags |= O_WRONLY;
+        auto write = bootstrap.Fuse->SendRequest<TWriteRequest>(reqWrite);
+        UNIT_ASSERT_NO_EXCEPTION(write.GetValue(WaitTimeout));
+
+        // Wait until automatic flush is called
+        UNIT_ASSERT_NO_EXCEPTION(
+            writeDataCalled.GetFuture().GetValue(WaitTimeout));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -2974,11 +2974,11 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         const ui64 nodeId = 123;
         const ui64 handleId = 456;
 
-        std::atomic<int> writeDataCalled = 0;
+        TPromise<void> writeDataCalled = NewPromise();
 
         bootstrap.Service->WriteDataHandler = [&] (auto callContext, auto) {
             UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
-            writeDataCalled++;
+            writeDataCalled.SetValue();
             NProto::TWriteDataResponse result;
             return MakeFuture(result);
         };
@@ -2998,16 +2998,14 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         auto write = bootstrap.Fuse->SendRequest<TWriteRequest>(reqWrite);
         UNIT_ASSERT_NO_EXCEPTION(write.GetValue(WaitTimeout));
 
-        while (true) {
-            bootstrap.Timer->Sleep(TDuration::MilliSeconds(1));
+        UNIT_ASSERT(writeDataCalled.GetFuture().Wait(WaitTimeout));
 
-            if (writeDataCalled.load() == 0) {
-                continue;
-            }
-
-            UNIT_ASSERT_VALUES_EQUAL(1, writeDataCalled.load());
-            break;
-        }
+        // The test will hang if we stop while WriteBackCache is handling
+        // WriteData response in the scheduler thread.
+        // We explicitly wait for the completion by calling flush.
+        auto flush =
+            bootstrap.Fuse->SendRequest<TFlushRequest>(nodeId, handleId);
+        UNIT_ASSERT_NO_EXCEPTION(flush.GetValue(WaitTimeout));
     }
 
     // We want to ensure that the same file cannot be reused for FileRingBuffers

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -2992,13 +2992,6 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT_NO_EXCEPTION(write.GetValue(WaitTimeout));
 
         UNIT_ASSERT(writeDataCalled.GetFuture().Wait(WaitTimeout));
-
-        // The test will hang if we stop while WriteBackCache is handling
-        // WriteData response in the scheduler thread.
-        // We explicitly wait for the completion by calling flush.
-        auto flush =
-            bootstrap.Fuse->SendRequest<TFlushRequest>(nodeId, handleId);
-        UNIT_ASSERT_NO_EXCEPTION(flush.GetValue(WaitTimeout));
     }
 
     // We want to ensure that the same file cannot be reused for FileRingBuffers


### PR DESCRIPTION
### Notes
The test hangs if `TBootstrap` is destroyed at the moment WriteBackCache is processing WriteData response in the scheduler thread.

Change the logic: the scheduler thread should be destroyed synchronously instead of Loop->StopAsync() callback.

```
2026-04-11T01:23:16.490315Z :NFS_FUSE DEBUG: : unique: 2, opcode: WRITE (16), nodeid: 123, insize: 80, pid: 0
2026-04-11T01:23:16.490328Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: WriteData #2 [f:fs1] REQUEST
2026-04-11T01:23:16.490333Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:691: WriteBuf #123 @456 offset:0 size:4096
2026-04-11T01:23:16.490386Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:205: invalidating node: 123, version: 2
2026-04-11T01:23:16.490392Z :NFS_FUSE DEBUG: :    unique: 2, success, outsize: 24
2026-04-11T01:23:16.490394Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 2 desc of length 24
2026-04-11T01:23:16.490425Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: WriteData #2 [f:fs1][c:] RESPONSE request completed(total_time: 77us, execution_time: 77us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 4.00 KiB, error: S_OK)
2026-04-11T01:23:16.490433Z :NFS_VHOST DEBUG: : virtq_push:676: /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952[0]: head = 3
2026-04-11T01:23:16.506419Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:225: [f:fs1] StopAsync: completing left: 0, requests left: 0, fuse cancellation code: 0
2026-04-11T01:23:16.506545Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1297: [f:"fs1"][c:""] WriteBackCache is not empty, starting FlushAllData
CRITICAL_EVENT:AppCriticalEvents/WriteBackCacheDataLossError:[f:"fs1"][c:""] WriteBackCache was not emptied after successful FlushAllData at DestroySession, possible data loss
2026-04-11T01:23:16.512986Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1338: [f:"fs1"][c:""] completed FlushAllData
2026-04-11T01:23:16.512994Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:652: stopping FUSE loop
2026-04-11T01:23:16.513000Z :NFS_VHOST INFO: : virtio_session_exit:517: unregister device /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952
2026-04-11T01:23:16.513054Z :NFS_VHOST INFO: : vdev_disconnect:2087: /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952: Close connection with client, sock = 12
2026-04-11T01:23:16.513102Z :NFS_VHOST INFO: : vring_mark_stopped:287: /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952[0]: stopped vring with 0 in-flight requests
2026-04-11T01:23:16.513108Z :NFS_VHOST INFO: : vring_mark_stopped:287: /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952[1]: stopped vring with 0 in-flight requests
2026-04-11T01:23:16.513169Z :NFS_VHOST INFO: : unregister_complete:332: stopping device /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952
2026-04-11T01:23:16.513177Z :NFS_VHOST INFO: : unregister_complete:336: finished stopping device /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952
2026-04-11T01:23:16.513181Z :NFS_VHOST INFO: : virtio_session_exit:526: finished unregister device
2026-04-11T01:23:16.513192Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:582: stopping FUSE loop thread 6.0
2026-04-11T01:23:16.513224Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:589: stopped FUSE loop thread 6.0
2026-04-11T01:23:16.513226Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:664: stopped FUSE loop
2026-04-11T01:23:16.513228Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:676: unmounting FUSE session
2026-04-11T01:23:16.513232Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1428: [f:"fs1"][c:""] got destroy request
2026-04-11T01:23:16.513235Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1438: [f:"fs1"][c:""][l:0] resetting session state
2026-04-11T01:23:16.513258Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1458: [f:"fs1"][c:""] session reset completed: S_OK
2026-04-11T01:23:16.513262Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:94: resetting filesystem cache
2026-04-11T01:23:16.513265Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:97: clear directory cache of size 0
2026-04-11T01:23:16.513269Z :NFS_VHOST INFO: : virtio_session_close:496: destroying device /home/nbsci/.ya/build/build_root/o1kt/000372/r3tmp/vhost.socket_385352015545342952
2026-04-11T01:23:16.513286Z :NFS_VHOST INFO: : virtio_session_close:505: finished destroying device
2026-04-11T01:23:16.513321Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: DestroySession #4495979746816372457 [f:fs1] REQUEST
2026-04-11T01:23:16.513329Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:557: [f:""][c:""][s:"f394537c-494e7fab-b0371e37-270f78e8"][n:0] destroying session
2026-04-11T01:23:16.513336Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:580: [f:""][c:""][s:"f394537c-494e7fab-b0371e37-270f78e8"][n:0] session destroyed
2026-04-11T01:23:16.513352Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: DestroySession #4495979746816372457 [f:fs1][c:] RESPONSE request completed(total_time: 25us, execution_time: 25us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
Uncaught exception: (TSystemError) (Error 35: Resource deadlock avoided) util/system/thread.cpp:198: can not join thread
??+0 (0x16E6421)
std::terminate()+41 (0x1886609)
??+0 (0x16E019E)
NCloud::NFileStore::NFuse::NWriteBackCache::TWriteBackCacheState::FlushSucceeded(unsigned long, unsigned long)+357 (0x374D6A5)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::CompleteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)+57 (0x374A7B9)
auto NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)::'lambda'(auto const&)::operator()<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse>>(auto const&)+148 (0x374A174)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteFlush(std::__y1::shared_ptr<NCloud::NFileStore::NFuse::NWriteBackCache::TNodeFlushState>)+368 (0x37497F0)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ScheduleFlushNode(unsigned long)+193 (0x3748261)
NCloud::NFileStore::NFuse::NWriteBackCache::TQueuedOperations::Release()+129 (0x3754321)
NCloud::NFileStore::NFuse::NWriteBackCache::TWriteBackCacheState::TriggerPeriodicFlushAll()+51 (0x374CC63)
NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::RequestAutomaticFlush()+26 (0x373EF5A)
std::__y1::__function::__func<NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ScheduleAutomaticFlushIfNeeded()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ScheduleAutomaticFlushIfNeeded()::'lambda'()>, void ()>::operator()()+46 (0x373EEAE)
??+0 (0x1EA6663)
??+0 (0x1EA606A)
??+0 (0x199C73F)
??+0 (0x7F7F14231AC3)
??+0 (0x7F7F142C38D0)
```