### PR TITLE
Refactor VolumeSession's Start/StopVolume response routing

### DIFF
--- a/cloud/blockstore/libs/storage/service/volume_session_actor.h
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor.h
@@ -80,6 +80,7 @@ private:
     ui64 LastPipeResetTick = 0;
 
     EVolumeRequest CurrentRequest = NONE;
+    TRequestInfoPtr VolumeRequestInfo;
 
     bool ShuttingDown = false;
     NProto::TError ShuttingDownError;

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_start.cpp
@@ -1102,6 +1102,9 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
     const TActorContext& ctx)
 {
     const auto& diskId = VolumeInfo->DiskId;
+    CurrentRequest = START_REQUEST;
+    VolumeRequestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext);
 
     if (!StartVolumeActor) {
         LOG_DEBUG(
@@ -1110,7 +1113,6 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
             "%s Starting volume locally",
             LogTitle.GetWithTime().c_str());
 
-        CurrentRequest = START_REQUEST;
         StartVolumeActor = NCloud::Register<TStartVolumeActor>(
             ctx,
             SelfId(),
@@ -1138,6 +1140,8 @@ void TVolumeSessionActor::HandleStartVolumeRequest(
             LogTitle.GetWithTime().c_str(),
             FormatError(response->GetError()).c_str());
         NCloud::Reply(ctx, *ev, std::move(response));
+        CurrentRequest = NONE;
+        VolumeRequestInfo = {};
         return;
     }
 
@@ -1179,10 +1183,14 @@ void TVolumeSessionActor::HandleVolumeTabletStatus(
 
     VolumeInfo->SetStarted(msg->TabletId, msg->VolumeInfo, msg->VolumeActor);
 
-    if (MountRequestActor) {
-        auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
-            *VolumeInfo->VolumeInfo);
-        NCloud::Send(ctx, MountRequestActor, std::move(response));
+    if (VolumeRequestInfo && CurrentRequest == START_REQUEST) {
+        auto response =
+            std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
+                *VolumeInfo->VolumeInfo);
+        NCloud::Reply(ctx, *VolumeRequestInfo, std::move(response));
+
+        CurrentRequest = NONE;
+        VolumeRequestInfo = {};
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_stop.cpp
@@ -45,6 +45,8 @@ void TVolumeSessionActor::HandleStopVolumeRequest(
 
     VolumeInfo->State = TVolumeInfo::STOPPING;
     CurrentRequest = STOP_REQUEST;
+    VolumeRequestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext);
     NCloud::Send<TEvents::TEvPoisonPill>(ctx, StartVolumeActor);
 }
 
@@ -65,18 +67,21 @@ void TVolumeSessionActor::HandleStartVolumeActorStopped(
     VolumeInfo->State = TVolumeInfo::INITIAL;
     VolumeInfo->Error.Clear();
 
-    if (MountRequestActor) {
+    if (VolumeRequestInfo) {
         if (CurrentRequest == START_REQUEST) {
-            auto response = std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
-                msg->Error);
-            NCloud::Send(ctx, MountRequestActor, std::move(response));
+            NCloud::Reply(
+                ctx,
+                *VolumeRequestInfo,
+                std::make_unique<TEvServicePrivate::TEvStartVolumeResponse>(
+                    msg->Error));
         } else {
-            auto response = std::make_unique<TEvServicePrivate::TEvStopVolumeResponse>();
-            NCloud::Send(ctx, MountRequestActor, std::move(response));
+            NCloud::Reply(
+                ctx,
+                *VolumeRequestInfo,
+                std::make_unique<TEvServicePrivate::TEvStopVolumeResponse>());
         }
-    } else if (UnmountRequestActor) {
-        auto response = std::make_unique<TEvServicePrivate::TEvStopVolumeResponse>();
-        NCloud::Send(ctx, UnmountRequestActor, std::move(response));
+        CurrentRequest = NONE;
+        VolumeRequestInfo = {};
     }
 }
 


### PR DESCRIPTION
Minor refactoring:
Currently VolumeSessionActor routes StartVolume/StopVolume responses directly to MountRequestActor/UnmountRequestActor.
However, there are no signs of this routing being a requirement.

This PR brings more flexible RequestInfo-based response routing making StartVolume/StopVolume API available to an arbitrary actor.
