### PR TITLE
[Filestore] fix filestore/tests/client/test.py flake8 test

### DIFF
--- a/cloud/filestore/tests/client/test.py
+++ b/cloud/filestore/tests/client/test.py
@@ -927,7 +927,7 @@ def test_client_should_not_crash_on_shutdown_while_listing_endpoints():
     # trigger a crash
     try:
         daemon.stop()
-    except Exception as _:
+    except Exception:
         pass
 
     assert 1 == daemon.daemon.exit_code


### PR DESCRIPTION
```
cloud/filestore/tests/client <flake8>
------ sole chunk ran 1 test (total:1.82s - test:1.81s)
[fail] test.py::flake8 [default-linux-x86_64-debug] (0.00s) cloud/filestore/tests/client/test.py:930: [F841] local variable '_' is assigned to but never used
Logsdir: /home/debnatkh/nbs/cloud/filestore/tests/client/test-results/flake8/testing_out_stuff
------ FAIL: 1 - FAIL cloud/filestore/tests/client

Total 1 suite:
        1 - FAIL
Total 1 test:
        1 - FAIL
Failed
```

### Notes
Describe your PR - what it does and why this needs to be done.

### Issue
Put links to the related issues here
