### PR TITLE
[Filestore] add deallocation for dynamic persistent table #5747

### DIFF
--- a/cloud/filestore/config/vfs.proto
+++ b/cloud/filestore/config/vfs.proto
@@ -79,6 +79,9 @@ message TVFSConfig
     // (and a subdirectory with session id as name) if not present.
     optional string DirectoryHandlesStoragePath = 22;
 
-    // Initial data area size for DirectoryHandles persistent table.
+    // Initial data area size for DirectoryHandles persistent table. Should be power of 2
     optional uint64 DirectoryHandlesInitialDataSize = 23;
+
+    // Max single growth step for DirectoryHandles persistent table data area.
+    optional uint64 DirectoryHandlesMaxDataAreaStepSize = 24;
 }

--- a/cloud/filestore/config/vhost.proto
+++ b/cloud/filestore/config/vhost.proto
@@ -81,12 +81,15 @@ message TVhostServiceConfig
     // (and a subdirectory with session id as name) if not present.
     optional string DirectoryHandlesStoragePath = 19;
 
-    // Initial data area size for DirectoryHandles persistent table.
+    // Initial data area size for DirectoryHandles persistent table. Should be power of 2
     optional uint64 DirectoryHandlesInitialDataSize = 20;
 
     // If nonzero, multiple permanent THandler actors will be used instead of
     // one TRequestActor per each request.
     optional uint32 PermanentActorCount = 21;
+
+    // Max single growth step for DirectoryHandles persistent table data area.
+    optional uint64 DirectoryHandlesMaxDataAreaStepSize = 22;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -433,7 +433,8 @@ void TBootstrapVhost::InitEndpoints()
             ProfileLog),
         THandleOpsQueueConfig{
             .PathPrefix = Configs->VhostServiceConfig->GetHandleOpsQueuePath(),
-            .MaxQueueSize = Configs->VhostServiceConfig->GetHandleOpsQueueSize(),
+            .MaxQueueSize =
+                Configs->VhostServiceConfig->GetHandleOpsQueueSize(),
         },
         TWriteBackCacheConfig{
             .PathPrefix = Configs->VhostServiceConfig->GetWriteBackCachePath(),
@@ -442,9 +443,8 @@ void TBootstrapVhost::InitEndpoints()
             .AutomaticFlushPeriod =
                 Configs->VhostServiceConfig
                     ->GetWriteBackCacheAutomaticFlushPeriod(),
-            .FlushRetryPeriod =
-                Configs->VhostServiceConfig
-                    ->GetWriteBackCacheFlushRetryPeriod(),
+            .FlushRetryPeriod = Configs->VhostServiceConfig
+                                    ->GetWriteBackCacheFlushRetryPeriod(),
             .FlushMaxWriteRequestSize =
                 Configs->VhostServiceConfig
                     ->GetWriteBackCacheFlushMaxWriteRequestSize(),
@@ -453,14 +453,15 @@ void TBootstrapVhost::InitEndpoints()
                     ->GetWriteBackCacheFlushMaxWriteRequestsCount(),
             .FlushMaxSumWriteRequestsSize =
                 Configs->VhostServiceConfig
-                    ->GetWriteBackCacheFlushMaxSumWriteRequestsSize()
-        },
+                    ->GetWriteBackCacheFlushMaxSumWriteRequestsSize()},
         TDirectoryHandleStorageConfig{
-            .PathPrefix = Configs->VhostServiceConfig->GetDirectoryHandlesStoragePath(),
-            .InitialDataSize =
-                Configs->VhostServiceConfig->GetDirectoryHandlesInitialDataSize()
-        }
-    );
+            .PathPrefix =
+                Configs->VhostServiceConfig->GetDirectoryHandlesStoragePath(),
+            .InitialDataSize = Configs->VhostServiceConfig
+                                   ->GetDirectoryHandlesInitialDataSize(),
+            .MaxDataAreaStepSize =
+                Configs->VhostServiceConfig
+                    ->GetDirectoryHandlesMaxDataAreaStepSize()});
 
     EndpointManager = CreateEndpointManager(
         Logging,

--- a/cloud/filestore/libs/endpoint_vhost/config.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/config.cpp
@@ -43,8 +43,9 @@ static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
     xxx(WriteBackCacheFlushMaxWriteRequestsCount,   ui32,       64            )\
     xxx(WriteBackCacheFlushMaxSumWriteRequestsSize, ui32,       32_MB         )\
     xxx(DirectoryHandlesStoragePath,                TString,    ""            )\
-    xxx(DirectoryHandlesInitialDataSize,            ui64,       1_GB          )\
+    xxx(DirectoryHandlesInitialDataSize,            ui64,       16_MB         )\
     xxx(PermanentActorCount,                        ui32,       0             )\
+    xxx(DirectoryHandlesMaxDataAreaStepSize,        ui64,       1_GB          )\
 // VHOST_SERVICE_CONFIG
 
 #define VHOST_SERVICE_DECLARE_CONFIG(name, type, value)                        \

--- a/cloud/filestore/libs/endpoint_vhost/config.h
+++ b/cloud/filestore/libs/endpoint_vhost/config.h
@@ -44,6 +44,7 @@ public:
 
     TString GetDirectoryHandlesStoragePath() const;
     ui64 GetDirectoryHandlesInitialDataSize() const;
+    ui64 GetDirectoryHandlesMaxDataAreaStepSize() const;
 
     ui32 GetPermanentActorCount() const;
 

--- a/cloud/filestore/libs/endpoint_vhost/listener.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/listener.cpp
@@ -90,7 +90,8 @@ public:
         , LoopFactory(std::move(loopFactory))
         , HandleOpsQueueConfig(std::move(handleOpsQueueConfig))
         , WriteBackCacheConfig(std::move(writeBackCacheConfig))
-        , DirectoryHandleStorageConfig(std::move(directoryHandleStorageConfig))
+        , DirectoryHandleStorageConfig(
+              std::move(directoryHandleStorageConfig))
     {
         Log = Logging->CreateLog("NFS_VHOST");
     }
@@ -139,8 +140,12 @@ public:
             WriteBackCacheConfig.FlushMaxWriteRequestsCount);
         protoConfig.SetWriteBackCacheFlushMaxSumWriteRequestsSize(
             WriteBackCacheConfig.FlushMaxSumWriteRequestsSize);
-        protoConfig.SetDirectoryHandlesStoragePath(DirectoryHandleStorageConfig.PathPrefix);
-        protoConfig.SetDirectoryHandlesInitialDataSize(DirectoryHandleStorageConfig.InitialDataSize);
+        protoConfig.SetDirectoryHandlesStoragePath(
+            DirectoryHandleStorageConfig.PathPrefix);
+        protoConfig.SetDirectoryHandlesInitialDataSize(
+            DirectoryHandleStorageConfig.InitialDataSize);
+        protoConfig.SetDirectoryHandlesMaxDataAreaStepSize(
+            DirectoryHandleStorageConfig.MaxDataAreaStepSize);
 
         auto vFSConfig = std::make_shared<TVFSConfig>(std::move(protoConfig));
         auto Loop = LoopFactory->Create(

--- a/cloud/filestore/libs/endpoint_vhost/listener.h
+++ b/cloud/filestore/libs/endpoint_vhost/listener.h
@@ -39,6 +39,7 @@ struct TDirectoryHandleStorageConfig
 {
     TString PathPrefix;
     ui64 InitialDataSize = 0;
+    ui64 MaxDataAreaStepSize = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs/config.cpp
+++ b/cloud/filestore/libs/vfs/config.cpp
@@ -40,7 +40,8 @@ namespace {
     xxx(WriteBackCacheFlushMaxSumWriteRequestsSize, ui32,       32_MB         )\
                                                                                \
     xxx(DirectoryHandlesStoragePath,        TString,   ""                     )\
-    xxx(DirectoryHandlesInitialDataSize,    ui64,      1_GB                   )\
+    xxx(DirectoryHandlesInitialDataSize,    ui64,      16_MB                  )\
+    xxx(DirectoryHandlesMaxDataAreaStepSize,ui64,      1_GB                   )\
 // FILESTORE_VFS_CONFIG
 
 #define FILESTORE_VFS_DECLARE_CONFIG(name, type, value)                        \

--- a/cloud/filestore/libs/vfs/config.h
+++ b/cloud/filestore/libs/vfs/config.h
@@ -53,6 +53,7 @@ public:
 
     TString GetDirectoryHandlesStoragePath() const;
     ui64 GetDirectoryHandlesInitialDataSize() const;
+    ui64 GetDirectoryHandlesMaxDataAreaStepSize() const;
 
     bool GetGuestKeepCacheAllowed() const;
 

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
@@ -19,15 +19,12 @@ TDirectoryHandleStorage::TDirectoryHandleStorage(
 {
     Table = std::make_unique<TDirectoryHandleTable>(
         filePath,
-        recordsCount,
-        initialDataAreaSize,
-        maxDataAreaStepSize,
-        initialDataCompactionBufferSize,
-        TDirectoryHandleTable::DefaultGapSpacePercentageCompactionThreshold,
-        TDirectoryHandleTable::DefaultShrinkLowMemoryOpThreshold,
-        TDirectoryHandleTable::DefaultShrinkTriggerPercent,
-        TDirectoryHandleTable::DefaultShrinkReservePercent,
-        TDirectoryHandleTable::DefaultShrinkMode);
+        TDynamicPersistentTableConfig{
+            .MaxRecords = recordsCount,
+            .InitialDataAreaSize = initialDataAreaSize,
+            .MaxDataAreaStepSize = maxDataAreaStepSize,
+            .InitialDataCompactionBufferSize = initialDataCompactionBufferSize,
+        });
 }
 
 void TDirectoryHandleStorage::StoreHandle(

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
@@ -13,6 +13,7 @@ TDirectoryHandleStorage::TDirectoryHandleStorage(
     const TString& filePath,
     ui64 recordsCount,
     ui64 initialDataAreaSize,
+    ui64 maxDataAreaStepSize,
     ui64 initialDataCompactionBufferSize)
     : Log(log)
 {
@@ -20,8 +21,13 @@ TDirectoryHandleStorage::TDirectoryHandleStorage(
         filePath,
         recordsCount,
         initialDataAreaSize,
+        maxDataAreaStepSize,
         initialDataCompactionBufferSize,
-        30);
+        TDirectoryHandleTable::DefaultGapSpacePercentageCompactionThreshold,
+        TDirectoryHandleTable::DefaultShrinkLowMemoryOpThreshold,
+        TDirectoryHandleTable::DefaultShrinkTriggerPercent,
+        TDirectoryHandleTable::DefaultShrinkReservePercent,
+        TDirectoryHandleTable::DefaultShrinkMode);
 }
 
 void TDirectoryHandleStorage::StoreHandle(
@@ -272,6 +278,7 @@ TDirectoryHandleStoragePtr CreateDirectoryHandleStorage(
     const TString& filePath,
     ui64 recordsCount,
     ui64 initialDataAreaSize,
+    ui64 maxDataAreaStepSize,
     ui64 initialDataCompactionBufferSize)
 {
     return std::make_unique<TDirectoryHandleStorage>(
@@ -279,6 +286,7 @@ TDirectoryHandleStoragePtr CreateDirectoryHandleStorage(
         filePath,
         recordsCount,
         initialDataAreaSize,
+        maxDataAreaStepSize,
         initialDataCompactionBufferSize);
 }
 

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_storage.h
@@ -48,6 +48,7 @@ public:
         const TString& filePath,
         ui64 recordsCount,
         ui64 initialDataAreaSize,
+        ui64 maxDataAreaStepSize,
         ui64 initialDataCompactionBufferSize);
 
     void StoreHandle(
@@ -76,6 +77,7 @@ TDirectoryHandleStoragePtr CreateDirectoryHandleStorage(
     const TString& filePath,
     ui64 recordsCount,
     ui64 initialDataAreaSize,
+    ui64 maxDataAreaStepSize,
     ui64 initialDataCompactionBufferSize);
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1091,6 +1091,7 @@ private:
                     path / DirectoryHandleStorageFileName,
                     FileSystemConfig->GetDirectoryHandlesTableSize(),
                     Config->GetDirectoryHandlesInitialDataSize(),
+                    Config->GetDirectoryHandlesMaxDataAreaStepSize(),
                     FileSystemConfig->GetMaxBufferSize());
 
                 DirectoryHandleStorageInitialized = true;

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1224,8 +1224,11 @@ private:
         config.SetDirectoryHandlesStorageEnabled(
             features.GetDirectoryHandlesStorageEnabled());
 
-        config.SetDirectoryHandlesTableSize(
-            features.GetDirectoryHandlesTableSize());
+        const ui64 directoryHandlesTableSize =
+            features.GetDirectoryHandlesTableSize();
+        if (directoryHandlesTableSize != 0) {
+            config.SetDirectoryHandlesTableSize(directoryHandlesTableSize);
+        }
 
         config.SetZeroCopyEnabled(features.GetZeroCopyEnabled());
 

--- a/cloud/filestore/tests/recipes/vhost/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost/__main__.py
@@ -95,7 +95,7 @@ def start(argv):
     directory_handles_storage_path = common.work_path() + "/directoryhandlesstorage-" + uid
     pathlib.Path(directory_handles_storage_path).mkdir(parents=True, exist_ok=True)
     config.VhostServiceConfig.DirectoryHandlesStoragePath = directory_handles_storage_path
-    config.VhostServiceConfig.DirectoryHandlesInitialDataSize = 1000100
+    config.VhostServiceConfig.DirectoryHandlesInitialDataSize = 1048576
 
     service_type = args.service or "local"
     kikimr_port = 0

--- a/cloud/storage/core/libs/common/dynamic_persistent_table.h
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table.h
@@ -9,6 +9,7 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 #include <util/stream/mem.h>
+#include <util/system/align.h>
 #include <util/system/file.h>
 #include <util/system/filemap.h>
 #include <util/system/yassert.h>
@@ -17,6 +18,19 @@
 #include <cstring>
 
 namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+inline ui64 CalculatePercentage(ui64 value, ui64 percent)
+{
+    Y_ABORT_UNLESS(percent <= 100, "Invalid percentage %lu", percent);
+
+    return value / 100 * percent + value % 100 * percent / 100;
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -90,6 +104,15 @@ public:
         Stored,
     };
 
+    // When the deallocation condition is met, AnyOp will attempt to shrink the
+    // data area for all operations, while AllocOnlyOp will attempt to shrink it
+    // only during allocations.
+    enum class EShrinkMode
+    {
+        AnyOp = 0,
+        AllocOnlyOp,
+    };
+
     struct TRecordDescriptor
     {
         ui64 DataOffset = 0;
@@ -99,6 +122,12 @@ public:
         ERecordState State = ERecordState::Free;
         ui32 Crc32 = 0;
     };
+
+    static constexpr ui64 DefaultGapSpacePercentageCompactionThreshold = 30;
+    static constexpr ui64 DefaultShrinkLowMemoryOpThreshold = 100;
+    static constexpr ui64 DefaultShrinkTriggerPercent = 25;
+    static constexpr ui64 DefaultShrinkReservePercent = 25;
+    static constexpr EShrinkMode DefaultShrinkMode = EShrinkMode::AllocOnlyOp;
 
 private:
     enum class EDataRetrievalMode
@@ -110,8 +139,15 @@ private:
     TString FileName;
     ui64 MaxRecords = 0;
     ui64 InitialDataAreaSize = 0;
+    ui64 MaxDataAreaStepSize = 0;
     ui64 InitialDataCompactionBufferSize = 0;
-    ui64 GapSpacePercentageCompactionThreshold = 30;
+
+    const ui64 GapSpacePercentageCompactionThreshold;
+    const ui64 ShrinkLowMemoryOpThreshold;
+    const ui64 ShrinkTriggerPercent;
+    const ui64 ShrinkReservePercent;
+    const EShrinkMode ShrinkMode;
+    ui64 LowMemoryOps = 0;
 
     ui64 NextFreeRecordIndex = 0;
     ui64 GapSpaceSize = 0;
@@ -226,16 +262,36 @@ public:
         const TString& fileName,
         ui64 maxRecords,
         ui64 initialDataAreaSize,
+        ui64 maxDataAreaStepSize,
         ui64 initialDataCompactionBufferSize,
-        ui64 gapSpacePercentageCompactionThreshold)
+        ui64 gapSpacePercentageCompactionThreshold,
+        ui64 shrinkLowMemoryOpThreshold,
+        ui64 shrinkTriggerPercent,
+        ui64 shrinkReservePercent,
+        EShrinkMode shrinkMode)
         : FileName(fileName)
         , MaxRecords(maxRecords)
         , InitialDataAreaSize(initialDataAreaSize)
+        , MaxDataAreaStepSize(maxDataAreaStepSize)
         , InitialDataCompactionBufferSize(initialDataCompactionBufferSize)
         , GapSpacePercentageCompactionThreshold(
               gapSpacePercentageCompactionThreshold)
+        , ShrinkLowMemoryOpThreshold(shrinkLowMemoryOpThreshold)
+        , ShrinkTriggerPercent(shrinkTriggerPercent)
+        , ShrinkReservePercent(shrinkReservePercent)
+        , ShrinkMode(shrinkMode)
         , DataAreaSize(initialDataAreaSize)
     {
+        Y_ABORT_UNLESS(
+            InitialDataAreaSize != 0,
+            "InitialDataAreaSize must not be zero");
+        Y_ABORT_UNLESS(
+            IsPowerOf2(InitialDataAreaSize),
+            "InitialDataAreaSize must be power of 2: %lu",
+            InitialDataAreaSize);
+        Y_ABORT_UNLESS(
+            MaxDataAreaStepSize != 0,
+            "MaxDataAreaStepSize must not be zero");
         Init();
     }
 
@@ -288,6 +344,8 @@ public:
         FinishAddRecord();
 
         NextDataOffset += dataSize;
+        UpdateShrinkCounters();
+        TryShrinkDataArea();
 
         return index;
     }
@@ -319,6 +377,10 @@ public:
         GapSpaceSize += DescriptorsPtr[index].DataSize;
 
         FreeRecordIndexes.push_back(index);
+        UpdateShrinkCounters();
+        if (ShrinkMode == EShrinkMode::AnyOp) {
+            TryShrinkDataArea();
+        }
 
         return true;
     }
@@ -326,6 +388,15 @@ public:
     ui64 CountRecords() const
     {
         return NextFreeRecordIndex - FreeRecordIndexes.size();
+    }
+
+    void TryDeallocateMemory()
+    {
+        if (!IsLowMemoryUsage()) {
+            return;
+        }
+
+        ShrinkDataArea();
     }
 
     void Clear()
@@ -529,6 +600,8 @@ private:
 
         ResizeAndRemap();
 
+        ResetShrinkState();
+
         FinishRemoveRecord();
         FinishAddRecord();
 
@@ -536,6 +609,7 @@ private:
 
         CompactRecords();
         CompactDataArea();
+        ShrinkDataArea();
     }
 
     ui64 CalcFileSize(ui64 dataAreaSize)
@@ -653,15 +727,89 @@ private:
 
     void TryCompactDataArea(ui64 requiredRecordDataSize)
     {
-        uint64_t threshold = (InitialDataAreaSize / 100) *
-                                 GapSpacePercentageCompactionThreshold +
-                             ((InitialDataAreaSize % 100) *
-                              GapSpacePercentageCompactionThreshold) /
-                                 100;
-        if (GapSpaceSize > threshold && GapSpaceSize >= requiredRecordDataSize)
-        {
+        const ui64 threshold = CalculatePercentage(
+            DataAreaSize,
+            GapSpacePercentageCompactionThreshold);
+        const bool shouldCompact =
+            GapSpaceSize > threshold || GapSpaceSize > MaxDataAreaStepSize;
+        if (shouldCompact && GapSpaceSize >= requiredRecordDataSize) {
             CompactDataArea();
         }
+    }
+
+private:
+    void UpdateShrinkCounters()
+    {
+        if (IsLowMemoryUsage()) {
+            ++LowMemoryOps;
+        } else {
+            LowMemoryOps = 0;
+        }
+    }
+
+    void TryShrinkDataArea()
+    {
+        if (LowMemoryOps < ShrinkLowMemoryOpThreshold) {
+            return;
+        }
+
+        ShrinkDataArea();
+    }
+
+    ui64 CalcShrinkTargetSize()
+    {
+        const ui64 live = GetLiveDataSize();
+        const ui64 shrinkTriggerThreshold =
+            CalculatePercentage(DataAreaSize, ShrinkTriggerPercent);
+
+        ui64 reserve = InitialDataAreaSize;
+        const ui64 percentReserve =
+            CalculatePercentage(live, ShrinkReservePercent);
+        if (reserve < percentReserve) {
+            reserve = percentReserve;
+        }
+
+        if (live > shrinkTriggerThreshold &&
+            DataAreaSize - live >= MaxDataAreaStepSize)
+        {
+            const ui64 maxStepReserve = MaxDataAreaStepSize / 2;
+            if (reserve < maxStepReserve) {
+                reserve = maxStepReserve;
+            }
+        }
+
+        if (reserve > MaxDataAreaStepSize) {
+            reserve = MaxDataAreaStepSize;
+        }
+
+        ui64 target = live + reserve;
+        target = AlignUp(target, InitialDataAreaSize);
+
+        if (target > DataAreaSize) {
+            return DataAreaSize;
+        }
+
+        return target;
+    }
+
+    void ShrinkDataArea()
+    {
+        if (GapSpaceSize != 0) {
+            CompactDataArea();
+        }
+
+        const ui64 newDataAreaSize = CalcShrinkTargetSize();
+        if (newDataAreaSize == DataAreaSize) {
+            ResetShrinkState();
+            return;
+        }
+
+        DataAreaSize = newDataAreaSize;
+        HeaderPtr->DataAreaSize = newDataAreaSize;
+
+        ResizeAndRemap();
+
+        ResetShrinkState();
     }
 
     void CompactDataArea()
@@ -737,14 +885,39 @@ private:
     void ExpandDataArea(ui64 requiredRecordDataSize)
     {
         ui64 newDataAreaSize = DataAreaSize;
-        while (NextDataOffset + requiredRecordDataSize > newDataAreaSize) {
-            newDataAreaSize *= 2;
+        while (requiredRecordDataSize > newDataAreaSize - NextDataOffset) {
+            const ui64 dataAreaStepSize = newDataAreaSize < MaxDataAreaStepSize
+                                              ? newDataAreaSize
+                                              : MaxDataAreaStepSize;
+
+            newDataAreaSize += dataAreaStepSize;
         }
 
         DataAreaSize = newDataAreaSize;
         HeaderPtr->DataAreaSize = DataAreaSize;
 
         ResizeAndRemap();
+
+        ResetShrinkState();
+    }
+
+    ui64 GetLiveDataSize() const
+    {
+        return NextDataOffset - GapSpaceSize;
+    }
+
+    bool IsLowMemoryUsage() const
+    {
+        const ui64 live = GetLiveDataSize();
+        const ui64 threshold =
+            CalculatePercentage(DataAreaSize, ShrinkTriggerPercent);
+        return live <= threshold ||
+               (DataAreaSize - live >= MaxDataAreaStepSize);
+    }
+
+    void ResetShrinkState()
+    {
+        LowMemoryOps = 0;
     }
 
     void ResizeAndRemap()

--- a/cloud/storage/core/libs/common/dynamic_persistent_table.h
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "numeric.h"
+
 #include <library/cpp/digest/crc32c/crc32c.h>
 
 #include <util/generic/deque.h>
@@ -21,16 +23,29 @@ namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace {
-
-inline ui64 CalculatePercentage(ui64 value, ui64 percent)
+// When the deallocation condition is met, AnyOp will attempt to shrink the
+// data area for all operations, while AllocOnlyOp will attempt to shrink it
+// only during allocations.
+enum class EDynamicPersistentTableShrinkMode
 {
-    Y_ABORT_UNLESS(percent <= 100, "Invalid percentage %lu", percent);
+    AnyOp = 0,
+    AllocOnlyOp,
+};
 
-    return value / 100 * percent + value % 100 * percent / 100;
-}
+struct TDynamicPersistentTableConfig
+{
+    using EShrinkMode = EDynamicPersistentTableShrinkMode;
 
-}   // namespace
+    const ui64 MaxRecords;
+    const ui64 InitialDataAreaSize;
+    const ui64 MaxDataAreaStepSize;
+    const ui64 InitialDataCompactionBufferSize;
+    const ui64 GapSpacePercentageCompactionThreshold = 30;
+    const ui64 ShrinkLowMemoryOpThreshold = 100;
+    const ui64 ShrinkTriggerPercent = 25;
+    const ui64 ShrinkReservePercent = 25;
+    const EShrinkMode ShrinkMode = EShrinkMode::AllocOnlyOp;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -62,6 +77,8 @@ template <typename H>
 class TDynamicPersistentTable
 {
 public:
+    using EShrinkMode = TDynamicPersistentTableConfig::EShrinkMode;
+
     enum class EListOperationState
     {
         None = 0,
@@ -104,15 +121,6 @@ public:
         Stored,
     };
 
-    // When the deallocation condition is met, AnyOp will attempt to shrink the
-    // data area for all operations, while AllocOnlyOp will attempt to shrink it
-    // only during allocations.
-    enum class EShrinkMode
-    {
-        AnyOp = 0,
-        AllocOnlyOp,
-    };
-
     struct TRecordDescriptor
     {
         ui64 DataOffset = 0;
@@ -123,12 +131,6 @@ public:
         ui32 Crc32 = 0;
     };
 
-    static constexpr ui64 DefaultGapSpacePercentageCompactionThreshold = 30;
-    static constexpr ui64 DefaultShrinkLowMemoryOpThreshold = 100;
-    static constexpr ui64 DefaultShrinkTriggerPercent = 25;
-    static constexpr ui64 DefaultShrinkReservePercent = 25;
-    static constexpr EShrinkMode DefaultShrinkMode = EShrinkMode::AllocOnlyOp;
-
 private:
     enum class EDataRetrievalMode
     {
@@ -137,16 +139,8 @@ private:
     };
 
     TString FileName;
+    const TDynamicPersistentTableConfig Config;
     ui64 MaxRecords = 0;
-    ui64 InitialDataAreaSize = 0;
-    ui64 MaxDataAreaStepSize = 0;
-    ui64 InitialDataCompactionBufferSize = 0;
-
-    const ui64 GapSpacePercentageCompactionThreshold;
-    const ui64 ShrinkLowMemoryOpThreshold;
-    const ui64 ShrinkTriggerPercent;
-    const ui64 ShrinkReservePercent;
-    const EShrinkMode ShrinkMode;
     ui64 LowMemoryOps = 0;
 
     ui64 NextFreeRecordIndex = 0;
@@ -260,37 +254,21 @@ public:
 public:
     TDynamicPersistentTable(
         const TString& fileName,
-        ui64 maxRecords,
-        ui64 initialDataAreaSize,
-        ui64 maxDataAreaStepSize,
-        ui64 initialDataCompactionBufferSize,
-        ui64 gapSpacePercentageCompactionThreshold,
-        ui64 shrinkLowMemoryOpThreshold,
-        ui64 shrinkTriggerPercent,
-        ui64 shrinkReservePercent,
-        EShrinkMode shrinkMode)
+        const TDynamicPersistentTableConfig& config)
         : FileName(fileName)
-        , MaxRecords(maxRecords)
-        , InitialDataAreaSize(initialDataAreaSize)
-        , MaxDataAreaStepSize(maxDataAreaStepSize)
-        , InitialDataCompactionBufferSize(initialDataCompactionBufferSize)
-        , GapSpacePercentageCompactionThreshold(
-              gapSpacePercentageCompactionThreshold)
-        , ShrinkLowMemoryOpThreshold(shrinkLowMemoryOpThreshold)
-        , ShrinkTriggerPercent(shrinkTriggerPercent)
-        , ShrinkReservePercent(shrinkReservePercent)
-        , ShrinkMode(shrinkMode)
-        , DataAreaSize(initialDataAreaSize)
+        , Config(config)
+        , MaxRecords(config.MaxRecords)
+        , DataAreaSize(config.InitialDataAreaSize)
     {
         Y_ABORT_UNLESS(
-            InitialDataAreaSize != 0,
+            Config.InitialDataAreaSize != 0,
             "InitialDataAreaSize must not be zero");
         Y_ABORT_UNLESS(
-            IsPowerOf2(InitialDataAreaSize),
+            IsPowerOf2(Config.InitialDataAreaSize),
             "InitialDataAreaSize must be power of 2: %lu",
-            InitialDataAreaSize);
+            Config.InitialDataAreaSize);
         Y_ABORT_UNLESS(
-            MaxDataAreaStepSize != 0,
+            Config.MaxDataAreaStepSize != 0,
             "MaxDataAreaStepSize must not be zero");
         Init();
     }
@@ -378,7 +356,7 @@ public:
 
         FreeRecordIndexes.push_back(index);
         UpdateShrinkCounters();
-        if (ShrinkMode == EShrinkMode::AnyOp) {
+        if (Config.ShrinkMode == EShrinkMode::AnyOp) {
             TryShrinkDataArea();
         }
 
@@ -573,7 +551,7 @@ private:
                 sizeof(THeader) + MaxRecords * sizeof(TRecordDescriptor);
             HeaderPtr->DataAreaSize = DataAreaSize;
             HeaderPtr->DataCompactionBufferSize =
-                InitialDataCompactionBufferSize;
+                Config.InitialDataCompactionBufferSize;
             HeaderPtr->CompactedRecordSrcIndex = InvalidIndex;
             HeaderPtr->CompactedRecordDstIndex = InvalidIndex;
         }
@@ -727,11 +705,11 @@ private:
 
     void TryCompactDataArea(ui64 requiredRecordDataSize)
     {
-        const ui64 threshold = CalculatePercentage(
+        const ui64 threshold = PercentOf(
             DataAreaSize,
-            GapSpacePercentageCompactionThreshold);
-        const bool shouldCompact =
-            GapSpaceSize > threshold || GapSpaceSize > MaxDataAreaStepSize;
+            Config.GapSpacePercentageCompactionThreshold);
+        const bool shouldCompact = GapSpaceSize > threshold ||
+                                   GapSpaceSize > Config.MaxDataAreaStepSize;
         if (shouldCompact && GapSpaceSize >= requiredRecordDataSize) {
             CompactDataArea();
         }
@@ -749,7 +727,7 @@ private:
 
     void TryShrinkDataArea()
     {
-        if (LowMemoryOps < ShrinkLowMemoryOpThreshold) {
+        if (LowMemoryOps < Config.ShrinkLowMemoryOpThreshold) {
             return;
         }
 
@@ -760,30 +738,30 @@ private:
     {
         const ui64 live = GetLiveDataSize();
         const ui64 shrinkTriggerThreshold =
-            CalculatePercentage(DataAreaSize, ShrinkTriggerPercent);
+            PercentOf(DataAreaSize, Config.ShrinkTriggerPercent);
 
-        ui64 reserve = InitialDataAreaSize;
+        ui64 reserve = Config.InitialDataAreaSize;
         const ui64 percentReserve =
-            CalculatePercentage(live, ShrinkReservePercent);
+            PercentOf(live, Config.ShrinkReservePercent);
         if (reserve < percentReserve) {
             reserve = percentReserve;
         }
 
         if (live > shrinkTriggerThreshold &&
-            DataAreaSize - live >= MaxDataAreaStepSize)
+            DataAreaSize - live >= Config.MaxDataAreaStepSize)
         {
-            const ui64 maxStepReserve = MaxDataAreaStepSize / 2;
+            const ui64 maxStepReserve = Config.MaxDataAreaStepSize / 2;
             if (reserve < maxStepReserve) {
                 reserve = maxStepReserve;
             }
         }
 
-        if (reserve > MaxDataAreaStepSize) {
-            reserve = MaxDataAreaStepSize;
+        if (reserve > Config.MaxDataAreaStepSize) {
+            reserve = Config.MaxDataAreaStepSize;
         }
 
         ui64 target = live + reserve;
-        target = AlignUp(target, InitialDataAreaSize);
+        target = AlignUp(target, Config.InitialDataAreaSize);
 
         if (target > DataAreaSize) {
             return DataAreaSize;
@@ -879,16 +857,18 @@ private:
 
         HeaderPtr->DataCompactionRecordIndex = InvalidIndex;
 
-        HeaderPtr->DataCompactionBufferSize = InitialDataCompactionBufferSize;
+        HeaderPtr->DataCompactionBufferSize =
+            Config.InitialDataCompactionBufferSize;
     }
 
     void ExpandDataArea(ui64 requiredRecordDataSize)
     {
         ui64 newDataAreaSize = DataAreaSize;
         while (requiredRecordDataSize > newDataAreaSize - NextDataOffset) {
-            const ui64 dataAreaStepSize = newDataAreaSize < MaxDataAreaStepSize
-                                              ? newDataAreaSize
-                                              : MaxDataAreaStepSize;
+            const ui64 dataAreaStepSize =
+                newDataAreaSize < Config.MaxDataAreaStepSize
+                    ? newDataAreaSize
+                    : Config.MaxDataAreaStepSize;
 
             newDataAreaSize += dataAreaStepSize;
         }
@@ -910,9 +890,9 @@ private:
     {
         const ui64 live = GetLiveDataSize();
         const ui64 threshold =
-            CalculatePercentage(DataAreaSize, ShrinkTriggerPercent);
+            PercentOf(DataAreaSize, Config.ShrinkTriggerPercent);
         return live <= threshold ||
-               (DataAreaSize - live >= MaxDataAreaStepSize);
+               (DataAreaSize - live >= Config.MaxDataAreaStepSize);
     }
 
     void ResetShrinkState()

--- a/cloud/storage/core/libs/common/dynamic_persistent_table.h
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table.h
@@ -34,17 +34,16 @@ enum class EDynamicPersistentTableShrinkMode
 
 struct TDynamicPersistentTableConfig
 {
-    using EShrinkMode = EDynamicPersistentTableShrinkMode;
-
-    const ui64 MaxRecords;
-    const ui64 InitialDataAreaSize;
-    const ui64 MaxDataAreaStepSize;
-    const ui64 InitialDataCompactionBufferSize;
-    const ui64 GapSpacePercentageCompactionThreshold = 30;
-    const ui64 ShrinkLowMemoryOpThreshold = 100;
-    const ui64 ShrinkTriggerPercent = 25;
-    const ui64 ShrinkReservePercent = 25;
-    const EShrinkMode ShrinkMode = EShrinkMode::AllocOnlyOp;
+    ui64 MaxRecords = 0;
+    ui64 InitialDataAreaSize = 0;
+    ui64 MaxDataAreaStepSize = 0;
+    ui64 InitialDataCompactionBufferSize = 0;
+    ui64 GapSpacePercentageCompactionThreshold = 30;
+    ui64 ShrinkLowMemoryOpThreshold = 100;
+    ui64 ShrinkTriggerPercent = 25;
+    ui64 ShrinkReservePercent = 25;
+    EDynamicPersistentTableShrinkMode ShrinkMode =
+        EDynamicPersistentTableShrinkMode::AllocOnlyOp;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,8 +76,6 @@ template <typename H>
 class TDynamicPersistentTable
 {
 public:
-    using EShrinkMode = TDynamicPersistentTableConfig::EShrinkMode;
-
     enum class EListOperationState
     {
         None = 0,
@@ -260,6 +257,7 @@ public:
         , MaxRecords(config.MaxRecords)
         , DataAreaSize(config.InitialDataAreaSize)
     {
+        Y_ABORT_UNLESS(Config.MaxRecords != 0, "MaxRecords must not be zero");
         Y_ABORT_UNLESS(
             Config.InitialDataAreaSize != 0,
             "InitialDataAreaSize must not be zero");
@@ -356,7 +354,7 @@ public:
 
         FreeRecordIndexes.push_back(index);
         UpdateShrinkCounters();
-        if (Config.ShrinkMode == EShrinkMode::AnyOp) {
+        if (Config.ShrinkMode == EDynamicPersistentTableShrinkMode::AnyOp) {
             TryShrinkDataArea();
         }
 

--- a/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
@@ -1090,7 +1090,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
                 .MaxDataAreaStepSize = 1_GB,
                 .InitialDataCompactionBufferSize = 1_KB,
                 .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
-                .ShrinkMode = TTable::EShrinkMode::AnyOp,
+                .ShrinkMode = EDynamicPersistentTableShrinkMode::AnyOp,
             });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
@@ -1404,7 +1404,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
                 .MaxDataAreaStepSize = maxDataAreaStepSize,
                 .InitialDataCompactionBufferSize = 1_KB,
                 .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
-                .ShrinkMode = TTable::EShrinkMode::AnyOp,
+                .ShrinkMode = EDynamicPersistentTableShrinkMode::AnyOp,
             });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);

--- a/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
@@ -4,6 +4,7 @@
 
 #include <util/folder/tempdir.h>
 #include <util/generic/map.h>
+#include <util/generic/size_literals.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 #include <util/random/random.h>
@@ -107,6 +108,32 @@ struct TTestData
 
 using TTable = TDynamicPersistentTable<TTestHeader>;
 
+TTable CreateTable(
+    const TString& fileName,
+    ui64 maxRecords,
+    ui64 initialDataAreaSize,
+    ui64 maxDataAreaStepSize = 1_GB,
+    ui64 initialDataCompactionBufferSize = 100,
+    ui64 gapSpacePercentageCompactionThreshold =
+        TTable::DefaultGapSpacePercentageCompactionThreshold,
+    ui64 shrinkLowMemoryOpThreshold = TTable::DefaultShrinkLowMemoryOpThreshold,
+    ui64 shrinkTriggerPercent = TTable::DefaultShrinkTriggerPercent,
+    ui64 shrinkReservePercent = TTable::DefaultShrinkReservePercent,
+    TTable::EShrinkMode shrinkMode = TTable::DefaultShrinkMode)
+{
+    return TTable(
+        fileName,
+        maxRecords,
+        initialDataAreaSize,
+        maxDataAreaStepSize,
+        initialDataCompactionBufferSize,
+        gapSpacePercentageCompactionThreshold,
+        shrinkLowMemoryOpThreshold,
+        shrinkTriggerPercent,
+        shrinkReservePercent,
+        shrinkMode);
+}
+
 // Helper functions for accessing internal table structures
 TTable::THeader* GetTableHeader(TTable& table)
 {
@@ -129,6 +156,33 @@ GetTableInternals(TTable& table)
         reinterpret_cast<char*>(tableHeader) + tableHeader->DataAreaOffset;
 
     return std::make_tuple(tableHeader, descriptorsPtr, dataPtr);
+}
+
+ui64 AllocAndCommitRecord(TTable& table, const TString& data)
+{
+    ui64 index = table.AllocRecord(data.size());
+    UNIT_ASSERT_VALUES_UNEQUAL(TTable::InvalidIndex, index);
+    UNIT_ASSERT(table.WriteRecordData(index, data.data(), data.size()));
+    UNIT_ASSERT(table.CommitRecord(index));
+    return index;
+}
+
+TVector<ui64>
+FillTable(TTable& table, ui64 recordsCount, const TString& payload)
+{
+    TVector<ui64> indices;
+    indices.reserve(recordsCount);
+    for (ui64 i = 0; i < recordsCount; ++i) {
+        indices.push_back(AllocAndCommitRecord(table, payload));
+    }
+    return indices;
+}
+
+void DeleteRecords(TTable& table, const TVector<ui64>& indices, ui64 fromIndex)
+{
+    for (ui64 i = fromIndex; i < indices.size(); ++i) {
+        UNIT_ASSERT(table.DeleteRecord(indices[i]));
+    }
 }
 
 TVector<TTestData> TestDataRecords = {
@@ -238,8 +292,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TString tablePath = tempDir.Path() / "test.table";
 
         {
-            TDynamicPersistentTable<TTestHeader>
-                table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             UNIT_ASSERT_VALUES_EQUAL(0, table.CountRecords());
 
             auto* header = table.HeaderData();
@@ -248,8 +301,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TDynamicPersistentTable<TTestHeader>
-                table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             UNIT_ASSERT_VALUES_EQUAL(0, table.CountRecords());
             UNIT_ASSERT_VALUES_EQUAL(42, table.HeaderData()->Val);
         }
@@ -260,8 +312,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader>
-            table(tablePath, 32, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 32, 1024);
 
         TTestData smallData{1, "small", {1, 2, 3}};
         TTestData largeData{
@@ -310,8 +361,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader>
-            table(tablePath, 32, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 32, 1024);
 
         TVector<TTestData> testRecords = {
             {1, "first", {1, 2}},
@@ -354,8 +404,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader>
-            table(tablePath, 32, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 32, 1024);
 
         TTestData data1{1, "first", {1, 2}};
         TTestData data2{2, "second", {3, 4}};
@@ -391,7 +440,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader> table(tablePath, 4, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 4, 1024);
 
         TVector<ui64> indices;
         for (int i = 0; i < 4; ++i) {
@@ -439,8 +488,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             {200, "persistent_second", {40, 50, 60, 70}}};
 
         {
-            TDynamicPersistentTable<TTestHeader>
-                table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             table.HeaderData()->Val = 123;
 
             for (const auto& data: testData) {
@@ -457,8 +505,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TDynamicPersistentTable<TTestHeader>
-                table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             UNIT_ASSERT_VALUES_EQUAL(123, table.HeaderData()->Val);
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
 
@@ -498,8 +545,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         ui64 index2 = TDynamicPersistentTable<TTestHeader>::InvalidIndex;
 
         {
-            TDynamicPersistentTable<TTestHeader>
-                table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             table.HeaderData()->Val = 123;
 
             TString serialized = testData[0].Serialize();
@@ -534,8 +580,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TDynamicPersistentTable<TTestHeader>
-                table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             UNIT_ASSERT_VALUES_EQUAL(123, table.HeaderData()->Val);
             UNIT_ASSERT_VALUES_EQUAL(2, table.CountRecords());
 
@@ -557,8 +602,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader>
-            table(tablePath, 100, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 100, 1024);
 
         TVector<ui64> indices;
         for (int i = 0; i < 50; ++i) {
@@ -597,7 +641,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader> table(tablePath, 10, 256, 100, 30);
+        auto table = CreateTable(tablePath, 10, 256);
 
         TVector<ui64> indices;
         size_t totalUsed = 0;
@@ -642,8 +686,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader>
-            table(tablePath, 32, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 32, 1024);
 
         TTestData originalData{
             1,
@@ -690,7 +733,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader> table(tablePath, 20, 512, 100, 30);
+        auto table = CreateTable(tablePath, 20, 512);
 
         TVector<ui64> indices;
         for (int i = 0; i < 10; ++i) {
@@ -758,7 +801,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader> table(tablePath, 3, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 3, 1024);
 
         TVector<ui64> indices;
 
@@ -817,8 +860,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTempDir tempDir;
         TString tablePath = tempDir.Path() / "test.table";
 
-        TDynamicPersistentTable<TTestHeader>
-            table(tablePath, 32, 1024, 100, 30);
+        auto table = CreateTable(tablePath, 32, 1024);
 
         ui64 index = table.AllocRecord(0);
         UNIT_ASSERT(
@@ -871,6 +913,491 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         UNIT_ASSERT_VALUES_EQUAL(2, table.CountRecords());
     }
 
+    Y_UNIT_TEST(ShouldShrinkDataAreaOnStartupAfterHistoricalSpike)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "startup_shrink.table";
+
+        const ui64 initialDataAreaSize = 4_KB;
+        const ui64 dataSize = 1_KB;
+        const ui32 totalRecords = 9;
+        const ui32 keptRecords = 2;
+
+        TVector<ui64> indices;
+        TVector<TString> keptPayloads;
+        ui64 grownDataAreaSize = 0;
+
+        {
+            auto table =
+                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 8_KB);
+
+            for (ui32 i = 0; i < totalRecords; ++i) {
+                TString payload(dataSize, static_cast<char>('a' + (i % 26)));
+
+                indices.push_back(AllocAndCommitRecord(table, payload));
+                if (i < keptRecords) {
+                    keptPayloads.push_back(payload);
+                }
+            }
+
+            grownDataAreaSize = GetTableHeader(table)->DataAreaSize;
+            UNIT_ASSERT_VALUES_EQUAL(16_KB, grownDataAreaSize);
+
+            for (ui32 i = keptRecords; i < indices.size(); ++i) {
+                UNIT_ASSERT(table.DeleteRecord(indices[i]));
+            }
+            UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+        }
+
+        {
+            auto table =
+                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 8_KB);
+
+            auto* header = GetTableHeader(table);
+            UNIT_ASSERT_VALUES_EQUAL(8_KB, header->DataAreaSize);
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                header->DataAreaSize % initialDataAreaSize);
+            UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+
+            for (ui32 i = 0; i < keptRecords; ++i) {
+                TStringBuf record = table.GetRecordWithValidation(i);
+                UNIT_ASSERT_VALUES_EQUAL(keptPayloads[i], TString(record));
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ShouldShrinkAfterAllocationOnLowMemoryOp)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "runtime_shrink_alloc.table";
+
+        const ui64 initialDataAreaSize = 4_KB;
+        const TString payload(1_KB, 'a');
+        const ui64 shrinkLowMemoryOpThreshold = 3;
+        const ui64 totalRecords = 9;
+        const ui64 keptRecords = 3;
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            1_GB,
+            1_KB,
+            TTable::DefaultGapSpacePercentageCompactionThreshold,
+            shrinkLowMemoryOpThreshold);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+
+        auto* header = GetTableHeader(table);
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, header->DataAreaSize);
+        UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
+
+        DeleteRecords(table, indices, keptRecords);
+        UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+
+        const ui64 dataAreaSizeBeforeShrink =
+            GetTableHeader(table)->DataAreaSize;
+        const ui64 newIndex = AllocAndCommitRecord(table, payload);
+        const ui64 dataAreaSizeAfterShrink =
+            GetTableHeader(table)->DataAreaSize;
+
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, dataAreaSizeBeforeShrink);
+        UNIT_ASSERT_VALUES_EQUAL(8_KB, dataAreaSizeAfterShrink);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            dataAreaSizeAfterShrink % initialDataAreaSize);
+
+        TStringBuf firstRecord = table.GetRecordWithValidation(indices.front());
+        UNIT_ASSERT_VALUES_EQUAL(payload, TString(firstRecord));
+
+        TStringBuf newRecord = table.GetRecordWithValidation(newIndex);
+        UNIT_ASSERT_VALUES_EQUAL(payload, TString(newRecord));
+    }
+
+    Y_UNIT_TEST(ShouldNotShrinkOnManyDeletionsInAllocOnlyModeUntilAllocation)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "runtime_shrink_alloc_only.table";
+
+        const ui64 initialDataAreaSize = 4_KB;
+        const TString payload(1_KB, 'p');
+        const ui64 shrinkLowMemoryOpThreshold = 1;
+        const ui64 totalRecords = 16;
+        const ui64 keptRecords = 1;
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            1_GB,
+            1_KB,
+            TTable::DefaultGapSpacePercentageCompactionThreshold,
+            shrinkLowMemoryOpThreshold);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+
+        auto* header = GetTableHeader(table);
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, header->DataAreaSize);
+        UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
+
+        DeleteRecords(table, indices, keptRecords);
+        UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+
+        const ui64 dataAreaSizeAfterDeletes =
+            GetTableHeader(table)->DataAreaSize;
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, dataAreaSizeAfterDeletes);
+
+        const ui64 newIndex = AllocAndCommitRecord(table, payload);
+        const ui64 dataAreaSizeAfterShrink =
+            GetTableHeader(table)->DataAreaSize;
+
+        UNIT_ASSERT_VALUES_EQUAL(8_KB, dataAreaSizeAfterShrink);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            dataAreaSizeAfterShrink % initialDataAreaSize);
+
+        TStringBuf firstRecord = table.GetRecordWithValidation(indices.front());
+        UNIT_ASSERT_VALUES_EQUAL(payload, TString(firstRecord));
+
+        TStringBuf newRecord = table.GetRecordWithValidation(newIndex);
+        UNIT_ASSERT_VALUES_EQUAL(payload, TString(newRecord));
+    }
+
+    Y_UNIT_TEST(ShouldShrinkAfterDeletionOnNextLowMemoryOpInAnyOpMode)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "runtime_shrink_threshold.table";
+
+        const ui64 initialDataAreaSize = 4_KB;
+        const TString payload(1_KB, 'h');
+        const ui64 shrinkLowMemoryOpThreshold = 4;
+        const ui64 totalRecords = 9;
+        const ui64 keptRecords = 3;
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            1_GB,
+            1_KB,
+            TTable::DefaultGapSpacePercentageCompactionThreshold,
+            shrinkLowMemoryOpThreshold,
+            TTable::DefaultShrinkTriggerPercent,
+            TTable::DefaultShrinkReservePercent,
+            TTable::EShrinkMode::AnyOp);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+
+        auto* header = GetTableHeader(table);
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, header->DataAreaSize);
+        UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
+
+        DeleteRecords(table, indices, keptRecords);
+        UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+
+        const ui64 dataAreaSizeBeforeAlloc =
+            GetTableHeader(table)->DataAreaSize;
+        const ui64 newIndex = AllocAndCommitRecord(table, payload);
+        UNIT_ASSERT_VALUES_EQUAL(
+            dataAreaSizeBeforeAlloc,
+            GetTableHeader(table)->DataAreaSize);
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, dataAreaSizeBeforeAlloc);
+
+        const ui64 dataAreaSizeBeforeShrink =
+            GetTableHeader(table)->DataAreaSize;
+        UNIT_ASSERT(table.DeleteRecord(newIndex));
+        UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+
+        const ui64 dataAreaSizeAfterShrink =
+            GetTableHeader(table)->DataAreaSize;
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, dataAreaSizeBeforeShrink);
+        UNIT_ASSERT_VALUES_EQUAL(8_KB, dataAreaSizeAfterShrink);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            dataAreaSizeAfterShrink % initialDataAreaSize);
+    }
+
+    Y_UNIT_TEST(
+        ShouldForceDeallocateMemoryWhenUsageIsLowButLowMemoryOpThresholdNotReady)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "manual_deallocate.table";
+
+        const ui64 initialDataAreaSize = 4_KB;
+        const TString payload(1_KB, 'd');
+        const ui64 shrinkLowMemoryOpThreshold = 100;
+        const ui64 totalRecords = 9;
+        const ui64 keptRecords = 3;
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            1_GB,
+            1_KB,
+            TTable::DefaultGapSpacePercentageCompactionThreshold,
+            shrinkLowMemoryOpThreshold);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, GetTableHeader(table)->DataAreaSize);
+        table.TryDeallocateMemory();
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, GetTableHeader(table)->DataAreaSize);
+
+        DeleteRecords(table, indices, keptRecords);
+
+        const ui64 dataAreaSizeBeforeShrink =
+            GetTableHeader(table)->DataAreaSize;
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, dataAreaSizeBeforeShrink);
+
+        table.TryDeallocateMemory();
+
+        const ui64 dataAreaSizeAfterShrink =
+            GetTableHeader(table)->DataAreaSize;
+        UNIT_ASSERT_VALUES_EQUAL(8_KB, dataAreaSizeAfterShrink);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            dataAreaSizeAfterShrink % initialDataAreaSize);
+    }
+
+    Y_UNIT_TEST(ShouldAvoidShrinkOscillationWhenLowUtilizationIsBrief)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "no_oscillation.table";
+
+        const ui64 initialDataAreaSize = 4_KB;
+        const TString payload(1_KB, 'o');
+        const ui64 shrinkLowMemoryOpThreshold = 2;
+        const ui64 totalRecords = 16;
+        const ui64 keptRecords = 4;
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            1_GB,
+            1_KB,
+            TTable::DefaultGapSpacePercentageCompactionThreshold,
+            shrinkLowMemoryOpThreshold);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+        UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, GetTableHeader(table)->DataAreaSize);
+
+        DeleteRecords(table, indices, keptRecords);
+        UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+
+        const ui64 dataAreaSizeBeforeCompaction =
+            GetTableHeader(table)->DataAreaSize;
+
+        // Deleting down to 4 records enters low-memory mode only once, so
+        // the next mutation must compact but still must not shrink.
+        AllocAndCommitRecord(table, payload);
+        const ui64 dataAreaSizeAfterFirstCompaction =
+            GetTableHeader(table)->DataAreaSize;
+        UNIT_ASSERT_VALUES_EQUAL(
+            dataAreaSizeBeforeCompaction,
+            dataAreaSizeAfterFirstCompaction);
+
+        // Once allocation leaves the low-memory zone, the counter is reset.
+        AllocAndCommitRecord(table, payload);
+        const ui64 dataAreaSizeAfterSecondAlloc =
+            GetTableHeader(table)->DataAreaSize;
+        UNIT_ASSERT_VALUES_EQUAL(
+            dataAreaSizeBeforeCompaction,
+            dataAreaSizeAfterSecondAlloc);
+    }
+
+    Y_UNIT_TEST(ShouldShrinkEmptyTableToInitialDataAreaOnStartup)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "empty_startup_shrink.table";
+
+        const ui64 initialDataAreaSize = 4_KB;
+        const TString payload(1_KB, 'e');
+        const ui64 totalRecords = 9;
+
+        TVector<ui64> indices;
+
+        {
+            auto table =
+                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 1_KB);
+            indices = FillTable(table, totalRecords, payload);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                16_KB,
+                GetTableHeader(table)->DataAreaSize);
+
+            DeleteRecords(table, indices, 0);
+            UNIT_ASSERT_VALUES_EQUAL(0, table.CountRecords());
+        }
+
+        {
+            auto table =
+                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 1_KB);
+            auto* header = GetTableHeader(table);
+
+            UNIT_ASSERT_VALUES_EQUAL(0, table.CountRecords());
+            UNIT_ASSERT_VALUES_EQUAL(initialDataAreaSize, header->DataAreaSize);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldUseCurrentDataAreaSizeForCompactionThreshold)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "current_threshold.table";
+
+        const ui64 initialDataAreaSize = 1_KB;
+        const TString payload(1_KB, 't');
+        const ui64 totalRecords = 8;
+
+        auto table =
+            CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 1_KB);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+        UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
+
+        auto* tableHeader = GetTableHeader(table);
+        UNIT_ASSERT_VALUES_EQUAL(8_KB, tableHeader->DataAreaSize);
+
+        UNIT_ASSERT(table.DeleteRecord(indices[2]));
+        UNIT_ASSERT(table.DeleteRecord(indices[3]));
+
+        const ui64 dataAreaSizeBefore = tableHeader->DataAreaSize;
+        AllocAndCommitRecord(table, payload);
+        const ui64 dataAreaSizeAfter = GetTableHeader(table)->DataAreaSize;
+
+        UNIT_ASSERT(dataAreaSizeAfter > dataAreaSizeBefore);
+    }
+
+    Y_UNIT_TEST(ShouldCompactWhenGapExceedsMaxStepWithoutPercentThreshold)
+    {
+        TTempDir tempDir;
+        TString tablePath =
+            tempDir.Path() / "max_step_compaction_threshold.table";
+
+        const ui64 initialDataAreaSize = 1_KB;
+        const ui64 maxDataAreaStepSize = 4_KB;
+        const TString payload(1_KB, 'm');
+        const ui64 totalRecords = 8;
+        const ui64 keptRecords = 3;
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            maxDataAreaStepSize,
+            1_KB,
+            100);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+        UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
+
+        auto* tableHeader = GetTableHeader(table);
+        UNIT_ASSERT_VALUES_EQUAL(8_KB, tableHeader->DataAreaSize);
+
+        DeleteRecords(table, indices, keptRecords);
+
+        const ui64 dataAreaSizeBefore = tableHeader->DataAreaSize;
+        AllocAndCommitRecord(table, payload);
+        const ui64 dataAreaSizeAfter = GetTableHeader(table)->DataAreaSize;
+
+        UNIT_ASSERT_VALUES_EQUAL(dataAreaSizeBefore, dataAreaSizeAfter);
+    }
+
+    Y_UNIT_TEST(ShouldLimitDataAreaGrowthStep)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "max_growth_step.table";
+
+        const ui64 initialDataAreaSize = 1_KB;
+        const ui64 maxDataAreaStepSize = 4_KB;
+        const TString payload(1_KB, 's');
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            maxDataAreaStepSize,
+            4_KB);
+
+        auto assertDataAreaSize = [&](ui64 expectedSize)
+        {
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedSize,
+                GetTableHeader(table)->DataAreaSize);
+        };
+
+        AllocAndCommitRecord(table, payload);
+        assertDataAreaSize(1_KB);
+
+        AllocAndCommitRecord(table, payload);
+        assertDataAreaSize(2_KB);
+
+        AllocAndCommitRecord(table, payload);
+        assertDataAreaSize(4_KB);
+
+        for (ui32 i = 0; i < 2; ++i) {
+            AllocAndCommitRecord(table, payload);
+        }
+        assertDataAreaSize(8_KB);
+
+        for (ui32 i = 0; i < 4; ++i) {
+            AllocAndCommitRecord(table, payload);
+        }
+        assertDataAreaSize(12_KB);
+
+        for (ui32 i = 0; i < 4; ++i) {
+            AllocAndCommitRecord(table, payload);
+        }
+        assertDataAreaSize(16_KB);
+    }
+
+    Y_UNIT_TEST(ShouldUseHalfMaxStepReserveWhenShrinkTriggeredByMaxStep)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "max_growth_step_shrink.table";
+
+        const ui64 initialDataAreaSize = 1_KB;
+        const ui64 maxDataAreaStepSize = 8_KB;
+        const TString payload(1_KB, 'r');
+        const ui64 shrinkLowMemoryOpThreshold = 4;
+        const ui64 totalRecords = 16;
+        const ui64 keptRecords = 7;
+
+        auto table = CreateTable(
+            tablePath,
+            32,
+            initialDataAreaSize,
+            maxDataAreaStepSize,
+            1_KB,
+            TTable::DefaultGapSpacePercentageCompactionThreshold,
+            shrinkLowMemoryOpThreshold,
+            TTable::DefaultShrinkTriggerPercent,
+            TTable::DefaultShrinkReservePercent,
+            TTable::EShrinkMode::AnyOp);
+
+        TVector<ui64> indices = FillTable(table, totalRecords, payload);
+
+        auto* header = GetTableHeader(table);
+        UNIT_ASSERT_VALUES_EQUAL(16_KB, header->DataAreaSize);
+        UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
+
+        DeleteRecords(table, indices, keptRecords);
+        UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+
+        const ui64 dataAreaSizeBeforeAlloc =
+            GetTableHeader(table)->DataAreaSize;
+        const ui64 firstShrinkIndex = AllocAndCommitRecord(table, payload);
+        UNIT_ASSERT_VALUES_EQUAL(
+            dataAreaSizeBeforeAlloc,
+            GetTableHeader(table)->DataAreaSize);
+        UNIT_ASSERT(table.DeleteRecord(firstShrinkIndex));
+        UNIT_ASSERT_VALUES_EQUAL(11_KB, GetTableHeader(table)->DataAreaSize);
+        UNIT_ASSERT_VALUES_EQUAL(keptRecords, table.CountRecords());
+    }
+
     Y_UNIT_TEST(ShouldResumeAbortedCompaction)
     {
         TTempDir tempDir;
@@ -879,7 +1406,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<TTestData> testData = TestDataRecords;
 
         {
-            TTable table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -915,7 +1442,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
 
             auto* tableHeader = GetTableHeader(table);
@@ -943,7 +1470,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
             auto* tableHeader = GetTableHeader(table);
 
             UNIT_ASSERT_VALUES_EQUAL(TTable::Version, tableHeader->Version);
@@ -977,7 +1504,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            TTable table(tablePath, 32, 1024, 1, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1016,7 +1543,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 2, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
@@ -1043,7 +1570,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            TTable table(tablePath, 32, 1024, 1, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1089,7 +1616,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 1, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
@@ -1116,7 +1643,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            TTable table(tablePath, 32, 1024, 2, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1169,7 +1696,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 2, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
@@ -1196,7 +1723,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            TTable table(tablePath, 32, 1024, 2, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1250,7 +1777,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 1, 30);
+            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
@@ -1278,7 +1805,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTestData testData2{2, "second", {30, 40}};
 
         {
-            TTable table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
 
             TString serialized1 = testData1.Serialize();
             ui64 index1 = table.AllocRecord(serialized1.size());
@@ -1304,7 +1831,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
 
             auto* tableHeader = GetTableHeader(table);
 
@@ -1339,7 +1866,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            TTable table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1372,7 +1899,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            TTable table(tablePath, 32, 1024, 100, 30);
+            auto table = CreateTable(tablePath, 32, 1024);
 
             auto* tableHeader = GetTableHeader(table);
 
@@ -1415,17 +1942,13 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         const ui32 testRecords = 2000;
         const double restoreProbability = 0.05;
 
-        std::unique_ptr<TDynamicPersistentTable<TTestHeader>> table;
+        std::unique_ptr<TTable> table;
         TReferenceImplementation ri(tableSize);
 
         auto restore = [&]()
         {
-            table = std::make_unique<TDynamicPersistentTable<TTestHeader>>(
-                tablePath,
-                tableSize,
-                1024,
-                100,
-                30);
+            table = std::make_unique<TTable>(
+                CreateTable(tablePath, tableSize, 1024));
         };
 
         restore();

--- a/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
@@ -107,31 +107,24 @@ struct TTestData
 };
 
 using TTable = TDynamicPersistentTable<TTestHeader>;
+using TTableConfig = TDynamicPersistentTableConfig;
 
-TTable CreateTable(
-    const TString& fileName,
-    ui64 maxRecords,
-    ui64 initialDataAreaSize,
-    ui64 maxDataAreaStepSize = 1_GB,
-    ui64 initialDataCompactionBufferSize = 100,
-    ui64 gapSpacePercentageCompactionThreshold =
-        TTable::DefaultGapSpacePercentageCompactionThreshold,
-    ui64 shrinkLowMemoryOpThreshold = TTable::DefaultShrinkLowMemoryOpThreshold,
-    ui64 shrinkTriggerPercent = TTable::DefaultShrinkTriggerPercent,
-    ui64 shrinkReservePercent = TTable::DefaultShrinkReservePercent,
-    TTable::EShrinkMode shrinkMode = TTable::DefaultShrinkMode)
+TTable CreateTable(const TString& fileName, const TTableConfig& config)
 {
-    return TTable(
+    return TTable(fileName, config);
+}
+
+TTable
+CreateTable(const TString& fileName, ui64 maxRecords, ui64 initialDataAreaSize)
+{
+    return CreateTable(
         fileName,
-        maxRecords,
-        initialDataAreaSize,
-        maxDataAreaStepSize,
-        initialDataCompactionBufferSize,
-        gapSpacePercentageCompactionThreshold,
-        shrinkLowMemoryOpThreshold,
-        shrinkTriggerPercent,
-        shrinkReservePercent,
-        shrinkMode);
+        TTableConfig{
+            .MaxRecords = maxRecords,
+            .InitialDataAreaSize = initialDataAreaSize,
+            .MaxDataAreaStepSize = 1_GB,
+            .InitialDataCompactionBufferSize = 100,
+        });
 }
 
 // Helper functions for accessing internal table structures
@@ -928,8 +921,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         ui64 grownDataAreaSize = 0;
 
         {
-            auto table =
-                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 8_KB);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = initialDataAreaSize,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 8_KB,
+                });
 
             for (ui32 i = 0; i < totalRecords; ++i) {
                 TString payload(dataSize, static_cast<char>('a' + (i % 26)));
@@ -950,8 +949,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            auto table =
-                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 8_KB);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = initialDataAreaSize,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 8_KB,
+                });
 
             auto* header = GetTableHeader(table);
             UNIT_ASSERT_VALUES_EQUAL(8_KB, header->DataAreaSize);
@@ -980,12 +985,13 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            1_GB,
-            1_KB,
-            TTable::DefaultGapSpacePercentageCompactionThreshold,
-            shrinkLowMemoryOpThreshold);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = 1_GB,
+                .InitialDataCompactionBufferSize = 1_KB,
+                .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
 
@@ -1028,12 +1034,13 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            1_GB,
-            1_KB,
-            TTable::DefaultGapSpacePercentageCompactionThreshold,
-            shrinkLowMemoryOpThreshold);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = 1_GB,
+                .InitialDataCompactionBufferSize = 1_KB,
+                .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
 
@@ -1077,15 +1084,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            1_GB,
-            1_KB,
-            TTable::DefaultGapSpacePercentageCompactionThreshold,
-            shrinkLowMemoryOpThreshold,
-            TTable::DefaultShrinkTriggerPercent,
-            TTable::DefaultShrinkReservePercent,
-            TTable::EShrinkMode::AnyOp);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = 1_GB,
+                .InitialDataCompactionBufferSize = 1_KB,
+                .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
+                .ShrinkMode = TTable::EShrinkMode::AnyOp,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
 
@@ -1132,12 +1138,13 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            1_GB,
-            1_KB,
-            TTable::DefaultGapSpacePercentageCompactionThreshold,
-            shrinkLowMemoryOpThreshold);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = 1_GB,
+                .InitialDataCompactionBufferSize = 1_KB,
+                .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
 
@@ -1174,12 +1181,13 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            1_GB,
-            1_KB,
-            TTable::DefaultGapSpacePercentageCompactionThreshold,
-            shrinkLowMemoryOpThreshold);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = 1_GB,
+                .InitialDataCompactionBufferSize = 1_KB,
+                .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
         UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
@@ -1221,8 +1229,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            auto table =
-                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 1_KB);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = initialDataAreaSize,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 1_KB,
+                });
             indices = FillTable(table, totalRecords, payload);
 
             UNIT_ASSERT_VALUES_EQUAL(
@@ -1234,8 +1248,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            auto table =
-                CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 1_KB);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = initialDataAreaSize,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 1_KB,
+                });
             auto* header = GetTableHeader(table);
 
             UNIT_ASSERT_VALUES_EQUAL(0, table.CountRecords());
@@ -1252,8 +1272,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         const TString payload(1_KB, 't');
         const ui64 totalRecords = 8;
 
-        auto table =
-            CreateTable(tablePath, 32, initialDataAreaSize, 1_GB, 1_KB);
+        auto table = CreateTable(
+            tablePath,
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = 1_GB,
+                .InitialDataCompactionBufferSize = 1_KB,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
         UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
@@ -1285,11 +1311,13 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            maxDataAreaStepSize,
-            1_KB,
-            100);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = maxDataAreaStepSize,
+                .InitialDataCompactionBufferSize = 1_KB,
+                .GapSpacePercentageCompactionThreshold = 100,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
         UNIT_ASSERT_VALUES_EQUAL(totalRecords, indices.size());
@@ -1317,10 +1345,12 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            maxDataAreaStepSize,
-            4_KB);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = maxDataAreaStepSize,
+                .InitialDataCompactionBufferSize = 4_KB,
+            });
 
         auto assertDataAreaSize = [&](ui64 expectedSize)
         {
@@ -1368,15 +1398,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(
             tablePath,
-            32,
-            initialDataAreaSize,
-            maxDataAreaStepSize,
-            1_KB,
-            TTable::DefaultGapSpacePercentageCompactionThreshold,
-            shrinkLowMemoryOpThreshold,
-            TTable::DefaultShrinkTriggerPercent,
-            TTable::DefaultShrinkReservePercent,
-            TTable::EShrinkMode::AnyOp);
+            TTableConfig{
+                .MaxRecords = 32,
+                .InitialDataAreaSize = initialDataAreaSize,
+                .MaxDataAreaStepSize = maxDataAreaStepSize,
+                .InitialDataCompactionBufferSize = 1_KB,
+                .ShrinkLowMemoryOpThreshold = shrinkLowMemoryOpThreshold,
+                .ShrinkMode = TTable::EShrinkMode::AnyOp,
+            });
 
         TVector<ui64> indices = FillTable(table, totalRecords, payload);
 
@@ -1504,7 +1533,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 1,
+                });
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1543,7 +1579,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 2,
+                });
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
@@ -1570,7 +1613,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 1,
+                });
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1616,7 +1666,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 1,
+                });
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
@@ -1643,7 +1700,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 2,
+                });
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1696,7 +1760,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 2,
+                });
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());
@@ -1723,7 +1794,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 2);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 2,
+                });
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
@@ -1777,7 +1855,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
 
         {
-            auto table = CreateTable(tablePath, 32, 1024, 1_GB, 1);
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataCompactionBufferSize = 1,
+                });
 
             // All records should be accessible and valid
             UNIT_ASSERT_VALUES_EQUAL(testData.size(), table.CountRecords());

--- a/cloud/storage/core/libs/common/numeric.cpp
+++ b/cloud/storage/core/libs/common/numeric.cpp
@@ -1,0 +1,1 @@
+#include "numeric.h"

--- a/cloud/storage/core/libs/common/numeric.h
+++ b/cloud/storage/core/libs/common/numeric.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "public.h"
+
+#include <util/system/yassert.h>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+inline ui64 PercentOf(ui64 value, ui64 percent)
+{
+    Y_ABORT_UNLESS(percent <= 100, "Invalid percentage %lu", percent);
+
+    return value / 100 * percent + value % 100 * percent / 100;
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/ya.make
+++ b/cloud/storage/core/libs/common/ya.make
@@ -26,6 +26,7 @@ SRCS(
     history.cpp
     lru_cache.cpp
     media.cpp
+    numeric.cpp
     page_size.cpp
     dynamic_persistent_table.cpp
     persistent_table.cpp


### PR DESCRIPTION
### Notes
- add simple mechanic that counts operations at low memory utilization and if we hit limit then trigger shrinking
- add public api to class for external usage when client class have information when shrinking can make sense
- use DataAreaSize for compaction threshold
- introduce MaxDataAreaStepSize which will limit max step for any memory increase related operation to avoid huge spikes
- add tests for all cases

### Issue
#5747
