### PR TITLE
Separate config parameters for recv and send queues sizes; migrate the rest of rdma ut to gtest

### DIFF
--- a/cloud/blockstore/config/rdma.proto
+++ b/cloud/blockstore/config/rdma.proto
@@ -32,6 +32,7 @@ message TBufferPool
 message TRdmaServer
 {
     uint32 Backlog = 1;
+    // Deprecated, use SendQueueSize and RecvQueueSize instead.
     uint32 QueueSize = 2;
     uint32 MaxBufferSize = 3;
     uint64 KeepAliveTimeout = 4;            // in milliseconds
@@ -50,10 +51,14 @@ message TRdmaServer
     bool VerbsQP = 13;
 
     TBufferPool BufferPool = 14;
+
+    uint32 SendQueueSize = 15;
+    uint32 RecvQueueSize = 16;
 }
 
 message TRdmaClient
 {
+    // Deprecated, use SendQueueSize and RecvQueueSize instead.
     uint32 QueueSize = 1;
     uint32 MaxBufferSize = 2;
     uint32 PollerThreads = 3;
@@ -73,6 +78,9 @@ message TRdmaClient
     uint64 MaxResponseDelay = 12;   // in milliseconds
 
     TBufferPool BufferPool = 13;
+
+    uint32 SendQueueSize = 14;
+    uint32 RecvQueueSize = 15;
 }
 
 message TRdmaTarget

--- a/cloud/blockstore/libs/rdma/iface/client.cpp
+++ b/cloud/blockstore/libs/rdma/iface/client.cpp
@@ -2,8 +2,6 @@
 
 #include <cloud/blockstore/config/rdma.pb.h>
 
-#include <cloud/storage/core/libs/common/proto_helpers.h>
-
 #include <library/cpp/monlib/service/pages/templates.h>
 
 namespace NCloud::NBlockStore::NRdma {
@@ -44,15 +42,14 @@ TClientConfig::TClientConfig()
     }
 }
 
-#define SET(param, ...)                                                        \
-    if (NCloud::HasField(config, #param)) {                                    \
-        param = __VA_ARGS__(config.Get##param());                              \
+#define SET(param, ...) \
+    if (const auto& value = config.Get##param()) { \
+        param = __VA_ARGS__(value); \
     }
 
-#define SET_NESTED(param1, param2, ...)                                        \
-    if (NCloud::HasField(config, #param1) &&                                   \
-        NCloud::HasField(config.Get##param1(), #param2)) {                     \
-        param1.param2 = __VA_ARGS__(config.Get##param1().Get##param2());       \
+#define SET_NESTED(param1, param2, ...) \
+    if (const auto& value = config.Get##param1().Get##param2()) { \
+        param1.param2 = __VA_ARGS__(value); \
     }
 
 TClientConfig::TClientConfig(const NProto::TRdmaClient& config)

--- a/cloud/blockstore/libs/rdma/iface/client.cpp
+++ b/cloud/blockstore/libs/rdma/iface/client.cpp
@@ -1,5 +1,9 @@
 #include "client.h"
 
+#include <cloud/blockstore/config/rdma.pb.h>
+
+#include <cloud/storage/core/libs/common/proto_helpers.h>
+
 #include <library/cpp/monlib/service/pages/templates.h>
 
 namespace NCloud::NBlockStore::NRdma {
@@ -29,14 +33,26 @@ NRdma::EWaitMode Convert(NProto::EWaitMode mode)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define SET(param, ...) \
-    if (const auto& value = config.Get##param()) { \
-        param = __VA_ARGS__(value); \
+TClientConfig::TClientConfig()
+{
+    // Compatibility with old config.
+    if (SendQueueSize == 0 && QueueSize > 0) {
+        SendQueueSize = QueueSize;
+    }
+    if (RecvQueueSize == 0 && QueueSize > 0) {
+        RecvQueueSize = QueueSize;
+    }
+}
+
+#define SET(param, ...)                                                        \
+    if (NCloud::HasField(config, #param)) {                                    \
+        param = __VA_ARGS__(config.Get##param());                              \
     }
 
-#define SET_NESTED(param1, param2, ...) \
-    if (const auto& value = config.Get##param1().Get##param2()) { \
-        param1.param2 = __VA_ARGS__(value); \
+#define SET_NESTED(param1, param2, ...)                                        \
+    if (HasField(config, #param1) &&                                           \
+        HasField(config.Get##param1(), #param2)) {                             \
+        param1.param2 = __VA_ARGS__(config.Get##param1().Get##param2());       \
     }
 
 TClientConfig::TClientConfig(const NProto::TRdmaClient& config)
@@ -53,10 +69,20 @@ TClientConfig::TClientConfig(const NProto::TRdmaClient& config)
     SET(IpTypeOfService);
     SET(SourceInterface);
     SET(VerbsQP);
+    SET(SendQueueSize);
+    SET(RecvQueueSize);
 
     SET_NESTED(BufferPool, ChunkSize);
     SET_NESTED(BufferPool, MaxChunkAlloc);
     SET_NESTED(BufferPool, MaxFreeChunks);
+
+    // Compatibility with old config.
+    if (SendQueueSize == 0 && QueueSize > 0) {
+        SendQueueSize = QueueSize;
+    }
+    if (RecvQueueSize == 0 && QueueSize > 0) {
+        RecvQueueSize = QueueSize;
+    }
 }
 
 #undef SET_NESTED
@@ -90,6 +116,8 @@ void TClientConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(IpTypeOfService, IpTypeOfService);
                 ENTRY(SourceInterface, SourceInterface);
                 ENTRY(VerbsQP, VerbsQP);
+                ENTRY(SendQueueSize, SendQueueSize);
+                ENTRY(RecvQueueSize, RecvQueueSize);
                 ENTRY(BufferPool.ChunkSize, BufferPool.ChunkSize);
                 ENTRY(BufferPool.MaxChunkAlloc, BufferPool.MaxChunkAlloc);
                 ENTRY(BufferPool.MaxFreeChunks, BufferPool.MaxFreeChunks);

--- a/cloud/blockstore/libs/rdma/iface/client.cpp
+++ b/cloud/blockstore/libs/rdma/iface/client.cpp
@@ -50,8 +50,8 @@ TClientConfig::TClientConfig()
     }
 
 #define SET_NESTED(param1, param2, ...)                                        \
-    if (HasField(config, #param1) &&                                           \
-        HasField(config.Get##param1(), #param2)) {                             \
+    if (NCloud::HasField(config, #param1) &&                                   \
+        NCloud::HasField(config.Get##param1(), #param2)) {                     \
         param1.param2 = __VA_ARGS__(config.Get##param1().Get##param2());       \
     }
 

--- a/cloud/blockstore/libs/rdma/iface/client.cpp
+++ b/cloud/blockstore/libs/rdma/iface/client.cpp
@@ -33,7 +33,7 @@ NRdma::EWaitMode Convert(NProto::EWaitMode mode)
 
 TClientConfig::TClientConfig()
 {
-    // Compatibility with old config.
+    // Compatibility with the old config.
     if (SendQueueSize == 0 && QueueSize > 0) {
         SendQueueSize = QueueSize;
     }
@@ -73,7 +73,7 @@ TClientConfig::TClientConfig(const NProto::TRdmaClient& config)
     SET_NESTED(BufferPool, MaxChunkAlloc);
     SET_NESTED(BufferPool, MaxFreeChunks);
 
-    // Compatibility with old config.
+    // Compatibility with the old config.
     if (SendQueueSize == 0 && QueueSize > 0) {
         SendQueueSize = QueueSize;
     }

--- a/cloud/blockstore/libs/rdma/iface/client.h
+++ b/cloud/blockstore/libs/rdma/iface/client.h
@@ -42,8 +42,10 @@ struct TClientConfig
     TString SourceInterface;
     bool VerbsQP = false;
     TBufferPoolConfig BufferPool;
+    ui32 SendQueueSize = 0;
+    ui32 RecvQueueSize = 0;
 
-    TClientConfig() = default;
+    TClientConfig();
     TClientConfig(const NProto::TRdmaClient& config);
 
     void Validate(TLog& log);

--- a/cloud/blockstore/libs/rdma/iface/configs_ut.cpp
+++ b/cloud/blockstore/libs/rdma/iface/configs_ut.cpp
@@ -1,0 +1,139 @@
+#include "client.h"
+#include "server.h"
+
+#include <cloud/storage/core/libs/common/helpers.h>
+
+#include <library/cpp/testing/gtest/gtest.h>
+
+#include <util/generic/singleton.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+namespace NCloud::NBlockStore::NRdma {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TClientConfigTraits
+{
+    using TProto = NProto::TRdmaClient;
+    using TConfig = TClientConfig;
+
+    static constexpr ui32 DefaultQueueSize = 10;
+
+    static TConfig Make(const TProto& proto)
+    {
+        return TConfig(proto);
+    }
+};
+
+struct TServerConfigTraits
+{
+    using TProto = NProto::TRdmaServer;
+    using TConfig = TServerConfig;
+
+    static constexpr ui32 DefaultQueueSize = 10;
+
+    static TConfig Make(const TProto& proto)
+    {
+        return TConfig(proto);
+    }
+};
+
+template <typename TTraits>
+class TQueueSizeCompatibilityTest: public ::testing::Test
+{
+};
+
+using TQueueSizeCompatibilityTestTypes =
+    ::testing::Types<TClientConfigTraits, TServerConfigTraits>;
+
+TYPED_TEST_SUITE(TQueueSizeCompatibilityTest, TQueueSizeCompatibilityTestTypes);
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TYPED_TEST(TQueueSizeCompatibilityTest, ShouldUseQueueSizeWhenSendAndRecvNotSet)
+{
+    using TTraits = TypeParam;
+    using TProto = typename TTraits::TProto;
+
+    TProto proto;
+    proto.SetQueueSize(128);
+
+    const auto config = TTraits::Make(proto);
+
+    EXPECT_EQ(128u, config.QueueSize);
+    EXPECT_EQ(128u, config.SendQueueSize);
+    EXPECT_EQ(128u, config.RecvQueueSize);
+}
+
+TYPED_TEST(TQueueSizeCompatibilityTest, ShouldNotOverrideExplicitSendQueueSize)
+{
+    using TTraits = TypeParam;
+    using TProto = typename TTraits::TProto;
+
+    TProto proto;
+    proto.SetQueueSize(128);
+    proto.SetSendQueueSize(64);
+
+    const auto config = TTraits::Make(proto);
+
+    EXPECT_EQ(128u, config.QueueSize);
+    EXPECT_EQ(64u, config.SendQueueSize);
+    EXPECT_EQ(128u, config.RecvQueueSize);
+}
+
+TYPED_TEST(TQueueSizeCompatibilityTest, ShouldNotOverrideExplicitRecvQueueSize)
+{
+    using TTraits = TypeParam;
+    using TProto = typename TTraits::TProto;
+
+    TProto proto;
+    proto.SetQueueSize(128);
+    proto.SetRecvQueueSize(32);
+
+    const auto config = TTraits::Make(proto);
+
+    EXPECT_EQ(128u, config.QueueSize);
+    EXPECT_EQ(128u, config.SendQueueSize);
+    EXPECT_EQ(32u, config.RecvQueueSize);
+}
+
+TYPED_TEST(
+    TQueueSizeCompatibilityTest,
+    ShouldNotOverrideExplicitSendAndRecvQueueSize)
+{
+    using TTraits = TypeParam;
+    using TProto = typename TTraits::TProto;
+
+    TProto proto;
+    proto.SetQueueSize(128);
+    proto.SetSendQueueSize(64);
+    proto.SetRecvQueueSize(32);
+
+    const auto config = TTraits::Make(proto);
+
+    EXPECT_EQ(128u, config.QueueSize);
+    EXPECT_EQ(64u, config.SendQueueSize);
+    EXPECT_EQ(32u, config.RecvQueueSize);
+}
+
+TYPED_TEST(
+    TQueueSizeCompatibilityTest,
+    ShouldDeriveSendAndRecvQueueSizeFromDefaultQueueSize)
+{
+    using TTraits = TypeParam;
+    using TProto = typename TTraits::TProto;
+
+    TProto proto;
+    const auto config = TTraits::Make(proto);
+
+    EXPECT_EQ(TTraits::DefaultQueueSize, config.QueueSize);
+    EXPECT_EQ(TTraits::DefaultQueueSize, config.SendQueueSize);
+    EXPECT_EQ(TTraits::DefaultQueueSize, config.RecvQueueSize);
+}
+
+}   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
+++ b/cloud/blockstore/libs/rdma/iface/protobuf_ut.cpp
@@ -2,13 +2,15 @@
 
 #include "protocol.h"
 
-#include <library/cpp/testing/unittest/registar.h>
-
 #include <cloud/blockstore/public/api/protos/io.pb.h>
 
 #include <cloud/storage/core/libs/common/helpers.h>
 
+#include <library/cpp/testing/gtest/gtest.h>
+
 #include <util/generic/singleton.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
 
 namespace NCloud::NBlockStore::NRdma {
 
@@ -26,7 +28,7 @@ struct TBlockStoreProtocol
 
     static TProtoMessageSerializer* Serializer()
     {
-        struct TSerializer : TProtoMessageSerializer
+        struct TSerializer: TProtoMessageSerializer
         {
             TSerializer()
             {
@@ -43,63 +45,66 @@ struct TBlockStoreProtocol
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_UNIT_TEST_SUITE(TProtoMessageSerializerTest)
+TEST(TProtoMessageSerializerTest, ShouldSerializeMessages)
 {
-    Y_UNIT_TEST(ShouldSerializeMessages)
-    {
-        auto* serializer = TBlockStoreProtocol::Serializer();
+    auto* serializer = TBlockStoreProtocol::Serializer();
 
-        NProto::TReadBlocksRequest proto;
-        proto.SetDiskId("test");
+    NProto::TReadBlocksRequest proto;
+    proto.SetDiskId("test");
 
-        auto data = TString(1024, 'A');
-        const TBlockDataRef part[1] = {
-            TBlockDataRef(data.data(), data.length())};
+    const auto data = TString(1024, 'A');
+    const TBlockDataRef part[1] = {TBlockDataRef(data.data(), data.length())};
 
-        size_t msgByteSize = NRdma::TProtoMessageSerializer::MessageByteSize(
-            proto,
-            data.length());
-        TVector testedFlags{0U, RDMA_PROTO_FLAG_DATA_AT_THE_END};
-        TVector testedBufferSizes{
-            msgByteSize,
-            msgByteSize + 1024,
-            msgByteSize + 4096};
+    const size_t msgByteSize =
+        NRdma::TProtoMessageSerializer::MessageByteSize(proto, data.length());
+    const TVector<ui32> testedFlags = {0U, RDMA_PROTO_FLAG_DATA_AT_THE_END};
+    const TVector<size_t> testedBufferSizes = {
+        msgByteSize,
+        msgByteSize + 1024,
+        msgByteSize + 4096,
+    };
 
-        for (auto bufferSize: testedBufferSizes) {
-            for (auto flag: testedFlags) {
-                ui32 flags = 0;
-                if (flag) {
-                    SetProtoFlag(flags, flag);
-                }
-
-                auto buffer = TString::Uninitialized(bufferSize);
-
-                size_t serializedBytes =
-                    NRdma::TProtoMessageSerializer::SerializeWithData(
-                        buffer,
-                        TBlockStoreProtocol::ReadBlocksRequest,
-                        flags,
-                        proto,
-                        part);
-
-                if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
-                    UNIT_ASSERT_VALUES_EQUAL(bufferSize, serializedBytes);
-                } else {
-                    UNIT_ASSERT_VALUES_EQUAL(msgByteSize, serializedBytes);
-                }
-
-                auto resultOrError = serializer->Parse(buffer);
-                UNIT_ASSERT(!HasError(resultOrError));
-
-                const auto& result = resultOrError.GetResult();
-                UNIT_ASSERT_EQUAL(TBlockStoreProtocol::ReadBlocksRequest, result.MsgId);
-                UNIT_ASSERT_EQUAL(data, result.Data);
-
-                const auto& proto2 = static_cast<const NProto::TReadBlocksRequest&>(*result.Proto);
-                UNIT_ASSERT_EQUAL("test", proto2.GetDiskId());
+    for (const auto bufferSize: testedBufferSizes) {
+        for (const auto flag: testedFlags) {
+            ui32 flags = 0;
+            if (flag) {
+                SetProtoFlag(flags, flag);
             }
+
+            auto buffer = TString::Uninitialized(bufferSize);
+
+            const size_t serializedBytes =
+                NRdma::TProtoMessageSerializer::SerializeWithData(
+                    buffer,
+                    TBlockStoreProtocol::ReadBlocksRequest,
+                    flags,
+                    proto,
+                    part);
+
+            if (HasProtoFlag(flags, RDMA_PROTO_FLAG_DATA_AT_THE_END)) {
+                ASSERT_EQ(bufferSize, serializedBytes)
+                    << "bufferSize=" << bufferSize
+                    << " msgByteSize=" << msgByteSize << " flags=" << flags;
+            } else {
+                ASSERT_EQ(msgByteSize, serializedBytes)
+                    << "bufferSize=" << bufferSize
+                    << " msgByteSize=" << msgByteSize << " flags=" << flags;
+            }
+
+            const auto resultOrError = serializer->Parse(buffer);
+            ASSERT_FALSE(HasError(resultOrError))
+                << "bufferSize=" << bufferSize << " msgByteSize=" << msgByteSize
+                << " flags=" << flags;
+
+            const auto& result = resultOrError.GetResult();
+            EXPECT_EQ(TBlockStoreProtocol::ReadBlocksRequest, result.MsgId);
+            EXPECT_EQ(data, result.Data);
+
+            const auto& proto2 =
+                static_cast<const NProto::TReadBlocksRequest&>(*result.Proto);
+            EXPECT_EQ("test", proto2.GetDiskId());
         }
     }
-};
+}
 
 }   // namespace NCloud::NBlockStore::NRdma

--- a/cloud/blockstore/libs/rdma/iface/protocol.h
+++ b/cloud/blockstore/libs/rdma/iface/protocol.h
@@ -97,8 +97,8 @@ struct Y_PACKED TConnectMessage
     union {
         struct {
             TMessageHeader Header;
-            ui32 QueueSize : 16;
-            ui32 Unused : 16;
+            ui32 SendQueueSize : 16;
+            ui32 RecvQueueSize : 16;
             ui32 MaxBufferSize;
         };
         ui8 Padding[RDMA_PRIVATE_SIZE];

--- a/cloud/blockstore/libs/rdma/iface/server.cpp
+++ b/cloud/blockstore/libs/rdma/iface/server.cpp
@@ -1,5 +1,7 @@
 #include "server.h"
 
+#include <cloud/storage/core/libs/common/proto_helpers.h>
+
 #include <library/cpp/monlib/service/pages/templates.h>
 
 namespace NCloud::NBlockStore::NRdma {
@@ -29,14 +31,26 @@ NRdma::EWaitMode Convert(NProto::EWaitMode mode)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define SET(param, ...) \
-    if (const auto& value = config.Get##param()) { \
-        param = __VA_ARGS__(value); \
+TServerConfig::TServerConfig()
+{
+    // Compatibility with old config.
+    if (SendQueueSize == 0 && QueueSize > 0) {
+        SendQueueSize = QueueSize;
+    }
+    if (RecvQueueSize == 0 && QueueSize > 0) {
+        RecvQueueSize = QueueSize;
+    }
+}
+
+#define SET(param, ...)                                                        \
+    if (NCloud::HasField(config, #param)) {                                    \
+        param = __VA_ARGS__(config.Get##param());                              \
     }
 
-#define SET_NESTED(param1, param2, ...) \
-    if (const auto& value = config.Get##param1().Get##param2()) { \
-        param1.param2 = __VA_ARGS__(value); \
+#define SET_NESTED(param1, param2, ...)                                        \
+    if (HasField(config, #param1) &&                                           \
+        HasField(config.Get##param1(), #param2)) {                             \
+        param1.param2 = __VA_ARGS__(config.Get##param1().Get##param2());       \
     }
 
 TServerConfig::TServerConfig(const NProto::TRdmaServer& config)
@@ -53,10 +67,20 @@ TServerConfig::TServerConfig(const NProto::TRdmaServer& config)
     SET(IpTypeOfService);
     SET(SourceInterface);
     SET(VerbsQP);
+    SET(SendQueueSize);
+    SET(RecvQueueSize);
 
     SET_NESTED(BufferPool, ChunkSize);
     SET_NESTED(BufferPool, MaxChunkAlloc);
     SET_NESTED(BufferPool, MaxFreeChunks);
+
+    // Compatibility with old config.
+    if (SendQueueSize == 0 && QueueSize > 0) {
+        SendQueueSize = QueueSize;
+    }
+    if (RecvQueueSize == 0 && QueueSize > 0) {
+        RecvQueueSize = QueueSize;
+    }
 }
 
 #undef SET_NESTED
@@ -90,6 +114,8 @@ void TServerConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(IpTypeOfService, IpTypeOfService);
                 ENTRY(SourceInterface, SourceInterface);
                 ENTRY(VerbsQP, VerbsQP);
+                ENTRY(SendQueueSize, SendQueueSize);
+                ENTRY(RecvQueueSize, RecvQueueSize);
                 ENTRY(BufferPool.ChunkSize, BufferPool.ChunkSize);
                 ENTRY(BufferPool.MaxChunkAlloc, BufferPool.MaxChunkAlloc);
                 ENTRY(BufferPool.MaxFreeChunks, BufferPool.MaxFreeChunks);

--- a/cloud/blockstore/libs/rdma/iface/server.cpp
+++ b/cloud/blockstore/libs/rdma/iface/server.cpp
@@ -1,7 +1,5 @@
 #include "server.h"
 
-#include <cloud/storage/core/libs/common/proto_helpers.h>
-
 #include <library/cpp/monlib/service/pages/templates.h>
 
 namespace NCloud::NBlockStore::NRdma {
@@ -42,15 +40,14 @@ TServerConfig::TServerConfig()
     }
 }
 
-#define SET(param, ...)                                                        \
-    if (NCloud::HasField(config, #param)) {                                    \
-        param = __VA_ARGS__(config.Get##param());                              \
+#define SET(param, ...) \
+    if (const auto& value = config.Get##param()) { \
+        param = __VA_ARGS__(value); \
     }
 
-#define SET_NESTED(param1, param2, ...)                                        \
-    if (HasField(config, #param1) &&                                           \
-        HasField(config.Get##param1(), #param2)) {                             \
-        param1.param2 = __VA_ARGS__(config.Get##param1().Get##param2());       \
+#define SET_NESTED(param1, param2, ...) \
+    if (const auto& value = config.Get##param1().Get##param2()) { \
+        param1.param2 = __VA_ARGS__(value); \
     }
 
 TServerConfig::TServerConfig(const NProto::TRdmaServer& config)

--- a/cloud/blockstore/libs/rdma/iface/server.h
+++ b/cloud/blockstore/libs/rdma/iface/server.h
@@ -35,8 +35,10 @@ struct TServerConfig
     TString SourceInterface;
     bool VerbsQP = false;
     TBufferPoolConfig BufferPool;
+    ui32 SendQueueSize = 0;
+    ui32 RecvQueueSize = 0;
 
-    TServerConfig() = default;
+    TServerConfig();
     explicit TServerConfig(const NProto::TRdmaServer& config);
 
     void Validate(TLog& log);

--- a/cloud/blockstore/libs/rdma/iface/ut/ya.make
+++ b/cloud/blockstore/libs/rdma/iface/ut/ya.make
@@ -3,6 +3,7 @@ GTEST()
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
+    ../configs_ut.cpp
     ../protobuf_ut.cpp
 )
 

--- a/cloud/blockstore/libs/rdma/iface/ut/ya.make
+++ b/cloud/blockstore/libs/rdma/iface/ut/ya.make
@@ -1,12 +1,13 @@
-UNITTEST_FOR(cloud/blockstore/libs/rdma/iface)
+GTEST()
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
-    protobuf_ut.cpp
+    ../protobuf_ut.cpp
 )
 
 PEERDIR(
+    cloud/blockstore/libs/rdma/iface
     cloud/blockstore/public/api/protos
 )
 

--- a/cloud/blockstore/libs/rdma/iface/ya.make
+++ b/cloud/blockstore/libs/rdma/iface/ya.make
@@ -12,6 +12,7 @@ SRCS(
 )
 
 PEERDIR(
+    cloud/blockstore/config
     cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/service
 

--- a/cloud/blockstore/libs/rdma/impl/client.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client.cpp
@@ -671,10 +671,10 @@ void TClientEndpoint::CreateQP()
 
     CompletionQueue = Verbs->CreateCompletionQueue(
         Connection->verbs,
-        Config.SendQueueSize +  Config.RecvQueueSize,     // send + recv
+        Config.SendQueueSize + Config.RecvQueueSize,   // send + recv
         this,
         CompletionChannel.get(),
-        0);                       // comp_vector
+        0);   // comp_vector
 
     ibv_qp_init_attr qp_attrs = {
         .qp_context = nullptr,

--- a/cloud/blockstore/libs/rdma/impl/client.cpp
+++ b/cloud/blockstore/libs/rdma/impl/client.cpp
@@ -671,7 +671,7 @@ void TClientEndpoint::CreateQP()
 
     CompletionQueue = Verbs->CreateCompletionQueue(
         Connection->verbs,
-        2 * Config.QueueSize,     // send + recv
+        Config.SendQueueSize +  Config.RecvQueueSize,     // send + recv
         this,
         CompletionChannel.get(),
         0);                       // comp_vector
@@ -681,8 +681,8 @@ void TClientEndpoint::CreateQP()
         .send_cq = CompletionQueue.get(),
         .recv_cq = CompletionQueue.get(),
         .cap = {
-            .max_send_wr = Config.QueueSize,
-            .max_recv_wr = Config.QueueSize,
+            .max_send_wr = Config.SendQueueSize,
+            .max_recv_wr = Config.RecvQueueSize,
             .max_send_sge = RDMA_MAX_SEND_SGE,
             .max_recv_sge = RDMA_MAX_RECV_SGE,
             .max_inline_data = 16,
@@ -708,13 +708,13 @@ void TClientEndpoint::CreateQP()
         IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
 
     SendBuffer = SendBuffers.AcquireBuffer(
-        Config.QueueSize * sizeof(TRequestMessage), true);
+        Config.SendQueueSize * sizeof(TRequestMessage), true);
 
     RecvBuffer = RecvBuffers.AcquireBuffer(
-        Config.QueueSize * sizeof(TResponseMessage), true);
+        Config.RecvQueueSize * sizeof(TResponseMessage), true);
 
-    SendWrs.resize(Config.QueueSize);
-    RecvWrs.resize(Config.QueueSize);
+    SendWrs.resize(Config.SendQueueSize);
+    RecvWrs.resize(Config.RecvQueueSize);
 
     Generation++;
 
@@ -1370,8 +1370,8 @@ void TClientEndpoint::Disconnect() noexcept
 
 bool TClientEndpoint::Flushed() const
 {
-    return SendQueue.Size() == Config.QueueSize
-        && RecvQueue.Size() == Config.QueueSize
+    return SendQueue.Size() == Config.SendQueueSize
+        && RecvQueue.Size() == Config.RecvQueueSize
         && ActiveRequests.Empty()
         && !InputRequests
         && !QueuedRequests
@@ -2234,7 +2234,8 @@ void TClient::BeginConnect(TClientEndpoint* endpoint) noexcept
         endpoint->Reconnect.Schedule(MIN_CONNECT_TIMEOUT);
 
         TConnectMessage message = {
-            .QueueSize = SafeCast<ui16>(endpoint->Config.QueueSize),
+            .SendQueueSize = SafeCast<ui16>(endpoint->Config.SendQueueSize),
+            .RecvQueueSize = SafeCast<ui16>(endpoint->Config.RecvQueueSize),
             .MaxBufferSize = SafeCast<ui32>(endpoint->Config.MaxBufferSize),
         };
         InitMessageHeader(&message, RDMA_PROTO_VERSION);

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -400,18 +400,18 @@ void TServerSession::CreateQP()
 
     CompletionQueue = Verbs->CreateCompletionQueue(
         Connection->verbs,
-        2 * Config->QueueSize,   // send + recv
+        Config->SendQueueSize + Config->RecvQueueSize,
         this,
         CompletionChannel.get(),
-        0);                      // comp_vector
+        0);   // comp_vector
 
     ibv_qp_init_attr qp_attrs = {
         .qp_context = nullptr,
         .send_cq = CompletionQueue.get(),
         .recv_cq = CompletionQueue.get(),
         .cap = {
-            .max_send_wr = Config->QueueSize,
-            .max_recv_wr = Config->QueueSize,
+            .max_send_wr = Config->SendQueueSize,
+            .max_recv_wr = Config->RecvQueueSize,
             .max_send_sge = RDMA_MAX_SEND_SGE,
             .max_recv_sge = RDMA_MAX_RECV_SGE,
             .max_inline_data = 16,
@@ -437,15 +437,15 @@ void TServerSession::CreateQP()
         IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
 
     SendBuffer = SendBuffers.AcquireBuffer(
-        Config->QueueSize * sizeof(TResponseMessage),
+        Config->SendQueueSize * sizeof(TResponseMessage),
         true);
 
     RecvBuffer = RecvBuffers.AcquireBuffer(
-        Config->QueueSize * sizeof(TRequestMessage),
+        Config->RecvQueueSize * sizeof(TRequestMessage),
         true);
 
-    SendWrs.resize(Config->QueueSize);
-    RecvWrs.resize(Config->QueueSize);
+    SendWrs.resize(Config->SendQueueSize);
+    RecvWrs.resize(Config->RecvQueueSize);
 
     ui32 i = 0;
     ui64 responseMsg = SendBuffer.Address;
@@ -628,8 +628,8 @@ void TServerSession::Flush() noexcept
 bool TServerSession::IsFlushed() const
 {
     return FlushStarted
-        && SendQueue.Size() == Config->QueueSize
-        && RecvQueue.Size() == Config->QueueSize;
+        && SendQueue.Size() == Config->SendQueueSize
+        && RecvQueue.Size() == Config->RecvQueueSize;
 }
 
 int TServerSession::ValidateCompletion(ibv_wc* wc) noexcept
@@ -1906,9 +1906,28 @@ void TServer::HandleConnectRequest(
         connectParams->private_data);
 
     if (Config->StrictValidation) {
-        if (connectMsg->QueueSize > Config->QueueSize ||
-            connectMsg->MaxBufferSize > Config->MaxBufferSize)
-        {
+        if (connectMsg->SendQueueSize > Config->RecvQueueSize) {
+            RDMA_ERROR(
+                "Failed to validate connect message. Client's send queue size "
+                << connectMsg->SendQueueSize
+                << " is greater than server's recv queue size "
+                << Config->RecvQueueSize);
+            return Reject(event->id, RDMA_PROTO_CONFIG_MISMATCH);
+        }
+        if (connectMsg->RecvQueueSize > Config->SendQueueSize) {
+            RDMA_ERROR(
+                "Failed to validate connect message. Client's recv queue size "
+                << connectMsg->RecvQueueSize
+                << " is greater than server's send queue size "
+                << Config->SendQueueSize);
+            return Reject(event->id, RDMA_PROTO_CONFIG_MISMATCH);
+        }
+        if (connectMsg->MaxBufferSize > Config->MaxBufferSize) {
+            RDMA_ERROR(
+                "Failed to validate connect message. Client's max buffer size "
+                << connectMsg->MaxBufferSize
+                << " is greater than server's max buffer size "
+                << Config->MaxBufferSize);
             return Reject(event->id, RDMA_PROTO_CONFIG_MISMATCH);
         }
     }
@@ -1986,7 +2005,8 @@ void TServer::Reject(rdma_cm_id* id, int status) noexcept
 
     TRejectMessage rejectMsg = {
         .Status = SafeCast<ui16>(status),
-        .QueueSize = SafeCast<ui16>(Config->QueueSize),
+        .QueueSize =
+            SafeCast<ui16>(Config->SendQueueSize + Config->RecvQueueSize),
         .MaxBufferSize = SafeCast<ui32>(Config->MaxBufferSize),
     };
     InitMessageHeader(&rejectMsg, RDMA_PROTO_VERSION);

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -1914,11 +1914,11 @@ void TServer::HandleConnectRequest(
                 << Config->RecvQueueSize);
             return Reject(event->id, RDMA_PROTO_CONFIG_MISMATCH);
         }
-        if (connectMsg->RecvQueueSize > Config->SendQueueSize) {
+        if (Config->SendQueueSize > connectMsg->RecvQueueSize) {
             RDMA_ERROR(
                 "Failed to validate connect message. Client's recv queue size "
                 << connectMsg->RecvQueueSize
-                << " is greater than server's send queue size "
+                << " is less than server's send queue size "
                 << Config->SendQueueSize);
             return Reject(event->id, RDMA_PROTO_CONFIG_MISMATCH);
         }

--- a/cloud/blockstore/libs/rdma/impl/server.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server.cpp
@@ -854,7 +854,7 @@ void TServerSession::RecvRequestCompleted(TRecvWr* recv) noexcept
             GetLogTitle(
                 "RECV",
                 TWorkRequestId(recv->wr.wr_id),
-                msg->ReqId)
+                req->ReqId)
             << " request exceeds maximum supported size " << req->In.Length
             << " > " << Config->MaxBufferSize);
 
@@ -871,7 +871,7 @@ void TServerSession::RecvRequestCompleted(TRecvWr* recv) noexcept
             GetLogTitle(
                 "RECV",
                 TWorkRequestId(recv->wr.wr_id),
-                msg->ReqId)
+                req->ReqId)
             << "response exceeds maximum supported size " << req->Out.Length
             << " > " << Config->MaxBufferSize);
 
@@ -890,7 +890,7 @@ void TServerSession::RecvRequestCompleted(TRecvWr* recv) noexcept
             GetLogTitle(
                 "RECV",
                 TWorkRequestId(recv->wr.wr_id),
-                msg->ReqId)
+                req->ReqId)
                 << "reached inflight limit, " << MaxInflightBytes << "/"
                 << Config->MaxInflightBytes << " bytes available");
 
@@ -913,7 +913,7 @@ void TServerSession::RecvRequestCompleted(TRecvWr* recv) noexcept
         } else {
             // no more WRs available
             RDMA_TRACE(
-                GetLogTitle("RECV", TWorkRequestId(recv->wr.wr_id), msg->ReqId)
+                GetLogTitle("RECV", TWorkRequestId(recv->wr.wr_id), req->ReqId)
                 << "no more send WRs available");
             Counters->RequestEnqueued();
             QueuedRequests.Enqueue(std::move(req));

--- a/cloud/blockstore/libs/rdma/impl/server_ut.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server_ut.cpp
@@ -2,18 +2,19 @@
 #include "server.h"
 #include "test_verbs.h"
 
-#include <cstring>
+#include <cloud/blockstore/libs/rdma/iface/protocol.h>
 
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
-
-#include <cloud/blockstore/libs/rdma/iface/protocol.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/gtest/gtest.h>
 
 #include <util/generic/scope.h>
 #include <util/stream/printf.h>
+
+#include <atomic>
+#include <cstring>
 
 namespace NCloud::NBlockStore::NRdma {
 
@@ -320,6 +321,84 @@ TEST(TRdmaServerTest, ShouldHandleErrors)
     wait(activeRecv, 8);
     wait(abortedRequests, 1);
     wait(activeRequests, 0);
+}
+
+TEST(TRdmaServerTest, ShouldRejectConnectionOnConfigMismatchInStrictValidation)
+{
+    NThreading::TPromise<void> done = NThreading::NewPromise<void>();
+    std::atomic<int> rejectCount = 0;
+    std::atomic<bool> createQpCalled = false;
+
+    auto context = MakeIntrusive<NVerbs::TTestContext>();
+
+    context->CreateQP = [&](rdma_cm_id* id, ibv_qp_init_attr* attr)
+    {
+        Y_UNUSED(id);
+        Y_UNUSED(attr);
+        createQpCalled.store(true);
+    };
+
+    auto monitoring = CreateMonitoringServiceStub();
+    auto serverConfig = std::make_shared<TServerConfig>();
+    serverConfig->StrictValidation = true;
+
+    context->Reject = [&](rdma_cm_id* id, const void* data, ui8 size)
+    {
+        Y_UNUSED(id);
+
+        EXPECT_EQ(sizeof(TRejectMessage), size);
+
+        const auto* rejectMsg = static_cast<const TRejectMessage*>(data);
+        EXPECT_EQ(RDMA_PROTO_VERSION, ParseMessageHeader(rejectMsg));
+        EXPECT_EQ(RDMA_PROTO_CONFIG_MISMATCH, rejectMsg->Status);
+        EXPECT_EQ(
+            serverConfig->SendQueueSize + serverConfig->RecvQueueSize,
+            rejectMsg->QueueSize);
+        EXPECT_EQ(serverConfig->MaxBufferSize, rejectMsg->MaxBufferSize);
+
+        if (++rejectCount == 3) {
+            done.TrySetValue();
+        }
+    };
+
+    auto verbs = NVerbs::CreateTestVerbs(context);
+
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+    auto server = CreateServer(verbs, logging, monitoring, serverConfig);
+
+    server->Start();
+    Y_DEFER
+    {
+        server->Stop();
+    };
+
+    auto serverEndpoint =
+        server->StartEndpoint("::", 10020, std::make_shared<TServerHandler>());
+    Y_UNUSED(serverEndpoint);
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->RecvQueueSize + 1),
+        static_cast<ui16>(serverConfig->SendQueueSize),
+        serverConfig->MaxBufferSize);
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->RecvQueueSize),
+        static_cast<ui16>(serverConfig->SendQueueSize + 1),
+        serverConfig->MaxBufferSize);
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->RecvQueueSize),
+        static_cast<ui16>(serverConfig->SendQueueSize),
+        serverConfig->MaxBufferSize + 1);
+
+    ASSERT_TRUE(done.GetFuture().Wait(TDuration::Seconds(5)));
+    EXPECT_EQ(3, rejectCount.load());
+    EXPECT_FALSE(createQpCalled.load());
 }
 
 int NVerbs::DestroyId(rdma_cm_id* id)

--- a/cloud/blockstore/libs/rdma/impl/server_ut.cpp
+++ b/cloud/blockstore/libs/rdma/impl/server_ut.cpp
@@ -380,20 +380,20 @@ TEST(TRdmaServerTest, ShouldRejectConnectionOnConfigMismatchInStrictValidation)
 
     NVerbs::CreateConnection(
         context,
-        static_cast<ui16>(serverConfig->RecvQueueSize + 1),
-        static_cast<ui16>(serverConfig->SendQueueSize),
-        serverConfig->MaxBufferSize);
-
-    NVerbs::CreateConnection(
-        context,
-        static_cast<ui16>(serverConfig->RecvQueueSize),
         static_cast<ui16>(serverConfig->SendQueueSize + 1),
+        static_cast<ui16>(serverConfig->RecvQueueSize),
         serverConfig->MaxBufferSize);
 
     NVerbs::CreateConnection(
         context,
-        static_cast<ui16>(serverConfig->RecvQueueSize),
         static_cast<ui16>(serverConfig->SendQueueSize),
+        static_cast<ui16>(serverConfig->RecvQueueSize - 1),
+        serverConfig->MaxBufferSize);
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->SendQueueSize),
+        static_cast<ui16>(serverConfig->RecvQueueSize),
         serverConfig->MaxBufferSize + 1);
 
     ASSERT_TRUE(done.GetFuture().Wait(TDuration::Seconds(5)));

--- a/cloud/blockstore/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/blockstore/libs/rdma/impl/test_verbs.cpp
@@ -576,8 +576,20 @@ IVerbsPtr CreateTestVerbs(TTestContextPtr context)
 
 void CreateConnection(TTestContextPtr context)
 {
-    TConnectMessage message;
+    CreateConnection(context, 10, 10, 4_MB + 4_KB);
+}
+
+void CreateConnection(
+    TTestContextPtr context,
+    ui16 sendQueueSize,
+    ui16 recvQueueSize,
+    ui32 maxBufferSize)
+{
+    TConnectMessage message = {};
     InitMessageHeader(&message, RDMA_PROTO_VERSION);
+    message.SendQueueSize = sendQueueSize;
+    message.RecvQueueSize = recvQueueSize;
+    message.MaxBufferSize = maxBufferSize;
 
     rdma_conn_param param = {
         .private_data = &message,

--- a/cloud/blockstore/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/blockstore/libs/rdma/impl/test_verbs.cpp
@@ -467,7 +467,8 @@ struct TTestVerbs
         // emulate internal server error
         TRejectMessage reject = {
             .Status = SafeCast<ui16>(status),
-            .QueueSize = connect->QueueSize,
+            .QueueSize =
+                SafeCast<ui16>(connect->SendQueueSize + connect->RecvQueueSize),
             .MaxBufferSize = connect->MaxBufferSize,
         };
         InitMessageHeader(&reject, RDMA_PROTO_VERSION);

--- a/cloud/blockstore/libs/rdma/impl/test_verbs.h
+++ b/cloud/blockstore/libs/rdma/impl/test_verbs.h
@@ -53,6 +53,11 @@ using TTestContextPtr = TIntrusivePtr<TTestContext>;
 IVerbsPtr CreateTestVerbs(TTestContextPtr context);
 
 void CreateConnection(TTestContextPtr context);
+void CreateConnection(
+    TTestContextPtr context,
+    ui16 sendQueueSize,
+    ui16 recvQueueSize,
+    ui32 maxBufferSize);
 void Disconnect(TTestContextPtr context);
 
 }   // namespace NCloud::NBlockStore::NRdma::NVerbs


### PR DESCRIPTION
### Notes
Currently, `QueueSize` is set to the maximum iodepth allowed to a user. And indeed, when iodepth is greater than recv queue size (server or client, doesn't matter) we see very bad latencies up to ~4-5 seconds per request.

But the sends queue size can be much lower than the iodepth. I have tested `SendQueueSize=16`, `RecvQueueSize=128` vs `SendQueueSize=128`, `RecvQueueSize=128` and did not see a difference in performance with 50k IOPS. 
So we can reduce the number of send WRs to make possible for clients with bigger disks and higher number of endpoints. 

### Issue
#5729
