### PR TITLE
Add support of IOMMUFD for local NVMe

### DIFF
--- a/cloud/blockstore/libs/local_nvme/device_provider_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/device_provider_ut.cpp
@@ -24,6 +24,7 @@ TVector<NProto::TNVMeDevice> PrepareDeviceFile(const TString& path)
             SerialNumber: "NVME_0"
             PCIAddress: "f1:00.0"
             IOMMUGroup: 10
+            VfioDevName: "vfio0"
             VendorId: 0x100
             DeviceId: 0x200
             Model: "Test NVMe 1"

--- a/cloud/blockstore/libs/local_nvme/protos/local_nvme.proto
+++ b/cloud/blockstore/libs/local_nvme/protos/local_nvme.proto
@@ -25,6 +25,9 @@ message TNVMeDevice
 
     // Model of NVMe.
     string Model = 6;
+
+    // vfio device name.
+    optional string VfioDevName = 7;
 }
 
 // List of NVMe devices.

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -268,6 +268,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
                 SerialNumber: "NVME_0"
                 PCIAddress: "0000:f1:00.0"
                 IOMMUGroup: 10
+                VfioDevName: "vfio0"
                 VendorId: 0x100
                 DeviceId: 0x200
                 Model: "Test NVMe 1"

--- a/cloud/blockstore/libs/local_nvme/service_proxy.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_proxy.cpp
@@ -72,6 +72,9 @@ public:
                     if (src.HasIOMMUGroup()) {
                         dst->SetIOMMUGroup(src.GetIOMMUGroup());
                     }
+                    if (src.HasVfioDevName()) {
+                        dst->SetVfioDevName(src.GetVfioDevName());
+                    }
                 }
 
                 return response;

--- a/cloud/blockstore/libs/local_nvme/service_proxy_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_proxy_ut.cpp
@@ -100,6 +100,7 @@ struct TFixture: public NUnitTest::TBaseFixture
                 SerialNumber: "NVME_0"
                 PCIAddress: "0000:f1:00.0"
                 IOMMUGroup: 10
+                VfioDevName: "vfio0"
                 VendorId: 0x100
                 DeviceId: 0x200
                 Model: "Test NVMe 1"
@@ -165,6 +166,16 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceProxyTest)
                 UNIT_ASSERT_VALUES_EQUAL(
                     expected.GetIOMMUGroup(),
                     device.GetIOMMUGroup());
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                expected.HasVfioDevName(),
+                device.HasVfioDevName());
+
+            if (expected.HasVfioDevName()) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    expected.GetVfioDevName(),
+                    device.GetVfioDevName());
             }
         }
     }

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
@@ -118,6 +118,19 @@ public:
             device.SetIOMMUGroup(std::stoul(value));
         }
 
+        const TFsPath vfioDevDir = path / "vfio-dev";
+        if (vfioDevDir.Exists()) {
+            TVector<TString> children;
+
+            vfioDevDir.ListNames(children);
+            for (const auto& child: children) {
+                if (child.StartsWith("vfio")) {
+                    device.SetVfioDevName(child);
+                    break;
+                }
+            }
+        }
+
         return device;
     }
 };

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
@@ -96,6 +96,9 @@ struct TFixture: public NUnitTest::TBaseFixture
             const auto& device = Devices[1];
             const TFsPath devicePath = GetPCIDevicePath(device);
             NFs::SymLink(VFIODriverPath, devicePath / "driver");
+
+            const TFsPath vfioDeviceDir = devicePath / "vfio-dev" / device.GetVfioDevName();
+            NFs::MakeDirectoryRecursive(vfioDeviceDir);
         }
     }
 
@@ -133,6 +136,7 @@ struct TFixture: public NUnitTest::TBaseFixture
                 SerialNumber: "NVME_1"
                 PCIAddress: "0000:31:00.0"
                 IOMMUGroup: 20
+                VfioDevName: "vfio0"
                 VendorId: 0x300
                 DeviceId: 0x400
                 Model: "Test NVMe 2"
@@ -306,6 +310,9 @@ Y_UNIT_TEST_SUITE(TSysFsHelpersTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 expected.GetDeviceId(),
                 device.GetDeviceId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                expected.GetVfioDevName(),
+                device.GetVfioDevName());
         }
     }
 }

--- a/cloud/blockstore/public/api/protos/local_nvme.proto
+++ b/cloud/blockstore/public/api/protos/local_nvme.proto
@@ -19,6 +19,9 @@ message TNVMeDeviceDesc
 
     // IOMMU group number.
     optional uint32 IOMMUGroup = 3;
+
+    // vfio device name.
+    optional string VfioDevName = 4;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
IOMMU groups are being superseded by VFIO characted devices and IOMMUFD interface that give much more flexibility and control.
Add support of IOMMUFD for local NVMe service.

#5250
