### PR TITLE
filestore: making shard balancer less sensitive to small changes in shard free space by rounding it to multiples of 1GiB

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -752,4 +752,8 @@ message TStorageConfig
 
     // Enable FUSE_POSIX_ACL on guest (FUSE client)
     optional bool GuestPosixAclEnabled = 492;
+
+    // Shard balancer will round free space per shard to a multiple of this
+    // number in bytes.
+    optional uint64 ShardBalancerPrecisionBytes = 493;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -75,6 +75,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(ShardBalancerPolicy,                                                   \
             NProto::EShardBalancerPolicy,                                      \
             NProto::SBP_ROUND_ROBIN                                           )\
+    xxx(ShardBalancerPrecisionBytes,                            ui64,   1_GB  )\
                                                                                \
     xxx(DirectoryCreationInShardsEnabled,                       bool,   false )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -325,6 +325,7 @@ public:
     ui64 GetShardBalancerDesiredFreeSpaceReserve() const;
     ui64 GetShardBalancerMinFreeSpaceReserve() const;
     NProto::EShardBalancerPolicy GetShardBalancerPolicy() const;
+    ui64 GetShardBalancerPrecisionBytes() const;
 
     bool GetDirectoryCreationInShardsEnabled() const;
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -4833,6 +4833,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardBalancerMinFreeSpaceReserve(4_KB);
         config.SetShardBalancerDesiredFreeSpaceReserve(1_MB);
         config.SetMultiTabletForwardingEnabled(true);
+        config.SetShardBalancerPrecisionBytes(4_KB);
 
         TTestEnv env({}, config);
 

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
@@ -20,8 +20,8 @@ struct TShardMetaComp
 {
     const ui64 Unit;
 
-    explicit TShardMetaComp(ui32 blockSize)
-        : Unit(1_GB / blockSize)
+    TShardMetaComp(ui64 precisionBytes, ui32 blockSize)
+        : Unit(Max(1UL, precisionBytes / blockSize))
     {}
 
     ui64 Score(const TShardBalancerBase::TShardMeta& m) const
@@ -53,11 +53,13 @@ struct TShardMetaComp
 
 TShardBalancerBase::TShardBalancerBase(
         ui32 blockSize,
+        ui64 precisionBytes,
         ui32 maxFileBlocks,
         ui64 desiredFreeSpaceReserve,
         ui64 minFreeSpaceReserve,
         TVector<TString> shardIds)
     : BlockSize(blockSize)
+    , PrecisionBytes(precisionBytes)
     , DesiredFreeSpaceReserve(desiredFreeSpaceReserve)
     , MinFreeSpaceReserve(minFreeSpaceReserve)
     , Ids(std::move(shardIds))
@@ -93,7 +95,7 @@ void TShardBalancerBase::Update(
     for (ui32 i = 0; i < stats.size(); ++i) {
         Metas[i] = TShardMeta(i, stats[i]);
     }
-    Sort(Metas.begin(), Metas.end(), TShardMetaComp(BlockSize));
+    Sort(Metas.begin(), Metas.end(), TShardMetaComp(PrecisionBytes, BlockSize));
 }
 
 size_t TShardBalancerBase::FindUpperBoundAmongAllShardsToFitFile(
@@ -103,13 +105,13 @@ size_t TShardBalancerBase::FindUpperBoundAmongAllShardsToFitFile(
         Metas.begin(),
         Metas.end(),
         (fileSize + DesiredFreeSpaceReserve) / BlockSize,
-        TShardMetaComp(BlockSize));
+        TShardMetaComp(PrecisionBytes, BlockSize));
     if (e == Metas.begin()) {
         e = UpperBound(
             Metas.begin(),
             Metas.end(),
             (fileSize + MinFreeSpaceReserve) / BlockSize,
-            TShardMetaComp(BlockSize));
+            TShardMetaComp(PrecisionBytes, BlockSize));
     }
 
     return std::distance(Metas.begin(), e);
@@ -161,12 +163,14 @@ NProto::TError TShardBalancerRandom::SelectShard(
 
 TShardBalancerWeightedRandom::TShardBalancerWeightedRandom(
         ui32 blockSize,
+        ui64 precisionBytes,
         ui32 maxFileBlocks,
         ui64 desiredFreeSpaceReserve,
         ui64 minFreeSpaceReserve,
         TVector<TString> shardIds)
     : TShardBalancerBase(
           blockSize,
+          precisionBytes,
           maxFileBlocks,
           desiredFreeSpaceReserve,
           minFreeSpaceReserve,
@@ -234,6 +238,7 @@ NProto::TError TShardBalancerWeightedRandom::SelectShard(
 IShardBalancerPtr CreateShardBalancer(
     NProto::EShardBalancerPolicy policy,
     ui32 blockSize,
+    ui64 precisionBytes,
     ui32 maxFileBlocks,
     ui64 desiredFreeSpaceReserve,
     ui64 minFreeSpaceReserve,
@@ -243,6 +248,7 @@ IShardBalancerPtr CreateShardBalancer(
         case NProto::SBP_ROUND_ROBIN:
             return std::make_shared<TShardBalancerRoundRobin>(
                 blockSize,
+                precisionBytes,
                 maxFileBlocks,
                 desiredFreeSpaceReserve,
                 minFreeSpaceReserve,
@@ -250,6 +256,7 @@ IShardBalancerPtr CreateShardBalancer(
         case NProto::SBP_RANDOM:
             return std::make_shared<TShardBalancerRandom>(
                 blockSize,
+                precisionBytes,
                 maxFileBlocks,
                 desiredFreeSpaceReserve,
                 minFreeSpaceReserve,
@@ -257,6 +264,7 @@ IShardBalancerPtr CreateShardBalancer(
         case NProto::SBP_WEIGHTED_RANDOM:
             return std::make_shared<TShardBalancerWeightedRandom>(
                 blockSize,
+                precisionBytes,
                 maxFileBlocks,
                 desiredFreeSpaceReserve,
                 minFreeSpaceReserve,

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
@@ -18,18 +18,34 @@ ui64 FreeSpace(const TShardStats& s)
 
 struct TShardMetaComp
 {
+    const ui64 Unit;
+
+    explicit TShardMetaComp(ui32 blockSize)
+        : Unit(1_GB / blockSize)
+    {}
+
+    ui64 Score(const TShardBalancerBase::TShardMeta& m) const
+    {
+        return Score(FreeSpace(m.Stats));
+    }
+
+    ui64 Score(ui64 s) const
+    {
+        return static_cast<ui64>(round(s / static_cast<double>(Unit)));
+    }
+
     bool operator()(
         const TShardBalancerBase::TShardMeta& lhs,
         const TShardBalancerBase::TShardMeta& rhs)
     {
-        return FreeSpace(lhs.Stats) == FreeSpace(rhs.Stats)
+        return Score(lhs) == Score(rhs)
             ? lhs.ShardIdx < rhs.ShardIdx
-            : FreeSpace(lhs.Stats) > FreeSpace(rhs.Stats);
+            : Score(lhs) > Score(rhs);
     }
 
     bool operator()(ui64 lhs, const TShardBalancerBase::TShardMeta& rhs)
     {
-        return lhs > FreeSpace(rhs.Stats);
+        return Score(lhs) > Score(rhs);
     }
 };
 
@@ -77,7 +93,7 @@ void TShardBalancerBase::Update(
     for (ui32 i = 0; i < stats.size(); ++i) {
         Metas[i] = TShardMeta(i, stats[i]);
     }
-    Sort(Metas.begin(), Metas.end(), TShardMetaComp());
+    Sort(Metas.begin(), Metas.end(), TShardMetaComp(BlockSize));
 }
 
 size_t TShardBalancerBase::FindUpperBoundAmongAllShardsToFitFile(
@@ -87,16 +103,27 @@ size_t TShardBalancerBase::FindUpperBoundAmongAllShardsToFitFile(
         Metas.begin(),
         Metas.end(),
         (fileSize + DesiredFreeSpaceReserve) / BlockSize,
-        TShardMetaComp());
+        TShardMetaComp(BlockSize));
     if (e == Metas.begin()) {
         e = UpperBound(
             Metas.begin(),
             Metas.end(),
             (fileSize + MinFreeSpaceReserve) / BlockSize,
-            TShardMetaComp());
+            TShardMetaComp(BlockSize));
     }
 
     return std::distance(Metas.begin(), e);
+}
+
+TVector<IShardBalancer::TShardDescr>
+TShardBalancerBase::MakeOrderedShardList() const
+{
+    TVector<TShardDescr> shardDescrs;
+    shardDescrs.reserve(Metas.size());
+    for (const auto& meta: Metas) {
+        shardDescrs.emplace_back(Ids[meta.ShardIdx], meta.Stats);
+    }
+    return shardDescrs;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
@@ -76,13 +76,15 @@ class TShardBalancerBase: public IShardBalancer
 public:
     TShardBalancerBase(
         ui32 blockSize,
+        ui64 precisionBytes,
         ui32 maxFileBlocks,
         ui64 desiredFreeSpaceReserve,
         ui64 minFreeSpaceReserve,
         TVector<TString> shardIds);
 
 private:
-    const ui32 BlockSize = 4_KB;
+    const ui32 BlockSize;
+    const ui64 PrecisionBytes;
     ui64 DesiredFreeSpaceReserve = 0;
     ui64 MinFreeSpaceReserve = 0;
 
@@ -152,6 +154,7 @@ private:
 public:
     TShardBalancerWeightedRandom(
         ui32 blockSize,
+        ui64 precisionBytes,
         ui32 maxFileBlocks,
         ui64 desiredFreeSpaceReserve,
         ui64 minFreeSpaceReserve,
@@ -168,6 +171,7 @@ public:
 IShardBalancerPtr CreateShardBalancer(
     NProto::EShardBalancerPolicy policy,
     ui32 blockSize,
+    ui64 precisionBytes,
     ui32 maxFileBlocks,
     ui64 desiredFreeSpaceReserve,
     ui64 minFreeSpaceReserve,

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
@@ -27,20 +27,6 @@ struct TShardStats
 class IShardBalancer
 {
 public:
-    virtual ~IShardBalancer() = default;
-
-    virtual void Update(
-        const TVector<TShardStats>& stats,
-        std::optional<ui64> desiredFreeSpaceReserve,
-        std::optional<ui64> minFreeSpaceReserve) = 0;
-    virtual NProto::TError SelectShard(ui64 fileSize, TString* shardId) = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-class TShardBalancerBase: public IShardBalancer
-{
-public:
     struct TShardMeta
     {
         ui32 ShardIdx;
@@ -52,6 +38,42 @@ public:
         {}
     };
 
+    struct TShardDescr
+    {
+        TString ShardId;
+        TShardStats Stats;
+
+        TShardDescr(TString shardId, TShardStats stats)
+            : ShardId(std::move(shardId))
+            , Stats(stats)
+        {}
+    };
+
+    virtual ~IShardBalancer() = default;
+
+    virtual void Update(
+        const TVector<TShardStats>& stats,
+        std::optional<ui64> desiredFreeSpaceReserve,
+        std::optional<ui64> minFreeSpaceReserve) = 0;
+    virtual NProto::TError SelectShard(ui64 fileSize, TString* shardId) = 0;
+
+    /**
+     * @brief Builds and returns the shard list ordered from best to worst.
+     *
+     * This method builds a new vector with shard descrs so it's not supposed to
+     * be used often because it's expensive. The main intended use case is
+     * introspection - log this info with debug loglevel or show it on monpages.
+     *
+     * @return The list of shard descrs.
+     */
+    [[nodiscard]] virtual TVector<TShardDescr> MakeOrderedShardList() const = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TShardBalancerBase: public IShardBalancer
+{
+public:
     TShardBalancerBase(
         ui32 blockSize,
         ui32 maxFileBlocks,
@@ -89,6 +111,8 @@ public:
         const TVector<TShardStats>& stats,
         std::optional<ui64> desiredFreeSpaceReserve = {},
         std::optional<ui64> minFreeSpaceReserve = {}) override;
+
+    [[nodiscard]] TVector<TShardDescr> MakeOrderedShardList() const override;
 };
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
@@ -40,7 +40,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
             BlockSize,
             MaxFileBlocks,
             1_TB /* desiredFreeSpaceReserve */,
-            1_MB /* minFreeSpaceReserve */,
+            1_GB /* minFreeSpaceReserve */,
             {"s1", "s2", "s3", "s4", "s5"});
         ASSERT_NO_SB_ERROR(0, "s1");
         ASSERT_NO_SB_ERROR(0, "s2");
@@ -248,7 +248,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
             BlockSize,
             MaxFileBlocks,
             1_TB /* desiredFreeSpaceReserve */,
-            1_MB /* minFreeSpaceReserve */,
+            1_GB /* minFreeSpaceReserve */,
             {"s1", "s2", "s3", "s4", "s5"});
 
         balancer.Update({

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
@@ -32,12 +32,14 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
 // ASSERT_ERROR
 
 constexpr ui32 BlockSize = 4_KB;
+constexpr ui64 PrecisionBytes = 1_GB;
 constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
 
     Y_UNIT_TEST(ShouldBalanceShardsRoundRobin)
     {
         TShardBalancerRoundRobin balancer(
             BlockSize,
+            PrecisionBytes,
             MaxFileBlocks,
             1_TB /* desiredFreeSpaceReserve */,
             1_GB /* minFreeSpaceReserve */,
@@ -188,6 +190,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
         // desiredFreeSpaceReserve, minFreeSpaceReserve are zero
         TShardBalancerRoundRobin balancer(
             BlockSize,
+            PrecisionBytes,
             MaxFileBlocks,
             0 /* desiredFreeSpaceReserve */,
             0 /* minFreeSpaceReserve */,
@@ -206,6 +209,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
     {
         TShardBalancerRandom balancer(
             BlockSize,
+            PrecisionBytes,
             MaxFileBlocks,
             0 /* desiredFreeSpaceReserve */,
             0 /* minFreeSpaceReserve */,
@@ -226,6 +230,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
     {
         TShardBalancerWeightedRandom balancer(
             BlockSize,
+            PrecisionBytes,
             MaxFileBlocks,
             0 /* desiredFreeSpaceReserve */,
             0 /* minFreeSpaceReserve */,
@@ -246,6 +251,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
     {
         TShardBalancerRoundRobin balancer(
             BlockSize,
+            PrecisionBytes,
             MaxFileBlocks,
             1_TB /* desiredFreeSpaceReserve */,
             1_GB /* minFreeSpaceReserve */,
@@ -254,8 +260,8 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
         balancer.Update({
             {5_TB / 4_KB, 512_GB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 1_TB / 4_KB + 1, 0, 0},
-            {5_TB / 4_KB, 1_TB / 4_KB + 1, 0, 0},
+            {5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
+            {5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, 3_TB / 4_KB, 0, 0},
         });
 
@@ -295,6 +301,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
     {
         TShardBalancerRandom balancer(
             BlockSize,
+            PrecisionBytes,
             MaxFileBlocks,
             1_TB /* desiredFreeSpaceReserve */,
             1_MB /* minFreeSpaceReserve */,
@@ -363,6 +370,7 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
     {
         TShardBalancerWeightedRandom balancer(
             BlockSize,
+            PrecisionBytes,
             MaxFileBlocks,
             1_TB /* desiredFreeSpaceReserve */,
             0 /* minFreeSpaceReserve */,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -548,8 +548,7 @@ void TIndexTabletActor::RegisterStatCounters(TInstant now)
 void TIndexTabletActor::ScheduleUpdateCounters(const TActorContext& ctx)
 {
     if (!UpdateCountersScheduled) {
-        //ctx.Schedule(UpdateCountersInterval,
-        ctx.Schedule(TDuration::Seconds(1),
+        ctx.Schedule(UpdateCountersInterval,
             new TEvIndexTabletPrivate::TEvUpdateCounters());
         UpdateCountersScheduled = true;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -265,6 +265,27 @@ STFUNC(TAggregateStatsActor::StateWork)
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+TString DescribeShardList(const TVector<IShardBalancer::TShardDescr>& shards)
+{
+    TStringBuilder sb;
+    for (ui32 i = 0; i < shards.size(); ++i) {
+        if (i) {
+            sb << ", ";
+        }
+
+        const auto& s = shards[i];
+        sb << "id=" << s.ShardId
+            << " blocks=" << s.Stats.UsedBlocksCount
+            << "/" << s.Stats.TotalBlocksCount
+            << " nodes=" << s.Stats.UsedNodesCount
+            << " load=" << s.Stats.CurrentLoad
+            << " suffer=" << s.Stats.Suffer;
+    }
+    return sb;
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -527,7 +548,8 @@ void TIndexTabletActor::RegisterStatCounters(TInstant now)
 void TIndexTabletActor::ScheduleUpdateCounters(const TActorContext& ctx)
 {
     if (!UpdateCountersScheduled) {
-        ctx.Schedule(UpdateCountersInterval,
+        //ctx.Schedule(UpdateCountersInterval,
+        ctx.Schedule(TDuration::Seconds(1),
             new TEvIndexTabletPrivate::TEvUpdateCounters());
         UpdateCountersScheduled = true;
     }
@@ -814,7 +836,7 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
         backgroundRequestDuration = ctx.Now() - CachedStatsFetchingStartTs;
         LOG_DEBUG(
             ctx,
-            TFileStoreComponents::TABLET_WORKER,
+            TFileStoreComponents::TABLET,
             "%s Background shard stats fetch completed in %s, ShardsCount: %lu",
             LogTag.c_str(),
             backgroundRequestDuration.ToString().c_str(),
@@ -832,6 +854,13 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
         CachedAggregateStats = std::move(msg->AggregateStats);
         CachedShardStats = std::move(msg->ShardStats);
         UpdateShardBalancer(CachedShardStats);
+
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s Updated shard balancer: %s",
+            LogTag.c_str(),
+            DescribeShardList(MakeOrderedShardList()).c_str());
 
         Store(
             Metrics.AggregateUsedBytesCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -178,6 +178,7 @@ void TIndexTabletState::LoadState(
     Impl->ShardBalancer = CreateShardBalancer(
         config.GetShardBalancerPolicy(),
         GetBlockSize(),
+        config.GetShardBalancerPrecisionBytes(),
         config.GetMaxFileBlocks(),
         config.GetShardBalancerDesiredFreeSpaceReserve(),
         config.GetShardBalancerMinFreeSpaceReserve(),
@@ -202,6 +203,7 @@ void TIndexTabletState::UpdateConfig(
     Impl->ShardBalancer = CreateShardBalancer(
         config.GetShardBalancerPolicy(),
         GetBlockSize(),
+        config.GetShardBalancerPrecisionBytes(),
         config.GetMaxFileBlocks(),
         config.GetShardBalancerDesiredFreeSpaceReserve(),
         config.GetShardBalancerMinFreeSpaceReserve(),

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -417,6 +417,8 @@ public:
 
     void UpdateShardBalancer(const TVector<TShardStats>& stats);
 
+    TVector<IShardBalancer::TShardDescr> MakeOrderedShardList() const;
+
     //
     // FileSystem Stats
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1563,4 +1563,10 @@ void TIndexTabletState::UpdateShardBalancer(const TVector<TShardStats>& stats)
         minFreeSpaceReserve);
 }
 
+TVector<IShardBalancer::TShardDescr>
+TIndexTabletState::MakeOrderedShardList() const
+{
+    return Impl->ShardBalancer->MakeOrderedShardList();
+}
+
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Notes
Small changes in free space - e.g. creation/deletion of 4KiB files and similar things - shouldn't affect shard order in the balancer. It makes load distribution more even and it also allows us to canonize shard ids in the results of some of our tests. Without rounding some of the tests - for example `tests/client_sharded_dir` - become unstable (reliant on the timing of balancer stats updates).

Logging balancer's per shard statistics with debug loglevel as well - otherwise it's hard to debug balancer-related issues.

### Issue
none