### PR TITLE
issue-2674: OpLog diagnostics improvement + fixing missing AbortUnlink OpLogEntry cleanup in some cases

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -623,6 +623,7 @@ void TIndexTabletActor::HandleUpdateCounters(
     CalculateActorCPUUsage(ctx);
     SendMetricsToExecutor(ctx);
 
+    Store(Metrics.OpLogEntryCount, GetOpLogEntryCount());
     Store(Metrics.ResponseLogEntryCount, GetResponseLogEntryCount());
 
     UpdateCountersScheduled = false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -474,7 +474,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
                 << args.OpLogEntry.ShortUtf8DebugString().Quote());
         }
 
-        db.WriteOpLogEntry(args.OpLogEntry);
+        WriteOpLogEntry(db, args.OpLogEntry);
     }
 
     AddDupCacheEntry(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -775,7 +775,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
                     << args.OpLogEntry.ShortUtf8DebugString().Quote());
             }
 
-            db.WriteOpLogEntry(args.OpLogEntry);
+            WriteOpLogEntry(db, args.OpLogEntry);
         }
     } else {
         // hard link
@@ -1059,7 +1059,7 @@ void TIndexTabletActor::ExecuteTx_CommitNodeCreationInShard(
         args.SessionId,
         args.RequestId,
         std::move(args.Response));
-    db.DeleteOpLogEntry(args.EntryId);
+    DeleteOpLogEntry(db, args.EntryId);
 }
 
 void TIndexTabletActor::CompleteTx_CommitNodeCreationInShard(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -267,10 +267,12 @@ void TIndexTabletActor::CompleteTx_LoadState(
         args.TabletStorageInfo,
         args.LargeDeletionMarkers,
         args.OrphanNodeIds,
+        args.OpLog,
         args.ResponseLog,
         config);
     UpdateLogTag();
 
+    NMetrics::Store(Metrics.OpLogEntryCount, GetOpLogEntryCount());
     NMetrics::Store(Metrics.ResponseLogEntryCount, GetResponseLogEntryCount());
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -31,8 +31,9 @@ void TIndexTabletActor::ReplayOpLog(
         if (serializedRequest
                 && !profileLogRequest.ParseFromString(serializedRequest))
         {
-            ReportBrokenProfileLogRequest(TStringBuilder() << "Replayed"
-                << " OpLogEntry: " << op.ShortUtf8DebugString().Quote());
+            ReportBrokenProfileLogRequest(TStringBuilder()
+                << "Replayed OpLogEntry: "
+                << op.ShortUtf8DebugString().Quote());
         }
 
         if (op.HasCreateNodeRequest()) {
@@ -76,14 +77,14 @@ void TIndexTabletActor::ReplayOpLog(
             if (shouldUnlockUponCompletion) {
                 // There is a need to unlock the node ref after the operation is
                 // completed, because the node ref should have been locked
-                const auto& originalRequest =
-                    op.GetUnlinkNodeInShardRequest().GetOriginalRequest();
+                const auto& request = op.GetUnlinkNodeInShardRequest();
+                const auto& originalRequest = request.GetOriginalRequest();
                 const bool locked = TryLockNodeRef(
                     {originalRequest.GetNodeId(), originalRequest.GetName()});
                 if (!locked) {
-                    ReportFailedToLockNodeRef(
-                        TStringBuilder()
-                        << "Request: " << op.ShortUtf8DebugString());
+                    ReportFailedToLockNodeRef(TStringBuilder()
+                        << "UnlinkNodeInShardRequest: "
+                        << request.ShortUtf8DebugString().Quote());
                 }
             }
 
@@ -102,8 +103,9 @@ void TIndexTabletActor::ReplayOpLog(
                 request.GetOriginalRequest().GetNodeId(),
                 request.GetOriginalRequest().GetName()});
             if (!locked) {
-                ReportFailedToLockNodeRef(TStringBuilder() << "Request: "
-                    << request.GetOriginalRequest().ShortUtf8DebugString());
+                ReportFailedToLockNodeRef(TStringBuilder()
+                    << "RenameNodeInDestinationRequest: "
+                    << request.ShortUtf8DebugString().Quote());
             }
 
             NProto::TProfileLogRequestInfo profileLogRequest;
@@ -129,8 +131,9 @@ void TIndexTabletActor::ReplayOpLog(
                 request.GetOriginalRequest().GetNewParentId(),
                 request.GetOriginalRequest().GetNewName()});
             if (!locked) {
-                ReportFailedToLockNodeRef(TStringBuilder() << "Request: "
-                    << request.GetOriginalRequest().ShortUtf8DebugString());
+                ReportFailedToLockNodeRef(TStringBuilder()
+                    << "AbortUnlinkDirectoryNodeInShardRequest: "
+                    << request.ShortUtf8DebugString().Quote());
             }
 
             NProto::TProfileLogRequestInfo profileLogRequest;
@@ -152,8 +155,8 @@ void TIndexTabletActor::ReplayOpLog(
                 false // isLocalRename - doesn't matter w/o requestInfo
             );
         } else {
-            const TString message = ReportUnknownOpLogEntry(
-                TStringBuilder() << "OpLogEntry: " << op.DebugString().Quote());
+            const TString message = ReportUnknownOpLogEntry(TStringBuilder()
+                << "OpLogEntry: " << op.DebugString().Quote());
 
             LOG_ERROR(
                 ctx,
@@ -209,7 +212,7 @@ void TIndexTabletActor::ExecuteTx_DeleteOpLogEntry(
     Y_UNUSED(ctx);
 
     TIndexTabletDatabase db(tx.DB);
-    db.DeleteOpLogEntry(args.EntryId);
+    DeleteOpLogEntry(db, args.EntryId);
 }
 
 void TIndexTabletActor::CompleteTx_DeleteOpLogEntry(
@@ -345,7 +348,7 @@ void TIndexTabletActor::ExecuteTx_WriteOpLogEntry(
 
     TIndexTabletDatabase db(tx.DB);
     args.Entry.SetEntryId(commitId);
-    db.WriteOpLogEntry(args.Entry);
+    WriteOpLogEntry(db, args.Entry);
 }
 
 void TIndexTabletActor::CompleteTx_WriteOpLogEntry(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -598,7 +598,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
             }
         } else {
             if (args.AbortUnlinkOpLogEntryId) {
-                db.DeleteOpLogEntry(args.AbortUnlinkOpLogEntryId);
+                DeleteOpLogEntry(db, args.AbortUnlinkOpLogEntryId);
             }
 
             // remove target ref
@@ -625,7 +625,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
             shardRequest->SetUnlinkDirectory(
                 args.DestinationNodeAttr.GetType() == NProto::E_DIRECTORY_NODE);
 
-            db.WriteOpLogEntry(args.OpLogEntry);
+            WriteOpLogEntry(db, args.OpLogEntry);
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -263,6 +263,22 @@ void TIndexTabletActor::HandleDoRenameNode(
         auto response =
             std::make_unique<TMethod::TResponse>(std::move(msg->Error));
         NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+
+        //
+        // Cleaning up AbortUnlink OpLogEntry after the response is fine. We
+        // only need to make sure that this transaction completes before any
+        // other transactions. If it doesn't complete then it means that the
+        // tablet rebooted => the transactions that were issued after this one
+        // also haven't completed.
+        //
+
+        if (msg->OpLogEntryId) {
+            ExecuteTx<TDeleteOpLogEntry>(
+                ctx,
+                nullptr /* requestInfo */,
+                msg->OpLogEntryId);
+        }
+
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -651,7 +651,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
             return;
         } else {
             if (args.AbortUnlinkOpLogEntryId) {
-                db.DeleteOpLogEntry(args.AbortUnlinkOpLogEntryId);
+                DeleteOpLogEntry(db, args.AbortUnlinkOpLogEntryId);
             }
 
             // remove target ref
@@ -685,7 +685,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
                     << args.OpLogEntry.ShortUtf8DebugString().Quote());
             }
 
-            db.WriteOpLogEntry(args.OpLogEntry);
+            WriteOpLogEntry(db, args.OpLogEntry);
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -467,6 +467,22 @@ void TIndexTabletActor::HandleDoRenameNodeInDestination(
         auto response =
             std::make_unique<TMethod::TResponse>(std::move(msg->Error));
         NCloud::Reply(ctx, *msg->RequestInfo, std::move(response));
+
+        //
+        // Cleaning up AbortUnlink OpLogEntry after the response is fine. We
+        // only need to make sure that this transaction completes before any
+        // other transactions. If it doesn't complete then it means that the
+        // tablet rebooted => the transactions that were issued after this one
+        // also haven't completed.
+        //
+
+        if (msg->OpLogEntryId) {
+            ExecuteTx<TDeleteOpLogEntry>(
+                ctx,
+                nullptr /* requestInfo */,
+                msg->OpLogEntryId);
+        }
+
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -511,7 +511,7 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
             args.ChildRef->ShardNodeName,
             args.NewParentShardId);
 
-    db.WriteOpLogEntry(args.OpLogEntry);
+    WriteOpLogEntry(db, args.OpLogEntry);
 
     // update old parent timestamps
     auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
@@ -785,7 +785,7 @@ void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
         }
     }
 
-    db.DeleteOpLogEntry(args.OpLogEntryId);
+    DeleteOpLogEntry(db, args.OpLogEntryId);
 }
 
 void TIndexTabletActor::CompleteTx_CommitRenameNodeInSource(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -517,7 +517,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
                 << args.OpLogEntry.ShortUtf8DebugString().Quote());
         }
 
-        db.WriteOpLogEntry(args.OpLogEntry);
+        WriteOpLogEntry(db, args.OpLogEntry);
     } else {
         auto e = UnlinkNode(
             db,
@@ -717,7 +717,7 @@ void TIndexTabletActor::ExecuteTx_CompleteUnlinkNode(
 {
     TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
 
-    db.DeleteOpLogEntry(args.OpLogEntryId);
+    DeleteOpLogEntry(db, args.OpLogEntryId);
 
     // If the original response was an error or prepare stage failed, we don't
     // need to do anything

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -377,6 +377,7 @@ void TTabletMetrics::Register(
 
     REGISTER_AGGREGATABLE_SUM(CPUUsageMicros, EMetricType::MT_DERIVATIVE);
 
+    REGISTER_LOCAL(OpLogEntryCount, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(ResponseLogEntryCount, EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -286,6 +286,7 @@ struct TTabletMetrics
     std::atomic<i64> CPUUsageMicros{0};
     i64 CPUUsageRate = 0;
 
+    std::atomic<i64> OpLogEntryCount{0};
     std::atomic<i64> ResponseLogEntryCount{0};
 
     std::atomic<i64> RenameNotSupportedErrorCount{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -95,6 +95,7 @@ void TIndexTabletState::LoadState(
     const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo,
     const TVector<TDeletionMarker>& largeDeletionMarkers,
     const TVector<ui64>& orphanNodeIds,
+    const TVector<NProto::TOpLogEntry>& opLog,
     const TVector<NProtoPrivate::TResponseLogEntry>& responseLog,
     const TThrottlerConfig& throttlerConfig)
 {
@@ -169,6 +170,10 @@ void TIndexTabletState::LoadState(
     }
 
     Impl->OrphanNodeIds.insert(orphanNodeIds.begin(), orphanNodeIds.end());
+
+    for (const auto& entry: opLog) {
+        Impl->OpLogEntryIds.insert(entry.GetEntryId());
+    }
 
     for (const auto& entry: responseLog) {
         CommitResponseLogEntry(entry);
@@ -273,6 +278,27 @@ ui64 TIndexTabletState::CalculateExpectedShardCount(
     }
 
     return Max(currentShardCount, autoShardCount);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletState::WriteOpLogEntry(
+    TIndexTabletDatabase& db,
+    const NProto::TOpLogEntry& e)
+{
+    db.WriteOpLogEntry(e);
+    Impl->OpLogEntryIds.insert(e.GetEntryId());
+}
+
+void TIndexTabletState::DeleteOpLogEntry(TIndexTabletDatabase& db, ui64 entryId)
+{
+    db.DeleteOpLogEntry(entryId);
+    Impl->OpLogEntryIds.erase(entryId);
+}
+
+ui64 TIndexTabletState::GetOpLogEntryCount() const
+{
+    return Impl->OpLogEntryIds.size();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -279,6 +279,7 @@ public:
         const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo,
         const TVector<TDeletionMarker>& largeDeletionMarkers,
         const TVector<ui64>& orphanNodeIds,
+        const TVector<NProto::TOpLogEntry>& opLog,
         const TVector<NProtoPrivate::TResponseLogEntry>& responseLog,
         const TThrottlerConfig& throttlerConfig);
 
@@ -898,6 +899,19 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_DECLARE_DUPCACHE)
     void CommitDupCacheEntry(
         const TString& sessionId,
         ui64 requestId);
+
+    //
+    // OpLog
+    //
+
+public:
+    void WriteOpLogEntry(
+        TIndexTabletDatabase& db,
+        const NProto::TOpLogEntry& e);
+
+    void DeleteOpLogEntry(TIndexTabletDatabase& db, ui64 entryId);
+
+    ui64 GetOpLogEntryCount() const;
 
     //
     // ResponseLog

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -73,6 +73,7 @@ struct TIndexTabletState::TImpl
     TSet<ui64> OrphanNodeIds;
     TSet<TString> PendingNodeCreateInShardNames;
     THashSet<TNodeRefKey, TNodeRefKeyHash> LockedNodeRefs;
+    THashSet<ui64> OpLogEntryIds;
     THashMap<
         TInternalRequestId,
         NProtoPrivate::TResponseLogEntry,

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2209,7 +2209,6 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         TTestEnv env({}, std::move(storageConfig));
         auto registry = env.GetRegistry();
 
-
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -466,6 +466,25 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
                 FormatError(response->GetError()));
         }
 
+        //
+        // AbortUnlink OpLogEntry should be cleaned up.
+        //
+
+        tablet.SendRequest(tablet.CreateUpdateCounters());
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        auto registry = env.GetRegistry();
+        TTestRegistryVisitor visitor;
+        // clang-format off
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {{
+                {"sensor", "OpLogEntryCount"},
+                {"filesystem", "test"}
+            }, 0},
+        });
+        // clang-format on
+
         DeleteRef(tablet, dir2, name3);
 
         if (useRenameInDestination) {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -859,6 +859,21 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
             UNIT_ASSERT_VALUES_EQUAL(shardId2, abortRequest.GetFileSystemId());
         }
 
+        tablet.SendRequest(tablet.CreateUpdateCounters());
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        auto registry = env.GetRegistry();
+        TTestRegistryVisitor visitor;
+        // clang-format off
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {{
+                {"sensor", "OpLogEntryCount"},
+                {"filesystem", "test"}
+            }, 1},
+        });
+        // clang-format on
+
         //
         // Rebooting - Abort request should be re-sent upon tablet start.
         //
@@ -1070,6 +1085,21 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
             "Expected at least 2 different generations due to tablet reboot, "
             "got "
                 << rebootTracker.GetGenerationCount());
+
+        tablet.SendRequest(tablet.CreateUpdateCounters());
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        auto registry = env.GetRegistry();
+        TTestRegistryVisitor visitor;
+        // clang-format off
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {{
+                {"sensor", "ResponseLogEntryCount"},
+                {"filesystem", "test"}
+            }, static_cast<i64>(requestIds.size())},
+        });
+        // clang-format on
 
         UNIT_ASSERT_GT(failures, 0);
     }


### PR DESCRIPTION
### Notes
* Better logging and crit event reporting upon OpLog replay
* OpLogEntryCount counter implemented
* fixed missing `AbortUnlink` `OpLogEntry` cleanup in case of dir to dir `RenameNode` attempts that result in `E_FS_NOTEMPTY` - in this case we first log `AbortUnlink`, then we do `PrepareUnlink` which fails with `E_FS_NOTEMPTY`, and then we need to delete the logged `AbortUnlink` `OpLogEntry`, not just reply with the error that we got 

### Issue
Follow-up improvements for https://github.com/ydb-platform/nbs/issues/2674 