### PR TITLE
issue-4875: start FreshBlocksWriter only for Partition ver1 tablet

### DIFF
--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -766,7 +766,7 @@ void TPartitionActor::HandlePatchBlob(
     Y_UNUSED(ctx);
 
     HandleUnexpectedEvent(
-        ev.Release(),
+        *ev,
         TBlockStoreComponents::PARTITION,
         __PRETTY_FUNCTION__);
 }
@@ -778,7 +778,7 @@ void TPartitionActor::HandleGetFreshChannelsInfo(
     Y_UNUSED(ctx);
 
     HandleUnexpectedEvent(
-        ev.Release(),
+        *ev,
         TBlockStoreComponents::PARTITION,
         __PRETTY_FUNCTION__);
 }
@@ -790,7 +790,7 @@ void TPartitionActor::HandleAddFreshBlocks(
     Y_UNUSED(ctx);
 
     HandleUnexpectedEvent(
-        ev.Release(),
+        *ev,
         TBlockStoreComponents::PARTITION,
         __PRETTY_FUNCTION__);
 }

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -763,9 +763,12 @@ void TPartitionActor::HandlePatchBlob(
     const TEvPartitionCommonPrivate::TEvPatchBlobRequest::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
-    Y_UNUSED(ev);
     Y_UNUSED(ctx);
-    Y_ABORT("Unimplemented");
+
+    HandleUnexpectedEvent(
+        ev.Get(),
+        TBlockStoreComponents::PARTITION,
+        __PRETTY_FUNCTION__);
 }
 
 void TPartitionActor::HandleGetFreshChannelsInfo(
@@ -774,7 +777,11 @@ void TPartitionActor::HandleGetFreshChannelsInfo(
 {
     Y_UNUSED(ev);
     Y_UNUSED(ctx);
-    Y_ABORT("Unimplemented");
+
+    HandleUnexpectedEvent(
+        ev.Get(),
+        TBlockStoreComponents::PARTITION,
+        __PRETTY_FUNCTION__);
 }
 
 void TPartitionActor::HandleAddFreshBlocks(
@@ -783,7 +790,11 @@ void TPartitionActor::HandleAddFreshBlocks(
 {
     Y_UNUSED(ev);
     Y_UNUSED(ctx);
-    Y_ABORT("Unimplemented");
+
+    HandleUnexpectedEvent(
+        ev.Get(),
+        TBlockStoreComponents::PARTITION,
+        __PRETTY_FUNCTION__);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -766,7 +766,7 @@ void TPartitionActor::HandlePatchBlob(
     Y_UNUSED(ctx);
 
     HandleUnexpectedEvent(
-        ev.Get(),
+        ev.Release(),
         TBlockStoreComponents::PARTITION,
         __PRETTY_FUNCTION__);
 }
@@ -775,11 +775,10 @@ void TPartitionActor::HandleGetFreshChannelsInfo(
     const TEvPartitionCommonPrivate::TEvGetFreshChannelsInfoRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    Y_UNUSED(ev);
     Y_UNUSED(ctx);
 
     HandleUnexpectedEvent(
-        ev.Get(),
+        ev.Release(),
         TBlockStoreComponents::PARTITION,
         __PRETTY_FUNCTION__);
 }
@@ -788,11 +787,10 @@ void TPartitionActor::HandleAddFreshBlocks(
     const TEvPartitionCommonPrivate::TEvAddFreshBlocksRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    Y_UNUSED(ev);
     Y_UNUSED(ctx);
 
     HandleUnexpectedEvent(
-        ev.Get(),
+        ev.Release(),
         TBlockStoreComponents::PARTITION,
         __PRETTY_FUNCTION__);
 }

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -629,8 +629,15 @@ bool TVolumeActor::CheckReadWriteBlockRange(const TBlockRange64& range) const
         .Contains(range);
 }
 
-bool TVolumeActor::IsFreshBlocksWriterEnabled() const
+bool TVolumeActor::IsFreshBlocksWriterEnabled(ui64 partTabletId) const
 {
+    const auto* part = State->GetPartition(partTabletId);
+    if (!part ||
+        part->StorageInfo->TabletType != TTabletTypes::BlockStorePartition)
+    {
+        return false;
+    }
+
     return Config->GetFreshBlocksWriterEnabled() ||
            Config->IsFreshBlocksWriterFeatureEnabled(
                State->GetConfig().GetCloudId(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -738,7 +738,7 @@ private:
     void ReplyToServiceStatisticsCollectorActor(
         const NActors::TActorContext& ctx);
 
-    bool IsFreshBlocksWriterEnabled() const;
+    bool IsFreshBlocksWriterEnabled(ui64 partTabletId) const;
 
 private:
     STFUNC(StateBoot);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -933,7 +933,7 @@ void TVolumeActor::HandleTabletStatus(
                 TActorsStack::EActorPurpose::BlobStoragePartitionTablet);
 
             TActorId freshBlocksWriterId;
-            if (IsFreshBlocksWriterEnabled()) {
+            if (IsFreshBlocksWriterEnabled(msg->TabletId)) {
                 actorStack = WrapWithFreshBlocksWriterIfNeeded(
                     ctx,
                     std::move(actorStack),
@@ -1074,7 +1074,7 @@ TActorsStack TVolumeActor::WrapWithFreshBlocksWriterIfNeeded(
     TActorsStack actors,
     ui64 partTabletId)
 {
-    if (!IsFreshBlocksWriterEnabled()) {
+    if (!IsFreshBlocksWriterEnabled(partTabletId)) {
         return actors;
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -7776,7 +7776,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             TVolumeClient volume(*runtime);
 
             ui32 freshBlocksWriterWaitReadyRequests = 0;
-            ui32 partitionWaitReadyRequests = 0;
 
             runtime->SetObserverFunc(
                 [&](TAutoPtr<IEventHandle>& event)
@@ -7795,13 +7794,6 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
                             ++freshBlocksWriterWaitReadyRequests;
                             break;
                         }
-                        case TEvPartition::EvWaitReadyRequest: {
-                            Cerr << "EvWaitReadyRequest Sender: "
-                                 << runtime->FindActorName(event->Sender)
-                                 << Endl;
-                            ++partitionWaitReadyRequests;
-                            break;
-                        }
                     }
 
                     return TTestActorRuntime::DefaultObserverFunc(event);
@@ -7810,23 +7802,21 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             volume.UpdateVolumeConfig();
             volume.WaitReady();
 
-            return std::make_pair(
-                freshBlocksWriterWaitReadyRequests,
-                partitionWaitReadyRequests);
+            return freshBlocksWriterWaitReadyRequests;
         };
 
         {
-            const auto [freshRequests, partitionRequests] =
+            const auto freshWaitReadyRequests =
                 runTest(TTabletTypes::BlockStorePartition);
 
-            UNIT_ASSERT_VALUES_UNEQUAL(0, freshRequests);
+            UNIT_ASSERT_VALUES_UNEQUAL(0, freshWaitReadyRequests);
         }
 
         {
-            const auto [freshRequests, partitionRequests] =
+            const auto freshWaitReadyRequests =
                 runTest(TTabletTypes::BlockStorePartition2);
 
-            UNIT_ASSERT_VALUES_EQUAL(0, freshRequests);
+            UNIT_ASSERT_VALUES_EQUAL(0, freshWaitReadyRequests);
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -1,6 +1,7 @@
 #include "volume_ut.h"
 
 #include <cloud/blockstore/libs/common/constants.h>
+#include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
 #include <cloud/blockstore/libs/storage/core/volume_model.h>
 #include <cloud/blockstore/libs/storage/model/composite_id.h>
@@ -7762,6 +7763,71 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         runtime->Send(
             new IEventHandle(partActorId, sender, new TEvents::TEvPoisonPill()));
         volume.WaitReady();
+    }
+
+    Y_UNIT_TEST(ShouldStartFreshBlocksWriterOnlyForPartitionTablet)
+    {
+        const auto runTest = [](TTabletTypes::EType tabletType)
+        {
+            NProto::TStorageServiceConfig config;
+            config.SetFreshBlocksWriterEnabled(true);
+
+            auto runtime = PrepareTestActorRuntime(config);
+            TVolumeClient volume(*runtime);
+
+            ui32 freshBlocksWriterWaitReadyRequests = 0;
+            ui32 partitionWaitReadyRequests = 0;
+
+            runtime->SetObserverFunc(
+                [&](TAutoPtr<IEventHandle>& event)
+                {
+                    switch (event->GetTypeRewrite()) {
+                        case TEvHiveProxy::EvBootExternalResponse: {
+                            auto* msg = event->Get<
+                                TEvHiveProxy::TEvBootExternalResponse>();
+                            auto* storageInfo = const_cast<TTabletStorageInfo*>(
+                                msg->StorageInfo.Get());
+                            storageInfo->TabletType = tabletType;
+                            break;
+                        }
+                        case NFreshBlocksWriter::TEvFreshBlocksWriter::
+                            EvWaitReadyRequest: {
+                            ++freshBlocksWriterWaitReadyRequests;
+                            break;
+                        }
+                        case TEvPartition::EvWaitReadyRequest: {
+                            Cerr << "EvWaitReadyRequest Sender: "
+                                 << runtime->FindActorName(event->Sender)
+                                 << Endl;
+                            ++partitionWaitReadyRequests;
+                            break;
+                        }
+                    }
+
+                    return TTestActorRuntime::DefaultObserverFunc(event);
+                });
+
+            volume.UpdateVolumeConfig();
+            volume.WaitReady();
+
+            return std::make_pair(
+                freshBlocksWriterWaitReadyRequests,
+                partitionWaitReadyRequests);
+        };
+
+        {
+            const auto [freshRequests, partitionRequests] =
+                runTest(TTabletTypes::BlockStorePartition);
+
+            UNIT_ASSERT_VALUES_UNEQUAL(0, freshRequests);
+        }
+
+        {
+            const auto [freshRequests, partitionRequests] =
+                runTest(TTabletTypes::BlockStorePartition2);
+
+            UNIT_ASSERT_VALUES_EQUAL(0, freshRequests);
+        }
     }
 
     Y_UNIT_TEST(ShouldCorrectlyCalculateDiskRegistryPartitionParameters)

--- a/cloud/storage/core/libs/actors/helpers.cpp
+++ b/cloud/storage/core/libs/actors/helpers.cpp
@@ -31,6 +31,10 @@ void LogUnexpectedEvent(
         location.c_str());
 }
 
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
 void HandleUnexpectedEvent(
     const IEventHandle& ev,
     int component,
@@ -43,11 +47,6 @@ void HandleUnexpectedEvent(
         EventInfo(ev).c_str(),
         location.c_str()));
 }
-
-}   // namespace
-
-////////////////////////////////////////////////////////////////////////////////
-
 
 void HandleUnexpectedEvent(
     const TAutoPtr<IEventHandle>& ev,

--- a/cloud/storage/core/libs/actors/helpers.h
+++ b/cloud/storage/core/libs/actors/helpers.h
@@ -10,6 +10,11 @@ namespace NCloud {
 ////////////////////////////////////////////////////////////////////////////////
 
 void HandleUnexpectedEvent(
+    const NActors::IEventHandle& ev,
+    int component,
+    const TString& location);
+
+void HandleUnexpectedEvent(
     const TAutoPtr<NActors::IEventHandle>& ev,
     int component,
     const TString& location);


### PR DESCRIPTION
### Notes
Fresh Blocks Writer is not supported for partitions v2, so we shouldn't try to start fbw for v2.

### Issue
#4875