### PR TITLE
fix: remove leftover rebase artifacts on long running runners

### DIFF
--- a/.github/workflows/build_and_test_proxy.yaml
+++ b/.github/workflows/build_and_test_proxy.yaml
@@ -66,7 +66,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/github_actions_scripts.yaml
+++ b/.github/workflows/github_actions_scripts.yaml
@@ -70,7 +70,10 @@ jobs:
       if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
       run: |
-        [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+        if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+          echo "Removing stale rebase state left on runner checkout"
+          rm -rf .git/rebase-merge .git/rebase-apply
+        fi
         git config user.email "robot-nbs@nebius.com"
         git config user.name "Robot NBS"
         git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -169,4 +172,3 @@ jobs:
           fi
           echo "=========="
         done
-

--- a/.github/workflows/on_demand_build_and_test.yaml
+++ b/.github/workflows/on_demand_build_and_test.yaml
@@ -156,7 +156,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -275,7 +278,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -119,7 +119,10 @@ jobs:
       if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
       run: |
-        [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+        if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+          echo "Removing stale rebase state left on runner checkout"
+          rm -rf .git/rebase-merge .git/rebase-apply
+        fi
         git config user.email "robot-nbs@nebius.com"
         git config user.name "Robot NBS"
         git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/on_hybrid_build_and_test.yaml
+++ b/.github/workflows/on_hybrid_build_and_test.yaml
@@ -156,7 +156,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -274,7 +277,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -119,7 +119,10 @@ jobs:
       if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
       run: |
-        [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+        if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+          echo "Removing stale rebase state left on runner checkout"
+          rm -rf .git/rebase-merge .git/rebase-apply
+        fi
         git config user.email "robot-nbs@nebius.com"
         git config user.name "Robot NBS"
         git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -130,7 +130,10 @@ jobs:
       if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
       run: |
-        [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+        if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+          echo "Removing stale rebase state left on runner checkout"
+          rm -rf .git/rebase-merge .git/rebase-apply
+        fi
         git config user.email "robot-nbs@nebius.com"
         git config user.name "Robot NBS"
         git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -310,7 +313,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -450,7 +450,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,7 +164,10 @@ jobs:
         if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
         run: |
-          [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
           git fetch origin ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/actions/runs/24390882066/job/71239408331
```
Run [ -f ".git/rebase-merge" ] && echo "Already rebasing, skipping rebase step" && exit 0 || true
From https://github.com/ydb-platform/nbs
 * branch                main       -> FETCH_HEAD
fatal: It seems that there is already a rebase-merge directory, and
I wonder if you are in the middle of another rebase.  If that is the
case, please try
	git rebase (--continue | --abort | --skip)
If that is not the case, please
	rm -fr ".git/rebase-merge"
and run me again.  I am stopping in case you still have something
valuable there.
```
