### PR TITLE
[NBS] Add ERequestSplitterPolicy to TNonreplicatedPartitionActor

### DIFF
--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -54,7 +54,7 @@ TNonreplicatedPartitionActor::TNonreplicatedPartitionActor(
     , PartConfig(std::move(partConfig))
     , VolumeActorId(volumeActorId)
     , StatActorId(statActorId)
-    , SplitterPolicy(config->GetRequestSplitterPolicy())
+    , SplitterPolicy(Config->GetRequestSplitterPolicy())
     , DeviceStats(CreateDeviceStats(*PartConfig, this))
     , PartCounters(CreatePartitionDiskCounters(
           EPublishingPolicy::DiskRegistryBased,
@@ -327,7 +327,9 @@ bool TNonreplicatedPartitionActor::InitRequests(
         } else if (
             SplitterPolicy == NProto::ERequestSplitterPolicy::RSP_DISABLE)
         {
-            deviceRequests->resize(1);
+            deviceRequests->erase(
+                deviceRequests->begin() + 1,
+                deviceRequests->end());
         }
     }
 
@@ -458,6 +460,7 @@ template bool TNonreplicatedPartitionActor::InitRequests<
     TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
     const char* methodName,
     const bool isWriteRequest,
+    const bool isReadOrWriteRequest,
     const TEvNonreplPartitionPrivate::TEvMultiAgentWriteRequest& msg,
     const TActorContext& ctx,
     const TRequestInfo& requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -316,13 +316,12 @@ bool TNonreplicatedPartitionActor::InitRequests(
 
     *deviceRequests = PartConfig->ToDeviceRequests(blockRange);
 
-    if (deviceRequests->size() > 1) {
-        if (SplitterPolicy ==
+    if (deviceRequests->size() > 1 &&
+        SplitterPolicy ==
             NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT)
-        {
-            ReportCrossPartitionRequestDetected(
-                {{"disk", PartConfig->GetName()}, {"range", blockRange}});
-        }
+    {
+        ReportCrossPartitionRequestDetected(
+            {{"disk", PartConfig->GetName()}, {"range", blockRange}});
     }
 
     if (deviceRequests->empty()) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -2,6 +2,7 @@
 
 #include "part_nonrepl_common.h"
 
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/forward_helpers.h>
@@ -48,11 +49,12 @@ TNonreplicatedPartitionActor::TNonreplicatedPartitionActor(
         TNonreplicatedPartitionConfigPtr partConfig,
         TActorId volumeActorId,
         TActorId statActorId)
-    : Config(std::move(config))
+    : Config(config)
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , PartConfig(std::move(partConfig))
     , VolumeActorId(volumeActorId)
     , StatActorId(statActorId)
+    , SplitterPolicy(config->GetRequestSplitterPolicy())
     , DeviceStats(CreateDeviceStats(*PartConfig, this))
     , PartCounters(CreatePartitionDiskCounters(
           EPublishingPolicy::DiskRegistryBased,
@@ -249,6 +251,7 @@ bool TNonreplicatedPartitionActor::InitRequests(
         typename TMethod::TResponse>(
         TMethod::Name,
         IsWriteMethod<TMethod>,
+        IsReadOrWriteMethod<TMethod>,
         msg,
         ctx,
         requestInfo,
@@ -262,6 +265,7 @@ template <typename TRequest, typename TResponse>
 bool TNonreplicatedPartitionActor::InitRequests(
     const char* methodName,
     const bool isWriteMethod,
+    const bool isReadOrWriteMethod,
     const TRequest& msg,
     const NActors::TActorContext& ctx,
     const TRequestInfo& requestInfo,
@@ -313,6 +317,19 @@ bool TNonreplicatedPartitionActor::InitRequests(
     }
 
     *deviceRequests = PartConfig->ToDeviceRequests(blockRange);
+
+    if (isReadOrWriteMethod && deviceRequests->size() > 1) {
+        if (SplitterPolicy ==
+            NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT)
+        {
+            ReportCrossPartitionRequestDetected(
+                {{"disk", PartConfig->GetName()}, {"range", blockRange}});
+        } else if (
+            SplitterPolicy == NProto::ERequestSplitterPolicy::RSP_DISABLE)
+        {
+            deviceRequests->resize(1);
+        }
+    }
 
     if (deviceRequests->empty()) {
         // block range contains only dummy devices

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -324,12 +324,6 @@ bool TNonreplicatedPartitionActor::InitRequests(
         {
             ReportCrossPartitionRequestDetected(
                 {{"disk", PartConfig->GetName()}, {"range", blockRange}});
-        } else if (
-            SplitterPolicy == NProto::ERequestSplitterPolicy::RSP_DISABLE)
-        {
-            deviceRequests->erase(
-                deviceRequests->begin() + 1,
-                deviceRequests->end());
         }
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -251,7 +251,6 @@ bool TNonreplicatedPartitionActor::InitRequests(
         typename TMethod::TResponse>(
         TMethod::Name,
         IsWriteMethod<TMethod>,
-        IsReadOrWriteMethod<TMethod>,
         msg,
         ctx,
         requestInfo,
@@ -265,7 +264,6 @@ template <typename TRequest, typename TResponse>
 bool TNonreplicatedPartitionActor::InitRequests(
     const char* methodName,
     const bool isWriteMethod,
-    const bool isReadOrWriteMethod,
     const TRequest& msg,
     const NActors::TActorContext& ctx,
     const TRequestInfo& requestInfo,
@@ -318,7 +316,7 @@ bool TNonreplicatedPartitionActor::InitRequests(
 
     *deviceRequests = PartConfig->ToDeviceRequests(blockRange);
 
-    if (isReadOrWriteMethod && deviceRequests->size() > 1) {
+    if (deviceRequests->size() > 1) {
         if (SplitterPolicy ==
             NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT)
         {
@@ -454,7 +452,6 @@ template bool TNonreplicatedPartitionActor::InitRequests<
     TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
     const char* methodName,
     const bool isWriteRequest,
-    const bool isReadOrWriteRequest,
     const TEvNonreplPartitionPrivate::TEvMultiAgentWriteRequest& msg,
     const TActorContext& ctx,
     const TRequestInfo& requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -49,7 +49,7 @@ TNonreplicatedPartitionActor::TNonreplicatedPartitionActor(
         TNonreplicatedPartitionConfigPtr partConfig,
         TActorId volumeActorId,
         TActorId statActorId)
-    : Config(config)
+    : Config(std::move(config))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , PartConfig(std::move(partConfig))
     , VolumeActorId(volumeActorId)

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -151,7 +151,6 @@ private:
     bool InitRequests(
         const char* methodName,
         const bool isWriteMethod,
-        const bool isReadOrWriteMethod,
         const TRequest& msg,
         const NActors::TActorContext& ctx,
         const TRequestInfo& requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.h
@@ -5,6 +5,7 @@
 #include "config.h"
 #include "part_nonrepl_events_private.h"
 
+#include <cloud/blockstore/config/storage.pb.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
@@ -58,6 +59,7 @@ private:
     const TNonreplicatedPartitionConfigPtr PartConfig;
     const NActors::TActorId VolumeActorId;
     const NActors::TActorId StatActorId;
+    const NProto::ERequestSplitterPolicy SplitterPolicy;
 
     TVector<TDeviceStat> DeviceStats;
 
@@ -149,6 +151,7 @@ private:
     bool InitRequests(
         const char* methodName,
         const bool isWriteMethod,
+        const bool isReadOrWriteMethod,
         const TRequest& msg,
         const NActors::TActorContext& ctx,
         const TRequestInfo& requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
@@ -309,7 +309,6 @@ void TNonreplicatedPartitionActor::HandleMultiAgentWrite(
         TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
         "MultiAgentWriteBlocks",
         true,
-        true,
         *msg,
         ctx,
         *requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
@@ -309,6 +309,7 @@ void TNonreplicatedPartitionActor::HandleMultiAgentWrite(
         TEvNonreplPartitionPrivate::TEvMultiAgentWriteResponse>(
         "MultiAgentWriteBlocks",
         true,
+        true,
         *msg,
         ctx,
         *requestInfo,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_ut.cpp
@@ -5,6 +5,7 @@
 
 #include <cloud/blockstore/libs/common/block_checksum.h>
 #include <cloud/blockstore/libs/common/iovector.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/api/stats_service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -75,6 +76,8 @@ struct TTestEnv
         NProto::EStorageMediaKind MediaKind =
             NProto::STORAGE_MEDIA_SSD_NONREPLICATED;
         TDuration MaxTimedOutDeviceStateDuration = TDuration::Seconds(20);
+        NProto::ERequestSplitterPolicy SplitterPolicy =
+            NProto::ERequestSplitterPolicy::RSP_ENABLE;
 
         TDevices Devices;
     };
@@ -120,6 +123,7 @@ struct TTestEnv
         storageConfig.SetNonReplicatedAgentMaxTimeout(300'000);
         storageConfig.SetAssignIdToWriteAndZeroRequestsEnabled(true);
         storageConfig.SetLaggingDeviceTimeoutThreshold(3'000);
+        storageConfig.SetRequestSplitterPolicy(params.SplitterPolicy);
 
         auto config = std::make_shared<TStorageConfig>(
             std::move(storageConfig),
@@ -2574,6 +2578,50 @@ Y_UNIT_TEST_SUITE(TNonreplicatedPartitionTest)
         UNIT_ASSERT_VALUES_EQUAL(
             DescribeRange(range),
             response->Record.FailInfo.FailedRanges[0]);
+    }
+
+    Y_UNIT_TEST(ShouldReportCrossDeviceRequestDetected)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(
+            runtime,
+            {.SplitterPolicy =
+                 NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT});
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto crossDeviceCounter = counters->GetCounter(
+            "AppCriticalEvents/CrossPartitionRequestDetected",
+            true);
+
+        client.WriteBlocks(TBlockRange64::WithLength(2000, 100), 1);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, crossDeviceCounter->Val());
+    }
+
+    Y_UNIT_TEST(ShouldNotReportCrossDeviceRequestDetectedForSingleDevice)
+    {
+        TTestBasicRuntime runtime;
+        TTestEnv env(
+            runtime,
+            {.SplitterPolicy =
+                 NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT});
+
+        TPartitionClient client(runtime, env.ActorId);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto crossDeviceCounter = counters->GetCounter(
+            "AppCriticalEvents/CrossPartitionRequestDetected",
+            true);
+
+        client.WriteBlocks(TBlockRange64::WithLength(0, 100), 1);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, crossDeviceCounter->Val());
     }
 }
 


### PR DESCRIPTION
 #5632 
                                                                                                                                                                                                    
  Adds ERequestSplitterPolicy to TNonreplicatedPartitionActor for gradual
  migration from actor-level request splitting to TSplitRequestService:                                                                                                                             
