### PR TITLE
issue-5715: dirtree tool - generates random deep directory trees

### DIFF
--- a/cloud/filestore/tests/dirtree/canondata/result.json
+++ b/cloud/filestore/tests/dirtree/canondata/result.json
@@ -1,0 +1,5 @@
+{
+    "test.test_default": {
+        "uri": "file://test.test_default/default_results.txt"
+    }
+}

--- a/cloud/filestore/tests/dirtree/canondata/test.test_default/default_results.txt
+++ b/cloud/filestore/tests/dirtree/canondata/test.test_default/default_results.txt
@@ -1,0 +1,4 @@
+Producer 0 depth=3, files=37, dirs=3
+Producer 1 depth=3, files=82, dirs=8
+Producer 2 depth=3, files=118, dirs=12
+Producer 3 depth=4, files=118, dirs=12

--- a/cloud/filestore/tests/dirtree/test.py
+++ b/cloud/filestore/tests/dirtree/test.py
@@ -1,0 +1,33 @@
+import os
+
+import yatest.common as common
+
+from cloud.storage.core.tools.testing.qemu.lib.common import (
+    env_with_guest_index,
+    SshToGuest,
+)
+
+
+def do_test(test_name, aux_params):
+    port = int(os.getenv(env_with_guest_index("QEMU_FORWARDING_PORT", 0)))
+    ssh_key = os.getenv("QEMU_SSH_KEY")
+    mount_dir = os.getenv("NFS_MOUNT_PATH")
+
+    ssh = SshToGuest(user="qemu", port=port, key=ssh_key)
+
+    dirtree_bin = common.binary_path(
+        "cloud/filestore/tools/testing/dirtree/bin/dirtree")
+
+    working_dir = os.path.join(mount_dir, "wd")
+
+    ret = ssh(f"{dirtree_bin} --test-dir {working_dir} --seed 111 {aux_params}")
+    results_path = f"{common.output_path()}/{test_name}_results.txt"
+    with open(results_path, 'w') as results:
+        results.write(ret.stdout.decode("utf8"))
+
+    ret = common.canonical_file(results_path, local=True)
+    return ret
+
+
+def test_default():
+    return do_test("default", "")

--- a/cloud/filestore/tests/dirtree/ya.make
+++ b/cloud/filestore/tests/dirtree/ya.make
@@ -1,0 +1,40 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+SPLIT_FACTOR(1)
+
+TEST_SRCS(
+    test.py
+)
+
+DEPENDS(
+    cloud/filestore/tools/testing/dirtree/bin
+)
+
+PEERDIR(
+    cloud/filestore/public/sdk/python/client
+    cloud/filestore/tests/python/lib
+
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/fmdtest/nfs-storage.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_INSTANCE_COUNT 1)
+SET(FILESTORE_VHOST_ENDPOINT_COUNT 1)
+SET(FILESTORE_BLOCKS_COUNT 5242880)
+SET(VIRTIOFS_SERVER_COUNT 1)
+SET(QEMU_INVOKE_TEST NO)
+
+SET(NFS_RESTART_INTERVAL 10)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/ya.make
+++ b/cloud/filestore/tests/ya.make
@@ -15,6 +15,7 @@ RECURSE_FOR_TESTS(
     close_to_open_consistency
     config_dispatcher
     directory_handles
+    dirtree
     endpoints
     fio
     fio_index

--- a/cloud/filestore/tools/testing/dirtree/bin/app.cpp
+++ b/cloud/filestore/tools/testing/dirtree/bin/app.cpp
@@ -1,0 +1,253 @@
+#include "app.h"
+
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <library/cpp/logger/stream.h>
+
+#include <util/datetime/base.h>
+#include <util/folder/dirut.h>
+#include <util/folder/path.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/singleton.h>
+#include <util/generic/vector.h>
+#include <util/random/fast.h>
+#include <util/stream/file.h>
+#include <util/string/builder.h>
+#include <util/system/fs.h>
+#include <util/system/thread.h>
+
+#include <atomic>
+#include <csignal>
+
+namespace NCloud::NFileStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TProducerThread: public ISimpleThread
+{
+private:
+    TLog Log;
+    const TOptions& Options;
+    const ui32 ThreadId;
+    TFastRng64 Rng;
+
+    std::atomic<ui32> Depth = 0;
+    std::atomic<ui64> FileCount = 0;
+    std::atomic<ui64> DirCount = 0;
+    std::atomic<bool> Done = false;
+    std::atomic<bool>& ShouldStop;
+
+    TFsPath DirPath;
+    ui64 NodeNo = 0;
+
+public:
+    TProducerThread(
+            TLog log,
+            const TOptions& options,
+            ui32 threadId,
+            std::atomic<bool>& shouldStop)
+        : Log(std::move(log))
+        , Options(options)
+        , ThreadId(threadId)
+        , Rng(ThreadId + options.Seed)
+        , ShouldStop(shouldStop)
+    {
+        DirPath = TFsPath(Options.TestDir)
+            / (TStringBuilder() << "producer_" << ThreadId);
+        MakeDirIfNotExist(DirPath.c_str());
+    }
+
+    void* ThreadProc() override
+    {
+        double p = Options.SubdirProbability;
+        TVector<TFsPath> dirs(1, DirPath);
+        while (dirs.size() && !ShouldStop.load()) {
+            TVector<TFsPath> newDirs;
+            for (const auto& dir: dirs) {
+                for (ui32 i = 0; i < Options.ChildrenCount; ++i) {
+                    if (Rng.GenRandReal2() < p) {
+                        newDirs.push_back(CreateDir(dir));
+                        DirCount.fetch_add(1, std::memory_order_relaxed);
+                    } else {
+                        CreateFile(dir);
+                        FileCount.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            }
+
+            dirs.swap(newDirs);
+            p *= Options.DecayFactor;
+            Depth.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        Done.store(true);
+        return nullptr;
+    }
+
+    const auto& GetDirPath() const
+    {
+        return DirPath;
+    }
+
+    ui32 GetDepth() const
+    {
+        return Depth.load(std::memory_order_relaxed);
+    }
+
+    ui64 GetFileCount() const
+    {
+        return FileCount.load(std::memory_order_relaxed);
+    }
+
+    ui64 GetDirCount() const
+    {
+        return DirCount.load(std::memory_order_relaxed);
+    }
+
+    bool IsDone() const
+    {
+        return Done.load();
+    }
+
+private:
+    TFsPath CreateDir(const TFsPath& parent)
+    {
+        TString dirName =
+            TStringBuilder() << "dir_" << ThreadId << "_" << NodeNo;
+        ++NodeNo;
+        TFsPath dirPath = parent / dirName;
+        MakeDirIfNotExist(dirPath.c_str());
+        return dirPath;
+    }
+
+    void CreateFile(const TFsPath& parent)
+    {
+        TString fileName =
+            TStringBuilder() << "file_" << ThreadId << "_" << NodeNo;
+        ++NodeNo;
+        TFsPath filePath = parent / fileName;
+
+        static constexpr EOpenMode OpenMode = CreateAlways | WrOnly | Seq;
+        TFile f(filePath, OpenMode);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TApp
+{
+private:
+    std::atomic<bool> ShouldStop{false};
+    TVector<THolder<TProducerThread>> ProducerThreads;
+
+public:
+    static TApp* GetInstance()
+    {
+        return Singleton<TApp>();
+    }
+
+    int Run(const TOptions& options)
+    {
+        // Create test directory
+        MakeDirIfNotExist(options.TestDir.c_str());
+
+        auto asyncLogger = CreateAsyncLogger();
+        asyncLogger->Start();
+        // capital 'L' letter needed for the logging macros
+        TLog Log = CreateComponentLog(
+            "BENCH",
+            std::make_shared<TStreamLogBackend>(&Cerr),
+            asyncLogger);
+
+        // Create producer threads
+        TVector<TProducerThread*> producerPtrs;
+        for (ui32 i = 0; i < options.ProducerThreads; ++i) {
+            auto p = MakeHolder<TProducerThread>(Log, options, i, ShouldStop);
+            producerPtrs.push_back(p.Get());
+            ProducerThreads.push_back(std::move(p));
+        }
+
+        // Run all threads
+        for (auto& p: ProducerThreads) {
+            p->Start();
+        }
+
+        // Wait for test duration
+        while (!ShouldStop.load()) {
+            Sleep(TDuration::Seconds(1));
+
+            bool done = true;
+            for (auto& p: ProducerThreads) {
+                STORAGE_INFO("Producer " << p->GetDirPath() << " at depth "
+                    << p->GetDepth() << ", created " << p->GetFileCount()
+                    << " files, " << p->GetDirCount() << " dirs");
+
+                if (!p->IsDone()) {
+                    done = false;
+                }
+            }
+
+            if (done) {
+                break;
+            }
+        }
+
+        // Wait for threads to finish
+        for (ui32 i = 0; i < options.ProducerThreads; ++i) {
+            auto& p = ProducerThreads[i];
+            p->Join();
+            Cout << "Producer " << i << " depth=" << p->GetDepth()
+                << ", files=" << p->GetFileCount()
+                << ", dirs=" << p->GetDirCount()
+                << Endl;
+        }
+
+        return 0;
+    }
+
+    void Stop()
+    {
+        ShouldStop.store(true);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ProcessSignal(int signum)
+{
+    if (signum == SIGINT || signum == SIGTERM) {
+        AppStop();
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ConfigureSignals()
+{
+    std::set_new_handler(abort);
+
+    // make sure that errors can be seen by everybody :)
+    (void) setvbuf(stdout, nullptr, _IONBF, 0);
+    (void) setvbuf(stderr, nullptr, _IONBF, 0);
+
+    // mask signals
+    (void) signal(SIGPIPE, SIG_IGN);
+    (void) signal(SIGINT, ProcessSignal);
+    (void) signal(SIGTERM, ProcessSignal);
+}
+
+int AppMain(const TOptions& options)
+{
+    return TApp::GetInstance()->Run(options);
+}
+
+void AppStop()
+{
+    TApp::GetInstance()->Stop();
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/tools/testing/dirtree/bin/app.h
+++ b/cloud/filestore/tools/testing/dirtree/bin/app.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "options.h"
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ConfigureSignals();
+
+int AppMain(const TOptions& options);
+void AppStop();
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/tools/testing/dirtree/bin/main.cpp
+++ b/cloud/filestore/tools/testing/dirtree/bin/main.cpp
@@ -1,0 +1,23 @@
+#include "app.h"
+#include "options.h"
+
+#include <util/generic/yexception.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char** argv)
+{
+    using namespace NCloud::NFileStore;
+
+    ConfigureSignals();
+
+    TOptions options;
+    try {
+        options.Parse(argc, argv);
+    } catch (...) {
+        Cerr << CurrentExceptionMessage() << Endl;
+        return 1;
+    }
+
+    return AppMain(options);
+}

--- a/cloud/filestore/tools/testing/dirtree/bin/options.cpp
+++ b/cloud/filestore/tools/testing/dirtree/bin/options.cpp
@@ -1,0 +1,61 @@
+#include "options.h"
+
+#include <library/cpp/getopt/small/last_getopt.h>
+
+namespace NCloud::NFileStore {
+
+using namespace NLastGetopt;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TOptions::Parse(int argc, char** argv)
+{
+    TOpts opts;
+    opts.AddHelpOption();
+
+    opts.AddLongOption("test-dir", "path to test directory")
+        .RequiredArgument("STR")
+        .Required()
+        .StoreResult(&TestDir);
+
+    //
+    // Producer settings.
+    //
+
+    opts.AddLongOption("producer-threads", "number of producer threads")
+        .RequiredArgument("NUM")
+        .DefaultValue(4)
+        .StoreResult(&ProducerThreads);
+
+    opts.AddLongOption("children-count", "children per dir")
+        .RequiredArgument("NUM")
+        .DefaultValue(10)
+        .StoreResult(&ChildrenCount);
+
+    opts.AddLongOption(
+            "subdir-probability",
+            "the probability of creating a subdir as a child")
+        .RequiredArgument("NUM")
+        .DefaultValue(0.5)
+        .StoreResult(&SubdirProbability);
+
+    opts.AddLongOption(
+            "decay-factor",
+            "the factor by which subdir-probability is multiplied upon each"
+            " level of hierarchy")
+        .RequiredArgument("NUM")
+        .DefaultValue(0.15)
+        .StoreResult(&DecayFactor);
+
+    opts.AddLongOption(
+            "seed",
+            "the seed for the rng used to decide whether we should create a"
+            " subdirectory or a file")
+        .RequiredArgument("NUM")
+        .DefaultValue(0)
+        .StoreResult(&Seed);
+
+    TOptsParseResultException(&opts, argc, argv);
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/tools/testing/dirtree/bin/options.h
+++ b/cloud/filestore/tools/testing/dirtree/bin/options.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <util/datetime/base.h>
+#include <util/generic/string.h>
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TOptions
+{
+    TString TestDir;
+
+    ui32 ProducerThreads{};
+    ui32 ChildrenCount{};
+    double SubdirProbability{};
+    double DecayFactor{};
+    ui64 Seed{};
+
+    void Parse(int argc, char** argv);
+};
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/tools/testing/dirtree/bin/ya.make
+++ b/cloud/filestore/tools/testing/dirtree/bin/ya.make
@@ -1,4 +1,4 @@
-PROGRAM(fmdtest)
+PROGRAM(dirtree)
 
 SRCS(
     app.cpp
@@ -10,7 +10,6 @@ PEERDIR(
     cloud/storage/core/libs/diagnostics
 
     library/cpp/getopt
-    library/cpp/json
 )
 
 END()

--- a/cloud/filestore/tools/testing/dirtree/ya.make
+++ b/cloud/filestore/tools/testing/dirtree/ya.make
@@ -1,0 +1,3 @@
+RECURSE(
+    bin
+)

--- a/cloud/filestore/tools/testing/ya.make
+++ b/cloud/filestore/tools/testing/ya.make
@@ -1,5 +1,6 @@
 RECURSE(
     directory_handles_test
+    dirtree
     fmdtest
     fs_posix_compliance
     loadtest


### PR DESCRIPTION
### Notes
This new tool is needed either for load testing (e.g. to test listing performance) or to test/show how the system behaves in some complex scenarios, e.g. this one: https://github.com/ydb-platform/nbs/issues/5715#issuecomment-4237533131

The tool can generate random directory trees with configurable height and child count per dir.

```
$ ../../../tools/testing/dirtree/bin/dirtree --test-dir another_dirtree_wd4 --seed 1 2> err.txt
Producer 0 depth=3, files=46, dirs=4
Producer 1 depth=3, files=118, dirs=12
Producer 2 depth=3, files=109, dirs=11
Producer 3 depth=3, files=64, dirs=6
```

```
$ ll another_dirtree_wd4/producer_0/
total 0
drwxrwxr-x 1 astr astr 0 Apr 15 16:24 ./
drwxrwxr-x 1 astr astr 0 Apr 15 16:24 ../
drwxrwxr-x 1 astr astr 0 Apr 15 16:24 dir_0_3/
drwxrwxr-x 1 astr astr 0 Apr 15 16:24 dir_0_8/
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_0
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_1
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_2
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_4
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_5
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_6
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_7
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_0_9
...
$ ll another_dirtree_wd4/producer_1/dir_1_2/
total 0
drwxrwxr-x 1 astr astr 0 Apr 15 16:24 ./
drwxrwxr-x 1 astr astr 0 Apr 15 16:24 ../
drwxrwxr-x 1 astr astr 0 Apr 15 16:24 dir_1_29/
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_20
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_21
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_22
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_23
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_24
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_25
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_26
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_27
-rw-rw-r-- 1 astr astr 0 Apr 15 16:24 file_1_28
```

### Issue
https://github.com/ydb-platform/nbs/issues/5715
