### PR TITLE
[Filestore] add filesystem info to the filestore monpage in HandleHttpInfo_Default

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1134,6 +1134,11 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         TAG(TH3) { out << "Stats"; }
         PRE() { DumpStats(out); }
 
+        TAG(TH3) { out << "FileSystem info"; }
+        COLLAPSED_BUTTON_CONTENT("filesystem-info", "Show") {
+            PRE() { out << GetFileSystem().DebugString(); }
+        }
+
         const ui32 topSize = FromStringWithDefault(params.Get("top-size"), 1);
         TAG(TH3) { out << "CompactionMap"; }
         DumpCompactionMap(out, TabletID(), GetCompactionMapStats(topSize));


### PR DESCRIPTION
### Notes
Looks like this:

*  <img width="300" height="106" alt="image" src="https://github.com/user-attachments/assets/f353189d-b56a-43ba-a02a-58e844ce155e" />

* <img width="493" height="547" alt="image" src="https://github.com/user-attachments/assets/5f5f8675-5d35-4b9e-b47b-460e31a5714c" />


### Issue
Put links to the related issues here
