### PR TITLE
Fix flapping test cloud/filestore/tests/fio/qemu-local-noserver-mq-test

### DIFF
--- a/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/test.py
+++ b/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/test.py
@@ -21,7 +21,10 @@ def test_fio(name):
 
     fio.run_test(file_name, TESTS[name], fail_on_errors=True)
 
-    time.sleep(15)  # Waiting for profile logs to be written
+    # Sleep for a while to ensure that the profile log is flushed
+    # before we start analyzing it
+    # The default value of ProfileLogTimeThreshold for tests is 100ms
+    time.sleep(2)
 
     profile_tool_bin_path = common.binary_path(
         "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool")

--- a/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/test.py
+++ b/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/test.py
@@ -8,6 +8,7 @@ import yatest.common as common
 from cloud.filestore.tests.python.lib.common import get_filestore_mount_path
 
 import sys
+import time
 
 
 TESTS = fio.generate_tests(iodepths=[32], duration=30)
@@ -19,6 +20,8 @@ def test_fio(name):
     file_name = fio.get_file_name(mount_dir, name)
 
     fio.run_test(file_name, TESTS[name], fail_on_errors=True)
+
+    time.sleep(15)  # Waiting for profile logs to be written
 
     profile_tool_bin_path = common.binary_path(
         "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool")


### PR DESCRIPTION
```
Error occured: (yexception) library/cpp/eventlog/logparser.cpp:201: Could not read frame payload: premature end of stream
```