### PR TITLE
issue-1751: [Filestore] Implement draining mode for WriteBackCache

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -37,6 +37,7 @@ namespace NCloud::NFileStore{
     xxx(WriteBackCacheCreatingOrDeletingError)                                 \
     xxx(WriteBackCacheCorruptionError)                                         \
     xxx(WriteBackCacheDataLossError)                                           \
+    xxx(WriteBackCacheStateError)                                              \
     xxx(ErrorWasSentToTheGuest)                                                \
     xxx(DirectoryHandlesStorageError)                                          \
     xxx(CalculateChecksumsBufferOverflow)                                      \

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -37,7 +37,7 @@ namespace NCloud::NFileStore{
     xxx(WriteBackCacheCreatingOrDeletingError)                                 \
     xxx(WriteBackCacheCorruptionError)                                         \
     xxx(WriteBackCacheDataLossError)                                           \
-    xxx(WriteBackCacheStateError)                                              \
+    xxx(WriteBackCacheWritingNotAllowedInDrainingMode)                         \
     xxx(ErrorWasSentToTheGuest)                                                \
     xxx(DirectoryHandlesStorageError)                                          \
     xxx(CalculateChecksumsBufferOverflow)                                      \

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.h
@@ -54,19 +54,17 @@ struct TReleaseRequest
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class EServerWriteBackCacheState
+enum class EWriteBackCacheRequestMode
 {
-    // WriteBackCache is turned off
-    Disabled,
+    // WriteBackCache should not be used, the requests should go directly to the
+    // session
+    Bypass,
 
-    // Requests should go to the WriteBackCache
-    Enabled,
+    // WriteBackCache should be used, with ReadData/WriteData
+    Cached,
 
-    // WriteBackCache is being turned off or a request with
-    // O_DIRECT/O_SYNC/O_DSYNC is made.
-    // Requests should wait until WriteBackCache is flushed and then go
-    // directly to the session
-    Draining
+    // WriteBackCache should be used, with ReadDataDirect/WriteDataDirect
+    Direct
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -408,7 +406,7 @@ private:
         fuse_ino_t ino,
         uint64_t fh);
 
-    EServerWriteBackCacheState GetServerWriteBackCacheState(
+    EWriteBackCacheRequestMode GetWriteBackCacheRequestMode(
         const fuse_file_info* fi) const;
 
     TDuration GetEntryCacheTimeout(const NProto::TNodeAttr& attrs) const;

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.h
@@ -54,17 +54,17 @@ struct TReleaseRequest
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class EWriteBackCacheRequestMode
+enum class EWriteBackCacheRequestStrategy
 {
     // WriteBackCache should not be used, the requests should go directly to the
     // session
-    Bypass,
+    DoNotUse,
 
     // WriteBackCache should be used, with ReadData/WriteData
-    Cached,
+    UseNonDirect,
 
-    // WriteBackCache should be used, with ReadDataDirect/WriteDataDirect
-    Direct
+    // WriteBackCache should be used, with ReadDataDirect/WriteDataDirect only
+    UseDirect
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -406,7 +406,7 @@ private:
         fuse_ino_t ino,
         uint64_t fh);
 
-    EWriteBackCacheRequestMode GetWriteBackCacheRequestMode(
+    EWriteBackCacheRequestStrategy GetWriteBackCacheRequestStrategy(
         const fuse_file_info* fi) const;
 
     TDuration GetEntryCacheTimeout(const NProto::TNodeAttr& attrs) const;

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -480,21 +480,21 @@ void TFileSystem::Read(
         }
     };
 
-    const auto mode = GetWriteBackCacheRequestMode(fi);
+    const auto strategy = GetWriteBackCacheRequestStrategy(fi);
 
-    switch (mode) {
-        case EWriteBackCacheRequestMode::Bypass: {
+    switch (strategy) {
+        case EWriteBackCacheRequestStrategy::DoNotUse: {
             Session->ReadData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
-        case EWriteBackCacheRequestMode::Direct: {
+        case EWriteBackCacheRequestStrategy::UseDirect: {
             WriteBackCache
                 .ReadDataDirect(std::move(callContext), std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
-        case EWriteBackCacheRequestMode::Cached: {
+        case EWriteBackCacheRequestStrategy::UseNonDirect: {
             WriteBackCache.ReadData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
@@ -547,7 +547,7 @@ void TFileSystem::DoWrite(
     ui64 size,
     fuse_file_info* fi)
 {
-    const auto mode = GetWriteBackCacheRequestMode(fi);
+    const auto strategy = GetWriteBackCacheRequestStrategy(fi);
 
     const auto handle = fi->fh;
     const auto reqId = callContext->RequestId;
@@ -562,7 +562,7 @@ void TFileSystem::DoWrite(
         const auto& response = future.GetValue();
         const auto& error = response.GetError();
 
-        if (mode != EWriteBackCacheRequestMode::Cached) {
+        if (strategy != EWriteBackCacheRequestStrategy::UseNonDirect) {
             self->FSyncQueue
                 ->Dequeue(reqId, error, TNodeId{ino}, THandle{handle});
         }
@@ -578,22 +578,22 @@ void TFileSystem::DoWrite(
         }
     };
 
-    if (mode != EWriteBackCacheRequestMode::Cached) {
+    if (strategy != EWriteBackCacheRequestStrategy::UseNonDirect) {
         FSyncQueue->Enqueue(reqId, TNodeId{ino}, THandle{handle});
     }
 
-    switch (mode) {
-        case EWriteBackCacheRequestMode::Cached: {
+    switch (strategy) {
+        case EWriteBackCacheRequestStrategy::UseNonDirect: {
             WriteBackCache.WriteData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
-        case EWriteBackCacheRequestMode::Bypass: {
+        case EWriteBackCacheRequestStrategy::DoNotUse: {
             Session->WriteData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
-        case EWriteBackCacheRequestMode::Direct: {
+        case EWriteBackCacheRequestStrategy::UseDirect: {
             WriteBackCache
                 .WriteDataDirect(std::move(callContext), std::move(request))
                 .Subscribe(std::move(callback));
@@ -1094,24 +1094,24 @@ void TFileSystem::FSyncDir(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-EWriteBackCacheRequestMode TFileSystem::GetWriteBackCacheRequestMode(
+EWriteBackCacheRequestStrategy TFileSystem::GetWriteBackCacheRequestStrategy(
     const fuse_file_info* fi) const
 {
     if (!WriteBackCache) {
-        return EWriteBackCacheRequestMode::Bypass;
+        return EWriteBackCacheRequestStrategy::DoNotUse;
     }
 
-    switch (WriteBackCache.GetState()) {
-        case EWriteBackCacheState::Normal:
+    switch (WriteBackCache.GetMode()) {
+        case EWriteBackCacheMode::Normal:
             return fi->flags & (O_DIRECT | O_SYNC | O_DSYNC)
-                       ? EWriteBackCacheRequestMode::Direct
-                       : EWriteBackCacheRequestMode::Cached;
+                       ? EWriteBackCacheRequestStrategy::UseDirect
+                       : EWriteBackCacheRequestStrategy::UseNonDirect;
 
-        case EWriteBackCacheState::Draining:
-            return EWriteBackCacheRequestMode::Direct;
+        case EWriteBackCacheMode::Draining:
+            return EWriteBackCacheRequestStrategy::UseDirect;
 
-        case EWriteBackCacheState::Drained:
-            return EWriteBackCacheRequestMode::Bypass;
+        case EWriteBackCacheMode::Drained:
+            return EWriteBackCacheRequestStrategy::DoNotUse;
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -480,21 +480,22 @@ void TFileSystem::Read(
         }
     };
 
-    const auto wbcState = GetServerWriteBackCacheState(fi);
-    switch (wbcState) {
-        case EServerWriteBackCacheState::Enabled: {
-            WriteBackCache.ReadData(callContext, std::move(request))
-                .Subscribe(std::move(callback));
-            break;
-        }
-        case EServerWriteBackCacheState::Disabled: {
+    const auto mode = GetWriteBackCacheRequestMode(fi);
+
+    switch (mode) {
+        case EWriteBackCacheRequestMode::Bypass: {
             Session->ReadData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
-        case EServerWriteBackCacheState::Draining: {
+        case EWriteBackCacheRequestMode::Direct: {
             WriteBackCache
                 .ReadDataDirect(std::move(callContext), std::move(request))
+                .Subscribe(std::move(callback));
+            break;
+        }
+        case EWriteBackCacheRequestMode::Cached: {
+            WriteBackCache.ReadData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
@@ -546,7 +547,7 @@ void TFileSystem::DoWrite(
     ui64 size,
     fuse_file_info* fi)
 {
-    const auto wbcState = GetServerWriteBackCacheState(fi);
+    const auto mode = GetWriteBackCacheRequestMode(fi);
 
     const auto handle = fi->fh;
     const auto reqId = callContext->RequestId;
@@ -561,7 +562,7 @@ void TFileSystem::DoWrite(
         const auto& response = future.GetValue();
         const auto& error = response.GetError();
 
-        if (wbcState != EServerWriteBackCacheState::Enabled) {
+        if (mode != EWriteBackCacheRequestMode::Cached) {
             self->FSyncQueue
                 ->Dequeue(reqId, error, TNodeId{ino}, THandle{handle});
         }
@@ -572,27 +573,27 @@ void TFileSystem::DoWrite(
             // that read node attributes.
             //
 
-            InvalidateNodeInCache(ino);
+            self->InvalidateNodeInCache(ino);
             self->ReplyWrite(*callContext, error, req, size);
         }
     };
 
-    if (wbcState != EServerWriteBackCacheState::Enabled) {
+    if (mode != EWriteBackCacheRequestMode::Cached) {
         FSyncQueue->Enqueue(reqId, TNodeId{ino}, THandle{handle});
     }
 
-    switch (wbcState) {
-        case EServerWriteBackCacheState::Enabled: {
+    switch (mode) {
+        case EWriteBackCacheRequestMode::Cached: {
             WriteBackCache.WriteData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
-        case EServerWriteBackCacheState::Disabled: {
+        case EWriteBackCacheRequestMode::Bypass: {
             Session->WriteData(callContext, std::move(request))
                 .Subscribe(std::move(callback));
             break;
         }
-        case EServerWriteBackCacheState::Draining: {
+        case EWriteBackCacheRequestMode::Direct: {
             WriteBackCache
                 .WriteDataDirect(std::move(callContext), std::move(request))
                 .Subscribe(std::move(callback));
@@ -1093,23 +1094,25 @@ void TFileSystem::FSyncDir(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-EServerWriteBackCacheState TFileSystem::GetServerWriteBackCacheState(
+EWriteBackCacheRequestMode TFileSystem::GetWriteBackCacheRequestMode(
     const fuse_file_info* fi) const
 {
     if (!WriteBackCache) {
-        return EServerWriteBackCacheState::Disabled;
+        return EWriteBackCacheRequestMode::Bypass;
     }
 
-    if (!Config->GetServerWriteBackCacheEnabled()) {
-        return WriteBackCache.IsEmpty() ? EServerWriteBackCacheState::Disabled
-                                        : EServerWriteBackCacheState::Draining;
-    }
+    switch (WriteBackCache.GetState()) {
+        case EWriteBackCacheState::Normal:
+            return fi->flags & (O_DIRECT | O_SYNC | O_DSYNC)
+                       ? EWriteBackCacheRequestMode::Direct
+                       : EWriteBackCacheRequestMode::Cached;
 
-    if (fi->flags & (O_DIRECT | O_SYNC | O_DSYNC)) {
-        return EServerWriteBackCacheState::Draining;
-    }
+        case EWriteBackCacheState::Draining:
+            return EWriteBackCacheRequestMode::Direct;
 
-    return EServerWriteBackCacheState::Enabled;
+        case EWriteBackCacheState::Drained:
+            return EWriteBackCacheRequestMode::Bypass;
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -3590,7 +3590,8 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 bootstrap.Stop();
             };
 
-            UNIT_ASSERT_VALUES_EQUAL(0, writeDataCalled2.load());
+            // Drain triggers flush immediately
+            UNIT_ASSERT_VALUES_EQUAL(1, writeDataCalled2.load());
 
             auto flush =
                 bootstrap.Fuse->SendRequest<TFlushRequest>(nodeId, handleId);

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1053,6 +1053,10 @@ private:
                          .ZeroCopyWriteEnabled =
                              FileSystemConfig->GetZeroCopyWriteEnabled()});
 
+                    if (!FileSystemConfig->GetServerWriteBackCacheEnabled()) {
+                        WriteBackCache.Drain();
+                    }
+
                     ModuleStatsRegistry->Register(
                         {.FileSystemId = Config->GetFileSystemId(),
                          .ClientId = Config->GetClientId(),
@@ -1300,12 +1304,14 @@ private:
 
     void StopAsyncOnCompletionQueueStopped(TPromise<void> stopCompleted)
     {
-        if (WriteBackCache && !WriteBackCache.IsEmpty()) {
+        if (WriteBackCache && !WriteBackCache.IsDrained()) {
             STORAGE_INFO(
-                "[f:%s][c:%s] WriteBackCache is not empty, starting "
-                "FlushAllData",
+                "[f:%s][c:%s] (DestroySession) WriteBackCache is not empty, "
+                "executing Drain + FlushAllData",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str());
+
+            WriteBackCache.Drain();
 
             WriteBackCache.FlushAllData().Subscribe(
                 [w = weak_from_this(),
@@ -1328,25 +1334,25 @@ private:
         TPromise<void> stopCompleted,
         const NProto::TError& error)
     {
-        if (HasError(error)) {
+        if (WriteBackCache.IsDrained()) {
+            STORAGE_INFO(
+                "[f:%s][c:%s] (DestroySession) WriteBackCache is drained",
+                Config->GetFileSystemId().Quote().c_str(),
+                Config->GetClientId().Quote().c_str());
+        } else if (HasError(error)) {
             STORAGE_WARN(
-                "[f:%s][c:%s] WriteBackCache::FlushAllData failed at "
-                "DestroySession, unflushed data will be lost. Error: %s",
+                "[f:%s][c:%s] (DestroySession) WriteBackCache::FlushAllData "
+                "failed, unflushed data will be lost. Error: %s",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str(),
                 FormatError(error).c_str());
-        } else if (WriteBackCache && WriteBackCache.IsEmpty()) {
+        } else {
             ReportWriteBackCacheDataLossError(Sprintf(
-                "[f:%s][c:%s] WriteBackCache was not emptied after successful "
-                "FlushAllData at DestroySession, possible data loss",
+                "[f:%s][c:%s] (DestroySession) WriteBackCache was not emptied "
+                "after successful FlushAllData, possible data loss",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str()));
         }
-
-        STORAGE_INFO(
-            "[f:%s][c:%s] completed FlushAllData",
-            Config->GetFileSystemId().Quote().c_str(),
-            Config->GetClientId().Quote().c_str());
 
         StopAsyncDestroySession(std::move(stopCompleted));
     }

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1306,7 +1306,7 @@ private:
     {
         if (WriteBackCache && !WriteBackCache.IsDrained()) {
             STORAGE_INFO(
-                "[f:%s][c:%s] (DestroySession) WriteBackCache is not empty, "
+                "[f:%s][c:%s] (DestroySession) WriteBackCache is not drained, "
                 "executing Drain + FlushAllData",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str());
@@ -1335,21 +1335,27 @@ private:
         const NProto::TError& error)
     {
         if (WriteBackCache.IsDrained()) {
+            // It is possible for WriteBackCache to become drained after
+            // unsuccessful FlushAllData call. This may happen if the data is
+            // dropped by WriteBackCache itself (for example, if ReleaseHandle
+            // was called). In this case, we do not report FlushAllData error
+            // because it should have been already reported by WriteBackCache
             STORAGE_INFO(
                 "[f:%s][c:%s] (DestroySession) WriteBackCache is drained",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str());
         } else if (HasError(error)) {
             STORAGE_WARN(
-                "[f:%s][c:%s] (DestroySession) WriteBackCache::FlushAllData "
-                "failed, unflushed data will be lost. Error: %s",
+                "[f:%s][c:%s] (DestroySession) WriteBackCache is not drained"
+                " because of FlushAllData error, unflushed data will be lost."
+                " Error: %s",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str(),
                 FormatError(error).c_str());
         } else {
             ReportWriteBackCacheDataLossError(Sprintf(
-                "[f:%s][c:%s] (DestroySession) WriteBackCache was not emptied "
-                "after successful FlushAllData, possible data loss",
+                "[f:%s][c:%s] (DestroySession) WriteBackCache is not drained "
+                "after successful FlushAllData, unflushed data will be lost",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str()));
         }

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1054,7 +1054,10 @@ private:
                              FileSystemConfig->GetZeroCopyWriteEnabled()});
 
                     if (!FileSystemConfig->GetServerWriteBackCacheEnabled()) {
-                        WriteBackCache.Drain();
+                        auto future = WriteBackCache.Drain();
+                        // Drain will run asynchronously in background
+                        // No need to wait for it
+                        Y_UNUSED(future);
                     }
 
                     ModuleStatsRegistry->Register(

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1307,18 +1307,16 @@ private:
         if (WriteBackCache && !WriteBackCache.IsDrained()) {
             STORAGE_INFO(
                 "[f:%s][c:%s] (DestroySession) WriteBackCache is not drained, "
-                "executing Drain + FlushAllData",
+                "executing Drain()",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str());
 
-            WriteBackCache.Drain();
-
-            WriteBackCache.FlushAllData().Subscribe(
+            WriteBackCache.Drain().Subscribe(
                 [w = weak_from_this(),
                  s = std::move(stopCompleted)](const auto& f) mutable
                 {
                     if (auto p = w.lock()) {
-                        p->StopAsyncOnWriteBackCacheFlushed(
+                        p->StopAsyncOnWriteBackCacheDrained(
                             std::move(s),
                             f.GetValue());
                     } else {
@@ -1330,7 +1328,7 @@ private:
         }
     }
 
-    void StopAsyncOnWriteBackCacheFlushed(
+    void StopAsyncOnWriteBackCacheDrained(
         TPromise<void> stopCompleted,
         const NProto::TError& error)
     {
@@ -1347,7 +1345,7 @@ private:
         } else if (HasError(error)) {
             STORAGE_WARN(
                 "[f:%s][c:%s] (DestroySession) WriteBackCache is not drained"
-                " because of FlushAllData error, unflushed data will be lost."
+                " because of Drain() error, unflushed data will be lost."
                 " Error: %s",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str(),
@@ -1355,7 +1353,7 @@ private:
         } else {
             ReportWriteBackCacheDataLossError(Sprintf(
                 "[f:%s][c:%s] (DestroySession) WriteBackCache is not drained "
-                "after successful FlushAllData, unflushed data will be lost",
+                "after successful Drain(), unflushed data will be lost",
                 Config->GetFileSystemId().Quote().c_str(),
                 Config->GetClientId().Quote().c_str()));
         }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -15,6 +15,8 @@
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/service/request.h>
 
+#include <atomic>
+
 namespace NCloud::NFileStore::NFuse {
 
 using namespace NThreading;
@@ -65,6 +67,9 @@ private:
 
     IPersistentStoragePtr PersistentStorage;
     TWriteBackCacheState State;
+
+    std::atomic<bool> DrainRequested = false;
+    std::atomic<bool> DrainCompleted = false;
 
 public:
     explicit TImpl(TWriteBackCacheArgs args)
@@ -153,6 +158,50 @@ public:
     {
         State.TriggerPeriodicFlushAll();
         ScheduleAutomaticFlushIfNeeded();
+    }
+
+    // Only transition Enabled -> Draining -> Disabled is possible
+    EWriteBackCacheState GetState()
+    {
+        // GetState may lie in a hot path - we want to avoid unnecessary mutex
+        // acquisition and memory synchronization
+        //
+        // DrainRequested and DrainCompleted don't participate
+        // in data synchronization so relaxed memory ordering can be used
+        //
+        if (!DrainRequested.load(std::memory_order_relaxed)) {
+            return EWriteBackCacheState::Normal;
+        }
+
+        return IsDrained() ? EWriteBackCacheState::Drained
+                           : EWriteBackCacheState::Draining;
+    }
+
+    void Drain()
+    {
+        if (!DrainRequested.exchange(true)) {
+            State.SetDrainingMode();
+            State.TriggerPeriodicFlushAll();
+            STORAGE_INFO(LogTag << " Start WriteBackCache draining");
+        }
+    }
+
+    bool IsDrained()
+    {
+        if (DrainCompleted.load(std::memory_order_relaxed)) {
+            return true;
+        }
+
+        // This call acquires mutex
+        if (!State.IsDrained()) {
+            return false;
+        }
+
+        if (!DrainCompleted.exchange(true)) {
+            STORAGE_INFO(LogTag << " Complete WriteBackCache draining");
+        }
+
+        return true;
     }
 
     TFuture<NProto::TReadDataResponse> ReadData(
@@ -324,11 +373,6 @@ public:
             nodeId,
             std::move(executor),
             std::move(callback));
-    }
-
-    bool IsEmpty() const
-    {
-        return !State.HasUnflushedRequests();
     }
 
     ui64 AcquireNodeStateRef()
@@ -543,6 +587,21 @@ TWriteBackCache::TWriteBackCache(TWriteBackCacheArgs args)
 
 TWriteBackCache::~TWriteBackCache() = default;
 
+EWriteBackCacheState TWriteBackCache::GetState() const
+{
+    return Impl->GetState();
+}
+
+void TWriteBackCache::Drain()
+{
+    Impl->Drain();
+}
+
+bool TWriteBackCache::IsDrained() const
+{
+    return Impl->IsDrained();
+}
+
 TFuture<NProto::TReadDataResponse> TWriteBackCache::ReadData(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TReadDataRequest> request)
@@ -591,11 +650,6 @@ TFuture<NProto::TSetNodeAttrResponse> TWriteBackCache::SetNodeAttr(
     std::shared_ptr<NProto::TSetNodeAttrRequest> request)
 {
     return Impl->SetNodeAttr(std::move(callContext), std::move(request));
-}
-
-bool TWriteBackCache::IsEmpty() const
-{
-    return Impl->IsEmpty();
 }
 
 ui64 TWriteBackCache::AcquireNodeStateRef()

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -160,7 +160,7 @@ public:
         ScheduleAutomaticFlushIfNeeded();
     }
 
-    // Only transition Enabled -> Draining -> Disabled is possible
+    // Only transition Normal -> Draining -> Drained is possible
     EWriteBackCacheState GetState()
     {
         // GetState may lie in a hot path - we want to avoid unnecessary mutex

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -161,29 +161,30 @@ public:
     }
 
     // Only transition Normal -> Draining -> Drained is possible
-    EWriteBackCacheState GetState()
+    EWriteBackCacheMode GetMode()
     {
-        // GetState may lie in a hot path - we want to avoid unnecessary mutex
+        // GetMode may lie in a hot path - we want to avoid unnecessary mutex
         // acquisition and memory synchronization
         //
         // DrainRequested and DrainCompleted don't participate
         // in data synchronization so relaxed memory ordering can be used
         //
         if (!DrainRequested.load(std::memory_order_relaxed)) {
-            return EWriteBackCacheState::Normal;
+            return EWriteBackCacheMode::Normal;
         }
 
-        return IsDrained() ? EWriteBackCacheState::Drained
-                           : EWriteBackCacheState::Draining;
+        return IsDrained() ? EWriteBackCacheMode::Drained
+                           : EWriteBackCacheMode::Draining;
     }
 
-    void Drain()
+    NThreading::TFuture<NCloud::NProto::TError> Drain()
     {
         if (!DrainRequested.exchange(true)) {
-            State.SetDrainingMode();
-            State.TriggerPeriodicFlushAll();
             STORAGE_INFO(LogTag << " Start WriteBackCache draining");
         }
+
+        State.SetDrainingMode();
+        return State.AddFlushAllRequest();
     }
 
     bool IsDrained()
@@ -587,14 +588,14 @@ TWriteBackCache::TWriteBackCache(TWriteBackCacheArgs args)
 
 TWriteBackCache::~TWriteBackCache() = default;
 
-EWriteBackCacheState TWriteBackCache::GetState() const
+EWriteBackCacheMode TWriteBackCache::GetMode() const
 {
-    return Impl->GetState();
+    return Impl->GetMode();
 }
 
-void TWriteBackCache::Drain()
+NThreading::TFuture<NCloud::NProto::TError> TWriteBackCache::Drain()
 {
-    Impl->Drain();
+    return Impl->Drain();
 }
 
 bool TWriteBackCache::IsDrained() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -137,7 +137,7 @@ public:
      * Note: the call is not reversible (WriteBackCache cannot be returned to
      * EWriteBackCacheMode::Normal mode without restart).
      */
-    NThreading::TFuture<NCloud::NProto::TError> Drain();
+    [[nodiscard]] NThreading::TFuture<NCloud::NProto::TError> Drain();
 
     // A reliable way to check that WriteBackCache has been drained
     bool IsDrained() const;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -73,7 +73,7 @@ struct TWriteBackCacheArgs
 ////////////////////////////////////////////////////////////////////////////////
 
 // Only transition Normal -> Draining -> Drained is possible
-enum class EWriteBackCacheState
+enum class EWriteBackCacheMode
 {
     // WriteBackCache is used normally
     // New cached WriteData requests are accepted
@@ -111,29 +111,33 @@ public:
         return !!Impl;
     }
 
-    /* Returns current state of WriteBackCache with weak memory ordering.
-     * The common EWriteBackCacheState::Normal and EWriteBackCacheState::Drained
+    /* Returns current mode of WriteBackCache with weak memory ordering.
+     * The common EWriteBackCacheMode::Normal and EWriteBackCacheMode::Drained
      * cases are returned without mutex acquisition and are suitable for hot
      * paths. In order to ensure that WriteBackCache has been drained,
-     * IsDrained() should be used, as drained state detection may require
+     * IsDrained() should be used, as drained mode detection may require
      * additional synchronization.
      */
-    EWriteBackCacheState GetState() const;
+    EWriteBackCacheMode GetMode() const;
 
-    /* Puts WriteBackCache into draining state - it prevents new WriteData
-     * requests from being added to the cache (WriteDataDirect calls will still
-     * be allowed).
+    /* Puts WriteBackCache into draining mode - it prevents new WriteData
+     * requests from being added to the cache and triggers flush
+     * (WriteDataDirect calls will still be allowed).
      *
-     * WriteBackCache will remain in EWriteBackCacheState::Draining state until
+     * WriteBackCache will remain in EWriteBackCacheMode::Draining mode until
      * all pending and unflushed are flushed - then it will become
-     * EWriteBackCacheState::Drained.
+     * EWriteBackCacheMode::Drained.
      *
-     * The call has no effect if WriteBackCache is already drained.
+     * The returned future is completed successfully when WriteBackCache become
+     * drained. An error is returned if flush is failed.
+     *
+     * The call has no effect if WriteBackCache is already drained and will
+     * return a completed future immediately.
      *
      * Note: the call is not reversible (WriteBackCache cannot be returned to
-     * a normal state without restart).
+     * EWriteBackCacheMode::Normal mode without restart).
      */
-    void Drain();
+    NThreading::TFuture<NCloud::NProto::TError> Drain();
 
     // A reliable way to check that WriteBackCache has been drained
     bool IsDrained() const;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -72,6 +72,27 @@ struct TWriteBackCacheArgs
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Only transition Normal -> Draining -> Drained is possible
+enum class EWriteBackCacheState
+{
+    // WriteBackCache is used normally
+    // New cached WriteData requests are accepted
+    Normal,
+
+    // WriteBackCache was requested to drain and it contains unflushed data
+    // New cached WriteData requests are not accepted and will return E_REJECTED
+    // Clients should continue working with WriteBackCache but use
+    // WriteDataDirect instead of WriteData
+    Draining,
+
+    // WriteBackCache was requested to drain and all the data is flushed
+    // New cached WriteData requests are not accepted and will return E_REJECTED
+    // Since WriteBackCache contains no data, clients may safely stop using it
+    Drained
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TWriteBackCache final
 {
 private:
@@ -89,6 +110,30 @@ public:
     {
         return !!Impl;
     }
+
+    // Returns current state of WriteBackCache with weak memory ordering
+    // (without mutex acquision and memory synchronization) - suitable for hot
+    // paths. In order to ensure that WriteBackCache has been drained,
+    // IsDrained() should be used.
+    EWriteBackCacheState GetState() const;
+
+    /* Puts WriteBackCache into draining state - it prevents new WriteData
+     * requests from being added to the cache (WriteDataDirect calls will still
+     * be allowed).
+     *
+     * WriteBackCache will remain in EWriteBackCacheState::Draining state until
+     * all pending and unflushed are flushed - then it will become
+     * EWriteBackCacheState::Drained.
+     *
+     * The call has no effect if WriteBackCache is already drained.
+     *
+     * Note: the call is not reversible (WriteBackCache cannot be returned to
+     * a normal state without restart).
+     */
+    void Drain();
+
+    // A reliable way to check that WriteBackCache has been drained
+    bool IsDrained() const;
 
     NThreading::TFuture<NProto::TReadDataResponse> ReadData(
         TCallContextPtr callContext,
@@ -159,8 +204,6 @@ public:
     NThreading::TFuture<NProto::TSetNodeAttrResponse> SetNodeAttr(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TSetNodeAttrRequest> request);
-
-    bool IsEmpty() const;
 
     // Keep information about MinNodeSize for flushed nodes
     ui64 AcquireNodeStateRef();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -111,10 +111,13 @@ public:
         return !!Impl;
     }
 
-    // Returns current state of WriteBackCache with weak memory ordering
-    // (without mutex acquision and memory synchronization) - suitable for hot
-    // paths. In order to ensure that WriteBackCache has been drained,
-    // IsDrained() should be used.
+    /* Returns current state of WriteBackCache with weak memory ordering.
+     * The common EWriteBackCacheState::Normal and EWriteBackCacheState::Drained
+     * cases are returned without mutex acquisition and are suitable for hot
+     * paths. In order to ensure that WriteBackCache has been drained,
+     * IsDrained() should be used, as drained state detection may require
+     * additional synchronization.
+     */
     EWriteBackCacheState GetState() const;
 
     /* Puts WriteBackCache into draining state - it prevents new WriteData

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -69,7 +69,7 @@ TFuture<TWriteDataResponse> TWriteBackCacheState::AddWriteDataRequest(
         //
         // But currently, Drain is called only at session creation
         // or destruction where WriteData requests are not expected.
-        // We will process a request normally but report an error.
+        // Therefore, we report an error.
         ReportWriteBackCacheStateError(
             LogTag +
             " Cached WriteData request received while WriteBackCache is "

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -43,17 +43,43 @@ bool TWriteBackCacheState::Init(IPersistentStoragePtr persistentStorage)
         { AddRequest(std::move(request)); });
 }
 
-bool TWriteBackCacheState::HasUnflushedRequests() const
+void TWriteBackCacheState::SetDrainingMode()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
-    return RequestManager.HasPendingOrUnflushedRequests();
+    DrainingMode = true;
+}
+
+bool TWriteBackCacheState::IsDrained() const
+{
+    auto guard = LockStateAndPostponeQueuedOperations();
+
+    return DrainingMode && !RequestManager.HasPendingOrUnflushedRequests();
 }
 
 TFuture<TWriteDataResponse> TWriteBackCacheState::AddWriteDataRequest(
     std::shared_ptr<TWriteDataRequest> request)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
+
+    if (DrainingMode) {
+        // This may happen due to race condition that is valid scenario:
+        // - TWriteBackCache::Drain is called in one thread;
+        // - WriteData request is being processed in another thread.
+        //
+        // But currently, Drain is called only at session creation
+        // or destruction where WriteData requests are not expected.
+        // We will process a request normally but report an error.
+        ReportWriteBackCacheStateError(
+            LogTag +
+            " Cached WriteData request received while WriteBackCache is "
+            "in draining mode");
+
+        return MakeFuture(
+            ErrorResponse<TWriteDataResponse>(
+                E_REJECTED,
+                "WriteBackCache doesn't accept new WriteData requests"));
+    }
 
     auto variant = RequestManager.AddRequest(std::move(request));
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -70,7 +70,7 @@ TFuture<TWriteDataResponse> TWriteBackCacheState::AddWriteDataRequest(
         // But currently, Drain is called only at session creation
         // or destruction where WriteData requests are not expected.
         // Therefore, we report an error.
-        ReportWriteBackCacheStateError(
+        ReportWriteBackCacheWritingNotAllowedInDrainingMode(
             LogTag +
             " Cached WriteData request received while WriteBackCache is "
             "in draining mode");

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -71,6 +71,8 @@ private:
     TIntrusiveList<TFlushRequest> FlushRequests;
     TIntrusiveList<TReleaseHandleRequest> ReleaseHandleRequests;
 
+    bool DrainingMode = false;
+
 public:
     using TEntryVisitor = TFunctionRef<bool(const TCachedWriteDataRequest*)>;
     using TPin = ui64;
@@ -86,7 +88,15 @@ public:
     // Read state from the persistent storage
     bool Init(IPersistentStoragePtr persistentStorage);
 
-    bool HasUnflushedRequests() const;
+    // Prevent new WriteData requests from being added to the cache - they
+    // will fail with E_REJECTED error.
+    // Note: exiting from draining mode is not possible.
+    void SetDrainingMode();
+
+    // Returns true if the cache is in draining mode and there are no more
+    // unflushed requests.
+    // Note: only transition from false to true is possible.
+    bool IsDrained() const;
 
     // Add a WriteData request to the pending queue and completes the future
     // when the request is stored in the persistent storage and becomes cached

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -411,7 +411,9 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
 
         b.State->FlushSucceeded(1, 3);
         b.State->FlushSucceeded(2, 1);
-        UNIT_ASSERT(!b.State->HasUnflushedRequests());
+
+        b.State->SetDrainingMode();
+        UNIT_ASSERT(b.State->IsDrained());
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             b.Metrics.WriteDataRequestDroppedCount->Get());
@@ -504,7 +506,8 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         UNIT_ASSERT(c3.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(error, c3.GetValue());
 
-        UNIT_ASSERT(!b.State->HasUnflushedRequests());
+        b.State->SetDrainingMode();
+        UNIT_ASSERT(b.State->IsDrained());
         UNIT_ASSERT_VALUES_EQUAL(
             2,
             b.Metrics.WriteDataRequestDroppedCount->Get());

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2029,14 +2029,16 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         auto flushAllDataFuture = b.Cache.FlushAllData();
 
-        b.Cache.Drain();
+        auto future = b.Cache.Drain();
         UNIT_ASSERT(!b.Cache.IsDrained());
+        UNIT_ASSERT(!future.HasValue());
 
         writeRequests.ProceedAll();
 
         UNIT_ASSERT(flushAllDataFuture.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(0, b.Metrics.UnflushedQueue.Count->Get());
         UNIT_ASSERT(b.Cache.IsDrained());
+        UNIT_ASSERT(future.HasValue());
     }
 
     Y_UNIT_TEST(ShouldNotReadBeyondFileEnd)
@@ -2189,18 +2191,18 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 ////////////////////////////////////////////////////////////////////////////////
 
 template <>
-void Out<NCloud::NFileStore::NFuse::EWriteBackCacheState>(
+void Out<NCloud::NFileStore::NFuse::EWriteBackCacheMode>(
     IOutputStream& out,
-    NCloud::NFileStore::NFuse::EWriteBackCacheState value)
+    NCloud::NFileStore::NFuse::EWriteBackCacheMode value)
 {
     switch (value) {
-        case NCloud::NFileStore::NFuse::EWriteBackCacheState::Normal:
+        case NCloud::NFileStore::NFuse::EWriteBackCacheMode::Normal:
             out << "Normal";
             break;
-        case NCloud::NFileStore::NFuse::EWriteBackCacheState::Draining:
+        case NCloud::NFileStore::NFuse::EWriteBackCacheMode::Draining:
             out << "Draining";
             break;
-        case NCloud::NFileStore::NFuse::EWriteBackCacheState::Drained:
+        case NCloud::NFileStore::NFuse::EWriteBackCacheMode::Drained:
             out << "Drained";
             break;
     }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2168,6 +2168,20 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
             0,
             persistentStorageMetrics.Storage.EntryMaxCount->Get());
     }
+
+    Y_UNIT_TEST(ShouldNotWriteToCacheInDrainingMode)
+    {
+        TBootstrap b;
+
+        b.WriteToCacheSync(1, 0, "abc");
+        b.Cache.Drain();
+
+        auto future = b.WriteToCache(1, 1, "def");
+        UNIT_ASSERT(future.HasValue());
+        auto error = future.GetValue().GetError();
+        UNIT_ASSERT(HasError(error));
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, error.GetCode());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2176,13 +2176,14 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         TBootstrap b;
 
         b.WriteToCacheSync(1, 0, "abc");
-        b.Cache.Drain();
+        auto drain = b.Cache.Drain();
 
         auto future = b.WriteToCache(1, 1, "def");
         UNIT_ASSERT(future.HasValue());
         auto error = future.GetValue().GetError();
         UNIT_ASSERT(HasError(error));
         UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, error.GetCode());
+        UNIT_ASSERT(drain.HasValue());
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -21,6 +21,7 @@
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
 #include <util/random/random.h>
+#include <util/stream/output.h>
 #include <util/system/mutex.h>
 #include <util/system/spinlock.h>
 #include <util/system/tempfile.h>
@@ -2028,13 +2029,14 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         auto flushAllDataFuture = b.Cache.FlushAllData();
 
-        UNIT_ASSERT(!b.Cache.IsEmpty());
+        b.Cache.Drain();
+        UNIT_ASSERT(!b.Cache.IsDrained());
 
         writeRequests.ProceedAll();
 
         UNIT_ASSERT(flushAllDataFuture.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(0, b.Metrics.UnflushedQueue.Count->Get());
-        UNIT_ASSERT(b.Cache.IsEmpty());
+        UNIT_ASSERT(b.Cache.IsDrained());
     }
 
     Y_UNIT_TEST(ShouldNotReadBeyondFileEnd)
@@ -2070,8 +2072,6 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         // Scenario 1: empty cache
         b.WriteToCacheSync(1, 2, "abcdef");
         b.FlushCache(1);
-
-        UNIT_ASSERT(b.Cache.IsEmpty());
 
         UNIT_ASSERT_VALUES_EQUAL("cdef", readFromSession(4, 12));
         UNIT_ASSERT_VALUES_EQUAL("", readFromSession(13, 5));
@@ -2171,3 +2171,23 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 }
 
 }   // namespace NCloud::NFileStore::NFuse
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <>
+void Out<NCloud::NFileStore::NFuse::EWriteBackCacheState>(
+    IOutputStream& out,
+    NCloud::NFileStore::NFuse::EWriteBackCacheState value)
+{
+    switch (value) {
+        case NCloud::NFileStore::NFuse::EWriteBackCacheState::Normal:
+            out << "Normal";
+            break;
+        case NCloud::NFileStore::NFuse::EWriteBackCacheState::Draining:
+            out << "Draining";
+            break;
+        case NCloud::NFileStore::NFuse::EWriteBackCacheState::Drained:
+            out << "Drained";
+            break;
+    }
+}


### PR DESCRIPTION
### Notes
Previously, draining mode was implemented on the `TFileSystem` side and was not reliable enough.
Features of the new implementation:
1. Getting state without acquiring mutexes and memory barriers.
2. Checking the usage on the WriteBackCache side.
3. Readyness for cache draining at migration.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
