### PR TITLE
[Blockstore, Filestore] remove the --iam-token-file option from (blockstore|filestore)-client and nbd tool

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -34,17 +34,14 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/protobuf/util/pb_io.h>
 
-#include <util/folder/dirut.h>
 #include <util/generic/guid.h>
 #include <util/stream/file.h>
 #include <util/string/ascii.h>
 #include <util/string/builder.h>
 #include <util/string/join.h>
-#include <util/string/strip.h>
 #include <util/string/subst.h>
 #include <util/system/env.h>
 #include <util/system/fs.h>
-#include <util/system/sysstat.h>
 
 namespace NCloud::NBlockStore::NClient {
 
@@ -54,48 +51,6 @@ namespace {
 
 const TString DefaultConfigFile = "/Berkanavt/nbs-server/cfg/nbs-client.txt";
 const TString DefaultIamConfigFile = "/Berkanavt/nbs-server/cfg/nbs-iam.txt";
-const TString DefaultIamTokenFile = "~/.nbs-client/iam-token";
-
-////////////////////////////////////////////////////////////////////////////////
-
-TString ResolvePath(const TString& path)
-{
-    if (path.StartsWith('~')) {
-        return TStringBuilder() << GetHomeDir() << path.substr(1);
-    }
-
-    return path;
-}
-
-TString GetIamTokenFromFile(const TString& iamTokenFile)
-{
-    auto filename = ResolvePath(iamTokenFile);
-    TFile file;
-    try {
-        file = TFile(filename, EOpenModeFlag::OpenExisting | EOpenModeFlag::RdOnly);
-    } catch (...) {
-        return {};
-    }
-
-#ifdef _unix_
-    struct stat buf;
-    auto code = stat(filename.c_str(), &buf);
-    Y_ENSURE(
-        code == 0,
-        TStringBuilder() << "failed to stat file " << filename
-            << ", code=" << code);
-
-    Y_ENSURE(
-        (buf.st_mode & (S_IROTH | S_IWOTH | S_IXOTH)) == 0,
-        TStringBuilder() << "bad st_mode: " << buf.st_mode);
-#endif
-
-    if (!file.IsOpen()) {
-        return {};
-    }
-
-    return Strip(TFileInput(file).ReadAll());
-}
 
 }   // namespace
 
@@ -191,10 +146,6 @@ TCommand::TCommand(IBlockStorePtr client)
 
     Opts.AddLongOption("grpc-trace", "turn on grpc tracing")
         .StoreTrue(&EnableGrpcTracing);
-
-    Opts.AddLongOption("iam-token-file", "path to iam token")
-        .RequiredArgument("STR")
-        .StoreResult(&IamTokenFile);
 
     Opts.AddLongOption(
         "client-performance-profile",
@@ -656,21 +607,9 @@ void TCommand::InitClientConfig()
         logConfig.SetLogLevel(*level);
     }
 
-    if (!IamTokenFile) {
-        auto& authConfig = appConfig.GetAuthConfig();
-        if (authConfig.HasIamTokenFile()) {
-            IamTokenFile = authConfig.GetIamTokenFile();
-        } else {
-            IamTokenFile = DefaultIamTokenFile;
-        }
-    }
-
     // Do not send token via insecure channel.
     if (clientConfig.GetSecurePort() != 0) {
         auto iamToken = GetEnv("IAM_TOKEN");
-        if (!iamToken) {
-            iamToken = GetIamTokenFromFile(IamTokenFile);
-        }
         if (!iamToken) {
             iamToken = GetIamTokenFromClient();
         }

--- a/cloud/blockstore/apps/client/lib/command.h
+++ b/cloud/blockstore/apps/client/lib/command.h
@@ -81,8 +81,6 @@ protected:
     // Use protobuf syntax for request/response
     bool Proto = false;
 
-    TString IamTokenFile;
-
     TString ClientPerformanceProfile;
 
     TString InputFile;

--- a/cloud/blockstore/config/client.proto
+++ b/cloud/blockstore/config/client.proto
@@ -250,18 +250,12 @@ message TMonitoringConfig
 
 ////////////////////////////////////////////////////////////////////////////////
 
-message TAuthConfig
-{
-    optional string IamTokenFile = 1;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 message TClientAppConfig
 {
+    reserved 4;
+
     optional TClientConfig ClientConfig = 1;
     optional TLogConfig LogConfig = 2;
     optional TMonitoringConfig MonitoringConfig = 3;
-    optional TAuthConfig AuthConfig = 4;
     optional NCloud.NProto.TIamClientConfig IamConfig = 5;
 }

--- a/cloud/blockstore/tools/fs/setup_fs_mask/__main__.py
+++ b/cloud/blockstore/tools/fs/setup_fs_mask/__main__.py
@@ -50,7 +50,7 @@ def parse_volume_info(stream):
     return info
 
 
-def mount_volume(disk_id, path, iam_token_file, mount_delay):
+def mount_volume(disk_id, path, mount_delay):
     logging.info(f'mount volume {disk_id} to {path} ...')
 
     args = [
@@ -64,12 +64,6 @@ def mount_volume(disk_id, path, iam_token_file, mount_delay):
         '--listen-path', f"/var/tmp/{disk_id}.nbd.socket",
         '--access-mode', 'ro'
     ]
-
-    if iam_token_file:
-        args += [
-            "--secure-port", "9768",
-            "--iam-token-file", iam_token_file
-        ]
 
     nbd = Popen(args, stderr=PIPE, text=True)
 
@@ -98,11 +92,10 @@ def mount_volume(disk_id, path, iam_token_file, mount_delay):
 
 class MountedVolume:
 
-    def __init__(self, disk_id, path, iam_token_file, delay_ms):
+    def __init__(self, disk_id, path, delay_ms):
         self.__disk_id = disk_id
         self.__path = path
         self.__process = None
-        self.__iam_token_file = iam_token_file
         self.__delay = delay_ms / 1000.0
 
     @property
@@ -113,7 +106,6 @@ class MountedVolume:
         self.__process = mount_volume(
             self.__disk_id,
             self.__path,
-            self.__iam_token_file,
             self.__delay)
 
         return self
@@ -189,9 +181,6 @@ class LoopDev:
 
 class NbsCli:
 
-    def __init__(self, iam_token_file):
-        self.__iam_token_file = iam_token_file
-
     def execute_action(self, action_name, input_bytes):
         logging.info(f'execute action {action_name} with {input_bytes}')
 
@@ -201,12 +190,6 @@ class NbsCli:
             '--verbose', 'error',
             '--input-bytes', json.dumps(input_bytes, separators=(',', ':')),
         ]
-
-        if self.__iam_token_file:
-            args += [
-                "--secure-port", "9768",
-                "--iam-token-file", self.__iam_token_file
-            ]
 
         run(args, check=True, text=True, stdout=sys.stdout, stderr=sys.stdout)
 
@@ -218,12 +201,6 @@ class NbsCli:
             '--disk-id', disk_id,
             '--verbose', 'error'
         ]
-
-        if self.__iam_token_file:
-            args += [
-                "--secure-port", "9768",
-                "--iam-token-file", self.__iam_token_file
-            ]
 
         p = run(args, check=True, text=True, stdout=PIPE, stderr=sys.stdout)
 
@@ -314,7 +291,7 @@ def generate_used_blocks(path):
 
 
 def reset_masks(args):
-    cli = NbsCli(args.iam_token_file)
+    cli = NbsCli()
 
     cli.disable_mask_unused_blocks(args.disk_id)
     cli.enable_track_used_blocks(args.disk_id)
@@ -380,7 +357,6 @@ def main():
 
     parser.add_argument("--device", type=str, default='/dev/nbd0', help='mount point for disk')
     parser.add_argument("--output-dir", type=str, default='./dumps', help='output folder')
-    parser.add_argument("--iam-token-file", type=str, help='IAM token file')
     parser.add_argument("--mask-unused", help="set 'mask-unused' tag", action='store_true', default=False)
     parser.add_argument("--always-track", help="alway set track-used flag", action='store_true', default=False)
     parser.add_argument("--reset-masks", help="remove used blocks mask from disk and 'mask-unused' 'track-used' tags", action='store_true', default=False)
@@ -400,7 +376,7 @@ def main():
 
     output_dir = os.path.join(args.output_dir, args.disk_id)
 
-    cli = NbsCli(args.iam_token_file)
+    cli = NbsCli()
 
     descr = cli.describe_volume(args.disk_id)
 
@@ -408,7 +384,7 @@ def main():
     cli.enable_read_only_mode(args.disk_id)
 
     try:
-        with MountedVolume(args.disk_id, args.device, args.iam_token_file, args.mount_delay_ms) as nbd:
+        with MountedVolume(args.disk_id, args.device, args.mount_delay_ms) as nbd:
             if args.device_offset:
                 with LoopDev(nbd.path, args.device_offset) as loop_dev:
                     dump_disk_info(loop_dev.path, descr["bs"], output_dir)

--- a/cloud/blockstore/tools/nbd/bootstrap.cpp
+++ b/cloud/blockstore/tools/nbd/bootstrap.cpp
@@ -44,8 +44,8 @@
 #include <util/datetime/base.h>
 #include <util/folder/dirut.h>
 #include <util/generic/guid.h>
-#include <util/stream/file.h>
-#include <util/string/strip.h>
+#include <util/system/env.h>
+#include <util/system/fs.h>
 #include <util/system/hostname.h>
 
 namespace NCloud::NBlockStore::NBD {
@@ -59,35 +59,6 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 const TString DefaultConfigFile = "/Berkanavt/nbs-server/cfg/nbs-client.txt";
-const TString DefaultIamTokenFile = "~/.nbs-client/iam-token";
-
-////////////////////////////////////////////////////////////////////////////////
-
-TString ResolvePath(const TString& path)
-{
-    if (path.StartsWith('~')) {
-        return TStringBuilder() << GetHomeDir() << path.substr(1);
-    }
-
-    return path;
-}
-
-TString GetIamToken(const TString& iamTokenFile)
-{
-    auto filename = ResolvePath(iamTokenFile);
-    TFile file;
-    try {
-        file = TFile(filename, EOpenModeFlag::OpenExisting | EOpenModeFlag::RdOnly);
-    } catch (...) {
-        return {};
-    }
-
-    if (!file.IsOpen()) {
-        return {};
-    }
-
-    return Strip(TFileInput(file).ReadAll());
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -223,19 +194,9 @@ void TBootstrap::InitClientConfig()
         monConfig.SetThreadsCount(1);  // reasonable defaults
     }
 
-    auto iamTokenFile = Options->IamTokenFile;
-    if (!iamTokenFile) {
-        auto& authConfig = appConfig.GetAuthConfig();
-        if (authConfig.HasIamTokenFile()) {
-            iamTokenFile = authConfig.GetIamTokenFile();
-        } else {
-            iamTokenFile = DefaultIamTokenFile;
-        }
-    }
-
     // Do not send token via insecure channel.
     if (clientConfig.GetSecurePort() != 0) {
-        clientConfig.SetAuthToken(GetIamToken(iamTokenFile));
+        clientConfig.SetAuthToken(GetEnv("IAM_TOKEN"));
     }
 
     if (!clientConfig.GetClientId()) {

--- a/cloud/blockstore/tools/nbd/options.cpp
+++ b/cloud/blockstore/tools/nbd/options.cpp
@@ -91,10 +91,6 @@ void TOptions::Parse(int argc, char** argv)
         .RequiredArgument("NUM")
         .StoreResult(&SecurePort);
 
-    opts.AddLongOption("iam-token-file", "path to iam token")
-        .RequiredArgument("STR")
-        .StoreResult(&IamTokenFile);
-
     opts.AddLongOption("device-mode", "nbs device connection mode [endpoint, proxy, null]")
         .RequiredArgument("STR")
         .Handler1T<TString>([this] (const auto& s) {

--- a/cloud/blockstore/tools/nbd/options.h
+++ b/cloud/blockstore/tools/nbd/options.h
@@ -30,7 +30,6 @@ struct TOptions
     TString Host;
     ui32 InsecurePort = 0;
     ui32 SecurePort = 0;
-    TString IamTokenFile;
 
     EDeviceMode DeviceMode = EDeviceMode::Endpoint;
 

--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -13,16 +13,10 @@
 #include <library/cpp/protobuf/util/pb_io.h>
 
 #include <util/datetime/base.h>
-#include <util/folder/dirut.h>
-#include <util/folder/path.h>
 #include <util/generic/guid.h>
-#include <util/stream/file.h>
-#include <util/string/strip.h>
 #include <util/system/env.h>
 #include <util/system/fs.h>
 #include <util/system/sysstat.h>
-
-#include <filesystem>
 
 namespace NCloud::NFileStore::NClient {
 
@@ -39,36 +33,6 @@ const TString DefaultVhostConfigFile = "/Berkanavt/nfs-vhost/cfg/nfs-client.txt"
 const TString DefaultVhostLocalConfigFile =
     "/Berkanavt/nfs-vhost/cfg/nfs-client-local.txt";
 const TString DefaultIamConfigFile = "/Berkanavt/nfs-server/cfg/nfs-iam.txt";
-const TString DefaultIamTokenFile = "~/.nfs-client/iam-token";
-
-////////////////////////////////////////////////////////////////////////////////
-
-TString GetIamTokenFromFile(const TString& iamTokenFile)
-{
-    auto path = TFsPath(iamTokenFile).RealPath();
-    TFile file;
-    try {
-        file = TFile(
-            path.GetPath(),
-            EOpenModeFlag::OpenExisting | EOpenModeFlag::RdOnly);
-    } catch (...) {
-        return {};
-    }
-
-    auto stats = std::filesystem::status(
-            std::filesystem::path(path.GetPath().c_str()));
-    auto perms = stats.permissions();
-
-    Y_ENSURE(
-        (perms & std::filesystem::perms::others_all) == std::filesystem::perms::none,
-        TStringBuilder() << "bad Mode: " << static_cast<ui32>(perms));
-
-    if (!file.IsOpen()) {
-        return {};
-    }
-
-    return Strip(TFileInput(file).ReadAll());
-}
 
 }   // namespace
 
@@ -114,10 +78,6 @@ TCommand::TCommand()
 
     Opts.AddLongOption("skip-cert-verification", "skip server certificate verification")
         .StoreTrue(&SkipCertVerification);
-
-    Opts.AddLongOption("iam-token-file", "path to iam token")
-        .RequiredArgument("STR")
-        .StoreResult(&IamTokenFile);
 
     Opts.AddLongOption("config")
         .Help(TStringBuilder()
@@ -258,21 +218,9 @@ void TCommand::Init()
 
     InitIamTokenClient();
 
-    if (!IamTokenFile) {
-        auto& authConfig = appConfig.GetAuthConfig();
-        if (authConfig.HasIamTokenFile()) {
-            IamTokenFile = authConfig.GetIamTokenFile();
-        } else {
-            IamTokenFile = DefaultIamTokenFile;
-        }
-    }
-
     // Do not send token via insecure channel.
     if (config.GetSecurePort() != 0) {
         auto iamToken = GetEnv("IAM_TOKEN");
-        if (!iamToken) {
-            iamToken = GetIamTokenFromFile(IamTokenFile);
-        }
         if (!iamToken) {
             iamToken = GetIamTokenFromClient();
         }

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -57,7 +57,6 @@ protected:
     ui32 SecurePort = 0;
     TString ServerUnixSocketPath;
     bool SkipCertVerification = false;
-    TString IamTokenFile;
     TString ConfigFile;
 
     TClientConfigPtr ClientConfig;


### PR DESCRIPTION
### Notes
Storing an IAM token in a file is strongly discouraged, since the token can be left on the file system, which is insecure. IAM_TOKEN environment variable should be used instead

### Issue
Put links to the related issues here
