### PR TITLE
issue-5715: RenameNotSupportedErrorCount sensor

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -543,6 +543,10 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
 
         if (!args.NewChildRef->IsExternal()) {
             if (GetFileSystem().GetForceDirectoryCreationInShards()) {
+                Metrics.RenameNotSupportedErrorCount.fetch_add(
+                    1,
+                    std::memory_order_relaxed);
+
                 args.Error = ErrorRenameNotSupported(
                     args.Request.GetOriginalRequest().GetNodeId(),
                     args.Request.GetNewParentId());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -460,6 +460,10 @@ bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
 
     if (!args.ChildRef->IsExternal()) {
         if (GetFileSystem().GetForceDirectoryCreationInShards()) {
+            Metrics.RenameNotSupportedErrorCount.fetch_add(
+                1,
+                std::memory_order_relaxed);
+
             args.Error = ErrorRenameNotSupported(
                 args.ParentNodeId,
                 args.Request.GetNewParentId());

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -379,6 +379,10 @@ void TTabletMetrics::Register(
 
     REGISTER_LOCAL(ResponseLogEntryCount, EMetricType::MT_ABSOLUTE);
 
+    REGISTER_AGGREGATABLE_SUM(
+        RenameNotSupportedErrorCount,
+        EMetricType::MT_DERIVATIVE);
+
 #undef REGISTER_LOCAL
 #undef REGISTER_AGGREGATABLE_SUM
 #undef REGISTER

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -288,6 +288,8 @@ struct TTabletMetrics
 
     std::atomic<i64> ResponseLogEntryCount{0};
 
+    std::atomic<i64> RenameNotSupportedErrorCount{0};
+
     const NMetrics::IMetricsRegistryPtr StorageRegistry;
     const NMetrics::IMetricsRegistryPtr StorageFsRegistry;
 

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_force_directory_creation_in_shards/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_force_directory_creation_in_shards/results.txt
@@ -123,3 +123,5 @@ locks():
 {
     "locks": []
 }
+counters():
+[{"kind": "RATE", "labels": {"component": "storage_fs", "host": "cluster", "filesystem": "fs0", "cloud": "test_cloud", "folder": "test_folder", "sensor": "RenameNotSupportedErrorCount"}, "value": 1}]

--- a/cloud/filestore/tests/client_sharded/test.py
+++ b/cloud/filestore/tests/client_sharded/test.py
@@ -4,6 +4,7 @@ import os
 import yatest.common as common
 
 from cloud.filestore.tests.python.lib.client import FilestoreCliClient
+from cloud.filestore.tests.python.lib.common import fetch_counters, filter_counters
 from cloud.filestore.tests.python.lib.fs import (
     FsItem,
     fill_fs,
@@ -345,6 +346,19 @@ def test_force_directory_creation_in_shards():
     with open(results_path, 'a') as results:
         results.write('locks():\n')
         results.write('{}\n'.format(result))
+
+    #
+    # Canonizing some counters.
+    #
+
+    counters = fetch_counters()
+    filtered_counters = filter_counters(
+        counters,
+        "fs0",
+        ["RenameNotSupportedErrorCount"])
+    with open(results_path, 'a') as results:
+        results.write('counters():\n')
+        results.write('{}\n'.format(json.dumps(filtered_counters)))
 
     #
     # Destroying the filesystem - important to do it after querying dirViewer.

--- a/cloud/filestore/tests/python/lib/common.py
+++ b/cloud/filestore/tests/python/lib/common.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import requests
 import signal
 import time
 import yatest.common as common
@@ -127,3 +128,26 @@ def flush_logs():
     #
 
     time.sleep(2)
+
+
+def fetch_counters():
+    #
+    # TODO(#568) - same as for flush_logs()
+    #
+
+    time.sleep(2)
+
+    mon_port = os.getenv("NFS_MON_PORT")
+    url = f"http://localhost:{mon_port}/counters/counters=filestore/json"
+    r = requests.get(url, timeout=10)
+    r.raise_for_status()
+    return r.json()
+
+
+def filter_counters(counters, fs_id, names):
+    result = []
+    for sensor in counters["sensors"]:
+        labels = sensor["labels"]
+        if labels.get("sensor") in names and labels.get("filesystem") == fs_id:
+            result.append(sensor)
+    return result

--- a/cloud/filestore/tests/python/lib/daemon_config.py
+++ b/cloud/filestore/tests/python/lib/daemon_config.py
@@ -237,6 +237,7 @@ class FilestoreDaemonConfigGenerator:
         config = TDiagnosticsConfig()
 
         config.ProfileLogTimeThreshold = 100
+        config.MetricsUpdateInterval = 100
         config.DumpTracksInterval = 100
         config.SamplingRate = self.__trace_sampling_rate or 10000
         config.SlowRequestSamplingRate = 1000


### PR DESCRIPTION
### Notes
Implemented a tablet-level sensor which counts `EXDEV` errors

### Issue
https://github.com/ydb-platform/nbs/issues/5715