### PR TITLE
[NBS] fix TVolumeStats Client-Instance accounting errors

### DIFF
--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -831,13 +831,16 @@ public:
                     const auto& diskId = info.VolumeBase->Volume.GetDiskId();
                     std::erase_if(
                         ClientVolumeToRealInstance,
-                        [&info, &diskId](const auto& clientVolume)
+                        [&info, &diskId](const auto& mapElement)
                         {
-                            const bool erase =
-                                clientVolume.first.second == diskId &&
-                                TRealInstanceKeyEqual()(
-                                    clientVolume.second,
-                                    info.RealInstanceId);
+                            const TClientVolume& clientVolume =
+                                mapElement.first;
+                            const TRealInstanceId& realInstanceId =
+                                mapElement.second;
+                            const bool erase = clientVolume.second == diskId &&
+                                               TRealInstanceKeyEqual()(
+                                                   realInstanceId,
+                                                   info.RealInstanceId);
                             return erase;
                         });
                     return true;

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -16,6 +16,8 @@
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/diagnostics/postpone_time_predictor.h>
 
+#include <contrib/ydb/core/util/tuples.h>
+
 #include <library/cpp/containers/sorted_vector/sorted_vector.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
@@ -464,6 +466,7 @@ class TVolumeStats final
     : public IVolumeStats
     , public std::enable_shared_from_this<TVolumeStats>
 {
+    using TClientVolume = std::pair<TString, TString>;   // [clientId, diskId]
     using TVolumeBasePtr = std::shared_ptr<TVolumeInfoBase>;
     using TVolumeInfoPtr = std::shared_ptr<TVolumeInfo>;
     using TVolumeMap = std::unordered_map<
@@ -537,6 +540,8 @@ private:
     std::unique_ptr<TSufferCounters> StrictSLASufferCounters;
     std::unique_ptr<TSufferCounters> CriticalSufferCounters;
 
+    std::unordered_map<TClientVolume, TRealInstanceId>
+        ClientVolumeToRealInstance;
     std::unordered_map<TString, TRealInstanceId> ClientToRealInstance;
     TVolumeHolderMap Volumes;
     TRWMutex Lock;
@@ -592,6 +597,10 @@ public:
             volumeInfoIt = infos.emplace(realInstanceId, volumeInfo).first;
             inserted = true;
             volumeInfoIt->second->PinCount = pinCountForNewInstance;
+            Cerr << "add volumeInfo " << volume.GetDiskId()
+                 << " with realInstanceId "
+                 << volumeInfoIt->second->RealInstanceId.GetRealInstanceId()
+                 << Endl;
         }
 
         /*
@@ -627,11 +636,30 @@ public:
 
         auto [itr, result] =
             ClientToRealInstance.try_emplace(clientId, clientId, instanceId);
+        Y_UNUSED(itr);
+
+        const auto& diskId = NStorage::GetLogicalDiskId(volume.GetDiskId());
+        auto [it, _] = ClientVolumeToRealInstance.try_emplace(
+            {clientId, diskId},
+            clientId,
+            instanceId);
+        Y_UNUSED(it);
+
+        Cerr << "mount ClientToRealInstance       size "
+             << ClientToRealInstance.size() << Endl;
+        Cerr << "mount ClientVolumeToRealInstance size "
+             << ClientVolumeToRealInstance.size() << Endl;
+
+        if (_) {
+            Cerr << "add   ClientVolumeToRealInstance [" << it->first.first
+                 << ", " << it->first.second << "] "
+                 << it->second.GetRealInstanceId() << Endl;
+        }
 
         return MountVolumeImpl(
             volume,
-            itr->second,
-            0 /* pinCountForNewInstance */);
+            it->second,
+            0);   // pinCountForNewInstance
 
         /*
         return MountVolumeImpl(
@@ -730,12 +758,30 @@ public:
             return infoIt->second;
         }
         */
+
+        /*
         const auto realInstanceIt = ClientToRealInstance.find(clientId);
         if (realInstanceIt == ClientToRealInstance.end()) {
             return nullptr;
         }
         const auto infoIt = infos.find(realInstanceIt->second);
         if (infoIt == infos.end()) {
+            return nullptr;
+        }
+        return infoIt->second;
+        */
+
+        const auto realInstanceIt =
+            ClientVolumeToRealInstance.find(std::tie(clientId, diskId));
+        if (realInstanceIt == ClientVolumeToRealInstance.end()) {
+            Cerr << "unknown [" << clientId << ", " << diskId << "]" << Endl;
+            return nullptr;
+        }
+        const auto infoIt = infos.find(realInstanceIt->second);
+        if (infoIt == infos.end()) {
+            Cerr << "no volumeInfo for [" << clientId << ", " << diskId
+                 << "] with realInstanceId "
+                 << realInstanceIt->second.GetRealInstanceId() << Endl;
             return nullptr;
         }
         return infoIt->second;
@@ -865,6 +911,30 @@ public:
                                 client.second,
                                 info.RealInstanceId);
                         });
+
+                    const auto& diskId = info.VolumeBase->Volume.GetDiskId();
+                    std::erase_if(
+                        ClientVolumeToRealInstance,
+                        [&info, &diskId](const auto& clientVolume)
+                        {
+                            const bool erase =
+                                clientVolume.first.second == diskId &&
+                                TRealInstanceKeyEqual()(
+                                    clientVolume.second,
+                                    info.RealInstanceId);
+                            if (erase) {
+                                Cerr << "rem   ClientVolumeToRealInstance ["
+                                     << clientVolume.first.first << ", "
+                                     << clientVolume.first.second << "] "
+                                     << clientVolume.second.GetRealInstanceId()
+                                     << Endl;
+                            }
+                            return erase;
+                        });
+                    Cerr << "trim  ClientToRealInstance       size "
+                         << ClientToRealInstance.size() << Endl;
+                    Cerr << "trim  ClientVolumeToRealInstance size "
+                         << ClientVolumeToRealInstance.size() << Endl;
                     return true;
                 }
                 return false;

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -472,6 +472,12 @@ class TVolumeStats final
         TRealInstanceKeyHash,
         TRealInstanceKeyEqual>;
 
+    /*
+    using TVolumeMap = std::unordered_map<
+        TString,   // ClientId
+        TVolumeInfoPtr>;
+    */
+
     struct TVolumeInfoHolder
     {
         TVolumeBasePtr VolumeBase;
@@ -579,18 +585,28 @@ public:
 
         TVolumeMap& infos = volumeIt->second.VolumeInfos;
 
-        auto instanceIt = infos.find(realInstanceId);
-        if (instanceIt == infos.end()) {
-            instanceIt = infos.emplace(
-                realInstanceId,
-                RegisterInstance(
-                    volumeIt->second.VolumeBase,
-                    realInstanceId)).first;
+        auto volumeInfoIt = infos.find(realInstanceId);
+        if (volumeInfoIt == infos.end()) {
+            auto volumeInfo =
+                RegisterInstance(volumeIt->second.VolumeBase, realInstanceId);
+            volumeInfoIt = infos.emplace(realInstanceId, volumeInfo).first;
             inserted = true;
-            instanceIt->second->PinCount = pinCountForNewInstance;
+            volumeInfoIt->second->PinCount = pinCountForNewInstance;
         }
 
-        instanceIt->second->LastRemountTime = Timer->Now();
+        /*
+        auto volumeInfoIt = infos.find(realInstanceId.GetClientId());
+        if (volumeInfoIt == infos.end()) {
+            auto volumeInfo =
+                RegisterInstance(volumeIt->second.VolumeBase, realInstanceId);
+            volumeInfoIt =
+                infos.emplace(realInstanceId.GetClientId(), volumeInfo).first;
+            inserted = true;
+            volumeInfoIt->second->PinCount = pinCountForNewInstance;
+        }
+        */
+
+        volumeInfoIt->second->LastRemountTime = Timer->Now();
 
         if (!inserted) {
             AlterVolumeImpl(
@@ -609,15 +625,20 @@ public:
     {
         TWriteGuard guard(Lock);
 
-        auto [itr, result] = ClientToRealInstance.try_emplace(
-            clientId,
-            clientId,
-            instanceId);
+        auto [itr, result] =
+            ClientToRealInstance.try_emplace(clientId, clientId, instanceId);
 
         return MountVolumeImpl(
             volume,
             itr->second,
             0 /* pinCountForNewInstance */);
+
+        /*
+        return MountVolumeImpl(
+            volume,
+            TRealInstanceId{clientId, instanceId},
+            0); // pinCountForNewInstance
+        */
     }
 
     void UnmountVolume(
@@ -694,6 +715,21 @@ public:
         }
 
         const TVolumeMap& infos = volumeIt->second.VolumeInfos;
+        /*
+        if (DiagnosticsConfig->GetEnableDurableVolumeInfo()) {
+            const auto infoIt = std::ranges::find_if(
+                infos,
+                [&](const auto& info)
+                {
+                    return info.second->RealInstanceId.GetClientId() ==
+                           clientId;
+                });
+            if (infoIt == infos.end()) {
+                return nullptr;
+            }
+            return infoIt->second;
+        }
+        */
         const auto realInstanceIt = ClientToRealInstance.find(clientId);
         if (realInstanceIt == ClientToRealInstance.end()) {
             return nullptr;

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -475,12 +475,6 @@ class TVolumeStats final
         TRealInstanceKeyHash,
         TRealInstanceKeyEqual>;
 
-    /*
-    using TVolumeMap = std::unordered_map<
-        TString,   // ClientId
-        TVolumeInfoPtr>;
-    */
-
     struct TVolumeInfoHolder
     {
         TVolumeBasePtr VolumeBase;
@@ -542,7 +536,6 @@ private:
 
     std::unordered_map<TClientVolume, TRealInstanceId>
         ClientVolumeToRealInstance;
-    std::unordered_map<TString, TRealInstanceId> ClientToRealInstance;
     TVolumeHolderMap Volumes;
     TRWMutex Lock;
 
@@ -597,23 +590,7 @@ public:
             volumeInfoIt = infos.emplace(realInstanceId, volumeInfo).first;
             inserted = true;
             volumeInfoIt->second->PinCount = pinCountForNewInstance;
-            Cerr << "add volumeInfo " << volume.GetDiskId()
-                 << " with realInstanceId "
-                 << volumeInfoIt->second->RealInstanceId.GetRealInstanceId()
-                 << Endl;
         }
-
-        /*
-        auto volumeInfoIt = infos.find(realInstanceId.GetClientId());
-        if (volumeInfoIt == infos.end()) {
-            auto volumeInfo =
-                RegisterInstance(volumeIt->second.VolumeBase, realInstanceId);
-            volumeInfoIt =
-                infos.emplace(realInstanceId.GetClientId(), volumeInfo).first;
-            inserted = true;
-            volumeInfoIt->second->PinCount = pinCountForNewInstance;
-        }
-        */
 
         volumeInfoIt->second->LastRemountTime = Timer->Now();
 
@@ -634,39 +611,16 @@ public:
     {
         TWriteGuard guard(Lock);
 
-        auto [itr, result] =
-            ClientToRealInstance.try_emplace(clientId, clientId, instanceId);
-        Y_UNUSED(itr);
-
         const auto& diskId = NStorage::GetLogicalDiskId(volume.GetDiskId());
         auto [it, _] = ClientVolumeToRealInstance.try_emplace(
             {clientId, diskId},
             clientId,
             instanceId);
-        Y_UNUSED(it);
-
-        Cerr << "mount ClientToRealInstance       size "
-             << ClientToRealInstance.size() << Endl;
-        Cerr << "mount ClientVolumeToRealInstance size "
-             << ClientVolumeToRealInstance.size() << Endl;
-
-        if (_) {
-            Cerr << "add   ClientVolumeToRealInstance [" << it->first.first
-                 << ", " << it->first.second << "] "
-                 << it->second.GetRealInstanceId() << Endl;
-        }
 
         return MountVolumeImpl(
             volume,
             it->second,
-            0);   // pinCountForNewInstance
-
-        /*
-        return MountVolumeImpl(
-            volume,
-            TRealInstanceId{clientId, instanceId},
-            0); // pinCountForNewInstance
-        */
+            0 /* pinCountForNewInstance */);
     }
 
     void UnmountVolume(
@@ -743,45 +697,15 @@ public:
         }
 
         const TVolumeMap& infos = volumeIt->second.VolumeInfos;
-        /*
-        if (DiagnosticsConfig->GetEnableDurableVolumeInfo()) {
-            const auto infoIt = std::ranges::find_if(
-                infos,
-                [&](const auto& info)
-                {
-                    return info.second->RealInstanceId.GetClientId() ==
-                           clientId;
-                });
-            if (infoIt == infos.end()) {
-                return nullptr;
-            }
-            return infoIt->second;
-        }
-        */
-
-        /*
-        const auto realInstanceIt = ClientToRealInstance.find(clientId);
-        if (realInstanceIt == ClientToRealInstance.end()) {
-            return nullptr;
-        }
-        const auto infoIt = infos.find(realInstanceIt->second);
-        if (infoIt == infos.end()) {
-            return nullptr;
-        }
-        return infoIt->second;
-        */
 
         const auto realInstanceIt =
             ClientVolumeToRealInstance.find(std::tie(clientId, diskId));
+
         if (realInstanceIt == ClientVolumeToRealInstance.end()) {
-            Cerr << "unknown [" << clientId << ", " << diskId << "]" << Endl;
             return nullptr;
         }
         const auto infoIt = infos.find(realInstanceIt->second);
         if (infoIt == infos.end()) {
-            Cerr << "no volumeInfo for [" << clientId << ", " << diskId
-                 << "] with realInstanceId "
-                 << realInstanceIt->second.GetRealInstanceId() << Endl;
             return nullptr;
         }
         return infoIt->second;
@@ -903,14 +827,6 @@ public:
 
                 if (removeInstance) {
                     UnregisterInstance(info.VolumeBase, info.RealInstanceId);
-                    std::erase_if(
-                        ClientToRealInstance,
-                        [&info](const auto& client)
-                        {
-                            return TRealInstanceKeyEqual()(
-                                client.second,
-                                info.RealInstanceId);
-                        });
 
                     const auto& diskId = info.VolumeBase->Volume.GetDiskId();
                     std::erase_if(
@@ -922,19 +838,8 @@ public:
                                 TRealInstanceKeyEqual()(
                                     clientVolume.second,
                                     info.RealInstanceId);
-                            if (erase) {
-                                Cerr << "rem   ClientVolumeToRealInstance ["
-                                     << clientVolume.first.first << ", "
-                                     << clientVolume.first.second << "] "
-                                     << clientVolume.second.GetRealInstanceId()
-                                     << Endl;
-                            }
                             return erase;
                         });
-                    Cerr << "trim  ClientToRealInstance       size "
-                         << ClientToRealInstance.size() << Endl;
-                    Cerr << "trim  ClientVolumeToRealInstance size "
-                         << ClientVolumeToRealInstance.size() << Endl;
                     return true;
                 }
                 return false;

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1690,6 +1690,89 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             UNIT_ASSERT(!client2Info);
         }
     }
+
+    Y_UNIT_TEST(ShouldProperlyAccountSeveralVolumesForSingleClient)
+    {
+        // Notes: single clientId allowed to mount volumes only under single
+        // instanceId (may be empty) - see TVolumeStats::ClientToRealInstance
+
+        auto inactivityTimeout = TDuration::MilliSeconds(10);
+
+        auto monitoring = CreateMonitoringServiceStub();
+        auto counters = monitoring->GetCounters()
+                            ->GetSubgroup("counters", "blockstore")
+                            ->GetSubgroup("component", "server_volume");
+
+        NProto::TDiagnosticsConfig config;
+        // Proper accounting is under EnableDurableVolumeInfo flag
+        // until considered functional
+        config.SetEnableDurableVolumeInfo(true);
+
+        std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            std::make_shared<TDiagnosticsConfig>(config),
+            inactivityTimeout,
+            EVolumeStatsType::EServerStats,
+            Timer);
+
+        // Initial mount
+        {
+            Mount(volumeStats, "disk-1", "client-1", "instance-1");
+            Mount(volumeStats, "disk-2", "client-1", "instance-1");
+            Mount(volumeStats, "disk-3", "client-1", "instance-1");
+
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-3", "client-1"));
+        }
+
+        // Remove volumes one by one by timeout, the rest must remain
+
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
+
+            // Mount(volumeStats, "disk-1", "client-1", "instance-1" );
+            Mount(volumeStats, "disk-2", "client-1", "instance-1");
+            Mount(volumeStats, "disk-3", "client-1", "instance-1");
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-3", "client-1"));
+        }
+
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
+
+            // Mount(volumeStats, "disk-1", "client-1", "instance-1" );
+            Mount(volumeStats, "disk-2", "client-1", "instance-1");
+            // Mount(volumeStats, "disk-3", "client-1", "instance-1" );
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-1"));
+        }
+
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
+
+            // Mount(volumeStats, "disk-1", "client-1", "instance-1" );
+            // Mount(volumeStats, "disk-2", "client-1", "instance-1" );
+            // Mount(volumeStats, "disk-3", "client-1", "instance-1" );
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-1"));
+        }
+    }
+
     /*
     Y_UNIT_TEST(
         ShouldProperlyAccountSeveralMountedVolumesForSameAndDifferentClients)
@@ -1699,7 +1782,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         auto monitoring = CreateMonitoringServiceStub();
         auto counters = monitoring
                             ->GetCounters()
-                            //->GetSubgroup("counters", "blockstore")
+                            ->GetSubgroup("counters", "blockstore")
                             ->GetSubgroup("component", "server_volume");
 
         NProto::TDiagnosticsConfig config;

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1666,9 +1666,10 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         {
             auto client1Info = volumeStats->GetVolumeInfo("Disk-1", "Client-1");
             auto client2Info = volumeStats->GetVolumeInfo("Disk-1", "Client-2");
-            // Information about all clients is kept until volume is unmounted
-            // (trimmed) even if threre are no mount requests form some clients
-            // during inactivityTimeout
+            // Note: information about all volume clients is kept until volume
+            // is unmounted (trimmed) even if threre are no mount requests form
+            // some clients during inactivityTimeout, and VolumeInfo can be
+            // obtained for such inactive client while exists
             UNIT_ASSERT_EQUAL(client1Info.get(), client2Info.get());
             UNIT_ASSERT(client1Info);
         }
@@ -1691,11 +1692,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldProperlyAccountSeveralVolumesForSingleClient)
+    Y_UNIT_TEST(ShouldProperlyAccountSeveralVolumesForSameClient)
     {
-        // Notes: single clientId allowed to mount volumes only under single
-        // instanceId (may be empty) - see TVolumeStats::ClientToRealInstance
-
         auto inactivityTimeout = TDuration::MilliSeconds(10);
 
         auto monitoring = CreateMonitoringServiceStub();
@@ -1704,9 +1702,6 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
                             ->GetSubgroup("component", "server_volume");
 
         NProto::TDiagnosticsConfig config;
-        // Proper accounting is under EnableDurableVolumeInfo flag
-        // until considered functional
-        config.SetEnableDurableVolumeInfo(true);
 
         std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
 
@@ -1717,11 +1712,13 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             EVolumeStatsType::EServerStats,
             Timer);
 
+        // clang-format off
+
         // Initial mount
         {
             Mount(volumeStats, "disk-1", "client-1", "instance-1");
-            Mount(volumeStats, "disk-2", "client-1", "instance-1");
-            Mount(volumeStats, "disk-3", "client-1", "instance-1");
+            Mount(volumeStats, "disk-2", "client-1", "instance-2");
+            Mount(volumeStats, "disk-3", "client-1", "instance-3");
 
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-1"));
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
@@ -1740,8 +1737,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             volumeStats->TrimVolumes();
 
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
-            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
-            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-3", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
         }
 
         {
@@ -1754,7 +1751,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             volumeStats->TrimVolumes();
 
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
-            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-1"));
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-1"));
         }
 
@@ -1771,11 +1768,10 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-1"));
         }
+        // clang-format on
     }
 
-    /*
-    Y_UNIT_TEST(
-        ShouldProperlyAccountSeveralMountedVolumesForSameAndDifferentClients)
+    Y_UNIT_TEST(ShouldProperlyAccountSeveralVolumesForSameAndDifferentClients)
     {
         auto inactivityTimeout = TDuration::MilliSeconds(10);
 
@@ -1786,9 +1782,6 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
                             ->GetSubgroup("component", "server_volume");
 
         NProto::TDiagnosticsConfig config;
-        // Proper accounting is under EnableDurableVolumeInfo flag
-        // until considered functional
-        config.SetEnableDurableVolumeInfo(true);
 
         std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
 
@@ -1803,12 +1796,17 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
 
         // Initial mount
         {
-            Mount(volumeStats, "disk-1", "client-1", ""           );
+            Mount(volumeStats, "disk-1", "client-1", "" );
             Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
-            Mount(volumeStats, "disk-1", "client-2", ""           );
+
+            Mount(volumeStats, "disk-1", "client-2", "" );
             Mount(volumeStats, "disk-2", "client-2", "instance-1" );
             Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            Mount(volumeStats, "disk-1", "client-3", "instance-1" );
+            Mount(volumeStats, "disk-2", "client-3", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-3", "instance-1" );
 
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-1"));
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
@@ -1816,81 +1814,156 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-2"));
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-2"));
             UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-3", "client-2"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-3"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-3"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-3", "client-3"));
         }
 
-        // Remove some volumes by timeout, the rest must remain
+        // Remove some volumes by timeout,
+        // every still existing [diskId, instanceId] combination must remain
+
+        // Note: information about all volume clients is kept until volume
+        // is unmounted (trimmed) even if threre are no mount requests form
+        // some clients during inactivityTimeout, and VolumeInfo can be obtained
+        // for such inactive client while exists
 
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
-            Mount(volumeStats, "disk-1", "client-1", ""           );
+            Mount(volumeStats, "disk-1", "client-1", "" );
             //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+
             Mount(volumeStats, "disk-1", "client-2", ""           );
             Mount(volumeStats, "disk-2", "client-2", "instance-1" );
             Mount(volumeStats, "disk-3", "client-2", "instance-2" );
 
+            Mount(volumeStats, "disk-1", "client-3", "instance-1" );
+            Mount(volumeStats, "disk-2", "client-3", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-3", "instance-1" );
+
             volumeStats->TrimVolumes();
 
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-1", "client-1"));
-            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-1"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-1", "client-2"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-2"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-1", "client-3"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-3"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-3"));
         }
 
+        // Keep:
+        //  - [disk-3, instance-2]
+        //  - [disk-2, instance-1]
+        //  - [disk-1, instance-1]
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
             //Mount(volumeStats, "disk-1", "client-1", ""           );
             //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+
             //Mount(volumeStats, "disk-1", "client-2", ""           );
             Mount(volumeStats, "disk-2", "client-2", "instance-1" );
             Mount(volumeStats, "disk-3", "client-2", "instance-2" );
 
+            Mount(volumeStats, "disk-1", "client-3", "instance-1" );
+            Mount(volumeStats, "disk-2", "client-3", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
+
             volumeStats->TrimVolumes();
 
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
-            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-1"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-2"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-2"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-1", "client-3"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-3"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-3"));
         }
 
+        // Keep:
+        //  - [disk-3, instance-2]
+        //  - [disk-2, instance-1]
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
             //Mount(volumeStats, "disk-1", "client-1", ""           );
             //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+
             //Mount(volumeStats, "disk-1", "client-2", ""           );
             Mount(volumeStats, "disk-2", "client-2", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+            Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            //Mount(volumeStats, "disk-1", "client-3", "instance-1" );
+            Mount(volumeStats, "disk-2", "client-3", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
 
             volumeStats->TrimVolumes();
 
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
-            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-1"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-2"));
             UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-2"));
-            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-2"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-3"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-3"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-3"));
         }
 
-        // Remove rest volumes by timeout, none must remain
+        // Keep:
+        //  - [disk-3, instance-2]
+        //  - [disk-2, instance-1]
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
 
+            //Mount(volumeStats, "disk-1", "client-1", ""           );
+            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+
+            //Mount(volumeStats, "disk-1", "client-2", ""           );
+            Mount(volumeStats, "disk-2", "client-2", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            //Mount(volumeStats, "disk-1", "client-3", "instance-1" );
+            //Mount(volumeStats, "disk-2", "client-3", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-2"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-3"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-3"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-3"));
+        }
+
+        // Keep none
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
             //Mount(volumeStats, "disk-1", "client-1", ""           );
             //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             //Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+
             //Mount(volumeStats, "disk-1", "client-2", ""           );
             //Mount(volumeStats, "disk-2", "client-2", "instance-1" );
             //Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            //Mount(volumeStats, "disk-1", "client-3", "instance-1" );
+            //Mount(volumeStats, "disk-2", "client-3", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
 
             volumeStats->TrimVolumes();
 
@@ -1900,11 +1973,14 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-2"));
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-2"));
             UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-2"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-3"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-3"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-3"));
         }
 
         // clang-format on
     }
-    */
+
     Y_UNIT_TEST(ShouldSkipReportingZeroBlocksMetricsForYDBBasedDisks)
     {
         auto monitoring = CreateMonitoringServiceStub();

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1730,7 +1730,6 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
-            // Mount(volumeStats, "disk-1", "client-1", "instance-1" );
             Mount(volumeStats, "disk-2", "client-1", "instance-1");
             Mount(volumeStats, "disk-3", "client-1", "instance-1");
 
@@ -1744,9 +1743,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
-            // Mount(volumeStats, "disk-1", "client-1", "instance-1" );
             Mount(volumeStats, "disk-2", "client-1", "instance-1");
-            // Mount(volumeStats, "disk-3", "client-1", "instance-1" );
 
             volumeStats->TrimVolumes();
 
@@ -1757,10 +1754,6 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
 
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
-
-            // Mount(volumeStats, "disk-1", "client-1", "instance-1" );
-            // Mount(volumeStats, "disk-2", "client-1", "instance-1" );
-            // Mount(volumeStats, "disk-3", "client-1", "instance-1" );
 
             volumeStats->TrimVolumes();
 
@@ -1827,11 +1820,12 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         // some clients during inactivityTimeout, and VolumeInfo can be obtained
         // for such inactive client while exists
 
+        // Keep:
+        //  - all
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
             Mount(volumeStats, "disk-1", "client-1", "" );
-            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
 
             Mount(volumeStats, "disk-1", "client-2", ""           );
@@ -1862,17 +1856,13 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
-            //Mount(volumeStats, "disk-1", "client-1", ""           );
-            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
 
-            //Mount(volumeStats, "disk-1", "client-2", ""           );
             Mount(volumeStats, "disk-2", "client-2", "instance-1" );
             Mount(volumeStats, "disk-3", "client-2", "instance-2" );
 
             Mount(volumeStats, "disk-1", "client-3", "instance-1" );
             Mount(volumeStats, "disk-2", "client-3", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
 
             volumeStats->TrimVolumes();
 
@@ -1893,17 +1883,12 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
-            //Mount(volumeStats, "disk-1", "client-1", ""           );
-            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
 
-            //Mount(volumeStats, "disk-1", "client-2", ""           );
             Mount(volumeStats, "disk-2", "client-2", "instance-1" );
             Mount(volumeStats, "disk-3", "client-2", "instance-2" );
 
-            //Mount(volumeStats, "disk-1", "client-3", "instance-1" );
             Mount(volumeStats, "disk-2", "client-3", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
 
             volumeStats->TrimVolumes();
 
@@ -1924,17 +1909,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
 
-            //Mount(volumeStats, "disk-1", "client-1", ""           );
-            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
             Mount(volumeStats, "disk-3", "client-1", "instance-2" );
 
-            //Mount(volumeStats, "disk-1", "client-2", ""           );
             Mount(volumeStats, "disk-2", "client-2", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-2", "instance-2" );
-
-            //Mount(volumeStats, "disk-1", "client-3", "instance-1" );
-            //Mount(volumeStats, "disk-2", "client-3", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
 
             volumeStats->TrimVolumes();
 
@@ -1952,18 +1929,6 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         // Keep none
         {
             Timer->AdvanceTime(inactivityTimeout * 1.1);
-
-            //Mount(volumeStats, "disk-1", "client-1", ""           );
-            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-1", "instance-2" );
-
-            //Mount(volumeStats, "disk-1", "client-2", ""           );
-            //Mount(volumeStats, "disk-2", "client-2", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-2", "instance-2" );
-
-            //Mount(volumeStats, "disk-1", "client-3", "instance-1" );
-            //Mount(volumeStats, "disk-2", "client-3", "instance-1" );
-            //Mount(volumeStats, "disk-3", "client-3", "instance-1" );
 
             volumeStats->TrimVolumes();
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1667,7 +1667,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             auto client1Info = volumeStats->GetVolumeInfo("Disk-1", "Client-1");
             auto client2Info = volumeStats->GetVolumeInfo("Disk-1", "Client-2");
             // Note: information about all volume clients is kept until volume
-            // is unmounted (trimmed) even if threre are no mount requests form
+            // is unmounted (trimmed) even if there are no mount requests form
             // some clients during inactivityTimeout, and VolumeInfo can be
             // obtained for such inactive client while exists
             UNIT_ASSERT_EQUAL(client1Info.get(), client2Info.get());
@@ -1823,7 +1823,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         // every still existing [diskId, instanceId] combination must remain
 
         // Note: information about all volume clients is kept until volume
-        // is unmounted (trimmed) even if threre are no mount requests form
+        // is unmounted (trimmed) even if there are no mount requests form
         // some clients during inactivityTimeout, and VolumeInfo can be obtained
         // for such inactive client while exists
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -117,7 +117,8 @@ void Mount(
     const TString& name,
     const TString& client,
     const TString& instance,
-    NCloud::NProto::EStorageMediaKind mediaKind)
+    NCloud::NProto::EStorageMediaKind mediaKind =
+        NCloud::NProto::STORAGE_MEDIA_SSD)
 {
     NProto::TVolume volume;
     volume.SetDiskId(name);
@@ -1679,7 +1680,138 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             UNIT_ASSERT(!client1Info);
         }
     }
+    /*
+    Y_UNIT_TEST(
+        ShouldProperlyAccountSeveralMountedVolumesForSameAndDifferentClients)
+    {
+        auto inactivityTimeout = TDuration::MilliSeconds(10);
 
+        auto monitoring = CreateMonitoringServiceStub();
+        auto counters = monitoring
+                            ->GetCounters()
+                            //->GetSubgroup("counters", "blockstore")
+                            ->GetSubgroup("component", "server_volume");
+
+        NProto::TDiagnosticsConfig config;
+        // Proper accounting is under EnableDurableVolumeInfo flag
+        // until considered functional
+        config.SetEnableDurableVolumeInfo(true);
+
+        std::shared_ptr<TTestTimer> Timer = std::make_shared<TTestTimer>();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            std::make_shared<TDiagnosticsConfig>(config),
+            inactivityTimeout,
+            EVolumeStatsType::EServerStats,
+            Timer);
+
+        // clang-format off
+
+        // Initial mount
+        {
+            Mount(volumeStats, "disk-1", "client-1", ""           );
+            Mount(volumeStats, "disk-2", "client-1", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+            Mount(volumeStats, "disk-1", "client-2", ""           );
+            Mount(volumeStats, "disk-2", "client-2", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-3", "client-1"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-1", "client-2"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-2", "client-2"));
+            UNIT_ASSERT(volumeStats->GetVolumeInfo("disk-3", "client-2"));
+        }
+
+        // Remove some volumes by timeout, the rest must remain
+
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
+
+            Mount(volumeStats, "disk-1", "client-1", ""           );
+            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+            Mount(volumeStats, "disk-1", "client-2", ""           );
+            Mount(volumeStats, "disk-2", "client-2", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-1", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-2"));
+        }
+
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
+
+            //Mount(volumeStats, "disk-1", "client-1", ""           );
+            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+            //Mount(volumeStats, "disk-1", "client-2", ""           );
+            Mount(volumeStats, "disk-2", "client-2", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-2"));
+        }
+
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
+
+            //Mount(volumeStats, "disk-1", "client-1", ""           );
+            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
+            Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+            //Mount(volumeStats, "disk-1", "client-2", ""           );
+            Mount(volumeStats, "disk-2", "client-2", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-3", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-2"));
+            UNIT_ASSERT( volumeStats->GetVolumeInfo("disk-2", "client-2"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-2"));
+        }
+
+        // Remove rest volumes by timeout, none must remain
+
+        {
+            Timer->AdvanceTime(inactivityTimeout * 1.1);
+
+            //Mount(volumeStats, "disk-1", "client-1", ""           );
+            //Mount(volumeStats, "disk-2", "client-1", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-1", "instance-2" );
+            //Mount(volumeStats, "disk-1", "client-2", ""           );
+            //Mount(volumeStats, "disk-2", "client-2", "instance-1" );
+            //Mount(volumeStats, "disk-3", "client-2", "instance-2" );
+
+            volumeStats->TrimVolumes();
+
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-1"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-1", "client-2"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-2", "client-2"));
+            UNIT_ASSERT(!volumeStats->GetVolumeInfo("disk-3", "client-2"));
+        }
+
+        // clang-format on
+    }
+    */
     Y_UNIT_TEST(ShouldSkipReportingZeroBlocksMetricsForYDBBasedDisks)
     {
         auto monitoring = CreateMonitoringServiceStub();

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1638,7 +1638,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->FindSubgroup("folder", DefaultFolderId));
 
         {
-            auto client1Info = volumeStats->GetVolumeInfo("Disk-1", "Client-2");
+            auto client1Info = volumeStats->GetVolumeInfo("Disk-1", "Client-1");
             auto client2Info = volumeStats->GetVolumeInfo("Disk-1", "Client-2");
             UNIT_ASSERT_EQUAL(client1Info.get(), client2Info.get());
             UNIT_ASSERT(client1Info);
@@ -1663,6 +1663,16 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("cloud", DefaultCloudId)
             ->FindSubgroup("folder", DefaultFolderId));
 
+        {
+            auto client1Info = volumeStats->GetVolumeInfo("Disk-1", "Client-1");
+            auto client2Info = volumeStats->GetVolumeInfo("Disk-1", "Client-2");
+            // Information about all clients is kept until volume is unmounted
+            // (trimmed) even if threre are no mount requests form some clients
+            // during inactivityTimeout
+            UNIT_ASSERT_EQUAL(client1Info.get(), client2Info.get());
+            UNIT_ASSERT(client1Info);
+        }
+
         Timer->AdvanceTime(inactivityTimeout * 1.1);
         volumeStats->TrimVolumes();
 
@@ -1674,10 +1684,10 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->FindSubgroup("folder", DefaultFolderId));
 
         {
-            auto client1Info = volumeStats->GetVolumeInfo("Disk-1", "Client-2");
+            auto client1Info = volumeStats->GetVolumeInfo("Disk-1", "Client-1");
             auto client2Info = volumeStats->GetVolumeInfo("Disk-1", "Client-2");
-            UNIT_ASSERT_EQUAL(client1Info.get(), client2Info.get());
             UNIT_ASSERT(!client1Info);
+            UNIT_ASSERT(!client2Info);
         }
     }
     /*


### PR DESCRIPTION
### Notes

**Was**

ClientId-InstanceId accounting for all volumes was implemented via unordered_map<clientId, {realInstanceId}> - TVolumeStats::ClientToRealInstance. ClientId-InstanceId pair was fixed for all volumes, mounted by client. ClientToRealInstance mapping was used for quick search of VolumeInfo in TVolumeStats::GetVolumeInfo(clientId, diskId). ClientToRealInstance records were erased on VolumeInfo remove by timeout (TrimInstance()).

This leads to errors in case of single client mounted several volumes: when VolimeInfo for one volume was removed by timeout, corresponding ClientId record was removed from TVolumeStats::ClientToRealInstance map, and because of that VolumeInfo for still mounted volumes became unavailable for some time (could be accessed via TVolumeStats::GetVolumeInfo()) until next periodic remount of still mounted volumes was performed (up to 4 seconds).
Error consequences:
1. With EnableDurableVolumeInfo flag set to false, statistics for still mounted volumes was lost (was not generated) during this period (e.g. inside of TServerStats::PrepareMetricRequest())
2. With EnableDurableVolumeInfo flag set to true, VolumeInfo could not be unpinned during this period

Also, single client (unique clientId) was implicitly allowed to mount all volumes only with single instanceId (empty or not) according to TVolumeStats::ClientToRealInstance implementation. In case of mount new volume with different instanceId, existing instanceId, assosiated with clientId, was applied to new volume - TVolumeStats::MountVolume() { ... ClientToRealInstance.try_emplace() ... }

**Now**

1. ClientId-InstanceId accounting replaced with TVolumeStats::ClientToRealInstance, which now includes diskId - unordered_map<{clientId, diskId}, {realInstanceId}>.
2. VolumeInfo availability is ensured continuously in case of single client mount/unmount several volumes.
3. Single client (unique clientId) is allowed to mount different volumes with different instanceId.