### PR TITLE
[Blockstore] Drop discard requests when needed (fixed version of #5626)

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -285,6 +285,9 @@ message TServerConfig
     // Enable WriteZeroes feature for vhost devices. Applies to
     // network-ssd and network-hdd disks.
     optional bool VhostWriteZeroesEnabled = 131;
+
+    // Drop all discard requests without processing them.
+    optional bool DropDiscardRequests = 132;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/common/constants.h
+++ b/cloud/blockstore/libs/common/constants.h
@@ -29,4 +29,6 @@ constexpr TStringBuf SourceDiskIdTagName = "source-disk-id";
 
 constexpr TStringBuf UseFastPathTagName = "use-fastpath";
 
+constexpr TStringBuf DropDiscardRequestsTagName = "drop-discard-requests";
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -480,6 +480,7 @@ void TBootstrapBase::Init()
                 Configs->ServerConfig->GetVhostDiscardOnlyEnabled(),
             Configs->ServerConfig->GetVhostDiscardEnabled() ||
                 Configs->ServerConfig->GetVhostWriteZeroesEnabled(),
+            Configs->ServerConfig->GetDropDiscardRequests(),
             Configs->ServerConfig->GetMaxZeroBlocksSubRequestSize(),
             Configs->ServerConfig->GetVhostOptimalIoSize());
 

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -1,6 +1,7 @@
 #include "vhost_server.h"
 
 #include <cloud/blockstore/libs/client/session.h>
+#include <cloud/blockstore/libs/common/constants.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_listener.h>
 #include <cloud/blockstore/libs/vhost/server.h>
 #include <cloud/storage/core/libs/common/media.h>
@@ -21,6 +22,7 @@ private:
     const NProto::TChecksumFlags ChecksumFlags;
     const bool VhostDiscardEnabled;
     const bool VhostWriteZeroesEnabled;
+    const bool DropDiscardRequests;
     const ui32 MaxZeroBlocksSubRequestSize;
     const ui32 OptimalIoSize;
 
@@ -30,12 +32,14 @@ public:
             NProto::TChecksumFlags checksumFlags,
             bool vhostDiscardEnabled,
             bool vhostWriteZeroesEnabled,
+            bool dropDiscardRequests,
             ui32 maxZeroBlocksSubRequestSize,
             ui32 optimalIoSize)
         : Server(std::move(server))
         , ChecksumFlags(std::move(checksumFlags))
         , VhostDiscardEnabled(vhostDiscardEnabled)
         , VhostWriteZeroesEnabled(vhostWriteZeroesEnabled)
+        , DropDiscardRequests(dropDiscardRequests)
         , MaxZeroBlocksSubRequestSize(maxZeroBlocksSubRequestSize)
         , OptimalIoSize(optimalIoSize)
     {}
@@ -58,6 +62,8 @@ public:
             ShouldEnableVhostDiscardForVolume(VhostDiscardEnabled, volume);
         options.WriteZeroesEnabled =
             VhostWriteZeroesEnabled && !IsDiskRegistryMediaKind(volume.GetStorageMediaKind());
+        options.DropDiscardRequests =
+            ShouldDropDiscardRequestsForVolume(DropDiscardRequests, volume);
         options.MaxZeroBlocksSubRequestSize = MaxZeroBlocksSubRequestSize;
         options.OptimalIoSize = OptimalIoSize;
 
@@ -114,11 +120,23 @@ bool ShouldEnableVhostDiscardForVolume(
            !IsDiskRegistryMediaKind(volume.GetStorageMediaKind());
 }
 
+bool ShouldDropDiscardRequestsForVolume(
+    bool dropDiscardRequests,
+    const NProto::TVolume& volume)
+{
+    // It is not safe to use ZeroBlocks as the implementation of discard
+    // for disk registry based disks.
+    return dropDiscardRequests ||
+           volume.GetTags().contains(DropDiscardRequestsTagName) ||
+           IsDiskRegistryMediaKind(volume.GetStorageMediaKind());
+}
+
 IEndpointListenerPtr CreateVhostEndpointListener(
     NVhost::IServerPtr server,
     const NProto::TChecksumFlags& checksumFlags,
     bool vhostDiscardEnabled,
     bool vhostWriteZeroesEnabled,
+    bool dropDiscardRequests,
     ui32 maxZeroBlocksSubRequestSize,
     ui32 optimalIoSize)
 {
@@ -127,6 +145,7 @@ IEndpointListenerPtr CreateVhostEndpointListener(
         checksumFlags,
         vhostDiscardEnabled,
         vhostWriteZeroesEnabled,
+        dropDiscardRequests,
         maxZeroBlocksSubRequestSize,
         optimalIoSize);
 }

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.h
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.h
@@ -15,11 +15,16 @@ bool ShouldEnableVhostDiscardForVolume(
     bool vhostDiscardEnabled,
     const NProto::TVolume& volume);
 
+bool ShouldDropDiscardRequestsForVolume(
+    bool dropDiscardRequests,
+    const NProto::TVolume& volume);
+
 IEndpointListenerPtr CreateVhostEndpointListener(
     NVhost::IServerPtr server,
     const NProto::TChecksumFlags& checksumFlags,
     bool vhostDiscardEnabled,
     bool vhostWriteZeroesEnabled,
+    bool dropDiscardRequests,
     ui32 maxZeroBlocksSubRequestSize,
     ui32 optimalIoSize);
 

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server_ut.cpp
@@ -1,5 +1,6 @@
 #include "vhost_server.h"
 
+#include <cloud/blockstore/libs/common/constants.h>
 #include <cloud/storage/core/protos/media.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -64,6 +65,47 @@ Y_UNIT_TEST_SUITE(TVhostEndpointTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 false,
                 ShouldEnableVhostDiscardForVolume(false, volume));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldDropDiscardRequestsCorrectly)
+    {
+        {
+            NProto::TVolume volume;
+            volume.SetStorageMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                ShouldDropDiscardRequestsForVolume(true, volume));
+        }
+
+        {
+            NProto::TVolume volume;
+            volume.SetStorageMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                false,
+                ShouldDropDiscardRequestsForVolume(false, volume));
+        }
+
+        {
+            NProto::TVolume volume;
+            volume.SetStorageMediaKind(NCloud::NProto::STORAGE_MEDIA_SSD);
+            (*volume.MutableTags())[TString(DropDiscardRequestsTagName)] = "";
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                ShouldDropDiscardRequestsForVolume(false, volume));
+        }
+
+        {
+            NProto::TVolume volume;
+            volume.SetStorageMediaKind(
+                NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                ShouldDropDiscardRequestsForVolume(false, volume));
         }
     }
 }

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -108,6 +108,7 @@ constexpr TDuration Seconds(int s)
     xxx(VhostDiscardEnabled,         bool,                   false            )\
     xxx(VhostDiscardOnlyEnabled,     bool,                   false            )\
     xxx(VhostWriteZeroesEnabled,     bool,                   false            )\
+    xxx(DropDiscardRequests,         bool,                   false            )\
     xxx(VhostOptimalIoSize,          ui32,                   0                )\
     xxx(MaxZeroBlocksSubRequestSize, ui32,                   0                )\
     xxx(EncryptZeroPolicy,                                                     \

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -140,6 +140,7 @@ public:
     bool GetVhostDiscardEnabled() const;
     bool GetVhostDiscardOnlyEnabled() const;
     bool GetVhostWriteZeroesEnabled() const;
+    bool GetDropDiscardRequests() const;
     ui32 GetVhostOptimalIoSize() const;
     ui32 GetMaxZeroBlocksSubRequestSize() const;
     NProto::EEncryptZeroPolicy GetEncryptZeroPolicy() const;

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -329,6 +329,11 @@ private:
             request->MetricRequest,
             *request->CallContext);
 
+        if (Options.DropDiscardRequests && vhostRequest->IsDiscardRequest) {
+            CompleteRequest(*request, NProto::TError{});
+            return nullptr;
+        }
+
         with_lock (RequestsLock) {
             if (!Stopped.test()) {
                 RequestsInFlight.PushBack(request.Get());

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -309,6 +309,8 @@ private:
         bool unaligned =
             startIndex * Options.BlockSize != vhostRequest->From ||
             endIndex * Options.BlockSize != vhostRequest->From + vhostRequest->Length;
+        bool shouldDrop =
+            Options.DropDiscardRequests && vhostRequest->IsDiscardRequest;
 
         auto request = MakeIntrusive<TRequest>(
             CreateRequestId(),
@@ -329,7 +331,7 @@ private:
             request->MetricRequest,
             *request->CallContext);
 
-        if (Options.DropDiscardRequests && vhostRequest->IsDiscardRequest) {
+        if (shouldDrop) {
             CompleteRequest(*request, NProto::TError{});
             return nullptr;
         }

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -31,6 +31,7 @@ struct TStorageOptions
     NProto::EStorageMediaKind StorageMediaKind = NProto::STORAGE_MEDIA_DEFAULT;
     bool DiscardEnabled = false;
     bool WriteZeroesEnabled = false;
+    bool DropDiscardRequests = false;
     ui32 MaxZeroBlocksSubRequestSize = 0;
     ui32 OptimalIoSize = 0;
 };

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -49,6 +49,7 @@ private:
     const ui32 VhostQueuesCount = 1;
     const ui32 BlockSize;
     const ui64 BlocksCount = 256;
+    const bool DropDiscardRequests;
 
     IServerPtr VhostServer;
     std::shared_ptr<TTestStorage> TestStorage;
@@ -60,8 +61,9 @@ private:
     TLockFreeQueue<TPromise<void>> FrozenPromises;
 
 public:
-    TTestEnvironment(ui32 blockSize)
+    TTestEnvironment(ui32 blockSize, bool dropDiscardRequests = false)
         : BlockSize(blockSize)
+        , DropDiscardRequests(dropDiscardRequests)
     {
         InitVhostDeviceEnvironment();
     }
@@ -221,6 +223,7 @@ private:
             options.VhostQueuesCount = VhostQueuesCount;
             options.UnalignedRequestsDisabled = false;
             options.OptimalIoSize = 4_MB;
+            options.DropDiscardRequests = DropDiscardRequests;
 
             auto future = VhostServer->StartEndpoint(
                 SocketPath.GetPath(),
@@ -1066,10 +1069,84 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 EBlockStoreRequest::ZeroBlocks,
                 firstSector * sectorSize,
                 totalSectors * sectorSize,
-                {});
+                {},
+                true /* isDiscardRequest */);
             const auto& response = future.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT(response == TVhostRequest::SUCCESS);
 
+            TTestRequest request;
+            bool res = environment.DequeueRequest(request);
+            UNIT_ASSERT(res);
+            UNIT_ASSERT(request.Type == EBlockStoreRequest::ZeroBlocks);
+            UNIT_ASSERT(
+                request.StartIndex * blockSize == firstSector * sectorSize);
+            UNIT_ASSERT(
+                request.BlocksCount * blockSize == totalSectors * sectorSize);
+            UNIT_ASSERT(!environment.DequeueRequest(request));
+        }
+
+        {
+            auto future = device->SendTestRequest(
+                EBlockStoreRequest::ZeroBlocks,
+                firstSector * sectorSize,
+                totalSectors * sectorSize,
+                {},
+                false /* isDiscardRequest */);
+            const auto& response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT(response == TVhostRequest::SUCCESS);
+
+            TTestRequest request;
+            bool res = environment.DequeueRequest(request);
+            UNIT_ASSERT(res);
+            UNIT_ASSERT(request.Type == EBlockStoreRequest::ZeroBlocks);
+            UNIT_ASSERT(
+                request.StartIndex * blockSize == firstSector * sectorSize);
+            UNIT_ASSERT(
+                request.BlocksCount * blockSize == totalSectors * sectorSize);
+            UNIT_ASSERT(!environment.DequeueRequest(request));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldDropDiscardRequestsIfNeeded)
+    {
+        const ui32 blockSize = 4096;
+        const ui64 firstSector = 8;
+        const ui64 totalSectors = 32;
+        const ui64 sectorSize = 512;
+
+        UNIT_ASSERT(totalSectors * sectorSize % blockSize == 0);
+
+        auto environment =
+            TTestEnvironment(blockSize, true /* dropDiscardRequests */);
+        auto device = environment.GetVhostDevice();
+
+        {
+            auto future = device->SendTestRequest(
+                EBlockStoreRequest::ZeroBlocks,
+                firstSector * sectorSize,
+                totalSectors * sectorSize,
+                {},
+                true /* isDiscardRequest */);
+            const auto& response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT(response == TVhostRequest::SUCCESS);
+
+            // Should drop the discard request.
+            TTestRequest request;
+            UNIT_ASSERT(!environment.DequeueRequest(request));
+        }
+
+        {
+            auto future = device->SendTestRequest(
+                EBlockStoreRequest::ZeroBlocks,
+                firstSector * sectorSize,
+                totalSectors * sectorSize,
+                {},
+                false /* isDiscardRequest */);
+            const auto& response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT(response == TVhostRequest::SUCCESS);
+
+            // This is not a discard request but a write zeroes request.
+            // Should not drop it.
             TTestRequest request;
             bool res = environment.DequeueRequest(request);
             UNIT_ASSERT(res);

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -56,7 +56,8 @@ public:
             ui64 from,
             ui64 length,
             TSgList sgList,
-            void* cookie)
+            void* cookie,
+            bool isDiscardRequest)
         : VhdIo(vhdIo)
     {
         Type = type;
@@ -64,6 +65,7 @@ public:
         Length = length;
         SgList.SetSgList(std::move(sgList));
         Cookie = cookie;
+        IsDiscardRequest = isDiscardRequest;
     }
 
     void Complete(EResult result) override
@@ -303,6 +305,7 @@ private:
         auto* vhdBdevIo = vhd_get_bdev_io(vhdRequest.io);
 
         EBlockStoreRequest type;
+        bool isDiscardRequest = false;
         switch (vhdBdevIo->type)
         {
             case VHD_BDEV_READ:
@@ -312,6 +315,9 @@ private:
                 type = EBlockStoreRequest::WriteBlocks;
                 break;
             case VHD_BDEV_DISCARD:
+                type = EBlockStoreRequest::ZeroBlocks;
+                isDiscardRequest = true;
+                break;
             case VHD_BDEV_WRITE_ZEROES:
                 type = EBlockStoreRequest::ZeroBlocks;
                 break;
@@ -327,7 +333,8 @@ private:
             vhdBdevIo->first_sector * VHD_SECTOR_SIZE,
             vhdBdevIo->total_sectors * VHD_SECTOR_SIZE,
             ConvertVhdSgList(vhdBdevIo->sglist),
-            cookie);
+            cookie,
+            isDiscardRequest);
     }
 
     static TSgList ConvertVhdSgList(const vhd_sglist& vhdSglist)

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -29,6 +29,7 @@ struct TVhostRequest
     ui64 Length = 0;
     TGuardedSgList SgList;
     void* Cookie = nullptr;
+    bool IsDiscardRequest = false;
 
     virtual ~TVhostRequest() = default;
 

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -29,7 +29,8 @@ public:
             ui64 from,
             ui64 length,
             TSgList sgList,
-            void* cookie)
+            void* cookie,
+            bool isDiscardRequest)
         : Promise(std::move(promise))
     {
         Type = type;
@@ -37,6 +38,7 @@ public:
         Length = length;
         SgList.SetSgList(std::move(sgList));
         Cookie = cookie;
+        IsDiscardRequest = isDiscardRequest;
     }
 
     void Complete(EResult result) override
@@ -117,7 +119,8 @@ public:
         EBlockStoreRequest type,
         ui64 from,
         ui64 length,
-        TSgList sgList) override
+        TSgList sgList,
+        bool isDiscardRequest = false) override
     {
         auto promise = NewPromise<TVhostRequest::EResult>();
         auto future = promise.GetFuture();
@@ -136,7 +139,8 @@ public:
             from,
             length,
             std::move(sgList),
-            Cookie);
+            Cookie,
+            isDiscardRequest);
         Requests.Enqueue(request.release());
         return future;
     }

--- a/cloud/blockstore/libs/vhost/vhost_test.h
+++ b/cloud/blockstore/libs/vhost/vhost_test.h
@@ -20,7 +20,8 @@ struct ITestVhostDevice
         EBlockStoreRequest type,
         ui64 from,
         ui64 length,
-        TSgList sgList) = 0;
+        TSgList sgList,
+        bool isDiscardRequest = false) = 0;
 
     virtual void DisableAutostop(bool disable) = 0;
 


### PR DESCRIPTION
### Notes

Fixed version of https://github.com/ydb-platform/nbs/pull/5626 (it was previously reverted due to crash: dereferense of moved shared_ptr in `cloud/blockstore/libs/vhost/server.cpp).

### Issue
Put links to the related issues here
