### PR TITLE
issue-5853: [Filestore] remove `MultiTabletForwardingEnabled` storage config field and set to true

### DIFF
--- a/cloud/disk_manager/test/recipe/nfs_launcher.py
+++ b/cloud/disk_manager/test/recipe/nfs_launcher.py
@@ -33,7 +33,6 @@ class NfsLauncher:
         )
         storage_config = TStorageConfig()
         storage_config.AllowFileStoreForceDestroy = allow_filestore_force_destroy
-        storage_config.MultiTabletForwardingEnabled = True
         storage_config.AutomaticShardCreationEnabled = True
         storage_config.ShardIdSelectionInLeaderEnabled = True
         self.__nfs_configurator = FilestoreServerConfigGenerator(

--- a/cloud/filestore/bin/nfs/nfs-storage.txt
+++ b/cloud/filestore/bin/nfs/nfs-storage.txt
@@ -1,5 +1,4 @@
 SchemeShardDir: "/Root/NFS"
-MultiTabletForwardingEnabled: true
 AllowFileStoreForceDestroy: true
 AutomaticShardCreationEnabled: true
 StrictFileSystemSizeEnforcementEnabled: true

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -321,10 +321,7 @@ message TStorageConfig
     // This numeric value is that x.
     optional uint32 PreferredBlockSizeMultiplier = 354;
 
-    // Enables request forwarding to shards in the StorageServiceActor.
-    // Forwarding is done based on the NodeId and Handle high bits.
-    // Disabling this thing shouldn't really be needed apart from tests.
-    optional bool MultiTabletForwardingEnabled = 355;
+    optional bool MultiTabletForwardingEnabled = 355 [deprecated = true];
 
     // Controls BlobIndexOps' priority over each other.
     optional EBlobIndexOpsPriority BlobIndexOpsPriority = 356;

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -215,7 +215,6 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
         TDuration,                                                             \
         TDuration::Seconds(10)                                                )\
     xxx(PreferredBlockSizeMultiplier,                   ui32,      1          )\
-    xxx(MultiTabletForwardingEnabled,                   bool,      false      )\
     xxx(AllowFileStoreForceDestroy,                     bool,      false      )\
     xxx(AllowFileStoreDestroyWithOrphanSessions,        bool,      false      )\
     xxx(TrimBytesItemCount,                             ui64,      100'000    )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -242,8 +242,6 @@ public:
 
     ui32 GetNodeIndexCacheMaxNodes() const;
 
-    bool GetMultiTabletForwardingEnabled() const;
-
     NProto::EBlobIndexOpsPriority GetBlobIndexOpsPriority() const;
     TDuration GetEnqueueBlobIndexOpIfNeededScheduleInterval() const;
 

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -232,22 +232,20 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
 
         {
             NProto::TStorageConfig newConfig;
-            newConfig.SetMultiTabletForwardingEnabled(true);
+            newConfig.SetThrottlingEnabled(true);
             const auto response = ExecuteChangeStorageConfig(
                 "fs0",
                 std::move(newConfig),
                 service);
             UNIT_ASSERT_VALUES_EQUAL(
-                response.GetStorageConfig().GetMultiTabletForwardingEnabled(),
+                response.GetStorageConfig().GetThrottlingEnabled(),
                 true);
         }
 
         {
             auto response = ExecuteGetStorageConfig("fs0", service);
 
-            UNIT_ASSERT_VALUES_EQUAL(
-                response.GetMultiTabletForwardingEnabled(),
-                true);
+            UNIT_ASSERT_VALUES_EQUAL(response.GetThrottlingEnabled(), true);
         }
     }
 
@@ -271,24 +269,20 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
 
         {
             NProto::TStorageConfig newConfig;
-            newConfig.SetMultiTabletForwardingEnabled(true);
+            newConfig.SetThrottlingEnabled(true);
             ExecuteChangeStorageConfig("fs0", std::move(newConfig), service);
         }
 
         {
             auto response = ExecuteGetStorageConfig("fs0", service, false);
             UNIT_ASSERT_VALUES_EQUAL(42, response.GetReadAheadCacheMaxNodes());
-            UNIT_ASSERT_VALUES_EQUAL(
-                true,
-                response.GetMultiTabletForwardingEnabled());
+            UNIT_ASSERT_VALUES_EQUAL(true, response.GetThrottlingEnabled());
         }
 
         {
             auto response = ExecuteGetStorageConfig("fs0", service, true);
             UNIT_ASSERT(!response.HasReadAheadCacheMaxNodes());
-            UNIT_ASSERT_VALUES_EQUAL(
-                true,
-                response.GetMultiTabletForwardingEnabled());
+            UNIT_ASSERT_VALUES_EQUAL(true, response.GetThrottlingEnabled());
         }
     }
 
@@ -462,7 +456,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
     {
         NProto::TStorageConfig config;
         // being explicit
-        config.SetMultiTabletForwardingEnabled(false);
+        config.SetThrottlingEnabled(false);
         TTestEnv env{{}, config};
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -664,7 +658,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
     {
         NProto::TStorageConfig config;
         // being explicit
-        config.SetMultiTabletForwardingEnabled(false);
+        config.SetThrottlingEnabled(false);
         TTestEnv env{{}, config};
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -764,7 +758,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
 
         NProto::TStorageConfig config;
         // being explicit
-        config.SetMultiTabletForwardingEnabled(false);
+        config.SetThrottlingEnabled(false);
         TTestEnv env{{}, config};
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -1005,7 +999,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         storageConfig.SetAutomaticShardCreationEnabled(true);
         storageConfig.SetShardAllocationUnit(1_GB);
         storageConfig.SetAutomaticallyCreatedShardSize(autoShardsSize);
-        storageConfig.SetMultiTabletForwardingEnabled(true);
+        storageConfig.SetThrottlingEnabled(true);
         storageConfig.SetStrictFileSystemSizeEnforcementEnabled(
             strictFileSystemSizeEnforcementEnabled);
 
@@ -1197,7 +1191,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         storageConfig.SetAutomaticShardCreationEnabled(true);
         storageConfig.SetShardAllocationUnit(2_GB);
         storageConfig.SetAutomaticallyCreatedShardSize(autoShardsSize);
-        storageConfig.SetMultiTabletForwardingEnabled(true);
+        storageConfig.SetThrottlingEnabled(true);
         storageConfig.SetStrictFileSystemSizeEnforcementEnabled(
             strictFileSystemSizeEnforcementEnabled);
 

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -455,8 +455,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
     Y_UNIT_TEST(ShouldPerformUnsafeNodeRefManipulations)
     {
         NProto::TStorageConfig config;
-        // being explicit
-        config.SetThrottlingEnabled(false);
         TTestEnv env{{}, config};
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -467,6 +465,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         service.CreateFileStore(fsId, 1'000);
 
         auto headers = service.InitSession("test", "client");
+        // being explicit
+        headers.DisableMultiTabletForwarding = true;
 
         const ui64 parentId = RootNodeId;
         const TString name1 = "file1";
@@ -657,8 +657,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
     Y_UNIT_TEST(ShouldPerformResponseLogEntryManipulations)
     {
         NProto::TStorageConfig config;
-        // being explicit
-        config.SetThrottlingEnabled(false);
         TTestEnv env{{}, config};
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -672,6 +670,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         service.CreateFileStore(fsId, 1'000);
 
         auto headers = service.InitSession("test", "client");
+        // being explicit
+        headers.DisableMultiTabletForwarding = true;
 
         {
             NProtoPrivate::TWriteResponseLogEntryRequest request;
@@ -757,8 +757,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         //
 
         NProto::TStorageConfig config;
-        // being explicit
-        config.SetThrottlingEnabled(false);
         TTestEnv env{{}, config};
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -787,6 +785,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         service.CreateFileStore(fsId, 1'000);
 
         auto headers = service.InitSession(fsId, "client");
+        // being explicit
+        headers.DisableMultiTabletForwarding = true;
 
         const ui64 nodeId = service.CreateNode(
             headers,

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -307,9 +307,8 @@ void TStorageServiceActor::HandleCreateHandle(
     }
 
     const auto& shardId = session->SelectShard();
-    const bool multiTabletForwardingEnabled =
-        !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
-    if (!multiTabletForwardingEnabled || !shardId) {
+    if (msg->Record.GetHeaders().GetDisableMultiTabletForwarding() || !shardId)
+    {
         ForwardRequest<TEvService::TCreateHandleMethod>(ctx, ev);
         return;
     }

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -308,8 +308,7 @@ void TStorageServiceActor::HandleCreateHandle(
 
     const auto& shardId = session->SelectShard();
     const bool multiTabletForwardingEnabled =
-        StorageConfig->GetMultiTabletForwardingEnabled()
-        && !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
+        !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
     if (!multiTabletForwardingEnabled || !shardId) {
         ForwardRequest<TEvService::TCreateHandleMethod>(ctx, ev);
         return;

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -400,7 +400,6 @@ void TStorageServiceActor::HandleCreateNode(
         }
     } else {
         const bool multiTabletForwardingEnabled =
-            StorageConfig->GetMultiTabletForwardingEnabled() &&
             !headers.GetDisableMultiTabletForwarding() &&
             (msg->Record.HasFile() ||
              filestore.GetFeatures().GetDirectoryCreationInShardsEnabled());

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -94,11 +94,7 @@ TResultOrError<TString> TStorageServiceActor::SelectShard(
         return TString();
     }
 
-    const bool multiTabletForwardingEnabled =
-        StorageConfig->GetMultiTabletForwardingEnabled()
-        && !disableMultiTabletForwarding;
-
-    if (multiTabletForwardingEnabled && shardNo) {
+    if (!disableMultiTabletForwarding && shardNo) {
         const int shardIdx = SafeIntegerCast<int>(shardNo - 1);
 
         if (shardIds.size() <= shardIdx) {

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -294,12 +294,14 @@ void TStorageServiceActor::HandleGetNodeAttr(
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
+    const bool disableMultiTabletForwarding =
+      msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
     auto actor = std::make_unique<TGetNodeAttrActor>(
         std::move(requestInfo),
         std::move(msg->Record),
         session->RequestStats,
         ProfileLog,
-        msg->Record.GetHeaders().GetDisableMultiTabletForwarding());
+        disableMultiTabletForwarding);
 
     NCloud::Register(ctx, std::move(actor));
 }

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -295,8 +295,7 @@ void TStorageServiceActor::HandleGetNodeAttr(
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
     const bool multiTabletForwardingEnabled =
-        StorageConfig->GetMultiTabletForwardingEnabled()
-        && !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
+        !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
     auto actor = std::make_unique<TGetNodeAttrActor>(
         std::move(requestInfo),
         std::move(msg->Record),

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -34,7 +34,7 @@ private:
     IRequestStatsPtr RequestStats;
     IProfileLogPtr ProfileLog;
 
-    const bool MultiTabletForwardingEnabled;
+    const bool DisableMultiTabletForwarding;
 
 public:
     TGetNodeAttrActor(
@@ -42,7 +42,7 @@ public:
         NProto::TGetNodeAttrRequest getNodeAttrRequest,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
-        bool multiTabletForwardingEnabled);
+        bool disableMultiTabletForwarding);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -74,13 +74,13 @@ TGetNodeAttrActor::TGetNodeAttrActor(
         NProto::TGetNodeAttrRequest getNodeAttrRequest,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
-        bool multiTabletForwardingEnabled)
+        bool disableMultiTabletForwarding)
     : RequestInfo(std::move(requestInfo))
     , GetNodeAttrRequest(std::move(getNodeAttrRequest))
     , LogTag(GetNodeAttrRequest.GetFileSystemId())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
-    , MultiTabletForwardingEnabled(multiTabletForwardingEnabled)
+    , DisableMultiTabletForwarding(disableMultiTabletForwarding)
 {
 }
 
@@ -160,7 +160,7 @@ void TGetNodeAttrActor::HandleGetNodeAttrResponse(
         msg->Record.GetNode().GetShardFileSystemId().c_str(),
         msg->Record.GetNode().GetShardNodeName().Quote().c_str());
 
-    if (!MultiTabletForwardingEnabled
+    if (DisableMultiTabletForwarding
             || msg->Record.GetNode().GetShardFileSystemId().empty())
     {
         ReplyAndDie(ctx, std::move(msg->Record));
@@ -294,14 +294,12 @@ void TStorageServiceActor::HandleGetNodeAttr(
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
-    const bool multiTabletForwardingEnabled =
-        !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
     auto actor = std::make_unique<TGetNodeAttrActor>(
         std::move(requestInfo),
         std::move(msg->Record),
         session->RequestStats,
         ProfileLog,
-        multiTabletForwardingEnabled);
+        msg->Record.GetHeaders().GetDisableMultiTabletForwarding());
 
     NCloud::Register(ctx, std::move(actor));
 }

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -642,8 +642,7 @@ void TStorageServiceActor::HandleListNodes(
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
     const bool multiTabletForwardingEnabled =
-        StorageConfig->GetMultiTabletForwardingEnabled()
-        && !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
+        !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
     auto actor = std::make_unique<TListNodesActor>(
         std::move(requestInfo),
         std::move(msg->Record),

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -641,10 +641,12 @@ void TStorageServiceActor::HandleListNodes(
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
+    const bool disableMultiTabletForwarding =
+        msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
     auto actor = std::make_unique<TListNodesActor>(
         std::move(requestInfo),
         std::move(msg->Record),
-        msg->Record.GetHeaders().GetDisableMultiTabletForwarding(),
+        disableMultiTabletForwarding,
         session->RequestStats,
         ProfileLog);
 

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -106,7 +106,7 @@ TListNodesActor::TListNodesActor(
     : RequestInfo(std::move(requestInfo))
     , ListNodesRequest(std::move(listNodesRequest))
     , LogTag(ListNodesRequest.GetFileSystemId())
-    , DisableMultiTabletForwarding(!disableMultiTabletForwarding)
+    , DisableMultiTabletForwarding(disableMultiTabletForwarding)
     , Unsafe(ListNodesRequest.GetUnsafe())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
@@ -139,7 +139,7 @@ void TListNodesActor::ListNodes(const TActorContext& ctx)
 
 void TListNodesActor::GetNodeAttrsBatch(const TActorContext& ctx)
 {
-    if (!DisableMultiTabletForwarding) {
+    if (DisableMultiTabletForwarding) {
         GetNodeAttrResponses = Response.NodesSize();
         return;
     }

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -36,7 +36,7 @@ private:
     const TString LogTag;
 
     // Control flags
-    const bool MultiTabletForwardingEnabled;
+    const bool DisableMultiTabletForwarding;
     const bool Unsafe;
 
     // Response data
@@ -58,7 +58,7 @@ public:
     TListNodesActor(
         TRequestInfoPtr requestInfo,
         NProto::TListNodesRequest listNodesRequest,
-        bool multiTabletForwardingEnabled,
+        bool disableMultiTabletForwarding,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog);
 
@@ -100,13 +100,13 @@ private:
 TListNodesActor::TListNodesActor(
         TRequestInfoPtr requestInfo,
         NProto::TListNodesRequest listNodesRequest,
-        bool multiTabletForwardingEnabled,
+        bool disableMultiTabletForwarding,
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog)
     : RequestInfo(std::move(requestInfo))
     , ListNodesRequest(std::move(listNodesRequest))
     , LogTag(ListNodesRequest.GetFileSystemId())
-    , MultiTabletForwardingEnabled(multiTabletForwardingEnabled)
+    , DisableMultiTabletForwarding(!disableMultiTabletForwarding)
     , Unsafe(ListNodesRequest.GetUnsafe())
     , RequestStats(std::move(requestStats))
     , ProfileLog(std::move(profileLog))
@@ -139,7 +139,7 @@ void TListNodesActor::ListNodes(const TActorContext& ctx)
 
 void TListNodesActor::GetNodeAttrsBatch(const TActorContext& ctx)
 {
-    if (!MultiTabletForwardingEnabled) {
+    if (!DisableMultiTabletForwarding) {
         GetNodeAttrResponses = Response.NodesSize();
         return;
     }
@@ -641,12 +641,10 @@ void TStorageServiceActor::HandleListNodes(
 
     auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
-    const bool multiTabletForwardingEnabled =
-        !msg->Record.GetHeaders().GetDisableMultiTabletForwarding();
     auto actor = std::make_unique<TListNodesActor>(
         std::move(requestInfo),
         std::move(msg->Record),
-        multiTabletForwardingEnabled,
+        msg->Record.GetHeaders().GetDisableMultiTabletForwarding(),
         session->RequestStats,
         ProfileLog);
 

--- a/cloud/filestore/libs/storage/service/service_ut_parentless.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_parentless.cpp
@@ -145,7 +145,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceParentlessTest)
         NProto::TStorageConfig config;
         TShardedFileSystemConfig fsConfig;
 
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetParentlessFilesOnly(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetAutomaticallyCreatedShardSize(

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -1041,7 +1041,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     {
         for (bool lazyXAttrsEnabled: {false, true}) {
             config.SetLazyXAttrsEnabled(lazyXAttrsEnabled);
-                TShardedFileSystemConfig fsConfig;
+            TShardedFileSystemConfig fsConfig;
             CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
             auto counters =

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -534,6 +534,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
         auto headers = service.InitSession(fsConfig.FsId, "client");
+        headers.DisableMultiTabletForwarding = true;
 
         ui64 nodeId1 =
             service
@@ -639,6 +640,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         auto headers1 = headers;
         headers1.FileSystemId = fsConfig.Shard1Id;
+        headers1.DisableMultiTabletForwarding = true;
 
         const auto nodeId = service.CreateNode(
             headers1,
@@ -721,6 +723,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
         auto headers = service.InitSession(fsConfig.FsId, "client");
+        headers.DisableMultiTabletForwarding = true;
 
         auto createHandleResponse = service.CreateHandle(
             headers,
@@ -4822,16 +4825,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         checkListNodes(TVector<TString>{});
 
         // send delayed response in shard and make sure node is listed
-        auto createNodeRsp =
-            std::make_unique<TEvService::TEvCreateNodeResponse>();
-        runtime.Send(
-            new IEventHandle(
-                createNodeOnShard->Sender,
-                createNodeOnShard->Recipient,
-                createNodeRsp.release(),
-                0,   // flags
-                createNodeOnShard->Cookie),
-            nodeIdx);
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        runtime.Send(createNodeOnShard.Release(), nodeIdx);
         runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
         checkListNodes(TVector<TString>{"file1"});

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -812,8 +812,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldReturnShardInfoFromUnsafeListNodes)
     {
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -862,8 +860,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldForwardRequestsToShard)
     {
         config.SetLazyXAttrsEnabled(false);
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -1072,9 +1068,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     {
         for (bool lazyXAttrsEnabled: {false, true}) {
             config.SetLazyXAttrsEnabled(lazyXAttrsEnabled);
-            config.SetMultiTabletForwardingEnabled(true);
-
-            TShardedFileSystemConfig fsConfig;
+                TShardedFileSystemConfig fsConfig;
             CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
             auto counters =
@@ -1232,8 +1226,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldCreateDirectoryStructureInLeader)
     {
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -1311,7 +1303,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldReturnErrorForInvalidShardNo)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -1346,7 +1337,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(
         ShouldNotReturnInvalidShardNoErrorForDirectShardRequests)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -1411,8 +1401,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(
         ShouldHandleCreateNodeErrorFromShardUponCreateHandleViaLeader)
     {
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -1474,8 +1462,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldNotFailListNodesUponGetAttrENOENT)
     {
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -1630,7 +1616,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SIMPLE(ShouldListMultipleNodesWithGetNodeAttrBatch)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -1825,7 +1810,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldRenameExternalNodes)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -2061,7 +2045,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldPerformLocksForExternalNodes)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -2185,7 +2168,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldLinkExternalNodes)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -2314,7 +2296,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SIMPLE(ShouldAggregateFileSystemMetrics)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -2403,7 +2384,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SIMPLE(
         ShouldGetMultishardedSystemTopologyWithStrictFileSystemSizeEnforcement)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -2465,7 +2445,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SIMPLE(ShouldGetStorageStatsInDifferentModes)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -2581,7 +2560,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         ShouldEnableStrictFileSystemSizeEnforcementAndDirectoryCreationInShards)
     {
         // Create file system with two shards 1000 * 4 * 1024 bytes each
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(false);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -2717,7 +2695,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         ShouldResizeShardsInStrictWithStrictFileSystemSizeEnforcement)
     {
         // Create file system with two shards 1000 * 4 * 1024 bytes each
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -2742,7 +2719,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SIMPLE(ShouldRetryFileSystemResize)
     {
         // Create a filsystem with two shards.
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
@@ -2918,7 +2894,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SIMPLE(ShouldAggregateFileSystemMetricsInBackground)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -3124,7 +3099,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldRetryUnlinkingInShard)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -3225,7 +3199,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(
         ShouldRetryUnlinkingInShardUponLeaderRestart)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -3314,7 +3287,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(
         ShouldRetryUnlinkingInShardUponLeaderRestartForRenameNode)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -3419,7 +3391,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER(ShouldRetryNodeCreationInShard)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -3508,7 +3479,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(
         ShouldRetryNodeCreationInShardUponLeaderRestart)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -3618,7 +3588,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(
         ShouldRetryNodeCreationInShardUponCreateHandle)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -3715,7 +3684,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER(
         ShouldRetryNodeCreationInShardUponCreateHandleUponLeaderRestart)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -4902,7 +4870,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticallyCreatedShardSize(4_MB);
         config.SetShardBalancerMinFreeSpaceReserve(4_KB);
         config.SetShardBalancerDesiredFreeSpaceReserve(1_MB);
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetShardBalancerPrecisionBytes(4_KB);
 
         TTestEnv env({}, config);
@@ -5077,7 +5044,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(ShouldCreateDirectoryStructureInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -5220,7 +5186,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldResizeFileSystemWithDirectoryCreationInShardsEnabled)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -5335,7 +5300,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldNotResizeShardWithStrictModeAndDirectoryCreationInShardsEnabled)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -5407,7 +5371,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldResizeShardWithDirectoryCreationInShardsEnabled)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
@@ -5535,7 +5498,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(ShouldCreateHardLinks)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -5563,7 +5525,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldListNodesAndGetNodeAttrInDirectoryInShard)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -5680,7 +5641,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldAggregateFileSystemMetricsInBackgroundWithDirectoriesInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -5816,7 +5776,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldUnlinkNodeWithDirectoriesInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -5936,7 +5895,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldHandleUnlinkedNodeUponListingWithDirectoriesInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -6033,7 +5991,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldHandleRenameNodeInDestinationError)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -6165,7 +6122,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldRetryRenameNodeInShardUponLeaderRestartWithDirectoriesInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -6295,7 +6251,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldLockSourceNodeRefsUponRenameNodeWithDirectoriesInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -6502,7 +6457,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldRestoreNodeRefLocksUponLeaderRestartWithDirectoriesInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -6608,7 +6562,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldProcessRenameNodeInDestinationErrorWithDirectoriesInShards)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(true);
 
         TShardedFileSystemConfig fsConfig;
@@ -6699,8 +6652,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SIMPLE(ShouldRestoreSessionAfterShardRestartViaGetNodeAttr)
     {
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -6806,8 +6757,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_DIR_CREATION_IN_SHARDS(
         ShouldNotRequireActiveSessionForGetNodeAttrBatchToShard)
     {
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -6867,7 +6816,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     // TODO(2566) get rid of this test after migration
     SERVICE_TEST_SIMPLE(ShouldReportSevenBytesHandlesCount)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
         config.SetShardBalancerPolicy(NProto::SBP_ROUND_ROBIN);
         TShardedFileSystemConfig fsConfig;
@@ -7019,7 +6967,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const ui64 fsSize =
             shardBlockCount * (shardCount - 1) + shardBlockCount / 2;
 
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
         config.SetShardBalancerPolicy(NProto::SBP_ROUND_ROBIN);
         config.SetAutomaticShardCreationEnabled(true);
@@ -7119,7 +7066,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const ui64 fsSize =
             shardBlockCount * (shardCount - 1) + shardBlockCount / 2;
 
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(shardAllocationUnit);
 
@@ -7187,7 +7133,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const ui64 fsSize =
             shardBlockCount * (shardCount - 1) + shardBlockCount / 2;
 
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(shardAllocationUnit);
         config.SetShardBalancerPolicy(NProto::SBP_ROUND_ROBIN);
@@ -7303,8 +7248,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST_SIMPLE(ShouldReturnListNodesMissingFromShardsWithUnsafeFlag)
     {
-        config.SetMultiTabletForwardingEnabled(true);
-
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
@@ -7388,7 +7331,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                 ? (fsSize * blockSize) / sizeToNodeRatio
                 : (2 * shardAllocationUnit) / sizeToNodeRatio;
 
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(
             strictFileSystemSizeEnforcementEnabled);
@@ -7558,7 +7500,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(
         ShouldSwitchOnDirectoryCreationInShardsForExistingFilesystem)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetDirectoryCreationInShardsEnabled(false);
 
         TShardedFileSystemConfig fsConfig;

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5480,7 +5480,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     // See #5826 for more details
     SERVICE_TEST(ShouldRejectHardLinkFromShardDirToMainTabletNode)
     {
-        config.SetMultiTabletForwardingEnabled(true);
         config.SetAutomaticShardCreationEnabled(true);
 
         const TString fsId = "test";

--- a/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
@@ -216,7 +216,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest)
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId, {});
 
         NProto::TStorageConfig patch;
-        patch.SetMultiTabletForwardingEnabled(true);
+        patch.SetThrottlingEnabled(true);
         tablet.ChangeStorageConfig(std::move(patch));
 
         tablet.RebootTablet();
@@ -224,7 +224,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest)
         auto response = tablet.GetStorageConfig();
         UNIT_ASSERT_VALUES_EQUAL(
             true,
-            response->Record.GetStorageConfig().GetMultiTabletForwardingEnabled());
+            response->Record.GetStorageConfig().GetThrottlingEnabled());
     }
 
     Y_UNIT_TEST(ShouldNotifyServiceWhenFileSystemConfigChanged)

--- a/cloud/filestore/tests/client/nfs-storage.txt
+++ b/cloud/filestore/tests/client/nfs-storage.txt
@@ -1,4 +1,3 @@
-MultiTabletForwardingEnabled: true
 LargeDeletionMarkersEnabled: true
 MaxFileBlocks: 536870912
 TwoStageReadEnabled: true

--- a/cloud/filestore/tests/client_sharded/nfs-storage.txt
+++ b/cloud/filestore/tests/client_sharded/nfs-storage.txt
@@ -1,4 +1,3 @@
-MultiTabletForwardingEnabled: true
 LargeDeletionMarkersEnabled: true
 MaxFileBlocks: 536870912
 AutomaticShardCreationEnabled: true

--- a/cloud/filestore/tests/client_sharded_dir/nfs-storage.txt
+++ b/cloud/filestore/tests/client_sharded_dir/nfs-storage.txt
@@ -1,4 +1,3 @@
-MultiTabletForwardingEnabled: true
 LargeDeletionMarkersEnabled: true
 MaxFileBlocks: 536870912
 AutomaticShardCreationEnabled: true

--- a/cloud/filestore/tests/client_sharded_dir_resize/nfs-storage.txt
+++ b/cloud/filestore/tests/client_sharded_dir_resize/nfs-storage.txt
@@ -1,4 +1,3 @@
-MultiTabletForwardingEnabled: true
 LargeDeletionMarkersEnabled: true
 MaxFileBlocks: 536870912
 AutomaticShardCreationEnabled: true

--- a/cloud/filestore/tests/common_configs/nfs-storage-multitablet2-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-multitablet2-patch.txt
@@ -5,7 +5,7 @@ UnalignedThreeStageWriteEnabled: true
 # Caches
 ReadAheadCacheRangeSize: 1048576
 # Sharding
-MultiTabletForwardingEnabled: true
+
 DirectoryCreationInShardsEnabled: true
 
 GidPropagationEnabled: true

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -4,7 +4,7 @@ NewCleanupEnabled: true
 ThreeStageWriteEnabled: true
 ReadAheadCacheRangeSize: 1048576
 PreferredBlockSizeMultiplier: 64
-MultiTabletForwardingEnabled: true
+
 UnalignedThreeStageWriteEnabled: true
 InMemoryIndexCacheEnabled: true
 InMemoryIndexCacheNodesCapacity: 10

--- a/cloud/filestore/tests/fio/qemu-kikimr-unconfirmed-data-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-unconfirmed-data-test/nfs-patch.txt
@@ -2,5 +2,5 @@ AddingUnconfirmedDataEnabled: true
 UnconfirmedDataCountHardLimit: 10000
 ThreeStageWriteEnabled: true
 UnalignedThreeStageWriteEnabled: true
-MultiTabletForwardingEnabled: true
+
 MaxTabletStep:2000

--- a/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-test/nfs-patch.txt
@@ -1,6 +1,6 @@
 ZeroCopyWriteEnabled: true
 ThreeStageWriteEnabled: true
 UnalignedThreeStageWriteEnabled: true
-MultiTabletForwardingEnabled: true
+
 ZeroCopyReadEnabled: true
 TwoStageReadEnabled: true

--- a/cloud/filestore/tests/fmdtest/nfs-storage.txt
+++ b/cloud/filestore/tests/fmdtest/nfs-storage.txt
@@ -1,4 +1,3 @@
-MultiTabletForwardingEnabled: true
 LargeDeletionMarkersEnabled: true
 MaxFileBlocks: 536870912
 AutomaticShardCreationEnabled: true

--- a/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/nfs-storage-config-patch.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/nfs-storage-config-patch.txt
@@ -1,4 +1,3 @@
 ParentlessFilesOnly: true
 AllowHandlelessIO: true
-MultiTabletForwardingEnabled: true
 AutomaticShardCreationEnabled: true

--- a/cloud/filestore/tests/service/service-kikimr-parentless-handleless-test/nfs-storage-config-patch.txt
+++ b/cloud/filestore/tests/service/service-kikimr-parentless-handleless-test/nfs-storage-config-patch.txt
@@ -1,4 +1,3 @@
 ParentlessFilesOnly: true
 AllowHandlelessIO: true
-MultiTabletForwardingEnabled: true
 AutomaticShardCreationEnabled: true


### PR DESCRIPTION
### Notes
MultiTabletForwardingEnabled is set to true by default and should be treated as such. Disabling it should always be done via headers

### Issue
#5853