### PR TITLE
filestore: cleanup log flush in tests + add flush in qemu-local-noserver-mq-test to stabilize it

### DIFF
--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -2,12 +2,12 @@ import json
 import logging
 import os
 import re
-import time
 
 import cloud.filestore.tools.testing.profile_log.common as profile
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.client import FilestoreCliClient
+from cloud.filestore.tests.python.lib.common import flush_logs
 
 BLOCK_SIZE = 4 * 1024
 BLOCKS_COUNT = 1000
@@ -785,15 +785,7 @@ def test_io_telemetry():
 
     client.destroy(fs_id)
 
-    #
-    # Sleep for a while to ensure that the profile log is flushed
-    # before we start analyzing it
-    # The default value of ProfileLogTimeThreshold for tests is 100ms
-    # TODO(#568) - here and in other similar places - introduce and use a
-    # private api method which would force profile-log flush
-    #
-
-    time.sleep(2)
+    flush_logs()
 
     profile_tool_bin_path = common.binary_path(
         "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool"

--- a/cloud/filestore/tests/client_sharded_dir/test.py
+++ b/cloud/filestore/tests/client_sharded_dir/test.py
@@ -1,10 +1,10 @@
 import json
 import os
-import time
 
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.client import FilestoreCliClient
+from cloud.filestore.tests.python.lib.common import flush_logs
 from cloud.filestore.tests.python.lib.fs import (
     FsItem,
     fill_fs,
@@ -164,15 +164,7 @@ def test_nonsharded_vs_sharded_fs():
     with open(results_path, "wb") as results_file:
         results_file.write(out)
 
-    #
-    # Sleep for a while to ensure that the profile log is flushed
-    # before we start analyzing it
-    # The default value of ProfileLogTimeThreshold for tests is 100ms
-    # TODO(#568) - here and in other similar places - introduce and use a
-    # private api method which would force profile-log flush
-    #
-
-    time.sleep(2)
+    flush_logs()
 
     profile_tool_bin_path = common.binary_path(
         "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool")

--- a/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/test.py
+++ b/cloud/filestore/tests/fio/qemu-local-noserver-mq-test/test.py
@@ -6,6 +6,7 @@ import cloud.storage.core.tools.testing.fio.lib as fio
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.common import get_filestore_mount_path
+from cloud.filestore.tests.python.lib.common import flush_logs
 
 import sys
 
@@ -19,6 +20,8 @@ def test_fio(name):
     file_name = fio.get_file_name(mount_dir, name)
 
     fio.run_test(file_name, TESTS[name], fail_on_errors=True)
+
+    flush_logs()
 
     profile_tool_bin_path = common.binary_path(
         "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool")

--- a/cloud/filestore/tests/guest_cache/guest_cache_entry_timeout/lib/__init__.py
+++ b/cloud/filestore/tests/guest_cache/guest_cache_entry_timeout/lib/__init__.py
@@ -1,11 +1,11 @@
 import os
-import time
 
 from retrying import retry
 
 import cloud.filestore.tools.testing.profile_log.common as profile
 import yatest.common as common
 
+from cloud.filestore.tests.python.lib.common import flush_logs
 from cloud.storage.core.tools.testing.qemu.lib.common import SshToGuest
 
 RETRY_COUNT = 3
@@ -50,10 +50,7 @@ def test_guest_cache_enty_timeout(expected_dir_stat_count: int,
     mkdir(ssh, f"{mount_dir}/dirname")
     create_file(ssh, mount_dir, "dirname/filename")
 
-    # Sleep for a while to ensure that the profile log is flushed
-    # before we start analyzing it
-    # The default value of ProfileLogTimeThreshold for tests is 100ms
-    time.sleep(2)
+    flush_logs()
 
     # Collect counters after setup
     initial_dir_stat_count = get_vhost_request_count_for_node("dirname")
@@ -61,7 +58,7 @@ def test_guest_cache_enty_timeout(expected_dir_stat_count: int,
 
     stat(ssh, mount_dir, "dirname/filename")
 
-    time.sleep(2)
+    flush_logs()
 
     # Count GetNodeAttr requests executed for the directory and the file
     final_dir_stat_count = get_vhost_request_count_for_node("dirname")

--- a/cloud/filestore/tests/guest_cache/guest_keep_cache_allowed/test.py
+++ b/cloud/filestore/tests/guest_cache/guest_keep_cache_allowed/test.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 from retrying import retry
 
@@ -7,6 +6,7 @@ import cloud.filestore.tools.testing.profile_log.common as profile
 import yatest.common as common
 
 from cloud.storage.core.tools.testing.qemu.lib.common import SshToGuest
+from cloud.filestore.tests.python.lib.common import flush_logs
 
 RETRY_COUNT = 3
 WAIT_TIMEOUT = 1000  # 1sec
@@ -45,10 +45,7 @@ def test():
         "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool"
     )
 
-    # Sleep for a while to ensure that the profile log is flushed
-    # before we start analyzing it
-    # The default value of ProfileLogTimeThreshold for tests is 100ms
-    time.sleep(2)
+    flush_logs()
 
     result = profile.analyze_profile_log(
         profile_tool_bin_path, common.output_path("vhost-profile.log"), fs_name

--- a/cloud/filestore/tests/guest_cache/guest_keep_cache_allowed_any_read/test.py
+++ b/cloud/filestore/tests/guest_cache/guest_keep_cache_allowed_any_read/test.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 from retrying import retry
 
@@ -7,6 +6,7 @@ import cloud.filestore.tools.testing.profile_log.common as profile
 import yatest.common as common
 
 from cloud.storage.core.tools.testing.qemu.lib.common import SshToGuest
+from cloud.filestore.tests.python.lib.common import flush_logs
 
 RETRY_COUNT = 3
 WAIT_TIMEOUT = 1000  # 1sec
@@ -44,10 +44,7 @@ def test():
         "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool"
     )
 
-    # Sleep for a while to ensure that the profile log is flushed
-    # before we start analyzing it
-    # The default value of ProfileLogTimeThreshold for tests is 100ms
-    time.sleep(2)
+    flush_logs()
 
     result = profile.analyze_profile_log(
         profile_tool_bin_path, common.output_path("vhost-profile.log"), fs_name

--- a/cloud/filestore/tests/python/lib/common.py
+++ b/cloud/filestore/tests/python/lib/common.py
@@ -115,3 +115,15 @@ def get_restart_flag(flag, name):
         return None
 
     return os.path.join(common.work_path(), name)
+
+
+def flush_logs():
+    #
+    # Sleep for a while to ensure that the profile log is flushed
+    # before we start analyzing it
+    # The default value of ProfileLogTimeThreshold for tests is 100ms
+    # TODO(#568) - here and in other similar places - introduce and use a
+    # private api method which would force profile-log flush
+    #
+
+    time.sleep(2)


### PR DESCRIPTION
### Notes
Moved `time.sleep(2)` and the comment saying that we should replace this with explicit log flush to a func, calling that func from the tests that need to read profile log

### Issue
none