### PR TITLE
issue-5726: introducing ListNodesInternal API for service<->tablet listing requests

### DIFF
--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -430,6 +430,7 @@ NProto::TNodeAttr TFileStoreCommand::ResolveNode(
     }
 
     auto request = CreateRequest<NProto::TGetNodeAttrRequest>();
+    request->MutableHeaders()->SetDisableMultiTabletForwarding(false);
     request->SetNodeId(parentNodeId);
     request->SetName(std::move(name));
 

--- a/cloud/filestore/apps/client/lib/ls.cpp
+++ b/cloud/filestore/apps/client/lib/ls.cpp
@@ -257,7 +257,6 @@ public:
         page.Cookie = CliArgs.Cookie;
         do {
             auto request = CreateRequest<NProto::TListNodesRequest>();
-
             request->SetNodeId(nodeId);
             request->SetCookie(page.Cookie);
             if (CliArgs.MaxBytes > 0) {

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -756,4 +756,7 @@ message TStorageConfig
     // Shard balancer will round free space per shard to a multiple of this
     // number in bytes.
     optional uint64 ShardBalancerPrecisionBytes = 493;
+
+    // Use ListNodesInternal API for internal ListNodes calls.
+    optional bool UseListNodesInternal = 494;
 }

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -88,6 +88,7 @@ namespace NCloud::NFileStore{
     xxx(BrokenProfileLogRequest)                                               \
     xxx(UnconfirmedDataNotInProgress)                                          \
     xxx(InvalidCommitIdInUnconfirmedAddBlobSafePoint)                          \
+    xxx(ListNodesInternalFailedToAddNodeRef)                                   \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -46,6 +46,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(ConfigureAsShard,           __VA_ARGS__)                               \
     xxx(GetStorageConfig,           __VA_ARGS__)                               \
     xxx(GetNodeAttrBatch,           __VA_ARGS__)                               \
+    xxx(ListNodesInternal,          __VA_ARGS__)                               \
     xxx(WriteCompactionMap,         __VA_ARGS__)                               \
     xxx(ForcedOperationStatus,      __VA_ARGS__)                               \
     xxx(GetFileSystemTopology,      __VA_ARGS__)                               \
@@ -200,6 +201,9 @@ struct TEvIndexTablet
 
         EvUnsafeChangeTabletStateRequest = EvBegin + 81,
         EvUnsafeChangeTabletStateResponse,
+
+        EvListNodesInternalRequest = EvBegin + 83,
+        EvListNodesInternalResponse,
 
         // After the TABLET sub-namespace we have TABLET_WORKER and TABLET_PROXY
         // sub-namespaces which don't have any non-local events so if we run out

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -325,6 +325,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(ListNodesSizeMode,                                                     \
         NProto::EListNodesSizeMode,                                            \
         NProto::LNSM_NAME_ONLY                                                )\
+    xxx(UseListNodesInternal,              bool,      false                   )\
                                                                                \
     xxx(ResponseLogEntryTTL,                TDuration,  TDuration::Hours(1)   )\
     xxx(TabletRegularTasksSchedulePeriod,   TDuration,  TDuration::Minutes(1) )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -180,6 +180,7 @@ public:
     ui32 GetMaxResponseEntries() const;
     ui32 GetMaxBytesMultiplier() const;
     NProto::EListNodesSizeMode GetListNodesSizeMode() const;
+    bool GetUseListNodesInternal() const;
 
     ui32 GetDefaultNodesLimit() const;
     ui32 GetSizeToNodesRatio() const;

--- a/cloud/filestore/libs/storage/core/helpers.cpp
+++ b/cloud/filestore/libs/storage/core/helpers.cpp
@@ -205,9 +205,9 @@ struct TListNodesInternalResponseBuilder::TImpl
     }
 
     void AddNodeRef(
-        TStringBuf name,
-        TStringBuf shardId,
-        TStringBuf shardNodeName)
+        const TString& name,
+        const TString& shardId,
+        const TString& shardNodeName)
     {
         memcpy(NameBuffer, name.data(), name.size());
         NameBuffer += name.size();
@@ -252,9 +252,9 @@ TListNodesInternalResponseBuilder::~TListNodesInternalResponseBuilder()
 {}
 
 void TListNodesInternalResponseBuilder::AddNodeRef(
-    TStringBuf name,
-    TStringBuf shardId,
-    TStringBuf shardNodeName)
+    const TString& name,
+    const TString& shardId,
+    const TString& shardNodeName)
 {
     Impl->AddNodeRef(name, shardId, shardNodeName);
 }

--- a/cloud/filestore/libs/storage/core/helpers.cpp
+++ b/cloud/filestore/libs/storage/core/helpers.cpp
@@ -99,6 +99,8 @@ void Convert(
         performanceProfile.GetMaxPostponedCount());
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 void Convert(
     NProtoPrivate::TListNodesInternalResponse& internalResponse,
     NProto::TListNodesResponse& response)
@@ -166,30 +168,95 @@ void Convert(
     }
 }
 
-void Store(
+////////////////////////////////////////////////////////////////////////////////
+
+struct TListNodesInternalResponseBuilder::TImpl
+{
+    google::protobuf::RepeatedField<ui32>& NameSizes;
+    google::protobuf::RepeatedField<ui32>& ExternalRefIndices;
+    google::protobuf::RepeatedField<ui32>& ShardIdSizes;
+    google::protobuf::RepeatedField<ui32>& ShardNodeNameSizes;
+    char* NameBuffer;
+    char* ExternalRefBuffer;
+    ui32 Index = 0;
+
+    TImpl(
+            NProtoPrivate::TListNodesInternalResponse& response,
+            ui64 nameBufferSize,
+            ui64 externalRefBufferSize,
+            ui64 nameCount,
+            ui64 externalRefCount)
+        : NameSizes(*response.MutableNameSizes())
+        , ExternalRefIndices(*response.MutableExternalRefIndices())
+        , ShardIdSizes(*response.MutableShardIdSizes())
+        , ShardNodeNameSizes(*response.MutableShardNodeNameSizes())
+    {
+        auto& nameBuffer = *response.MutableNameBuffer();
+        nameBuffer.ReserveAndResize(nameBufferSize);
+        NameBuffer = nameBuffer.begin();
+        auto& externalRefBuffer = *response.MutableExternalRefBuffer();
+        externalRefBuffer.ReserveAndResize(externalRefBufferSize);
+        ExternalRefBuffer = externalRefBuffer.begin();
+
+        NameSizes.Reserve(nameCount);
+        ExternalRefIndices.Reserve(externalRefCount);
+        ShardIdSizes.Reserve(externalRefCount);
+        ShardNodeNameSizes.Reserve(externalRefCount);
+    }
+
+    void AddNodeRef(
+        TStringBuf name,
+        TStringBuf shardId,
+        TStringBuf shardNodeName)
+    {
+        memcpy(NameBuffer, name.data(), name.size());
+        NameBuffer += name.size();
+        NameSizes.Add(name.size());
+
+        if (shardId) {
+            ExternalRefIndices.Add(Index);
+
+            memcpy(
+                ExternalRefBuffer,
+                shardId.data(),
+                shardId.size());
+            ExternalRefBuffer += shardId.size();
+            ShardIdSizes.Add(shardId.size());
+            memcpy(
+                ExternalRefBuffer,
+                shardNodeName.data(),
+                shardNodeName.size());
+            ExternalRefBuffer += shardNodeName.size();
+            ShardNodeNameSizes.Add(shardNodeName.size());
+        }
+
+        ++Index;
+    }
+};
+
+TListNodesInternalResponseBuilder::TListNodesInternalResponseBuilder(
+        NProtoPrivate::TListNodesInternalResponse& response,
+        ui64 nameBufferSize,
+        ui64 externalRefBufferSize,
+        ui64 nameCount,
+        ui64 externalRefCount)
+    : Impl(new TImpl(
+        response,
+        nameBufferSize,
+        externalRefBufferSize,
+        nameCount,
+        externalRefCount))
+{}
+
+TListNodesInternalResponseBuilder::~TListNodesInternalResponseBuilder()
+{}
+
+void TListNodesInternalResponseBuilder::AddNodeRef(
     TStringBuf name,
     TStringBuf shardId,
-    TStringBuf shardNodeName,
-    ui32 i,
-    NProtoPrivate::TListNodesInternalResponse& internalResponse)
+    TStringBuf shardNodeName)
 {
-    auto& nameBuffer = *internalResponse.MutableNameBuffer();
-    auto& nameSizes = *internalResponse.MutableNameSizes();
-    nameBuffer.append(name);
-    nameSizes.Add(name.size());
-
-    if (shardId) {
-        internalResponse.AddExternalRefIndices(i);
-
-        auto& extRefBuffer = *internalResponse.MutableExternalRefBuffer();
-        auto& idSizes = *internalResponse.MutableShardIdSizes();
-        auto& nodeNameSizes = *internalResponse.MutableShardNodeNameSizes();
-
-        extRefBuffer.append(shardId);
-        idSizes.Add(shardId.size());
-        extRefBuffer.append(shardNodeName);
-        nodeNameSizes.Add(shardNodeName.size());
-    }
+    Impl->AddNodeRef(name, shardId, shardNodeName);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/helpers.cpp
+++ b/cloud/filestore/libs/storage/core/helpers.cpp
@@ -1,10 +1,33 @@
 #include "helpers.h"
 
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
 #include <cloud/filestore/public/api/protos/fs.pb.h>
+
+#include <cloud/storage/core/libs/common/error.h>
 
 #include <contrib/ydb/core/protos/filestore_config.pb.h>
 
+#include <util/string/builder.h>
+
 namespace NCloud::NFileStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool Consume(TStringBuf& buffer, ui64 len, TString* chunk)
+{
+    if (buffer.Size() < len) {
+        buffer.Clear();
+        return false;
+    }
+
+    chunk->assign(buffer.Data(), len);
+    buffer.Skip(len);
+    return true;
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -74,6 +97,99 @@ void Convert(
         performanceProfile.GetMaxPostponedTime());
     config.SetPerformanceProfileMaxPostponedCount(
         performanceProfile.GetMaxPostponedCount());
+}
+
+void Convert(
+    NProtoPrivate::TListNodesInternalResponse& internalResponse,
+    NProto::TListNodesResponse& response)
+{
+    if (HasError(internalResponse.GetError())) {
+        *response.MutableError() = std::move(*internalResponse.MutableError());
+        return;
+    }
+
+    response.SetCookie(internalResponse.GetCookie());
+    *response.MutableHeaders() = std::move(*internalResponse.MutableHeaders());
+
+    const ui32 nameCount = internalResponse.NameSizesSize();
+    const ui32 externalRefCount = internalResponse.ExternalRefIndicesSize();
+    response.MutableNames()->Reserve(nameCount);
+    response.MutableNodes()->Reserve(nameCount);
+
+    TStringBuf nameBuffer(internalResponse.GetNameBuffer());
+    TStringBuf extRefBuffer(internalResponse.GetExternalRefBuffer());
+
+    if (externalRefCount != internalResponse.ShardIdSizesSize()
+            || externalRefCount != internalResponse.ShardNodeNameSizesSize())
+    {
+        *response.MutableError() = MakeError(E_INVALID_STATE, TStringBuilder()
+            << "inconsistent external ref/id/nodename counts");
+        return;
+    }
+
+    bool success = true;
+    ui32 j = 0;
+    ui32 i = 0;
+    while (i < nameCount && success) {
+        const ui32 nextExternalNodeRefIdx =
+            j < externalRefCount
+            ? internalResponse.GetExternalRefIndices(j) : Max<ui32>();
+
+        success &= Consume(
+            nameBuffer,
+            internalResponse.GetNameSizes(i),
+            response.AddNames());
+
+        auto* node = response.AddNodes();
+        if (i == nextExternalNodeRefIdx) {
+            success &= Consume(
+                extRefBuffer,
+                internalResponse.GetShardIdSizes(j),
+                node->MutableShardFileSystemId());
+            success &= Consume(
+                extRefBuffer,
+                internalResponse.GetShardNodeNameSizes(j),
+                node->MutableShardNodeName());
+            ++j;
+        } else if (i - j < internalResponse.NodesSize()) {
+            *node = std::move(*internalResponse.MutableNodes(i - j));
+        } else {
+            success = false;
+        }
+
+        ++i;
+    }
+
+    if (!success) {
+        *response.MutableError() = MakeError(E_INVALID_STATE, TStringBuilder()
+            << "failed to parse response at name " << i);
+    }
+}
+
+void Store(
+    TStringBuf name,
+    TStringBuf shardId,
+    TStringBuf shardNodeName,
+    ui32 i,
+    NProtoPrivate::TListNodesInternalResponse& internalResponse)
+{
+    auto& nameBuffer = *internalResponse.MutableNameBuffer();
+    auto& nameSizes = *internalResponse.MutableNameSizes();
+    nameBuffer.append(name);
+    nameSizes.Add(name.size());
+
+    if (shardId) {
+        internalResponse.AddExternalRefIndices(i);
+
+        auto& extRefBuffer = *internalResponse.MutableExternalRefBuffer();
+        auto& idSizes = *internalResponse.MutableShardIdSizes();
+        auto& nodeNameSizes = *internalResponse.MutableShardNodeNameSizes();
+
+        extRefBuffer.append(shardId);
+        idSizes.Add(shardId.size());
+        extRefBuffer.append(shardNodeName);
+        nodeNameSizes.Add(shardNodeName.size());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/helpers.cpp
+++ b/cloud/filestore/libs/storage/core/helpers.cpp
@@ -164,7 +164,7 @@ void Convert(
 
     if (!success) {
         *response.MutableError() = MakeError(E_INVALID_STATE, TStringBuilder()
-            << "failed to parse response at name " << i);
+            << "failed to parse response at name " << (i - 1));
     }
 }
 

--- a/cloud/filestore/libs/storage/core/helpers.cpp
+++ b/cloud/filestore/libs/storage/core/helpers.cpp
@@ -15,15 +15,15 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool Consume(TStringBuf& buffer, ui64 len, TString* chunk)
+bool Consume(TStringBuf& input, ui64 len, TString* chunk)
 {
-    if (buffer.Size() < len) {
-        buffer.Clear();
+    if (input.Size() < len) {
+        input.Clear();
         return false;
     }
 
-    chunk->assign(buffer.Data(), len);
-    buffer.Skip(len);
+    chunk->assign(input.Data(), len);
+    input.Skip(len);
     return true;
 }
 
@@ -177,7 +177,9 @@ struct TListNodesInternalResponseBuilder::TImpl
     google::protobuf::RepeatedField<ui32>& ShardIdSizes;
     google::protobuf::RepeatedField<ui32>& ShardNodeNameSizes;
     char* NameBuffer;
+    ui64 NameBufferSize;
     char* ExternalRefBuffer;
+    ui64 ExternalRefBufferSize;
     ui32 Index = 0;
 
     TImpl(
@@ -190,6 +192,8 @@ struct TListNodesInternalResponseBuilder::TImpl
         , ExternalRefIndices(*response.MutableExternalRefIndices())
         , ShardIdSizes(*response.MutableShardIdSizes())
         , ShardNodeNameSizes(*response.MutableShardNodeNameSizes())
+        , NameBufferSize(nameBufferSize)
+        , ExternalRefBufferSize(externalRefBufferSize)
     {
         auto& nameBuffer = *response.MutableNameBuffer();
         nameBuffer.ReserveAndResize(nameBufferSize);
@@ -204,13 +208,23 @@ struct TListNodesInternalResponseBuilder::TImpl
         ShardNodeNameSizes.Reserve(externalRefCount);
     }
 
-    void AddNodeRef(
+    bool AddNodeRef(
         const TString& name,
         const TString& shardId,
         const TString& shardNodeName)
     {
+        if (name.size() > NameBufferSize) {
+            return false;
+        }
+
+        const ui64 externalRefSize = shardId.size() + shardNodeName.size();
+        if (shardId && externalRefSize > ExternalRefBufferSize) {
+            return false;
+        }
+
         memcpy(NameBuffer, name.data(), name.size());
         NameBuffer += name.size();
+        NameBufferSize -= name.size();
         NameSizes.Add(name.size());
 
         if (shardId) {
@@ -221,16 +235,24 @@ struct TListNodesInternalResponseBuilder::TImpl
                 shardId.data(),
                 shardId.size());
             ExternalRefBuffer += shardId.size();
+            ExternalRefBufferSize -= shardId.size();
             ShardIdSizes.Add(shardId.size());
             memcpy(
                 ExternalRefBuffer,
                 shardNodeName.data(),
                 shardNodeName.size());
             ExternalRefBuffer += shardNodeName.size();
+            ExternalRefBufferSize -= shardNodeName.size();
             ShardNodeNameSizes.Add(shardNodeName.size());
         }
 
         ++Index;
+        return true;
+    }
+
+    ui32 GetIndex() const
+    {
+        return Index;
     }
 };
 
@@ -251,12 +273,17 @@ TListNodesInternalResponseBuilder::TListNodesInternalResponseBuilder(
 TListNodesInternalResponseBuilder::~TListNodesInternalResponseBuilder()
 {}
 
-void TListNodesInternalResponseBuilder::AddNodeRef(
+bool TListNodesInternalResponseBuilder::AddNodeRef(
     const TString& name,
     const TString& shardId,
     const TString& shardNodeName)
 {
-    Impl->AddNodeRef(name, shardId, shardNodeName);
+    return Impl->AddNodeRef(name, shardId, shardNodeName);
+}
+
+ui32 TListNodesInternalResponseBuilder::GetIndex() const
+{
+    return Impl->GetIndex();
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/helpers.h
+++ b/cloud/filestore/libs/storage/core/helpers.h
@@ -54,10 +54,12 @@ public:
     ~TListNodesInternalResponseBuilder();
 
 public:
-    void AddNodeRef(
+    [[nodiscard]] bool AddNodeRef(
         const TString& name,
         const TString& shardId,
         const TString& shardNodeName);
+
+    [[nodiscard]] ui32 GetIndex() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/core/helpers.h
+++ b/cloud/filestore/libs/storage/core/helpers.h
@@ -29,16 +29,36 @@ void Convert(
     const NProto::TFileStorePerformanceProfile& performanceProfile,
     NKikimrFileStore::TConfig& config);
 
+////////////////////////////////////////////////////////////////////////////////
+
 void Convert(
     NProtoPrivate::TListNodesInternalResponse& internalResponse,
     NProto::TListNodesResponse& response);
 
-void Store(
-    TStringBuf name,
-    TStringBuf shardId,
-    TStringBuf shardNodeName,
-    ui32 i,
-    NProtoPrivate::TListNodesInternalResponse& internalResponse);
+////////////////////////////////////////////////////////////////////////////////
+
+class TListNodesInternalResponseBuilder
+{
+private:
+    struct TImpl;
+    THolder<TImpl> Impl;
+
+public:
+    TListNodesInternalResponseBuilder(
+        NProtoPrivate::TListNodesInternalResponse& response,
+        ui64 nameBufferSize,
+        ui64 externalRefBufferSize,
+        ui64 nameCount,
+        ui64 externalRefCount);
+
+    ~TListNodesInternalResponseBuilder();
+
+public:
+    void AddNodeRef(
+        TStringBuf name,
+        TStringBuf shardId,
+        TStringBuf shardNodeName);
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/core/helpers.h
+++ b/cloud/filestore/libs/storage/core/helpers.h
@@ -55,9 +55,9 @@ public:
 
 public:
     void AddNodeRef(
-        TStringBuf name,
-        TStringBuf shardId,
-        TStringBuf shardNodeName);
+        const TString& name,
+        const TString& shardId,
+        const TString& shardNodeName);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/core/helpers.h
+++ b/cloud/filestore/libs/storage/core/helpers.h
@@ -6,11 +6,16 @@
 
 namespace NKikimrFileStore {
     class TConfig;
-}
+}   // namespace NKikimrFileStore
 
 namespace NCloud::NFileStore::NProto {
     class TFileStorePerformanceProfile;
-}
+    class TListNodesResponse;
+}   // namespace NCloud::NFileStore::NProto
+
+namespace NCloud::NFileStore::NProtoPrivate {
+    class TListNodesInternalResponse;
+}   // namespace NCloud::NFileStore::NProtoPrivate
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -23,6 +28,17 @@ void Convert(
 void Convert(
     const NProto::TFileStorePerformanceProfile& performanceProfile,
     NKikimrFileStore::TConfig& config);
+
+void Convert(
+    NProtoPrivate::TListNodesInternalResponse& internalResponse,
+    NProto::TListNodesResponse& response);
+
+void Store(
+    TStringBuf name,
+    TStringBuf shardId,
+    TStringBuf shardNodeName,
+    ui32 i,
+    NProtoPrivate::TListNodesInternalResponse& internalResponse);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/core/helpers_ut.cpp
+++ b/cloud/filestore/libs/storage/core/helpers_ut.cpp
@@ -1,6 +1,9 @@
 #include "helpers.h"
 
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
 #include <cloud/filestore/public/api/protos/fs.pb.h>
+
+#include <cloud/storage/core/libs/common/error.h>
 
 #include <google/protobuf/util/message_differencer.h>
 
@@ -157,6 +160,155 @@ Y_UNIT_TEST_SUITE(THelpers)
 
         Comparator.Compare(TargetConfig, config);
         UNIT_ASSERT_VALUES_EQUAL("", ReportDiff);
+    }
+
+    auto MakeListNodesInternalResponse()
+    {
+        NProtoPrivate::TListNodesInternalResponse internalResponse;
+        Store("name1", "shard1", "nodename1", 0, internalResponse);
+        Store("name2", "", "", 1, internalResponse);
+        internalResponse.AddNodes()->SetId(111);
+        Store("name3", "", "", 2, internalResponse);
+        internalResponse.AddNodes()->SetId(222);
+        Store("name4", "shard2", "nodename2", 3, internalResponse);
+        Store("name5", "", "", 4, internalResponse);
+        internalResponse.AddNodes()->SetId(333);
+        internalResponse.SetCookie("cookie");
+        return internalResponse;
+    }
+
+    Y_UNIT_TEST(ShouldConvertListNodesInternalResponse)
+    {
+        auto internalResponse = MakeListNodesInternalResponse();
+
+        NProto::TListNodesResponse response;
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_C(
+            !HasError(response.GetError()),
+            FormatError(response.GetError()));
+
+        UNIT_ASSERT_VALUES_EQUAL(5, response.NamesSize());
+        UNIT_ASSERT_VALUES_EQUAL("name1", response.GetNames(0));
+        UNIT_ASSERT_VALUES_EQUAL("name2", response.GetNames(1));
+        UNIT_ASSERT_VALUES_EQUAL("name3", response.GetNames(2));
+        UNIT_ASSERT_VALUES_EQUAL("name4", response.GetNames(3));
+        UNIT_ASSERT_VALUES_EQUAL("name5", response.GetNames(4));
+
+        UNIT_ASSERT_VALUES_EQUAL(5, response.NodesSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "shard1",
+            response.GetNodes(0).GetShardFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "nodename1",
+            response.GetNodes(0).GetShardNodeName());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            response.GetNodes(1).GetShardFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL("", response.GetNodes(1).GetShardNodeName());
+        UNIT_ASSERT_VALUES_EQUAL(111, response.GetNodes(1).GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            response.GetNodes(2).GetShardFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL("", response.GetNodes(2).GetShardNodeName());
+        UNIT_ASSERT_VALUES_EQUAL(222, response.GetNodes(2).GetId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "shard2",
+            response.GetNodes(3).GetShardFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "nodename2",
+            response.GetNodes(3).GetShardNodeName());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            response.GetNodes(4).GetShardFileSystemId());
+        UNIT_ASSERT_VALUES_EQUAL("", response.GetNodes(4).GetShardNodeName());
+        UNIT_ASSERT_VALUES_EQUAL(333, response.GetNodes(4).GetId());
+
+        UNIT_ASSERT_VALUES_EQUAL("cookie", response.GetCookie());
+    }
+
+    Y_UNIT_TEST(ShouldConvertListNodesInternalResponseError)
+    {
+        NProtoPrivate::TListNodesInternalResponse internalResponse;
+        internalResponse.MutableError()->SetCode(E_REJECTED);
+        NProto::TListNodesResponse response;
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+    }
+
+    Y_UNIT_TEST(ShouldConvertListNodesInternalResponseBroken)
+    {
+        auto internalResponse = MakeListNodesInternalResponse();
+        internalResponse.MutableNameBuffer()->resize(
+            internalResponse.GetNameBuffer().size() / 2);
+
+        NProto::TListNodesResponse response;
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_INVALID_STATE,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        internalResponse = MakeListNodesInternalResponse();
+        internalResponse.MutableExternalRefBuffer()->resize(
+            internalResponse.GetExternalRefBuffer().size() / 2);
+
+        response.Clear();
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_INVALID_STATE,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        internalResponse = MakeListNodesInternalResponse();
+        internalResponse.ClearExternalRefIndices();
+
+        response.Clear();
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_INVALID_STATE,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        internalResponse = MakeListNodesInternalResponse();
+        internalResponse.ClearShardIdSizes();
+
+        response.Clear();
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_INVALID_STATE,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        internalResponse = MakeListNodesInternalResponse();
+        internalResponse.ClearShardNodeNameSizes();
+
+        response.Clear();
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_INVALID_STATE,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
+
+        internalResponse = MakeListNodesInternalResponse();
+        internalResponse.ClearNodes();
+
+        response.Clear();
+        Convert(internalResponse, response);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_INVALID_STATE,
+            response.GetError().GetCode(),
+            FormatError(response.GetError()));
     }
 }
 

--- a/cloud/filestore/libs/storage/core/helpers_ut.cpp
+++ b/cloud/filestore/libs/storage/core/helpers_ut.cpp
@@ -138,6 +138,26 @@ struct TConfigs
     {}
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
+auto MakeListNodesInternalResponse()
+{
+    NProtoPrivate::TListNodesInternalResponse internalResponse;
+    TListNodesInternalResponseBuilder builder(internalResponse, 25, 30, 5, 2);
+    internalResponse.MutableNameBuffer()->ReserveAndResize(25);
+    internalResponse.MutableExternalRefBuffer()->ReserveAndResize(30);
+    builder.AddNodeRef("name1", "shard1", "nodename1");
+    builder.AddNodeRef("name2", "", "");
+    internalResponse.AddNodes()->SetId(111);
+    builder.AddNodeRef("name3", "", "");
+    internalResponse.AddNodes()->SetId(222);
+    builder.AddNodeRef("name4", "shard2", "nodename2");
+    builder.AddNodeRef("name5", "", "");
+    internalResponse.AddNodes()->SetId(333);
+    internalResponse.SetCookie("cookie");
+    return internalResponse;
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -160,21 +180,6 @@ Y_UNIT_TEST_SUITE(THelpers)
 
         Comparator.Compare(TargetConfig, config);
         UNIT_ASSERT_VALUES_EQUAL("", ReportDiff);
-    }
-
-    auto MakeListNodesInternalResponse()
-    {
-        NProtoPrivate::TListNodesInternalResponse internalResponse;
-        Store("name1", "shard1", "nodename1", 0, internalResponse);
-        Store("name2", "", "", 1, internalResponse);
-        internalResponse.AddNodes()->SetId(111);
-        Store("name3", "", "", 2, internalResponse);
-        internalResponse.AddNodes()->SetId(222);
-        Store("name4", "shard2", "nodename2", 3, internalResponse);
-        Store("name5", "", "", 4, internalResponse);
-        internalResponse.AddNodes()->SetId(333);
-        internalResponse.SetCookie("cookie");
-        return internalResponse;
     }
 
     Y_UNIT_TEST(ShouldConvertListNodesInternalResponse)

--- a/cloud/filestore/libs/storage/core/helpers_ut.cpp
+++ b/cloud/filestore/libs/storage/core/helpers_ut.cpp
@@ -146,15 +146,19 @@ auto MakeListNodesInternalResponse()
     TListNodesInternalResponseBuilder builder(internalResponse, 25, 30, 5, 2);
     internalResponse.MutableNameBuffer()->ReserveAndResize(25);
     internalResponse.MutableExternalRefBuffer()->ReserveAndResize(30);
-    builder.AddNodeRef("name1", "shard1", "nodename1");
-    builder.AddNodeRef("name2", "", "");
+    UNIT_ASSERT(builder.AddNodeRef("name1", "shard1", "nodename1"));
+    UNIT_ASSERT(builder.AddNodeRef("name2", "", ""));
     internalResponse.AddNodes()->SetId(111);
-    builder.AddNodeRef("name3", "", "");
+    UNIT_ASSERT(builder.AddNodeRef("name3", "", ""));
     internalResponse.AddNodes()->SetId(222);
-    builder.AddNodeRef("name4", "shard2", "nodename2");
-    builder.AddNodeRef("name5", "", "");
+    UNIT_ASSERT(builder.AddNodeRef("name4", "shard2", "nodename2"));
+    UNIT_ASSERT(builder.AddNodeRef("name5", "", ""));
     internalResponse.AddNodes()->SetId(333);
     internalResponse.SetCookie("cookie");
+    internalResponse.MutableHeaders()->MutableBackendInfo()
+        ->SetIsOverloaded(true);
+    UNIT_ASSERT(!builder.AddNodeRef("name6", "", ""));
+    UNIT_ASSERT(!builder.AddNodeRef("", "shard3", "nodename3"));
     return internalResponse;
 }
 
@@ -230,6 +234,7 @@ Y_UNIT_TEST_SUITE(THelpers)
         UNIT_ASSERT_VALUES_EQUAL(333, response.GetNodes(4).GetId());
 
         UNIT_ASSERT_VALUES_EQUAL("cookie", response.GetCookie());
+        UNIT_ASSERT(response.GetHeaders().GetBackendInfo().GetIsOverloaded());
     }
 
     Y_UNIT_TEST(ShouldConvertListNodesInternalResponseError)

--- a/cloud/filestore/libs/storage/core/ya.make
+++ b/cloud/filestore/libs/storage/core/ya.make
@@ -16,6 +16,7 @@ SRCS(
 PEERDIR(
     cloud/filestore/config
     cloud/filestore/libs/service
+    cloud/filestore/private/api/protos
     cloud/filestore/public/api/protos
 
     cloud/storage/core/libs/common

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -274,9 +274,6 @@ void TListNodesActor::HandleListNodesInternalResponse(
 {
     auto* msg = ev->Get();
 
-    Response.SetCookie(msg->Record.GetCookie());
-    *Response.MutableHeaders() = std::move(*msg->Record.MutableHeaders());
-
     LOG_TRACE(
         ctx,
         TFileStoreComponents::SERVICE,

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -284,8 +284,8 @@ void TListNodesActor::HandleListNodesInternalResponse(
         msg->Record.ShortUtf8DebugString().Quote().c_str());
 
     Convert(msg->Record, Response);
-    if (HasError(msg->GetError())) {
-        HandleError(ctx, *msg->Record.MutableError());
+    if (HasError(Response.GetError())) {
+        HandleError(ctx, *Response.MutableError());
         return;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -37,6 +37,7 @@ private:
 
     // Control flags
     const bool DisableMultiTabletForwarding;
+    const bool UseListNodesInternal;
     const bool Unsafe;
 
     // Response data
@@ -59,6 +60,7 @@ public:
         TRequestInfoPtr requestInfo,
         NProto::TListNodesRequest listNodesRequest,
         bool disableMultiTabletForwarding,
+        bool useListNodesInternal,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog);
 
@@ -72,6 +74,12 @@ private:
 
     void HandleListNodesResponse(
         const TEvService::TEvListNodesResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void ListNodesInternal(const TActorContext& ctx);
+
+    void HandleListNodesInternalResponse(
+        const TEvIndexTablet::TEvListNodesInternalResponse::TPtr& ev,
         const TActorContext& ctx);
 
     void GetNodeAttrsBatch(const TActorContext& ctx);
@@ -101,12 +109,14 @@ TListNodesActor::TListNodesActor(
         TRequestInfoPtr requestInfo,
         NProto::TListNodesRequest listNodesRequest,
         bool disableMultiTabletForwarding,
+        bool useListNodesInternal,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog)
     : RequestInfo(std::move(requestInfo))
     , ListNodesRequest(std::move(listNodesRequest))
     , LogTag(ListNodesRequest.GetFileSystemId())
     , DisableMultiTabletForwarding(disableMultiTabletForwarding)
+    , UseListNodesInternal(useListNodesInternal)
     , Unsafe(ListNodesRequest.GetUnsafe())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
@@ -115,7 +125,12 @@ TListNodesActor::TListNodesActor(
 
 void TListNodesActor::Bootstrap(const TActorContext& ctx)
 {
-    ListNodes(ctx);
+    if (UseListNodesInternal) {
+        ListNodesInternal(ctx);
+    } else {
+        ListNodes(ctx);
+    }
+
     Become(&TThis::StateWork);
 }
 
@@ -130,6 +145,25 @@ void TListNodesActor::ListNodes(const TActorContext& ctx)
 
     auto request = std::make_unique<TEvService::TEvListNodesRequest>();
     request->Record = ListNodesRequest;
+
+    // forward request through tablet proxy
+    ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
+}
+
+void TListNodesActor::ListNodesInternal(const TActorContext& ctx)
+{
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "[%s] Executing ListNodesInternal in leader for %lu",
+        LogTag.c_str(),
+        ListNodesRequest.GetNodeId());
+
+    auto request =
+        std::make_unique<TEvIndexTablet::TEvListNodesInternalRequest>();
+    *request->Record.MutableOriginalRequest() = ListNodesRequest;
+    *request->Record.MutableHeaders() = ListNodesRequest.GetHeaders();
+    request->Record.SetFileSystemId(ListNodesRequest.GetFileSystemId());
 
     // forward request through tablet proxy
     ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
@@ -158,7 +192,8 @@ void TListNodesActor::GetNodeAttrsBatch(const TActorContext& ctx)
         if (node.GetShardFileSystemId()) {
             auto& batch = batches[node.GetShardFileSystemId()];
             if (batch.Record.GetHeaders().GetSessionId().empty()) {
-                batch.Record.MutableHeaders()->CopyFrom(ListNodesRequest.GetHeaders());
+                batch.Record.MutableHeaders()->CopyFrom(
+                    ListNodesRequest.GetHeaders());
                 batch.Record.MutableHeaders()->SetBehaveAsDirectoryTablet(
                     false);
                 batch.Record.SetFileSystemId(node.GetShardFileSystemId());
@@ -218,6 +253,72 @@ void TListNodesActor::HandleListNodesResponse(
     Response = std::move(msg->Record);
     GetNodeAttrsBatch(ctx);
 
+    if (GetNodeAttrResponses == Response.NodesSize()) {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "No nodes at shards for parent %lu",
+            ListNodesRequest.GetNodeId());
+
+        ReplyAndDie(ctx);
+        return;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TListNodesActor::HandleListNodesInternalResponse(
+    const TEvIndexTablet::TEvListNodesInternalResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, *msg->Record.MutableError());
+        return;
+    }
+
+    Response.SetCookie(msg->Record.GetCookie());
+    *Response.MutableHeaders() = std::move(*msg->Record.MutableHeaders());
+
+    LOG_TRACE(
+        ctx,
+        TFileStoreComponents::SERVICE,
+        "ListNodesInternalResponse %s",
+        msg->Record.ShortUtf8DebugString().Quote().c_str());
+
+    ui32 j = 0;
+    Response.MutableNames()->Reserve(msg->Record.NameSizesSize());
+    Response.MutableNodes()->Reserve(msg->Record.NameSizesSize());
+    const char* nameBuffer = msg->Record.GetNameBuffer().data();
+    const char* extRefBuffer = msg->Record.GetExternalRefBuffer().data();
+    for (ui32 i = 0; i < msg->Record.NameSizesSize(); ++i) {
+        const ui32 nextExternalNodeRefIdx =
+            j < msg->Record.ExternalRefIndicesSize()
+            ? msg->Record.GetExternalRefIndices(j) : Max<ui32>();
+
+        auto* name = Response.AddNames();
+        name->assign(nameBuffer, msg->Record.GetNameSizes(i));
+        nameBuffer += msg->Record.GetNameSizes(i);
+
+        auto* node = Response.AddNodes();
+        if (i == nextExternalNodeRefIdx) {
+            auto* shardId = node->MutableShardFileSystemId();
+            shardId->assign(extRefBuffer, msg->Record.GetShardIdSizes(j));
+            extRefBuffer += msg->Record.GetShardIdSizes(j);
+
+            auto* shardNodeName = node->MutableShardNodeName();
+            shardNodeName->assign(
+                extRefBuffer,
+                msg->Record.GetShardNodeNameSizes(j));
+            extRefBuffer += msg->Record.GetShardNodeNameSizes(j);
+            ++j;
+        } else {
+            *node = std::move(*msg->Record.MutableNodes(i - j));
+        }
+    }
+
+    GetNodeAttrsBatch(ctx);
 
     if (GetNodeAttrResponses == Response.NodesSize()) {
         LOG_DEBUG(
@@ -552,6 +653,9 @@ STFUNC(TListNodesActor::StateWork)
             TEvService::TEvListNodesResponse,
             HandleListNodesResponse);
         HFunc(
+            TEvIndexTablet::TEvListNodesInternalResponse,
+            HandleListNodesInternalResponse);
+        HFunc(
             TEvIndexTablet::TEvGetNodeAttrBatchResponse,
             HandleGetNodeAttrBatchResponse);
 
@@ -616,7 +720,7 @@ void TStorageServiceActor::HandleListNodes(
             ctx,
             sessionId,
             seqNo,
-            headers.GetDisableMultiTabletForwarding(),
+            false /* disableMultiTabletForwarding */,
             TEvService::TListNodesMethod::Name,
             msg->CallContext->RequestId,
             filestore,
@@ -647,6 +751,7 @@ void TStorageServiceActor::HandleListNodes(
         std::move(requestInfo),
         std::move(msg->Record),
         disableMultiTabletForwarding,
+        filestore.GetFeatures().GetUseListNodesInternal(),
         session->RequestStats,
         ProfileLog);
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -5,6 +5,7 @@
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/core/helpers.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -273,11 +274,6 @@ void TListNodesActor::HandleListNodesInternalResponse(
 {
     auto* msg = ev->Get();
 
-    if (HasError(msg->GetError())) {
-        HandleError(ctx, *msg->Record.MutableError());
-        return;
-    }
-
     Response.SetCookie(msg->Record.GetCookie());
     *Response.MutableHeaders() = std::move(*msg->Record.MutableHeaders());
 
@@ -287,35 +283,10 @@ void TListNodesActor::HandleListNodesInternalResponse(
         "ListNodesInternalResponse %s",
         msg->Record.ShortUtf8DebugString().Quote().c_str());
 
-    ui32 j = 0;
-    Response.MutableNames()->Reserve(msg->Record.NameSizesSize());
-    Response.MutableNodes()->Reserve(msg->Record.NameSizesSize());
-    const char* nameBuffer = msg->Record.GetNameBuffer().data();
-    const char* extRefBuffer = msg->Record.GetExternalRefBuffer().data();
-    for (ui32 i = 0; i < msg->Record.NameSizesSize(); ++i) {
-        const ui32 nextExternalNodeRefIdx =
-            j < msg->Record.ExternalRefIndicesSize()
-            ? msg->Record.GetExternalRefIndices(j) : Max<ui32>();
-
-        auto* name = Response.AddNames();
-        name->assign(nameBuffer, msg->Record.GetNameSizes(i));
-        nameBuffer += msg->Record.GetNameSizes(i);
-
-        auto* node = Response.AddNodes();
-        if (i == nextExternalNodeRefIdx) {
-            auto* shardId = node->MutableShardFileSystemId();
-            shardId->assign(extRefBuffer, msg->Record.GetShardIdSizes(j));
-            extRefBuffer += msg->Record.GetShardIdSizes(j);
-
-            auto* shardNodeName = node->MutableShardNodeName();
-            shardNodeName->assign(
-                extRefBuffer,
-                msg->Record.GetShardNodeNameSizes(j));
-            extRefBuffer += msg->Record.GetShardNodeNameSizes(j);
-            ++j;
-        } else {
-            *node = std::move(*msg->Record.MutableNodes(i - j));
-        }
+    Convert(msg->Record, Response);
+    if (HasError(msg->GetError())) {
+        HandleError(ctx, *msg->Record.MutableError());
+        return;
     }
 
     GetNodeAttrsBatch(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -557,6 +557,14 @@ private:
         ui64 value) const;
     TBackgroundOpsBackpressureStatus GetBackgroundOpsBackpressureStatus() const;
 
+    void ReplyListNodes(
+        const NActors::TActorContext& ctx,
+        TTxIndexTablet::TListNodes& args);
+
+    void ReplyListNodesInternal(
+        const NActors::TActorContext& ctx,
+        TTxIndexTablet::TListNodes& args);
+
     void HandleWakeup(
         const NActors::TEvents::TEvWakeup::TPtr& ev,
         const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -107,6 +107,8 @@ void FillFeatures(
 
     features->SetUnconfirmedFlowEnabled(
         config.GetAddingUnconfirmedDataEnabled());
+
+    features->SetUseListNodesInternal(config.GetUseListNodesInternal());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -123,7 +123,7 @@ void TIndexTabletActor::HandleListNodesInternal(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
-    AddInFlightRequest<TEvService::TListNodesMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TListNodesInternalMethod>(*requestInfo);
 
     auto maxBytes = Min(
         Config->GetMaxResponseEntries() * MaxName,
@@ -226,7 +226,7 @@ bool TIndexTabletActor::PrepareTx_ListNodes(
     // get actual nodes
     args.ChildNodes.reserve(args.ChildRefs.size());
     for (const auto& ref: args.ChildRefs) {
-        if (ref.ShardId) {
+        if (ref.IsExternal()) {
             continue;
         }
 
@@ -262,7 +262,7 @@ void TIndexTabletActor::ReplyListNodes(
         for (size_t i = 0; i < args.ChildRefs.size(); ++i) {
             auto& ref = args.ChildRefs[i];
             requestBytes += ref.Name.size();
-            if (ref.ShardId) {
+            if (ref.IsExternal()) {
                 if (!HasPendingNodeCreateInShard(ref.ShardNodeName)) {
                     AddExternalNode(
                         record,
@@ -325,13 +325,15 @@ void TIndexTabletActor::ReplyListNodesInternal(
         int extRefCount = 0;
         int skippedRefCount = 0;
         for (const auto& ref: args.ChildRefs) {
-            if (ref.ShardId && HasPendingNodeCreateInShard(ref.ShardNodeName)) {
+            if (ref.IsExternal()
+                    && HasPendingNodeCreateInShard(ref.ShardNodeName))
+            {
                 ++skippedRefCount;
                 continue;
             }
 
             nameBufferSize += ref.Name.size();
-            if (!ref.ShardId) {
+            if (!ref.IsExternal()) {
                 continue;
             }
 
@@ -356,12 +358,25 @@ void TIndexTabletActor::ReplyListNodesInternal(
 
         ui32 j = 0;
         for (auto& ref: args.ChildRefs) {
-            if (ref.ShardId && HasPendingNodeCreateInShard(ref.ShardNodeName)) {
+            if (ref.IsExternal()
+                    && HasPendingNodeCreateInShard(ref.ShardNodeName))
+            {
                 continue;
             }
 
-            builder.AddNodeRef(ref.Name, ref.ShardId, ref.ShardNodeName);
-            if (ref.ShardId) {
+            const bool added = builder.AddNodeRef(
+                ref.Name,
+                ref.ShardId,
+                ref.ShardNodeName);
+            if (!added) {
+                auto message = ReportListNodesInternalFailedToAddNodeRef(
+                    TStringBuilder() << "builder index: " << builder.GetIndex());
+                *response->Record.MutableError() =
+                    MakeError(E_INVALID_STATE, std::move(message));
+                break;
+            }
+
+            if (ref.IsExternal()) {
                 continue;
             }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -44,6 +44,12 @@ NProto::TError ValidateRequest(const NProto::TListNodesRequest& request)
     return {};
 }
 
+NProto::TError ValidateInternalRequest(
+    const NProtoPrivate::TListNodesInternalRequest& request)
+{
+    return ValidateRequest(request.GetOriginalRequest());
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -92,7 +98,53 @@ void TIndexTabletActor::HandleListNodes(
         std::move(requestInfo),
         msg->Record,
         maxBytes,
-        Config->GetMaxBytesMultiplier());
+        Config->GetMaxBytesMultiplier(),
+        false /* replyInternal */);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleListNodesInternal(
+    const TEvIndexTablet::TEvListNodesInternalRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    using TMethod = TEvIndexTablet::TListNodesInternalMethod;
+    auto* msg = ev->Get();
+
+    if (!AcceptRequestNoSession<TMethod>(ev, ctx, ValidateInternalRequest)) {
+        return;
+    }
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+    requestInfo->StartedTs = ctx.Now();
+
+    AddInFlightRequest<TEvService::TListNodesMethod>(*requestInfo);
+
+    auto maxBytes = Min(
+        Config->GetMaxResponseEntries() * MaxName,
+        Config->GetMaxResponseBytes());
+    auto& originalRequest = *msg->Record.MutableOriginalRequest();
+    if (auto bytes = originalRequest.GetMaxBytes()) {
+        maxBytes = Min(bytes, maxBytes);
+    }
+
+    // Set size calculation mode from config if not explicitly set in request.
+    // TODO(#5148): explicitly pass the mode from client side.
+    if (originalRequest.GetListNodesSizeMode() == NProto::LNSM_UNSPECIFIED)
+    {
+        originalRequest.SetListNodesSizeMode(Config->GetListNodesSizeMode());
+    }
+
+    ExecuteTx<TListNodes>(
+        ctx,
+        std::move(requestInfo),
+        std::move(originalRequest),
+        maxBytes,
+        Config->GetMaxBytesMultiplier(),
+        true /* replyInternal */);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -133,7 +185,9 @@ bool TIndexTabletActor::PrepareTx_ListNodes(
     if (!args.Node) {
         args.Error = ErrorInvalidTarget(args.NodeId);
         return true;
-    } else if (args.Node->Attrs.GetType() != NProto::E_DIRECTORY_NODE) {
+    }
+
+    if (args.Node->Attrs.GetType() != NProto::E_DIRECTORY_NODE) {
         args.Error = ErrorIsNotDirectory(args.NodeId);
         return true;
     }
@@ -189,12 +243,10 @@ bool TIndexTabletActor::PrepareTx_ListNodes(
     return ready;
 }
 
-void TIndexTabletActor::CompleteTx_ListNodes(
+void TIndexTabletActor::ReplyListNodes(
     const TActorContext& ctx,
     TTxIndexTablet::TListNodes& args)
 {
-    RemoveInFlightRequest(*args.RequestInfo);
-
     auto response =
         std::make_unique<TEvService::TEvListNodesResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {
@@ -253,6 +305,135 @@ void TIndexTabletActor::CompleteTx_ListNodes(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+void TIndexTabletActor::ReplyListNodesInternal(
+    const TActorContext& ctx,
+    TTxIndexTablet::TListNodes& args)
+{
+    using TResponse = TEvIndexTablet::TEvListNodesInternalResponse;
+    auto response = std::make_unique<TResponse>(args.Error);
+    if (SUCCEEDED(args.Error.GetCode())) {
+        ui64 nameBufferSize = 0;
+        ui64 extRefBufferSize = 0;
+        int extRefCount = 0;
+        int skippedRefCount = 0;
+        for (const auto& ref: args.ChildRefs) {
+            nameBufferSize += ref.Name.size();
+            if (!ref.ShardId) {
+                continue;
+            }
+
+            if (HasPendingNodeCreateInShard(ref.ShardNodeName)) {
+                ++skippedRefCount;
+                continue;
+            }
+
+            extRefBufferSize += ref.ShardId.size();
+            extRefBufferSize += ref.ShardNodeName.size();
+            ++extRefCount;
+        }
+
+        auto& record = response->Record;
+        auto& nameSizes = *record.MutableNameSizes();
+        nameSizes.Reserve(args.ChildRefs.size());
+
+        auto& extRefIndices = *record.MutableExternalRefIndices();
+        extRefIndices.Reserve(extRefCount);
+        auto& shardIdSizes = *record.MutableShardIdSizes();
+        shardIdSizes.Reserve(extRefCount);
+        auto& shardNodeNameSizes = *record.MutableShardNodeNameSizes();
+        shardNodeNameSizes.Reserve(extRefCount);
+        for (size_t i = 0; i < args.ChildRefs.size(); ++i) {
+            auto& ref = args.ChildRefs[i];
+            if (ref.ShardId
+                    && !HasPendingNodeCreateInShard(ref.ShardNodeName))
+            {
+                extRefIndices.Add(i);
+            }
+        }
+
+        record.MutableNameBuffer()->ReserveAndResize(nameBufferSize);
+        record.MutableExternalRefBuffer()->ReserveAndResize(extRefBufferSize);
+        char* nameBuffer = record.MutableNameBuffer()->begin();
+        char* extRefBuffer = record.MutableExternalRefBuffer()->begin();
+
+        record.MutableNodes()->Reserve(
+            args.ChildRefs.size() - extRefCount - skippedRefCount);
+
+        size_t j = 0;
+        for (size_t i = 0; i < args.ChildRefs.size(); ++i) {
+            auto& ref = args.ChildRefs[i];
+            memcpy(nameBuffer, ref.Name.data(), ref.Name.size());
+            nameBuffer += ref.Name.size();
+            nameSizes.Add(ref.Name.size());
+
+            if (ref.ShardId) {
+                if (HasPendingNodeCreateInShard(ref.ShardNodeName)) {
+                    continue;
+                }
+
+                memcpy(extRefBuffer, ref.ShardId.data(), ref.ShardId.size());
+                extRefBuffer += ref.ShardId.size();
+                shardIdSizes.Add(ref.ShardId.size());
+
+                memcpy(
+                    extRefBuffer,
+                    ref.ShardNodeName.data(),
+                    ref.ShardNodeName.size());
+                extRefBuffer += ref.ShardNodeName.size();
+                shardNodeNameSizes.Add(ref.ShardNodeName.size());
+
+                continue;
+            }
+
+            ConvertNodeFromAttrs(
+                *record.AddNodes(),
+                ref.ChildNodeId,
+                args.ChildNodes[j].Attrs);
+
+            ++j;
+        }
+
+        if (args.Next) {
+            record.SetCookie(args.Next);
+        }
+
+        Metrics.ListNodes.Update(
+            1,
+            nameBufferSize,
+            ctx.Now() - args.RequestInfo->StartedTs);
+        Metrics.ListNodesExtra.RequestedBytesPrecharge.fetch_add(
+            args.BytesToPrecharge,
+            std::memory_order_relaxed);
+        Metrics.ListNodesExtra.PrepareAttempts.fetch_add(
+            args.PrepareAttempts,
+            std::memory_order_relaxed);
+        Metrics.ListNodesExtra.ResponseNodeRefs.fetch_add(
+            args.ChildRefs.size(),
+            std::memory_order_relaxed);
+    }
+
+    CompleteResponse<TEvIndexTablet::TListNodesInternalMethod>(
+        response->Record,
+        args.RequestInfo->CallContext,
+        ctx);
+
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+void TIndexTabletActor::CompleteTx_ListNodes(
+    const TActorContext& ctx,
+    TTxIndexTablet::TListNodes& args)
+{
+    RemoveInFlightRequest(*args.RequestInfo);
+
+    if (args.ReplyInternal) {
+        ReplyListNodesInternal(ctx, args);
+        return;
+    }
+
+    ReplyListNodes(ctx, args);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -2,6 +2,8 @@
 
 #include "helpers.h"
 
+#include <cloud/filestore/libs/storage/core/helpers.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
@@ -314,18 +316,22 @@ void TIndexTabletActor::ReplyListNodesInternal(
     using TResponse = TEvIndexTablet::TEvListNodesInternalResponse;
     auto response = std::make_unique<TResponse>(args.Error);
     if (SUCCEEDED(args.Error.GetCode())) {
+        //
+        // Allocate memory.
+        //
+
         ui64 nameBufferSize = 0;
         ui64 extRefBufferSize = 0;
         int extRefCount = 0;
         int skippedRefCount = 0;
         for (const auto& ref: args.ChildRefs) {
-            nameBufferSize += ref.Name.size();
-            if (!ref.ShardId) {
+            if (ref.ShardId && HasPendingNodeCreateInShard(ref.ShardNodeName)) {
+                ++skippedRefCount;
                 continue;
             }
 
-            if (HasPendingNodeCreateInShard(ref.ShardNodeName)) {
-                ++skippedRefCount;
+            nameBufferSize += ref.Name.size();
+            if (!ref.ShardId) {
                 continue;
             }
 
@@ -335,55 +341,28 @@ void TIndexTabletActor::ReplyListNodesInternal(
         }
 
         auto& record = response->Record;
-        auto& nameSizes = *record.MutableNameSizes();
-        nameSizes.Reserve(args.ChildRefs.size());
-
-        auto& extRefIndices = *record.MutableExternalRefIndices();
-        extRefIndices.Reserve(extRefCount);
-        auto& shardIdSizes = *record.MutableShardIdSizes();
-        shardIdSizes.Reserve(extRefCount);
-        auto& shardNodeNameSizes = *record.MutableShardNodeNameSizes();
-        shardNodeNameSizes.Reserve(extRefCount);
-        for (size_t i = 0; i < args.ChildRefs.size(); ++i) {
-            auto& ref = args.ChildRefs[i];
-            if (ref.ShardId
-                    && !HasPendingNodeCreateInShard(ref.ShardNodeName))
-            {
-                extRefIndices.Add(i);
-            }
-        }
-
-        record.MutableNameBuffer()->ReserveAndResize(nameBufferSize);
-        record.MutableExternalRefBuffer()->ReserveAndResize(extRefBufferSize);
-        char* nameBuffer = record.MutableNameBuffer()->begin();
-        char* extRefBuffer = record.MutableExternalRefBuffer()->begin();
-
+        record.MutableNameSizes()->Reserve(args.ChildRefs.size());
+        record.MutableExternalRefIndices()->Reserve(extRefCount);
+        record.MutableShardIdSizes()->Reserve(extRefCount);
+        record.MutableShardNodeNameSizes()->Reserve(extRefCount);
+        record.MutableNameBuffer()->reserve(nameBufferSize);
+        record.MutableExternalRefBuffer()->reserve(extRefBufferSize);
         record.MutableNodes()->Reserve(
             args.ChildRefs.size() - extRefCount - skippedRefCount);
 
-        size_t j = 0;
-        for (size_t i = 0; i < args.ChildRefs.size(); ++i) {
+        //
+        // Build response.
+        //
+
+        ui32 j = 0;
+        for (ui32 i = 0; i < args.ChildRefs.size(); ++i) {
             auto& ref = args.ChildRefs[i];
-            memcpy(nameBuffer, ref.Name.data(), ref.Name.size());
-            nameBuffer += ref.Name.size();
-            nameSizes.Add(ref.Name.size());
+            if (ref.ShardId && HasPendingNodeCreateInShard(ref.ShardNodeName)) {
+                continue;
+            }
 
+            Store(ref.Name, ref.ShardId, ref.ShardNodeName, i, record);
             if (ref.ShardId) {
-                if (HasPendingNodeCreateInShard(ref.ShardNodeName)) {
-                    continue;
-                }
-
-                memcpy(extRefBuffer, ref.ShardId.data(), ref.ShardId.size());
-                extRefBuffer += ref.ShardId.size();
-                shardIdSizes.Add(ref.ShardId.size());
-
-                memcpy(
-                    extRefBuffer,
-                    ref.ShardNodeName.data(),
-                    ref.ShardNodeName.size());
-                extRefBuffer += ref.ShardNodeName.size();
-                shardNodeNameSizes.Add(ref.ShardNodeName.size());
-
                 continue;
             }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -341,12 +341,12 @@ void TIndexTabletActor::ReplyListNodesInternal(
         }
 
         auto& record = response->Record;
-        record.MutableNameSizes()->Reserve(args.ChildRefs.size());
-        record.MutableExternalRefIndices()->Reserve(extRefCount);
-        record.MutableShardIdSizes()->Reserve(extRefCount);
-        record.MutableShardNodeNameSizes()->Reserve(extRefCount);
-        record.MutableNameBuffer()->reserve(nameBufferSize);
-        record.MutableExternalRefBuffer()->reserve(extRefBufferSize);
+        TListNodesInternalResponseBuilder builder(
+            record,
+            nameBufferSize,
+            extRefBufferSize,
+            args.ChildRefs.size() - skippedRefCount,
+            extRefCount);
         record.MutableNodes()->Reserve(
             args.ChildRefs.size() - extRefCount - skippedRefCount);
 
@@ -355,13 +355,12 @@ void TIndexTabletActor::ReplyListNodesInternal(
         //
 
         ui32 j = 0;
-        for (ui32 i = 0; i < args.ChildRefs.size(); ++i) {
-            auto& ref = args.ChildRefs[i];
+        for (auto& ref: args.ChildRefs) {
             if (ref.ShardId && HasPendingNodeCreateInShard(ref.ShardNodeName)) {
                 continue;
             }
 
-            Store(ref.Name, ref.ShardId, ref.ShardNodeName, i, record);
+            builder.AddNodeRef(ref.Name, ref.ShardId, ref.ShardNodeName);
             if (ref.ShardId) {
                 continue;
             }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -166,6 +166,7 @@ FILESTORE_GENERATE_IMPL(GetNodeAttrBatch, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(RenameNodeInDestination, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(PrepareUnlinkDirectoryNodeInShard, TEvIndexTablet)
 FILESTORE_GENERATE_IMPL(AbortUnlinkDirectoryNodeInShard, TEvIndexTablet)
+FILESTORE_GENERATE_IMPL(ListNodesInternal, TEvIndexTablet)
 
 #undef FILESTORE_GENERATE_IMPL
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1473,6 +1473,7 @@ struct TTxIndexTablet
         const TString Cookie;
         const ui32 MaxBytes;
         const ui32 MaxBytesMultiplier;
+        const bool ReplyInternal;
 
         ui64 CommitId = InvalidCommitId;
         TMaybe<IIndexTabletDatabase::TNode> Node;
@@ -1487,7 +1488,8 @@ struct TTxIndexTablet
                 TRequestInfoPtr requestInfo,
                 const NProto::TListNodesRequest& request,
                 ui32 maxBytes,
-                ui32 maxBytesMultiplier)
+                ui32 maxBytesMultiplier,
+                bool replyInternal)
             : TSessionAware(request)
             , RequestInfo(std::move(requestInfo))
             , Request(request)
@@ -1495,6 +1497,7 @@ struct TTxIndexTablet
             , Cookie(request.GetCookie())
             , MaxBytes(maxBytes)
             , MaxBytesMultiplier(maxBytesMultiplier)
+            , ReplyInternal(replyInternal)
             , BytesToPrecharge(MaxBytes)
         {}
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -1284,3 +1284,37 @@ message TMarkNodeRefsExhaustiveResponse
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// ListNodesInternal request/response
+
+message TListNodesInternalRequest
+{
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // FileSystem identifier.
+    string FileSystemId = 2;
+
+    // Original request.
+    NProto.TListNodesRequest OriginalRequest = 3;
+}
+
+message TListNodesInternalResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    bytes NameBuffer = 2;
+    repeated uint32 NameSizes = 3;
+    bytes ExternalRefBuffer = 4;
+    repeated uint32 ShardIdSizes = 5;
+    repeated uint32 ShardNodeNameSizes = 6;
+    repeated NProto.TNodeAttr Nodes = 7;
+    repeated uint32 ExternalRefIndices = 8;
+
+    bytes Cookie = 9;
+
+    // Optional response headers.
+    NProto.TResponseHeaders Headers = 1000;
+}

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -53,6 +53,7 @@ message TFileStoreFeatures
     bool FakeDescribeDataEnabled = 38;
     bool UnconfirmedFlowEnabled = 39;
     bool GuestPosixAclEnabled = 40;
+    bool UseListNodesInternal = 41;
 }
 
 message TFileStore

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -66,9 +66,9 @@ message TNodeAttr
 
     // Shard FS id. Set if this node is actually located in the shard FS.
     // ATime, MTime, CTime and Size are stored in the shard FS.
-    string ShardFileSystemId = 11;
+    bytes ShardFileSystemId = 11;
     // Node name in the shard FS.
-    string ShardNodeName = 12;
+    bytes ShardNodeName = 12;
 
     uint64 DevId = 13;
 }

--- a/cloud/filestore/public/sdk/go/client/client.go
+++ b/cloud/filestore/public/sdk/go/client/client.go
@@ -394,8 +394,8 @@ func (client *Client) ListNodes(
 			GID:               uint64(nodes[idx].GetGid()),
 			Links:             nodes[idx].GetLinks(),
 			Type:              nodeType,
-			ShardFileSystemID: nodes[idx].GetShardFileSystemId(),
-			ShardNodeName:     nodes[idx].GetShardNodeName(),
+			ShardFileSystemID: string(nodes[idx].GetShardFileSystemId()),
+			ShardNodeName:     string(nodes[idx].GetShardNodeName()),
 			DevID:             nodes[idx].GetDevId(),
 		}
 	}

--- a/cloud/filestore/tests/fmdtest/canondata/result.json
+++ b/cloud/filestore/tests/fmdtest/canondata/result.json
@@ -4,5 +4,8 @@
     },
     "test.test_create_unlink_steal": {
         "uri": "file://test.test_create_unlink_steal/create_unlink_steal_results.txt"
+    },
+    "test.test_create_unlink_steal_list_nodes_internal": {
+        "uri": "file://test.test_create_unlink_steal_list_nodes_internal/create_unlink_steal_results.txt"
     }
 }

--- a/cloud/filestore/tests/fmdtest/canondata/test.test_create_unlink_steal_list_nodes_internal/create_unlink_steal_results.txt
+++ b/cloud/filestore/tests/fmdtest/canondata/test.test_create_unlink_steal_list_nodes_internal/create_unlink_steal_results.txt
@@ -1,0 +1,15 @@
+{
+    "create": true,
+    "create-lat-us": true,
+    "unlink": true,
+    "unlink-lat-us": true,
+    "rename": true,
+    "rename-lat-us": true,
+    "stat": true,
+    "stat-lat-us": true,
+    "list": true,
+    "list-lat-us": true,
+    "list-w": true,
+    "list-wlat-us": true,
+    "errors": false
+}

--- a/cloud/filestore/tests/fmdtest/test.py
+++ b/cloud/filestore/tests/fmdtest/test.py
@@ -3,13 +3,26 @@ import os
 
 import yatest.common as common
 
+from cloud.filestore.tests.python.lib.client import FilestoreCliClient
 from cloud.storage.core.tools.testing.qemu.lib.common import (
     env_with_guest_index,
     SshToGuest,
 )
 
 
-def do_test(test_name, aux_params):
+def do_test(test_name, aux_params, storage_config_patch=None):
+    if storage_config_patch is not None:
+        port = os.getenv("NFS_SERVER_PORT")
+        binary_path = common.binary_path(
+            "cloud/filestore/apps/client/filestore-client")
+        client = FilestoreCliClient(
+            binary_path,
+            port,
+            cwd=common.output_path())
+
+        filesystem = os.getenv("NFS_FILESYSTEM")
+        client.change_storage_service_config(filesystem, storage_config_patch)
+
     port = int(os.getenv(env_with_guest_index("QEMU_FORWARDING_PORT", 0)))
     ssh_key = os.getenv("QEMU_SSH_KEY")
     mount_dir = os.getenv("NFS_MOUNT_PATH")
@@ -19,7 +32,7 @@ def do_test(test_name, aux_params):
     fmdtest_bin = common.binary_path(
         "cloud/filestore/tools/testing/fmdtest/bin/fmdtest")
 
-    working_dir = os.path.join(mount_dir, "wd")
+    working_dir = os.path.join(mount_dir, test_name + "_wd")
     report_file = "report.json"
 
     ssh(f"{fmdtest_bin} --test-dir {working_dir} --report-path {report_file}"
@@ -49,3 +62,10 @@ def test_create_list():
         "create_list",
         "--duration 20s --unlink-percentage 0"
         " --stealer-threads 0 --lister-threads 1")
+
+
+def test_create_unlink_steal_list_nodes_internal():
+    return do_test(
+        "create_unlink_steal_list_nodes_internal",
+        "--duration 60s --stealer-threads 1",
+        {"UseListNodesInternal": True})

--- a/cloud/filestore/tests/fmdtest/ya.make
+++ b/cloud/filestore/tests/fmdtest/ya.make
@@ -8,6 +8,7 @@ TEST_SRCS(
 )
 
 DEPENDS(
+    cloud/filestore/apps/client
     cloud/filestore/tools/testing/fmdtest/bin
 )
 

--- a/cloud/filestore/tests/recipes/vhost-endpoint/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost-endpoint/__main__.py
@@ -60,6 +60,7 @@ def start(argv):
             "test_cloud",
             "test_folder",
             blk_count=args.blocks_count)
+    set_env("NFS_FILESYSTEM", args.filesystem)
 
     if args.shard_count > 0:
         shards = []


### PR DESCRIPTION
### Notes
We spend a lot of time building `TListNodesResponse`s in the tablet in charge of the listed directory - this is one of the main bottlenecks in single directory listings.

I used our local filestore setup and created a directory with 15k files, then used `fmdtest` to benchmark directory listing. Since everything was running on the same node, the overall performance was more or less defined by the performance of the `GetNodeAttrBatch` requests so it's hard to see the exact improvement that we would get, but by looking at the flamegraphs we can see that the directory tablet part of the workload improves significantly - response serialization used to take approx 50% of the time needed to process `ListNodes` requests and with `UseListNodesInternal: true` it takes only about 22% of the time.

before:
<img width="1200" height="2134" alt="before" src="https://github.com/user-attachments/assets/51120f53-8794-40e5-b82c-065dc028ff31" />

after:
<img width="1200" height="2038" alt="after" src="https://github.com/user-attachments/assets/71e2f835-46ce-45e7-af32-d41e8b1a2f3a" />

Extra changes:
* fixed filestore-client ls + storage service layer listnodes logic to actually properly work with `--disable-multitablet-forwarding` and directories in shards
* changed the types of `ShardFileSystemId` and `ShardNodeName` in `TNodeAttr` from `string` to `bytes` - no point in doing utf8 validation for those

### Issue
https://github.com/ydb-platform/nbs/issues/5726