### PR TITLE
[Filestore] use service verify instead of tablet #5483

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -1,14 +1,15 @@
 #include "service_actor.h"
 
+#include "verify.h"
+
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
-#include <cloud/filestore/libs/storage/tablet/model/verify.h>
-
-#include <util/string/join.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <util/string/join.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -236,9 +237,9 @@ void TListNodesActor::HandleGetNodeAttrBatchResponse(
 {
     auto* msg = ev->Get();
 
-    TABLET_VERIFY(ev->Cookie < Cookie2NodeIndices.size());
+    SERVICE_VERIFY(ev->Cookie < Cookie2NodeIndices.size());
     const auto& nodeIndices = Cookie2NodeIndices[ev->Cookie];
-    TABLET_VERIFY(ev->Cookie < Cookie2ShardId.size());
+    SERVICE_VERIFY(ev->Cookie < Cookie2ShardId.size());
     const auto& shardId = Cookie2ShardId[ev->Cookie];
 
     if (HasError(msg->GetError())) {

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -1,5 +1,7 @@
 #include "service_actor.h"
+
 #include "rope_utils.h"
+#include "verify.h"
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
@@ -10,7 +12,6 @@
 #include <cloud/filestore/libs/storage/core/probes.h>
 #include <cloud/filestore/libs/storage/model/block_buffer.h>
 #include <cloud/filestore/libs/storage/tablet/model/sparse_segment.h>
-#include <cloud/filestore/libs/storage/tablet/model/verify.h>
 
 #include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
@@ -360,7 +361,7 @@ void TReadDataActor::HandleDescribeDataResponse(
     auto* msg = ev->Get();
     const auto& error = msg->GetError();
 
-    TABLET_VERIFY(InFlightRequest);
+    SERVICE_VERIFY(InFlightRequest);
 
     FinalizeProfileLogRequestInfo(
         InFlightRequest->AccessProfileLogRequest(),
@@ -545,11 +546,11 @@ void TReadDataActor::HandleReadBlobResponse(
         return;
     }
 
-    TABLET_VERIFY(ev->Cookie < DescribeResponse.BlobPiecesSize());
+    SERVICE_VERIFY(ev->Cookie < DescribeResponse.BlobPiecesSize());
     const auto& blobPiece = DescribeResponse.GetBlobPieces(ev->Cookie);
 
     for (size_t i = 0; i < msg->ResponseSz; ++i) {
-        TABLET_VERIFY(i < blobPiece.RangesSize());
+        SERVICE_VERIFY(i < blobPiece.RangesSize());
 
         const auto& blobPiece = DescribeResponse.GetBlobPieces(ev->Cookie);
         const auto& blobRange = blobPiece.GetRanges(i);
@@ -614,7 +615,7 @@ void TReadDataActor::HandleReadBlobResponse(
             DescribeResponse.DebugString().Quote().c_str(),
             i,
             response.Buffer.size());
-        TABLET_VERIFY(blobRange.GetOffset() >= AlignedByteRange.Offset);
+        SERVICE_VERIFY(blobRange.GetOffset() >= AlignedByteRange.Offset);
 
         const auto blobByteRange =
             TByteRange{blobRange.GetOffset(), blobRange.GetLength(), BlockSize};

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -1,16 +1,16 @@
 #include "service_actor.h"
 
 #include "rope_utils.h"
+#include "verify.h"
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/diagnostics/trace_serializer.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
-#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/core/helpers.h>
 #include <cloud/filestore/libs/storage/core/probes.h>
-#include <cloud/filestore/libs/storage/tablet/model/verify.h>
 
 #include <cloud/storage/core/libs/common/backoff_delay_provider.h>
 #include <cloud/storage/core/libs/common/byte_range.h>
@@ -263,7 +263,7 @@ private:
         auto* msg = ev->Get();
         const auto& error = msg->GetError();
 
-        TABLET_VERIFY(InFlightRequest);
+        SERVICE_VERIFY(InFlightRequest);
 
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
@@ -294,7 +294,7 @@ private:
             LogTag.c_str(),
             GenerateBlobIdsResponse.DebugString().Quote().c_str());
 
-        TABLET_VERIFY(
+        SERVICE_VERIFY(
             UseUnconfirmedFlow ||
             !GenerateBlobIdsResponse.GetUnconfirmedFlowEnabled());
 
@@ -367,7 +367,7 @@ private:
                     &putData[0],
                     ropeIt,
                     blobId.BlobSize());
-                TABLET_VERIFY(bytesCopied == blobId.BlobSize());
+                SERVICE_VERIFY(bytesCopied == blobId.BlobSize());
                 request = std::make_unique<TEvBlobStorage::TEvPut>(
                     blobId,
                     std::move(putData),
@@ -468,9 +468,9 @@ private:
 
         // It is implicitly expected that cookies are generated in increasing
         // order starting from 0.
-        // TODO: replace this TABLET_VERIFY with a critical event + WriteData
+        // TODO: replace this SERVICE_VERIFY with a critical event + WriteData
         // fallback
-        TABLET_VERIFY(
+        SERVICE_VERIFY(
             blobIdx < InFlightBSRequests.size() &&
             InFlightBSRequests[blobIdx] &&
             !InFlightBSRequests[blobIdx]->IsCompleted());
@@ -589,7 +589,7 @@ private:
     {
         auto* msg = ev->Get();
 
-        TABLET_VERIFY(InFlightRequest);
+        SERVICE_VERIFY(InFlightRequest);
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
@@ -678,7 +678,7 @@ private:
     {
         auto* msg = ev->Get();
 
-        TABLET_VERIFY(InFlightRequest);
+        SERVICE_VERIFY(InFlightRequest);
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
@@ -713,7 +713,7 @@ private:
     {
         auto* msg = ev->Get();
 
-        TABLET_VERIFY(InFlightRequest);
+        SERVICE_VERIFY(InFlightRequest);
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
@@ -774,7 +774,7 @@ private:
         ++TabletProxyRetries;
 
         if (TabletProxyRetries % ProxyCriticalRetryThreshold == 0) {
-            TABLET_VERIFY(retryRequest != ETabletRetryRequest::None);
+            SERVICE_VERIFY(retryRequest != ETabletRetryRequest::None);
 
             const auto requestType =
                 retryRequest == ETabletRetryRequest::ConfirmAddData
@@ -912,7 +912,7 @@ private:
             } else {
                 TString buffer;
                 auto bytesCopied = CopyBufferFromRope(Rope, buffer, 0, length);
-                TABLET_VERIFY(bytesCopied == length);
+                SERVICE_VERIFY(bytesCopied == length);
                 unalignedHead.SetContent(std::move(buffer));
             }
         }
@@ -929,7 +929,7 @@ private:
                 TString buffer;
                 auto bytesCopied =
                     CopyBufferFromRope(Rope, buffer, offset, length);
-                TABLET_VERIFY(bytesCopied == length);
+                SERVICE_VERIFY(bytesCopied == length);
                 unalignedTail.SetContent(std::move(buffer));
             }
         }

--- a/cloud/filestore/libs/storage/service/verify.h
+++ b/cloud/filestore/libs/storage/service/verify.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/storage/core/libs/common/verify.h>
+
+#define SERVICE_VERIFY_C(expr, message)                                        \
+    STORAGE_VERIFY_C(expr, TWellKnownEntityTypes::FILESYSTEM, LogTag, message) \
+    // SERVICE_VERIFY_C
+
+#define SERVICE_VERIFY(expr)   \
+    SERVICE_VERIFY_C(expr, "") \
+    // SERVICE_VERIFY
+
+#define SERVICE_VERIFY_DEBUG_C(expr, message) \
+    STORAGE_VERIFY_DEBUG_C(                   \
+        expr,                                 \
+        TWellKnownEntityTypes::FILESYSTEM,    \
+        LogTag,                               \
+        message)                              \
+    // SERVICE_VERIFY_DEBUG_C
+
+#define SERVICE_VERIFY_DEBUG(expr)   \
+    SERVICE_VERIFY_DEBUG_C(expr, "") \
+// SERVICE_VERIFY_DEBUG


### PR DESCRIPTION
### Notes
use service verify instead of tablet for service actor

### Issue
#5483 
