### PR TITLE
rename variable to make govet happy

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/session_with_re_establish_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/session_with_re_establish_test.go
@@ -22,7 +22,7 @@ var invalidSessionError = &nfs_client.ClientError{
 	Message: "invalid session",
 }
 
-var otherError = fmt.Errorf("some other error")
+var errOther = fmt.Errorf("some other error")
 
 var reEstablishedSession = nfs_client.Session{
 	SessionID:    "re-established-session",
@@ -74,10 +74,10 @@ func TestSessionWithReEstablishCreateCheckpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionMock.On("CreateCheckpoint", mock.Anything, "fs-1", "cp-1", uint64(42)).
-		Return(otherError).Once()
+		Return(errOther).Once()
 
 	err = s.CreateCheckpoint(ctx, "fs-1", "cp-1", 42)
-	require.ErrorIs(t, err, otherError)
+	require.ErrorIs(t, err, errOther)
 
 	sessionMock.AssertExpectations(t)
 	nfsMock.AssertExpectations(t)
@@ -113,10 +113,10 @@ func TestSessionWithReEstablishListNodes(t *testing.T) {
 	require.Equal(t, "next", cookie)
 
 	sessionMock.On("ListNodes", mock.Anything, uint64(0), "", uint32(1024), false).
-		Return([]nfs.Node(nil), "", otherError).Once()
+		Return([]nfs.Node(nil), "", errOther).Once()
 
 	_, _, err = s.ListNodes(ctx, 0, "", 1024, false)
-	require.ErrorIs(t, err, otherError)
+	require.ErrorIs(t, err, errOther)
 
 	sessionMock.AssertExpectations(t)
 	nfsMock.AssertExpectations(t)
@@ -158,10 +158,10 @@ func TestSessionWithReEstablishCreateNode(t *testing.T) {
 	require.Equal(t, uint64(42), nodeID)
 
 	sessionMock.On("CreateNode", mock.Anything, testNode).
-		Return(uint64(0), otherError).Once()
+		Return(uint64(0), errOther).Once()
 
 	_, err = s.CreateNode(ctx, testNode)
-	require.ErrorIs(t, err, otherError)
+	require.ErrorIs(t, err, errOther)
 
 	sessionMock.AssertExpectations(t)
 	nfsMock.AssertExpectations(t)
@@ -203,10 +203,10 @@ func TestSessionWithReEstablishCreateNodeIdempotent(t *testing.T) {
 	require.Equal(t, uint64(42), nodeID)
 
 	sessionMock.On("CreateNodeIdempotent", mock.Anything, testNode).
-		Return(uint64(0), otherError).Once()
+		Return(uint64(0), errOther).Once()
 
 	_, err = s.CreateNodeIdempotent(ctx, testNode)
-	require.ErrorIs(t, err, otherError)
+	require.ErrorIs(t, err, errOther)
 
 	sessionMock.AssertExpectations(t)
 	nfsMock.AssertExpectations(t)
@@ -246,10 +246,10 @@ func TestSessionWithReEstablishReadLink(t *testing.T) {
 	require.Equal(t, []byte("/target"), data)
 
 	sessionMock.On("ReadLink", mock.Anything, uint64(42)).
-		Return([]byte(nil), otherError).Once()
+		Return([]byte(nil), errOther).Once()
 
 	_, err = s.ReadLink(ctx, 42)
-	require.ErrorIs(t, err, otherError)
+	require.ErrorIs(t, err, errOther)
 
 	sessionMock.AssertExpectations(t)
 	nfsMock.AssertExpectations(t)
@@ -291,10 +291,10 @@ func TestSessionWithReEstablishGetNodeAttr(t *testing.T) {
 	require.Equal(t, expectedNode, node)
 
 	sessionMock.On("GetNodeAttr", mock.Anything, uint64(1), "testfile").
-		Return(nfs.Node{}, otherError).Once()
+		Return(nfs.Node{}, errOther).Once()
 
 	_, err = s.GetNodeAttr(ctx, 1, "testfile")
-	require.ErrorIs(t, err, otherError)
+	require.ErrorIs(t, err, errOther)
 
 	sessionMock.AssertExpectations(t)
 	nfsMock.AssertExpectations(t)
@@ -417,10 +417,10 @@ func TestSessionWithReEstablishUnlinkNode(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionMock.On("UnlinkNode", mock.Anything, uint64(1), "testfile", false).
-		Return(otherError).Once()
+		Return(errOther).Once()
 
 	err = s.UnlinkNode(ctx, 1, "testfile", false)
-	require.ErrorIs(t, err, otherError)
+	require.ErrorIs(t, err, errOther)
 
 	sessionMock.AssertExpectations(t)
 	nfsMock.AssertExpectations(t)


### PR DESCRIPTION
### Notes
Got the following error with local go linter
`$S/cloud/disk_manager/internal/pkg/clients/nfs/tests/session_with_re_establish_test.go:25:5: "ST1012: error var otherError should have name of the form errFoo"
$S/cloud/disk_manager/internal/pkg/clients/nfs/tests/session_with_re_establish_test.go:25:5: "ST1012: if you believe this report is false positive, please silence it with //nolint:st1012 comment"`

Renamed variable to make go happy

### Issue
Put links to the related issues here
