### PR TITLE
issue-5644: support for dedicated file-only shards

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5179,6 +5179,201 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             counters->GetCounter("UnlinkNodeInShard.Count")->GetAtomic());
     }
 
+    SERVICE_TEST(ShouldCreateFilesInFileShards)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+        config.SetDirectoryCreationInShardsEnabled(true);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        //
+        // Configuring file shard list.
+        //
+
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(fsConfig.Shard1Id);
+            request.SetShardNo(1);
+            request.AddShardFileSystemIds(fsConfig.Shard1Id);
+            request.AddShardFileSystemIds(fsConfig.Shard2Id);
+            request.AddFileShardFileSystemIds(fsConfig.Shard1Id);
+            request.SetDirectoryCreationInShardsEnabled(true);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            auto jsonResponse = service.ExecuteAction("configureasshard", buf);
+            NProtoPrivate::TConfigureAsShardResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+
+            request.SetFileSystemId(fsConfig.Shard2Id);
+            request.SetShardNo(2);
+            buf.clear();
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            jsonResponse = service.ExecuteAction("configureasshard", buf);
+            response.Clear();
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+        }
+
+        {
+            NProtoPrivate::TConfigureShardsRequest request;
+            request.SetFileSystemId(fsConfig.FsId);
+            request.AddShardFileSystemIds(fsConfig.Shard1Id);
+            request.AddShardFileSystemIds(fsConfig.Shard2Id);
+            request.AddFileShardFileSystemIds(fsConfig.Shard1Id);
+            request.SetDirectoryCreationInShardsEnabled(true);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            auto jsonResponse = service.ExecuteAction("configureshards", buf);
+            NProtoPrivate::TConfigureShardsResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+        }
+
+        //
+        // Waiting for IndexTablet start after the restart triggered by
+        // configureshards
+        //
+
+        WaitForTabletStart(service);
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        auto createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir1"))->Record;
+        const auto dir1Id = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(2, ExtractShardNo(dir1Id));
+
+        createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(dir1Id, "dir1_1"))->Record;
+        const auto dir1_1Id = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(2, ExtractShardNo(dir1_1Id));
+
+        createNodeResponse = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(dir1Id, "dir1_2"))->Record;
+        const auto dir1_2Id = createNodeResponse.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(2, ExtractShardNo(dir1_2Id));
+
+        auto createHandleResponse = service.CreateHandle(
+            headers,
+            fsConfig.FsId,
+            dir1_1Id,
+            "file1",
+            TCreateHandleArgs::CREATE)->Record;
+
+        const auto nodeId1 = createHandleResponse.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId1));
+
+        const auto handle1 = createHandleResponse.GetHandle();
+        UNIT_ASSERT_VALUES_EQUAL_C(1, ExtractShardNo(handle1), handle1);
+
+        createHandleResponse = service.CreateHandle(
+            headers,
+            fsConfig.FsId,
+            dir1_2Id,
+            "file1",
+            TCreateHandleArgs::CREATE)->Record;
+
+        const auto nodeId2 = createHandleResponse.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId2));
+
+        const auto handle2 = createHandleResponse.GetHandle();
+        UNIT_ASSERT_VALUES_EQUAL_C(1, ExtractShardNo(handle2), handle2);
+
+        createHandleResponse = service.CreateHandle(
+            headers,
+            fsConfig.FsId,
+            dir1_2Id,
+            "file2",
+            TCreateHandleArgs::CREATE)->Record;
+
+        const auto nodeId3 = createHandleResponse.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId3));
+
+        const auto handle3 = createHandleResponse.GetHandle();
+        UNIT_ASSERT_VALUES_EQUAL_C(1, ExtractShardNo(handle3), handle3);
+
+        auto data1 = GenerateValidateData(256_KB, 1);
+        service.WriteData(headers, fsConfig.FsId, nodeId1, handle1, 0, data1);
+
+        auto data2 = GenerateValidateData(1_MB, 2);
+        service.WriteData(headers, fsConfig.FsId, nodeId2, handle2, 0, data2);
+
+        auto data3 = GenerateValidateData(512_KB, 3);
+        service.WriteData(headers, fsConfig.FsId, nodeId3, handle3, 0, data3);
+
+        auto readDataResponse = service.ReadData(
+            headers,
+            fsConfig.FsId,
+            nodeId1,
+            handle1,
+            0,
+            data1.size())->Record;
+        UNIT_ASSERT_VALUES_EQUAL(data1, readDataResponse.GetBuffer());
+
+        readDataResponse = service.ReadData(
+            headers,
+            fsConfig.FsId,
+            nodeId2,
+            handle2,
+            0,
+            data2.size())->Record;
+        UNIT_ASSERT_VALUES_EQUAL(data2, readDataResponse.GetBuffer());
+
+        readDataResponse = service.ReadData(
+            headers,
+            fsConfig.FsId,
+            nodeId3,
+            handle3,
+            0,
+            data3.size())->Record;
+        UNIT_ASSERT_VALUES_EQUAL(data3, readDataResponse.GetBuffer());
+
+        service.DestroyHandle(headers, fsConfig.FsId, nodeId1, handle1);
+        service.DestroyHandle(headers, fsConfig.FsId, nodeId2, handle2);
+        service.DestroyHandle(headers, fsConfig.FsId, nodeId3, handle3);
+
+        service.GetNodeAttr(headers, fsConfig.FsId, dir1_1Id, "file1");
+        service.UnlinkNode(headers, dir1_1Id, "file1", false);
+
+        env.GetRegistry()->Update(env.GetRuntime().GetCurrentTime());
+        auto counters = env.GetRuntime().GetAppData().Counters
+            ->FindSubgroup("counters", "filestore")
+            ->FindSubgroup("component", "storage")
+            ->FindSubgroup("type", "hdd");
+        // counters->OutputPlainText(Cerr);
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            counters->GetCounter("CreateHandle.Count")->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            counters->GetCounter("CreateHandleInShard.Count")->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            counters->GetCounter("CreateNode.Count")->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            6,
+            counters->GetCounter("CreateNodeInShard.Count")->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter("GetNodeAttr.Count")->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter("GetNodeAttrInShard.Count")->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter("UnlinkNode.Count")->GetAtomic());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            counters->GetCounter("UnlinkNodeInShard.Count")->GetAtomic());
+    }
+
     SERVICE_TEST(ShouldResizeFileSystemWithDirectoryCreationInShardsEnabled)
     {
         config.SetMultiTabletForwardingEnabled(true);

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -1706,8 +1706,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
-        const auto shard3Id = fsConfig.FsId + "-f3";
-        service.CreateFileStore(shard3Id, 1'000);
+        const auto shard3Id = fsConfig.FsId + "_s3";
+        service.CreateFileStore(shard3Id, fsConfig.ShardBlockCount - 1);
 
         // ShardNo change not allowed
         {

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -4527,6 +4527,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             NProtoPrivate::TConfigureAsShardRequest request;
             request.SetFileSystemId(shardId);
             request.SetShardNo(++shardNo);
+            *request.AddShardFileSystemIds() = shard1Id;
+            *request.AddShardFileSystemIds() = shard2Id;
 
             TString buf;
             google::protobuf::util::MessageToJsonString(request, &buf);
@@ -4648,6 +4650,152 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             google::protobuf::util::MessageToJsonString(request, &buf);
             service.SendExecuteActionRequest("configureshards", buf);
             response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // reconfigure shard 1
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            request.SetForce(true);
+            *request.AddShardFileSystemIds() = shard1Id;
+            *request.AddShardFileSystemIds() = shard2Id;
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // shard order change not allowed
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            *request.AddShardFileSystemIds() = shard2Id;
+            *request.AddShardFileSystemIds() = shard1Id;
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // shard list cropping not allowed
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            *request.AddShardFileSystemIds() = shard1Id;
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // force flag should override checks
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            request.SetForce(true);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // reconfigure shard 1
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            *request.AddShardFileSystemIds() = shard1Id;
+            *request.AddShardFileSystemIds() = shard2Id;
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // file shard list should be a strict subset of the shard list
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            *request.AddShardFileSystemIds() = shard1Id;
+            *request.AddShardFileSystemIds() = shard2Id;
+            *request.AddFileShardFileSystemIds() = shard1Id;
+            *request.AddFileShardFileSystemIds() = "shard3";
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            *request.AddShardFileSystemIds() = shard1Id;
+            *request.AddShardFileSystemIds() = shard2Id;
+            *request.AddFileShardFileSystemIds() = shard1Id;
+            *request.AddFileShardFileSystemIds() = shard2Id;
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(shard1Id);
+            request.SetShardNo(1);
+            *request.AddShardFileSystemIds() = shard1Id;
+            *request.AddShardFileSystemIds() = shard2Id;
+            *request.AddFileShardFileSystemIds() = shard1Id;
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("configureasshard", buf);
+            auto response = service.RecvExecuteActionResponse();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 response->GetStatus(),
@@ -5341,37 +5489,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         service.GetNodeAttr(headers, fsConfig.FsId, dir1_1Id, "file1");
         service.UnlinkNode(headers, dir1_1Id, "file1", false);
-
-        env.GetRegistry()->Update(env.GetRuntime().GetCurrentTime());
-        auto counters = env.GetRuntime().GetAppData().Counters
-            ->FindSubgroup("counters", "filestore")
-            ->FindSubgroup("component", "storage")
-            ->FindSubgroup("type", "hdd");
-        // counters->OutputPlainText(Cerr);
-        UNIT_ASSERT_VALUES_EQUAL(
-            3,
-            counters->GetCounter("CreateHandle.Count")->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(
-            3,
-            counters->GetCounter("CreateHandleInShard.Count")->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(
-            3,
-            counters->GetCounter("CreateNode.Count")->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(
-            6,
-            counters->GetCounter("CreateNodeInShard.Count")->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            counters->GetCounter("GetNodeAttr.Count")->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            counters->GetCounter("GetNodeAttrInShard.Count")->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            counters->GetCounter("UnlinkNode.Count")->GetAtomic());
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
-            counters->GetCounter("UnlinkNodeInShard.Count")->GetAtomic());
     }
 
     SERVICE_TEST(ShouldResizeFileSystemWithDirectoryCreationInShardsEnabled)

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -54,6 +54,8 @@ message TFileSystem
     bool StrictFileSystemSizeEnforcementEnabled = 19;
     bool Frozen = 20;
     bool ForceDirectoryCreationInShards = 21;
+
+    repeated string FileShardFileSystemIds = 22;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -246,7 +246,10 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
             if (!behaveAsShard
                     && !GetFileSystem().GetShardFileSystemIds().empty())
             {
-                args.Error = SelectShard(0 /*fileSize*/, &shardId);
+                args.Error = SelectShard(
+                    NProto::E_REGULAR_NODE,
+                    0 /*fileSize*/,
+                    &shardId);
                 if (HasError(args.Error)) {
                     return true;
                 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -551,7 +551,10 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
                 && (!isMainWithLocalNodes
                     || GetFileSystem().GetForceDirectoryCreationInShards())))
     {
-        args.Error = SelectShard(args.Attrs.GetSize(), &args.ShardId);
+        args.Error = SelectShard(
+            static_cast<NProto::ENodeType>(args.Attrs.GetType()),
+            args.Attrs.GetSize(),
+            &args.ShardId);
         if (HasError(args.Error)) {
             return true;
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -150,7 +150,7 @@ NProto::TError ValidateFileShardList(
         }
     }
 
-    if (shardIdSet.empty()) {
+    if (shardIdSet.empty() && !shardIds.empty()) {
         return MakeError(E_ARGUMENT, "non-file shard set is empty");
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -107,6 +107,58 @@ TString ValidateUpdateConfigRequest(
     return {};
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError ValidateShardList(
+    const TStorageConfig& config,
+    const google::protobuf::RepeatedPtrField<TString>& shardIds,
+    const google::protobuf::RepeatedPtrField<TString>& newShardIds)
+{
+    if (newShardIds.size() < shardIds.size()) {
+        return MakeError(E_ARGUMENT, TStringBuilder() << "new shard list"
+            " is smaller than prev shard list: "
+            << newShardIds.size() << " < " << shardIds.size());
+    }
+
+    if (static_cast<ui32>(newShardIds.size()) > config.GetMaxShardCount())
+    {
+        return MakeError(E_ARGUMENT, TStringBuilder() << "new shard list"
+            " is bigger than limit: "
+            << newShardIds.size() << " > " << config.GetMaxShardCount());
+    }
+
+    for (int i = 0; i < shardIds.size(); ++i) {
+        if (shardIds[i] != newShardIds[i]) {
+            return MakeError(E_ARGUMENT, TStringBuilder() << "shard"
+                " change not allowed, pos=" << i << ", prev="
+                << shardIds[i] << ", new="
+                << newShardIds[i]);
+        }
+    }
+
+    return {};
+}
+
+NProto::TError ValidateFileShardList(
+    const google::protobuf::RepeatedPtrField<TString>& shardIds,
+    const google::protobuf::RepeatedPtrField<TString>& fileShardIds)
+{
+    THashSet<TString> shardIdSet(shardIds.begin(), shardIds.end());
+    for (const auto& fileShardId: fileShardIds) {
+        const bool erased = shardIdSet.erase(fileShardId) > 0;
+        if (!erased) {
+            return MakeError(E_ARGUMENT, TStringBuilder() << "file shard "
+                << fileShardId << " not found in shard list");
+        }
+    }
+
+    if (shardIdSet.empty()) {
+        return MakeError(E_ARGUMENT, "non-file shard set is empty");
+    }
+
+    return {};
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -157,6 +209,8 @@ void TIndexTabletActor::HandleUpdateConfig(
     // Setting the fields that schemeshard is not aware of.
     *newConfig.MutableShardFileSystemIds() =
         oldConfig.GetShardFileSystemIds();
+    *newConfig.MutableFileShardFileSystemIds() =
+        oldConfig.GetFileShardFileSystemIds();
     newConfig.SetShardNo(oldConfig.GetShardNo());
     newConfig.SetMainFileSystemId(oldConfig.GetMainFileSystemId());
     newConfig.SetAutomaticShardCreationEnabled(
@@ -289,6 +343,7 @@ void TIndexTabletActor::HandleConfigureShards(
     requestInfo->StartedTs = ctx.Now();
 
     const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
+    const auto& newShardIds = msg->Record.GetShardFileSystemIds();
     NProto::TError error;
     if (!IsMainTablet() && !msg->Record.GetForce()) {
         error = MakeError(E_INVALID_STATE, TStringBuilder() << "can't configure"
@@ -297,29 +352,15 @@ void TIndexTabletActor::HandleConfigureShards(
     }
 
     if (!HasError(error) && !msg->Record.GetForce()) {
-        if (msg->Record.GetShardFileSystemIds().size() < shardIds.size()) {
-            error = MakeError(E_ARGUMENT, TStringBuilder() << "new shard list"
-                " is smaller than prev shard list: "
-                << msg->Record.GetShardFileSystemIds().size() << " < "
-                << shardIds.size());
-        } else if (
-            msg->Record.ShardFileSystemIdsSize() > Config->GetMaxShardCount())
-        {
-            error = MakeError(E_ARGUMENT, TStringBuilder() << "new shard list"
-                " is bigger than limit: "
-                << msg->Record.GetShardFileSystemIds().size() << " > "
-                << Config->GetMaxShardCount());
-        } else {
-            for (int i = 0; i < shardIds.size(); ++i) {
-                if (shardIds[i] != msg->Record.GetShardFileSystemIds(i)) {
-                    error = MakeError(E_ARGUMENT, TStringBuilder() << "shard"
-                        " change not allowed, pos=" << i << ", prev="
-                        << shardIds[i] << ", new="
-                        << msg->Record.GetShardFileSystemIds(i));
-                    break;
-                }
-            }
-        }
+        error = ValidateShardList(*Config, shardIds, newShardIds);
+    }
+
+    const auto& newFileShardIds = msg->Record.GetFileShardFileSystemIds();
+    if (!HasError(error)
+            && !msg->Record.GetForce()
+            && !newFileShardIds.empty())
+    {
+        error = ValidateFileShardList(newShardIds, newFileShardIds);
     }
 
     if (error.GetCode() != S_OK) {
@@ -363,6 +404,8 @@ void TIndexTabletActor::ExecuteTx_ConfigureShards(
     auto config = GetFileSystem();
     *config.MutableShardFileSystemIds() =
         std::move(*args.Request.MutableShardFileSystemIds());
+    *config.MutableFileShardFileSystemIds() =
+        std::move(*args.Request.MutableFileShardFileSystemIds());
     config.SetDirectoryCreationInShardsEnabled(
         args.Request.GetDirectoryCreationInShardsEnabled());
     config.SetForceDirectoryCreationInShards(
@@ -385,9 +428,10 @@ void TIndexTabletActor::CompleteTx_ConfigureShards(
     TTxIndexTablet::TConfigureShards& args)
 {
     LOG_INFO(ctx, TFileStoreComponents::TABLET,
-        "%s Configured shards, new shard list: %s",
+        "%s Configured shards, new shard list: %s, new file shard list: %s",
         LogTag.c_str(),
-        JoinSeq(",", GetFileSystem().GetShardFileSystemIds()).c_str());
+        JoinSeq(",", GetFileSystem().GetShardFileSystemIds()).c_str(),
+        JoinSeq(",", GetFileSystem().GetFileShardFileSystemIds()).c_str());
 
     auto response =
         std::make_unique<TEvIndexTablet::TEvConfigureShardsResponse>();
@@ -432,6 +476,22 @@ void TIndexTabletActor::HandleConfigureAsShard(
         return;
     }
 
+    const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
+    const auto& newShardIds = msg->Record.GetShardFileSystemIds();
+
+    NProto::TError error;
+    if (!HasError(error) && !msg->Record.GetForce()) {
+        error = ValidateShardList(*Config, shardIds, newShardIds);
+    }
+
+    const auto& newFileShardIds = msg->Record.GetFileShardFileSystemIds();
+    if (!HasError(error)
+            && !msg->Record.GetForce()
+            && !newFileShardIds.empty())
+    {
+        error = ValidateFileShardList(newShardIds, newFileShardIds);
+    }
+
     ExecuteTx<TConfigureAsShard>(
         ctx,
         std::move(requestInfo),
@@ -466,6 +526,8 @@ void TIndexTabletActor::ExecuteTx_ConfigureAsShard(
     config.SetMainFileSystemId(args.Request.GetMainFileSystemId());
     *config.MutableShardFileSystemIds() =
         std::move(*args.Request.MutableShardFileSystemIds());
+    *config.MutableFileShardFileSystemIds() =
+        std::move(*args.Request.MutableFileShardFileSystemIds());
     config.SetDirectoryCreationInShardsEnabled(
         args.Request.GetDirectoryCreationInShardsEnabled());
     config.SetForceDirectoryCreationInShards(
@@ -481,10 +543,12 @@ void TIndexTabletActor::CompleteTx_ConfigureAsShard(
     TTxIndexTablet::TConfigureAsShard& args)
 {
     LOG_INFO(ctx, TFileStoreComponents::TABLET,
-        "%s Configured as shard, ShardNo: %u, new shard list: %s",
+        "%s Configured as shard, ShardNo: %u, new shard list: %s"
+        ", new file shard list: %s",
         LogTag.c_str(),
         args.Request.GetShardNo(),
-        JoinSeq(",", GetFileSystem().GetShardFileSystemIds()).c_str());
+        JoinSeq(",", GetFileSystem().GetShardFileSystemIds()).c_str(),
+        JoinSeq(",", GetFileSystem().GetFileShardFileSystemIds()).c_str());
 
     RegisterFileStore(ctx);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -464,22 +464,17 @@ void TIndexTabletActor::HandleConfigureAsShard(
     requestInfo->StartedTs = ctx.Now();
 
     const auto currentShardNo = GetFileSystem().GetShardNo();
+    NProto::TError error;
     if (currentShardNo && currentShardNo != msg->Record.GetShardNo()) {
-        auto response =
-            std::make_unique<TEvIndexTablet::TEvConfigureAsShardResponse>();
-        *response->Record.MutableError() = MakeError(
+        error = MakeError(
             E_ARGUMENT,
             TStringBuilder() << "ShardNo change not allowed: "
                 << currentShardNo << " != " << msg->Record.GetShardNo());
-
-        NCloud::Reply(ctx, *requestInfo, std::move(response));
-        return;
     }
 
     const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
     const auto& newShardIds = msg->Record.GetShardFileSystemIds();
 
-    NProto::TError error;
     if (!HasError(error) && !msg->Record.GetForce()) {
         error = ValidateShardList(*Config, shardIds, newShardIds);
     }
@@ -490,6 +485,15 @@ void TIndexTabletActor::HandleConfigureAsShard(
             && !newFileShardIds.empty())
     {
         error = ValidateFileShardList(newShardIds, newFileShardIds);
+    }
+
+    if (error.GetCode() != S_OK) {
+        auto response =
+            std::make_unique<TEvIndexTablet::TEvConfigureAsShardResponse>();
+        *response->Record.MutableError() = std::move(error);
+
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
     }
 
     ExecuteTx<TConfigureAsShard>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -120,8 +120,7 @@ NProto::TError ValidateShardList(
             << newShardIds.size() << " < " << shardIds.size());
     }
 
-    if (static_cast<ui32>(newShardIds.size()) > config.GetMaxShardCount())
-    {
+    if (static_cast<ui32>(newShardIds.size()) > config.GetMaxShardCount()) {
         return MakeError(E_ARGUMENT, TStringBuilder() << "new shard list"
             " is bigger than limit: "
             << newShardIds.size() << " > " << config.GetMaxShardCount());
@@ -129,10 +128,9 @@ NProto::TError ValidateShardList(
 
     for (int i = 0; i < shardIds.size(); ++i) {
         if (shardIds[i] != newShardIds[i]) {
-            return MakeError(E_ARGUMENT, TStringBuilder() << "shard"
-                " change not allowed, pos=" << i << ", prev="
-                << shardIds[i] << ", new="
-                << newShardIds[i]);
+            return MakeError(E_ARGUMENT, TStringBuilder()
+                << "shard change not allowed, pos=" << i
+                << ", prev=" << shardIds[i] << ", new=" << newShardIds[i]);
         }
     }
 
@@ -344,6 +342,7 @@ void TIndexTabletActor::HandleConfigureShards(
 
     const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
     const auto& newShardIds = msg->Record.GetShardFileSystemIds();
+
     NProto::TError error;
     if (!IsMainTablet() && !msg->Record.GetForce()) {
         error = MakeError(E_INVALID_STATE, TStringBuilder() << "can't configure"
@@ -356,10 +355,7 @@ void TIndexTabletActor::HandleConfigureShards(
     }
 
     const auto& newFileShardIds = msg->Record.GetFileShardFileSystemIds();
-    if (!HasError(error)
-            && !msg->Record.GetForce()
-            && !newFileShardIds.empty())
-    {
+    if (!HasError(error) && !msg->Record.GetForce()) {
         error = ValidateFileShardList(newShardIds, newFileShardIds);
     }
 
@@ -463,7 +459,10 @@ void TIndexTabletActor::HandleConfigureAsShard(
         MakeIntrusive<TCallContext>(GetFileSystemId()));
     requestInfo->StartedTs = ctx.Now();
 
-    const auto currentShardNo = GetFileSystem().GetShardNo();
+    const ui32 currentShardNo = GetFileSystem().GetShardNo();
+    const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
+    const auto& newShardIds = msg->Record.GetShardFileSystemIds();
+
     NProto::TError error;
     if (currentShardNo && currentShardNo != msg->Record.GetShardNo()) {
         error = MakeError(
@@ -472,18 +471,12 @@ void TIndexTabletActor::HandleConfigureAsShard(
                 << currentShardNo << " != " << msg->Record.GetShardNo());
     }
 
-    const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
-    const auto& newShardIds = msg->Record.GetShardFileSystemIds();
-
     if (!HasError(error) && !msg->Record.GetForce()) {
         error = ValidateShardList(*Config, shardIds, newShardIds);
     }
 
     const auto& newFileShardIds = msg->Record.GetFileShardFileSystemIds();
-    if (!HasError(error)
-            && !msg->Record.GetForce()
-            && !newFileShardIds.empty())
-    {
+    if (!HasError(error) && !msg->Record.GetForce()) {
         error = ValidateFileShardList(newShardIds, newFileShardIds);
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -188,6 +188,18 @@ void TIndexTabletState::LoadState(
         config.GetShardBalancerDesiredFreeSpaceReserve(),
         config.GetShardBalancerMinFreeSpaceReserve(),
         TVector<TString>(shardIds.begin(), shardIds.end()));
+
+    const auto& fileShardIds = GetFileSystem().GetFileShardFileSystemIds();
+    if (fileShardIds.size()) {
+        Impl->FileShardBalancer = CreateShardBalancer(
+            config.GetShardBalancerPolicy(),
+            GetBlockSize(),
+            config.GetShardBalancerPrecisionBytes(),
+            config.GetMaxFileBlocks(),
+            config.GetShardBalancerDesiredFreeSpaceReserve(),
+            config.GetShardBalancerMinFreeSpaceReserve(),
+            TVector<TString>(fileShardIds.begin(), fileShardIds.end()));
+    }
 }
 
 void TIndexTabletState::UpdateConfig(

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -87,6 +87,44 @@ void TIndexTabletState::UpdateLogTag(TString tag)
     LogTag = std::move(tag);
 }
 
+void TIndexTabletState::InitShardBalancer(const TStorageConfig& config)
+{
+    const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
+    TVector<TString> balancerShardIds;
+
+    const auto& fileShardIds = GetFileSystem().GetFileShardFileSystemIds();
+    if (fileShardIds.size()) {
+        Impl->FileShardBalancer = CreateShardBalancer(
+            config.GetShardBalancerPolicy(),
+            GetBlockSize(),
+            config.GetShardBalancerPrecisionBytes(),
+            config.GetMaxFileBlocks(),
+            config.GetShardBalancerDesiredFreeSpaceReserve(),
+            config.GetShardBalancerMinFreeSpaceReserve(),
+            TVector<TString>(fileShardIds.begin(), fileShardIds.end()));
+
+        THashSet<TString> fileShardIdSet(
+            fileShardIds.begin(),
+            fileShardIds.end());
+        for (const auto& shardId: shardIds) {
+            if (!fileShardIdSet.contains(shardId)) {
+                balancerShardIds.push_back(shardId);
+            }
+        }
+    } else {
+        balancerShardIds.assign(shardIds.begin(), shardIds.end());
+    }
+
+    Impl->ShardBalancer = CreateShardBalancer(
+        config.GetShardBalancerPolicy(),
+        GetBlockSize(),
+        config.GetShardBalancerPrecisionBytes(),
+        config.GetMaxFileBlocks(),
+        config.GetShardBalancerDesiredFreeSpaceReserve(),
+        config.GetShardBalancerMinFreeSpaceReserve(),
+        std::move(balancerShardIds));
+}
+
 void TIndexTabletState::LoadState(
     ui32 generation,
     const TStorageConfig& config,
@@ -179,27 +217,7 @@ void TIndexTabletState::LoadState(
         CommitResponseLogEntry(entry);
     }
 
-    const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
-    Impl->ShardBalancer = CreateShardBalancer(
-        config.GetShardBalancerPolicy(),
-        GetBlockSize(),
-        config.GetShardBalancerPrecisionBytes(),
-        config.GetMaxFileBlocks(),
-        config.GetShardBalancerDesiredFreeSpaceReserve(),
-        config.GetShardBalancerMinFreeSpaceReserve(),
-        TVector<TString>(shardIds.begin(), shardIds.end()));
-
-    const auto& fileShardIds = GetFileSystem().GetFileShardFileSystemIds();
-    if (fileShardIds.size()) {
-        Impl->FileShardBalancer = CreateShardBalancer(
-            config.GetShardBalancerPolicy(),
-            GetBlockSize(),
-            config.GetShardBalancerPrecisionBytes(),
-            config.GetMaxFileBlocks(),
-            config.GetShardBalancerDesiredFreeSpaceReserve(),
-            config.GetShardBalancerMinFreeSpaceReserve(),
-            TVector<TString>(fileShardIds.begin(), fileShardIds.end()));
-    }
+    InitShardBalancer(config);
 }
 
 void TIndexTabletState::UpdateConfig(
@@ -216,15 +234,7 @@ void TIndexTabletState::UpdateConfig(
     Impl->RangeIdHasher = CreateHasher(fileSystem);
     Impl->ThrottlingPolicy.Reset(throttlerConfig);
 
-    const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
-    Impl->ShardBalancer = CreateShardBalancer(
-        config.GetShardBalancerPolicy(),
-        GetBlockSize(),
-        config.GetShardBalancerPrecisionBytes(),
-        config.GetMaxFileBlocks(),
-        config.GetShardBalancerDesiredFreeSpaceReserve(),
-        config.GetShardBalancerMinFreeSpaceReserve(),
-        TVector<TString>(shardIds.begin(), shardIds.end()));
+    InitShardBalancer(config);
 }
 
 void TIndexTabletState::SetFrozen(TIndexTabletDatabase& db, bool frozen)

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -414,7 +414,10 @@ public:
 
     ui64 CalculateExpectedShardCount(ui32 maxShardCount) const;
 
-    NProto::TError SelectShard(ui64 fileSize, TString* shardId);
+    NProto::TError SelectShard(
+        NProto::ENodeType nodeType,
+        ui64 fileSize,
+        TString* shardId);
 
     void UpdateShardBalancer(const TVector<TShardStats>& stats);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -419,6 +419,8 @@ public:
         ui64 fileSize,
         TString* shardId);
 
+    void InitShardBalancer(const TStorageConfig& config);
+
     void UpdateShardBalancer(const TVector<TShardStats>& stats);
 
     TVector<IShardBalancer::TShardDescr> MakeOrderedShardList() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1535,9 +1535,17 @@ TReadAheadCacheStats TIndexTabletState::CalculateReadAheadCacheStats() const
 ////////////////////////////////////////////////////////////////////////////////
 // Balancing
 
-NProto::TError TIndexTabletState::SelectShard(ui64 fileSize, TString* shardId)
+NProto::TError TIndexTabletState::SelectShard(
+    NProto::ENodeType nodeType,
+    ui64 fileSize,
+    TString* shardId)
 {
-    auto e = Impl->ShardBalancer->SelectShard(fileSize, shardId);
+    auto* balancer = Impl->ShardBalancer.get();
+    if (nodeType == NProto::E_REGULAR_NODE && Impl->FileShardBalancer) {
+        balancer = Impl->FileShardBalancer.get();
+    }
+
+    auto e = balancer->SelectShard(fileSize, shardId);
     if (HasError(e)) {
         return e;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -87,6 +87,7 @@ struct TIndexTabletState::TImpl
     TThrottlingPolicy ThrottlingPolicy;
 
     IShardBalancerPtr ShardBalancer;
+    IShardBalancerPtr FileShardBalancer;
 
     explicit TImpl(const TFileStoreAllocRegistry& registry)
         : FreshBytes(registry.GetAllocator(EAllocatorTag::FreshBytes))

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -679,6 +679,10 @@ message TConfigureShardsRequest
     // If DirectoryCreationInShardsEnabled is true, forces directory creation
     // in shards even if main tablet has already created some nodes.
     bool ForceDirectoryCreationInShards = 6;
+
+    // Shard FileSystem identifiers for regular files. If empty, then
+    // ShardFileSystemIds will be used for regular files.
+    repeated string FileShardFileSystemIds = 7;
 }
 
 message TConfigureShardsResponse
@@ -713,6 +717,10 @@ message TConfigureAsShardRequest
     // If DirectoryCreationInShardsEnabled is true, forces directory creation
     // in shards even if main tablet has already created some nodes.
     bool ForceDirectoryCreationInShards = 7;
+
+    // Shard FileSystem identifiers for regular files. If empty, then
+    // ShardFileSystemIds will be used for regular files.
+    repeated string FileShardFileSystemIds = 8;
 }
 
 message TConfigureAsShardResponse
@@ -967,6 +975,9 @@ message TGetFileSystemTopologyResponse
     uint32 MaxShardCount = 6;
 
     bool ForceDirectoryCreationInShards = 7;
+
+    // Shard FileSystem identifiers for regular files.
+    repeated string FileShardFileSystemIds = 8;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -721,6 +721,9 @@ message TConfigureAsShardRequest
     // Shard FileSystem identifiers for regular files. If empty, then
     // ShardFileSystemIds will be used for regular files.
     repeated string FileShardFileSystemIds = 8;
+
+    // Override shard list validation.
+    bool Force = 9;
 }
 
 message TConfigureAsShardResponse


### PR DESCRIPTION
### Notes
We need the ability to specify different shard lists for regular inodes (aka files) and other inodes (directories, symlinks, etc). This is needed to be able to implement specialized shards optimized for regular inode storage. See https://github.com/ydb-platform/nbs/issues/5643

Also extracted shard list validation logic from `HandleConfigureShards()` into a separate func and reused it in `HandleConfigureAsShard` + added uts

### Issue
https://github.com/ydb-platform/nbs/issues/5643
https://github.com/ydb-platform/nbs/issues/5644
