### PR TITLE
chore: update github-script from deprecated v7 to v9

### DIFF
--- a/.github/workflows/approvals.yaml
+++ b/.github/workflows/approvals.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: [self-hosted, "self-hosted", "runner_light"]
         steps:
         - name: Check approvals from left and right teams
-          uses: actions/github-script@v7
+          uses: actions/github-script@v9
           with:
             github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
             script: |

--- a/.github/workflows/on_demand_build_and_test.yaml
+++ b/.github/workflows/on_demand_build_and_test.yaml
@@ -299,7 +299,7 @@ jobs:
         continue-on-error: true
       - name: Decide whether to remove VM
         id: decider
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           ANY_CANCELLED: ${{ contains(needs.*.result, 'cancelled') }}
           REMOVE_CANCELLED_VMS: ${{ vars.NEBIUS_REMOVE_CANCELLED_VMS }}

--- a/.github/workflows/on_hybrid_build_and_test.yaml
+++ b/.github/workflows/on_hybrid_build_and_test.yaml
@@ -298,7 +298,7 @@ jobs:
         continue-on-error: true
       - name: Decide whether to remove VM
         id: decider
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           ANY_CANCELLED: ${{ contains(needs.*.result, 'cancelled') }}
           REMOVE_CANCELLED_VMS: ${{ vars.NEBIUS_REMOVE_CANCELLED_VMS }}

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Check if running tests is allowed
         id: check-ownership-membership
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
@@ -141,7 +141,7 @@ jobs:
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false' &&
             github.event.action == 'opened'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -151,7 +151,7 @@ jobs:
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
       - name: cleanup-labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             let labelsToRemove = ['ok-to-test', 'recheck'];
@@ -322,7 +322,7 @@ jobs:
 
       - name: comment on issue (${{ steps.pytest.outcome }})
         if: ${{ github.event_name == 'pull_request' && always() }}
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v9
         env:
           STEP_OUTCOME: ${{ steps.pytest.outcome }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
@@ -405,7 +405,7 @@ jobs:
           sudo -E -H -u github aws s3 cp --acl public-read --follow-symlinks --no-progress "$OUTPUT_FILE" "$S3_BUCKET_PATH/workflow_lint/workflow-lint.txt"
 
       - name: comment on issue
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v9
         if:  ${{ github.event_name == 'pull_request' }}
         env:
           STEP_OUTCOME: ${{ steps.lint.outcome }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Check if running tests is allowed
         id: check-ownership-membership
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
@@ -110,7 +110,7 @@ jobs:
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false' &&
             github.event.action == 'opened'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -120,7 +120,7 @@ jobs:
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
       - name: cleanup-labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             let labelsToRemove = ['ok-to-test', 'recheck'];


### PR DESCRIPTION
```Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@v7. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/```