### PR TITLE
Revert "[Blockstore] Drop discard requests when needed"

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -285,9 +285,6 @@ message TServerConfig
     // Enable WriteZeroes feature for vhost devices. Applies to
     // network-ssd and network-hdd disks.
     optional bool VhostWriteZeroesEnabled = 131;
-
-    // Drop all discard requests without processing them.
-    optional bool DropDiscardRequests = 132;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/common/constants.h
+++ b/cloud/blockstore/libs/common/constants.h
@@ -29,6 +29,4 @@ constexpr TStringBuf SourceDiskIdTagName = "source-disk-id";
 
 constexpr TStringBuf UseFastPathTagName = "use-fastpath";
 
-constexpr TStringBuf DropDiscardRequestsTagName = "drop-discard-requests";
-
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -480,7 +480,6 @@ void TBootstrapBase::Init()
                 Configs->ServerConfig->GetVhostDiscardOnlyEnabled(),
             Configs->ServerConfig->GetVhostDiscardEnabled() ||
                 Configs->ServerConfig->GetVhostWriteZeroesEnabled(),
-            Configs->ServerConfig->GetDropDiscardRequests(),
             Configs->ServerConfig->GetMaxZeroBlocksSubRequestSize(),
             Configs->ServerConfig->GetVhostOptimalIoSize());
 

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -1,7 +1,6 @@
 #include "vhost_server.h"
 
 #include <cloud/blockstore/libs/client/session.h>
-#include <cloud/blockstore/libs/common/constants.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_listener.h>
 #include <cloud/blockstore/libs/vhost/server.h>
 #include <cloud/storage/core/libs/common/media.h>
@@ -22,7 +21,6 @@ private:
     const NProto::TChecksumFlags ChecksumFlags;
     const bool VhostDiscardEnabled;
     const bool VhostWriteZeroesEnabled;
-    const bool DropDiscardRequests;
     const ui32 MaxZeroBlocksSubRequestSize;
     const ui32 OptimalIoSize;
 
@@ -32,14 +30,12 @@ public:
             NProto::TChecksumFlags checksumFlags,
             bool vhostDiscardEnabled,
             bool vhostWriteZeroesEnabled,
-            bool dropDiscardRequests,
             ui32 maxZeroBlocksSubRequestSize,
             ui32 optimalIoSize)
         : Server(std::move(server))
         , ChecksumFlags(std::move(checksumFlags))
         , VhostDiscardEnabled(vhostDiscardEnabled)
         , VhostWriteZeroesEnabled(vhostWriteZeroesEnabled)
-        , DropDiscardRequests(dropDiscardRequests)
         , MaxZeroBlocksSubRequestSize(maxZeroBlocksSubRequestSize)
         , OptimalIoSize(optimalIoSize)
     {}
@@ -62,8 +58,6 @@ public:
             ShouldEnableVhostDiscardForVolume(VhostDiscardEnabled, volume);
         options.WriteZeroesEnabled =
             VhostWriteZeroesEnabled && !IsDiskRegistryMediaKind(volume.GetStorageMediaKind());
-        options.DropDiscardRequests =
-            ShouldDropDiscardRequestsForVolume(DropDiscardRequests, volume);
         options.MaxZeroBlocksSubRequestSize = MaxZeroBlocksSubRequestSize;
         options.OptimalIoSize = OptimalIoSize;
 
@@ -120,23 +114,11 @@ bool ShouldEnableVhostDiscardForVolume(
            !IsDiskRegistryMediaKind(volume.GetStorageMediaKind());
 }
 
-bool ShouldDropDiscardRequestsForVolume(
-    bool dropDiscardRequests,
-    const NProto::TVolume& volume)
-{
-    // It is not safe to use ZeroBlocks as the implementation of discard
-    // for disk registry based disks.
-    return dropDiscardRequests ||
-           volume.GetTags().contains(DropDiscardRequestsTagName) ||
-           IsDiskRegistryMediaKind(volume.GetStorageMediaKind());
-}
-
 IEndpointListenerPtr CreateVhostEndpointListener(
     NVhost::IServerPtr server,
     const NProto::TChecksumFlags& checksumFlags,
     bool vhostDiscardEnabled,
     bool vhostWriteZeroesEnabled,
-    bool dropDiscardRequests,
     ui32 maxZeroBlocksSubRequestSize,
     ui32 optimalIoSize)
 {
@@ -145,7 +127,6 @@ IEndpointListenerPtr CreateVhostEndpointListener(
         checksumFlags,
         vhostDiscardEnabled,
         vhostWriteZeroesEnabled,
-        dropDiscardRequests,
         maxZeroBlocksSubRequestSize,
         optimalIoSize);
 }

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.h
@@ -15,16 +15,11 @@ bool ShouldEnableVhostDiscardForVolume(
     bool vhostDiscardEnabled,
     const NProto::TVolume& volume);
 
-bool ShouldDropDiscardRequestsForVolume(
-    bool dropDiscardRequests,
-    const NProto::TVolume& volume);
-
 IEndpointListenerPtr CreateVhostEndpointListener(
     NVhost::IServerPtr server,
     const NProto::TChecksumFlags& checksumFlags,
     bool vhostDiscardEnabled,
     bool vhostWriteZeroesEnabled,
-    bool dropDiscardRequests,
     ui32 maxZeroBlocksSubRequestSize,
     ui32 optimalIoSize);
 

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
@@ -1,6 +1,5 @@
 #include "vhost_server.h"
 
-#include <cloud/blockstore/libs/common/constants.h>
 #include <cloud/storage/core/protos/media.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -65,47 +64,6 @@ Y_UNIT_TEST_SUITE(TVhostEndpointTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 false,
                 ShouldEnableVhostDiscardForVolume(false, volume));
-        }
-    }
-
-    Y_UNIT_TEST(ShouldDropDiscardRequestsCorrectly)
-    {
-        {
-            NProto::TVolume volume;
-            volume.SetStorageMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
-
-            UNIT_ASSERT_VALUES_EQUAL(
-                true,
-                ShouldDropDiscardRequestsForVolume(true, volume));
-        }
-
-        {
-            NProto::TVolume volume;
-            volume.SetStorageMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
-
-            UNIT_ASSERT_VALUES_EQUAL(
-                false,
-                ShouldDropDiscardRequestsForVolume(false, volume));
-        }
-
-        {
-            NProto::TVolume volume;
-            volume.SetStorageMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
-            (*volume.MutableTags())[TString(DropDiscardRequestsTagName)] = "";
-
-            UNIT_ASSERT_VALUES_EQUAL(
-                true,
-                ShouldDropDiscardRequestsForVolume(false, volume));
-        }
-
-        {
-            NProto::TVolume volume;
-            volume.SetStorageMediaKind(
-                NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
-
-            UNIT_ASSERT_VALUES_EQUAL(
-                true,
-                ShouldDropDiscardRequestsForVolume(false, volume));
         }
     }
 }

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -108,7 +108,6 @@ constexpr TDuration Seconds(int s)
     xxx(VhostDiscardEnabled,         bool,                   false            )\
     xxx(VhostDiscardOnlyEnabled,     bool,                   false            )\
     xxx(VhostWriteZeroesEnabled,     bool,                   false            )\
-    xxx(DropDiscardRequests,         bool,                   false            )\
     xxx(VhostOptimalIoSize,          ui32,                   0                )\
     xxx(MaxZeroBlocksSubRequestSize, ui32,                   0                )\
     xxx(EncryptZeroPolicy,                                                     \

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -140,7 +140,6 @@ public:
     bool GetVhostDiscardEnabled() const;
     bool GetVhostDiscardOnlyEnabled() const;
     bool GetVhostWriteZeroesEnabled() const;
-    bool GetDropDiscardRequests() const;
     ui32 GetVhostOptimalIoSize() const;
     ui32 GetMaxZeroBlocksSubRequestSize() const;
     NProto::EEncryptZeroPolicy GetEncryptZeroPolicy() const;

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -329,11 +329,6 @@ private:
             request->MetricRequest,
             *request->CallContext);
 
-        if (Options.DropDiscardRequests && vhostRequest->IsDiscardRequest) {
-            CompleteRequest(*request, NProto::TError{});
-            return nullptr;
-        }
-
         with_lock (RequestsLock) {
             if (!Stopped.test()) {
                 RequestsInFlight.PushBack(request.Get());

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -31,7 +31,6 @@ struct TStorageOptions
     NProto::EStorageMediaKind StorageMediaKind = NProto::STORAGE_MEDIA_DEFAULT;
     bool DiscardEnabled = false;
     bool WriteZeroesEnabled = false;
-    bool DropDiscardRequests = false;
     ui32 MaxZeroBlocksSubRequestSize = 0;
     ui32 OptimalIoSize = 0;
 };

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -56,8 +56,7 @@ public:
             ui64 from,
             ui64 length,
             TSgList sgList,
-            void* cookie,
-            bool isDiscardRequest)
+            void* cookie)
         : VhdIo(vhdIo)
     {
         Type = type;
@@ -65,7 +64,6 @@ public:
         Length = length;
         SgList.SetSgList(std::move(sgList));
         Cookie = cookie;
-        IsDiscardRequest = isDiscardRequest;
     }
 
     void Complete(EResult result) override
@@ -305,7 +303,6 @@ private:
         auto* vhdBdevIo = vhd_get_bdev_io(vhdRequest.io);
 
         EBlockStoreRequest type;
-        bool isDiscardRequest = false;
         switch (vhdBdevIo->type)
         {
             case VHD_BDEV_READ:
@@ -315,9 +312,6 @@ private:
                 type = EBlockStoreRequest::WriteBlocks;
                 break;
             case VHD_BDEV_DISCARD:
-                type = EBlockStoreRequest::ZeroBlocks;
-                isDiscardRequest = true;
-                break;
             case VHD_BDEV_WRITE_ZEROES:
                 type = EBlockStoreRequest::ZeroBlocks;
                 break;
@@ -333,8 +327,7 @@ private:
             vhdBdevIo->first_sector * VHD_SECTOR_SIZE,
             vhdBdevIo->total_sectors * VHD_SECTOR_SIZE,
             ConvertVhdSgList(vhdBdevIo->sglist),
-            cookie,
-            isDiscardRequest);
+            cookie);
     }
 
     static TSgList ConvertVhdSgList(const vhd_sglist& vhdSglist)

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -29,7 +29,6 @@ struct TVhostRequest
     ui64 Length = 0;
     TGuardedSgList SgList;
     void* Cookie = nullptr;
-    bool IsDiscardRequest = false;
 
     virtual ~TVhostRequest() = default;
 


### PR DESCRIPTION
Reverts ydb-platform/nbs#5626

code crashes due to shared prt dereference after move https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/vhost/server.cpp#L315 -> https://arcanum.yandex-team.ru/arcadia/cloud/blockstore/libs/vhost/server.cpp?rev=r19344757#L332.