### PR TITLE
Avoid using  Singleton<TGlobalLogsStorage>() in ~TLogBackend()

### DIFF
--- a/library/cpp/logger/backend.cpp
+++ b/library/cpp/logger/backend.cpp
@@ -1,22 +1,32 @@
 #include "backend.h"
-#include <util/generic/vector.h>
-#include <util/system/mutex.h>
+
 #include <util/generic/singleton.h>
+#include <util/generic/vector.h>
 #include <util/generic/yexception.h>
+#include <util/system/mutex.h>
 
 namespace {
-    class TGlobalLogsStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TGlobalLogsStorage
+{
+private:
+    class TImpl: public IGlobalLogsStorage
+    {
     private:
         TVector<TLogBackend*> Backends;
         TMutex Mutex;
 
     public:
-        void Register(TLogBackend* backend) {
+        void Register(TLogBackend* backend) override
+        {
             TGuard<TMutex> g(Mutex);
             Backends.push_back(backend);
         }
 
-        void UnRegister(TLogBackend* backend) {
+        void UnRegister(TLogBackend* backend) override
+        {
             TGuard<TMutex> g(Mutex);
             for (ui32 i = 0; i < Backends.size(); ++i) {
                 if (Backends[i] == backend) {
@@ -27,9 +37,10 @@ namespace {
             Y_ABORT("Incorrect pointer for log backend");
         }
 
-        void Reopen(bool flush) {
+        void Reopen(bool flush) override
+        {
             TGuard<TMutex> g(Mutex);
-            for (auto& b : Backends) {
+            for (auto& b: Backends) {
                 if (typeid(*b) == typeid(TLogBackend)) {
                     continue;
                 }
@@ -41,34 +52,47 @@ namespace {
             }
         }
     };
-}
 
-template <>
-class TSingletonTraits<TGlobalLogsStorage> {
+    std::shared_ptr<TImpl> Storage = std::make_shared<TImpl>();
+
 public:
-    static const size_t Priority = 50;
+    std::shared_ptr<IGlobalLogsStorage> Get() const
+    {
+        return Storage;
+    }
 };
 
-ELogPriority TLogBackend::FiltrationLevel() const {
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ELogPriority TLogBackend::FiltrationLevel() const
+{
     return LOG_MAX_PRIORITY;
 }
 
-TLogBackend::TLogBackend() noexcept {
-    Singleton<TGlobalLogsStorage>()->Register(this);
+TLogBackend::TLogBackend() noexcept
+    : GlobalLogsStorage(Singleton<TGlobalLogsStorage>()->Get())
+{
+    GlobalLogsStorage->Register(this);
 }
 
-TLogBackend::~TLogBackend() {
-    Singleton<TGlobalLogsStorage>()->UnRegister(this);
+TLogBackend::~TLogBackend()
+{
+    GlobalLogsStorage->UnRegister(this);
 }
 
-void TLogBackend::ReopenLogNoFlush() {
+void TLogBackend::ReopenLogNoFlush()
+{
     ReopenLog();
 }
 
-void TLogBackend::ReopenAllBackends(bool flush) {
-    Singleton<TGlobalLogsStorage>()->Reopen(flush);
+void TLogBackend::ReopenAllBackends(bool flush)
+{
+    Singleton<TGlobalLogsStorage>()->Get()->Reopen(flush);
 }
 
-size_t TLogBackend::QueueSize() const {
+size_t TLogBackend::QueueSize() const
+{
     ythrow yexception() << "Not implemented.";
 }

--- a/library/cpp/logger/backend.h
+++ b/library/cpp/logger/backend.h
@@ -5,11 +5,16 @@
 #include <util/generic/noncopyable.h>
 
 #include <cstddef>
+#include <memory>
 
+struct IGlobalLogsStorage;
 struct TLogRecord;
 
 // NOTE: be aware that all `TLogBackend`s are registred in singleton.
 class TLogBackend: public TNonCopyable {
+private:
+    std::shared_ptr<IGlobalLogsStorage> GlobalLogsStorage;
+
 public:
     TLogBackend() noexcept;
     virtual ~TLogBackend();
@@ -27,4 +32,13 @@ public:
     static void ReopenAllBackends(bool flush = true);
 
     virtual size_t QueueSize() const;
+};
+
+struct IGlobalLogsStorage
+{
+    virtual ~IGlobalLogsStorage() = default;
+
+    virtual void Register(TLogBackend* backend) = 0;
+    virtual void UnRegister(TLogBackend* backend) = 0;
+    virtual void Reopen(bool flush) = 0;
 };


### PR DESCRIPTION
### Notes
Problem:
```
2026-04-24T06:22:04.251216Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp:131: clear directory cache of size 0
2026-04-24T06:22:04.395350Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: CreateSession #6714494050668913418 [f:fs1] REQUEST
2026-04-24T06:22:04.395403Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:439: [f:""][c:""][s:""][n:0] initiating session f: 3
2026-04-24T06:22:04.395474Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:482: [f:""][c:""][s:"a0bd43d6-57192227-9d3701e2-3ee67586"][n:0] session established 0
2026-04-24T06:22:04.395587Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: CreateSession #6714494050668913418 [f:fs1][c:] RESPONSE request completed(total_time: 207us, execution_time: 207us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2026-04-24T06:22:04.396132Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp:75: [f:fs1][c:] WriteBackCache has been initialized {"FilePath":"\/home\/github\/.ya\/build\/build_root\/9t15\/00178d\/r3tmp\/tmpg6wgl8\/WriteBackCache\/fs1\/a0bd43d6-57192227-9d3701e2-3ee67586\/write_back_cache","RawCapacityByteCount":1049600,"RawUsedByteCount":0,"EntryCount":0}
2026-04-24T06:22:04.399450Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1133: [f:"fs1"][c:""] starting new session
2026-04-24T06:22:04.399545Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1149: [f:"fs1"][c:""] new session (1 threads) filestore config: "FileSystemId: fs1\nBlockSize: 4096\nLockRetryTimeout: 1.000000s\nEntryTimeout: 15.000000s\nRegularFileEntryTimeout: 0.000000s\nNegativeEntryTimeout: 0.000000s\nAttrTimeout: 15.000000s\nXAttrCacheLimit: 512\nXAttrCacheTimeout: 15.000000s\nMaxBufferSize: 1048576\nPreferredBlockSize: 4096\nAsyncDestroyHandleEnabled: 0\nAsyncHandleOperationPeriod: 0.000000s\nDirectIoEnabled: 0\nDirectIoAlign: 0\nGuestWriteBackCacheEnabled: 0\nZeroCopyEnabled: 0\nGuestPageCacheDisabled: 0\nExtendedAttributesDisabled: 0\nServerWriteBackCacheEnabled: 1\nDirectoryHandlesStorageEnabled: 0\nDirectoryHandlesTableSize: 100000\nGuestKeepCacheAllowed: 0\nMaxBackground: 0\nMaxFuseLoopThreads: 0\nZeroCopyWriteEnabled: 0\nFSyncQueueDisabled: 0\nGuestHandleKillPrivV2Enabled: 0\nGuestPosixAclEnabled: 0\nZeroCopyReadEnabled: 0\n"
2026-04-24T06:22:04.399608Z :NFS_VHOST INFO: : virtio_session_mount:442: starting device /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719, num_frontend_queues=2, num_backend_queues=1
2026-04-24T06:22:04.400521Z :NFS_VHOST INFO: : server_read:2210: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: Connection established, sock = 12
2026-04-24T06:22:04.400574Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: GET_FEATURES (1)
2026-04-24T06:22:04.400596Z :NFS_VHOST INFO: : vhost_get_features:807: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: GET_FEATURES: reply with supported_features 0x154000000
2026-04-24T06:22:04.400659Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_FEATURES (2)
2026-04-24T06:22:04.400672Z :NFS_VHOST INFO: : vhost_set_features:847: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_FEATURES: features 0x100000000
2026-04-24T06:22:04.411220Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: GET_PROTOCOL_FEATURES (15)
2026-04-24T06:22:04.411277Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_PROTOCOL_FEATURES (16)
2026-04-24T06:22:04.411311Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_OWNER (3)
2026-04-24T06:22:04.411345Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: GET_QUEUE_NUM (17)
2026-04-24T06:22:04.411478Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_MEM_TABLE (5)
2026-04-24T06:22:04.412028Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_NUM (8)
2026-04-24T06:22:04.412068Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_BASE (10)
2026-04-24T06:22:04.412154Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_ADDR (9)
2026-04-24T06:22:04.412193Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_ERR (14)
2026-04-24T06:22:04.412232Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_KICK (12)
2026-04-24T06:22:04.412382Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_CALL (13)
2026-04-24T06:22:04.412589Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_NUM (8)
2026-04-24T06:22:04.412614Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_BASE (10)
2026-04-24T06:22:04.412635Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_ADDR (9)
2026-04-24T06:22:04.412658Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_ERR (14)
2026-04-24T06:22:04.412682Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_KICK (12)
2026-04-24T06:22:04.412780Z :NFS_VHOST DEBUG: : vdev_handle_start:657: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: SET_VRING_CALL (13)
2026-04-24T06:22:04.437034Z :NFS_VHOST DEBUG: : virtq_dequeue_many:472: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: resubmit inflight requests, if any
2026-04-24T06:22:04.437100Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 104 and 2 OUT desc of length 80
2026-04-24T06:22:04.437125Z :NFS_FUSE DEBUG: : unique: 1, opcode: INIT (26), nodeid: 0, insize: 104, pid: 0
2026-04-24T06:22:04.437148Z :NFS_FUSE INFO: : INIT REQ: 7.38
2026-04-24T06:22:04.437158Z :NFS_FUSE INFO: : flags=0x03fffffb
2026-04-24T06:22:04.437167Z :NFS_FUSE INFO: : max_readahead=0x00000000
2026-04-24T06:22:04.437199Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1449: [f:"fs1"][c:""][l:17] resetting session state
2026-04-24T06:22:04.437296Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1469: [f:"fs1"][c:""] session reset completed: S_OK
2026-04-24T06:22:04.437307Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:86: resetting filesystem cache
2026-04-24T06:22:04.437323Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp:139: reset directory cache of size 0
2026-04-24T06:22:04.437335Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:80: scheduling destroy handle queue processing
2026-04-24T06:22:04.437343Z :NFS_FUSE INFO: :    INIT RSP: 7.31
2026-04-24T06:22:04.437351Z :NFS_FUSE INFO: :    flags=0x0044b42b
2026-04-24T06:22:04.437358Z :NFS_FUSE INFO: :    max_readahead=0x00000000
2026-04-24T06:22:04.437365Z :NFS_FUSE INFO: :    max_write=0x00100000
2026-04-24T06:22:04.437372Z :NFS_FUSE INFO: :    max_background=16384
2026-04-24T06:22:04.437378Z :NFS_FUSE INFO: :    congestion_threshold=12288
2026-04-24T06:22:04.437384Z :NFS_FUSE INFO: :    time_gran=1
2026-04-24T06:22:04.437392Z :NFS_FUSE DEBUG: :    unique: 1, success, outsize: 80
2026-04-24T06:22:04.437401Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 2 desc of length 80
2026-04-24T06:22:04.437460Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: head = 0
2026-04-24T06:22:04.438933Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 4176 and 2 OUT desc of length 24
2026-04-24T06:22:04.438966Z :NFS_FUSE DEBUG: : unique: 2, opcode: WRITE (16), nodeid: 123, insize: 80, pid: 0
2026-04-24T06:22:04.439016Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: WriteData #2 [f:fs1] REQUEST
2026-04-24T06:22:04.439036Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:691: WriteBuf #123 @124 offset:0 size:4096
2026-04-24T06:22:04.439218Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:190: invalidating node: 123, version: 2
2026-04-24T06:22:04.439245Z :NFS_FUSE DEBUG: :    unique: 2, success, outsize: 24
2026-04-24T06:22:04.439261Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 2 desc of length 24
2026-04-24T06:22:04.439429Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: WriteData #2 [f:fs1][c:] RESPONSE request completed(total_time: 294us, execution_time: 294us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 4.00 KiB, error: S_OK)
2026-04-24T06:22:04.439453Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: head = 3
2026-04-24T06:22:04.440513Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 128 and 2 OUT desc of length 120
2026-04-24T06:22:04.440542Z :NFS_FUSE DEBUG: : unique: 3, opcode: SETATTR (4), nodeid: 123, insize: 128, pid: 0
2026-04-24T06:22:04.440710Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: SetNodeAttr #3 [f:fs1] REQUEST
2026-04-24T06:22:04.440724Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_attr.cpp:26: SetAttr #123 mask:8
2026-04-24T06:22:04.440738Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:229: [fs1][FSYNC] Request was started #123 @0 id:3
2026-04-24T06:22:04.440754Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:28: [fs1][FSYNC] Request was added to meta maps #123 @0 id:3
2026-04-24T06:22:04.440924Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:247: [fs1][FSYNC] Request was finished #123 @0 id:3
2026-04-24T06:22:04.440938Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:102: [fs1][FSYNC] Request was removed from local meta map #123 @0 id:3
2026-04-24T06:22:04.440953Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:112: [fs1][FSYNC] Request was removed from global meta map #123 @0 id:3
2026-04-24T06:22:04.440972Z :NFS_FUSE ERROR: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:111: request #3 failed: E_FAIL xxx
2026-04-24T06:22:04.440996Z :NFS_FUSE DEBUG: :    unique: 3, error: -5 (Input/output error), outsize: 16
2026-04-24T06:22:04.441005Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 1 desc of length 16
2026-04-24T06:22:04.441088Z :NFS_FUSE ERROR: cloud/filestore/libs/diagnostics/request_stats.cpp:138: SetNodeAttr #3 [f:fs1][c:] RESPONSE request failed(total_time: 332us, execution_time: 332us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: E_FAIL xxx)
CRITICAL_EVENT:AppCriticalEvents/ErrorWasSentToTheGuest:SetNodeAttr #3 [f:fs1] EIO error was sent to the guest: { Code: 2147483648 Message: "xxx" }
2026-04-24T06:22:04.441214Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: head = 6
2026-04-24T06:22:04.441619Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 64 and 1 OUT desc of length 16
2026-04-24T06:22:04.441639Z :NFS_FUSE DEBUG: : unique: 4, opcode: FLUSH (25), nodeid: 123, insize: 64, pid: 0
2026-04-24T06:22:04.441658Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: Unknown #4 [f:fs1] REQUEST
2026-04-24T06:22:04.441673Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:821: Flush #123 @124
2026-04-24T06:22:04.441688Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:282: [fs1][FSYNC] FSync request was received #123 @124 id:4 data
2026-04-24T06:22:04.441702Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:53: [fs1][FSYNC] FSync request was added to local data map #123 @124 id:4
2026-04-24T06:22:04.441716Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:206: [fs1][FSYNC] FSync request was notified and erased #123 @124 id:4
2026-04-24T06:22:04.542738Z :NFS_FUSE ERROR: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:111: request #4 failed: E_FAIL xxx
2026-04-24T06:22:04.542915Z :NFS_FUSE DEBUG: :    unique: 4, error: -5 (Input/output error), outsize: 16
2026-04-24T06:22:04.542936Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 1 desc of length 16
2026-04-24T06:22:04.543039Z :NFS_FUSE ERROR: cloud/filestore/libs/diagnostics/request_stats.cpp:138: Unknown #4 [f:fs1][c:] RESPONSE request failed(total_time: 101.319ms, execution_time: 101.319ms, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: E_FAIL xxx)
2026-04-24T06:22:04.543049Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: head = 9
CRITICAL_EVENT:AppCriticalEvents/ErrorWasSentToTheGuest:Unknown #4 [f:fs1] EIO error was sent to the guest: { Code: 2147483648 Message: "xxx" }
2026-04-24T06:22:04.543683Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 4176 and 2 OUT desc of length 24
2026-04-24T06:22:04.543714Z :NFS_FUSE DEBUG: : unique: 5, opcode: WRITE (16), nodeid: 123, insize: 80, pid: 0
2026-04-24T06:22:04.543767Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: WriteData #5 [f:fs1] REQUEST
2026-04-24T06:22:04.543788Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:691: WriteBuf #123 @124 offset:11 size:4096
2026-04-24T06:22:04.543847Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:229: [fs1][FSYNC] Request was started #123 @124 id:5
2026-04-24T06:22:04.543863Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:28: [fs1][FSYNC] Request was added to meta maps #123 @124 id:5
2026-04-24T06:22:04.543878Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:35: [fs1][FSYNC] Request was added to data maps #123 @124 id:5
2026-04-24T06:22:04.647181Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:247: [fs1][FSYNC] Request was finished #123 @124 id:5
2026-04-24T06:22:04.647219Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:102: [fs1][FSYNC] Request was removed from local meta map #123 @124 id:5
2026-04-24T06:22:04.647231Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:112: [fs1][FSYNC] Request was removed from global meta map #123 @124 id:5
2026-04-24T06:22:04.647247Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:140: [fs1][FSYNC] Request was removed from local data map #123 @124 id:5
2026-04-24T06:22:04.647257Z :NFS_FUSE TRACE: cloud/filestore/libs/vfs/fsync_queue.cpp:150: [fs1][FSYNC] Request was removed from global data map #123 @124 id:5
2026-04-24T06:22:04.647278Z :NFS_FUSE ERROR: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:111: request #5 failed: E_FAIL xxx
2026-04-24T06:22:04.647314Z :NFS_FUSE DEBUG: :    unique: 5, error: -5 (Input/output error), outsize: 16
2026-04-24T06:22:04.647327Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 1 desc of length 16
2026-04-24T06:22:04.647391Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: head = 11
2026-04-24T06:22:04.647851Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 64 and 1 OUT desc of length 16
2026-04-24T06:22:04.647887Z :NFS_FUSE DEBUG: : unique: 6, opcode: RELEASE (18), nodeid: 123, insize: 64, pid: 0
2026-04-24T06:22:04.648121Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: DestroyHandle #6 [f:fs1] REQUEST
2026-04-24T06:22:04.648141Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:263: Release #123 @124
2026-04-24T06:22:04.648314Z :NFS_FUSE ERROR: cloud/filestore/libs/diagnostics/request_stats.cpp:138: WriteData #5 [f:fs1][c:] RESPONSE request failed(total_time: 104.393ms, execution_time: 104.393ms, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 4.00 KiB, error: E_FAIL xxx)
CRITICAL_EVENT:AppCriticalEvents/ErrorWasSentToTheGuest:WriteData #5 [f:fs1] EIO error was sent to the guest: { Code: 2147483648 Message: "xxx" }
2026-04-24T06:22:04.772080Z :NFS_FUSE ERROR: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:111: request #6 failed: E_FAIL xxx
2026-04-24T06:22:04.772114Z :NFS_FUSE DEBUG: :    unique: 6, error: -5 (Input/output error), outsize: 16
2026-04-24T06:22:04.772127Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 1 desc of length 16
2026-04-24T06:22:04.772254Z :NFS_FUSE ERROR: cloud/filestore/libs/diagnostics/request_stats.cpp:138: DestroyHandle #6 [f:fs1][c:] RESPONSE request failed(total_time: 124.039ms, execution_time: 124.039ms, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: E_FAIL xxx)
CRITICAL_EVENT:AppCriticalEvents/ErrorWasSentToTheGuest:DestroyHandle #6 [f:fs1] EIO error was sent to the guest: { Code: 2147483648 Message: "xxx" }
2026-04-24T06:22:04.772383Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: head = 14
2026-04-24T06:22:04.772787Z :NFS_VHOST DEBUG: : process_request:261: request with 1 IN desc of length 64 and 1 OUT desc of length 16
2026-04-24T06:22:04.772809Z :NFS_FUSE DEBUG: : unique: 7, opcode: RELEASE (18), nodeid: 123, insize: 64, pid: 0
2026-04-24T06:22:04.772844Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: DestroyHandle #7 [f:fs1] REQUEST
2026-04-24T06:22:04.772861Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:263: Release #123 @124
2026-04-24T06:22:04.772916Z :NFS_FUSE DEBUG: :    unique: 7, success, outsize: 16
2026-04-24T06:22:04.772927Z :NFS_VHOST DEBUG: : virtio_send_msg:570: response with 1 desc of length 16
2026-04-24T06:22:04.772996Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: DestroyHandle #7 [f:fs1][c:] RESPONSE request completed(total_time: 119us, execution_time: 119us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2026-04-24T06:22:04.773048Z :NFS_VHOST DEBUG: : virtq_push:676: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: head = 16
2026-04-24T06:22:04.773365Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:226: [f:fs1] StopAsync: completing left: 0, requests left: 0, fuse cancellation code: 0
2026-04-24T06:22:04.773755Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:653: stopping FUSE loop
2026-04-24T06:22:04.773801Z :NFS_VHOST INFO: : virtio_session_exit:517: unregister device /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719
2026-04-24T06:22:04.773917Z :NFS_VHOST INFO: : vdev_disconnect:2087: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719: Close connection with client, sock = 12
2026-04-24T06:22:04.774087Z :NFS_VHOST INFO: : vring_mark_stopped:287: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[0]: stopped vring with 0 in-flight requests
2026-04-24T06:22:04.774107Z :NFS_VHOST INFO: : vring_mark_stopped:287: /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719[1]: stopped vring with 0 in-flight requests
2026-04-24T06:22:04.774402Z :NFS_VHOST INFO: : unregister_complete:332: stopping device /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719
2026-04-24T06:22:04.774424Z :NFS_VHOST INFO: : unregister_complete:336: finished stopping device /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719
2026-04-24T06:22:04.778296Z :NFS_VHOST INFO: : virtio_session_exit:526: finished unregister device
2026-04-24T06:22:04.778351Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:583: stopping FUSE loop thread 13.0
2026-04-24T06:22:04.778365Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:590: stopped FUSE loop thread 13.0
2026-04-24T06:22:04.778373Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:665: stopped FUSE loop
2026-04-24T06:22:04.778382Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:677: unmounting FUSE session
2026-04-24T06:22:04.778404Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1439: [f:"fs1"][c:""] got destroy request
2026-04-24T06:22:04.778421Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1449: [f:"fs1"][c:""][l:0] resetting session state
2026-04-24T06:22:04.778536Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/loop.cpp:1469: [f:"fs1"][c:""] session reset completed: S_OK
2026-04-24T06:22:04.778548Z :NFS_FUSE INFO: cloud/filestore/libs/vfs_fuse/fs_impl.cpp:86: resetting filesystem cache
2026-04-24T06:22:04.778560Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp:139: reset directory cache of size 0
2026-04-24T06:22:04.778577Z :NFS_VHOST INFO: : virtio_session_close:496: destroying device /home/github/.ya/build/build_root/9t15/00178d/r3tmp/vhost.socket_2923017190244832719
2026-04-24T06:22:04.778610Z :NFS_VHOST INFO: : virtio_session_close:505: finished destroying device
2026-04-24T06:22:04.778761Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:99: DestroySession #1604469042126497155 [f:fs1] REQUEST
2026-04-24T06:22:04.778791Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:557: [f:""][c:""][s:"a0bd43d6-57192227-9d3701e2-3ee67586"][n:0] destroying session
2026-04-24T06:22:04.778823Z :NFS_CLIENT INFO: cloud/filestore/libs/client/session.cpp:580: [f:""][c:""][s:"a0bd43d6-57192227-9d3701e2-3ee67586"][n:0] session destroyed
2026-04-24T06:22:04.778891Z :NFS_FUSE TRACE: cloud/filestore/libs/diagnostics/request_stats.cpp:138: DestroySession #1604469042126497155 [f:fs1][c:] RESPONSE request completed(total_time: 94us, execution_time: 94us, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2026-04-24T06:22:04.795195Z :NFS_FUSE DEBUG: cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp:131: clear directory cache of size 0
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x150 has a premature terminator entry at offset 0x160
warning: address range table at offset 0x180 has a premature terminator entry at offset 0x190
warning: address range table at offset 0x1b0 has a premature terminator entry at offset 0x1c0
warning: address range table at offset 0x1e0 has a premature terminator entry at offset 0x1f0
warning: address range table at offset 0x210 has a premature terminator entry at offset 0x220
warning: address range table at offset 0x240 has a premature terminator entry at offset 0x250
warning: address range table at offset 0x270 has a premature terminator entry at offset 0x280
warning: address range table at offset 0x2a0 has a premature terminator entry at offset 0x2b0
warning: address range table at offset 0x2d0 has a premature terminator entry at offset 0x2e0
warning: address range table at offset 0x300 has a premature terminator entry at offset 0x310
warning: address range table at offset 0x330 has a premature terminator entry at offset 0x340
warning: address range table at offset 0x360 has a premature terminator entry at offset 0x370
warning: address range table at offset 0x390 has a premature terminator entry at offset 0x3a0
warning: address range table at offset 0x3c0 has a premature terminator entry at offset 0x3d0
warning: address range table at offset 0x3f0 has a premature terminator entry at offset 0x400
warning: address range table at offset 0x420 has a premature terminator entry at offset 0x430
warning: address range table at offset 0x450 has a premature terminator entry at offset 0x460
warning: address range table at offset 0x480 has a premature terminator entry at offset 0x490
warning: address range table at offset 0xa60 has a premature terminator entry at offset 0xa70
==================
WARNING: ThreadSanitizer: use of an invalid mutex (e.g. uninitialized or destroyed) (pid=145270)
    #0 pthread_mutex_lock /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1367:3 (cloud-filestore-libs-vfs_fuse-ut+0x192926b) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #1 TMutex::TImpl::Acquire /actions-runner/_work/nbs/nbs/util/system/mutex.cpp:62:22 (cloud-filestore-libs-vfs_fuse-ut+0x1b614b4) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #2 TMutex::Acquire() /actions-runner/_work/nbs/nbs/util/system/mutex.cpp:133:12 (cloud-filestore-libs-vfs_fuse-ut+0x1b614b4)
    #3 TCommonLockOps<TMutex>::Acquire /actions-runner/_work/nbs/nbs/util/system/guard.h:9:12 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #4 TGuard<TMutex, TCommonLockOps<TMutex> >::Init /actions-runner/_work/nbs/nbs/util/system/guard.h:81:9 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #5 TGuard<TMutex, TCommonLockOps<TMutex> >::TGuard /actions-runner/_work/nbs/nbs/util/system/guard.h:42:9 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #6 (anonymous namespace)::TGlobalLogsStorage::UnRegister /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:20:28 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #7 TLogBackend::~TLogBackend() /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:61:38 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #8 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-filestore-libs-vfs_fuse-ut+0x3ff86b6) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #9 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-filestore-libs-vfs_fuse-ut+0x3ff86e9) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #10 CheckedDelete<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #11 TDelete::Destroy<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #12 THolder<TLogBackend, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #13 THolder<TLogBackend, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #14 TLog::TImpl::~TImpl /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:26:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #15 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #16 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #17 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #18 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #19 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #20 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #21 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #22 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #23 NCloud::NFileStore::NVFS::TFSyncCache::~TFSyncCache() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs/fsync_queue.h:27:7 (cloud-filestore-libs-vfs_fuse-ut+0x432883c) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #24 NCloud::NFileStore::NVFS::TFSyncQueue::~TFSyncQueue /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs/fsync_queue.h:110:7 (cloud-filestore-libs-vfs_fuse-ut+0x432851b) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #25 NCloud::NFileStore::NVFS::TFSyncQueue::~TFSyncQueue() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs/fsync_queue.h:110:7 (cloud-filestore-libs-vfs_fuse-ut+0x432851b)
    #26 std::__y1::default_delete<NCloud::NFileStore::NVFS::IFSyncQueue>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:69:5 (cloud-filestore-libs-vfs_fuse-ut+0x431af86) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #27 std::__y1::unique_ptr<NCloud::NFileStore::NVFS::IFSyncQueue, std::__y1::default_delete<NCloud::NFileStore::NVFS::IFSyncQueue> >::reset /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:298:7 (cloud-filestore-libs-vfs_fuse-ut+0x431af86)
    #28 std::__y1::unique_ptr<NCloud::NFileStore::NVFS::IFSyncQueue, std::__y1::default_delete<NCloud::NFileStore::NVFS::IFSyncQueue> >::~unique_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:264:75 (cloud-filestore-libs-vfs_fuse-ut+0x431af86)
    #29 NCloud::NFileStore::NFuse::TFileSystem::~TFileSystem() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_impl.cpp:76:1 (cloud-filestore-libs-vfs_fuse-ut+0x431af86)
    #30 std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:172:15 (cloud-filestore-libs-vfs_fuse-ut+0x431630d) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #31 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem> >::destroy<NCloud::NFileStore::NFuse::TFileSystem, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:315:13 (cloud-filestore-libs-vfs_fuse-ut+0x431630d)
    #32 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::TFileSystem, std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem> >::__on_zero_shared_impl<std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem>, 0> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:349:9 (cloud-filestore-libs-vfs_fuse-ut+0x431630d)
    #33 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::TFileSystem, std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:353:9 (cloud-filestore-libs-vfs_fuse-ut+0x431630d)
    #34 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:186:9 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #35 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:240:27 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9)
    #36 std::__y1::shared_ptr<NCloud::NFileStore::NFuse::IFileSystem>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:801:23 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9)
    #37 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::~TFileSystemLoop() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:689:7 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9)
    #38 std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:172:15 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #39 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop> >::destroy<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:315:13 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd)
    #40 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop, std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop> >::__on_zero_shared_impl<std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>, 0> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:349:9 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd)
    #41 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop, std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:353:9 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd)
    #42 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:186:9 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #43 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:240:27 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #44 std::__y1::shared_ptr<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:801:23 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #45 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:807:9 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #46 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::(anonymous class)::operator()(NThreading::TFuture<void>)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:817:25 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #47 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #48 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:419:5 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #49 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:195:16 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #50 std::__y1::__function::__func<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::'lambda'(NThreading::TFuture<void>)::operator()(NThreading::TFuture<void>)::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::'lambda'(NThreading::TFuture<void>)::operator()(NThreading::TFuture<void>)::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:366:12 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #51 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16 (cloud-filestore-libs-vfs_fuse-ut+0x22755b5) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #52 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12 (cloud-filestore-libs-vfs_fuse-ut+0x22755b5)
    #53 (anonymous namespace)::TThreadFactoryFuncObj::DoExecute() /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:61:13 (cloud-filestore-libs-vfs_fuse-ut+0x22755b5)
    #54 IThreadFactory::IThreadAble::Execute /actions-runner/_work/nbs/nbs/util/thread/factory.h:15:13 (cloud-filestore-libs-vfs_fuse-ut+0x2275a52) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #55 (anonymous namespace)::TSystemThreadFactory::TPoolThread::ThreadProc(void*) /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:36:41 (cloud-filestore-libs-vfs_fuse-ut+0x2275a52)
    #56 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (cloud-filestore-libs-vfs_fuse-ut+0x1b739ec) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
  Mutex M0 (0x7b0c00009540) created at:
    #0 pthread_mutex_lock /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:1367:3 (cloud-filestore-libs-vfs_fuse-ut+0x192926b) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #1 TMutex::TImpl::Acquire /actions-runner/_work/nbs/nbs/util/system/mutex.cpp:62:22 (cloud-filestore-libs-vfs_fuse-ut+0x1b614b4) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #2 TMutex::Acquire() /actions-runner/_work/nbs/nbs/util/system/mutex.cpp:133:12 (cloud-filestore-libs-vfs_fuse-ut+0x1b614b4)
    #3 TCommonLockOps<TMutex>::Acquire /actions-runner/_work/nbs/nbs/util/system/guard.h:9:12 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #4 TGuard<TMutex, TCommonLockOps<TMutex> >::Init /actions-runner/_work/nbs/nbs/util/system/guard.h:81:9 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #5 TGuard<TMutex, TCommonLockOps<TMutex> >::TGuard /actions-runner/_work/nbs/nbs/util/system/guard.h:42:9 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #6 (anonymous namespace)::TGlobalLogsStorage::UnRegister /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:20:28 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #7 TLogBackend::~TLogBackend() /actions-runner/_work/nbs/nbs/library/cpp/logger/backend.cpp:61:38 (cloud-filestore-libs-vfs_fuse-ut+0x226a1e2)
    #8 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-filestore-libs-vfs_fuse-ut+0x3ff86b6) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #9 NCloud::(anonymous namespace)::TComponentLogBackend::~TComponentLogBackend() /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/logging.cpp:30:7 (cloud-filestore-libs-vfs_fuse-ut+0x3ff86e9) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #10 CheckedDelete<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #11 TDelete::Destroy<TLogBackend> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #12 THolder<TLogBackend, TDelete>::DoDestroy /actions-runner/_work/nbs/nbs/util/generic/ptr.h:341:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #13 THolder<TLogBackend, TDelete>::~THolder /actions-runner/_work/nbs/nbs/util/generic/ptr.h:278:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #14 TLog::TImpl::~TImpl /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:26:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #15 CheckedDelete<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:36:5 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #16 TDelete::Destroy<TLog::TImpl> /actions-runner/_work/nbs/nbs/util/generic/ptr.h:57:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #17 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:386:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #18 TRefCounted<TLog::TImpl, TAtomicCounter, TDelete>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:391:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #19 TDefaultIntrusivePtrOps<TLog::TImpl>::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:462:12 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #20 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::UnRef /actions-runner/_work/nbs/nbs/util/generic/ptr.h:599:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #21 TIntrusivePtr<TLog::TImpl, TDefaultIntrusivePtrOps<TLog::TImpl> >::~TIntrusivePtr /actions-runner/_work/nbs/nbs/util/generic/ptr.h:504:9 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #22 TLog::~TLog() /actions-runner/_work/nbs/nbs/library/cpp/logger/log.cpp:142:13 (cloud-filestore-libs-vfs_fuse-ut+0x226ee0e)
    #23 NCloud::NFileStore::NVFS::TFSyncCache::~TFSyncCache() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs/fsync_queue.h:27:7 (cloud-filestore-libs-vfs_fuse-ut+0x432883c) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #24 NCloud::NFileStore::NVFS::TFSyncQueue::~TFSyncQueue /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs/fsync_queue.h:110:7 (cloud-filestore-libs-vfs_fuse-ut+0x432851b) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #25 NCloud::NFileStore::NVFS::TFSyncQueue::~TFSyncQueue() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs/fsync_queue.h:110:7 (cloud-filestore-libs-vfs_fuse-ut+0x432851b)
    #26 std::__y1::default_delete<NCloud::NFileStore::NVFS::IFSyncQueue>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:69:5 (cloud-filestore-libs-vfs_fuse-ut+0x431af86) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #27 std::__y1::unique_ptr<NCloud::NFileStore::NVFS::IFSyncQueue, std::__y1::default_delete<NCloud::NFileStore::NVFS::IFSyncQueue> >::reset /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:298:7 (cloud-filestore-libs-vfs_fuse-ut+0x431af86)
    #28 std::__y1::unique_ptr<NCloud::NFileStore::NVFS::IFSyncQueue, std::__y1::default_delete<NCloud::NFileStore::NVFS::IFSyncQueue> >::~unique_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:264:75 (cloud-filestore-libs-vfs_fuse-ut+0x431af86)
    #29 NCloud::NFileStore::NFuse::TFileSystem::~TFileSystem() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_impl.cpp:76:1 (cloud-filestore-libs-vfs_fuse-ut+0x431af86)
    #30 std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:172:15 (cloud-filestore-libs-vfs_fuse-ut+0x431630d) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #31 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem> >::destroy<NCloud::NFileStore::NFuse::TFileSystem, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:315:13 (cloud-filestore-libs-vfs_fuse-ut+0x431630d)
    #32 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::TFileSystem, std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem> >::__on_zero_shared_impl<std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem>, 0> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:349:9 (cloud-filestore-libs-vfs_fuse-ut+0x431630d)
    #33 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::TFileSystem, std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:353:9 (cloud-filestore-libs-vfs_fuse-ut+0x431630d)
    #34 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:186:9 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #35 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:240:27 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9)
    #36 std::__y1::shared_ptr<NCloud::NFileStore::NFuse::IFileSystem>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:801:23 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9)
    #37 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::~TFileSystemLoop() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:689:7 (cloud-filestore-libs-vfs_fuse-ut+0x424cdc9)
    #38 std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>::destroy /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:172:15 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #39 std::__y1::allocator_traits<std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop> >::destroy<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:315:13 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd)
    #40 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop, std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop> >::__on_zero_shared_impl<std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>, 0> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:349:9 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd)
    #41 std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop, std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>>::__on_zero_shared() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:353:9 (cloud-filestore-libs-vfs_fuse-ut+0x424cacd)
    #42 std::__y1::__shared_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:186:9 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #43 std::__y1::__shared_weak_count::__release_shared /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:240:27 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #44 std::__y1::shared_ptr<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop>::~shared_ptr /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:801:23 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #45 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:807:9 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #46 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::(anonymous class)::operator()(NThreading::TFuture<void>)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:817:25 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #47 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #48 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:419:5 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #49 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:816:21)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:195:16 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #50 std::__y1::__function::__func<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::'lambda'(NThreading::TFuture<void>)::operator()(NThreading::TFuture<void>)::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::StopAsync()::'lambda'(NThreading::TFuture<void>)::operator()(NThreading::TFuture<void>)::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:366:12 (cloud-filestore-libs-vfs_fuse-ut+0x427c40f)
    #51 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16 (cloud-filestore-libs-vfs_fuse-ut+0x22755b5) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #52 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12 (cloud-filestore-libs-vfs_fuse-ut+0x22755b5)
    #53 (anonymous namespace)::TThreadFactoryFuncObj::DoExecute() /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:61:13 (cloud-filestore-libs-vfs_fuse-ut+0x22755b5)
    #54 IThreadFactory::IThreadAble::Execute /actions-runner/_work/nbs/nbs/util/thread/factory.h:15:13 (cloud-filestore-libs-vfs_fuse-ut+0x2275a52) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
    #55 (anonymous namespace)::TSystemThreadFactory::TPoolThread::ThreadProc(void*) /actions-runner/_work/nbs/nbs/util/thread/factory.cpp:36:41 (cloud-filestore-libs-vfs_fuse-ut+0x2275a52)
    #56 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (cloud-filestore-libs-vfs_fuse-ut+0x1b739ec) (BuildId: bfa5c5dbdd7f1822faac0c31b6c4a703fef6631b)
SUMMARY: ThreadSanitizer: use of an invalid mutex (e.g. uninitialized or destroyed) /actions-runner/_work/nbs/nbs/util/system/mutex.cpp:62:22 in TMutex::TImpl::Acquire
==================
VERIFY failed (2026-04-24T06:22:05.471619Z): mutex lock failure (Invalid argument)
  util/system/mutex.cpp:63
  Acquire(): requirement result == 0 failed
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char>>, char const*, unsigned long)+708 (0x1B6BF84)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+378 (0x1B6291A)
TMutex::Acquire()+118 (0x1B61506)
TLogBackend::~TLogBackend()+99 (0x226A1E3)
??+0 (0x3FF86B7)
??+0 (0x3FF86EA)
TLog::~TLog()+175 (0x226EE0F)
NCloud::NFileStore::NVFS::TFSyncCache::~TFSyncCache()+445 (0x432883D)
NCloud::NFileStore::NVFS::TFSyncQueue::~TFSyncQueue()+28 (0x432851C)
NCloud::NFileStore::NFuse::TFileSystem::~TFileSystem()+727 (0x431AF87)
std::__y1::__shared_ptr_emplace<NCloud::NFileStore::NFuse::TFileSystem, std::__y1::allocator<NCloud::NFileStore::NFuse::TFileSystem>>::__on_zero_shared()+30 (0x431630E)
??+0 (0x424CDCA)
??+0 (0x424CACE)
??+0 (0x427C410)
??+0 (0x22755B6)
??+0 (0x2275A53)
??+0 (0x1B739ED)
??+0 (0x192753F)
??+0 (0x7FD4E0294AC3)
??+0 (0x7FD4E03268D0)
```

Root cause: Singleton is destroyed too early.

Solution: use `shared_ptr` to prevent object destruction when it is in use.