### PR TITLE
[Blockstore, Filestore] add retries for FDNHostName function used in (blockstore|filestore)-client

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -18,7 +18,9 @@
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/blockstore/libs/throttling/throttler_logger.h>
 #include <cloud/blockstore/libs/throttling/throttler_metrics.h>
+
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/hostname.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -29,7 +31,6 @@
 #include <cloud/storage/core/libs/version/version.h>
 
 #include <library/cpp/lwtrace/mon/mon_lwtrace.h>
-
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/protobuf/util/pb_io.h>
 
@@ -43,7 +44,6 @@
 #include <util/string/subst.h>
 #include <util/system/env.h>
 #include <util/system/fs.h>
-#include <util/system/hostname.h>
 #include <util/system/sysstat.h>
 
 namespace NCloud::NBlockStore::NClient {
@@ -608,8 +608,15 @@ void TCommand::InitClientConfig()
     if (clientConfig.GetHost() == "localhost" &&
         clientConfig.GetSecurePort() != 0)
     {
-        // With TLS on transform localhost into fully qualified domain name.
-        clientConfig.SetHost(FQDNHostName());
+        // With TLS, we must use a fully qualified domain name instead of
+        // localhost - otherwise, the certificate hostname check will fail
+        clientConfig.SetHost(
+            GetFqdnHostNameWithRetries(
+                [this] (const yexception&) {
+                    GetErrorStream()
+                        << "FQDNHostName failed: " << CurrentExceptionMessage()
+                        << "\n";
+                }));
     }
     if (SkipCertVerification) {
         clientConfig.SetSkipCertVerification(SkipCertVerification);

--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -4,6 +4,7 @@
 #include <cloud/filestore/libs/client/probes.h>
 #include <cloud/filestore/libs/vfs/probes.h>
 
+#include <cloud/storage/core/libs/common/hostname.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
 #include <cloud/storage/core/libs/iam/iface/config.h>
@@ -19,7 +20,6 @@
 #include <util/string/strip.h>
 #include <util/system/env.h>
 #include <util/system/fs.h>
-#include <util/system/hostname.h>
 #include <util/system/sysstat.h>
 
 #include <filesystem>
@@ -243,7 +243,14 @@ void TCommand::Init()
         config.GetSecurePort() != 0)
     {
         // With TLS on transform localhost into fully qualified domain name.
-        config.SetHost(FQDNHostName());
+        config.SetHost(
+            GetFqdnHostNameWithRetries(
+                [this] (const yexception&) {
+                    STORAGE_ERROR(
+                        "FQDNHostName failed: " << CurrentExceptionMessage()
+                        << "\n");
+                }));
+
     }
     if (SkipCertVerification) {
         config.SetSkipCertVerification(SkipCertVerification);

--- a/cloud/storage/core/libs/common/hostname.cpp
+++ b/cloud/storage/core/libs/common/hostname.cpp
@@ -1,0 +1,36 @@
+#include "hostname.h"
+
+#include <library/cpp/retry/retry.h>
+
+#include <util/datetime/base.h>
+#include <util/system/hostname.h>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const ui32 GetFqdnHostNameRetryCount = 10;
+// Duration between two consecutive retries
+const TDuration GetFqdnHostNameSleepDuration = TDuration::Seconds(2);
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString GetFqdnHostNameWithRetries(
+    const std::function<void(const yexception&)>& onFail)
+{
+    const auto hostname = DoWithRetry<TString, yexception>(
+        [] () { return FQDNHostName(); },
+        onFail,
+        TRetryOptions(
+            GetFqdnHostNameRetryCount,
+            GetFqdnHostNameSleepDuration));
+
+    Y_ENSURE(hostname);
+    return *hostname;
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/hostname.h
+++ b/cloud/storage/core/libs/common/hostname.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/generic/yexception.h>
+
+#include <functional>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString GetFqdnHostNameWithRetries(
+    const std::function<void(const yexception&)>& onFail);
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/ya.make
+++ b/cloud/storage/core/libs/common/ya.make
@@ -24,6 +24,7 @@ SRCS(
     guarded_sglist.cpp
     helpers.cpp
     history.cpp
+    hostname.cpp
     lru_cache.cpp
     media.cpp
     page_size.cpp
@@ -60,6 +61,7 @@ PEERDIR(
     library/cpp/logger
     library/cpp/lwtrace
     library/cpp/protobuf/util
+    library/cpp/retry
     library/cpp/threading/future
 
     contrib/ydb/library/actors/prof


### PR DESCRIPTION
### Notes
Sometimes the blockstore-client (or filestore-client) tool fails to retrieve the FQDN:
```
util/system/hostname.cpp:74: can not get FQDN (return code is -3, hostname is "XXX"
```
These errors can cause our release tool (krelease) to trigger a rollback, which is frustrating for DevOps engineers since the errors are flapping. 
To address this, I decided to add synchronous retries for this case.

This approach is preferable to adding retries in krelease, as the tool does not expect blockstore-client to fail and cannot reliably distinguish which errors are safe to retry

### Issue
Put links to the related issues here
