### PR TITLE
suppress service errors for describe requests from cells

### DIFF
--- a/cloud/blockstore/libs/cells/impl/describe_volume.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume.cpp
@@ -143,7 +143,7 @@ TFuture<NProto::TDescribeVolumeResponse> TMultiCellDescribeHandler::Start(
     for (auto& cell: Cells) {
         ui32 hostIndex = 0;
         for (auto& host: cell.Hosts) {
-            if (cell.CellId != LocalDescribeLabel) {
+            if (!cell.CellId.empty()) {
                 STORAGE_DEBUG(
                     TStringBuilder()
                     << "Send remote Describe Request to " << host.Fqdn

--- a/cloud/blockstore/libs/cells/impl/describe_volume.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume.cpp
@@ -373,7 +373,7 @@ TDescribeVolumeFuture DescribeVolume(
         cells.emplace_back(std::move(cell));
     }
 
-    TCellInfo localCell("", 1);
+    TCellInfo localCell("local", 1);
     localCell.Hosts.emplace_back("local", service);
     cells.emplace_back(std::move(localCell));
 

--- a/cloud/blockstore/libs/cells/impl/describe_volume.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume.cpp
@@ -26,6 +26,10 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+const TString LocalDescribeLabel{"local"};
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TCellHostInfo
 {
     TString Fqdn;
@@ -139,7 +143,7 @@ TFuture<NProto::TDescribeVolumeResponse> TMultiCellDescribeHandler::Start(
     for (auto& cell: Cells) {
         ui32 hostIndex = 0;
         for (auto& host: cell.Hosts) {
-            if (!cell.CellId.empty()) {
+            if (cell.CellId != LocalDescribeLabel) {
                 STORAGE_DEBUG(
                     TStringBuilder()
                     << "Send remote Describe Request to " << host.Fqdn
@@ -373,8 +377,8 @@ TDescribeVolumeFuture DescribeVolume(
         cells.emplace_back(std::move(cell));
     }
 
-    TCellInfo localCell("local", 1);
-    localCell.Hosts.emplace_back("local", service);
+    TCellInfo localCell(LocalDescribeLabel, 1);
+    localCell.Hosts.emplace_back(LocalDescribeLabel, service);
     cells.emplace_back(std::move(localCell));
 
     auto describeHandler = std::make_shared<TMultiCellDescribeHandler>(

--- a/cloud/blockstore/libs/cells/impl/describe_volume.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume.cpp
@@ -263,10 +263,12 @@ void TDescribeResponseHandler::Start()
 
     auto req = std::make_shared<NProto::TDescribeVolumeRequest>();
     req->CopyFrom(Request);
+    auto& headers = *req->MutableHeaders();
     if (Cell.CellId) {
-        auto& headers = *req->MutableHeaders();
         headers.ClearInternal();
         headers.SetCellId(Cell.CellId);
+    } else {
+        headers.SetCellId(LocalDescribeLabel);
     }
 
     auto weak = weak_from_this();
@@ -377,7 +379,7 @@ TDescribeVolumeFuture DescribeVolume(
         cells.emplace_back(std::move(cell));
     }
 
-    TCellInfo localCell(LocalDescribeLabel, 1);
+    TCellInfo localCell("", 1);
     localCell.Hosts.emplace_back(LocalDescribeLabel, service);
     cells.emplace_back(std::move(localCell));
 

--- a/cloud/blockstore/libs/cells/impl/describe_volume_ut.cpp
+++ b/cloud/blockstore/libs/cells/impl/describe_volume_ut.cpp
@@ -78,8 +78,8 @@ std::shared_ptr<TTestServiceClient> CreateService()
     {
         UNIT_ASSERT_C(
             req.GetHeaders().HasInternal(),
-            "Internal should not be set");
-        UNIT_ASSERT_VALUES_EQUAL("", req.GetHeaders().GetCellId());
+            "Internal should be set");
+        UNIT_ASSERT_VALUES_UNEQUAL("", req.GetHeaders().GetCellId());
     };
 
     service->OnDescribeVolume = describeCheck;

--- a/cloud/blockstore/libs/storage/service/service_actor_describe.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_describe.cpp
@@ -28,6 +28,7 @@ private:
     const TStorageConfigPtr Config;
     const TString DiskId;
     const bool ExactDiskIdMatch = false;
+    const bool IsCellRequest = false;
 
     NProto::TVolume Volume;
 
@@ -36,7 +37,8 @@ public:
         TRequestInfoPtr requestInfo,
         TStorageConfigPtr config,
         TString diskId,
-        bool exactDiskIdMatch);
+        bool exactDiskIdMatch,
+        bool isCellRequest);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -66,11 +68,13 @@ TDescribeVolumeActor::TDescribeVolumeActor(
         TRequestInfoPtr requestInfo,
         TStorageConfigPtr config,
         TString diskId,
-        bool exactDiskIdMatch)
+        bool exactDiskIdMatch,
+        bool isCellRequest)
     : RequestInfo(std::move(requestInfo))
     , Config(std::move(config))
     , DiskId(std::move(diskId))
     , ExactDiskIdMatch(exactDiskIdMatch)
+    , IsCellRequest(isCellRequest)
 {}
 
 void TDescribeVolumeActor::Bootstrap(const TActorContext& ctx)
@@ -113,10 +117,12 @@ void TDescribeVolumeActor::HandleDescribeVolumeResponse(
 
     const auto& error = msg->GetError();
     if (FAILED(error.GetCode())) {
-        LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
-            "Volume %s: describe failed: %s",
-            DiskId.Quote().data(),
-            FormatError(error).data());
+        if (!IsCellRequest) {
+            LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
+                "Volume %s: describe failed: %s",
+                DiskId.Quote().data(),
+                FormatError(error).data());
+        }
 
         ReplyAndDie(
             ctx,
@@ -154,10 +160,12 @@ void TDescribeVolumeActor::HandleDescribeDiskResponse(
 
     const auto& error = msg->GetError();
     if (FAILED(error.GetCode())) {
-        LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
-            "Non-replicated volume %s: describe failed: %s",
-            DiskId.Quote().data(),
-            FormatError(error).data());
+        if (!IsCellRequest) {
+            LOG_ERROR(ctx, TBlockStoreComponents::SERVICE,
+                "Non-replicated volume %s: describe failed: %s",
+                DiskId.Quote().data(),
+                FormatError(error).data());
+        }
 
         ReplyAndDie(
             ctx,
@@ -240,7 +248,8 @@ void TServiceActor::HandleDescribeVolume(
         std::move(requestInfo),
         Config,
         request.GetDiskId(),
-        request.GetHeaders().GetExactDiskIdMatch());
+        request.GetHeaders().GetExactDiskIdMatch(),
+        !request.GetHeaders().GetCellId().empty());
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
### Notes
During the volume discovery process in multi-cell environments, service actor often report "Volume not found" errors when a volume is located in a different cell. To reduce log noise and prevent confusion, error reporting has been suppressed for volume description requests initiated by the Cell Manager.

### Issue
Put links to the related issues here
