### PR TITLE
[Filestore] fix build missing `SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY` -> `SERVICE_TEST` rename

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -7744,7 +7744,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             listNodesResponse.GetNodes(0).GetId());
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(ShouldReproRaceWhileCreatingHandle)
+    SERVICE_TEST(ShouldReproRaceWhileCreatingHandle)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
@@ -7866,7 +7866,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
               0}});
     }
 
-    SERVICE_TEST_SID_SELECT_IN_LEADER_ONLY(ShouldReplayOpLog)
+    SERVICE_TEST(ShouldReplayOpLog)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);


### PR DESCRIPTION
### Notes
These tests were added here: https://github.com/ydb-platform/nbs/pull/5813/files#diff-def88e5c1392adec700b7c7096df8742cc449a872e9c13123dac45a89a444d30, but these macros were deleted later here: https://github.com/ydb-platform/nbs/pull/5841

### Issue
#5813
