### PR TITLE
Tidy the stats pull scheme: merge two transactions into one, fix trying to reply to service too frequently

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
 #include <cloud/blockstore/libs/storage/volume/model/helpers.h>
 
+#include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler_logger.h>
 
@@ -217,8 +218,11 @@ void TVolumeActor::RegisterCounters(const TActorContext& ctx)
 
 void TVolumeActor::ScheduleRegularUpdates(const TActorContext& ctx)
 {
-    if (!UpdateCountersScheduled) {
-        ctx.Schedule(UpdateCountersInterval,
+    if (!UpdateCountersScheduled &&
+        !Config->GetUsePullSchemeForVolumeStatistics())
+    {
+        ctx.Schedule(
+            UpdateCountersInterval,
             new TEvVolumePrivate::TEvUpdateCounters());
         UpdateCountersScheduled = true;
     }
@@ -280,14 +284,12 @@ void TVolumeActor::UpdateLeakyBucketCounters(const TActorContext& ctx)
 
 void TVolumeActor::UpdateCounters(const TActorContext& ctx)
 {
-    Y_UNUSED(ctx);
-
     if (!State) {
         return;
     }
 
     if (Config->GetUsePullSchemeForVolumeStatistics()) {
-        SendStatsToServiceStatisticsCollectorActor(ctx);
+        ReplyToServiceStatisticsCollectorActor(ctx);
         return;
     }
 
@@ -710,23 +712,24 @@ void TVolumeActor::HandleUpdateCounters(
 {
     UpdateCountersScheduled = false;
 
-    // Under these conditions, the counters are updated at the request of the
-    // service.
-    if (Config->GetUsePullSchemeForVolumeStatistics() && State &&
-        GetVolumeStatus() != EStatus::STATUS_INACTIVE)
-    {
+    if (Config->GetUsePullSchemeForVolumeStatistics()) {
+        // The counters are updated at the request of the service.
         return;
     }
 
     UpdateCounters(ctx);
     ScheduleRegularUpdates(ctx);
-    CleanupHistory(ctx, ev->Sender, ev->Cookie, ev->Get()->CallContext);
+    CleanupHistory(
+        ctx,
+        CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext));
 }
 
 void TVolumeActor::HandleGetServiceStatistics(
     const TEvStatsService::TEvGetServiceStatisticsRequest::TPtr& ev,
     const TActorContext& ctx)
 {
+    STORAGE_CHECK_PRECONDITION(Config->GetUsePullSchemeForVolumeStatistics());
+
     if (StatisticRequestInfo) {
         NCloud::Reply(
             ctx,
@@ -761,7 +764,7 @@ void TVolumeActor::HandleGetServiceStatistics(
 
     State->IsDiskRegistryMediaKind()
         ? SendStatisticRequestForDiskRegistryBasedPartition(ctx)
-        : SendStatisticRequests(ctx);
+        : SendStatisticRequestsForYDBBasedPartitions(ctx);
 }
 
 void TVolumeActor::RejectGetServiceStatistics(

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -1121,7 +1121,6 @@ STFUNC(TVolumeActor::StateWork)
             TEvVolume::TEvDiskRegistryBasedPartitionCounters,
             HandleDiskRegistryBasedPartCounters);
         HFunc(TEvStatsService::TEvVolumePartCounters, HandlePartCounters);
-        HFunc(TEvVolumePrivate::TEvPartStatsSaved, HandlePartStatsSaved);
         HFunc(TEvVolume::TEvScrubberCounters, HandleScrubberCounters);
         HFunc(
             TEvVolumePrivate::TEvWriteOrZeroCompleted,
@@ -1245,6 +1244,7 @@ STFUNC(TVolumeActor::StateWork)
             TEvService::TEvSetVhostDiscardFlagResponse,
             HandleSetVhostDiscardFlagResponse);
 
+        IgnoreFunc(TEvVolumePrivate::TEvPartStatsSaved);
         IgnoreFunc(TEvLocal::TEvTabletMetrics);
 
         default:

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -707,16 +707,14 @@ private:
 
     bool CheckReadWriteBlockRange(const TBlockRange64& range) const;
 
-    void SendStatisticRequests(const NActors::TActorContext& ctx);
+    void SendStatisticRequestsForYDBBasedPartitions(const NActors::TActorContext& ctx);
 
     void SendStatisticRequestForDiskRegistryBasedPartition(
         const NActors::TActorContext& ctx);
 
     void CleanupHistory(
         const NActors::TActorContext& ctx,
-        const NActors::TActorId& sender,
-        ui64 cookie,
-        TCallContextPtr callContext);
+        TRequestInfoPtr requestInfo);
 
     void UpdateDiskRegistryBasedPartCounters(
         const NActors::TActorContext& ctx,
@@ -737,7 +735,7 @@ private:
     TEvStatsService::TVolumeSelfCounters GetVolumeSelfCounters(
         const NActors::TActorContext& ctx);
 
-    void SendStatsToServiceStatisticsCollectorActor(
+    void ReplyToServiceStatisticsCollectorActor(
         const NActors::TActorContext& ctx);
 
     bool IsFreshBlocksWriterEnabled() const;
@@ -876,7 +874,7 @@ private:
         const TEvVolume::TEvDiskRegistryBasedPartitionCounters::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    std::optional<TTxVolume::TSavePartStats> UpdatePartCounters(
+    std::optional<TVolumeDatabase::TPartStats> UpdatePartCounters(
         const NActors::TActorContext& ctx,
         TPartCountersData& partCountersData);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -882,10 +882,6 @@ private:
         const TEvStatsService::TEvVolumePartCounters::TPtr& ev,
         const NActors::TActorContext& ctx);
 
-    void HandlePartStatsSaved(
-        const TEvVolumePrivate::TEvPartStatsSaved::TPtr& ev,
-        const NActors::TActorContext& ctx);
-
     void HandleScrubberCounters(
         const TEvVolume::TEvScrubberCounters::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -194,14 +194,6 @@ void TVolumeActor::UpdateTabletMetrics(
             volumeMetrics));
 }
 
-void TVolumeActor::HandlePartStatsSaved(
-    const TEvVolumePrivate::TEvPartStatsSaved::TPtr& ev,
-    const TActorContext& ctx)
-{
-    Y_UNUSED(ev);
-    Y_UNUSED(ctx);
-}
-
 void TVolumeActor::HandleScrubberCounters(
     const TEvVolume::TEvScrubberCounters::TPtr& ev,
     const TActorContext& ctx)

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -288,7 +288,7 @@ void TVolumeActor::UpdateDiskRegistryBasedPartCounters(
     ExecuteTx<TSavePartStats>(
         ctx,
         std::move(requestInfo),
-        std::move(partStats));
+        TVector<TVolumeDatabase::TPartStats>{std::move(partStats)});
 }
 
 void TVolumeActor::HandleDiskRegistryBasedPartCounters(
@@ -333,16 +333,11 @@ void TVolumeActor::HandleGetDiskRegistryBasedPartCountersResponse(
     UpdateDiskRegistryBasedPartCounters(ctx, std::move(data));
 }
 
-std::optional<TTxVolume::TSavePartStats> TVolumeActor::UpdatePartCounters(
+std::optional<TVolumeDatabase::TPartStats> TVolumeActor::UpdatePartCounters(
     const TActorContext& ctx,
     TPartCountersData& partCountersData)
 {
     Y_DEBUG_ABORT_UNLESS(!State->IsDiskRegistryMediaKind());
-
-    auto requestInfo = CreateRequestInfo(
-        partCountersData.Sender,
-        partCountersData.Cookie,
-        partCountersData.CallContext);
 
     auto tabletId = State->FindPartitionTabletId(partCountersData.Sender);
     auto* statInfo =
@@ -380,10 +375,7 @@ std::optional<TTxVolume::TSavePartStats> TVolumeActor::UpdatePartCounters(
 
     partStats.TabletId = statInfo->TabletId;
     partStats.Stats = statInfo->CachedCountersProto;
-
-    return TTxVolume::TSavePartStats(
-        std::move(requestInfo),
-        std::move(partStats));
+    return partStats;
 }
 
 void TVolumeActor::HandlePartCounters(
@@ -405,7 +397,10 @@ void TVolumeActor::HandlePartCounters(
         std::move(msg->BlobLoadMetrics));
 
     if (auto stats = UpdatePartCounters(ctx, partCountersData)) {
-        ExecuteTx<TSavePartStats>(ctx, std::move(*stats));
+        ExecuteTx<TSavePartStats>(
+            ctx,
+            /*requestInfo=*/nullptr,
+            TVector<TVolumeDatabase::TPartStats>{std::move(*stats)});
     }
 }
 
@@ -427,8 +422,7 @@ void TVolumeActor::HandlePartCountersCombined(
             FormatError(msg->Error).c_str());
     }
 
-    TVector<TTxVolume::TSavePartStats> partStats;
-
+    TVector<TVolumeDatabase::TPartStats> partStats;
     for (auto& partCounters: msg->PartCounters) {
         TPartCountersData partCountersData(
             partCounters.PartActorId,
@@ -447,16 +441,13 @@ void TVolumeActor::HandlePartCountersCombined(
 
     if (partStats.empty()) {
         UpdateCounters(ctx);
-        CleanupHistory(
-            ctx,
-            SelfId(),                       // sender
-            0,                              // cookie
-            MakeIntrusive<TCallContext>()   // callContext
-        );
         return;
     }
 
-    ExecuteTx<TSaveMultiplePartStats>(ctx, std::move(partStats));
+    ExecuteTx<TSavePartStats>(
+        ctx,
+        /*requestInfo=*/nullptr,
+        std::move(partStats));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -481,11 +472,14 @@ void TVolumeActor::ExecuteSavePartStats(
     Y_UNUSED(ctx);
 
     TVolumeDatabase db(tx.DB);
-    if (State->IsDiskRegistryMediaKind()) {
-        db.WriteNonReplPartStats(args.PartStats.TabletId, args.PartStats.Stats);
-    } else {
-        Y_DEBUG_ABORT_UNLESS(args.PartStats.TabletId);
-        db.WritePartStats(args.PartStats.TabletId, args.PartStats.Stats);
+
+    for (const auto& stats: args.PartStats) {
+        if (State->IsDiskRegistryMediaKind()) {
+            db.WriteNonReplPartStats(stats.TabletId, stats.Stats);
+        } else {
+            Y_DEBUG_ABORT_UNLESS(stats.TabletId);
+            db.WritePartStats(stats.TabletId, stats.Stats);
+        }
     }
 }
 
@@ -496,20 +490,25 @@ void TVolumeActor::CompleteSavePartStats(
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::VOLUME,
-        "%s Part %lu stats saved",
+        "%s Parts: %s stats saved",
         LogTitle.GetWithTime().c_str(),
-        args.PartStats.TabletId);
+        [&args, isDiskRegistry = State->IsDiskRegistryMediaKind()]()
+        {
+            TStringBuilder builder;
+            if (isDiskRegistry) {
+                return builder;
+            }
 
-    if (Config->GetUsePullSchemeForVolumeStatistics() &&
-        State->IsDiskRegistryMediaKind())
+            for (const auto& stats: args.PartStats) {
+                builder << stats.TabletId << " ";
+            }
+            return builder;
+        }()
+            .c_str());
+
+    if (Config->GetUsePullSchemeForVolumeStatistics())
     {
         UpdateCounters(ctx);
-        CleanupHistory(
-            ctx,
-            SelfId(),                       // sender
-            0,                              // cookie
-            MakeIntrusive<TCallContext>()   // callContext
-        );
     }
 
     NCloud::Send(
@@ -517,71 +516,6 @@ void TVolumeActor::CompleteSavePartStats(
         SelfId(),
         std::make_unique<TEvVolumePrivate::TEvPartStatsSaved>()
     );
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-bool TVolumeActor::PrepareSaveMultiplePartStats(
-    const TActorContext& ctx,
-    TTransactionContext& tx,
-    TTxVolume::TSaveMultiplePartStats& args)
-{
-    Y_UNUSED(ctx);
-    Y_UNUSED(tx);
-    Y_UNUSED(args);
-
-    return true;
-}
-
-void TVolumeActor::ExecuteSaveMultiplePartStats(
-    const TActorContext& ctx,
-    TTransactionContext& tx,
-    TTxVolume::TSaveMultiplePartStats& args)
-{
-    Y_DEBUG_ABORT_UNLESS(!State->IsDiskRegistryMediaKind());
-    Y_UNUSED(ctx);
-
-    TVolumeDatabase db(tx.DB);
-
-    for (const auto& stats: args.PartStats) {
-        Y_DEBUG_ABORT_UNLESS(stats.PartStats.TabletId);
-        db.WritePartStats(stats.PartStats.TabletId, stats.PartStats.Stats);
-    }
-}
-
-void TVolumeActor::CompleteSaveMultiplePartStats(
-    const TActorContext& ctx,
-    TTxVolume::TSaveMultiplePartStats& args)
-{
-    LOG_DEBUG(
-        ctx,
-        TBlockStoreComponents::VOLUME,
-        "[%lu] Parts: %s stats saved",
-        TabletID(),
-        [&args]()
-        {
-            TStringBuilder builder;
-
-            for (const auto& stats: args.PartStats) {
-                builder << stats.PartStats.TabletId << " ";
-            }
-
-            return builder;
-        }()
-            .c_str());
-
-    UpdateCounters(ctx);
-    CleanupHistory(
-        ctx,
-        SelfId(),                       // sender
-        0,                              // cookie
-        MakeIntrusive<TCallContext>()   // callContext
-    );
-
-    NCloud::Send(
-        ctx,
-        SelfId(),
-        std::make_unique<TEvVolumePrivate::TEvPartStatsSaved>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -883,7 +817,27 @@ void TVolumeActor::HandleLongRunningBlobOperation(
     }
 }
 
-void TVolumeActor::SendStatisticRequests(const TActorContext& ctx)
+void TVolumeActor::CleanupHistory(
+    const TActorContext& ctx,
+    TRequestInfoPtr requestInfo)
+{
+    if (!State) {
+        return;
+    }
+
+    const auto oldestEntry = ctx.Now() - Config->GetVolumeHistoryDuration();
+
+    State->AccessMountHistory().CleanupHistoryIfNeeded(oldestEntry);
+
+    ExecuteTx<TCleanupHistory>(
+        ctx,
+        std::move(requestInfo),
+        oldestEntry,
+        Config->GetVolumeHistoryCleanupItemCount());
+}
+
+void TVolumeActor::SendStatisticRequestsForYDBBasedPartitions(
+    const TActorContext& ctx)
 {
     STORAGE_VERIFY_C(
         State->GetPartitions(),
@@ -905,29 +859,6 @@ void TVolumeActor::SendStatisticRequests(const TActorContext& ctx)
     Actors.insert(actor);
 }
 
-void TVolumeActor::CleanupHistory(
-    const TActorContext& ctx,
-    const TActorId& sender,
-    ui64 cookie,
-    TCallContextPtr callContext)
-{
-    if (!State) {
-        return;
-    }
-
-    const auto oldestEntry = ctx.Now() - Config->GetVolumeHistoryDuration();
-
-    State->AccessMountHistory().CleanupHistoryIfNeeded(oldestEntry);
-
-    auto requestInfo = CreateRequestInfo(sender, cookie, callContext);
-
-    ExecuteTx<TCleanupHistory>(
-        ctx,
-        std::move(requestInfo),
-        oldestEntry,
-        Config->GetVolumeHistoryCleanupItemCount());
-}
-
 void TVolumeActor::SendStatisticRequestForDiskRegistryBasedPartition(
     const TActorContext& ctx)
 {
@@ -944,7 +875,7 @@ void TVolumeActor::SendStatisticRequestForDiskRegistryBasedPartition(
                              TEvGetDiskRegistryBasedPartCountersRequest>());
 }
 
-void TVolumeActor::SendStatsToServiceStatisticsCollectorActor(
+void TVolumeActor::ReplyToServiceStatisticsCollectorActor(
     const NActors::TActorContext& ctx)
 {
     if (!StatisticRequestInfo) {
@@ -981,8 +912,11 @@ void TVolumeActor::SendStatsToServiceStatisticsCollectorActor(
     }
 
     NCloud::Reply(ctx, *StatisticRequestInfo, std::move(response));
-
     StatisticRequestInfo.Reset();
+
+    CleanupHistory(
+        ctx,
+        CreateRequestInfo(SelfId(), 0, MakeIntrusive<TCallContext>()));
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_tx.h
+++ b/cloud/blockstore/libs/storage/volume/volume_tx.h
@@ -28,7 +28,6 @@ namespace NCloud::NBlockStore::NStorage {
     xxx(ReadHistory,                    __VA_ARGS__)                           \
     xxx(CleanupHistory,                 __VA_ARGS__)                           \
     xxx(SavePartStats,                  __VA_ARGS__)                           \
-    xxx(SaveMultiplePartStats,          __VA_ARGS__)                           \
     xxx(SaveCheckpointRequest,          __VA_ARGS__)                           \
     xxx(UpdateCheckpointRequest,        __VA_ARGS__)                           \
     xxx(UpdateShadowDiskState,          __VA_ARGS__)                           \
@@ -423,27 +422,13 @@ struct TTxVolume
     struct TSavePartStats
     {
         const TRequestInfoPtr RequestInfo;
-        const TVolumeDatabase::TPartStats PartStats;
+        const TVector<TVolumeDatabase::TPartStats> PartStats;
 
         TSavePartStats(
-                TRequestInfoPtr requestInfo,
-                TVolumeDatabase::TPartStats partStats)
+            TRequestInfoPtr requestInfo,
+            TVector<TVolumeDatabase::TPartStats> partStats)
             : RequestInfo(std::move(requestInfo))
             , PartStats(std::move(partStats))
-        {}
-
-        void Clear()
-        {
-            // nothing to do
-        }
-    };
-
-    struct TSaveMultiplePartStats
-    {
-        const TVector<TSavePartStats> PartStats;
-
-        explicit TSaveMultiplePartStats(TVector<TSavePartStats> partStats)
-            : PartStats(std::move(partStats))
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/volume/volume_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_stats.cpp
@@ -1285,6 +1285,92 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldNotCleanupHistoryOnUpdateCountersInPullScheme)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetUsePullSchemeForVolumeStatistics(true);
+        storageServiceConfig.SetVolumeHistoryDuration(1000);
+        storageServiceConfig.SetVolumeHistoryCleanupItemCount(20);
+
+        auto runtime = PrepareTestActorRuntime(std::move(storageServiceConfig));
+
+        TVolumeClient volume(*runtime);
+        volume.UpdateVolumeConfig();
+        volume.WaitReady();
+
+        auto firstClientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+        volume.AddClient(firstClientInfo);
+
+        for (ui32 i = 0; i < 39; ++i) {
+            auto clientInfo = CreateVolumeClientInfo(
+                NProto::VOLUME_ACCESS_READ_WRITE,
+                NProto::VOLUME_MOUNT_LOCAL,
+                0);
+            volume.SendAddClientRequest(clientInfo);
+            auto response = volume.RecvAddClientResponse();
+            UNIT_ASSERT_C(
+                FAILED(response->GetStatus()),
+                "Unexpected successful result");
+        }
+
+        runtime->AdvanceCurrentTime(TDuration::Minutes(1));
+        volume.RebootTablet();
+        volume.WaitReady();
+
+        volume.SendToPipe(
+            std::make_unique<TEvVolumePrivate::TEvReadHistoryRequest>(
+                runtime->GetCurrentTime(),
+                TInstant::Seconds(0),
+                Max<size_t>()));
+        {
+            auto response =
+                volume.RecvResponse<TEvVolumePrivate::TEvReadHistoryResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(40, response->History.size());
+        }
+
+        // This should do nothing because the counters are updated at the
+        // request of the service.
+        volume.SendToPipe(
+            std::make_unique<TEvVolumePrivate::TEvUpdateCounters>());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        volume.SendToPipe(
+            std::make_unique<TEvVolumePrivate::TEvReadHistoryRequest>(
+                runtime->GetCurrentTime(),
+                TInstant::Seconds(0),
+                Max<size_t>()));
+        {
+            auto response =
+                volume.RecvResponse<TEvVolumePrivate::TEvReadHistoryResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(40, response->History.size());
+        }
+
+        // Pull the statistics from the volume.
+        volume.SendToPipe(
+            std::make_unique<TEvStatsService::TEvGetServiceStatisticsRequest>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvVolumePrivate::EvPartStatsSaved);
+            runtime->DispatchEvents(options);
+        }
+
+        // The history should be truncated.
+        volume.SendToPipe(
+            std::make_unique<TEvVolumePrivate::TEvReadHistoryRequest>(
+                runtime->GetCurrentTime(),
+                TInstant::Seconds(0),
+                Max<size_t>()));
+        {
+            auto response =
+                volume.RecvResponse<TEvVolumePrivate::TEvReadHistoryResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(20, response->History.size());
+        }
+    }
+
     Y_UNIT_TEST(ShouldPullStatisticsFromPartitions)
     {
         NProto::TStorageServiceConfig storageServiceConfig;


### PR DESCRIPTION
### Notes
Error logs are full of messages like:
```
volume_actor_stats.cpp:953: [v:<tablet_id> g:556 d:<disk_id> t:8d 4h 39m 23s] Failed to send volume <tablet_id> statistics due to empty StatisticRequestInfo
```

This is due hitting the "reply path" twice: after the partition reply with the stats (good one) and scheduled update (bad one). This PR fixes the issue and removes the unnecessary second transaction for saving the stats.

### Issue
#3154
