### PR TITLE
feat: test run status update in comments with extended information

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -448,6 +448,7 @@ runs:
             --summary-out-env-path "$SUMMARY_OUT_ENV_PATH" \
             --summary-url-prefix "$S3_WEBSITE_PREFIX/summary/${COMPONENT_DIR}${i}/" \
             --build-preset "${platform_name}-${BUILD_PRESET}" \
+            --workload-status in_progress \
             --test-target "${TEST_TARGET//\"/}" \
             --test-time $((TEST_END_TIME - TEST_START_TIME)) \
             "Tests" ya-test.html "${JUNIT_REPORT_XML}.${i}"

--- a/.github/actions/workload_comment/action.yaml
+++ b/.github/actions/workload_comment/action.yaml
@@ -1,0 +1,100 @@
+name: Workload comment
+description: Initialize or update PR workload comments for split checks
+
+inputs:
+  command:
+    required: true
+    description: "init or update"
+  build_preset:
+    required: true
+    description: "Build preset suffix, for example relwithdebinfo"
+  matrix_include:
+    required: false
+    default: ""
+    description: "Matrix include JSON used by init"
+  workload_status:
+    required: false
+    default: "in_progress"
+    description: "Overall workload status for init"
+  component:
+    required: false
+    default: ""
+    description: "Matrix component for update"
+  workload_check_status:
+    required: false
+    default: ""
+    description: "running or completed"
+  current_job_name:
+    required: false
+    default: ""
+    description: "Current GitHub Actions job name for live link lookup"
+  runner_name:
+    required: false
+    default: ""
+    description: "Runner name for narrowing the current job lookup"
+  add_summary_link:
+    required: false
+    default: "no"
+    description: "Append resolved job link to GITHUB_STEP_SUMMARY"
+
+outputs:
+  job_url:
+    description: "Resolved GitHub Actions job URL"
+    value: ${{ steps.update.outputs.job_url }}
+
+runs:
+  using: composite
+  steps:
+    - name: install dependencies
+      shell: bash
+      run: pip install -r .github/scripts/requirements.txt
+
+    - name: resolve build preset
+      id: build-preset
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "full_build_preset=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)-${{ inputs.build_preset }}" >> "$GITHUB_OUTPUT"
+
+    - name: initialize workload comment
+      if: ${{ inputs.command == 'init' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
+        python3 -m scripts.tests.workload_comment init \
+          --matrix-include '${{ inputs.matrix_include }}' \
+          --build-preset '${{ steps.build-preset.outputs.full_build_preset }}' \
+          --workload-status '${{ inputs.workload_status }}'
+
+    - name: update workload comment
+      if: ${{ inputs.command == 'update' }}
+      id: update
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
+        JOB_URL_OUT=$(mktemp)
+        python3 -m scripts.tests.workload_comment update \
+          --build-preset '${{ steps.build-preset.outputs.full_build_preset }}' \
+          --component '${{ inputs.component }}' \
+          --workload-check-status '${{ inputs.workload_check_status }}' \
+          --current-job-name '${{ inputs.current_job_name }}' \
+          --runner-name '${{ inputs.runner_name }}' \
+          --job-url-out "$JOB_URL_OUT"
+        echo "job_url=$(cat "$JOB_URL_OUT")" >> "$GITHUB_OUTPUT"
+
+    - name: add job link to summary
+      if: ${{ inputs.command == 'update' && inputs.add_summary_link == 'yes' && steps.update.outputs.job_url != '' }}
+      shell: bash
+      run: |
+        {
+          echo "### GitHub job"
+          echo
+          echo "- [Build and test job](${{ steps.update.outputs.job_url }})"
+          echo
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/workload_comment/action.yaml
+++ b/.github/actions/workload_comment/action.yaml
@@ -23,7 +23,7 @@ inputs:
   workload_check_status:
     required: false
     default: ""
-    description: "running or completed"
+    description: "running, completed, or failed_build"
   current_job_name:
     required: false
     default: ""

--- a/.github/actions/workload_comment/action.yaml
+++ b/.github/actions/workload_comment/action.yaml
@@ -52,22 +52,27 @@ runs:
     - name: resolve build preset
       id: build-preset
       shell: bash
+      env:
+        BUILD_PRESET: ${{ inputs.build_preset }}
       run: |
         set -euo pipefail
-        echo "full_build_preset=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)-${{ inputs.build_preset }}" >> "$GITHUB_OUTPUT"
+        echo "full_build_preset=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)-${BUILD_PRESET}" >> "$GITHUB_OUTPUT"
 
     - name: initialize workload comment
       if: ${{ inputs.command == 'init' }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        MATRIX_INCLUDE: ${{ inputs.matrix_include }}
+        FULL_BUILD_PRESET: ${{ steps.build-preset.outputs.full_build_preset }}
+        WORKLOAD_STATUS: ${{ inputs.workload_status }}
       run: |
         set -euo pipefail
         export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
         python3 -m scripts.tests.workload_comment init \
-          --matrix-include '${{ inputs.matrix_include }}' \
-          --build-preset '${{ steps.build-preset.outputs.full_build_preset }}' \
-          --workload-status '${{ inputs.workload_status }}'
+          --matrix-include "${MATRIX_INCLUDE}" \
+          --build-preset "${FULL_BUILD_PRESET}" \
+          --workload-status "${WORKLOAD_STATUS}"
 
     - name: update workload comment
       if: ${{ inputs.command == 'update' }}
@@ -75,26 +80,33 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        FULL_BUILD_PRESET: ${{ steps.build-preset.outputs.full_build_preset }}
+        COMPONENT: ${{ inputs.component }}
+        WORKLOAD_CHECK_STATUS: ${{ inputs.workload_check_status }}
+        CURRENT_JOB_NAME: ${{ inputs.current_job_name }}
+        RUNNER_NAME: ${{ inputs.runner_name }}
       run: |
         set -euo pipefail
         export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
         JOB_URL_OUT=$(mktemp)
         python3 -m scripts.tests.workload_comment update \
-          --build-preset '${{ steps.build-preset.outputs.full_build_preset }}' \
-          --component '${{ inputs.component }}' \
-          --workload-check-status '${{ inputs.workload_check_status }}' \
-          --current-job-name '${{ inputs.current_job_name }}' \
-          --runner-name '${{ inputs.runner_name }}' \
+          --build-preset "${FULL_BUILD_PRESET}" \
+          --component "${COMPONENT}" \
+          --workload-check-status "${WORKLOAD_CHECK_STATUS}" \
+          --current-job-name "${CURRENT_JOB_NAME}" \
+          --runner-name "${RUNNER_NAME}" \
           --job-url-out "$JOB_URL_OUT"
         echo "job_url=$(cat "$JOB_URL_OUT")" >> "$GITHUB_OUTPUT"
 
     - name: add job link to summary
       if: ${{ inputs.command == 'update' && inputs.add_summary_link == 'yes' && steps.update.outputs.job_url != '' }}
       shell: bash
+      env:
+        JOB_URL: ${{ steps.update.outputs.job_url }}
       run: |
         {
           echo "### GitHub job"
           echo
-          echo "- [Build and test job](${{ steps.update.outputs.job_url }})"
+          echo "- [Build and test job](${JOB_URL})"
           echo
         } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/scripts/tests/finalize_workload_comments.py
+++ b/.github/scripts/tests/finalize_workload_comments.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from github import Auth as GithubAuth, Github
+from github.PullRequest import PullRequest
+
+from ..helpers import setup_logger
+from . import generate_summary as gs
+
+
+def get_pull_request() -> PullRequest:
+    gh = Github(auth=GithubAuth.Token(os.environ["GITHUB_TOKEN"]))
+
+    with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
+        event = json.load(fp)
+
+    return gh.create_from_raw_data(PullRequest, event["pull_request"])
+
+
+def iter_build_presets(matrix_include: str) -> list[str]:
+    matrix = json.loads(matrix_include)
+    return sorted({entry["build_preset"] for entry in matrix.get("include", [])})
+
+
+def main() -> None:
+    setup_logger(name=__name__, fmt="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--matrix-include", required=True)
+    parser.add_argument(
+        "--platform-name",
+        required=True,
+        help="Normalized platform prefix, for example linux-x86_64",
+    )
+    parser.add_argument(
+        "--workload-status",
+        choices=("in_progress", "completed"),
+        default="completed",
+    )
+    parser.add_argument(
+        "--is-dry-run",
+        default=False,
+        action="store_true",
+        help="Match comments created from dry-run summaries",
+    )
+    args = parser.parse_args()
+
+    if os.environ.get("GITHUB_EVENT_NAME") not in (
+        "pull_request",
+        "pull_request_target",
+    ):
+        return
+
+    pr = get_pull_request()
+    run_number = int(os.environ.get("GITHUB_RUN_NUMBER", "0"))
+
+    for build_preset in iter_build_presets(args.matrix_include):
+        gs.update_pr_comment_workload_status(
+            run_number=run_number,
+            pr=pr,
+            build_preset=f"{args.platform_name}-{build_preset}",
+            is_dry_run=args.is_dry_run,
+            workload_status=args.workload_status,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/finalize_workload_comments.py
+++ b/.github/scripts/tests/finalize_workload_comments.py
@@ -58,10 +58,17 @@ def main() -> None:
     run_number = int(os.environ.get("GITHUB_RUN_NUMBER", "0"))
 
     for build_preset in iter_build_presets(args.matrix_include):
+        full_build_preset = f"{args.platform_name}-{build_preset}"
+        gs.complete_pr_comment_workload_checks(
+            run_number=run_number,
+            pr=pr,
+            build_preset=full_build_preset,
+            is_dry_run=args.is_dry_run,
+        )
         gs.update_pr_comment_workload_status(
             run_number=run_number,
             pr=pr,
-            build_preset=f"{args.platform_name}-{build_preset}",
+            build_preset=full_build_preset,
             is_dry_run=args.is_dry_run,
             workload_status=args.workload_status,
         )

--- a/.github/scripts/tests/finalize_workload_comments_test.py
+++ b/.github/scripts/tests/finalize_workload_comments_test.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from scripts.tests import finalize_workload_comments as fwc
+
+
+def test_iter_build_presets_returns_unique_sorted_values() -> None:
+    matrix_include = """
+    {
+      "include": [
+        {"build_preset": "relwithdebinfo"},
+        {"build_preset": "release-asan"},
+        {"build_preset": "relwithdebinfo"}
+      ]
+    }
+    """
+
+    assert fwc.iter_build_presets(matrix_include) == [
+        "release-asan",
+        "relwithdebinfo",
+    ]

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -6,6 +6,7 @@ import dataclasses
 import json
 import logging
 import os
+import re
 import sys
 from contextlib import contextmanager
 from enum import Enum
@@ -23,6 +24,8 @@ LOGGER = logging.getLogger(__name__)
 TitlePathTriplet: TypeAlias = tuple[str, str, str]
 TitlePathPair: TypeAlias = tuple[str, str]
 LogUrls: TypeAlias = dict[str, str]
+WORKLOAD_STATUS_START = "<!-- workload-status -->"
+WORKLOAD_STATUS_END = "<!-- /workload-status -->"
 
 
 class IssueCommentLike(Protocol):
@@ -504,6 +507,66 @@ def get_comment_text(
     return body
 
 
+def get_workload_status_text(
+    build_preset: str,
+    workload_status: str,
+) -> list[str]:
+    if workload_status == "in_progress":
+        status_note = [
+            "> [!IMPORTANT]",
+            f"> Workload for **{build_preset}** is not finished yet. This comment will be updated after all workloads complete.",
+        ]
+    else:
+        status_note = [
+            "> [!NOTE]",
+            f"> All workloads for **{build_preset}** have completed.",
+        ]
+
+    return [WORKLOAD_STATUS_START, *status_note, WORKLOAD_STATUS_END]
+
+
+def get_comment_header(
+    pr_number: int,
+    run_number: int,
+    build_preset: str,
+    is_dry_run: bool,
+) -> str:
+    return (
+        f"<!-- status pr={pr_number}, run={run_number}, "
+        f"build_preset={build_preset}, dry_run={is_dry_run} -->"
+    )
+
+
+def replace_workload_status_block(
+    body: str,
+    build_preset: str,
+    workload_status: str,
+) -> str:
+    status_block = "\n".join(get_workload_status_text(build_preset, workload_status))
+    pattern = re.compile(
+        rf"{re.escape(WORKLOAD_STATUS_START)}.*?{re.escape(WORKLOAD_STATUS_END)}",
+        re.DOTALL,
+    )
+
+    if pattern.search(body):
+        return pattern.sub(status_block, body, count=1)
+
+    lines = body.splitlines()
+    insert_at = len(lines)
+    for idx, line in enumerate(lines):
+        if line.startswith("> [!NOTE]") or line.startswith("> [!IMPORTANT]"):
+            continue
+        if line.startswith("> This is "):
+            continue
+        if line == "":
+            continue
+        insert_at = idx
+        break
+
+    updated_lines = lines[:insert_at] + [status_block, ""] + lines[insert_at:]
+    return "\n".join(updated_lines)
+
+
 def update_pr_comment(
     run_number: int,
     pr: PullRequestLike,
@@ -513,8 +576,9 @@ def update_pr_comment(
     test_target: str,
     test_time: str,
     is_dry_run: bool,
+    workload_status: str,
 ) -> None:
-    header = f"<!-- status pr={pr.number}, run={run_number}, build_preset={build_preset}, dry_run={is_dry_run} -->"
+    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
 
     body: list[str] | None = None
     comment: IssueCommentLike | None = None
@@ -544,8 +608,18 @@ def update_pr_comment(
                 "",
             ]
         )
+        body.extend(get_workload_status_text(build_preset, workload_status))
+        body.append("")
     else:
-        body.extend(["", ""])
+        body = [
+            replace_workload_status_block(
+                body[0],
+                build_preset,
+                workload_status,
+            ),
+            "",
+            "",
+        ]
 
     body.extend(
         get_comment_text(
@@ -566,6 +640,32 @@ def update_pr_comment(
     else:
         LOGGER.info("Updating existing comment")
         comment.edit(body)
+
+
+def update_pr_comment_workload_status(
+    run_number: int,
+    pr: PullRequestLike,
+    build_preset: str,
+    is_dry_run: bool,
+    workload_status: str,
+) -> None:
+    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
+
+    for comment in pr.get_issue_comments():
+        if not comment.body.startswith(header):
+            continue
+
+        LOGGER.info("Updating workload status for comment id=%s", comment.id)
+        comment.edit(
+            replace_workload_status_block(
+                comment.body,
+                build_preset,
+                workload_status,
+            )
+        )
+        return
+
+    LOGGER.info("No existing comment found for workload status update")
 
 
 def parse_title_html_path_args(args: list[str]) -> list[TitlePathTriplet]:
@@ -598,17 +698,34 @@ def main() -> None:
         help="Add mark in comments that this is simulation, not real result",
     )
     parser.add_argument("--test-time", default="0", required=False)
-    parser.add_argument("args", nargs="+", metavar="TITLE html_out path")
+    parser.add_argument(
+        "--workload-status",
+        choices=("in_progress", "completed"),
+        default="completed",
+        help="Update the PR comment workload state",
+    )
+    parser.add_argument(
+        "--update-workload-status-only",
+        default=False,
+        action="store_true",
+        help="Only update the workload status block in an existing PR comment",
+    )
+    parser.add_argument("args", nargs="*", metavar="TITLE html_out path")
     args = parser.parse_args()
 
-    try:
-        title_path = parse_title_html_path_args(args.args)
-    except ValueError as error:
-        LOGGER.error(str(error))
-        raise SystemExit(-1) from error
+    summary: TestSummary | None = None
+    if args.args:
+        try:
+            title_path = parse_title_html_path_args(args.args)
+        except ValueError as error:
+            LOGGER.error(str(error))
+            raise SystemExit(-1) from error
 
-    summary = gen_summary(args.summary_url_prefix, args.summary_out_path, title_path)
-    write_summary(summary, args.summary_out_env_path)
+        summary = gen_summary(args.summary_url_prefix, args.summary_out_path, title_path)
+        write_summary(summary, args.summary_out_env_path)
+    elif not args.update_workload_status_only:
+        LOGGER.error("No summary inputs provided")
+        raise SystemExit(-1)
 
     if os.environ.get("GITHUB_EVENT_NAME") not in (
         "pull_request",
@@ -626,16 +743,27 @@ def main() -> None:
 
     run_number = int(os.environ.get("GITHUB_RUN_NUMBER", "0"))
     pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
-    update_pr_comment(
-        run_number,
-        pr,
-        summary,
-        args.build_preset,
-        args.test_history_url,
-        args.test_target,
-        args.test_time,
-        args.is_dry_run,
-    )
+    if args.update_workload_status_only:
+        update_pr_comment_workload_status(
+            run_number,
+            pr,
+            args.build_preset,
+            args.is_dry_run,
+            args.workload_status,
+        )
+    else:
+        assert summary is not None
+        update_pr_comment(
+            run_number,
+            pr,
+            summary,
+            args.build_preset,
+            args.test_history_url,
+            args.test_target,
+            args.test_time,
+            args.is_dry_run,
+            args.workload_status,
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -516,7 +516,10 @@ def get_workload_status_text(
     if workload_status == "in_progress":
         status_note = [
             "> [!IMPORTANT]",
-            f"> Workload for **{build_preset}** is not finished yet. This comment will be updated after all workloads complete.",
+            (
+                f"> Workload for **{build_preset}** is not finished yet. "
+                "This comment will be updated after all workloads complete."
+            ),
         ]
     else:
         status_note = [
@@ -800,6 +803,7 @@ def update_pr_comment_workload_status(
         )
     )
 
+
 def initialize_pr_comment(
     run_number: int,
     pr: PullRequestLike,
@@ -929,7 +933,9 @@ def main() -> None:
             LOGGER.error(str(error))
             raise SystemExit(-1) from error
 
-        summary = gen_summary(args.summary_url_prefix, args.summary_out_path, title_path)
+        summary = gen_summary(
+            args.summary_url_prefix, args.summary_out_path, title_path
+        )
         write_summary(summary, args.summary_out_env_path)
     elif not args.update_workload_status_only:
         LOGGER.error("No summary inputs provided")

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -563,11 +563,21 @@ def get_workload_check_line(
         "pending": ":white_circle:",
         "running": ":hourglass_flowing_sand:",
         "completed": ":white_check_mark:",
+        "failed_build": ":red_circle:",
+    }
+    suffixes = {
+        "pending": "",
+        "running": "",
+        "completed": "",
+        "failed_build": " (build failed)",
     }
     label = get_workload_label(component)
     if job_url:
         label = f"[{label}]({job_url})"
-    return f"- {icons[status]} {label} {get_workload_check_marker(component)}"
+    return (
+        f"- {icons[status]} {label}{suffixes[status]} "
+        f"{get_workload_check_marker(component)}"
+    )
 
 
 def get_workload_checks_text(
@@ -676,6 +686,8 @@ def complete_workload_checks_block(body: str) -> str:
     )
 
     def _replace(match: re.Match[str]) -> str:
+        if "build failed" in match.group(0):
+            return match.group(0)
         component = match.group("component")
         job_url_match = re.search(r"\]\((?P<url>[^)]+)\)", match.group(0))
         job_url = job_url_match.group("url") if job_url_match else ""

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -26,6 +26,8 @@ TitlePathPair: TypeAlias = tuple[str, str]
 LogUrls: TypeAlias = dict[str, str]
 WORKLOAD_STATUS_START = "<!-- workload-status -->"
 WORKLOAD_STATUS_END = "<!-- /workload-status -->"
+WORKLOAD_CHECKS_START = "<!-- workload-checks -->"
+WORKLOAD_CHECKS_END = "<!-- /workload-checks -->"
 
 
 class IssueCommentLike(Protocol):
@@ -537,6 +539,62 @@ def get_comment_header(
     )
 
 
+def get_workload_label(component: str) -> str:
+    if component == "all":
+        return "all"
+    if component == "none":
+        return "sanitized"
+    return component.replace("_", " + ")
+
+
+def get_workload_check_marker(component: str) -> str:
+    return f"<!-- workload-check component={component} -->"
+
+
+def get_workload_check_line(
+    component: str,
+    status: str,
+    job_url: str = "",
+) -> str:
+    icons = {
+        "pending": ":white_circle:",
+        "running": ":hourglass_flowing_sand:",
+        "completed": ":white_check_mark:",
+    }
+    label = get_workload_label(component)
+    if job_url:
+        label = f"[{label}]({job_url})"
+    return f"- {icons[status]} {label} {get_workload_check_marker(component)}"
+
+
+def get_workload_checks_text(
+    build_preset: str,
+    components: list[str],
+) -> list[str]:
+    return [
+        WORKLOAD_CHECKS_START,
+        "> [!TIP]",
+        f"> Planned checks for **{build_preset}**.",
+        "",
+        *[get_workload_check_line(component, "pending") for component in components],
+        WORKLOAD_CHECKS_END,
+    ]
+
+
+def _insert_managed_block(
+    body: str,
+    block: str,
+    *,
+    after_marker: str,
+) -> str:
+    if after_marker in body:
+        return body.replace(after_marker, f"{after_marker}\n\n{block}", 1)
+
+    lines = body.splitlines()
+    lines.extend(["", block])
+    return "\n".join(lines)
+
+
 def replace_workload_status_block(
     body: str,
     build_preset: str,
@@ -567,6 +625,105 @@ def replace_workload_status_block(
     return "\n".join(updated_lines)
 
 
+def replace_workload_checks_block(
+    body: str,
+    build_preset: str,
+    components: list[str],
+) -> str:
+    checks_block = "\n".join(get_workload_checks_text(build_preset, components))
+    pattern = re.compile(
+        rf"{re.escape(WORKLOAD_CHECKS_START)}.*?{re.escape(WORKLOAD_CHECKS_END)}",
+        re.DOTALL,
+    )
+    if pattern.search(body):
+        return pattern.sub(checks_block, body, count=1)
+
+    return _insert_managed_block(
+        body,
+        checks_block,
+        after_marker=WORKLOAD_STATUS_END,
+    )
+
+
+def update_workload_check_block(
+    body: str,
+    component: str,
+    status: str,
+    job_url: str = "",
+) -> str:
+    marker = get_workload_check_marker(component)
+    pattern = re.compile(rf"^.*{re.escape(marker)}$", re.MULTILINE)
+    match = pattern.search(body)
+    if match is None:
+        return body
+    if not job_url:
+        job_url_match = re.search(r"\]\((?P<url>[^)]+)\)", match.group(0))
+        job_url = job_url_match.group("url") if job_url_match else ""
+    return pattern.sub(
+        get_workload_check_line(component, status, job_url),
+        body,
+        count=1,
+    )
+
+
+def complete_workload_checks_block(body: str) -> str:
+    pattern = re.compile(
+        r"^.*<!-- workload-check component=(?P<component>[^ ]+) -->$",
+        re.MULTILINE,
+    )
+
+    def _replace(match: re.Match[str]) -> str:
+        component = match.group("component")
+        job_url_match = re.search(r"\]\((?P<url>[^)]+)\)", match.group(0))
+        job_url = job_url_match.group("url") if job_url_match else ""
+        return get_workload_check_line(component, "completed", job_url)
+
+    return pattern.sub(_replace, body)
+
+
+def find_pr_comment(
+    pr: PullRequestLike,
+    header: str,
+) -> IssueCommentLike | None:
+    for comment in pr.get_issue_comments():
+        if comment.body.startswith(header):
+            LOGGER.info("Found comment with id=%s", comment.id)
+            return comment
+    return None
+
+
+def get_base_comment_body(
+    header: str,
+    build_preset: str,
+    is_dry_run: bool,
+    workload_status: str,
+    workload_components: list[str] | None = None,
+) -> list[str]:
+    body = [header]
+
+    if is_dry_run:
+        body.extend(
+            [
+                "> [!NOTE]",
+                "> This is a simulation, not a real result. If you see this, everything is as it should be.",
+                "",
+            ]
+        )
+    body.extend(
+        [
+            "> [!NOTE]",
+            "> This is an automated comment that will be appended during run.",
+            "",
+        ]
+    )
+    body.extend(get_workload_status_text(build_preset, workload_status))
+    body.append("")
+    if workload_components is not None:
+        body.extend(get_workload_checks_text(build_preset, workload_components))
+        body.append("")
+    return body
+
+
 def update_pr_comment(
     run_number: int,
     pr: PullRequestLike,
@@ -579,41 +736,19 @@ def update_pr_comment(
     workload_status: str,
 ) -> None:
     header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
+    comment = find_pr_comment(pr, header)
 
-    body: list[str] | None = None
-    comment: IssueCommentLike | None = None
-
-    for c in pr.get_issue_comments():
-        if c.body.startswith(header):
-            LOGGER.info("Found comment with id=%s", c.id)
-            comment = c
-            body = [c.body]
-            break
-
-    if body is None:
-        body = [header]
-
-        if is_dry_run:
-            body.extend(
-                [
-                    "> [!NOTE]",
-                    "> This is a simulation, not a real result. If you see this, everything is as it should be.",
-                    "",
-                ]
-            )
-        body.extend(
-            [
-                "> [!NOTE]",
-                "> This is an automated comment that will be appended during run.",
-                "",
-            ]
+    if comment is None:
+        body = get_base_comment_body(
+            header,
+            build_preset,
+            is_dry_run,
+            workload_status,
         )
-        body.extend(get_workload_status_text(build_preset, workload_status))
-        body.append("")
     else:
         body = [
             replace_workload_status_block(
-                body[0],
+                comment.body,
                 build_preset,
                 workload_status,
             ),
@@ -650,22 +785,95 @@ def update_pr_comment_workload_status(
     workload_status: str,
 ) -> None:
     header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
+    comment = find_pr_comment(pr, header)
 
-    for comment in pr.get_issue_comments():
-        if not comment.body.startswith(header):
-            continue
+    if comment is None:
+        LOGGER.info("No existing comment found for workload status update")
+        return
 
-        LOGGER.info("Updating workload status for comment id=%s", comment.id)
-        comment.edit(
-            replace_workload_status_block(
-                comment.body,
-                build_preset,
-                workload_status,
+    LOGGER.info("Updating workload status for comment id=%s", comment.id)
+    comment.edit(
+        replace_workload_status_block(
+            comment.body,
+            build_preset,
+            workload_status,
+        )
+    )
+
+def initialize_pr_comment(
+    run_number: int,
+    pr: PullRequestLike,
+    build_preset: str,
+    is_dry_run: bool,
+    workload_status: str,
+    workload_components: list[str],
+) -> None:
+    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
+    comment = find_pr_comment(pr, header)
+
+    if comment is None:
+        LOGGER.info("Creating new pre-run comment")
+        pr.create_issue_comment(
+            "\n".join(
+                get_base_comment_body(
+                    header,
+                    build_preset,
+                    is_dry_run,
+                    workload_status,
+                    workload_components,
+                )
             )
         )
         return
 
-    LOGGER.info("No existing comment found for workload status update")
+    LOGGER.info("Refreshing existing pre-run comment id=%s", comment.id)
+    body = replace_workload_status_block(comment.body, build_preset, workload_status)
+    body = replace_workload_checks_block(body, build_preset, workload_components)
+    comment.edit(body)
+
+
+def update_pr_comment_workload_check(
+    run_number: int,
+    pr: PullRequestLike,
+    build_preset: str,
+    component: str,
+    is_dry_run: bool,
+    workload_check_status: str,
+    job_url: str = "",
+) -> None:
+    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
+    comment = find_pr_comment(pr, header)
+
+    if comment is None:
+        LOGGER.info("No existing comment found for workload check update")
+        return
+
+    LOGGER.info("Updating workload check for comment id=%s", comment.id)
+    comment.edit(
+        update_workload_check_block(
+            comment.body,
+            component,
+            workload_check_status,
+            job_url,
+        )
+    )
+
+
+def complete_pr_comment_workload_checks(
+    run_number: int,
+    pr: PullRequestLike,
+    build_preset: str,
+    is_dry_run: bool,
+) -> None:
+    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
+    comment = find_pr_comment(pr, header)
+
+    if comment is None:
+        LOGGER.info("No existing comment found for workload checks completion")
+        return
+
+    LOGGER.info("Completing workload checks for comment id=%s", comment.id)
+    comment.edit(complete_workload_checks_block(comment.body))
 
 
 def parse_title_html_path_args(args: list[str]) -> list[TitlePathTriplet]:

--- a/.github/scripts/tests/generate_summary_test.py
+++ b/.github/scripts/tests/generate_summary_test.py
@@ -209,12 +209,15 @@ def test_update_pr_comment_creates_new_comment(monkeypatch) -> None:
         test_target="",
         test_time="0",
         is_dry_run=True,
+        workload_status="in_progress",
     )
 
     assert len(pr.created) == 1
     body = pr.created[0]
     assert "<!-- status pr=77, run=12, build_preset=linux, dry_run=True -->" in body
     assert "This is a simulation, not a real result" in body
+    assert "<!-- workload-status -->" in body
+    assert "Workload for **linux** is not finished yet" in body
     assert "all tests PASSED for commit deadbeef." in body
 
 
@@ -248,7 +251,22 @@ def test_update_pr_comment_updates_existing_comment() -> None:
             self.created.append(body)
 
     header = "<!-- status pr=77, run=12, build_preset=linux, dry_run=False -->"
-    existing = FakeComment(header + "\nold text")
+    existing = FakeComment(
+        "\n".join(
+            [
+                header,
+                "> [!NOTE]",
+                "> This is an automated comment that will be appended during run.",
+                "",
+                gs.WORKLOAD_STATUS_START,
+                "> [!NOTE]",
+                "> All workloads for **linux** have completed.",
+                gs.WORKLOAD_STATUS_END,
+                "",
+                "old text",
+            ]
+        )
+    )
     pr = FakePR(existing)
 
     summary = gs.TestSummary()
@@ -266,8 +284,72 @@ def test_update_pr_comment_updates_existing_comment() -> None:
         test_target="",
         test_time="0",
         is_dry_run=False,
+        workload_status="in_progress",
     )
 
     assert len(pr.created) == 0
     assert len(existing.edits) == 1
+    assert "All workloads for **linux** have completed." not in existing.body
+    assert "Workload for **linux** is not finished yet" in existing.body
+    assert "old text" in existing.body
     assert "some tests FAILED for commit abc123." in existing.body
+
+
+def test_update_pr_comment_workload_status_only_preserves_existing_body() -> None:
+    class FakeHead:
+        sha = "abc123"
+
+    class FakeComment:
+        id = 1001
+
+        def __init__(self, body: str) -> None:
+            self.body = body
+            self.edits = []
+
+        def edit(self, body: str) -> None:
+            self.body = body
+            self.edits.append(body)
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self, comment: FakeComment) -> None:
+            self._comment = comment
+
+        def get_issue_comments(self) -> list[FakeComment]:
+            return [self._comment]
+
+        def create_issue_comment(self, body: str) -> None:
+            raise AssertionError("should not create a new comment")
+
+    existing = FakeComment(
+        "\n".join(
+            [
+                "<!-- status pr=77, run=12, build_preset=linux, dry_run=False -->",
+                "> [!NOTE]",
+                "> This is an automated comment that will be appended during run.",
+                "",
+                gs.WORKLOAD_STATUS_START,
+                "> [!IMPORTANT]",
+                "> Workload for **linux** is not finished yet. This comment will be updated after all workloads complete.",
+                gs.WORKLOAD_STATUS_END,
+                "",
+                ":green_circle: **linux**: all tests PASSED for commit abc123.",
+            ]
+        )
+    )
+    pr = FakePR(existing)
+
+    gs.update_pr_comment_workload_status(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        is_dry_run=False,
+        workload_status="completed",
+    )
+
+    assert len(existing.edits) == 1
+    assert "Workload for **linux** is not finished yet" not in existing.body
+    assert "All workloads for **linux** have completed." in existing.body
+    assert ":green_circle: **linux**: all tests PASSED for commit abc123." in existing.body

--- a/.github/scripts/tests/generate_summary_test.py
+++ b/.github/scripts/tests/generate_summary_test.py
@@ -353,3 +353,96 @@ def test_update_pr_comment_workload_status_only_preserves_existing_body() -> Non
     assert "Workload for **linux** is not finished yet" not in existing.body
     assert "All workloads for **linux** have completed." in existing.body
     assert ":green_circle: **linux**: all tests PASSED for commit abc123." in existing.body
+
+
+def test_initialize_pr_comment_creates_workload_checks_block() -> None:
+    class FakeHead:
+        sha = "abc123"
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self) -> None:
+            self.created = []
+
+        def get_issue_comments(self) -> list[object]:
+            return []
+
+        def create_issue_comment(self, body: str) -> None:
+            self.created.append(body)
+
+    pr = FakePR()
+    gs.initialize_pr_comment(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        is_dry_run=False,
+        workload_status="in_progress",
+        workload_components=["blockstore", "tasks_storage"],
+    )
+
+    assert len(pr.created) == 1
+    body = pr.created[0]
+    assert gs.WORKLOAD_CHECKS_START in body
+    assert "Planned checks for **linux**." in body
+    assert "blockstore" in body
+    assert "tasks + storage" in body
+
+
+def test_update_pr_comment_workload_check_preserves_existing_job_url() -> None:
+    class FakeHead:
+        sha = "abc123"
+
+    class FakeComment:
+        id = 1001
+
+        def __init__(self, body: str) -> None:
+            self.body = body
+            self.edits = []
+
+        def edit(self, body: str) -> None:
+            self.body = body
+            self.edits.append(body)
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self, comment: FakeComment) -> None:
+            self._comment = comment
+
+        def get_issue_comments(self) -> list[FakeComment]:
+            return [self._comment]
+
+        def create_issue_comment(self, body: str) -> None:
+            raise AssertionError("should not create a new comment")
+
+    existing = FakeComment(
+        "\n".join(
+            [
+                "<!-- status pr=77, run=12, build_preset=linux, dry_run=False -->",
+                gs.WORKLOAD_CHECKS_START,
+                gs.get_workload_check_line(
+                    "blockstore",
+                    "running",
+                    "https://github.example/job/123",
+                ),
+                gs.WORKLOAD_CHECKS_END,
+            ]
+        )
+    )
+    pr = FakePR(existing)
+
+    gs.update_pr_comment_workload_check(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        component="blockstore",
+        is_dry_run=False,
+        workload_check_status="completed",
+    )
+
+    assert len(existing.edits) == 1
+    assert ":white_check_mark:" in existing.body
+    assert "https://github.example/job/123" in existing.body

--- a/.github/scripts/tests/generate_summary_test.py
+++ b/.github/scripts/tests/generate_summary_test.py
@@ -320,7 +320,7 @@ def test_update_pr_comment_workload_status_only_preserves_existing_body() -> Non
         def get_issue_comments(self) -> list[FakeComment]:
             return [self._comment]
 
-        def create_issue_comment(self, body: str) -> None:
+        def create_issue_comment(self, body: str) -> None:  # noqa: U100
             raise AssertionError("should not create a new comment")
 
     existing = FakeComment(
@@ -352,7 +352,9 @@ def test_update_pr_comment_workload_status_only_preserves_existing_body() -> Non
     assert len(existing.edits) == 1
     assert "Workload for **linux** is not finished yet" not in existing.body
     assert "All workloads for **linux** have completed." in existing.body
-    assert ":green_circle: **linux**: all tests PASSED for commit abc123." in existing.body
+    assert (
+        ":green_circle: **linux**: all tests PASSED for commit abc123." in existing.body
+    )
 
 
 def test_initialize_pr_comment_creates_workload_checks_block() -> None:
@@ -415,7 +417,7 @@ def test_update_pr_comment_workload_check_preserves_existing_job_url() -> None:
         def get_issue_comments(self) -> list[FakeComment]:
             return [self._comment]
 
-        def create_issue_comment(self, body: str) -> None:
+        def create_issue_comment(self, body: str) -> None:  # noqa: U100
             raise AssertionError("should not create a new comment")
 
     existing = FakeComment(

--- a/.github/scripts/tests/generate_summary_test.py
+++ b/.github/scripts/tests/generate_summary_test.py
@@ -448,3 +448,30 @@ def test_update_pr_comment_workload_check_preserves_existing_job_url() -> None:
     assert len(existing.edits) == 1
     assert ":white_check_mark:" in existing.body
     assert "https://github.example/job/123" in existing.body
+
+
+def test_complete_workload_checks_block_preserves_failed_build_rows() -> None:
+    body = "\n".join(
+        [
+            gs.WORKLOAD_CHECKS_START,
+            gs.get_workload_check_line(
+                "blockstore",
+                "failed_build",
+                "https://github.example/job/123",
+            ),
+            gs.get_workload_check_line(
+                "filestore",
+                "running",
+                "https://github.example/job/456",
+            ),
+            gs.WORKLOAD_CHECKS_END,
+        ]
+    )
+
+    updated = gs.complete_workload_checks_block(body)
+
+    assert ":red_circle:" in updated
+    assert "build failed" in updated
+    assert ":white_check_mark:" in updated
+    assert "https://github.example/job/123" in updated
+    assert "https://github.example/job/456" in updated

--- a/.github/scripts/tests/workload_comment.py
+++ b/.github/scripts/tests/workload_comment.py
@@ -104,7 +104,7 @@ def main() -> None:
     update_parser.add_argument("--component", required=True)
     update_parser.add_argument(
         "--workload-check-status",
-        choices=("running", "completed"),
+        choices=("running", "completed", "failed_build"),
         required=True,
     )
     update_parser.add_argument("--current-job-name", default="")

--- a/.github/scripts/tests/workload_comment.py
+++ b/.github/scripts/tests/workload_comment.py
@@ -53,19 +53,39 @@ def get_run_url() -> str:
     return f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
 
 
+def job_name_matches(expected_name: str, actual_name: str) -> bool:
+    if actual_name == expected_name:
+        return True
+
+    reusable_prefix = f"/ {expected_name}"
+    if actual_name.endswith(reusable_prefix):
+        return True
+
+    return False
+
+
 def find_current_job_url(current_job_name: str, runner_name: str) -> str:
     try:
         jobs = fetch_jobs()
     except HTTPError:
         return get_run_url()
 
-    for job in jobs:
-        if job.get("name") != current_job_name:
-            continue
-        if runner_name and job.get("runner_name") != runner_name:
-            continue
-        if job.get("status") not in ("queued", "in_progress", "completed"):
-            continue
+    matching_jobs = [
+        job
+        for job in jobs
+        if job_name_matches(current_job_name, job.get("name", ""))
+        and job.get("status") in ("queued", "in_progress", "completed")
+    ]
+
+    if runner_name:
+        for job in matching_jobs:
+            if job.get("runner_name") != runner_name:
+                continue
+            html_url = job.get("html_url")
+            if html_url:
+                return html_url
+
+    for job in matching_jobs:
         html_url = job.get("html_url")
         if html_url:
             return html_url

--- a/.github/scripts/tests/workload_comment.py
+++ b/.github/scripts/tests/workload_comment.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from github import Auth as GithubAuth, Github
+from github.PullRequest import PullRequest
+
+from ..helpers import setup_logger
+from . import generate_summary as gs
+
+
+def get_pull_request() -> PullRequest:
+    gh = Github(auth=GithubAuth.Token(os.environ["GITHUB_TOKEN"]))
+
+    with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
+        event = json.load(fp)
+
+    return gh.create_from_raw_data(PullRequest, event["pull_request"])
+
+
+def iter_components(matrix_include: str) -> list[str]:
+    matrix = json.loads(matrix_include)
+    return [entry["component"] for entry in matrix.get("include", [])]
+
+
+def fetch_jobs() -> list[dict]:
+    owner, repo = os.environ["GITHUB_REPOSITORY"].split("/", 1)
+    run_id = os.environ["GITHUB_RUN_ID"]
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "1")
+    url = (
+        f"https://api.github.com/repos/{owner}/{repo}/actions/runs/"
+        f"{run_id}/attempts/{run_attempt}/jobs?per_page=100"
+    )
+    request = Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urlopen(request) as response:
+        payload = json.load(response)
+    return payload.get("jobs", [])
+
+
+def get_run_url() -> str:
+    return f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+
+
+def find_current_job_url(current_job_name: str, runner_name: str) -> str:
+    try:
+        jobs = fetch_jobs()
+    except HTTPError:
+        return get_run_url()
+
+    for job in jobs:
+        if job.get("name") != current_job_name:
+            continue
+        if runner_name and job.get("runner_name") != runner_name:
+            continue
+        if job.get("status") not in ("queued", "in_progress", "completed"):
+            continue
+        html_url = job.get("html_url")
+        if html_url:
+            return html_url
+
+    return get_run_url()
+
+
+def write_output(path: str, value: str) -> None:
+    if not path:
+        return
+    with open(path, "w") as fp:
+        fp.write(value)
+
+
+def main() -> None:
+    setup_logger(name=__name__, fmt="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("--matrix-include", required=True)
+    init_parser.add_argument("--build-preset", required=True)
+    init_parser.add_argument(
+        "--workload-status",
+        choices=("in_progress", "completed"),
+        default="in_progress",
+    )
+    init_parser.add_argument(
+        "--is-dry-run",
+        default=False,
+        action="store_true",
+    )
+
+    update_parser = subparsers.add_parser("update")
+    update_parser.add_argument("--build-preset", required=True)
+    update_parser.add_argument("--component", required=True)
+    update_parser.add_argument(
+        "--workload-check-status",
+        choices=("running", "completed"),
+        required=True,
+    )
+    update_parser.add_argument("--current-job-name", default="")
+    update_parser.add_argument("--runner-name", default="")
+    update_parser.add_argument("--job-url-out", default="")
+    update_parser.add_argument(
+        "--is-dry-run",
+        default=False,
+        action="store_true",
+    )
+
+    args = parser.parse_args()
+
+    if os.environ.get("GITHUB_EVENT_NAME") not in (
+        "pull_request",
+        "pull_request_target",
+    ):
+        return
+
+    pr = get_pull_request()
+    run_number = int(os.environ.get("GITHUB_RUN_NUMBER", "0"))
+
+    if args.command == "init":
+        gs.initialize_pr_comment(
+            run_number=run_number,
+            pr=pr,
+            build_preset=args.build_preset,
+            is_dry_run=args.is_dry_run,
+            workload_status=args.workload_status,
+            workload_components=iter_components(args.matrix_include),
+        )
+        return
+
+    job_url = ""
+    if args.current_job_name:
+        job_url = find_current_job_url(args.current_job_name, args.runner_name)
+        write_output(args.job_url_out, job_url)
+    gs.update_pr_comment_workload_check(
+        run_number=run_number,
+        pr=pr,
+        build_preset=args.build_preset,
+        component=args.component,
+        is_dry_run=args.is_dry_run,
+        workload_check_status=args.workload_check_status,
+        job_url=job_url,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/workload_comment_test.py
+++ b/.github/scripts/tests/workload_comment_test.py
@@ -26,4 +26,6 @@ def test_find_current_job_url_falls_back_to_run_url(monkeypatch) -> None:
     monkeypatch.setenv("GITHUB_RUN_ID", "123")
     monkeypatch.setattr(wc, "fetch_jobs", lambda: [])
 
-    assert wc.find_current_job_url("job", "runner") == "https://github.com/org/repo/actions/runs/123"
+    assert wc.find_current_job_url("job", "runner") == (
+        "https://github.com/org/repo/actions/runs/123"
+    )

--- a/.github/scripts/tests/workload_comment_test.py
+++ b/.github/scripts/tests/workload_comment_test.py
@@ -29,3 +29,56 @@ def test_find_current_job_url_falls_back_to_run_url(monkeypatch) -> None:
     assert wc.find_current_job_url("job", "runner") == (
         "https://github.com/org/repo/actions/runs/123"
     )
+
+
+def test_find_current_job_url_matches_reusable_workflow_job_name(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setattr(
+        wc,
+        "fetch_jobs",
+        lambda: [
+            {
+                "name": "On-demand build and test / Build and test relwithdebinfo [id=1 ip=10.0.0.1]",
+                "runner_name": "runner-1",
+                "status": "in_progress",
+                "html_url": "https://github.com/org/repo/actions/runs/123/job/999",
+            }
+        ],
+    )
+
+    assert (
+        wc.find_current_job_url(
+            "Build and test relwithdebinfo [id=1 ip=10.0.0.1]",
+            "runner-1",
+        )
+        == "https://github.com/org/repo/actions/runs/123/job/999"
+    )
+
+
+def test_find_current_job_url_prefers_runner_specific_match(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setattr(
+        wc,
+        "fetch_jobs",
+        lambda: [
+            {
+                "name": "Pooled build and test / Build and test relwithdebinfo",
+                "runner_name": "runner-a",
+                "status": "in_progress",
+                "html_url": "https://github.com/org/repo/actions/runs/123/job/111",
+            },
+            {
+                "name": "Pooled build and test / Build and test relwithdebinfo",
+                "runner_name": "runner-b",
+                "status": "in_progress",
+                "html_url": "https://github.com/org/repo/actions/runs/123/job/222",
+            },
+        ],
+    )
+
+    assert (
+        wc.find_current_job_url("Build and test relwithdebinfo", "runner-b")
+        == "https://github.com/org/repo/actions/runs/123/job/222"
+    )

--- a/.github/scripts/tests/workload_comment_test.py
+++ b/.github/scripts/tests/workload_comment_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from scripts.tests import workload_comment as wc
+
+
+def test_iter_components_preserves_matrix_order() -> None:
+    matrix_include = """
+    {
+      "include": [
+        {"component": "blockstore"},
+        {"component": "tasks_storage"},
+        {"component": "filestore"}
+      ]
+    }
+    """
+
+    assert wc.iter_components(matrix_include) == [
+        "blockstore",
+        "tasks_storage",
+        "filestore",
+    ]
+
+
+def test_find_current_job_url_falls_back_to_run_url(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setattr(wc, "fetch_jobs", lambda: [])
+
+    assert wc.find_current_job_url("job", "runner") == "https://github.com/org/repo/actions/runs/123"

--- a/.github/workflows/build_and_test_proxy.yaml
+++ b/.github/workflows/build_and_test_proxy.yaml
@@ -99,12 +99,60 @@ jobs:
           NEBIUS_SPLIT_RUNNERS_TSAN: ${{ inputs.allow_split_workload && vars.NEBIUS_SPLIT_RUNNERS_TSAN == 'true' && 'true' || 'false' }}
           NEBIUS_SPLIT_RUNNERS_MSAN: ${{ inputs.allow_split_workload && vars.NEBIUS_SPLIT_RUNNERS_MSAN == 'true' && 'true' || 'false' }}
           NEBIUS_SPLIT_RUNNERS_UBSAN: ${{ inputs.allow_split_workload && vars.NEBIUS_SPLIT_RUNNERS_UBSAN == 'true' && 'true' || 'false' }}
- 
+
+  prepare-pr-comment:
+    name: Prepare PR comment
+    runs-on: [ self-hosted, "self-hosted", "runner_light" ]
+    needs: plan
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+    steps:
+      - name: checkout PR
+        uses: actions/checkout@v6
+        if: github.event.pull_request.head.sha != ''
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
+      - name: rebase PR
+        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+        shell: bash
+        run: |
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
+          git config user.email "robot-nbs@nebius.com"
+          git config user.name "Robot NBS"
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
+      - name: checkout
+        uses: actions/checkout@v6
+        if: github.event.pull_request.head.sha == ''
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+      - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
+        if: ${{ always() }}
+        run: git config core.sparseCheckout false
+        continue-on-error: true
+      - name: initialize workload comment
+        uses: ./.github/actions/workload_comment
+        with:
+          command: init
+          matrix_include: ${{ needs.plan.outputs.matrix_include }}
+          build_preset: ${{ inputs.build_preset }}
+          workload_status: in_progress
+
   on_demand:
     if: ${{ inputs.mode == 'on_demand' }}
     uses: ./.github/workflows/on_demand_build_and_test.yaml
     name: On-demand build and test
-    needs: plan
+    needs:
+      - plan
+      - prepare-pr-comment
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix_include) }}
@@ -127,7 +175,9 @@ jobs:
     if: ${{ inputs.mode == 'pooled' }}
     uses: ./.github/workflows/on_pooled_build_and_test.yaml
     name: Pooled build and test
-    needs: plan
+    needs:
+      - plan
+      - prepare-pr-comment
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix_include) }}
@@ -149,7 +199,9 @@ jobs:
     if: ${{ inputs.mode == 'hybrid' }}
     uses: ./.github/workflows/on_hybrid_build_and_test.yaml
     name: Hybrid build and test
-    needs: plan
+    needs:
+      - plan
+      - prepare-pr-comment
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix_include) }}

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -135,6 +135,19 @@ jobs:
         submodules: true
         clean: true
 
+    - name: mark workload as running
+      id: workload-comment
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: running
+        current_job_name: Build and test ${{ inputs.build_preset }} [id=${{ inputs.runner_instance_id }} ip=${{ inputs.runner_ipv4 }}]
+        runner_name: ${{ runner.name }}
+        add_summary_link: yes
+
     - name: Prepare s3cmd
       uses: ./.github/actions/s3cmd
       with:
@@ -207,3 +220,12 @@ jobs:
       uses: ./.github/actions/sleep
       with:
         sleep_after_tests: ${{ inputs.sleep_after_tests != '0' && inputs.sleep_after_tests || '7200' }}
+
+    - name: mark workload as completed
+      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: completed

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -178,6 +178,7 @@ jobs:
         done &
 
     - name: Build
+      id: build
       uses: ./.github/actions/build
       if: inputs.run_build
       with:
@@ -214,6 +215,16 @@ jobs:
         use_network_cache: ${{ inputs.use_network_cache }}
         number_of_retries: ${{ inputs.number_of_retries }}
         truncate_enabled: ${{ inputs.truncate_enabled }}
+
+    - name: mark workload build failed
+      if: ${{ failure() && steps.build.outcome == 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: failed_build
+
     - id: failure
       name: set sleep_after_tests in case of failure
       if: failure()
@@ -222,7 +233,7 @@ jobs:
         sleep_after_tests: ${{ inputs.sleep_after_tests != '0' && inputs.sleep_after_tests || '7200' }}
 
     - name: mark workload as completed
-      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      if: ${{ always() && steps.build.outcome != 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
       uses: ./.github/actions/workload_comment
       with:
         command: update

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -105,7 +105,7 @@ jobs:
     runs-on: [ self-hosted, "${{ inputs.runner_kind }}", "${{ inputs.runner_label }}" ]
     outputs:
         sleep_after_tests: ${{ steps.failure.outputs.sleep_after_tests }}
-    timeout-minutes: 1440
+    timeout-minutes: 480
     steps:
     - name: Checkout PR
       uses: actions/checkout@v6

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -135,6 +135,19 @@ jobs:
         submodules: true
         clean: true
 
+    - name: mark workload as running
+      id: workload-comment
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: running
+        current_job_name: Build and test ${{ inputs.build_preset }} [id=${{ inputs.runner_instance_id }} ip=${{ inputs.runner_ipv4 }}]
+        runner_name: ${{ runner.name }}
+        add_summary_link: yes
+
     - name: Prepare s3cmd
       uses: ./.github/actions/s3cmd
       with:
@@ -207,3 +220,12 @@ jobs:
       uses: ./.github/actions/sleep
       with:
         sleep_after_tests: ${{ inputs.sleep_after_tests != '0' && inputs.sleep_after_tests || '7200' }}
+
+    - name: mark workload as completed
+      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: completed

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -178,6 +178,7 @@ jobs:
         done &
 
     - name: Build
+      id: build
       uses: ./.github/actions/build
       if: inputs.run_build
       with:
@@ -214,6 +215,16 @@ jobs:
         use_network_cache: ${{ inputs.use_network_cache }}
         number_of_retries: ${{ inputs.number_of_retries }}
         truncate_enabled: ${{ inputs.truncate_enabled }}
+
+    - name: mark workload build failed
+      if: ${{ failure() && steps.build.outcome == 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: failed_build
+
     - id: failure
       name: set sleep_after_tests in case of failure
       if: failure()
@@ -222,7 +233,7 @@ jobs:
         sleep_after_tests: ${{ inputs.sleep_after_tests != '0' && inputs.sleep_after_tests || '7200' }}
 
     - name: mark workload as completed
-      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      if: ${{ always() && steps.build.outcome != 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
       uses: ./.github/actions/workload_comment
       with:
         command: update

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -105,7 +105,7 @@ jobs:
     runs-on: [ self-hosted, "${{ inputs.runner_kind }}", "${{ inputs.runner_label }}" ]
     outputs:
         sleep_after_tests: ${{ steps.failure.outputs.sleep_after_tests }}
-    timeout-minutes: 1440
+    timeout-minutes: 480
     steps:
     - name: Checkout PR
       uses: actions/checkout@v6

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -182,6 +182,19 @@ jobs:
         vm_preset: ${{ steps.get-runner.outputs.VM_PRESET }}
         tests_size: ${{ inputs.test_size }}
 
+    - name: mark workload as running
+      id: workload-comment
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: running
+        current_job_name: Build and test ${{ inputs.build_preset }}
+        runner_name: ${{ runner.name }}
+        add_summary_link: yes
+
     - name: Prepare s3cmd
       uses: ./.github/actions/s3cmd
       with:
@@ -248,10 +261,19 @@ jobs:
         SLEEP_AFTER_TESTS: ${{ inputs.sleep_after_tests || '7200' }}
       run: |
         sleep "$SLEEP_AFTER_TESTS"
+
+    - name: mark workload as completed
+      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: completed
   debug:
     name: Debug
     runs-on: [self-hosted, "self-hosted", "runner_light"]
-    needs: 
+    needs:
       - calculate-runs-on
       - build-and-test
     if: ${{ !cancelled() }}
@@ -273,7 +295,6 @@ jobs:
           echo "Test failed is empty: ${{ needs.build-and-test.outputs.test_failed == '' }}"
           echo "Condition: ${{ needs.build-and-test.outputs.test_failed == null && needs.build-and-test.outputs.test_run_outcome == null }}"
           echo "Condition: ${{ needs.build-and-test.outputs.test_failed == '' && needs.build-and-test.outputs.test_run_outcome == '' }}"
-          
         env:
           test_run_outcome: ${{ needs.build-and-test.outputs.test_run_outcome }}
           test_failed: ${{ needs.build-and-test.outputs.test_failed }}
@@ -287,7 +308,7 @@ jobs:
           test_run_outcome_is_cancelled: ${{ needs.build-and-test.outputs.test_run_outcome == 'cancelled' }}
           test_run_outcome_is_empty: ${{ needs.build-and-test.outputs.test_run_outcome == '' }}
           test_failed_is_empty: ${{ needs.build-and-test.outputs.test_failed == '' }}
-    
+
   test-retry:
     name: Retry tests
     runs-on: ${{ fromJson(needs.calculate-runs-on.outputs.runs-on) }}

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -105,7 +105,7 @@ jobs:
   build-and-test:
     name: Build and test ${{ inputs.build_preset }}
     runs-on: ${{ fromJson(needs.calculate-runs-on.outputs.runs-on) }}
-    timeout-minutes: 420
+    timeout-minutes: 480
     needs: calculate-runs-on
     outputs:
       # outcome failure and test_failed is null -> vm is broken

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -216,6 +216,7 @@ jobs:
         sudo apt-get install -y unattended-upgrades
 
     - name: Build
+      id: build
       uses: ./.github/actions/build
       if: inputs.run_build
       with:
@@ -253,6 +254,16 @@ jobs:
         use_network_cache: ${{ inputs.use_network_cache }}
         number_of_retries: ${{ inputs.number_of_retries }}
         truncate_enabled: ${{ inputs.truncate_enabled }}
+
+    - name: mark workload build failed
+      if: ${{ failure() && steps.build.outcome == 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      uses: ./.github/actions/workload_comment
+      with:
+        command: update
+        build_preset: ${{ inputs.build_preset }}
+        component: ${{ inputs.component == '' && 'all' || inputs.component }}
+        workload_check_status: failed_build
+
     - id: sleep
       name: Sleep after failed tests
       if: ${{ inputs.sleep_after_tests != '0' && failure() }}
@@ -263,7 +274,7 @@ jobs:
         sleep "$SLEEP_AFTER_TESTS"
 
     - name: mark workload as completed
-      if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      if: ${{ always() && steps.build.outcome != 'failure' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
       uses: ./.github/actions/workload_comment
       with:
         command: update

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -565,3 +565,33 @@ jobs:
       cache_update_tests: false
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
+
+  finalize-build-and-test-comments:
+    needs: [check-running-allowed, create-build-and-test-target-var, build_and_test]
+    if: ${{ always() && needs.check-running-allowed.outputs.result == 'true' }}
+    runs-on: [self-hosted, "self-hosted", "runner_light"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+      - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
+        if: ${{ always() }}
+        run: git config core.sparseCheckout false
+        continue-on-error: true
+      - name: set up dependencies
+        run: pip install -r .github/scripts/requirements_dev.txt
+      - name: finalize workload comments
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MATRIX_INCLUDE: ${{ needs.create-build-and-test-target-var.outputs.matrix_include }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
+          platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
+          python3 -m scripts.tests.finalize_workload_comments \
+            --matrix-include "$MATRIX_INCLUDE" \
+            --platform-name "$platform_name" \
+            --workload-status completed

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -582,7 +582,7 @@ jobs:
         run: git config core.sparseCheckout false
         continue-on-error: true
       - name: set up dependencies
-        run: pip install -r .github/scripts/requirements_dev.txt
+        run: pip install -r .github/scripts/requirements.txt
       - name: finalize workload comments
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -290,13 +290,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workdir: .github/
           reporter: ${{ steps.reporter.outputs.value }}
-          flake8_args: "--max-line-length 128 --ignore Q000,D100,D101,D102,D103,D104,D105,D106,D107,D401,D205,D400,E704"
+          flake8_args: "--max-line-length 128 --ignore Q000,D100,D101,D102,D103,D104,D105,D106,D107,D401,D205,D400,E704,W503"
 
       - name: flake8 (act)
         if: ${{ env.ACT == 'true' }}
         run: |
           pip install flake8==7.3.0
-          flake8 --max-line-length 128 --ignore Q000,D100,D101,D102,D103,D104,D105,D106,D107,D401,D205,D400 .github/
+          flake8 --max-line-length 128 --ignore Q000,D100,D101,D102,D103,D104,D105,D106,D107,D401,D205,D400,E704,W503 .github/
 
       - name: black
         if: ${{ env.ACT != 'true' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -249,7 +249,7 @@ jobs:
         run: git config core.sparseCheckout false
         continue-on-error: true
       - name: set up dependencies
-        run: pip install -r .github/scripts/requirements_dev.txt
+        run: pip install -r .github/scripts/requirements.txt
       - name: finalize workload comments
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -210,3 +210,55 @@ jobs:
       cache_update_tests: false
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
+
+  finalize-build-and-test-comments:
+    needs: [check-running-allowed, create-build-and-test-target-var, build_and_test]
+    if: ${{ always() && needs.check-running-allowed.outputs.result == 'true' }}
+    runs-on: [self-hosted, "self-hosted", "runner_light"]
+    steps:
+      - name: checkout PR
+        uses: actions/checkout@v6
+        if: github.event.pull_request.head.sha != ''
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
+      - name: rebase PR
+        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+        shell: bash
+        run: |
+          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+            echo "Removing stale rebase state left on runner checkout"
+            rm -rf .git/rebase-merge .git/rebase-apply
+          fi
+          git config user.email "robot-nbs@nebius.com"
+          git config user.name "Robot NBS"
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
+      - name: checkout
+        uses: actions/checkout@v6
+        if: github.event.pull_request.head.sha == ''
+        with:
+          submodules: false
+          clean: true
+          sparse-checkout: '.github'
+      - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
+        if: ${{ always() }}
+        run: git config core.sparseCheckout false
+        continue-on-error: true
+      - name: set up dependencies
+        run: pip install -r .github/scripts/requirements_dev.txt
+      - name: finalize workload comments
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MATRIX_INCLUDE: ${{ needs.create-build-and-test-target-var.outputs.matrix_include }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
+          platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
+          python3 -m scripts.tests.finalize_workload_comments \
+            --matrix-include "$MATRIX_INCLUDE" \
+            --platform-name "$platform_name" \
+            --workload-status completed


### PR DESCRIPTION
Currently there are few problems addressed in this PR:

1. You don't know which checks are running and whether you should wait for them to finish
2. If check is failed on build stage you have no way of knowing about it except to look in statuses of checks or going to the build job itself

This fixes it buy providing status plaque before runs are initialized and they are updated as they go