### PR TITLE
issue-1559: [Disk Manager] Move TraversalQueueDeletionLimit to FilesystemTraversalConfig

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/config/config.proto
@@ -13,7 +13,6 @@ message FilesystemScrubbingConfig {
     optional filesystem_traversal.FilesystemTraversalConfig TraversalConfig = 1;
     // 0 disables the limit.
     optional uint32 ListNodesMaxBytes = 2 [default = 4096];
-    optional uint64 TraversalQueueDeletionLimit = 3 [default = 1000];
     repeated types.Filesystem FilesystemsWithRegularScrubbingEnabled = 4;
     optional string RegularFilesystemScrubbingSchedulingInterval = 5 [default = "15m"];
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task.go
@@ -11,7 +11,7 @@ import (
 	scrubbing_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/config"
 	scrubbing_protos "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/protos"
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal"
-	filesystem_snapshot_storage "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage"
+	filesystem_traversal_storage "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage"
 	"github.com/ydb-platform/nbs/cloud/tasks"
 	"github.com/ydb-platform/nbs/cloud/tasks/logging"
 )
@@ -25,7 +25,7 @@ type OnScrubbedCallback func([]nfs.Node)
 type scrubFilesystemTask struct {
 	config   *scrubbing_config.FilesystemScrubbingConfig
 	factory  nfs.Factory
-	storage  filesystem_snapshot_storage.Storage
+	storage  filesystem_traversal_storage.Storage
 	request  *scrubbing_protos.ScrubFilesystemRequest
 	state    *scrubbing_protos.ScrubFilesystemTaskState
 	callback OnScrubbedCallback
@@ -112,7 +112,6 @@ func (t *scrubFilesystemTask) Cancel(
 	return t.storage.ClearDirectoryListingQueue(
 		ctx,
 		t.getSnapshotID(execCtx),
-		t.config.GetTraversalQueueDeletionLimit(),
 	)
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task_test.go
@@ -59,7 +59,7 @@ func newStorage(
 	err := filesystem_snapshot_schema.Create(ctx, storageFolder, db, false)
 	require.NoError(t, err)
 
-	storage := traversal_storage.NewStorage(db, storageFolder)
+	storage := traversal_storage.NewStorage(db, storageFolder, 1000)
 	require.NotNil(t, storage)
 
 	return storage

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/config/config.proto
@@ -10,4 +10,5 @@ message FilesystemTraversalConfig {
     optional uint32 TraversalWorkersCount = 1 [default = 2];
     optional uint64 SelectNodesToListLimit = 2 [default = 1000];
     optional string StorageFolder = 3 [default = "filesystem/traversal"];
+    optional uint64 TraversalQueueDeletionLimit = 4 [default = 1000];
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/mocks/storage_mock.go
@@ -50,10 +50,9 @@ func (s *StorageMock) ScheduleChildNodesForListing(
 func (s *StorageMock) ClearDirectoryListingQueue(
 	ctx context.Context,
 	snapshotID string,
-	deletionLimit uint64,
 ) error {
 
-	args := s.Called(ctx, snapshotID, deletionLimit)
+	args := s.Called(ctx, snapshotID)
 	return args.Error(0)
 }
 

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage.go
@@ -44,6 +44,5 @@ type Storage interface {
 	ClearDirectoryListingQueue(
 		ctx context.Context,
 		snapshotID string,
-		deletionLimit uint64,
 	) error
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb.go
@@ -11,18 +11,21 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 type storageYDB struct {
-	db         *persistence.YDBClient
-	tablesPath string
+	db            *persistence.YDBClient
+	tablesPath    string
+	deletionLimit uint64
 }
 
 func NewStorage(
 	db *persistence.YDBClient,
 	tablesPath string,
+	deletionLimit uint64,
 ) Storage {
 
 	return &storageYDB{
-		db:         db,
-		tablesPath: db.AbsolutePath(tablesPath),
+		db:            db,
+		tablesPath:    db.AbsolutePath(tablesPath),
+		deletionLimit: deletionLimit,
 	}
 }
 
@@ -328,7 +331,6 @@ func (s *storageYDB) ScheduleChildNodesForListing(
 func (s *storageYDB) ClearDirectoryListingQueue(
 	ctx context.Context,
 	snapshotID string,
-	deletionLimit uint64,
 ) error {
 
 	err := s.db.Execute(
@@ -341,7 +343,7 @@ func (s *storageYDB) ClearDirectoryListingQueue(
 					ctx,
 					session,
 					snapshotID,
-					deletionLimit,
+					s.deletionLimit,
 				)
 			}
 			return err

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/storage/storage_ydb_test.go
@@ -45,12 +45,13 @@ func newStorage(
 	ctx context.Context,
 	db *persistence.YDBClient,
 	storageFolder string,
+	deletionLimit uint64,
 ) Storage {
 
 	err := schema.Create(ctx, storageFolder, db, false)
 	require.NoError(t, err)
 
-	storage := NewStorage(db, storageFolder)
+	storage := NewStorage(db, storageFolder, deletionLimit)
 	require.NotNil(t, storage)
 
 	return storage
@@ -94,7 +95,7 @@ func createFixture(t *testing.T) *fixture {
 		"filesystem_snapshot_storage_ydb_test/%v",
 		t.Name(),
 	)
-	storage := newStorage(t, ctx, db, storageFolder)
+	storage := newStorage(t, ctx, db, storageFolder, 1000)
 
 	return &fixture{
 		t:             t,
@@ -393,7 +394,7 @@ func TestClearDirectoryListingQueue(t *testing.T) {
 	require.ElementsMatch(t, getNodeIDs(entries2), savedSnapshot2IDs)
 
 	// 8. Delete from snapshot2 using public method, require no elements remain.
-	err = f.storage.ClearDirectoryListingQueue(f.ctx, snapshot2, 2)
+	err = f.storage.ClearDirectoryListingQueue(f.ctx, snapshot2)
 	require.NoError(t, err)
 
 	entries2, err = f.storage.SelectNodesToList(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
@@ -57,7 +57,7 @@ func newStorage(
 	err := schema.Create(ctx, storageFolder, db, false)
 	require.NoError(t, err)
 
-	storage := storage.NewStorage(db, storageFolder)
+	storage := storage.NewStorage(db, storageFolder, 1000)
 	require.NotNil(t, storage)
 
 	return storage

--- a/cloud/disk_manager/pkg/app/dataplane.go
+++ b/cloud/disk_manager/pkg/app/dataplane.go
@@ -115,6 +115,7 @@ func initFilesystemDataplane(
 	traversalStorage := traversal_storage.NewStorage(
 		filesystemDB,
 		traversalConfig.GetStorageFolder(),
+		traversalConfig.GetTraversalQueueDeletionLimit(),
 	)
 
 	err := scrubbing.RegisterForExecution(


### PR DESCRIPTION
### Notes
It is config common for both scrubbing and snapshot tasks cancellation. Make it a part of traversal storage

### Issue
#1559
