### PR TITLE
issue-4608: do not validate session in the shard upon GetNodeAttrBatchRequest from the TListNodesActor in case of sharded directories

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -158,6 +158,8 @@ void TListNodesActor::GetNodeAttrsBatch(const TActorContext& ctx)
             auto& batch = batches[node.GetShardFileSystemId()];
             if (batch.Record.GetHeaders().GetSessionId().empty()) {
                 batch.Record.MutableHeaders()->CopyFrom(ListNodesRequest.GetHeaders());
+                batch.Record.MutableHeaders()->SetBehaveAsDirectoryTablet(
+                    false);
                 batch.Record.SetFileSystemId(node.GetShardFileSystemId());
                 batch.Record.SetNodeId(RootNodeId);
             }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -40,6 +40,13 @@ NProto::TStorageConfig MakeStorageConfigWithShardIdSelectionInLeader()
     return config;
 }
 
+NProto::TStorageConfig MakeStorageConfigWithDirectoryCreationInShards()
+{
+    NProto::TStorageConfig config;
+    config.SetDirectoryCreationInShardsEnabled(true);
+    return config;
+}
+
 NProtoPrivate::TGetFileSystemTopologyResponse GetFileSystemTopology(
     TServiceClient& service,
     const TString& fsId)
@@ -145,6 +152,20 @@ void CheckShardsSize(
     }                                                                          \
     SERVICE_TEST_DECL(name)                                                    \
 // SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY
+
+#define SERVICE_TEST_DIR_CREATION_IN_SHARDS(name)                         \
+    SERVICE_TEST_DECL(name);                                              \
+    Y_UNIT_TEST(name)                                                     \
+    {                                                                     \
+        TestImpl##name(MakeStorageConfig());                              \
+    }                                                                     \
+    Y_UNIT_TEST(name##WithDirectoryCreationInShards)                      \
+    {                                                                     \
+        TestImpl##name(MakeStorageConfigWithDirectoryCreationInShards()); \
+    }                                                                     \
+    SERVICE_TEST_DECL(name)
+
+// SERVICE_TEST_DIR_CREATION_IN_SHARDS
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -6731,6 +6752,66 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             "AppCriticalEvents/ReceivedNodeOpErrorFromShard");
 
         UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
+    }
+    SERVICE_TEST_DIR_CREATION_IN_SHARDS(
+        ShouldNotRequireActiveSessionForGetNodeAttrBatchToShard)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        const auto nodeId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file1"))
+                ->Record.GetNode()
+                .GetId();
+        const ui64 shardTabletId = ExtractShardNo(nodeId) == 1
+                                       ? fsInfo.Shard1TabletId
+                                       : fsInfo.Shard2TabletId;
+
+        TAutoPtr<IEventHandle> getNodeAttrBatchEvent;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() ==
+                    TEvIndexTablet::EvGetNodeAttrBatchRequest)
+                {
+                    getNodeAttrBatchEvent = event.Release();
+                    return true;
+                }
+                return false;
+            });
+
+        service.SendListNodesRequest(headers, RootNodeId);
+
+        for (ui32 attempt = 0; attempt < 100 && !getNodeAttrBatchEvent;
+             ++attempt)
+        {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+        UNIT_ASSERT(getNodeAttrBatchEvent);
+        env.GetRuntime().SetEventFilter(
+            TTestActorRuntimeBase::DefaultFilterFunc);
+
+        TIndexTabletClient shard(env.GetRuntime(), nodeIdx, shardTabletId);
+        shard.RebootTablet();
+
+        env.GetRuntime().Send(getNodeAttrBatchEvent.Release(), nodeIdx);
+
+        for (ui32 attempt = 0; attempt < 100; ++attempt) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        auto listResponse = service.RecvListNodesResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            listResponse->GetError().GetCode(),
+            listResponse->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(1, listResponse->Record.NodesSize());
     }
 
     // TODO(2566) get rid of this test after migration


### PR DESCRIPTION
### Notes

In case of `DirectoryCreationInShardsEnabled` set to true, we will set `BehaveAsDirectoryTablet` header in the TListNodes request to true: https://github.com/ydb-platform/nbs/blob/558b7d60894e0dbb6865c9dd906cc5ffb020b7df/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp#L607-L608

It will get copied to the GetNodeAttrBatchRequest here: https://github.com/ydb-platform/nbs/blob/558b7d60894e0dbb6865c9dd906cc5ffb020b7df/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp#L161

Which will in turn make the tablet validate the session in the GetNodeAttrBatch request: https://github.com/ydb-platform/nbs/blob/558b7d60894e0dbb6865c9dd906cc5ffb020b7df/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp#L222-L237

There is no need to validate the session in such a request (same as stated in this PR: https://github.com/ydb-platform/nbs/pull/5547)


### Issue
#4608
