### PR TITLE
issue-5826: [Filestore] reject hard links from shard directories to main filesystem nodes

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -54,6 +54,7 @@ namespace NCloud::NFileStore{
     xxx(NodeCacheInvalidNode)                                                  \
     xxx(ConfirmBlobsFailed)                                                    \
     xxx(UnconfirmedFlowProxyRetryThresholdReached)                             \
+    xxx(HardLinkFromShardDirToMainTabletNode)                                  \
 // FILESTORE_CRITICAL_EVENTS
 
 #define FILESTORE_CRITICAL_EVENTS_WITHOUT_LOGGING(xxx)                         \

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -368,6 +368,17 @@ void TStorageServiceActor::HandleCreateNode(
                 std::move(error));
             return NCloud::Reply(ctx, *ev, std::move(response));
         }
+        if (!shardId &&
+            ExtractShardNoSafe(filestore, msg->Record.GetNodeId()) != 0)
+        {
+            // TODO(#5826): remove this check and support hard links from shards
+            // directories to main filesystem
+            auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
+                ErrorNotSupported(
+                    "hard links from shard directories to main filesystem nodes"
+                    " are not supported"));
+            return NCloud::Reply(ctx, *ev, std::move(response));
+        }
         if (shardId) {
             // If the target node is located on a shard, start a worker actor
             // to separately increment the link count in the shard and insert

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -373,6 +373,7 @@ void TStorageServiceActor::HandleCreateNode(
         {
             // TODO(#5826): remove this check and support hard links from shards
             // directories to main filesystem
+            ReportHardLinkFromShardDirToMainTabletNode();
             auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
                 ErrorNotSupported(
                     "hard links from shard directories to main filesystem nodes"

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5560,6 +5560,67 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             TCreateNodeArgs::Link(dirId, "link1", file1Id));
     }
 
+    // See #5826 for more details
+    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+        ShouldRejectHardLinkFromShardDirToMainTabletNode)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+        config.SetAutomaticShardCreationEnabled(true);
+
+        const TString fsId = "test";
+        const ui64 blockCount = 1'000;
+
+        TTestEnv env({}, config);
+        ui32 nodeIdx = env.AddDynamicNode();
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        // Create a single-tablet filesystem (no shards yet; default
+        // AutomaticallyCreatedShardSize is 5TB, so none are created).
+        service.CreateFileStore(fsId, blockCount);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        // File created before shards exist — lives in the main tablet,
+        // shardNo == 0 even after shards are added later.
+        const auto fileId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_EQUAL(0, ExtractShardNo(fileId));
+
+        // Add two shards and enable DirectoryCreationInShards.
+        service.ResizeFileStore(
+            fsId,
+            blockCount,
+            false /* force */,
+            2 /* shardCount */,
+            false /* enableStrictSizeMode */,
+            true /* directoryCreationInShards */);
+        WaitForTabletStart(service);
+
+        headers = service.InitSession(fsId, "client");
+
+        const auto dirId =
+            service
+                .CreateNode(
+                    headers,
+                    TCreateNodeArgs::Directory(RootNodeId, "dir"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(dirId));
+
+        // Linking a main-tablet node into a shard directory is not yet
+        // supported and must return E_FS_NOTSUPP.
+        auto response = service.SendAndRecvCreateNode(
+            headers,
+            TCreateNodeArgs::Link(dirId, "link", fileId));
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_FS_NOTSUPP,
+            response->GetError().GetCode(),
+            response->GetError().GetMessage());
+    }
+
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldListNodesAndGetNodeAttrInDirectoryInShard)
     {

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5610,6 +5610,13 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                 .GetId();
         UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(dirId));
 
+        const auto counters =
+            env.GetCounters()->FindSubgroup("component", "service");
+        UNIT_ASSERT(counters);
+        const auto counter = counters->GetCounter(
+            "AppCriticalEvents/HardLinkFromShardDirToMainTabletNode");
+        UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
+
         // Linking a main-tablet node into a shard directory is not yet
         // supported and must return E_FS_NOTSUPP.
         auto response = service.SendAndRecvCreateNode(
@@ -5619,6 +5626,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             E_FS_NOTSUPP,
             response->GetError().GetCode(),
             response->GetError().GetMessage());
+
+        UNIT_ASSERT_VALUES_EQUAL(1, counter->GetAtomic());
     }
 
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(


### PR DESCRIPTION
### Notes
This is a quick patch to mask the problem in the linked issue, necessary before the issue is properly resolved

Example of this shortcut working:

```
$ touch a
$ filestore-client resize --filesystem nfs --shard-count 8 --blocks-count $[`numfmt --from iec 1T` / 4096]   
$ mkdir b
$ ls --inode 
2 a
144115188075855874 b
$ ln a c
# works since the target directory is in the main filesystem
$ ln a b/d
ln: failed to create hard link 'b/d' => 'a': Operation not supported
```



### Issue
#5826
