### PR TITLE
issue-1559: [Disk Manager] Synchronise disk-manager node types with filestore enums, add devices

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nfs/session.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/session.go
@@ -20,12 +20,15 @@ const (
 )
 
 const (
-	NODE_KIND_INVALID = nfs_client.NodeType(nfs_client.NODE_KIND_INVALID)
-	NODE_KIND_FILE    = nfs_client.NodeType(nfs_client.NODE_KIND_FILE)
-	NODE_KIND_DIR     = nfs_client.NodeType(nfs_client.NODE_KIND_DIR)
-	NODE_KIND_SYMLINK = nfs_client.NodeType(nfs_client.NODE_KIND_SYMLINK)
-	NODE_KIND_LINK    = nfs_client.NodeType(nfs_client.NODE_KIND_LINK)
-	NODE_KIND_SOCK    = nfs_client.NodeType(nfs_client.NODE_KIND_SOCK)
+	NODE_KIND_INVALID  = nfs_client.NodeType(nfs_client.NODE_KIND_INVALID)
+	NODE_KIND_FILE     = nfs_client.NodeType(nfs_client.NODE_KIND_FILE)
+	NODE_KIND_DIR      = nfs_client.NodeType(nfs_client.NODE_KIND_DIR)
+	NODE_KIND_SYMLINK  = nfs_client.NodeType(nfs_client.NODE_KIND_SYMLINK)
+	NODE_KIND_LINK     = nfs_client.NodeType(nfs_client.NODE_KIND_LINK)
+	NODE_KIND_SOCK     = nfs_client.NodeType(nfs_client.NODE_KIND_SOCK)
+	NODE_KIND_FIFO     = nfs_client.NodeType(nfs_client.NODE_KIND_FIFO)
+	NODE_KIND_CHARDEV  = nfs_client.NodeType(nfs_client.NODE_KIND_CHARDEV)
+	NODE_KIND_BLOCKDEV = nfs_client.NodeType(nfs_client.NODE_KIND_BLOCKDEV)
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/disk_manager/internal/pkg/clients/nfs/testing/filesystem_model.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/testing/filesystem_model.go
@@ -427,10 +427,8 @@ func (f *FileSystemModel) RequireNodesEqual(
 		expectedNode := f.ExpectedNodes[index]
 		require.Equal(f.t, expectedNode.ParentID, node.ParentID)
 		require.Equal(f.t, expectedNode.Name, node.Name)
-		if expectedNode.Type.IsSymlink() {
-			require.Equal(f.t, nfs.NODE_KIND_LINK, node.Type)
-		} else {
-			require.Equal(f.t, expectedNode.Type, node.Type)
+		require.Equal(f.t, expectedNode.Type, node.Type)
+		if !expectedNode.Type.IsSymlink() {
 			require.Equal(f.t, expectedNode.Mode, node.Mode)
 		}
 

--- a/cloud/disk_manager/internal/pkg/clients/nfs/testing/filesystem_model.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/testing/filesystem_model.go
@@ -81,6 +81,7 @@ type Node struct {
 	Children []Node
 	FileType nfs_client.NodeType
 	Target   string
+	DevID    uint64
 }
 
 func Dir(name string, children ...Node) Node {
@@ -98,12 +99,41 @@ func File(name string) Node {
 	}
 }
 
-// TODO (jkuradobery): support sockets, devices, etc.
 func Symlink(name string, target string) Node {
 	return Node{
 		Name:     name,
 		FileType: nfs_client.NODE_KIND_SYMLINK,
 		Target:   target,
+	}
+}
+
+func Sock(name string) Node {
+	return Node{
+		Name:     name,
+		FileType: nfs_client.NODE_KIND_SOCK,
+	}
+}
+
+func Fifo(name string) Node {
+	return Node{
+		Name:     name,
+		FileType: nfs_client.NODE_KIND_FIFO,
+	}
+}
+
+func CharDev(name string, devID uint64) Node {
+	return Node{
+		Name:     name,
+		FileType: nfs_client.NODE_KIND_CHARDEV,
+		DevID:    devID,
+	}
+}
+
+func BlockDev(name string, devID uint64) Node {
+	return Node{
+		Name:     name,
+		FileType: nfs_client.NODE_KIND_BLOCKDEV,
+		DevID:    devID,
 	}
 }
 
@@ -201,6 +231,51 @@ func HomogeneousDirectoryTree(layers []FilesystemLayerConfig) Node {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+var StandardFilesystem = Root(
+	Dir("etc",
+		File("passwd"),
+		File("hosts"),
+	),
+	Dir(
+		"var",
+		Dir(
+			"log",
+		),
+	),
+	Symlink("bin", "/usr/bin"),
+	Dir("usr",
+		Dir("bin", File("bash"), File("ls")),
+		Dir("lib", File("libc.so")),
+	),
+	Dir("empty"),
+	Sock("test.sock"),
+	Fifo("test.fifo"),
+	CharDev("test.chardev", 1),
+	BlockDev("test.blockdev", 2),
+)
+
+var StandardFilesystemExpectedNames = []string{
+	"bin",
+	"empty",
+	"etc",
+	"hosts",
+	"passwd",
+	"test.blockdev",
+	"test.chardev",
+	"test.fifo",
+	"test.sock",
+	"usr",
+	"bin",
+	"bash",
+	"ls",
+	"lib",
+	"libc.so",
+	"var",
+	"log",
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 type FileSystemModel struct {
 	root          Node
 	t             *testing.T
@@ -231,6 +306,7 @@ func (f *FileSystemModel) CreateNodesRecursively(
 		UID:        1,
 		GID:        1,
 		LinkTarget: nodeToCreate.Target,
+		DevID:      nodeToCreate.DevID,
 	}
 	id, err := f.session.CreateNode(f.ctx, expectedNode)
 	require.NoError(f.t, err)
@@ -351,8 +427,10 @@ func (f *FileSystemModel) RequireNodesEqual(
 		expectedNode := f.ExpectedNodes[index]
 		require.Equal(f.t, expectedNode.ParentID, node.ParentID)
 		require.Equal(f.t, expectedNode.Name, node.Name)
-		require.Equal(f.t, expectedNode.Type, node.Type)
-		if !expectedNode.Type.IsSymlink() {
+		if expectedNode.Type.IsSymlink() {
+			require.Equal(f.t, nfs.NODE_KIND_LINK, node.Type)
+		} else {
+			require.Equal(f.t, expectedNode.Type, node.Type)
 			require.Equal(f.t, expectedNode.Mode, node.Mode)
 		}
 

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -12,41 +12,6 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-var listNodesRootDir = nfs_testing.Root(
-	nfs_testing.Dir("etc",
-		nfs_testing.File("passwd"),
-		nfs_testing.File("hosts"),
-	),
-	nfs_testing.Dir(
-		"var",
-		nfs_testing.Dir(
-			"log",
-		),
-	),
-	nfs_testing.Symlink("bin", "/usr/bin"),
-	nfs_testing.Dir("usr",
-		nfs_testing.Dir("bin", nfs_testing.File("bash"), nfs_testing.File("ls")),
-		nfs_testing.Dir("lib", nfs_testing.File("libc.so")),
-	),
-)
-
-var listNodesExpectedNames = []string{
-	"bin",
-	"etc",
-	"hosts",
-	"passwd",
-	"usr",
-	"bin",
-	"bash",
-	"ls",
-	"lib",
-	"libc.so",
-	"var",
-	"log",
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 func TestCreateFilesystem(t *testing.T) {
 	ctx := nfs_testing.NewContext()
 	client := nfs_testing.NewClient(t, ctx)
@@ -154,12 +119,12 @@ func TestListNodesFileSystem(t *testing.T) {
 	require.NoError(t, err)
 	defer session.Close(ctx)
 
-	model := nfs_testing.NewFileSystemModel(t, ctx, session, listNodesRootDir)
+	model := nfs_testing.NewFileSystemModel(t, ctx, session, nfs_testing.StandardFilesystem)
 	model.CreateAllNodesRecursively()
 
 	nodes := model.ListAllNodesRecursively(false)
 	model.RequireNodesEqual(nodes)
-	require.Equal(t, listNodesExpectedNames, nfs_testing.NodeNames(nodes))
+	require.Equal(t, nfs_testing.StandardFilesystemExpectedNames, nfs_testing.NodeNames(nodes))
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -188,12 +153,12 @@ func TestListNodesFileSystemUnsafe(t *testing.T) {
 	require.NoError(t, err)
 	defer session.Close(ctx)
 
-	model := nfs_testing.NewFileSystemModel(t, ctx, session, listNodesRootDir)
+	model := nfs_testing.NewFileSystemModel(t, ctx, session, nfs_testing.StandardFilesystem)
 	model.CreateAllNodesRecursively()
 
 	nodes := model.ListAllNodesRecursively(true)
 	model.RequireNodesEqual(nodes)
-	require.Equal(t, listNodesExpectedNames, nfs_testing.NodeNames(nodes))
+	require.Equal(t, nfs_testing.StandardFilesystemExpectedNames, nfs_testing.NodeNames(nodes))
 
 	// Open sessions to shard filesystems for GetNodeAttr verification.
 	shardSessions := make(map[string]nfs.Session, shardCount)
@@ -420,6 +385,7 @@ func TestCreateNodeIdempotent(t *testing.T) {
 		Mode:     0644,
 		UID:      1,
 		GID:      1,
+		Type:     nfs.NODE_KIND_FILE,
 	}
 
 	createdID, err := session.CreateNode(ctx, node)

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -119,12 +119,21 @@ func TestListNodesFileSystem(t *testing.T) {
 	require.NoError(t, err)
 	defer session.Close(ctx)
 
-	model := nfs_testing.NewFileSystemModel(t, ctx, session, nfs_testing.StandardFilesystem)
+	model := nfs_testing.NewFileSystemModel(
+		t,
+		ctx,
+		session,
+		nfs_testing.StandardFilesystem,
+	)
 	model.CreateAllNodesRecursively()
 
 	nodes := model.ListAllNodesRecursively(false)
 	model.RequireNodesEqual(nodes)
-	require.Equal(t, nfs_testing.StandardFilesystemExpectedNames, nfs_testing.NodeNames(nodes))
+	require.Equal(
+		t,
+		nfs_testing.StandardFilesystemExpectedNames,
+		nfs_testing.NodeNames(nodes),
+	)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -153,12 +162,21 @@ func TestListNodesFileSystemUnsafe(t *testing.T) {
 	require.NoError(t, err)
 	defer session.Close(ctx)
 
-	model := nfs_testing.NewFileSystemModel(t, ctx, session, nfs_testing.StandardFilesystem)
+	model := nfs_testing.NewFileSystemModel(
+		t,
+		ctx,
+		session,
+		nfs_testing.StandardFilesystem,
+	)
 	model.CreateAllNodesRecursively()
 
 	nodes := model.ListAllNodesRecursively(true)
 	model.RequireNodesEqual(nodes)
-	require.Equal(t, nfs_testing.StandardFilesystemExpectedNames, nfs_testing.NodeNames(nodes))
+	require.Equal(
+		t,
+		nfs_testing.StandardFilesystemExpectedNames,
+		nfs_testing.NodeNames(nodes),
+	)
 
 	// Open sessions to shard filesystems for GetNodeAttr verification.
 	shardSessions := make(map[string]nfs.Session, shardCount)

--- a/cloud/filestore/public/sdk/go/client/client.go
+++ b/cloud/filestore/public/sdk/go/client/client.go
@@ -54,12 +54,15 @@ func (t NodeType) IsSymlink() bool {
 ////////////////////////////////////////////////////////////////////////////////
 
 const (
-	NODE_KIND_INVALID NodeType = iota
-	NODE_KIND_FILE
-	NODE_KIND_DIR
-	NODE_KIND_SYMLINK
-	NODE_KIND_LINK
-	NODE_KIND_SOCK
+	NODE_KIND_INVALID  NodeType = NodeType(protos.ENodeType_E_INVALID_NODE)
+	NODE_KIND_FILE     NodeType = NodeType(protos.ENodeType_E_REGULAR_NODE)
+	NODE_KIND_DIR      NodeType = NodeType(protos.ENodeType_E_DIRECTORY_NODE)
+	NODE_KIND_LINK     NodeType = NodeType(protos.ENodeType_E_LINK_NODE)
+	NODE_KIND_SOCK     NodeType = NodeType(protos.ENodeType_E_SOCK_NODE)
+	NODE_KIND_SYMLINK  NodeType = NodeType(protos.ENodeType_E_SYMLINK_NODE)
+	NODE_KIND_FIFO     NodeType = NodeType(protos.ENodeType_E_FIFO_NODE)
+	NODE_KIND_CHARDEV  NodeType = NodeType(protos.ENodeType_E_CHARDEV_NODE)
+	NODE_KIND_BLOCKDEV NodeType = NodeType(protos.ENodeType_E_BLOCKDEV_NODE)
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -357,6 +360,13 @@ func (client *Client) ListNodes(
 	nodes := resp.GetNodes()
 	result := make([]Node, len(nodes))
 	for idx, name := range resp.GetNames() {
+		// On the filestore side, symlinks are represented as links
+		// and links are regular files with Links >= 2.
+		nodeType := NodeType(nodes[idx].GetType())
+		if nodeType == NODE_KIND_LINK {
+			nodeType = NODE_KIND_SYMLINK
+		}
+
 		result[idx] = Node{
 			ParentID:          nodeID,
 			NodeID:            nodes[idx].GetId(),
@@ -369,7 +379,7 @@ func (client *Client) ListNodes(
 			UID:               uint64(nodes[idx].GetUid()),
 			GID:               uint64(nodes[idx].GetGid()),
 			Links:             nodes[idx].GetLinks(),
-			Type:              NodeType(nodes[idx].GetType()),
+			Type:              nodeType,
 			ShardFileSystemID: nodes[idx].GetShardFileSystemId(),
 			ShardNodeName:     nodes[idx].GetShardNodeName(),
 			DevID:             nodes[idx].GetDevId(),
@@ -428,6 +438,33 @@ func (client *Client) CreateNode(
 				TargetNode: node.NodeID,
 			},
 		}
+	case NODE_KIND_FIFO:
+		req.Params = &protos.TCreateNodeRequest_Fifo{
+			Fifo: &protos.TCreateNodeRequest_TFifo{
+				Mode: node.Mode,
+			},
+		}
+	case NODE_KIND_CHARDEV:
+		req.Params = &protos.TCreateNodeRequest_CharDevice{
+			CharDevice: &protos.TCreateNodeRequest_TCharDevice{
+				Mode:   node.Mode,
+				Device: node.DevID,
+			},
+		}
+	case NODE_KIND_BLOCKDEV:
+		req.Params = &protos.TCreateNodeRequest_BlockDevice{
+			BlockDevice: &protos.TCreateNodeRequest_TBlockDevice{
+				Mode:   node.Mode,
+				Device: node.DevID,
+			},
+		}
+	case NODE_KIND_INVALID:
+		return 0, errors.NewNonRetriableErrorf("CreateNode: invalid node type")
+	default:
+		return 0, errors.NewNonRetriableErrorf(
+			"CreateNode: unknown node type %v",
+			node.Type,
+		)
 	}
 
 	resp, err := client.Impl.CreateNode(ctx, req)
@@ -497,6 +534,7 @@ func (client *Client) GetNodeAttr(
 		GID:      uint64(attr.GetGid()),
 		Links:    attr.GetLinks(),
 		Type:     NodeType(attr.GetType()),
+		DevID:    attr.GetDevId(),
 	}, nil
 }
 


### PR DESCRIPTION
### Notes
NODE_KIND_* enum was incorrect before. Make NODE_KIND_* consts consistent with ENodeType enum in filestore. 
Fix symlinks listing and creation, fix symlinks

### Issue
#1559