### PR TITLE
issue-5431: ShardIdSelectionInLeaderEnabled is now obsolete

### DIFF
--- a/cloud/filestore/bin/nfs/nfs-storage.txt
+++ b/cloud/filestore/bin/nfs/nfs-storage.txt
@@ -11,4 +11,3 @@ TwoStageReadEnabled: true
 TwoStageReadThreshold: 65536
 MaxFuseLoopThreads: 8
 DirectoryCreationInShardsEnabled: true
-ShardIdSelectionInLeaderEnabled: true

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -517,7 +517,7 @@ message TStorageConfig
     //
     // Obsolete.
     // TODO(#5431): remove
-    optional bool ShardIdSelectionInLeaderEnabled = 411;
+    optional bool ShardIdSelectionInLeaderEnabled = 411 [deprecated = true];
 
     // Shard balancer will prefer shards which have at least this amount of
     // free space in bytes.

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -514,6 +514,9 @@ message TStorageConfig
     // Enables ShardId selection in Leader for CreateNode and CreateHandle
     // requests. ShardIds selected in Leader have priority over ShardIds
     // selected at the StorageServiceActor level.
+    //
+    // Obsolete.
+    // TODO(#5431): remove
     optional bool ShardIdSelectionInLeaderEnabled = 411;
 
     // Shard balancer will prefer shards which have at least this amount of

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -69,7 +69,6 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(AutomaticallyCreatedShardSize,                          ui64,   5_TB  )\
     xxx(EnforceCorrectFileSystemShardCountUponSessionCreation,  bool,   false )\
                                                                                \
-    xxx(ShardIdSelectionInLeaderEnabled,                        bool,   false )\
     xxx(ShardBalancerDesiredFreeSpaceReserve,                   ui64,   1_TB  )\
     xxx(ShardBalancerMinFreeSpaceReserve,                       ui64,   1_MB  )\
     xxx(ShardBalancerPolicy,                                                   \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -321,7 +321,6 @@ public:
     ui64 GetAutomaticallyCreatedShardSize() const;
     bool GetEnforceCorrectFileSystemShardCountUponSessionCreation() const;
 
-    bool GetShardIdSelectionInLeaderEnabled() const;
     ui64 GetShardBalancerDesiredFreeSpaceReserve() const;
     ui64 GetShardBalancerMinFreeSpaceReserve() const;
     NProto::EShardBalancerPolicy GetShardBalancerPolicy() const;

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -306,16 +306,13 @@ void TStorageServiceActor::HandleCreateHandle(
         msg->Record.SetFileSystemId(shardId);
     }
 
-    const auto& shardId = session->SelectShard();
     const bool multiTabletForwardingEnabled =
         StorageConfig->GetMultiTabletForwardingEnabled()
         && !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
-    if (!multiTabletForwardingEnabled || !shardId) {
+    if (!multiTabletForwardingEnabled || !session->HasShards()) {
         ForwardRequest<TEvService::TCreateHandleMethod>(ctx, ev);
         return;
     }
-
-    msg->Record.SetShardFileSystemId(shardId);
 
     LOG_DEBUG(
         ctx,

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -410,18 +410,6 @@ void TStorageServiceActor::HandleCreateNode(
 
             return;
         }
-    } else {
-        const bool multiTabletForwardingEnabled =
-            StorageConfig->GetMultiTabletForwardingEnabled() &&
-            !headers.GetDisableMultiTabletForwarding() &&
-            (msg->Record.HasFile() ||
-             filestore.GetFeatures().GetDirectoryCreationInShardsEnabled());
-
-        if (multiTabletForwardingEnabled) {
-            if (const auto& shardId = session->SelectShard()) {
-                msg->Record.SetShardFileSystemId(shardId);
-            }
-        }
     }
 
     ForwardRequest<TEvService::TCreateNodeMethod>(ctx, ev);

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -398,6 +398,11 @@ struct TSessionInfo
         return MainTabletState;
     }
 
+    bool HasShards() const
+    {
+        return FileStore.ShardFileSystemIdsSize() > 0;
+    }
+
     const TString& SelectShard()
     {
         const auto& shards = FileStore.GetShardFileSystemIds();

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -33,13 +33,6 @@ NProto::TStorageConfig MakeStorageConfig()
     return config;
 }
 
-NProto::TStorageConfig MakeStorageConfigWithShardIdSelectionInLeader()
-{
-    NProto::TStorageConfig config;
-    config.SetShardIdSelectionInLeaderEnabled(true);
-    return config;
-}
-
 NProto::TStorageConfig MakeStorageConfigWithDirectoryCreationInShards()
 {
     NProto::TStorageConfig config;
@@ -122,20 +115,7 @@ void CheckShardsSize(
     void TestImpl##name(NProto::TStorageConfig config)                         \
 // SERVICE_TEST_DECL
 
-#define SERVICE_TEST_SID_SELECT_IN_LEADER(name)                                \
-    SERVICE_TEST_DECL(name);                                                   \
-    Y_UNIT_TEST(name)                                                          \
-    {                                                                          \
-        TestImpl##name(MakeStorageConfig());                                   \
-    }                                                                          \
-    Y_UNIT_TEST(name##WithShardIdSelectionInLeader)                            \
-    {                                                                          \
-        TestImpl##name(MakeStorageConfigWithShardIdSelectionInLeader());       \
-    }                                                                          \
-    SERVICE_TEST_DECL(name)                                                    \
-// SERVICE_TEST_SID_SELECT_IN_LEADER
-
-#define SERVICE_TEST_SIMPLE(name)                                              \
+#define SERVICE_TEST(name)                                                     \
     SERVICE_TEST_DECL(name);                                                   \
     Y_UNIT_TEST(name)                                                          \
     {                                                                          \
@@ -143,15 +123,6 @@ void CheckShardsSize(
     }                                                                          \
     SERVICE_TEST_DECL(name)                                                    \
 // SERVICE_TEST_SIMPLE
-
-#define SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(name)                           \
-    SERVICE_TEST_DECL(name);                                                   \
-    Y_UNIT_TEST(name##WithShardIdSelectionInLeader)                            \
-    {                                                                          \
-        TestImpl##name(MakeStorageConfigWithShardIdSelectionInLeader());       \
-    }                                                                          \
-    SERVICE_TEST_DECL(name)                                                    \
-// SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY
 
 #define SERVICE_TEST_DIR_CREATION_IN_SHARDS(name)                         \
     SERVICE_TEST_DECL(name);                                              \
@@ -216,7 +187,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     Y_UNUSED(fsInfo);                                                         \
     // CREATE_ENV_AND_SHARDED_FILESYSTEM
 
-    SERVICE_TEST_SIMPLE(ShouldCreateSessionInShards)
+    SERVICE_TEST(ShouldCreateSessionInShards)
     {
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -356,7 +327,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldRestoreSessionInShardAfterShardRestart)
+    SERVICE_TEST(ShouldRestoreSessionInShardAfterShardRestart)
     {
         const auto idleSessionTimeout = TDuration::Minutes(2);
         config.SetIdleSessionTimeout(idleSessionTimeout.MilliSeconds());
@@ -528,7 +499,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             TString(1_MB, 'a'));
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldCreateNodeInShardViaLeader)
+    SERVICE_TEST(ShouldCreateNodeInShardViaLeader)
     {
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -671,7 +642,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             counter->GetAtomic());
     }
 
-    SERVICE_TEST_SIMPLE(ShouldCheckAttrForNodeCreatedInShardViaLeader)
+    SERVICE_TEST(ShouldCheckAttrForNodeCreatedInShardViaLeader)
     {
         // If the size is changed with mtime update, this is an acceptable
         // situation and should not trigger the critical event
@@ -714,8 +685,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             true);
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldCreateNodeInShardByCreateHandleViaLeader)
+    SERVICE_TEST(ShouldCreateNodeInShardByCreateHandleViaLeader)
     {
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -810,7 +780,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             listNodesResponse.GetNodes(0).GetShardNodeName());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldReturnShardInfoFromUnsafeListNodes)
+    SERVICE_TEST(ShouldReturnShardInfoFromUnsafeListNodes)
     {
         config.SetMultiTabletForwardingEnabled(true);
 
@@ -859,7 +829,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             listNodesResponse.GetNodes(0).GetShardNodeName());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldForwardRequestsToShard)
+    SERVICE_TEST(ShouldForwardRequestsToShard)
     {
         config.SetLazyXAttrsEnabled(false);
         config.SetMultiTabletForwardingEnabled(true);
@@ -1068,7 +1038,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             setNodeXAttrResponseEvent->GetErrorReason());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldSetHasXAttrsFlagOnFirstSetNodeXAttr)
+    SERVICE_TEST(ShouldSetHasXAttrsFlagOnFirstSetNodeXAttr)
     {
         for (bool lazyXAttrsEnabled: {false, true}) {
             config.SetLazyXAttrsEnabled(lazyXAttrsEnabled);
@@ -1230,7 +1200,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldCreateDirectoryStructureInLeader)
+    SERVICE_TEST(ShouldCreateDirectoryStructureInLeader)
     {
         config.SetMultiTabletForwardingEnabled(true);
 
@@ -1309,7 +1279,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         service.DestroyHandle(headers, fsConfig.FsId, nodeId2, handle2);
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldReturnErrorForInvalidShardNo)
+    SERVICE_TEST(ShouldReturnErrorForInvalidShardNo)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -1343,8 +1313,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             writeDataResponse->GetErrorReason());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldNotReturnInvalidShardNoErrorForDirectShardRequests)
+    SERVICE_TEST(ShouldNotReturnInvalidShardNoErrorForDirectShardRequests)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TTestEnv env({}, config);
@@ -1408,8 +1377,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(data, readDataResponse->Record.GetBuffer());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldHandleCreateNodeErrorFromShardUponCreateHandleViaLeader)
+    SERVICE_TEST(ShouldHandleCreateNodeErrorFromShardUponCreateHandleViaLeader)
     {
         config.SetMultiTabletForwardingEnabled(true);
 
@@ -1472,7 +1440,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             FormatError(response->GetError()));
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldNotFailListNodesUponGetAttrENOENT)
+    SERVICE_TEST(ShouldNotFailListNodesUponGetAttrENOENT)
     {
         config.SetMultiTabletForwardingEnabled(true);
 
@@ -1628,7 +1596,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             response->GetErrorReason());
     }
 
-    SERVICE_TEST_SIMPLE(ShouldListMultipleNodesWithGetNodeAttrBatch)
+    SERVICE_TEST(ShouldListMultipleNodesWithGetNodeAttrBatch)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -1701,7 +1669,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldValidateRequestsWithShardId)
+    SERVICE_TEST(ShouldValidateRequestsWithShardId)
     {
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -1733,7 +1701,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             createHandleResponseEvent->GetErrorReason());
     }
 
-    SERVICE_TEST_SIMPLE(ShouldValidateShardConfiguration)
+    SERVICE_TEST(ShouldValidateShardConfiguration)
     {
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -1823,7 +1791,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // to the shard order in leader's config
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldRenameExternalNodes)
+    SERVICE_TEST(ShouldRenameExternalNodes)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -2059,7 +2027,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             getNodeAttrResponse->GetErrorReason().c_str());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldPerformLocksForExternalNodes)
+    SERVICE_TEST(ShouldPerformLocksForExternalNodes)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -2183,7 +2151,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             NProto::E_SHARED);
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldLinkExternalNodes)
+    SERVICE_TEST(ShouldLinkExternalNodes)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -2312,7 +2280,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             TCreateNodeArgs::Link(RootNodeId, "file3", nodeId1 + 100));
     }
 
-    SERVICE_TEST_SIMPLE(ShouldAggregateFileSystemMetrics)
+    SERVICE_TEST(ShouldAggregateFileSystemMetrics)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -2400,7 +2368,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(
+    SERVICE_TEST(
         ShouldGetMultishardedSystemTopologyWithStrictFileSystemSizeEnforcement)
     {
         config.SetMultiTabletForwardingEnabled(true);
@@ -2463,7 +2431,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         testFileSystemTopology(2, fsConfig.Shard2Id);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldGetStorageStatsInDifferentModes)
+    SERVICE_TEST(ShouldGetStorageStatsInDifferentModes)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
@@ -2577,7 +2545,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(
+    SERVICE_TEST(
         ShouldEnableStrictFileSystemSizeEnforcementAndDirectoryCreationInShards)
     {
         // Create file system with two shards 1000 * 4 * 1024 bytes each
@@ -2713,7 +2681,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             GenerateValidateData(fileSize, 0xBADF00D));
     }
 
-    SERVICE_TEST_SIMPLE(
+    SERVICE_TEST(
         ShouldResizeShardsInStrictWithStrictFileSystemSizeEnforcement)
     {
         // Create file system with two shards 1000 * 4 * 1024 bytes each
@@ -2739,7 +2707,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             newBlocksCount * 2);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldRetryFileSystemResize)
+    SERVICE_TEST(ShouldRetryFileSystemResize)
     {
         // Create a filsystem with two shards.
         config.SetMultiTabletForwardingEnabled(true);
@@ -2813,7 +2781,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldSwitchOldFilesystemToStrictMode)
+    SERVICE_TEST(ShouldSwitchOldFilesystemToStrictMode)
     {
         // This test starts the storage service with
         // StrictFileSystemSizeEnforcementEnabled == flase, then restarts it
@@ -2870,7 +2838,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldUseOldFileSystemInStrictMode)
+    SERVICE_TEST(ShouldUseOldFileSystemInStrictMode)
     {
         const ui64 blockSize = 4_KB;
         config.SetAutomaticShardCreationEnabled(true);
@@ -2916,7 +2884,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldAggregateFileSystemMetricsInBackground)
+    SERVICE_TEST(ShouldAggregateFileSystemMetricsInBackground)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -3122,7 +3090,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             10'000'000);
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldRetryUnlinkingInShard)
+    SERVICE_TEST(ShouldRetryUnlinkingInShard)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -3222,8 +3190,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             unlinkResponse->GetError().GetMessage());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldRetryUnlinkingInShardUponLeaderRestart)
+    SERVICE_TEST(ShouldRetryUnlinkingInShardUponLeaderRestart)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -3311,8 +3278,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldRetryUnlinkingInShardUponLeaderRestartForRenameNode)
+    SERVICE_TEST(ShouldRetryUnlinkingInShardUponLeaderRestartForRenameNode)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -3417,7 +3383,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(0, listNodesResponse.NodesSize());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldRetryNodeCreationInShard)
+    SERVICE_TEST(ShouldRetryNodeCreationInShard)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -3505,8 +3471,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             createResponse->Record.GetNode().GetId());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldRetryNodeCreationInShardUponLeaderRestart)
+    SERVICE_TEST(ShouldRetryNodeCreationInShardUponLeaderRestart)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -3615,8 +3580,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             createResponse->Record.GetNode().GetId());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
-        ShouldRetryNodeCreationInShardUponCreateHandle)
+    SERVICE_TEST(ShouldRetryNodeCreationInShardUponCreateHandle)
     {
         config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
@@ -3712,7 +3676,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             createHandleResponse->Record.GetNodeAttr().GetId());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER(
+    SERVICE_TEST(
         ShouldRetryNodeCreationInShardUponCreateHandleUponLeaderRestart)
     {
         config.SetMultiTabletForwardingEnabled(true);
@@ -3892,7 +3856,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldConfigureShardsAutomatically)
+    SERVICE_TEST(ShouldConfigureShardsAutomatically)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -3916,8 +3880,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             {fsId, fsId + "_s1", fsId + "_s2"});
     }
 
-    SERVICE_TEST_SIMPLE(
-        ShouldNotConfigureShardsAutomaticallyForSmallFileSystems)
+    SERVICE_TEST(ShouldNotConfigureShardsAutomaticallyForSmallFileSystems)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -3934,7 +3897,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         DoTestShardedFileSystemConfigured(fsId, service, {fsId});
     }
 
-    SERVICE_TEST_SIMPLE(ShouldHandleErrorsDuringShardedFileSystemCreation)
+    SERVICE_TEST(ShouldHandleErrorsDuringShardedFileSystemCreation)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -4096,7 +4059,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             {fsId, fsId + "_s1", fsId + "_s2"});
     }
 
-    SERVICE_TEST_SIMPLE(ShouldDeleteShardsAutomatically)
+    SERVICE_TEST(ShouldDeleteShardsAutomatically)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -4146,7 +4109,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldHandleErrorsDuringShardedFileSystemDestruction)
+    SERVICE_TEST(ShouldHandleErrorsDuringShardedFileSystemDestruction)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -4285,7 +4248,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldAddShardsAutomaticallyUponResize)
+    SERVICE_TEST(ShouldAddShardsAutomaticallyUponResize)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -4337,7 +4300,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldHandleErrorsDuringShardedFileSystemResize)
+    SERVICE_TEST(ShouldHandleErrorsDuringShardedFileSystemResize)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -4544,7 +4507,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         DoTestShardedFileSystemConfigured(fsId, service, expected);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldValidateShardList)
+    SERVICE_TEST(ShouldValidateShardList)
     {
         TTestEnv env({}, config);
 
@@ -4692,7 +4655,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldCreateSessionDirectlyInShard)
+    SERVICE_TEST(ShouldCreateSessionDirectlyInShard)
     {
         TTestEnv env({}, config);
 
@@ -4729,7 +4692,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldNotAutomaticallyAddShardsToShards)
+    SERVICE_TEST(ShouldNotAutomaticallyAddShardsToShards)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -5031,7 +4994,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldAddExplicitShardCountAutomaticallyUponResize)
+    SERVICE_TEST(ShouldAddExplicitShardCountAutomaticallyUponResize)
     {
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(4_TB);
@@ -5075,7 +5038,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(ShouldCreateDirectoryStructureInShards)
+    SERVICE_TEST(ShouldCreateDirectoryStructureInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -5217,8 +5180,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             counters->GetCounter("UnlinkNodeInShard.Count")->GetAtomic());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldResizeFileSystemWithDirectoryCreationInShardsEnabled)
+    SERVICE_TEST(ShouldResizeFileSystemWithDirectoryCreationInShardsEnabled)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -5332,7 +5294,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+    SERVICE_TEST(
         ShouldNotResizeShardWithStrictModeAndDirectoryCreationInShardsEnabled)
     {
         config.SetMultiTabletForwardingEnabled(true);
@@ -5404,8 +5366,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldResizeShardWithDirectoryCreationInShardsEnabled)
+    SERVICE_TEST(ShouldResizeShardWithDirectoryCreationInShardsEnabled)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -5533,7 +5494,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(ShouldCreateHardLinks)
+    SERVICE_TEST(ShouldCreateHardLinks)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -5561,8 +5522,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     }
 
     // See #5826 for more details
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldRejectHardLinkFromShardDirToMainTabletNode)
+    SERVICE_TEST(ShouldRejectHardLinkFromShardDirToMainTabletNode)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
@@ -5630,8 +5590,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(1, counter->GetAtomic());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldListNodesAndGetNodeAttrInDirectoryInShard)
+    SERVICE_TEST(ShouldListNodesAndGetNodeAttrInDirectoryInShard)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -5747,7 +5706,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             getAttrResponse.GetNode().GetType());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+    SERVICE_TEST(
         ShouldAggregateFileSystemMetricsInBackgroundWithDirectoriesInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
@@ -5883,8 +5842,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     };
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldUnlinkNodeWithDirectoriesInShards)
+    SERVICE_TEST(ShouldUnlinkNodeWithDirectoriesInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -6003,8 +5961,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL("file-link2", listing.GetNames(1));
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldHandleUnlinkedNodeUponListingWithDirectoriesInShards)
+    SERVICE_TEST(ShouldHandleUnlinkedNodeUponListingWithDirectoriesInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -6100,8 +6057,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldHandleRenameNodeInDestinationError)
+    SERVICE_TEST(ShouldHandleRenameNodeInDestinationError)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -6232,7 +6188,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+    SERVICE_TEST(
         ShouldRetryRenameNodeInShardUponLeaderRestartWithDirectoriesInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
@@ -6362,8 +6318,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldLockSourceNodeRefsUponRenameNodeWithDirectoriesInShards)
+    SERVICE_TEST(ShouldLockSourceNodeRefsUponRenameNodeWithDirectoriesInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
@@ -6569,7 +6524,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+    SERVICE_TEST(
         ShouldRestoreNodeRefLocksUponLeaderRestartWithDirectoriesInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
@@ -6675,7 +6630,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
+    SERVICE_TEST(
         ShouldProcessRenameNodeInDestinationErrorWithDirectoriesInShards)
     {
         config.SetMultiTabletForwardingEnabled(true);
@@ -6767,7 +6722,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
-    SERVICE_TEST_SIMPLE(ShouldRestoreSessionAfterShardRestartViaGetNodeAttr)
+    SERVICE_TEST(ShouldRestoreSessionAfterShardRestartViaGetNodeAttr)
     {
         config.SetMultiTabletForwardingEnabled(true);
 
@@ -6873,6 +6828,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
     }
+
     SERVICE_TEST_DIR_CREATION_IN_SHARDS(
         ShouldNotRequireActiveSessionForGetNodeAttrBatchToShard)
     {
@@ -6935,7 +6891,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     }
 
     // TODO(2566) get rid of this test after migration
-    SERVICE_TEST_SIMPLE(ShouldReportSevenBytesHandlesCount)
+    SERVICE_TEST(ShouldReportSevenBytesHandlesCount)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
@@ -7068,7 +7024,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         });
     }
 
-    SERVICE_TEST_SIMPLE(ShouldReportStrictFileSystemSizeEnforcementMetrics)
+    SERVICE_TEST(ShouldReportStrictFileSystemSizeEnforcementMetrics)
     {
         DoShouldReportStrictFileSystemSizeEnforcementMetrics(
             config,
@@ -7080,7 +7036,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             true);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldCreateALotOfshards)
+    SERVICE_TEST(ShouldCreateALotOfshards)
     {
         const ui64 blockSize = 4_KB;
         const ui64 shardBlockCount = 1024;
@@ -7176,7 +7132,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             mainStats.GetStats().GetSevenBytesHandlesCount());
     }
 
-    SERVICE_TEST_SIMPLE(ShouldUseOldHandles)
+    SERVICE_TEST(ShouldUseOldHandles)
     {
         // This test verifies that when TStorageConfig::maxShardCount is defualt
         // (254) and we create a handle that uses the 7th byte,
@@ -7248,7 +7204,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(fsId, fsIdFromRequest);
     }
 
-    SERVICE_TEST_SIMPLE(ShouldUnsafeCreateHandlesInShards)
+    SERVICE_TEST(ShouldUnsafeCreateHandlesInShards)
     {
         const ui64 blockSize = 4_KB;
         const ui64 shardBlockCount = 1024;
@@ -7371,7 +7327,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_EQUAL(MaxOneByteShardCount, stats.GetShardStats().size());
     }
 
-    SERVICE_TEST_SIMPLE(ShouldReturnListNodesMissingFromShardsWithUnsafeFlag)
+    SERVICE_TEST(ShouldReturnListNodesMissingFromShardsWithUnsafeFlag)
     {
         config.SetMultiTabletForwardingEnabled(true);
 
@@ -7556,16 +7512,14 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                 ->GetAtomic());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldShardedFileSystemHitNodesCountLimit)
+    SERVICE_TEST(ShouldShardedFileSystemHitNodesCountLimit)
     {
         DoShouldShardedFileSystemHitNodesCountLimit(config, true, true);
         DoShouldShardedFileSystemHitNodesCountLimit(config, true, false);
         DoShouldShardedFileSystemHitNodesCountLimit(config, false, true);
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldNotUpdateShardBalancerInTabletZombieState)
+    SERVICE_TEST(ShouldNotUpdateShardBalancerInTabletZombieState)
     {
         // This test verifies the fix for the following crash:
         // 1. TEvAggregateStatsCompleted was sent.
@@ -7625,8 +7579,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             nodeIdx);
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
-        ShouldSwitchOnDirectoryCreationInShardsForExistingFilesystem)
+    SERVICE_TEST(ShouldSwitchOnDirectoryCreationInShardsForExistingFilesystem)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(false);

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -4859,7 +4859,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     Y_UNIT_TEST(ShouldBalanceShardsByFreeSpace)
     {
         NProto::TStorageConfig config;
-        config.SetShardIdSelectionInLeaderEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(4_MB);
         config.SetAutomaticallyCreatedShardSize(4_MB);
@@ -5556,7 +5555,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             false /* force */,
             2 /* shardCount */,
             false /* enableStrictSizeMode */,
-            true /* directoryCreationInShards */);
+            true /* directoryCreationInShards */,
+            true /* forceDirectoryCreationInShards */);
         WaitForTabletStart(service);
 
         headers = service.InitSession(fsId, "client");

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -244,8 +244,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
 
             auto shardId = args.RequestShardId;
             if (!behaveAsShard
-                    && !GetFileSystem().GetShardFileSystemIds().empty()
-                    && Config->GetShardIdSelectionInLeaderEnabled())
+                    && !GetFileSystem().GetShardFileSystemIds().empty())
             {
                 args.Error = SelectShard(0 /*fileSize*/, &shardId);
                 if (HasError(args.Error)) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -539,18 +539,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
     const bool isParentNodeLinkRequest =
         args.Request.HasLink() && args.Request.GetLink().GetShardNodeName();
 
-    //
-    // If directory creation in shards is enabled we cannot allow the service
-    // layer to decide where to create the node because we need to perform some
-    // extra checks which the service layer is unable to do.
-    //
-
-    const bool shardIdSelectionEnabled =
-        Config->GetShardIdSelectionInLeaderEnabled()
-        || GetFileSystem().GetDirectoryCreationInShardsEnabled();
-
     if (!BehaveAsShard(args.Request.GetHeaders())
-            && shardIdSelectionEnabled
             && !GetFileSystem().GetShardFileSystemIds().empty()
             && (args.Attrs.GetType() == NProto::E_REGULAR_NODE
                 || GetFileSystem().GetDirectoryCreationInShardsEnabled()

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_force_directory_creation_in_shards/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_force_directory_creation_in_shards/results.txt
@@ -1,6 +1,6 @@
 [
     {
-        "ShardFileSystemId": "fs0_s2",
+        "ShardFileSystemId": "fs0_s3",
         "Name": ".something"
     },
     {
@@ -15,15 +15,15 @@
         "Name": "a1"
     },
     {
-        "ShardFileSystemId": "fs0_s3",
+        "ShardFileSystemId": "fs0_s1",
         "Name": "another.something"
     },
     {
-        "ShardFileSystemId": "fs0_s1",
+        "ShardFileSystemId": "fs0_s3",
         "Name": "f18.txt"
     },
     {
-        "ShardFileSystemId": "fs0_s1",
+        "ShardFileSystemId": "fs0_s2",
         "Name": "file.txt"
     }
 ][
@@ -32,42 +32,42 @@
         "Links": 1,
         "Name": "b1",
         "Mode": 511,
-        "Id": 72057594037927950
+        "Id": 72057594037927943
     },
     {
         "Type": 2,
         "Links": 1,
         "Name": "b2",
         "Mode": 511,
-        "Id": 144115188075855874
+        "Id": 144115188075855878
     },
     {
         "Type": 2,
         "Links": 1,
         "Name": "b3",
         "Mode": 511,
-        "Id": 216172782113783810
+        "Id": 72057594037927947
     },
     {
         "Type": 2,
         "Links": 1,
         "Name": "b5",
         "Mode": 511,
-        "Id": 72057594037927960
+        "Id": 144115188075855883
     },
     {
         "Type": 2,
         "Links": 1,
         "Name": "b6",
         "Mode": 511,
-        "Id": 72057594037927962
+        "Id": 72057594037927949
     }
 ]dirViewer(1):
 [
     {
         "name": ".something",
         "node": {
-            "shardId": "fs0_s2",
+            "shardId": "fs0_s3",
             "type": 1,
             "size": 0,
             "mode": 420
@@ -94,7 +94,7 @@
     {
         "name": "another.something",
         "node": {
-            "shardId": "fs0_s3",
+            "shardId": "fs0_s1",
             "type": 1,
             "size": 0,
             "mode": 420
@@ -103,7 +103,7 @@
     {
         "name": "f18.txt",
         "node": {
-            "shardId": "fs0_s1",
+            "shardId": "fs0_s3",
             "type": 1,
             "size": 62,
             "mode": 0
@@ -112,7 +112,7 @@
     {
         "name": "file.txt",
         "node": {
-            "shardId": "fs0_s1",
+            "shardId": "fs0_s2",
             "type": 1,
             "size": 0,
             "mode": 420

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_shard_autoaddition/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_shard_autoaddition/results.txt
@@ -55,28 +55,28 @@ E_NOT_FOUND ss error: SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path not found, 
         "Links": 1,
         "Size": 9,
         "Name": "xxx4",
-        "Id": 72057594037927941
+        "Id": 144115188075855874
     },
     {
         "Type": 1,
         "Links": 1,
         "Size": 9,
         "Name": "xxx5",
-        "Id": 72057594037927942
+        "Id": 216172782113783810
     },
     {
         "Type": 1,
         "Links": 1,
         "Size": 9,
         "Name": "xxx6",
-        "Id": 72057594037927943
+        "Id": 72057594037927941
     },
     {
         "Type": 1,
         "Links": 1,
         "Size": 9,
         "Name": "xxx7",
-        "Id": 72057594037927944
+        "Id": 144115188075855875
     }
 ][
     {
@@ -92,11 +92,11 @@ E_NOT_FOUND ss error: SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path not found, 
         "Name": "xxx3"
     },
     {
-        "ShardFileSystemId": "fs0_s1",
+        "ShardFileSystemId": "fs0_s2",
         "Name": "xxx4"
     },
     {
-        "ShardFileSystemId": "fs0_s1",
+        "ShardFileSystemId": "fs0_s3",
         "Name": "xxx5"
     },
     {
@@ -104,7 +104,7 @@ E_NOT_FOUND ss error: SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path not found, 
         "Name": "xxx6"
     },
     {
-        "ShardFileSystemId": "fs0_s1",
+        "ShardFileSystemId": "fs0_s2",
         "Name": "xxx7"
     }
 ]{"Sessions":[{"SessionId":"session0","ClientId":"client0"}]}

--- a/cloud/filestore/tests/client_sharded_dir/nfs-storage.txt
+++ b/cloud/filestore/tests/client_sharded_dir/nfs-storage.txt
@@ -4,5 +4,4 @@ MaxFileBlocks: 536870912
 AutomaticShardCreationEnabled: true
 ShardAllocationUnit: 1073741824
 AutomaticallyCreatedShardSize: 1073741824
-ShardIdSelectionInLeaderEnabled: true
 DirectoryCreationInShardsEnabled: true

--- a/cloud/filestore/tests/fmdtest/nfs-storage.txt
+++ b/cloud/filestore/tests/fmdtest/nfs-storage.txt
@@ -4,5 +4,4 @@ MaxFileBlocks: 536870912
 AutomaticShardCreationEnabled: true
 ShardAllocationUnit: 1073741824
 AutomaticallyCreatedShardSize: 1073741824
-ShardIdSelectionInLeaderEnabled: true
 DirectoryCreationInShardsEnabled: true


### PR DESCRIPTION
### Notes
We use `ShardIdSelectionInLeaderEnabled` everywhere and don't need the legacy mode (when `ShardId` is selected by the service layer). The legacy mode starts to cause issues because some of the checks are impossible to implement for that mode.

### Issue
https://github.com/ydb-platform/nbs/issues/5431
