### PR TITLE
added include to fix vfs fuse arcadia build

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -28,6 +28,8 @@
 #include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
+#include <cloud/contrib/virtiofsd/fuse_common.h>
+
 #include <util/datetime/base.h>
 #include <util/folder/path.h>
 #include <util/generic/bitops.h>


### PR DESCRIPTION
### Notes
Fixing build error
```
$(SOURCE_ROOT)/cloud/filestore/libs/vfs_fuse/loop.cpp:1289:27: error: use of undeclared identifier 'FUSE_CAP_POSIX_ACL'
 1289 |             conn->want |= FUSE_CAP_POSIX_ACL;
      |                           ^
1 error generated.

```
