### PR TITLE
issue-5726: not copying Name, ShardId, ShardNodeName in CompleteTx_ListNodes

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -26,13 +26,13 @@ void AddNode(
 void AddExternalNode(
     NProto::TListNodesResponse& record,
     TString name,
-    const TString& shardId,
-    const TString& shardNodeName)
+    TString shardId,
+    TString shardNodeName)
 {
     record.AddNames(std::move(name));
     auto* node = record.AddNodes();
-    node->SetShardFileSystemId(shardId);
-    node->SetShardNodeName(shardNodeName);
+    node->SetShardFileSystemId(std::move(shardId));
+    node->SetShardNodeName(std::move(shardNodeName));
 }
 
 NProto::TError ValidateRequest(const NProto::TListNodesRequest& request)
@@ -195,7 +195,8 @@ void TIndexTabletActor::CompleteTx_ListNodes(
 {
     RemoveInFlightRequest(*args.RequestInfo);
 
-    auto response = std::make_unique<TEvService::TEvListNodesResponse>(args.Error);
+    auto response =
+        std::make_unique<TEvService::TEvListNodesResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {
         auto& record = response->Record;
         record.MutableNames()->Reserve(args.ChildRefs.size());
@@ -205,16 +206,15 @@ void TIndexTabletActor::CompleteTx_ListNodes(
 
         size_t j = 0;
         for (size_t i = 0; i < args.ChildRefs.size(); ++i) {
-            const auto& ref = args.ChildRefs[i];
+            auto& ref = args.ChildRefs[i];
             requestBytes += ref.Name.size();
             if (ref.ShardId) {
                 if (!HasPendingNodeCreateInShard(ref.ShardNodeName)) {
                     AddExternalNode(
                         record,
-                        ref.Name,
-                        ref.ShardId,
-                        ref.ShardNodeName);
-
+                        std::move(ref.Name),
+                        std::move(ref.ShardId),
+                        std::move(ref.ShardNodeName));
                 }
 
                 continue;
@@ -222,7 +222,7 @@ void TIndexTabletActor::CompleteTx_ListNodes(
 
             AddNode(
                 record,
-                ref.Name,
+                std::move(ref.Name),
                 ref.ChildNodeId,
                 args.ChildNodes[j].Attrs);
             ++j;


### PR DESCRIPTION
### Notes
I tested this by running `fmdtest` first to create a dir with 750 files and then running it again with only lister threads.
Before:
```
$ ../../../tools/testing/fmdtest/bin/fmdtest --test-dir fmdtest_wd --producer-threads 1 --stealer-threads 0 --lister-threads 8 --duration 60s --files-per-producer 0 --lister-sleep-duration 0s
...
2026-04-14T17:37:01.303410Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: list: count=88307, lat-us=5381, weight=66583478, wlat-us=7
2026-04-14T17:37:01.309306Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:697: Report: bench-report.json, errors: 0
```

After:
```
$ ../../../tools/testing/fmdtest/bin/fmdtest --test-dir fmdtest_wd --producer-threads 1 --stealer-threads 0 --lister-threads 8 --duration 60s --files-per-producer 0 --lister-sleep-duration 0s
...
2026-04-14T19:47:51.607067Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: list: count=100261, lat-us=4733, weight=75596794, wlat-us=6
2026-04-14T19:47:51.612033Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:697: Report: bench-report.json, errors: 0
```

Approx 14% better

// the improvement might be a bit different in other setups.

### Issue
https://github.com/ydb-platform/nbs/issues/5726