### PR TITLE
issue-5758: make immediate controls configurable in nbs/filestore processes

### DIFF
--- a/cloud/storage/core/libs/kikimr/config_initializer.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer.cpp
@@ -181,6 +181,14 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
             Options->SharedCacheConfig,
             sharedCacheConfig);
     }
+
+    if (Options->ImmediateControlsConfig) {
+        auto& immediateControlsConfig =
+            *KikimrConfig->MutableImmediateControlsConfig();
+        ParseProtoTextFromFile(
+            Options->ImmediateControlsConfig,
+            immediateControlsConfig);
+    }
 }
 
 NKikimrConfig::TLogConfig TConfigInitializerYdbBase::GetLogConfig() const

--- a/cloud/storage/core/libs/kikimr/options.cpp
+++ b/cloud/storage/core/libs/kikimr/options.cpp
@@ -30,6 +30,10 @@ TOptionsYdbBase::TOptionsYdbBase()
         .OptionalArgument("FILE")
         .StoreResult(&SharedCacheConfig);
 
+    Opts.AddLongOption("immediate-controls-file")
+        .RequiredArgument("FILE")
+        .StoreResult(&ImmediateControlsConfig);
+
     Opts.AddLongOption("sys-file")
         .RequiredArgument("FILE")
         .StoreResult(&SysConfig);

--- a/cloud/storage/core/libs/kikimr/options.h
+++ b/cloud/storage/core/libs/kikimr/options.h
@@ -21,6 +21,7 @@ struct TOptionsYdbBase
     TString AuthConfig;
     TString KikimrFeaturesConfig;
     TString SharedCacheConfig;
+    TString ImmediateControlsConfig;
 
     TString InterconnectConfig;
     ui32 InterconnectPort = 0;

--- a/cloud/storage/core/tools/common/go/configurator/kikimr-proto/immediate_controls.proto
+++ b/cloud/storage/core/tools/common/go/configurator/kikimr-proto/immediate_controls.proto
@@ -1,0 +1,13 @@
+syntax = "proto2";
+
+option go_package = "github.com/ydb-platform/nbs/cloud/storage/core/tools/common/go/configurator/kikimr-proto";
+
+message TImmediateControlsConfig {
+    message TDSProxyControls {
+        optional uint64 PredictedDelayMultiplier = 2;
+        optional uint64 PredictedDelayMultiplierHDD = 7;
+        optional uint64 PredictedDelayMultiplierSSD = 10;
+    }
+
+    optional TDSProxyControls DSProxyControls = 9;
+}

--- a/cloud/storage/core/tools/common/go/configurator/kikimr-proto/ya.make
+++ b/cloud/storage/core/tools/common/go/configurator/kikimr-proto/ya.make
@@ -5,6 +5,7 @@ ONLY_TAGS(GO_PROTO)
 SRCS(
     auth.proto
     ic.proto
+    immediate_controls.proto
     log.proto
     shared_cache.proto
     sys.proto

--- a/cloud/storage/core/tools/ops/config_generator/main.go
+++ b/cloud/storage/core/tools/ops/config_generator/main.go
@@ -56,11 +56,12 @@ func getNbsConfigMap() configurator.ConfigMap {
 		// for kikimr initializer configs used custom protobuf files
 		// from cloud/storage/core/tools/common/go/configurator/kikimr-proto
 		// with a minimum set of parameters to avoid dependencies
-		"nbs-auth.txt":         {Proto: &kikimrProto.TAuthConfig{}, FileName: "auth.txt"},
-		"nbs-ic.txt":           {Proto: &kikimrProto.TInterconnectConfig{}, FileName: "ic.txt"},
-		"nbs-log.txt":          {Proto: &kikimrProto.TLogConfig{}, FileName: "log.txt"},
-		"nbs-shared-cache.txt": {Proto: &kikimrProto.TSharedCacheConfig{}, FileName: "shared-cache.txt"},
-		"nbs-sys.txt":          {Proto: &kikimrProto.TActorSystemConfig{}, FileName: "sys.txt"},
+		"nbs-auth.txt":               {Proto: &kikimrProto.TAuthConfig{}, FileName: "auth.txt"},
+		"nbs-ic.txt":                 {Proto: &kikimrProto.TInterconnectConfig{}, FileName: "ic.txt"},
+		"nbs-immediate-controls.txt": {Proto: &kikimrProto.TImmediateControlsConfig{}, FileName: "immediate-controls.txt"},
+		"nbs-log.txt":                {Proto: &kikimrProto.TLogConfig{}, FileName: "log.txt"},
+		"nbs-shared-cache.txt":       {Proto: &kikimrProto.TSharedCacheConfig{}, FileName: "shared-cache.txt"},
+		"nbs-sys.txt":                {Proto: &kikimrProto.TActorSystemConfig{}, FileName: "sys.txt"},
 	}
 }
 
@@ -77,11 +78,12 @@ func getNfsConfigMap() configurator.ConfigMap {
 		// for kikimr initializer configs used custom protobuf files
 		// from cloud/storage/core/tools/common/go/configurator/kikimr-proto
 		// with a minimum set of parameters to avoid dependencies
-		"nfs-auth.txt":  {Proto: &kikimrProto.TAuthConfig{}, FileName: "auth.txt"},
-		"nfs-ic.txt":    {Proto: &kikimrProto.TInterconnectConfig{}, FileName: "ic.txt"},
-		"nfs-log.txt":   {Proto: &kikimrProto.TLogConfig{}, FileName: "log.txt"},
-		"nfs-sys.txt":   {Proto: &kikimrProto.TActorSystemConfig{}, FileName: "sys.txt"},
-		"vhost-log.txt": {Proto: &kikimrProto.TLogConfig{}, FileName: "vhost-log.txt"},
+		"nfs-auth.txt":               {Proto: &kikimrProto.TAuthConfig{}, FileName: "auth.txt"},
+		"nfs-ic.txt":                 {Proto: &kikimrProto.TInterconnectConfig{}, FileName: "ic.txt"},
+		"nfs-immediate-controls.txt": {Proto: &kikimrProto.TImmediateControlsConfig{}, FileName: "immediate-controls.txt"},
+		"nfs-log.txt":                {Proto: &kikimrProto.TLogConfig{}, FileName: "log.txt"},
+		"nfs-sys.txt":                {Proto: &kikimrProto.TActorSystemConfig{}, FileName: "sys.txt"},
+		"vhost-log.txt":              {Proto: &kikimrProto.TLogConfig{}, FileName: "vhost-log.txt"},
 	}
 }
 


### PR DESCRIPTION
### Notes

Seems to be working with this config, for example:
```
DSProxyControls {
    PredictedDelayMultiplier: 3000
    PredictedDelayMultiplierHDD: 3000
    PredictedDelayMultiplierSSD: 3000
}
```
and this change in the start script:
```
--- a/cloud/filestore/bin/filestore-server.sh
+++ b/cloud/filestore/bin/filestore-server.sh
@@ -31,5 +31,6 @@ $BIN_DIR/filestore-server \
     --ic-file            $CONFIG_DIR/nfs-ic.txt \
     --storage-file       $CONFIG_DIR/nfs-storage.txt \
     --features-file      $CONFIG_DIR/nfs-features.txt \
+    --immediate-controls-file $CONFIG_DIR/nfs-immediate-controls.txt \
     --profile-file       $LOG_DIR/filestore-server-profile-log.bin \
     $@
```

<img width="1177" height="383" alt="image" src="https://github.com/user-attachments/assets/48e23a90-51ab-41dd-a966-0f0f4257a112" />

---

### Issue
#5758 
