### PR TITLE
[NBS] Fix TServiceMountVolumeTest::ShouldKillMountActorIfTabletIsChangedDuringTabletStart test in arcadia

### DIFF
--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -5274,13 +5274,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
     Y_UNIT_TEST(ShouldKillMountActorIfTabletIsChangedDuringTabletStart)
     {
-        constexpr TDuration InactiveClientsTimeout = TDuration::Seconds(5);
-
         TTestEnv env(1, 1);
-        NProto::TStorageServiceConfig config;
-        config.SetInactiveClientsTimeout(InactiveClientsTimeout.MilliSeconds());
-
-        ui32 nodeIdx = SetupTestEnv(env, config);
+        ui32 nodeIdx = SetupTestEnv(env);
 
         TServiceClient service(env.GetRuntime(), nodeIdx);
 

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -5274,8 +5274,13 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
     Y_UNIT_TEST(ShouldKillMountActorIfTabletIsChangedDuringTabletStart)
     {
+        constexpr TDuration InactiveClientsTimeout = TDuration::Seconds(5);
+
         TTestEnv env(1, 1);
-        ui32 nodeIdx = SetupTestEnv(env);
+        NProto::TStorageServiceConfig config;
+        config.SetInactiveClientsTimeout(InactiveClientsTimeout.MilliSeconds());
+
+        ui32 nodeIdx = SetupTestEnv(env, config);
 
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -5320,7 +5325,13 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         UNIT_ASSERT(volumeTabletId);
 
-        RebootTablet(env.GetRuntime(), volumeTabletId, service.GetSender(), nodeIdx);
+        service.UnmountVolume(DefaultDiskId, sessionId);
+
+        RebootTablet(
+            env.GetRuntime(),
+            volumeTabletId,
+            service.GetSender(),
+            nodeIdx);
 
         service.SendMountVolumeRequest(
             DefaultDiskId,

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -5320,14 +5320,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         UNIT_ASSERT(volumeTabletId);
 
-        service.UnmountVolume(DefaultDiskId, sessionId);
-
-        RebootTablet(
-            env.GetRuntime(),
-            volumeTabletId,
-            service.GetSender(),
-            nodeIdx);
-
         service.SendMountVolumeRequest(
             DefaultDiskId,
             TString(),
@@ -5346,6 +5338,12 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                         const_cast<NProto::TError&>(msg->Error) = MakeKikimrError(
                             NKikimrProto::ERROR,
                             "Could not connect");
+                        break;
+                    }
+                    case TEvVolume::EvAddClientResponse: {
+                        auto* msg =
+                            event->Get<TEvVolume::TEvAddClientResponse>();
+                        msg->Record.SetForceTabletRestart(true);
                         break;
                     }
                     case TEvServicePrivate::EvSessionActorDied: {


### PR DESCRIPTION
### Notes

ShouldKillMountActorIfTabletIsChangedDuringTabletStart should check that if there is tablet restart during remount, and if the acquisition of a lock has resulted in an error, it should kill the SessionActor and return an error on the mount request.

The test now tests a completely different scenario. It implicitly waits for the client to unmount due to an inactivity timeout, and then tries to mount the volume, which results in a tablet restart.

In this pr, I removed the unnecessary reboot of the tablet and added an intercepting AddClientResponse to trigger a tablet restart during the remount process

### Issue
Put links to the related issues here
