### PR TITLE
issue-5726: TLRUCache - support for FindInIndex, using it in NodeRefs cache to optimize individual ref lookups

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -231,8 +231,8 @@ bool TInMemoryIndexState::ReadNodeRef(
     const TString& name,
     TMaybe<TNodeRef>& ref)
 {
-    auto it = NodeRefs.find(TNodeRefsKey(nodeId, name));
-    if (it == NodeRefs.end()) {
+    auto* v = NodeRefs.FindInIndex(TNodeRefsKey(nodeId, name));
+    if (!v) {
         // If the cache is exhaustive for the node and we did not find the
         // entry, then we are sure that the entry does not exist and we can
         // return true, meaning that cache lookup was successful. But we do not
@@ -240,16 +240,16 @@ bool TInMemoryIndexState::ReadNodeRef(
         return NodeRefsExhaustivenessInfo.IsExhaustiveForNode(nodeId);
     }
 
-    ui64 minCommitId = it->second.CommitId;
+    ui64 minCommitId = v->CommitId;
     ui64 maxCommitId = InvalidCommitId;
 
     if (VisibleCommitId(commitId, minCommitId, maxCommitId)) {
         ref = TNodeRef{
             nodeId,
             name,
-            it->second.ChildId,
-            it->second.ShardId,
-            it->second.ShardNodeName,
+            v->ChildId,
+            v->ShardId,
+            v->ShardNodeName,
             minCommitId,
             maxCommitId};
     }
@@ -359,21 +359,21 @@ void TInMemoryIndexState::WriteNodeRef(
     const TString& shardNodeName)
 {
     const auto key = TNodeRefsKey(nodeId, name);
-    auto it = NodeRefs.find(key);
+    auto* v = NodeRefs.FindInIndex(key);
     TNodeRefsRow value{
         .CommitId = commitId,
         .ChildId = childNode,
         .ShardId = shardId,
         .ShardNodeName = shardNodeName};
 
-    if (it == NodeRefs.end()) {
+    if (!v) {
         const auto [_, inserted, evicted] = NodeRefs.emplace(key, value);
         if (evicted) {
             NodeRefsExhaustivenessInfo.NodeRefsEvictionObserved(
                 evicted->NodeId);
         }
     } else {
-        it->second = value;
+        *v = value;
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -299,6 +299,7 @@ private:
     NCloud::TLRUCache<
         TNodeRefsKey,
         TNodeRefsRow,
+        true /* UseIndexLookup */,
         TNodeRefsKeyHash,
         TMap<TNodeRefsKey, TNodeRefsRow, TLess<TNodeRefsKey>, TStlAllocator>>
         NodeRefs;

--- a/cloud/storage/core/libs/common/lru_cache.h
+++ b/cloud/storage/core/libs/common/lru_cache.h
@@ -117,8 +117,8 @@ private:
         }
         while (Base.size() > MaxSize) {
             auto& ole = OrderList.back();
-            Base.erase(ole.Key);
             Index.erase(ole.Key);
+            Base.erase(ole.Key);
             evictedKeys.emplace_back(ole.Key);
             OrderList.pop_back();
         }
@@ -182,10 +182,12 @@ public:
     TValue* FindInIndex(const TKey& key)
     {
         auto indexIt = Index.find(key);
-        if (indexIt) {
+        if (indexIt != Index.end()) {
             Touch(indexIt);
+            return indexIt->second->Value;
         }
-        return indexIt ? indexIt->second->Value : nullptr;
+
+        return nullptr;
     }
 
     iterator find(const TKey& key)

--- a/cloud/storage/core/libs/common/lru_cache.h
+++ b/cloud/storage/core/libs/common/lru_cache.h
@@ -25,13 +25,31 @@ concept HasReserve = requires(T t) {
 template <
     typename TKey,
     typename TValue,
+    bool UseIndexLookup = false,
     typename THashFunc = THash<TKey>,
     typename TBase =
         THashMap<TKey, TValue, THashFunc, TEqualTo<TKey>, TStlAllocator>>
-class TLRUCache: public TMapOps<TLRUCache<TKey, TValue, THashFunc, TBase>>
+class TLRUCache
+    : public TMapOps<TLRUCache<TKey, TValue, UseIndexLookup, THashFunc, TBase>>
 {
-    using TOrderList = TList<TKey, TStlAllocator>;
-    using TOrderPositions = THashMap<
+    template <bool WithValue>
+    struct TOrderListEntry;
+
+    template <>
+    struct TOrderListEntry<true>
+    {
+        TKey Key;
+        TValue* Value;
+    };
+
+    template <>
+    struct TOrderListEntry<false>
+    {
+        TKey Key;
+    };
+
+    using TOrderList = TList<TOrderListEntry<UseIndexLookup>, TStlAllocator>;
+    using TIndex = THashMap<
         TKey,
         typename TOrderList::iterator,
         THashFunc,
@@ -45,18 +63,42 @@ class TLRUCache: public TMapOps<TLRUCache<TKey, TValue, THashFunc, TBase>>
     TOrderList OrderList;
     // Contains the position of each key in OrderList, needed to quickly find
     // and update the order when accessing a key
-    TOrderPositions OrderPositions;
+    TIndex Index;
 
     IAllocator* Alloc;
 
     size_t MaxSize = 0;
 
-    inline void RemoveFromOrder(const TKey& key)
+private:
+    void Touch(TIndex::iterator indexIt)
     {
-        auto it = OrderPositions.find(key);
-        if (it != OrderPositions.end()) {
-            OrderList.erase(it->second);
-            OrderPositions.erase(it);
+        OrderList.splice(OrderList.begin(), OrderList, indexIt->second);
+    }
+
+    void UpdateIndex(TBase::iterator it)
+    {
+        typename TIndex::insert_ctx ctx;
+        auto indexIt = Index.find(it->first, ctx);
+        if (indexIt != Index.end()) {
+            Touch(indexIt);
+            return;
+        }
+
+        if constexpr (UseIndexLookup) {
+            OrderList.emplace_front(it->first, &it->second);
+        } else {
+            OrderList.emplace_front(it->first);
+        }
+
+        Index.emplace_direct(ctx, it->first, OrderList.begin());
+    }
+
+    void RemoveFromIndex(const TKey& key)
+    {
+        auto indexIt = Index.find(key);
+        if (indexIt != Index.end()) {
+            OrderList.erase(indexIt->second);
+            Index.erase(indexIt);
         }
     }
 
@@ -74,10 +116,10 @@ class TLRUCache: public TMapOps<TLRUCache<TKey, TValue, THashFunc, TBase>>
             evictedKeys.reserve(Base.size() - MaxSize);
         }
         while (Base.size() > MaxSize) {
-            auto& key = OrderList.back();
-            Base.erase(key);
-            OrderPositions.erase(key);
-            evictedKeys.emplace_back(key);
+            auto& ole = OrderList.back();
+            Base.erase(ole.Key);
+            Index.erase(ole.Key);
+            evictedKeys.emplace_back(ole.Key);
             OrderList.pop_back();
         }
         return evictedKeys;
@@ -89,7 +131,7 @@ public:
     explicit TLRUCache(IAllocator* alloc)
         : Base(alloc)
         , OrderList(alloc)
-        , OrderPositions(alloc)
+        , Index(alloc)
         , Alloc(alloc)
     {}
 
@@ -112,20 +154,19 @@ public:
         if constexpr (HasReserve<TBase>) {
             Base.reserve(hint);
         }
-        OrderPositions.reserve(hint);
+        Index.reserve(hint);
     }
 
     // Moves the key to the front of the order list; used upon any access
-    void TouchKey(const TKey& key)
+    bool TouchKey(const TKey& key)
     {
-        auto it = OrderPositions.find(key);
-        if (it != OrderPositions.end()) {
-            OrderList.splice(OrderList.begin(), OrderList, it->second);
-        } else {
-            OrderPositions.emplace(
-                key,
-                OrderList.insert(OrderList.begin(), key));
+        auto it = Index.find(key);
+        if (it != Index.end()) {
+            Touch(it);
+            return true;
         }
+
+        return false;
     }
 
     iterator begin()
@@ -138,18 +179,28 @@ public:
         return Base.end();
     }
 
+    TValue* FindInIndex(const TKey& key)
+    {
+        auto indexIt = Index.find(key);
+        if (indexIt) {
+            Touch(indexIt);
+        }
+        return indexIt ? indexIt->second->Value : nullptr;
+    }
+
     iterator find(const TKey& key)
     {
         auto result = Base.find(key);
         if (result != Base.end()) {
-            TouchKey(key);
+            const bool touched = TouchKey(key);
+            Y_DEBUG_ABORT_UNLESS(touched);
         }
         return result;
     }
 
     void erase(iterator it)
     {
-        RemoveFromOrder(it->first);
+        RemoveFromIndex(it->first);
         Base.erase(it);
     }
 
@@ -157,7 +208,7 @@ public:
     {
         auto it = Base.find(key);
         if (it != Base.end()) {
-            RemoveFromOrder(it->first);
+            RemoveFromIndex(it->first);
             Base.erase(it);
         }
     }
@@ -186,7 +237,7 @@ public:
             return {Base.end(), false, std::nullopt};
         }
         auto result = Base.emplace(std::forward<Args>(args)...);
-        TouchKey(result.first->first);
+        UpdateIndex(result.first);
         auto excessKey = CleanupIfNeeded();
         // There should always be at most one excess key
         Y_DEBUG_ABORT_UNLESS(excessKey.size() <= 1);
@@ -199,7 +250,8 @@ public:
     TValue& at(const TKey& key)
     {
         auto& result = Base.at(key);
-        TouchKey(key);
+        const bool touched = TouchKey(key);
+        Y_DEBUG_ABORT_UNLESS(touched);
         return result;
     }
 

--- a/cloud/storage/core/libs/common/lru_cache_ut.cpp
+++ b/cloud/storage/core/libs/common/lru_cache_ut.cpp
@@ -10,9 +10,11 @@ namespace NCloud {
 
 Y_UNIT_TEST_SUITE(TLRUCache)
 {
-    Y_UNIT_TEST(ShouldEnforceCapacity)
+    template <bool UseIndexLookup>
+    void DoTestShouldEnforceCapacity()
     {
-        TLRUCache<TString, TString> hashMap(TDefaultAllocator::Instance());
+        TLRUCache<TString, TString, UseIndexLookup> hashMap(
+            TDefaultAllocator::Instance());
         hashMap.SetMaxSize(2);
 
         UNIT_ASSERT_VALUES_EQUAL(0, hashMap.size());
@@ -25,6 +27,15 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         UNIT_ASSERT_VALUES_EQUAL("value1", hashMap.find("key1")->second);
         UNIT_ASSERT_VALUES_EQUAL("value2", hashMap.find("key2")->second);
 
+        if constexpr (UseIndexLookup) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                "value1",
+                *hashMap.FindInIndex("key1"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "value2",
+                *hashMap.FindInIndex("key2"));
+        }
+
         auto [_, inserted, evicted] =
             hashMap.emplace("key3", "value3");   // Should evict "key1"
         UNIT_ASSERT_VALUES_EQUAL(true, inserted);
@@ -34,32 +45,79 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key1"));
         UNIT_ASSERT_VALUES_EQUAL("value2", hashMap.find("key2")->second);
         UNIT_ASSERT_VALUES_EQUAL("value3", hashMap.find("key3")->second);
+
+        if constexpr (UseIndexLookup) {
+            UNIT_ASSERT(!hashMap.FindInIndex("key1"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "value2",
+                *hashMap.FindInIndex("key2"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "value3",
+                *hashMap.FindInIndex("key3"));
+        }
     }
 
-    Y_UNIT_TEST(ShouldHandleAccessOrder)
+    Y_UNIT_TEST(ShouldEnforceCapacity)
     {
-        TLRUCache<TString, TString> hashMap(TDefaultAllocator::Instance());
+        DoTestShouldEnforceCapacity<false>();
+    }
+
+    Y_UNIT_TEST(ShouldEnforceCapacityWithIndexLookup)
+    {
+        DoTestShouldEnforceCapacity<true>();
+    }
+
+    template <bool UseIndexLookup>
+    void DoTestShouldHandleAccessOrder()
+    {
+        TLRUCache<TString, TString, UseIndexLookup> hashMap(
+            TDefaultAllocator::Instance());
         hashMap.SetMaxSize(3);
 
         hashMap.emplace("key1", "value1");
         hashMap.emplace("key2", "value2");
         hashMap.emplace("key3", "value3");
 
-        // Access key2 to make it most recently used
-        hashMap.find("key2");
+        if constexpr (UseIndexLookup) {
+            // Access key2 to make it most recently used
+            hashMap.FindInIndex("key2");
 
-        // Insert a new key, evicting the least recently used (key1)
-        hashMap.emplace("key4", "value4");
+            // Insert a new key, evicting the least recently used (key1)
+            hashMap.emplace("key4", "value4");
 
-        UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key1"));
-        UNIT_ASSERT_VALUES_EQUAL("value2", hashMap.find("key2")->second);
-        UNIT_ASSERT_VALUES_EQUAL("value3", hashMap.find("key3")->second);
-        UNIT_ASSERT_VALUES_EQUAL("value4", hashMap.find("key4")->second);
+            UNIT_ASSERT(!hashMap.FindInIndex("key1"));
+            UNIT_ASSERT_VALUES_EQUAL("value2", *hashMap.FindInIndex("key2"));
+            UNIT_ASSERT_VALUES_EQUAL("value3", *hashMap.FindInIndex("key3"));
+            UNIT_ASSERT_VALUES_EQUAL("value4", *hashMap.FindInIndex("key4"));
+        } else {
+            // Access key2 to make it most recently used
+            hashMap.find("key2");
+
+            // Insert a new key, evicting the least recently used (key1)
+            hashMap.emplace("key4", "value4");
+
+            UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key1"));
+            UNIT_ASSERT_VALUES_EQUAL("value2", hashMap.find("key2")->second);
+            UNIT_ASSERT_VALUES_EQUAL("value3", hashMap.find("key3")->second);
+            UNIT_ASSERT_VALUES_EQUAL("value4", hashMap.find("key4")->second);
+        }
     }
 
-    Y_UNIT_TEST(ShouldHandleErase)
+    Y_UNIT_TEST(ShouldHandleAccessOrder)
     {
-        TLRUCache<TString, TString> hashMap(TDefaultAllocator::Instance());
+        DoTestShouldHandleAccessOrder<false>();
+    }
+
+    Y_UNIT_TEST(ShouldHandleAccessOrderWithIndexLookup)
+    {
+        DoTestShouldHandleAccessOrder<true>();
+    }
+
+    template <bool UseIndexLookup>
+    void DoTestShouldHandleErase()
+    {
+        TLRUCache<TString, TString, UseIndexLookup> hashMap(
+            TDefaultAllocator::Instance());
         hashMap.SetMaxSize(3);
 
         hashMap.emplace("key1", "value1");
@@ -72,6 +130,11 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         hashMap.erase(hashMap.find("key2"));
 
         UNIT_ASSERT_VALUES_EQUAL(2, hashMap.size());
+        if constexpr (UseIndexLookup) {
+            UNIT_ASSERT(!hashMap.FindInIndex("key2"));
+            UNIT_ASSERT_VALUES_EQUAL("value1", *hashMap.FindInIndex("key1"));
+            UNIT_ASSERT_VALUES_EQUAL("value3", *hashMap.FindInIndex("key3"));
+        }
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key2"));
         UNIT_ASSERT_VALUES_EQUAL("value1", hashMap.find("key1")->second);
         UNIT_ASSERT_VALUES_EQUAL("value3", hashMap.find("key3")->second);
@@ -83,6 +146,20 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         UNIT_ASSERT_VALUES_EQUAL(0, hashMap.size());
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key1"));
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key3"));
+        if constexpr (UseIndexLookup) {
+            UNIT_ASSERT(!hashMap.FindInIndex("key1"));
+            UNIT_ASSERT(!hashMap.FindInIndex("key3"));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleErase)
+    {
+        DoTestShouldHandleErase<false>();
+    }
+
+    Y_UNIT_TEST(ShouldHandleEraseWithIndexLookup)
+    {
+        DoTestShouldHandleErase<true>();
     }
 
     Y_UNIT_TEST(ShouldThrowOnAtForNonExistentKey)
@@ -97,9 +174,11 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         UNIT_ASSERT_EXCEPTION(hashMap.at("key2"), yexception);
     }
 
-    Y_UNIT_TEST(ShouldHandleEdgeCases)
+    template <bool UseIndexLookup>
+    void DoTestShouldHandleEdgeCases()
     {
-        TLRUCache<TString, TString> hashMap(TDefaultAllocator::Instance());
+        TLRUCache<TString, TString, UseIndexLookup> hashMap(
+            TDefaultAllocator::Instance());
         hashMap.SetMaxSize(0);
 
         // Test capacity 0
@@ -108,6 +187,9 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         UNIT_ASSERT(!evicted.has_value());
         UNIT_ASSERT_EQUAL(hashMap.end(), it);
         UNIT_ASSERT_VALUES_EQUAL(0, hashMap.size());
+        if constexpr (UseIndexLookup) {
+            UNIT_ASSERT(!hashMap.FindInIndex("key1"));
+        }
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key1"));
 
         hashMap.SetMaxSize(2);
@@ -124,6 +206,9 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         UNIT_ASSERT(!evicted3.has_value());
 
         UNIT_ASSERT_VALUES_EQUAL(1, hashMap.size());
+        if constexpr (UseIndexLookup) {
+            UNIT_ASSERT_VALUES_EQUAL("value1", *hashMap.FindInIndex("key1"));
+        }
         UNIT_ASSERT_VALUES_EQUAL("value1", hashMap.find("key1")->second);
 
         // Test downsizing capacity
@@ -132,16 +217,35 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         hashMap.emplace("key1", "value1");
         hashMap.emplace("key2", "value2");
         hashMap.emplace("key3", "value3");
-        hashMap.find("key1");
+        if constexpr (UseIndexLookup) {
+            hashMap.FindInIndex("key1");
+        } else {
+            hashMap.find("key1");
+        }
         // Now the order is key1, key3, key2
         auto evicted4 = hashMap.SetMaxSize(2);
         UNIT_ASSERT_VALUES_EQUAL(1, evicted4.size());
         UNIT_ASSERT_VALUES_EQUAL("key2", evicted4[0]);
         // Should evict key2
+        if constexpr (UseIndexLookup) {
+            UNIT_ASSERT(!hashMap.FindInIndex("key2"));
+            UNIT_ASSERT_VALUES_EQUAL("value1", *hashMap.FindInIndex("key1"));
+            UNIT_ASSERT_VALUES_EQUAL("value3", *hashMap.FindInIndex("key3"));
+        }
         UNIT_ASSERT_EQUAL(hashMap.end(), hashMap.find("key2"));
         UNIT_ASSERT_VALUES_EQUAL("value1", hashMap.find("key1")->second);
         UNIT_ASSERT_VALUES_EQUAL("value3", hashMap.find("key3")->second);
         UNIT_ASSERT_VALUES_EQUAL(2, hashMap.size());
+    }
+
+    Y_UNIT_TEST(ShouldHandleEdgeCases)
+    {
+        DoTestShouldHandleEdgeCases<false>();
+    }
+
+    Y_UNIT_TEST(ShouldHandleEdgeCasesWithIndexLookup)
+    {
+        DoTestShouldHandleEdgeCases<true>();
     }
 
     Y_UNIT_TEST(ShouldUseOrderedMap)
@@ -149,6 +253,7 @@ Y_UNIT_TEST_SUITE(TLRUCache)
         NCloud::TLRUCache<
             TString,
             TString,
+            false,
             THash<TString>,
             TMap<TString, TString, TLess<TString>, TStlAllocator>>
         hashMap(TDefaultAllocator::Instance());


### PR DESCRIPTION
### Notes
`NodeRefs` cache uses `TMap` as the underlying container because it needs ordered listing to serve paginated `ListNodes` requests. But we also do a lot of single-ref lookups:
* to serve `GetNodeAttr` calls - these mostly originate from path resolution, e.g. `openat()`
* to serve `GetNodeAttrBatch` calls which are done directly after node ref listing

Even though `GetNodeAttrBatch` is served by multiple tablets (because we scatter the children of every dir across many shards), it still affects dir listing performance - in my local tests the majority of the time is spent processing this call in the tablet code:
<img width="1200" height="998" alt="flamegraph_base_HandleRequests" src="https://github.com/user-attachments/assets/2e69d6ed-58db-4e7a-b402-e7acaca50091" />

But `TLRUCache` already uses a `THashMap` - to maintain the key -> position mapping. I added an optional template parameter that adds `TValue*` to the position and enables the `FindInIndex()` method. And used this for the `NodeRefs` cache. In my local tests I see a 37% improvement in directory listing performance.

Test initialization stage:
```
$ ../../../tools/testing/fmdtest/bin/fmdtest --test-dir fmdtest_wd --producer-threads 16 --stealer-threads 0 --lister-threads 0 --duration 3h --files-per-producer 100000 --lister-sleep-duration 0s --unlink-percentage 0
...
$ ls fmdtest_wd/producer_0/|grep file_|wc -l
100000
```

The test:
```
../../../tools/testing/fmdtest/bin/fmdtest --test-dir fmdtest_wd --producer-threads 1 --stealer-threads 0 --lister-threads 8 --duration 5m --files-per-producer 0 --lister-sleep-duration 0s --unlink-percentage 0
```

Before this PR:
```
2026-04-18T10:10:58.784282Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:666: === Test Results ===
2026-04-18T10:10:58.784287Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:667: Duration: 301.199171 seconds
2026-04-18T10:10:58.784289Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: create: count=0, lat-us=0
2026-04-18T10:10:58.784290Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: unlink: count=0, lat-us=0
2026-04-18T10:10:58.784290Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: rename: count=0, lat-us=0
2026-04-18T10:10:58.784292Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: stat: count=0, lat-us=0
2026-04-18T10:10:58.784294Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: list: count=1037, lat-us=2318889, weight=103700000, wlat-us=23
2026-04-18T10:10:58.794649Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:697: Report: bench-report.json, errors: 0
```

After this PR:
```
2026-04-18T17:48:43.785617Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:666: === Test Results ===
2026-04-18T17:48:43.785621Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:667: Duration: 300.480556 seconds
2026-04-18T17:48:43.785648Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: create: count=0, lat-us=0
2026-04-18T17:48:43.785659Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: unlink: count=0, lat-us=0
2026-04-18T17:48:43.785660Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: rename: count=0, lat-us=0
2026-04-18T17:48:43.785661Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: stat: count=0, lat-us=0
2026-04-18T17:48:43.785663Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:85: list: count=1417, lat-us=1692658, weight=141700000, wlat-us=16
2026-04-18T17:48:43.796564Z :BENCH INFO: cloud/filestore/tools/testing/fmdtest/bin/app.cpp:697: Report: bench-report.json, errors: 0
```

It's hard to say by how much the performance would increase on a large cluster, but in any case this is a reasonable and useful optimization.

### Issue
https://github.com/ydb-platform/nbs/issues/5726
