### PR TITLE
[Blockstore] Init RDMA without logging and monitoring usage

### DIFF
--- a/cloud/blockstore/libs/rdma/helper.cpp
+++ b/cloud/blockstore/libs/rdma/helper.cpp
@@ -1,29 +1,10 @@
 #include "helper.h"
 
-#include <cloud/storage/core/libs/diagnostics/logging.h>
-#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 #include <cloud/storage/core/libs/rdma/impl/client.h>
 #include <cloud/storage/core/libs/rdma/impl/server.h>
 #include <cloud/storage/core/libs/rdma/impl/verbs.h>
 
-#include <library/cpp/monlib/dynamic_counters/counters.h>
-
 namespace NCloud::NBlockStore::NRdma {
-
-namespace {
-
-////////////////////////////////////////////////////////////////////////////////
-
-NMonitoring::TDynamicCountersPtr CreateRdmaCounters(
-    IMonitoringServicePtr monitoring,
-    TString component)
-{
-    return monitoring->GetCounters()
-        ->GetSubgroup("counters", "blockstore")
-        ->GetSubgroup("component", std::move(component));
-}
-
-}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -34,8 +15,11 @@ NCloud::NStorage::NRdma::IClientPtr CreateRdmaClient(
 {
     return NCloud::NStorage::NRdma::CreateClient(
         NCloud::NStorage::NRdma::NVerbs::CreateVerbs(),
-        logging->CreateLog("BLOCKSTORE_RDMA"),
-        CreateRdmaCounters(std::move(monitoring), "rdma_client"),
+        std::move(logging),
+        std::move(monitoring),
+        "BLOCKSTORE_RDMA",
+        "blockstore",
+        "rdma_client",
         std::move(config));
 }
 
@@ -46,8 +30,11 @@ NCloud::NStorage::NRdma::IServerPtr CreateRdmaServer(
 {
     return NCloud::NStorage::NRdma::CreateServer(
         NCloud::NStorage::NRdma::NVerbs::CreateVerbs(),
-        logging->CreateLog("BLOCKSTORE_RDMA"),
-        CreateRdmaCounters(std::move(monitoring), "rdma_server"),
+        std::move(logging),
+        std::move(monitoring),
+        "BLOCKSTORE_RDMA",
+        "blockstore",
+        "rdma_server",
         std::move(config));
 }
 

--- a/cloud/blockstore/libs/rdma/ya.make
+++ b/cloud/blockstore/libs/rdma/ya.make
@@ -8,7 +8,6 @@ PEERDIR(
     cloud/storage/core/libs/diagnostics
     cloud/storage/core/libs/rdma/iface
     cloud/storage/core/libs/rdma/impl
-    library/cpp/monlib/dynamic_counters
 )
 
 END()

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -1814,10 +1814,15 @@ class TClient final
 private:
     NVerbs::IVerbsPtr Verbs;
 
-    TLog Log;
-    NMonitoring::TDynamicCountersPtr CountersGroup;
+    ILoggingServicePtr Logging;
+    IMonitoringServicePtr Monitoring;
+    TString LogComponent;
+    TString CountersGroupName;
+    TString CountersComponentName;
+
     TClientConfigPtr Config;
     TEndpointCountersPtr Counters;
+    TLog Log;
 
     TConnectionPollerPtr ConnectionPoller;
     TVector<TCompletionPollerPtr> CompletionPollers;
@@ -1825,8 +1830,11 @@ private:
 public:
     TClient(
         NVerbs::IVerbsPtr verbs,
-        TLog log,
-        NMonitoring::TDynamicCountersPtr counters,
+        ILoggingServicePtr logging,
+        IMonitoringServicePtr monitoring,
+        TString logComponent,
+        TString countersGroupName,
+        TString countersComponentName,
         TClientConfigPtr config);
 
     // called from external thread
@@ -1864,12 +1872,18 @@ private:
 
 TClient::TClient(
         NVerbs::IVerbsPtr verbs,
-        TLog log,
-        NMonitoring::TDynamicCountersPtr counters,
+        ILoggingServicePtr logging,
+        IMonitoringServicePtr monitoring,
+        TString logComponent,
+        TString countersGroupName,
+        TString countersComponentName,
         TClientConfigPtr config)
     : Verbs(std::move(verbs))
-    , Log(std::move(log))
-    , CountersGroup(std::move(counters))
+    , Logging(std::move(logging))
+    , Monitoring(std::move(monitoring))
+    , LogComponent(std::move(logComponent))
+    , CountersGroupName(std::move(countersGroupName))
+    , CountersComponentName(std::move(countersComponentName))
     , Config(std::move(config))
     , Counters(new TEndpointCounters())
 {
@@ -1880,9 +1894,14 @@ TClient::TClient(
 
 void TClient::Start() noexcept
 {
+    Log = Logging->CreateLog(LogComponent);
+
     RDMA_INFO("start client");
 
-    Counters->Register(*CountersGroup);
+    auto countersGroup = Monitoring->GetCounters()
+        ->GetSubgroup("counters", CountersGroupName)
+        ->GetSubgroup("component", CountersComponentName);
+    Counters->Register(*countersGroup);
 
     CompletionPollers.resize(Config->PollerThreads);
     for (size_t i = 0; i < CompletionPollers.size(); ++i) {
@@ -2414,14 +2433,20 @@ inline IOutputStream& operator<<(IOutputStream& out, TRecvWr* recv)
 
 IClientPtr CreateClient(
     NVerbs::IVerbsPtr verbs,
-    TLog log,
-    NMonitoring::TDynamicCountersPtr counters,
+    ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
+    TString logComponent,
+    TString countersGroupName,
+    TString countersComponentName,
     TClientConfigPtr config)
 {
     return std::make_shared<TClient>(
         std::move(verbs),
-        std::move(log),
-        std::move(counters),
+        std::move(logging),
+        std::move(monitoring),
+        std::move(logComponent),
+        std::move(countersGroupName),
+        std::move(countersComponentName),
         std::move(config));
 }
 

--- a/cloud/storage/core/libs/rdma/impl/client.h
+++ b/cloud/storage/core/libs/rdma/impl/client.h
@@ -10,8 +10,11 @@ namespace NCloud::NStorage::NRdma {
 
 IClientPtr CreateClient(
     NVerbs::IVerbsPtr verbs,
-    TLog log,
-    NMonitoring::TDynamicCountersPtr counters,
+    ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
+    TString logComponent,
+    TString countersGroupName,
+    TString countersComponentName,
     TClientConfigPtr config);
 
 }   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -31,10 +31,11 @@ IClientPtr CreateTestClient(
 {
     return CreateClient(
         std::move(verbs),
-        logging->CreateLog("RDMA_TEST"),
-        monitoring->GetCounters()
-            ->GetSubgroup("counters", "rdma")
-            ->GetSubgroup("component", "client"),
+        logging,
+        monitoring,
+        "RDMA_TEST",
+        "rdma",
+        "client",
         std::move(config));
 }
 

--- a/cloud/storage/core/libs/rdma/impl/server.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server.cpp
@@ -1494,10 +1494,15 @@ class TServer final
 private:
     NVerbs::IVerbsPtr Verbs;
 
-    TLog Log;
-    const NMonitoring::TDynamicCountersPtr CountersGroup;
+    ILoggingServicePtr Logging;
+    IMonitoringServicePtr Monitoring;
+    TString LogComponent;
+    TString CountersGroupName;
+    TString CountersComponentName;
+
     TServerConfigPtr Config;
     TEndpointCountersPtr Counters;
+    TLog Log;
 
     TVector<TServerEndpointPtr> Endpoints;
     TMutex EndpointsLock;
@@ -1508,8 +1513,11 @@ private:
 public:
     TServer(
         NVerbs::IVerbsPtr verbs,
-        TLog log,
-        NMonitoring::TDynamicCountersPtr counters,
+        ILoggingServicePtr logging,
+        IMonitoringServicePtr monitoring,
+        TString logComponent,
+        TString countersGroupName,
+        TString countersComponentName,
         TServerConfigPtr config);
 
     // called from external thread
@@ -1540,12 +1548,18 @@ private:
 
 TServer::TServer(
         NVerbs::IVerbsPtr verbs,
-        TLog log,
-        NMonitoring::TDynamicCountersPtr counters,
+        ILoggingServicePtr logging,
+        IMonitoringServicePtr monitoring,
+        TString logComponent,
+        TString countersGroupName,
+        TString countersComponentName,
         TServerConfigPtr config)
     : Verbs(std::move(verbs))
-    , Log(std::move(log))
-    , CountersGroup(std::move(counters))
+    , Logging(std::move(logging))
+    , Monitoring(std::move(monitoring))
+    , LogComponent(std::move(logComponent))
+    , CountersGroupName(std::move(countersGroupName))
+    , CountersComponentName(std::move(countersComponentName))
     , Config(std::move(config))
     , Counters(new TEndpointCounters())
 {
@@ -1556,9 +1570,14 @@ TServer::TServer(
 
 void TServer::Start()
 {
+    Log = Logging->CreateLog(LogComponent);
+
     RDMA_DEBUG("start server");
 
-    Counters->Register(*CountersGroup);
+    auto countersGroup = Monitoring->GetCounters()
+        ->GetSubgroup("counters", CountersGroupName)
+        ->GetSubgroup("component", CountersComponentName);
+    Counters->Register(*countersGroup);
 
     CompletionPollers.resize(Config->PollerThreads);
     for (size_t i = 0; i < CompletionPollers.size(); ++i) {
@@ -1974,14 +1993,20 @@ inline IOutputStream& operator<<(IOutputStream& out, TRecvWr* recv)
 
 IServerPtr CreateServer(
     NVerbs::IVerbsPtr verbs,
-    TLog log,
-    NMonitoring::TDynamicCountersPtr counters,
+    ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
+    TString logComponent,
+    TString countersGroupName,
+    TString countersComponentName,
     TServerConfigPtr config)
 {
     return std::make_shared<TServer>(
         std::move(verbs),
-        std::move(log),
-        std::move(counters),
+        std::move(logging),
+        std::move(monitoring),
+        std::move(logComponent),
+        std::move(countersGroupName),
+        std::move(countersComponentName),
         std::move(config));
 }
 

--- a/cloud/storage/core/libs/rdma/impl/server.h
+++ b/cloud/storage/core/libs/rdma/impl/server.h
@@ -10,8 +10,11 @@ namespace NCloud::NStorage::NRdma {
 
 IServerPtr CreateServer(
     NVerbs::IVerbsPtr verbs,
-    TLog log,
-    NMonitoring::TDynamicCountersPtr counters,
+    ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
+    TString logComponent,
+    TString countersGroupName,
+    TString countersComponentName,
     TServerConfigPtr config);
 
 }   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -30,10 +30,11 @@ IServerPtr CreateTestServer(
 {
     return CreateServer(
         std::move(verbs),
-        logging->CreateLog("RDMA_TEST"),
-        monitoring->GetCounters()
-            ->GetSubgroup("counters", "rdma")
-            ->GetSubgroup("component", "server"),
+        logging,
+        monitoring,
+        "RDMA_TEST",
+        "rdma",
+        "server",
         std::move(config));
 }
 


### PR DESCRIPTION
### Notes
Provide logging and monitoring tags to RDMA for later initialization
Remove log and monitoring initialization during RDMA init

### Issue
#5388
