### PR TITLE
[Blockstore] Ignore unknown params for all NBS and DA static and cms configs

### DIFF
--- a/cloud/blockstore/libs/daemon/common/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/common/config_initializer.h
@@ -28,8 +28,8 @@ struct TConfigInitializerCommon
 {
     const TOptionsCommonPtr Options;
 
-    NDiscovery::TDiscoveryConfigPtr DiscoveryConfig;
     TServerAppConfigPtr ServerConfig;
+    NDiscovery::TDiscoveryConfigPtr DiscoveryConfig;
     NClient::TClientAppConfigPtr EndpointConfig;
     NStorage::TDiskAgentConfigPtr DiskAgentConfig;
     NStorage::TDiskRegistryProxyConfigPtr DiskRegistryProxyConfig;
@@ -45,13 +45,13 @@ struct TConfigInitializerCommon
     TConfigInitializerCommon(TOptionsCommonPtr options);
     virtual ~TConfigInitializerCommon();
 
+    void InitServerConfig();
     void InitDiagnosticsConfig();
-    void InitDiscoveryConfig();
+    void InitDiscoveryConfig();   // requires ServerConfig
     void InitDiskAgentConfig();
     void InitDiskRegistryProxyConfig();
     void InitEndpointConfig();
     void InitHostPerformanceProfile();
-    void InitServerConfig();
     void InitSpdkEnvConfig();
     void InitRdmaConfig();
     void InitCellsConfig();

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -297,6 +297,10 @@ void TConfigInitializerYdb::ApplyServerAppConfig(const TString& text)
     if (LogbrokerConfig) {
         ApplyLogbrokerConfig(ProtoToText(*LogbrokerConfig->GetConfig()));
     }
+    if (StorageConfig) {
+        ApplyStorageServiceConfig(
+            ProtoToText(StorageConfig->GetStorageConfigProto()));
+    }
     ApplyRootKmsConfig(ProtoToText(RootKmsConfig));
 }
 
@@ -439,6 +443,7 @@ void TConfigInitializerYdb::ApplyNamedConfigs(
     using TSelf = TConfigInitializerYdb;
     using TApplyFn = void (TSelf::*)(const TString&);
 
+    // clang-format off
     const TVector<std::pair<TString, TApplyFn>> configHandlers {
         { "ActorSystemConfig",       &TSelf::ApplyActorSystemConfig       },
         { "AuthConfig",              &TSelf::ApplyAuthConfig              },
@@ -462,6 +467,7 @@ void TConfigInitializerYdb::ApplyNamedConfigs(
         { "ComputeClientConfig",     &TSelf::ApplyComputeClientConfig     },
         { "LocalNVMeConfig",         &TSelf::ApplyLocalNVMeConfig         },
     };
+    // clang-format on
 
     for (const auto& handler: configHandlers) {
         auto it = configs.find(handler.first);

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.cpp
@@ -133,7 +133,7 @@ void TConfigInitializerYdb::InitIamClientConfig()
     NProto::TIamClientConfig config;
 
     if (Options->IamConfig) {
-        ParseProtoTextFromFile(Options->IamConfig, config);
+        ParseProtoTextFromFileRobust(Options->IamConfig, config);
     }
 
     IamClientConfig = std::make_shared<NIamClient::TIamClientConfig>(
@@ -145,7 +145,7 @@ void TConfigInitializerYdb::InitKmsClientConfig()
     NProto::TGrpcClientConfig config;
 
     if (Options->KmsConfig) {
-        ParseProtoTextFromFile(Options->KmsConfig, config);
+        ParseProtoTextFromFileRobust(Options->KmsConfig, config);
     }
 
     KmsClientConfig = std::move(config);
@@ -156,7 +156,7 @@ void TConfigInitializerYdb::InitRootKmsConfig()
     NProto::TRootKmsConfig config;
 
     if (Options->RootKmsConfig) {
-        ParseProtoTextFromFile(Options->RootKmsConfig, config);
+        ParseProtoTextFromFileRobust(Options->RootKmsConfig, config);
     }
 
     if (!config.GetRootCertsFile()) {
@@ -171,7 +171,7 @@ void TConfigInitializerYdb::InitComputeClientConfig()
     NProto::TGrpcClientConfig config;
 
     if (Options->ComputeConfig) {
-        ParseProtoTextFromFile(Options->ComputeConfig, config);
+        ParseProtoTextFromFileRobust(Options->ComputeConfig, config);
     }
 
     ComputeClientConfig = std::move(config);
@@ -182,7 +182,7 @@ void TConfigInitializerYdb::InitLocalNVMeConfig()
     NProto::TLocalNVMeConfig proto;
 
     if (Options->LocalNVMeConfig) {
-        ParseProtoTextFromFile(Options->LocalNVMeConfig, proto);
+        ParseProtoTextFromFileRobust(Options->LocalNVMeConfig, proto);
     }
 
     LocalNVMeConfig = std::make_shared<TLocalNVMeConfig>(std::move(proto));
@@ -237,6 +237,11 @@ void TConfigInitializerYdb::ApplyFeaturesConfig(const TString& text)
         std::make_shared<NFeatures::TFeaturesConfig>(config);
 
     // features config has changed, update storage config
+    if (!StorageConfig) {
+        StorageConfig = std::make_shared<NStorage::TStorageConfig>(
+            NProto::TStorageServiceConfig(),
+            nullptr);
+    }
     StorageConfig->SetFeaturesConfig(FeaturesConfig);
 }
 
@@ -245,7 +250,7 @@ void TConfigInitializerYdb::ApplyLogbrokerConfig(const TString& text)
     NProto::TLogbrokerConfig config;
     ParseProtoTextFromStringRobust(text, config);
 
-    if (!config.GetCaCertFilename()) {
+    if (ServerConfig && !config.GetCaCertFilename()) {
         config.SetCaCertFilename(ServerConfig->GetRootCertsFile());
     }
 
@@ -257,7 +262,7 @@ void TConfigInitializerYdb::ApplyNotifyConfig(const TString& text)
     NProto::TNotifyConfig config;
     ParseProtoTextFromStringRobust(text, config);
 
-    if (!config.GetCaCertFilename()) {
+    if (ServerConfig && !config.GetCaCertFilename()) {
         config.SetCaCertFilename(ServerConfig->GetRootCertsFile());
     }
 
@@ -281,6 +286,18 @@ void TConfigInitializerYdb::ApplyServerAppConfig(const TString& text)
 
     ServerConfig = std::make_shared<TServerAppConfig>(appConfig);
     SetGrpcThreadsLimit(ServerConfig->GetGrpcThreadsLimit());
+
+    // Update dependent configs
+    if (DiscoveryConfig) {
+        ApplyDiscoveryServiceConfig(ProtoToText(*DiscoveryConfig->GetConfig()));
+    }
+    if (NotifyConfig) {
+        ApplyNotifyConfig(ProtoToText(*NotifyConfig->GetConfig()));
+    }
+    if (LogbrokerConfig) {
+        ApplyLogbrokerConfig(ProtoToText(*LogbrokerConfig->GetConfig()));
+    }
+    ApplyRootKmsConfig(ProtoToText(RootKmsConfig));
 }
 
 void TConfigInitializerYdb::ApplyDiagnosticsConfig(const TString& text)
@@ -326,7 +343,9 @@ void TConfigInitializerYdb::ApplyDiscoveryServiceConfig(const TString& text)
     NProto::TDiscoveryServiceConfig discoveryConfig;
     ParseProtoTextFromStringRobust(text, discoveryConfig);
 
-    SetupDiscoveryPorts(discoveryConfig);
+    if (ServerConfig) {
+        SetupDiscoveryPorts(discoveryConfig);
+    }
 
     DiscoveryConfig = std::make_shared<TDiscoveryConfig>(discoveryConfig);
 }
@@ -358,7 +377,7 @@ void TConfigInitializerYdb::ApplyDiskRegistryProxyConfig(const TString& text)
 void TConfigInitializerYdb::ApplyIamClientConfig(const TString& text)
 {
     NProto::TIamClientConfig config;
-    ParseProtoTextFromString(text, config);
+    ParseProtoTextFromStringRobust(text, config);
 
     IamClientConfig = std::make_shared<NIamClient::TIamClientConfig>(
         std::move(config));
@@ -367,7 +386,7 @@ void TConfigInitializerYdb::ApplyIamClientConfig(const TString& text)
 void TConfigInitializerYdb::ApplyKmsClientConfig(const TString& text)
 {
     NProto::TGrpcClientConfig config;
-    ParseProtoTextFromString(text, config);
+    ParseProtoTextFromStringRobust(text, config);
 
     KmsClientConfig = std::move(config);
 }
@@ -375,7 +394,11 @@ void TConfigInitializerYdb::ApplyKmsClientConfig(const TString& text)
 void TConfigInitializerYdb::ApplyRootKmsConfig(const TString& text)
 {
     NProto::TRootKmsConfig config;
-    ParseProtoTextFromString(text, config);
+    ParseProtoTextFromStringRobust(text, config);
+
+    if (ServerConfig && !config.GetRootCertsFile()) {
+        config.SetRootCertsFile(ServerConfig->GetRootCertsFile());
+    }
 
     RootKmsConfig = std::move(config);
 }
@@ -383,7 +406,7 @@ void TConfigInitializerYdb::ApplyRootKmsConfig(const TString& text)
 void TConfigInitializerYdb::ApplyComputeClientConfig(const TString& text)
 {
     NProto::TGrpcClientConfig config;
-    ParseProtoTextFromString(text, config);
+    ParseProtoTextFromStringRobust(text, config);
 
     ComputeClientConfig = std::move(config);
 }
@@ -391,7 +414,7 @@ void TConfigInitializerYdb::ApplyComputeClientConfig(const TString& text)
 void TConfigInitializerYdb::ApplyLocalNVMeConfig(const TString& text)
 {
     NProto::TLocalNVMeConfig proto;
-    ParseProtoTextFromString(text, proto);
+    ParseProtoTextFromStringRobust(text, proto);
 
     LocalNVMeConfig = std::make_shared<TLocalNVMeConfig>(std::move(proto));
 }

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer.h
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer.h
@@ -84,9 +84,6 @@ struct TConfigInitializerYdb final
 
     void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config) override;
 
-private:
-    void SetupStorageConfig(NProto::TStorageServiceConfig& config) const;
-
     void ApplyDiagnosticsConfig(const TString& text);
     void ApplyDiscoveryServiceConfig(const TString& text);
     void ApplyDiskAgentConfig(const TString& text);
@@ -108,6 +105,9 @@ private:
     void ApplyBlockstoreConfig(const NKikimrConfig::TAppConfig& config);
     void ApplyAllowedKikimrFeatureFlags(
         const NKikimrConfig::TAppConfig& config);
+
+private:
+    void SetupStorageConfig(NProto::TStorageServiceConfig& config) const;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
@@ -227,7 +227,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
     Y_UNIT_TEST(ShouldIgnoreUnknownFieldsAndComponentsInStaticLogConfig)
     {
-        auto logConfigStr = R"(
+        auto configStr = R"(
             Entry {
                 Component: "BLOCKSTORE_SERVER"
                 Level: 6
@@ -243,14 +243,14 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         )";
 
         TTempDir dir;
-        auto logConfigPath = dir.Path() / "nbs-log.txt";
+        auto configPath = dir.Path() / "component.txt";
 
-        TOFStream(logConfigPath.GetPath()).Write(logConfigStr);
+        TOFStream(configPath.GetPath()).Write(configStr);
 
         auto options = CreateOptions();
 
         // - TConfigInitializerYdbBase
-        options->LogConfig = logConfigPath.GetPath();
+        options->LogConfig = configPath.GetPath();
 
         auto ci = TConfigInitializerYdb(std::move(options));
 
@@ -275,14 +275,14 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
     Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInStaticNbsConfigs)
     {
-        auto nbsComponentConfigStr = R"(
+        auto configStr = R"(
             NoSuchField: "x"
         )";
 
         TTempDir dir;
-        auto nbsComponentConfigPath = dir.Path() / "nbs-component.txt";
+        auto configPath = dir.Path() / "component.txt";
 
-        TOFStream(nbsComponentConfigPath.GetPath()).Write(nbsComponentConfigStr);
+        TOFStream(configPath.GetPath()).Write(configStr);
 
         auto options = CreateOptions();
 
@@ -295,7 +295,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         options->EndpointConfig          =
         options->ServerConfig            =
         options->RdmaConfig              =
-        options->CellsConfig             = nbsComponentConfigPath.GetPath();
+        options->CellsConfig             = configPath.GetPath();
         // - TConfigInitializerYdb: TOptionsYdb
         options->FeaturesConfig     =
         options->LogbrokerConfig    =
@@ -306,7 +306,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         options->KmsConfig          =
         options->RootKmsConfig      =
         options->ComputeConfig      =
-        options->LocalNVMeConfig    = nbsComponentConfigPath.GetPath();
+        options->LocalNVMeConfig    = configPath.GetPath();
         // clang-format on
 
         auto ci = TConfigInitializerYdb(std::move(options));
@@ -335,9 +335,9 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         UNIT_ASSERT_NO_EXCEPTION(ci.InitLocalNVMeConfig());
     }
 
-    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInDynamicConfigs)
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInCmsConfigs)
     {
-        auto nbsComponentConfigStr = R"(
+        auto configStr = R"(
              NoSuchField: "x"
         )";
 
@@ -370,57 +370,114 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 
         auto ci = TConfigInitializerYdb(CreateOptions());
 
-        // To detect mutual dependencies:
+        ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+        NKikimrConfig::TAppConfig appCfg;
+        auto& directFullNamedConfigs = *appCfg.MutableNamedConfigs();
+
+        for (const auto& configName: configNames) {
+            auto* namedConfig = directFullNamedConfigs.Add();
+            namedConfig->SetName("Cloud.NBS." + configName);
+            namedConfig->SetConfig(configStr);
+        }
+
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+    }
+
+    Y_UNIT_TEST(ShouldApplyCmsConfigsInAnyOrder)
+    {
+        auto configStr = "";
+
+        // clang-format off
+        // Elements ordered as in TConfigInitializerYdb::ApplyNamedConfigs()
+        const TVector<TString> configNames {
+            "ActorSystemConfig",
+            "AuthConfig",
+            "DiagnosticsConfig",
+            "DiscoveryServiceConfig",
+            "DiskAgentConfig",
+            "DiskRegistryProxyConfig",
+            "FeaturesConfig",
+            "InterconnectConfig",
+            "LogbrokerConfig",
+            "LogConfig",
+            "MonitoringConfig",
+            "NotifyConfig",
+            "ServerAppConfig",
+            "SpdkEnvConfig",
+            "StorageServiceConfig",
+            "YdbStatsConfig",
+            "IamClientConfig",
+            "KmsClientConfig",
+            "RootKmsConfig",
+            "ComputeClientConfig",
+            "LocalNVMeConfig",
+        };
+        // clang-format on
+
+        auto ci = TConfigInitializerYdb(CreateOptions());
+
+        // To detect possible mutual dependencies:
         //  - one at time
         //  - all at once, direct and reverse order
 
         // 1. One at time
-        for (const auto& configName: configNames) {
-            ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
-            NKikimrConfig::TAppConfig singleAppCfg;
-            auto& singleNamedConfigs = *singleAppCfg.MutableNamedConfigs();
-
-            auto* singleNamedConfig = singleNamedConfigs.Add();
-            singleNamedConfig->SetName("Cloud.NBS." + configName);
-            singleNamedConfig->SetConfig(nbsComponentConfigStr);
-
-            Cerr << Endl << "Apply NamedConfigs['"
-                 << singleNamedConfig->GetName() << "'] = '"
-                 << singleNamedConfig->GetConfig() << "'" << Endl;
-            UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(singleAppCfg));
-        }
-
-        // 2. All at once, direct order
-        ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
-        NKikimrConfig::TAppConfig directFullAppCfg;
-        auto& directFullNamedConfigs = *directFullAppCfg.MutableNamedConfigs();
-
-        for (const auto& configName: configNames) {
-            auto* directFullNamedConfig = directFullNamedConfigs.Add();
-            directFullNamedConfig->SetName("Cloud.NBS." + configName);
-            directFullNamedConfig->SetConfig(nbsComponentConfigStr);
-        }
-
-        Cerr << Endl << "Apply all NamedConfigs[] in direct order" << Endl;
-        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(directFullAppCfg));
-
-        // 3. All at once, reverse order
-        ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
-        NKikimrConfig::TAppConfig reverseFullAppCfg;
-        auto& reverseFullNamedConfigs =
-            *reverseFullAppCfg.MutableNamedConfigs();
-
-        for (auto configName = configNames.rbegin();
-             configName != configNames.rend();
-             configName++)
         {
-            auto* reverseFullNamedConfig = reverseFullNamedConfigs.Add();
-            reverseFullNamedConfig->SetName("Cloud.NBS." + *configName);
-            reverseFullNamedConfig->SetConfig(nbsComponentConfigStr);
+            for (const auto& configName: configNames) {
+                ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+                NKikimrConfig::TAppConfig appCfg;
+                auto& namedConfigs = *appCfg.MutableNamedConfigs();
+
+                ::NKikimrConfig::TNamedConfig* namedConfig = nullptr;
+                for (auto i = 0; i < 3; i++) {
+                    // May be several NamedConfigs[] with same name
+                    namedConfig = namedConfigs.Add();
+                    namedConfig->SetName("Cloud.NBS." + configName);
+                    namedConfig->SetConfig(configStr);
+                }
+
+                Cerr << Endl << "Apply NamedConfigs['" << namedConfig->GetName()
+                     << "']" << Endl;
+                UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+            }
         }
 
-        Cerr << Endl << "Apply all NamedConfigs[] in reverse order" << Endl;
-        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(reverseFullAppCfg));
+        // 2. All at once, direct order, single entities
+        {
+            ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+            NKikimrConfig::TAppConfig appCfg;
+            auto& namedConfigs = *appCfg.MutableNamedConfigs();
+
+            for (const auto& configName: configNames) {
+                auto* namedConfig = namedConfigs.Add();
+                namedConfig->SetName("Cloud.NBS." + configName);
+                namedConfig->SetConfig(configStr);
+            }
+
+            Cerr << Endl << "Apply all NamedConfigs[] in direct order" << Endl;
+            UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+        }
+
+        // 3. All at once, reverse order, multiple entities
+        {
+            ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+            NKikimrConfig::TAppConfig appCfg;
+            auto& namedConfigs = *appCfg.MutableNamedConfigs();
+
+            for (auto i = 0; i < 3; i++) {
+                // May be several NamedConfigs[] with same name
+                for (auto configName = configNames.rbegin();
+                     configName != configNames.rend();
+                     configName++)
+                {
+                    auto* namedConfig = namedConfigs.Add();
+                    namedConfig->SetName("Cloud.NBS." + *configName);
+                    namedConfig->SetConfig(configStr);
+                }
+            }
+
+            Cerr << Endl << "Apply all NamedConfigs[] in reverse order" << Endl;
+            UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+        }
     }
 
     Y_UNIT_TEST(ShouldInitHostPerformanceProfile)

--- a/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/config_initializer_ut.cpp
@@ -225,7 +225,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         UNIT_ASSERT_VALUES_EQUAL(true, ci.StorageConfig->GetMultipartitionVolumesEnabled());
     }
 
-    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInLogConfigAndNbsConfigs)
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsAndComponentsInStaticLogConfig)
     {
         auto logConfigStr = R"(
             Entry {
@@ -242,44 +242,20 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
             SysLogService: "NBS_SERVER"
         )";
 
-        auto nbsComponentConfigStr = R"(
-            NoSuchField: "x"
-        )";
-
         TTempDir dir;
         auto logConfigPath = dir.Path() / "nbs-log.txt";
-        auto nbsComponentConfigPath = dir.Path() / "nbs-component.txt";
 
         TOFStream(logConfigPath.GetPath()).Write(logConfigStr);
-        TOFStream(nbsComponentConfigPath.GetPath()).Write(nbsComponentConfigStr);
 
         auto options = CreateOptions();
+
+        // - TConfigInitializerYdbBase
         options->LogConfig = logConfigPath.GetPath();
-        options->StatsUploadConfig = nbsComponentConfigPath.GetPath();
-        options->DiscoveryConfig = nbsComponentConfigPath.GetPath();
-        options->DiagnosticsConfig = nbsComponentConfigPath.GetPath();
-        options->StorageConfig = nbsComponentConfigPath.GetPath();
-        options->DiskRegistryProxyConfig = nbsComponentConfigPath.GetPath();
-        options->DiskAgentConfig = nbsComponentConfigPath.GetPath();
-        options->ServerConfig = nbsComponentConfigPath.GetPath();
-        options->EndpointConfig = nbsComponentConfigPath.GetPath();
-        options->FeaturesConfig = nbsComponentConfigPath.GetPath();
-        options->LogbrokerConfig = nbsComponentConfigPath.GetPath();
-        options->NotifyConfig = nbsComponentConfigPath.GetPath();
 
         auto ci = TConfigInitializerYdb(std::move(options));
-        ci.InitKikimrConfig();
-        ci.InitStatsUploadConfig();
-        ci.InitServerConfig();
-        ci.InitDiscoveryConfig();
-        ci.InitDiagnosticsConfig();
-        ci.InitStorageConfig();
-        ci.InitDiskRegistryProxyConfig();
-        ci.InitDiskAgentConfig();
-        ci.InitEndpointConfig();
-        ci.InitFeaturesConfig();
-        ci.InitLogbrokerConfig();
-        ci.InitNotifyConfig();
+
+        // - TConfigInitializerYdbBase
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitKikimrConfig());
 
         const auto& logConfig = ci.KikimrConfig->GetLogConfig();
         UNIT_ASSERT(logConfig.GetSysLog());
@@ -295,6 +271,156 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
             "UNKNOWN_COMPONENT",
             logConfig.GetEntry(1).GetComponent());
         UNIT_ASSERT_VALUES_EQUAL(6, logConfig.GetEntry(1).GetLevel());
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInStaticNbsConfigs)
+    {
+        auto nbsComponentConfigStr = R"(
+            NoSuchField: "x"
+        )";
+
+        TTempDir dir;
+        auto nbsComponentConfigPath = dir.Path() / "nbs-component.txt";
+
+        TOFStream(nbsComponentConfigPath.GetPath()).Write(nbsComponentConfigStr);
+
+        auto options = CreateOptions();
+
+        // clang-format off
+        // - TConfigInitializerCommon: TOptionsBase, TOptionsCommon
+        options->DiagnosticsConfig       =
+        options->DiscoveryConfig         =
+        options->DiskAgentConfig         =
+        options->DiskRegistryProxyConfig =
+        options->EndpointConfig          =
+        options->ServerConfig            =
+        options->RdmaConfig              =
+        options->CellsConfig             = nbsComponentConfigPath.GetPath();
+        // - TConfigInitializerYdb: TOptionsYdb
+        options->FeaturesConfig     =
+        options->LogbrokerConfig    =
+        options->NotifyConfig       =
+        options->StatsUploadConfig  =
+        options->StorageConfig      =
+        options->IamConfig          =
+        options->KmsConfig          =
+        options->RootKmsConfig      =
+        options->ComputeConfig      =
+        options->LocalNVMeConfig    = nbsComponentConfigPath.GetPath();
+        // clang-format on
+
+        auto ci = TConfigInitializerYdb(std::move(options));
+
+        // - TConfigInitializerCommon
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitServerConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitDiagnosticsConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitDiscoveryConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitDiskAgentConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitDiskRegistryProxyConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitEndpointConfig());
+        // InitHostPerformanceProfile() - not loaded from file
+        // InitSpdkEnvConfig()          - not loaded from file
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitRdmaConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitCellsConfig());
+        // - TConfigInitializerYdb
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitFeaturesConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitLogbrokerConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitNotifyConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitStatsUploadConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitStorageConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitIamClientConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitKmsClientConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitRootKmsConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitComputeClientConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitLocalNVMeConfig());
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInDynamicConfigs)
+    {
+        auto nbsComponentConfigStr = R"(
+             NoSuchField: "x"
+        )";
+
+        // clang-format off
+        // Elements ordered as in TConfigInitializerYdb::ApplyNamedConfigs()
+        const TVector<TString> configNames {
+            "ActorSystemConfig",
+            "AuthConfig",
+            "DiagnosticsConfig",
+            "DiscoveryServiceConfig",
+            "DiskAgentConfig",
+            "DiskRegistryProxyConfig",
+            "FeaturesConfig",
+            "InterconnectConfig",
+            "LogbrokerConfig",
+            "LogConfig",
+            "MonitoringConfig",
+            "NotifyConfig",
+            "ServerAppConfig",
+            "SpdkEnvConfig",
+            "StorageServiceConfig",
+            "YdbStatsConfig",
+            "IamClientConfig",
+            "KmsClientConfig",
+            "RootKmsConfig",
+            "ComputeClientConfig",
+            "LocalNVMeConfig",
+        };
+        // clang-format on
+
+        auto ci = TConfigInitializerYdb(CreateOptions());
+
+        // To detect mutual dependencies:
+        //  - one at time
+        //  - all at once, direct and reverse order
+
+        // 1. One at time
+        for (const auto& configName: configNames) {
+            ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+            NKikimrConfig::TAppConfig singleAppCfg;
+            auto& singleNamedConfigs = *singleAppCfg.MutableNamedConfigs();
+
+            auto* singleNamedConfig = singleNamedConfigs.Add();
+            singleNamedConfig->SetName("Cloud.NBS." + configName);
+            singleNamedConfig->SetConfig(nbsComponentConfigStr);
+
+            Cerr << Endl << "Apply NamedConfigs['"
+                 << singleNamedConfig->GetName() << "'] = '"
+                 << singleNamedConfig->GetConfig() << "'" << Endl;
+            UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(singleAppCfg));
+        }
+
+        // 2. All at once, direct order
+        ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+        NKikimrConfig::TAppConfig directFullAppCfg;
+        auto& directFullNamedConfigs = *directFullAppCfg.MutableNamedConfigs();
+
+        for (const auto& configName: configNames) {
+            auto* directFullNamedConfig = directFullNamedConfigs.Add();
+            directFullNamedConfig->SetName("Cloud.NBS." + configName);
+            directFullNamedConfig->SetConfig(nbsComponentConfigStr);
+        }
+
+        Cerr << Endl << "Apply all NamedConfigs[] in direct order" << Endl;
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(directFullAppCfg));
+
+        // 3. All at once, reverse order
+        ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+        NKikimrConfig::TAppConfig reverseFullAppCfg;
+        auto& reverseFullNamedConfigs =
+            *reverseFullAppCfg.MutableNamedConfigs();
+
+        for (auto configName = configNames.rbegin();
+             configName != configNames.rend();
+             configName++)
+        {
+            auto* reverseFullNamedConfig = reverseFullNamedConfigs.Add();
+            reverseFullNamedConfig->SetName("Cloud.NBS." + *configName);
+            reverseFullNamedConfig->SetConfig(nbsComponentConfigStr);
+        }
+
+        Cerr << Endl << "Apply all NamedConfigs[] in reverse order" << Endl;
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(reverseFullAppCfg));
     }
 
     Y_UNIT_TEST(ShouldInitHostPerformanceProfile)

--- a/cloud/blockstore/libs/discovery/config.cpp
+++ b/cloud/blockstore/libs/discovery/config.cpp
@@ -108,6 +108,11 @@ TDiscoveryConfig::TDiscoveryConfig(NProto::TDiscoveryServiceConfig config)
 {
 }
 
+const NProto::TDiscoveryServiceConfig* TDiscoveryConfig::GetConfig() const
+{
+    return &Config;
+}
+
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
 type TDiscoveryConfig::Get##name() const                                       \
 {                                                                              \

--- a/cloud/blockstore/libs/discovery/config.h
+++ b/cloud/blockstore/libs/discovery/config.h
@@ -19,6 +19,8 @@ private:
 public:
     TDiscoveryConfig(NProto::TDiscoveryServiceConfig discoveryServiceConfig = {});
 
+    const NProto::TDiscoveryServiceConfig* GetConfig() const;
+
     TString GetConductorApiUrl() const;
     TString GetInstanceListFile() const;
     TString GetBannedInstanceListFile() const;

--- a/cloud/blockstore/libs/disk_agent/config_initializer.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.cpp
@@ -112,23 +112,25 @@ void TConfigInitializer::InitKikimrConfig()
 
     auto& sysConfig = *KikimrConfig->MutableActorSystemConfig();
     if (Options->SysConfig) {
-        ParseProtoTextFromFile(Options->SysConfig, sysConfig);
+        ParseProtoTextFromFileRobust(Options->SysConfig, sysConfig);
     }
 
     auto& interconnectConfig = *KikimrConfig->MutableInterconnectConfig();
     if (Options->InterconnectConfig) {
-        ParseProtoTextFromFile(Options->InterconnectConfig, interconnectConfig);
+        ParseProtoTextFromFileRobust(
+            Options->InterconnectConfig,
+            interconnectConfig);
     }
     interconnectConfig.SetStartTcp(true);
 
     auto& domainsConfig = *KikimrConfig->MutableDomainsConfig();
     if (Options->DomainsConfig) {
-        ParseProtoTextFromFile(Options->DomainsConfig, domainsConfig);
+        ParseProtoTextFromFileRobust(Options->DomainsConfig, domainsConfig);
     }
 
     auto& monConfig = *KikimrConfig->MutableMonitoringConfig();
     if (Options->MonitoringConfig) {
-        ParseProtoTextFromFile(Options->MonitoringConfig, monConfig);
+        ParseProtoTextFromFileRobust(Options->MonitoringConfig, monConfig);
     }
     SetupMonitoringConfig(monConfig);
 
@@ -139,10 +141,9 @@ void TConfigInitializer::InitKikimrConfig()
 
     auto& nameServiceConfig = *KikimrConfig->MutableNameserviceConfig();
     if (Options->NameServiceConfig) {
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->NameServiceConfig,
-            nameServiceConfig
-        );
+            nameServiceConfig);
     }
 
     if (Options->SuppressVersionCheck) {
@@ -152,15 +153,14 @@ void TConfigInitializer::InitKikimrConfig()
     auto& dynamicNameServiceConfig =
         *KikimrConfig->MutableDynamicNameserviceConfig();
     if (Options->DynamicNameServiceConfig) {
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->DynamicNameServiceConfig,
-            dynamicNameServiceConfig
-        );
+            dynamicNameServiceConfig);
     }
 
     if (Options->AuthConfig) {
         auto& authConfig = *KikimrConfig->MutableAuthConfig();
-        ParseProtoTextFromFile(Options->AuthConfig, authConfig);
+        ParseProtoTextFromFileRobust(Options->AuthConfig, authConfig);
     }
 
     auto& bsConfig = *KikimrConfig->MutableBlobStorageConfig();
@@ -309,7 +309,7 @@ NKikimrConfig::TMonitoringConfig TConfigInitializer::GetMonitoringConfig() const
     // TODO: move to custom config
     NKikimrConfig::TMonitoringConfig monConfig;
     if (Options->MonitoringConfig) {
-        ParseProtoTextFromFile(Options->MonitoringConfig, monConfig);
+        ParseProtoTextFromFileRobust(Options->MonitoringConfig, monConfig);
     }
 
     SetupMonitoringConfig(monConfig);
@@ -389,7 +389,7 @@ void TConfigInitializer::ApplyLogConfig(const TString& text)
 
 void TConfigInitializer::ApplyAuthConfig(const TString& text)
 {
-    ParseProtoTextFromString(text, *KikimrConfig->MutableAuthConfig());
+    ParseProtoTextFromStringRobust(text, *KikimrConfig->MutableAuthConfig());
 }
 
 void TConfigInitializer::ApplyFeaturesConfig(const TString& text)
@@ -401,6 +401,11 @@ void TConfigInitializer::ApplyFeaturesConfig(const TString& text)
         std::make_shared<NFeatures::TFeaturesConfig>(config);
 
     // features config has changed, update storage config
+    if (!StorageConfig) {
+        StorageConfig = std::make_shared<NStorage::TStorageConfig>(
+            NProto::TStorageServiceConfig(),
+            nullptr);
+    }
     StorageConfig->SetFeaturesConfig(FeaturesConfig);
 }
 
@@ -417,19 +422,27 @@ void TConfigInitializer::ApplyServerAppConfig(const TString& text)
     ParseProtoTextFromStringRobust(text, appConfig);
 
     ServerConfig = std::make_shared<TServerAppConfig>(appConfig);
+
+    // Update dependent configs
+    if (StorageConfig) {
+        ApplyStorageServiceConfig(
+            ProtoToText(StorageConfig->GetStorageConfigProto()));
+    }
 }
 
 void TConfigInitializer::ApplyMonitoringConfig(const TString& text)
 {
     auto& monConfig = *KikimrConfig->MutableMonitoringConfig();
-    ParseProtoTextFromString(text, monConfig);
+    ParseProtoTextFromStringRobust(text, monConfig);
 
     SetupMonitoringConfig(monConfig);
 }
 
 void TConfigInitializer::ApplyActorSystemConfig(const TString& text)
 {
-    ParseProtoTextFromString(text, *KikimrConfig->MutableActorSystemConfig());
+    ParseProtoTextFromStringRobust(
+        text,
+        *KikimrConfig->MutableActorSystemConfig());
 }
 
 void TConfigInitializer::ApplyDiagnosticsConfig(const TString& text)
@@ -447,7 +460,7 @@ void TConfigInitializer::ApplyDiagnosticsConfig(const TString& text)
 void TConfigInitializer::ApplyInterconnectConfig(const TString& text)
 {
     auto& interconnectConfig = *KikimrConfig->MutableInterconnectConfig();
-    ParseProtoTextFromString(text, interconnectConfig);
+    ParseProtoTextFromStringRobust(text, interconnectConfig);
 
     interconnectConfig.SetStartTcp(true);
 }
@@ -481,7 +494,9 @@ void TConfigInitializer::ApplyDiskAgentConfig(const TString& text)
     SetupDiskAgentConfig(config);
     ApplySpdkEnvConfig(config.GetSpdkEnvConfig());
 
-    if (!config.GetStorageDiscoveryConfig().PathConfigsSize()) {
+    if (DiskAgentConfig &&
+        !config.GetStorageDiscoveryConfig().PathConfigsSize())
+    {
         config.MutableStorageDiscoveryConfig()->CopyFrom(
             DiskAgentConfig->GetStorageDiscoveryConfig());
     }
@@ -527,19 +542,21 @@ void TConfigInitializer::ApplyNamedConfigs(
     using TSelf = TConfigInitializer;
     using TApplyFn = void (TSelf::*)(const TString&);
 
+    // clang-format off
     const TVector<std::pair<TString, TApplyFn>> configHandlers {
         { "ActorSystemConfig",       &TSelf::ApplyActorSystemConfig       },
         { "AuthConfig",              &TSelf::ApplyAuthConfig              },
         { "DiagnosticsConfig",       &TSelf::ApplyDiagnosticsConfig       },
         { "DiskAgentConfig",         &TSelf::ApplyDiskAgentConfig         },
         { "DiskRegistryProxyConfig", &TSelf::ApplyDiskRegistryProxyConfig },
+        { "FeaturesConfig",          &TSelf::ApplyFeaturesConfig          },
         { "InterconnectConfig",      &TSelf::ApplyInterconnectConfig      },
         { "LogConfig",               &TSelf::ApplyLogConfig               },
         { "MonitoringConfig",        &TSelf::ApplyMonitoringConfig        },
         { "ServerAppConfig",         &TSelf::ApplyServerAppConfig         },
-        { "FeaturesConfig",          &TSelf::ApplyFeaturesConfig          },
         { "StorageServiceConfig",    &TSelf::ApplyStorageServiceConfig    },
     };
+    // clang-format on
 
     for (const auto& handler: configHandlers) {
         auto it = configs.find(handler.first);

--- a/cloud/blockstore/libs/disk_agent/config_initializer.h
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.h
@@ -50,11 +50,11 @@ struct TConfigInitializer
     void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config);
 
     void InitKikimrConfig();
+    void InitServerConfig();
     void InitDiagnosticsConfig();
     void InitStorageConfig();
     void InitDiskAgentConfig();
     void InitDiskRegistryProxyConfig();
-    void InitServerConfig();
     void InitSpdkEnvConfig();
     void InitFeaturesConfig();
     void InitRdmaConfig();

--- a/cloud/blockstore/libs/disk_agent/config_initializer.h
+++ b/cloud/blockstore/libs/disk_agent/config_initializer.h
@@ -46,9 +46,6 @@ struct TConfigInitializer
         : Options(std::move(options))
     {}
 
-    void ApplyCMSConfigs(NKikimrConfig::TAppConfig cmsConfig);
-    void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config);
-
     void InitKikimrConfig();
     void InitServerConfig();
     void InitDiagnosticsConfig();
@@ -62,12 +59,8 @@ struct TConfigInitializer
     NKikimrConfig::TLogConfig GetLogConfig() const;
     NKikimrConfig::TMonitoringConfig GetMonitoringConfig() const;
 
-private:
-    TString GetFullSchemeShardDir() const;
-
-    void SetupMonitoringConfig(NKikimrConfig::TMonitoringConfig& monConfig) const;
-    void SetupLogConfig(NKikimrConfig::TLogConfig& logConfig) const;
-    void SetupDiskAgentConfig(NProto::TDiskAgentConfig& config) const;
+    void ApplyCMSConfigs(NKikimrConfig::TAppConfig cmsConfig);
+    void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config);
 
     void ApplyLogConfig(const TString& text);
     void ApplyAuthConfig(const TString& text);
@@ -86,6 +79,14 @@ private:
     void ApplyNamedConfigs(const NKikimrConfig::TAppConfig& config);
     void ApplyAllowedKikimrFeatureFlags(
         const NKikimrConfig::TAppConfig& config);
+
+private:
+    TString GetFullSchemeShardDir() const;
+
+    void SetupMonitoringConfig(
+        NKikimrConfig::TMonitoringConfig& monConfig) const;
+    void SetupLogConfig(NKikimrConfig::TLogConfig& logConfig) const;
+    void SetupDiskAgentConfig(NProto::TDiskAgentConfig& config) const;
 };
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/disk_agent/config_initializer_ut.cpp
+++ b/cloud/blockstore/libs/disk_agent/config_initializer_ut.cpp
@@ -221,6 +221,229 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         UNIT_ASSERT_VALUES_EQUAL(true, ci.StorageConfig->GetMultipartitionVolumesEnabled());
     }
 
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsAndComponentsInStaticLogConfig)
+    {
+        auto logConfigStr = R"(
+            Entry {
+                Component: "BLOCKSTORE_DISK_AGENT"
+                Level: 6
+            }
+            Entry {
+                Component: "UNKNOWN_COMPONENT"
+                Level: 6
+            }
+            SysLog: true
+            DefaultLevel: 4
+            UnknownField: "xxx"
+            SysLogService: "NBS_SERVER"
+        )";
+
+        TTempDir dir;
+        auto logConfigPath = dir.Path() / "nbs-log.txt";
+
+        TOFStream(logConfigPath.GetPath()).Write(logConfigStr);
+
+        auto options = CreateOptions();
+
+        // - TConfigInitializerYdbBase
+        options->LogConfig = logConfigPath.GetPath();
+
+        auto ci = TConfigInitializer(std::move(options));
+
+        // - TConfigInitializerYdbBase
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitKikimrConfig());
+
+        const auto& logConfig = ci.KikimrConfig->GetLogConfig();
+        UNIT_ASSERT(logConfig.GetSysLog());
+        UNIT_ASSERT(logConfig.GetIgnoreUnknownComponents());
+        UNIT_ASSERT_VALUES_EQUAL(4, logConfig.GetDefaultLevel());
+        UNIT_ASSERT_VALUES_EQUAL("NBS_SERVER", logConfig.GetSysLogService());
+        UNIT_ASSERT_VALUES_EQUAL(2, logConfig.EntrySize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "BLOCKSTORE_DISK_AGENT",
+            logConfig.GetEntry(0).GetComponent());
+        UNIT_ASSERT_VALUES_EQUAL(6, logConfig.GetEntry(0).GetLevel());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "UNKNOWN_COMPONENT",
+            logConfig.GetEntry(1).GetComponent());
+        UNIT_ASSERT_VALUES_EQUAL(6, logConfig.GetEntry(1).GetLevel());
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInStaticConfigs)
+    {
+        auto componentConfigStr = R"(
+            NoSuchField: "x"
+        )";
+
+        TTempDir dir;
+        auto configPath = dir.Path() / "component.txt";
+
+        TOFStream(configPath.GetPath()).Write(componentConfigStr);
+
+        auto options = CreateOptions();
+
+        // clang-format off
+        // - TOptionsYdbBase
+        options->LogConfig                =
+        options->SysConfig                =
+        options->DomainsConfig            =
+        options->NameServiceConfig        =
+        options->DynamicNameServiceConfig =
+        options->AuthConfig               =
+        options->KikimrFeaturesConfig     =
+        options->SharedCacheConfig        =
+        options->ImmediateControlsConfig  =
+        options->InterconnectConfig       =
+        options->MonitoringConfig         = configPath.GetPath();
+        // - TOptionsBase
+        options->DiagnosticsConfig       =
+        options->ServerConfig            = configPath.GetPath();
+        // - TOptions
+        options->DiskAgentConfig         =
+        options->DiskRegistryProxyConfig =
+        options->FeaturesConfig          =
+        options->RdmaConfig              =
+        options->StorageConfig           = configPath.GetPath();
+        // clang-format on
+
+        auto ci = TConfigInitializer(std::move(options));
+
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitKikimrConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitServerConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitDiagnosticsConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitDiskAgentConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitDiskRegistryProxyConfig());
+        // InitSpdkEnvConfig()          - not loaded from file
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitRdmaConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitFeaturesConfig());
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitStorageConfig());
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInCmsConfigs)
+    {
+        auto configStr = R"(
+             NoSuchField: "x"
+        )";
+
+        // clang-format off
+        // Elements ordered as in TConfigInitializer::ApplyNamedConfigs()
+        const TVector<TString> configNames {
+            "ActorSystemConfig",
+            "AuthConfig",
+            "DiagnosticsConfig",
+            "DiskAgentConfig",
+            "DiskRegistryProxyConfig",
+            "FeaturesConfig",
+            "InterconnectConfig",
+            "LogConfig",
+            "MonitoringConfig",
+            "ServerAppConfig",
+            "StorageServiceConfig",
+        };
+        // clang-format on
+
+        auto ci = TConfigInitializer(CreateOptions());
+
+        ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+        NKikimrConfig::TAppConfig appCfg;
+        auto& directFullNamedConfigs = *appCfg.MutableNamedConfigs();
+
+        for (const auto& configName: configNames) {
+            auto* namedConfig = directFullNamedConfigs.Add();
+            namedConfig->SetName("Cloud.NBS." + configName);
+            namedConfig->SetConfig(configStr);
+        }
+
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+    }
+
+    Y_UNIT_TEST(ShouldApplyCmsConfigsInAnyOrder)
+    {
+        auto configStr = "";
+
+        // clang-format off
+        // Elements ordered as in TConfigInitializer::ApplyNamedConfigs()
+        const TVector<TString> configNames {
+            "ActorSystemConfig",
+            "AuthConfig",
+            "DiagnosticsConfig",
+            "DiskAgentConfig",
+            "DiskRegistryProxyConfig",
+            "FeaturesConfig",
+            "InterconnectConfig",
+            "LogConfig",
+            "MonitoringConfig",
+            "ServerAppConfig",
+            "StorageServiceConfig",
+        };
+        // clang-format on
+
+        auto ci = TConfigInitializer(CreateOptions());
+
+        // To detect possible mutual dependencies:
+        //  - one at time
+        //  - all at once, direct and reverse order
+
+        // 1. One at time
+        {
+            for (const auto& configName: configNames) {
+                ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+                NKikimrConfig::TAppConfig appCfg;
+                auto& namedConfigs = *appCfg.MutableNamedConfigs();
+
+                ::NKikimrConfig::TNamedConfig* namedConfig = nullptr;
+                for (auto i = 0; i < 3; i++) {
+                    // May be several NamedConfigs[] with same name
+                    namedConfig = namedConfigs.Add();
+                    namedConfig->SetName("Cloud.NBS." + configName);
+                    namedConfig->SetConfig(configStr);
+                }
+
+                Cerr << Endl << "Apply NamedConfigs['" << namedConfig->GetName()
+                     << "']" << Endl;
+                UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+            }
+        }
+
+        // 2. All at once, direct order, single entities
+        {
+            ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+            NKikimrConfig::TAppConfig appCfg;
+            auto& namedConfigs = *appCfg.MutableNamedConfigs();
+
+            for (const auto& configName: configNames) {
+                auto* namedConfig = namedConfigs.Add();
+                namedConfig->SetName("Cloud.NBS." + configName);
+                namedConfig->SetConfig(configStr);
+            }
+
+            Cerr << Endl << "Apply all NamedConfigs[] in direct order" << Endl;
+            UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+        }
+
+        // 3. All at once, reverse order, multiple entities
+        {
+            ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+            NKikimrConfig::TAppConfig appCfg;
+            auto& namedConfigs = *appCfg.MutableNamedConfigs();
+
+            for (auto i = 0; i < 3; i++) {
+                // May be several NamedConfigs[] with same name
+                for (auto configName = configNames.rbegin();
+                     configName != configNames.rend();
+                     configName++)
+                {
+                    auto* namedConfig = namedConfigs.Add();
+                    namedConfig->SetName("Cloud.NBS." + *configName);
+                    namedConfig->SetConfig(configStr);
+                }
+            }
+
+            Cerr << Endl << "Apply all NamedConfigs[] in reverse order" << Endl;
+            UNIT_ASSERT_NO_EXCEPTION(ci.ApplyCMSConfigs(appCfg));
+        }
+    }
+
     Y_UNIT_TEST(ShouldLoadAllowedKikimrFeaturesFromCms)
     {
         std::vector<std::string> featureNames = {

--- a/cloud/blockstore/libs/logbroker/iface/config.cpp
+++ b/cloud/blockstore/libs/logbroker/iface/config.cpp
@@ -100,6 +100,11 @@ TLogbrokerConfig::TLogbrokerConfig(
     : Config(std::move(config))
 {}
 
+const NProto::TLogbrokerConfig* TLogbrokerConfig::GetConfig() const
+{
+    return &Config;
+}
+
 TAuthConfig TLogbrokerConfig::GetAuthConfig() const
 {
     if (GetMetadataServerAddress()) {

--- a/cloud/blockstore/libs/logbroker/iface/config.h
+++ b/cloud/blockstore/libs/logbroker/iface/config.h
@@ -60,6 +60,8 @@ private:
 public:
     explicit TLogbrokerConfig(NProto::TLogbrokerConfig config = {});
 
+    const NProto::TLogbrokerConfig* GetConfig() const;
+
     TString GetAddress() const;
     ui32 GetPort() const;
     TString GetDatabase() const;

--- a/cloud/blockstore/libs/notify/iface/config.cpp
+++ b/cloud/blockstore/libs/notify/iface/config.cpp
@@ -40,6 +40,11 @@ TNotifyConfig::TNotifyConfig(
     : Config(std::move(config))
 {}
 
+const NProto::TNotifyConfig* TNotifyConfig::GetConfig() const
+{
+    return &Config;
+}
+
 #define BLOCKSTORE_CONFIG_GETTER(name, type, ...)                              \
 type TNotifyConfig::Get##name() const                                          \
 {                                                                              \

--- a/cloud/blockstore/libs/notify/iface/config.h
+++ b/cloud/blockstore/libs/notify/iface/config.h
@@ -20,6 +20,8 @@ private:
 public:
     explicit TNotifyConfig(NProto::TNotifyConfig config);
 
+    const NProto::TNotifyConfig* GetConfig() const;
+
     TString GetEndpoint() const;
     TString GetCaCertFilename() const;
     ui32 GetVersion() const;

--- a/cloud/storage/core/libs/kikimr/config_initializer.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer.cpp
@@ -182,7 +182,7 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
     if (Options->ImmediateControlsConfig) {
         auto& immediateControlsConfig =
             *KikimrConfig->MutableImmediateControlsConfig();
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->ImmediateControlsConfig,
             immediateControlsConfig);
     }

--- a/cloud/storage/core/libs/kikimr/config_initializer.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer.cpp
@@ -105,7 +105,7 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
 
     auto& sysConfig = *KikimrConfig->MutableActorSystemConfig();
     if (Options->SysConfig) {
-        ParseProtoTextFromFile(Options->SysConfig, sysConfig);
+        ParseProtoTextFromFileRobust(Options->SysConfig, sysConfig);
     }
     AdjustActorSystemThreadsAccordingToAvailableCpus(
         sysConfig,
@@ -113,7 +113,7 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
 
     auto& interconnectConfig = *KikimrConfig->MutableInterconnectConfig();
     if (Options->InterconnectConfig) {
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->InterconnectConfig,
             interconnectConfig);
     }
@@ -121,12 +121,12 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
 
     auto& domainsConfig = *KikimrConfig->MutableDomainsConfig();
     if (Options->DomainsConfig) {
-        ParseProtoTextFromFile(Options->DomainsConfig, domainsConfig);
+        ParseProtoTextFromFileRobust(Options->DomainsConfig, domainsConfig);
     }
 
     auto& monConfig = *KikimrConfig->MutableMonitoringConfig();
     if (Options->MonitoringConfig) {
-        ParseProtoTextFromFile(Options->MonitoringConfig, monConfig);
+        ParseProtoTextFromFileRobust(Options->MonitoringConfig, monConfig);
     }
     SetupMonitoringConfig(monConfig);
 
@@ -137,10 +137,9 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
 
     auto& nameServiceConfig = *KikimrConfig->MutableNameserviceConfig();
     if (Options->NameServiceConfig) {
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->NameServiceConfig,
-            nameServiceConfig
-        );
+            nameServiceConfig);
     }
 
     if (Options->SuppressVersionCheck) {
@@ -150,15 +149,14 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
     auto& dynamicNameServiceConfig =
         *KikimrConfig->MutableDynamicNameserviceConfig();
     if (Options->DynamicNameServiceConfig) {
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->DynamicNameServiceConfig,
-            dynamicNameServiceConfig
-        );
+            dynamicNameServiceConfig);
     }
 
     if (Options->AuthConfig) {
         auto& authConfig = *KikimrConfig->MutableAuthConfig();
-        ParseProtoTextFromFile(Options->AuthConfig, authConfig);
+        ParseProtoTextFromFileRobust(Options->AuthConfig, authConfig);
     }
 
     auto& bsConfig = *KikimrConfig->MutableBlobStorageConfig();
@@ -166,10 +164,9 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
 
     auto& kikimrFeaturesConfig = *KikimrConfig->MutableFeatureFlags();
     if (Options->KikimrFeaturesConfig) {
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->KikimrFeaturesConfig,
-            kikimrFeaturesConfig
-        );
+            kikimrFeaturesConfig);
     } else {
         // we want to use VPatch by default for EvPatch
         kikimrFeaturesConfig.SetEnableVPatch(true);
@@ -177,7 +174,7 @@ void TConfigInitializerYdbBase::InitKikimrConfig()
 
     if (Options->SharedCacheConfig) {
         auto& sharedCacheConfig = *KikimrConfig->MutableSharedCacheConfig();
-        ParseProtoTextFromFile(
+        ParseProtoTextFromFileRobust(
             Options->SharedCacheConfig,
             sharedCacheConfig);
     }
@@ -207,7 +204,7 @@ NKikimrConfig::TMonitoringConfig TConfigInitializerYdbBase::GetMonitoringConfig(
 {
     NKikimrConfig::TMonitoringConfig monConfig;
     if (Options->MonitoringConfig) {
-        ParseProtoTextFromFile(Options->MonitoringConfig, monConfig);
+        ParseProtoTextFromFileRobust(Options->MonitoringConfig, monConfig);
     }
 
     SetupMonitoringConfig(monConfig);
@@ -248,20 +245,22 @@ TString TConfigInitializerYdbBase::GetFullSchemeShardDir() const
 void TConfigInitializerYdbBase::ApplyMonitoringConfig(const TString& text)
 {
     auto& monConfig = *KikimrConfig->MutableMonitoringConfig();
-    ParseProtoTextFromString(text, monConfig);
+    ParseProtoTextFromStringRobust(text, monConfig);
 
     SetupMonitoringConfig(monConfig);
 }
 
 void TConfigInitializerYdbBase::ApplyActorSystemConfig(const TString& text)
 {
-    ParseProtoTextFromString(text, *KikimrConfig->MutableActorSystemConfig());
+    ParseProtoTextFromStringRobust(
+        text,
+        *KikimrConfig->MutableActorSystemConfig());
 }
 
 void TConfigInitializerYdbBase::ApplyInterconnectConfig(const TString& text)
 {
     auto& interconnectConfig = *KikimrConfig->MutableInterconnectConfig();
-    ParseProtoTextFromString(text, interconnectConfig);
+    ParseProtoTextFromStringRobust(text, interconnectConfig);
 
     interconnectConfig.SetStartTcp(true);
 }
@@ -277,7 +276,7 @@ void TConfigInitializerYdbBase::ApplyLogConfig(const TString& text)
 
 void TConfigInitializerYdbBase::ApplyAuthConfig(const TString& text)
 {
-    ParseProtoTextFromString(text, *KikimrConfig->MutableAuthConfig());
+    ParseProtoTextFromStringRobust(text, *KikimrConfig->MutableAuthConfig());
 }
 
 ui32 TConfigInitializerYdbBase::GetLogDefaultLevel() const

--- a/cloud/storage/core/libs/kikimr/config_initializer.h
+++ b/cloud/storage/core/libs/kikimr/config_initializer.h
@@ -38,16 +38,16 @@ struct TConfigInitializerYdbBase
 
     virtual void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig& config) = 0;
 
-protected:
-    NKikimrConfig::TLogConfig GetLogConfig() const;
-    NKikimrConfig::TMonitoringConfig GetMonitoringConfig() const;
-    TString GetFullSchemeShardDir() const;
-
     void ApplyActorSystemConfig(const TString& text);
     void ApplyInterconnectConfig(const TString& text);
     void ApplyAuthConfig(const TString& text);
     void ApplyLogConfig(const TString& text);
     void ApplyMonitoringConfig(const TString& text);
+
+protected:
+    NKikimrConfig::TLogConfig GetLogConfig() const;
+    NKikimrConfig::TMonitoringConfig GetMonitoringConfig() const;
+    TString GetFullSchemeShardDir() const;
 };
 
 }   // namespace NCloud::NServer

--- a/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
@@ -39,39 +39,12 @@ TOptionsYdbBasePtr CreateOptions()
 struct TConfigInitializerYdb
     : public TConfigInitializerYdbBase
 {
-    using TBase = TConfigInitializerYdbBase;
-
     explicit TConfigInitializerYdb(TOptionsYdbBasePtr options)
         : TConfigInitializerYdbBase(std::move(options))
     {}
 
     void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig&) override
     {}
-
-    void ApplyActorSystemConfig(const TString& text)
-    {
-        TBase::ApplyActorSystemConfig(text);
-    }
-
-    void ApplyInterconnectConfig(const TString& text)
-    {
-        TBase::ApplyInterconnectConfig(text);
-    }
-
-    void ApplyAuthConfig(const TString& text)
-    {
-        TBase::ApplyAuthConfig(text);
-    }
-
-    void ApplyLogConfig(const TString& text)
-    {
-        TBase::ApplyLogConfig(text);
-    }
-
-    void ApplyMonitoringConfig(const TString& text)
-    {
-        TBase::ApplyMonitoringConfig(text);
-    }
 };
 
 }   // namespace

--- a/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
@@ -39,12 +39,39 @@ TOptionsYdbBasePtr CreateOptions()
 struct TConfigInitializerYdb
     : public TConfigInitializerYdbBase
 {
+    using TBase = TConfigInitializerYdbBase;
+
     explicit TConfigInitializerYdb(TOptionsYdbBasePtr options)
         : TConfigInitializerYdbBase(std::move(options))
     {}
 
     void ApplyCustomCMSConfigs(const NKikimrConfig::TAppConfig&) override
     {}
+
+    void ApplyActorSystemConfig(const TString& text)
+    {
+        TBase::ApplyActorSystemConfig(text);
+    }
+
+    void ApplyInterconnectConfig(const TString& text)
+    {
+        TBase::ApplyInterconnectConfig(text);
+    }
+
+    void ApplyAuthConfig(const TString& text)
+    {
+        TBase::ApplyAuthConfig(text);
+    }
+
+    void ApplyLogConfig(const TString& text)
+    {
+        TBase::ApplyLogConfig(text);
+    }
+
+    void ApplyMonitoringConfig(const TString& text)
+    {
+        TBase::ApplyMonitoringConfig(text);
+    }
 };
 
 }   // namespace
@@ -53,6 +80,54 @@ struct TConfigInitializerYdb
 
 Y_UNIT_TEST_SUITE(TConfigInitializerTest)
 {
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInStaticConfigs)
+    {
+        auto configStr = R"(
+            NoSuchField: "x"
+        )";
+
+        TTempDir dir;
+        auto configPath = dir.Path() / "component.txt";
+
+        TOFStream(configPath.GetPath()).Write(configStr);
+
+        auto options = CreateOptions();
+
+        // clang-format off
+        options->LogConfig                =
+        options->SysConfig                =
+        options->DomainsConfig            =
+        options->NameServiceConfig        =
+        options->DynamicNameServiceConfig =
+        options->AuthConfig               =
+        options->KikimrFeaturesConfig     =
+        options->SharedCacheConfig        =
+        options->InterconnectConfig       =
+        options->MonitoringConfig         = configPath.GetPath();
+        // clang-format on
+
+        auto ci = TConfigInitializerYdb(std::move(options));
+
+        UNIT_ASSERT_NO_EXCEPTION(ci.InitKikimrConfig());
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInDynamicConfigs)
+    {
+        auto configStr = R"(
+            NoSuchField: "x"
+        )";
+
+        auto options = CreateOptions();
+        auto ci = TConfigInitializerYdb(std::move(options));
+        ci.KikimrConfig = std::make_shared<NKikimrConfig::TAppConfig>();
+
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyActorSystemConfig(configStr));
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyInterconnectConfig(configStr));
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyAuthConfig(configStr));
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyLogConfig(configStr));
+        UNIT_ASSERT_NO_EXCEPTION(ci.ApplyMonitoringConfig(configStr));
+    }
+
     Y_UNIT_TEST(ShouldLoadSysConfig)
     {
         auto sysConfigStr = R"(

--- a/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
+++ b/cloud/storage/core/libs/kikimr/config_initializer_ut.cpp
@@ -102,6 +102,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         options->AuthConfig               =
         options->KikimrFeaturesConfig     =
         options->SharedCacheConfig        =
+        options->ImmediateControlsConfig  =
         options->InterconnectConfig       =
         options->MonitoringConfig         = configPath.GetPath();
         // clang-format on
@@ -111,7 +112,7 @@ Y_UNIT_TEST_SUITE(TConfigInitializerTest)
         UNIT_ASSERT_NO_EXCEPTION(ci.InitKikimrConfig());
     }
 
-    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInDynamicConfigs)
+    Y_UNIT_TEST(ShouldIgnoreUnknownFieldsInCmsConfigs)
     {
         auto configStr = R"(
             NoSuchField: "x"


### PR DESCRIPTION
### Notes
Previously unknown parameters were ignored for the most part of NBS static configs and only for LogConfig in dynamic (cms) configs. Now all Kikimr, NBS and DiskAgent unknown parameters are not treated as errors for all types of static and dynamic configs. This prevents potential cluster failures:
* due to incompatible cms configs
* due to binaries rollback to older versions with configuration for newer version (with new parameters) left.

### Issue
This PR is part of #5519
