### PR TITLE
Add NewlyZeroedBlocks parameter, add GetTopByGarbageIgnoringZeroed to compaction map

### DIFF
--- a/cloud/blockstore/libs/storage/core/compaction_map.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map.cpp
@@ -44,6 +44,15 @@ struct TCompactionMap::TImpl
         }
     };
 
+    struct TCompareByGarbageIgnoringZeroed
+    {
+        template <typename T1, typename T2>
+        static bool Compare(const T1& l, const T2& r)
+        {
+            return GetGarbageIgnoringZeroed(l) > GetGarbageIgnoringZeroed(r);
+        }
+    };
+
     struct TGroupByBlockIndexNode
         : public TRbTreeItem<TGroupByBlockIndexNode, TCompareByBlockIndex>
     {};
@@ -59,15 +68,24 @@ struct TCompactionMap::TImpl
         >
     {};
 
+    struct TGroupByGarbageIgnoringZeroedNode
+        : public TRbTreeItem<
+          TGroupByGarbageIgnoringZeroedNode,
+          TCompareByGarbageIgnoringZeroed
+        >
+    {};
+
     struct TGroupNode
         : public TIntrusiveListItem<TGroupNode>
         , public TGroupByBlockIndexNode
         , public TGroupByScoreNode
         , public TGroupByGarbageBlockCountNode
+        , public TGroupByGarbageIgnoringZeroedNode
     {
         ui32 BlockIndex = 0;
         float Score = 0;
         ui16 GarbageBlockCount = 0;
+        ui16 GarbageIgnoringZeroed = 0;
         ui32 Range = 0;
 
         std::array<TRangeStat, GroupSize> Stats {};
@@ -78,6 +96,8 @@ struct TCompactionMap::TImpl
     using TGroupByScoreTree = TRbTree<TGroupByScoreNode, TCompareByScore>;
     using TGroupByGarbageBlockCountTree =
         TRbTree<TGroupByGarbageBlockCountNode, TCompareByGarbageBlockCount>;
+    using TGroupByGarbageIgnoringZeroedTree =
+        TRbTree<TGroupByGarbageIgnoringZeroedNode, TCompareByGarbageIgnoringZeroed>;
 
     const ui32 RangeSize;
     const ICompactionPolicyPtr Policy;
@@ -86,6 +106,7 @@ struct TCompactionMap::TImpl
     TGroupByBlockIndexTree GroupByBlockIndex;
     TGroupByScoreTree GroupByScore;
     TGroupByGarbageBlockCountTree GroupByGarbageBlockCount;
+    TGroupByGarbageIgnoringZeroedTree GroupByGarbageIgnoringZeroed;
     ui32 NonEmptyRangeCount = 0;
 
     TImpl(ui32 rangeSize, ICompactionPolicyPtr policy)
@@ -143,6 +164,15 @@ struct TCompactionMap::TImpl
         return nullptr;
     }
 
+    const TGroupNode* GetTopGroupByGarbageIgnoringZeroed() const
+    {
+        if (!GroupByGarbageIgnoringZeroed.Empty()) {
+            return static_cast<const TGroupNode*>(
+                &*GroupByGarbageIgnoringZeroed.Begin());
+        }
+        return nullptr;
+    }
+
     void InitGroupScores(TGroupNode* group)
     {
         auto score = Policy->CalculateScore({}).Score;
@@ -177,6 +207,19 @@ struct TCompactionMap::TImpl
         }
     }
 
+    void RecalculateGroupGarbageIgnoringZeroed(TGroupNode* group)
+    {
+        group->GarbageIgnoringZeroed = 0;
+        for (ui32 i = 0; i < group->Stats.size(); ++i) {
+            const auto& stat = group->Stats[i];
+            if (!stat.Compacted) {
+                group->GarbageIgnoringZeroed =
+                    Max(group->GarbageIgnoringZeroed,
+                        stat.GarbageIgnoringZeroed());
+            }
+        }
+    }
+
     TGroupNode* AddGroup(ui32 blockIndex)
     {
         const auto groupStart = GetGroupStart(blockIndex, RangeSize);
@@ -198,6 +241,7 @@ struct TCompactionMap::TImpl
         ui32 blobCount,
         ui32 blockCount,
         ui32 usedBlockCount,
+        ui32 newlyZeroedBlocks,
         bool compacted)
     {
         auto* group = AddGroup(blockIndex);
@@ -207,6 +251,7 @@ struct TCompactionMap::TImpl
         if (prev.BlobCount != blobCount
                 || prev.BlockCount != blockCount
                 || prev.UsedBlockCount != usedBlockCount
+                || prev.NewlyZeroedBlocks != newlyZeroedBlocks
                 || prev.Compacted != compacted)
         {
             if (blobCount && !prev.BlobCount) {
@@ -221,6 +266,9 @@ struct TCompactionMap::TImpl
                 usedBlockCount,
                 &group->Stats[index].UsedBlockCount
             );
+            UpdateCompactionCounter(
+                newlyZeroedBlocks,
+                &group->Stats[index].NewlyZeroedBlocks);
 
             if (compacted) {
                 group->Stats[index].ReadRequestCount = 0;
@@ -256,6 +304,20 @@ struct TCompactionMap::TImpl
                 // Garbage block count in the top range has decreased, need to
                 // recalculate the maximal garbage block count.
                 RecalculateGroupGarbageBlockCount(group);
+            }
+
+            const auto newGarbageIgnoringZeroed =
+                compacted ? 0 : group->Stats[index].GarbageIgnoringZeroed();
+
+            if (prev.GarbageIgnoringZeroed() < newGarbageIgnoringZeroed) {
+                if (GetGarbageIgnoringZeroed(*group) < newGarbageIgnoringZeroed)
+                {
+                    group->GarbageIgnoringZeroed = newGarbageIgnoringZeroed;
+                }
+            } else if (
+                prev.GarbageIgnoringZeroed() == group->GarbageIgnoringZeroed)
+            {
+                RecalculateGroupGarbageIgnoringZeroed(group);
             }
         }
 
@@ -333,6 +395,17 @@ struct TCompactionMap::TImpl
         return static_cast<const TGroupNode&>(node).GarbageBlockCount;
     }
 
+    static ui16 GetGarbageIgnoringZeroed(ui16 garbageIgnoringZeroed)
+    {
+        return garbageIgnoringZeroed;
+    }
+
+    template <typename T>
+    static ui16 GetGarbageIgnoringZeroed(const T& node)
+    {
+        return static_cast<const TGroupNode&>(node).GarbageIgnoringZeroed;
+    }
+
     ui32 GetNonEmptyRangeCount() const
     {
         return NonEmptyRangeCount;
@@ -374,6 +447,7 @@ void TCompactionMap::Update(
             c.Stat.BlobCount,
             c.Stat.BlockCount,
             usedBlockCount,
+            c.Stat.NewlyZeroedBlocks,
             c.Stat.BlobCount < 2   // compacted
         );
     }
@@ -383,6 +457,7 @@ void TCompactionMap::Update(
     {
         Impl->GroupByScore.Insert(*group);
         Impl->GroupByGarbageBlockCount.Insert(*group);
+        Impl->GroupByGarbageIgnoringZeroed.Insert(*group);
     }
 }
 
@@ -391,6 +466,7 @@ void TCompactionMap::Update(
     ui32 blobCount,
     ui32 blockCount,
     ui32 usedBlockCount,
+    ui32 newlyZeroedBlocks,
     bool compacted)
 {
     auto* group = Impl->Update(
@@ -398,10 +474,12 @@ void TCompactionMap::Update(
         blobCount,
         blockCount,
         usedBlockCount,
+        newlyZeroedBlocks,
         compacted);
 
     Impl->GroupByScore.Insert(group);
     Impl->GroupByGarbageBlockCount.Insert(group);
+    Impl->GroupByGarbageIgnoringZeroed.Insert(group);
 }
 
 void TCompactionMap::RegisterRead(ui32 blockIndex, ui32 blobCount, ui32 blockCount)
@@ -428,6 +506,7 @@ void TCompactionMap::Clear()
     Impl->GroupByBlockIndex.Clear();
     Impl->GroupByScore.Clear();
     Impl->GroupByGarbageBlockCount.Clear();
+    Impl->GroupByGarbageIgnoringZeroed.Clear();
     Impl->Groups.Clear();
 }
 
@@ -482,6 +561,27 @@ TCompactionCounter TCompactionMap::GetTopByGarbageBlockCount() const
     return {0, {}};
 }
 
+TCompactionCounter TCompactionMap::GetTopByGarbageIgnoringZeroed() const
+{
+    if (auto* group = Impl->GetTopGroupByGarbageIgnoringZeroed()) {
+        ui32 range = 0;
+        TRangeStat stat;
+        for (ui32 i = 0; i < GroupSize; ++i) {
+            if (!group->Stats[i].Compacted &&
+                group->Stats[i].GarbageIgnoringZeroed() >
+                    stat.GarbageIgnoringZeroed())
+            {
+                stat = group->Stats[i];
+                range = i;
+            }
+        }
+
+        return {group->BlockIndex + range * Impl->RangeSize, stat};
+    }
+
+    return {0, {}};
+}
+
 TVector<TCompactionCounter> TCompactionMap::GetTop(size_t count) const
 {
     TVector<TCompactionCounter> result(Reserve(Impl->Groups.Size() * GroupSize));
@@ -526,6 +626,38 @@ TVector<TCompactionCounter> TCompactionMap::GetTopByGarbageBlockCount(
 
         return l.Stat.GarbageBlockCount() > r.Stat.GarbageBlockCount();
     });
+
+    result.crop(count);
+    return result;
+}
+
+TVector<TCompactionCounter> TCompactionMap::GetTopByGarbageIgnoringZeroed(
+    size_t count) const
+{
+    TVector<TCompactionCounter> result(
+        Reserve(Impl->Groups.Size() * GroupSize));
+
+    for (const auto& group: Impl->Groups) {
+        for (ui32 i = 0; i < group.Stats.size(); ++i) {
+            if (group.Stats[i].BlobCount > 0) {
+                result.emplace_back(
+                    group.BlockIndex + (i * Impl->RangeSize),
+                    group.Stats[i]);
+            }
+        }
+    }
+
+    Sort(
+        result,
+        [](const auto& l, const auto& r)
+        {
+            if (l.Stat.Compacted != r.Stat.Compacted) {
+                return r.Stat.Compacted;
+            }
+
+            return l.Stat.GarbageIgnoringZeroed() >
+                   r.Stat.GarbageIgnoringZeroed();
+        });
 
     result.crop(count);
     return result;

--- a/cloud/blockstore/libs/storage/core/compaction_map.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map.cpp
@@ -309,7 +309,7 @@ struct TCompactionMap::TImpl
             const auto newGarbageIgnoringZeroed =
                 compacted ? 0 : group->Stats[index].GarbageIgnoringZeroed();
 
-            if (prev.GarbageIgnoringZeroed() < newGarbageIgnoringZeroed) {
+            if (prev.GarbageIgnoringZeroed() <= newGarbageIgnoringZeroed) {
                 if (GetGarbageIgnoringZeroed(*group) < newGarbageIgnoringZeroed)
                 {
                     group->GarbageIgnoringZeroed = newGarbageIgnoringZeroed;
@@ -317,6 +317,9 @@ struct TCompactionMap::TImpl
             } else if (
                 prev.GarbageIgnoringZeroed() == group->GarbageIgnoringZeroed)
             {
+                // GarbageIgnoringZeroed block count in the top range has
+                // decreased, need to recalculate the maximal
+                // GarbageIgnoringZeroed block count.
                 RecalculateGroupGarbageIgnoringZeroed(group);
             }
         }

--- a/cloud/blockstore/libs/storage/core/compaction_map.h
+++ b/cloud/blockstore/libs/storage/core/compaction_map.h
@@ -67,6 +67,7 @@ public:
         ui32 blobCount,
         ui32 blockCount,
         ui32 usedBlockCount,
+        ui32 newlyZeroedBlocks,
         bool compacted);
     void RegisterRead(ui32 blockIndex, ui32 blobCount, ui32 blockCount);
     void Clear();
@@ -75,9 +76,11 @@ public:
     TCompactionCounter GetTop() const;
     TVector<TCompactionCounter> GetTopsFromGroups(size_t groupCount) const;
     TCompactionCounter GetTopByGarbageBlockCount() const;
+    TCompactionCounter GetTopByGarbageIgnoringZeroed() const;
 
     TVector<TCompactionCounter> GetTop(size_t count) const;
     TVector<TCompactionCounter> GetTopByGarbageBlockCount(size_t count) const;
+    TVector<TCompactionCounter> GetTopByGarbageIgnoringZeroed(size_t count) const;
     TVector<ui32> GetNonEmptyRanges() const;
     ui32 GetNonEmptyRangeCount() const;
     ui32 GetRangeStart(ui32 blockIndex) const;

--- a/cloud/blockstore/libs/storage/core/compaction_map_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map_ut.cpp
@@ -39,7 +39,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap map(RangeSize, BuildDefaultCompactionPolicy(5));
         for (size_t i = 1; i <= 100; ++i) {
-            map.Update(GetGroupIndex(i), i, i * 10, i * 5, false);
+            map.Update(GetGroupIndex(i), i, i * 10, i * 5, 0, false);
             map.RegisterRead(GetGroupIndex(i), i + 1, i * 10 + 5);
         }
 
@@ -75,7 +75,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         UNIT_ASSERT_VALUES_EQUAL(1005, map.Get(GetGroupIndex(100)).ReadRequestBlockCount);
         UNIT_ASSERT_VALUES_EQUAL(false, map.Get(GetGroupIndex(100)).Compacted);
 
-        map.Update(GetGroupIndex(1), 22, 33, 11, true);
+        map.Update(GetGroupIndex(1), 22, 33, 11, 0, true);
         UNIT_ASSERT_VALUES_EQUAL(22, map.Get(GetGroupIndex(1)).BlobCount);
         UNIT_ASSERT_VALUES_EQUAL(33, map.Get(GetGroupIndex(1)).BlockCount);
         UNIT_ASSERT_VALUES_EQUAL(11, map.Get(GetGroupIndex(1)).UsedBlockCount);
@@ -92,24 +92,24 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         const auto blockCount = 123;
         const auto usedBlockCount = 23;
         for (size_t i = 1; i <= 100; ++i) {
-            map.Update(GetGroupIndex(i), i, blockCount, usedBlockCount, false);
+            map.Update(GetGroupIndex(i), i, blockCount, usedBlockCount, 0, false);
         }
 
         UNIT_ASSERT_VALUES_EQUAL(GetGroupIndex(100), map.GetTop().BlockIndex);
 
-        map.Update(GetGroupIndex(50), 101, blockCount, usedBlockCount, false);
+        map.Update(GetGroupIndex(50), 101, blockCount, usedBlockCount, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(GetGroupIndex(50), map.GetTop().BlockIndex);
 
-        map.Update(GetGroupIndex(0), 102, blockCount, usedBlockCount, false);
+        map.Update(GetGroupIndex(0), 102, blockCount, usedBlockCount, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(GetGroupIndex(0), map.GetTop().BlockIndex);
 
-        map.Update(GetGroupIndex(0), 0, 0, 0, false);
+        map.Update(GetGroupIndex(0), 0, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(GetGroupIndex(50), map.GetTop().BlockIndex);
 
-        map.Update(GetGroupIndex(50), 0, 0, 0, false);
+        map.Update(GetGroupIndex(50), 0, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(GetGroupIndex(100), map.GetTop().BlockIndex);
 
-        map.Update(GetGroupIndex(100), 0, 0, 0, false);
+        map.Update(GetGroupIndex(100), 0, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(GetGroupIndex(99), map.GetTop().BlockIndex);
 
         map.Update(
@@ -117,6 +117,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             103,
             blockCount,
             usedBlockCount,
+            0,
             false
         );
         UNIT_ASSERT_VALUES_EQUAL(
@@ -130,7 +131,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         TCompactionMap map(RangeSize, BuildDefaultCompactionPolicy(5));
         const auto blobCount = 3;
         for (size_t i = 1; i <= 100; ++i) {
-            map.Update(GetGroupIndex(i), blobCount, i * 10, i * 5, false);
+            map.Update(GetGroupIndex(i), blobCount, i * 10, i * 5, 0, false);
         }
 
         UNIT_ASSERT_VALUES_EQUAL(
@@ -138,46 +139,111 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             map.GetTopByGarbageBlockCount().BlockIndex
         );
 
-        map.Update(GetGroupIndex(50), blobCount, 1010, 505, false);
+        map.Update(GetGroupIndex(50), blobCount, 1010, 505, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             GetGroupIndex(50),
             map.GetTopByGarbageBlockCount().BlockIndex
         );
 
-        map.Update(GetGroupIndex(0), blobCount, 600, 1, false);
+        map.Update(GetGroupIndex(0), blobCount, 600, 1, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             GetGroupIndex(0),
             map.GetTopByGarbageBlockCount().BlockIndex
         );
 
-        map.Update(GetGroupIndex(0), 0, 0, 0, false);
+        map.Update(GetGroupIndex(0), 0, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             GetGroupIndex(50),
             map.GetTopByGarbageBlockCount().BlockIndex
         );
 
-        map.Update(GetGroupIndex(50), 0, 0, 0, false);
+        map.Update(GetGroupIndex(50), 0, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             GetGroupIndex(100),
             map.GetTopByGarbageBlockCount().BlockIndex
         );
 
-        map.Update(GetGroupIndex(100), 0, 0, 0, false);
+        map.Update(GetGroupIndex(100), 0, 0, 0, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             GetGroupIndex(99),
             map.GetTopByGarbageBlockCount().BlockIndex
         );
 
-        map.Update(GetGroupIndex(10) + RangeSize, blobCount, 1030, 515, false);
+        map.Update(GetGroupIndex(10) + RangeSize, blobCount, 1030, 515, 0, false);
         UNIT_ASSERT_VALUES_EQUAL(
             GetGroupIndex(10) + RangeSize,
             map.GetTopByGarbageBlockCount().BlockIndex
         );
 
-        map.Update(GetGroupIndex(10) + RangeSize, blobCount, 1030, 515, true);
+        map.Update(GetGroupIndex(10) + RangeSize, blobCount, 1030, 515, 0, true);
         UNIT_ASSERT_VALUES_EQUAL(
             GetGroupIndex(99),
             map.GetTopByGarbageBlockCount().BlockIndex
+        );
+    }
+
+    Y_UNIT_TEST(ShouldTrackTopByGarbageIgnoringZeroed)
+    {
+        TCompactionMap map(RangeSize, BuildDefaultCompactionPolicy(5));
+        const auto blobCount = 3;
+        for (size_t i = 1; i <= 100; ++i) {
+            // BlockCount = i * 10, UsedBlockCount = i * 5, NewlyZeroedBlocks = i
+            // GarbageIgnoringZeroed = BlockCount - UsedBlockCount - NewlyZeroedBlocks
+            //                      = i * 10 - i * 5 - i = i * 4
+            map.Update(GetGroupIndex(i), blobCount, i * 10, i * 5, i, false);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(100),
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
+        );
+
+        // GarbageIgnoringZeroed = 1010 - 550 - 0 = 460
+        map.Update(GetGroupIndex(50), blobCount, 1010, 550, 0, false);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(50),
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
+        );
+        UNIT_ASSERT(
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex !=
+            map.GetTopByGarbageBlockCount().BlockIndex);
+
+        // GarbageIgnoringZeroed = 600 - 1 - 10 = 589
+        map.Update(GetGroupIndex(0), blobCount, 600, 1, 10, false);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(0),
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
+        );
+
+        map.Update(GetGroupIndex(0), 0, 0, 0, 0, false);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(50),
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
+        );
+
+        map.Update(GetGroupIndex(50), 0, 0, 0, 0, false);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(100),
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
+        );
+
+        map.Update(GetGroupIndex(100), 0, 0, 0, 0, false);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(99),
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
+        );
+
+        // GarbageIgnoringZeroed = 1030 - 300 - 300 = 430
+        map.Update(GetGroupIndex(10) + RangeSize, blobCount, 1030, 300, 300, false);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(10) + RangeSize,
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
+        );
+
+        map.Update(GetGroupIndex(10) + RangeSize, blobCount, 1030, 300, 300, true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetGroupIndex(99),
+            map.GetTopByGarbageIgnoringZeroed().BlockIndex
         );
     }
 
@@ -185,7 +251,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
     {
         TCompactionMap map(RangeSize, BuildDefaultCompactionPolicy(5));
         for (size_t i = 1; i <= 100; ++i) {
-            map.Update(GetGroupIndex(i), i, i * 10, i * 5, false);
+            map.Update(GetGroupIndex(i), i, i * 10, i * 5, 0, false);
         }
 
         map.Clear();
@@ -251,7 +317,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         const auto blockCount = 123;
         const auto usedBlockCount = 23;
         for (size_t i = 1; i <= 100; ++i) {
-            map.Update(GetGroupIndex(i), i, blockCount, usedBlockCount, false);
+            map.Update(GetGroupIndex(i), i, blockCount, usedBlockCount, 0, false);
         }
 
         {
@@ -261,7 +327,7 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
         }
 
         // empty range must be skipped
-        map.Update(GetGroupIndex(46), 0, blockCount, usedBlockCount, false);
+        map.Update(GetGroupIndex(46), 0, blockCount, usedBlockCount, 0, false);
         {
             const auto nonEmptyCount = map.GetNonEmptyRanges().size();
             UNIT_ASSERT_VALUES_EQUAL(nonEmptyCount, map.GetNonEmptyRangeCount());

--- a/cloud/blockstore/libs/storage/core/compaction_map_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map_ut.cpp
@@ -2,6 +2,10 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/algorithm.h>
+#include <util/generic/hash.h>
+#include <util/random/random.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 namespace {
@@ -13,6 +17,212 @@ const ui32 RangeSize = 1024;
 ui32 GetGroupIndex(ui32 group)
 {
     return group * RangeSize * TCompactionMap::GroupSize;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TReferenceImplementation
+{
+    const ui32 RangeSize;
+    const ICompactionPolicyPtr Policy;
+    const float CompactedRangeScore = -1000;
+
+    THashMap<ui32, TRangeStat> Stats;
+
+    TReferenceImplementation(ui32 rangeSize, ICompactionPolicyPtr policy)
+        : RangeSize(rangeSize)
+        , Policy(std::move(policy))
+    {}
+
+    void Update(
+        ui32 blockIndex,
+        ui32 blobCount,
+        ui32 blockCount,
+        ui32 usedBlockCount,
+        ui32 newlyZeroedBlocks,
+        bool compacted)
+    {
+        const ui32 rangeStart =
+            TCompactionMap::GetRangeStart(blockIndex, RangeSize);
+        auto& stat = Stats[rangeStart];
+
+        TCompactionMap::UpdateCompactionCounter(blobCount, &stat.BlobCount);
+        TCompactionMap::UpdateCompactionCounter(blockCount, &stat.BlockCount);
+        TCompactionMap::UpdateCompactionCounter(
+            usedBlockCount,
+            &stat.UsedBlockCount);
+        TCompactionMap::UpdateCompactionCounter(
+            newlyZeroedBlocks,
+            &stat.NewlyZeroedBlocks);
+
+        if (compacted) {
+            stat.ReadRequestCount = 0;
+            stat.ReadRequestBlobCount = 0;
+            stat.ReadRequestBlockCount = 0;
+        }
+        stat.Compacted = compacted;
+
+        stat.CompactionScore = compacted
+            ? TCompactionScore(CompactedRangeScore)
+            : Policy->CalculateScore(stat);
+    }
+
+    const TRangeStat* Get(ui32 blockIndex) const
+    {
+        const ui32 rangeStart =
+            TCompactionMap::GetRangeStart(blockIndex, RangeSize);
+
+        if (const auto* stat = Stats.FindPtr(rangeStart)) {
+            return stat;
+        }
+        return nullptr;
+    }
+
+    TCompactionCounter GetTop() const
+    {
+        TCompactionCounter top(0, {});
+        top.Stat.CompactionScore = Policy->CalculateScore({});
+
+        for (const auto& [rangeStart, stat] : Stats) {
+            if (stat.CompactionScore.Score > top.Stat.CompactionScore.Score) {
+                top = {rangeStart, stat};
+            }
+        }
+        return top;
+    }
+
+    TCompactionCounter GetTopByGarbageBlockCount() const
+    {
+        TCompactionCounter top(0, {});
+        ui16 maxGarbage = 0;
+
+        for (const auto& [rangeStart, stat] : Stats) {
+            if (!stat.Compacted) {
+                const auto garbage = stat.GarbageBlockCount();
+                if (garbage > maxGarbage) {
+                    maxGarbage = garbage;
+                    top = {rangeStart, stat};
+                }
+            }
+        }
+        return top;
+    }
+
+    TCompactionCounter GetTopByGarbageIgnoringZeroed() const
+    {
+        TCompactionCounter top(0, {});
+        ui16 maxGarbage = 0;
+
+        for (const auto& [rangeStart, stat] : Stats) {
+            if (!stat.Compacted) {
+                const auto garbage = stat.GarbageIgnoringZeroed();
+                if (garbage > maxGarbage) {
+                    maxGarbage = garbage;
+                    top = {rangeStart, stat};
+                }
+            }
+        }
+        return top;
+    }
+
+    TVector<TCompactionCounter> GetTop(size_t count) const
+    {
+        TVector<TCompactionCounter> result(Reserve(Stats.size()));
+        for (const auto& [rangeStart, stat] : Stats) {
+            if (stat.BlobCount > 0) {
+                result.emplace_back(rangeStart, stat);
+            }
+        }
+
+        Sort(result, [](const auto& l, const auto& r) {
+            return l.Stat.CompactionScore.Score > r.Stat.CompactionScore.Score;
+        });
+
+        result.crop(count);
+        return result;
+    }
+
+    TVector<TCompactionCounter> GetTopByGarbageBlockCount(size_t count) const
+    {
+        TVector<TCompactionCounter> result(Reserve(Stats.size()));
+        for (const auto& [rangeStart, stat] : Stats) {
+            if (stat.BlobCount > 0) {
+                result.emplace_back(rangeStart, stat);
+            }
+        }
+
+        Sort(result, [](const auto& l, const auto& r) {
+            if (l.Stat.Compacted != r.Stat.Compacted) {
+                return r.Stat.Compacted;
+            }
+
+            return l.Stat.GarbageBlockCount() > r.Stat.GarbageBlockCount();
+        });
+
+        result.crop(count);
+        return result;
+    }
+
+    TVector<TCompactionCounter> GetTopByGarbageIgnoringZeroed(
+        size_t count) const
+    {
+        TVector<TCompactionCounter> result(Reserve(Stats.size()));
+        for (const auto& [rangeStart, stat] : Stats) {
+            if (stat.BlobCount > 0) {
+                result.emplace_back(rangeStart, stat);
+            }
+        }
+
+        Sort(result, [](const auto& l, const auto& r) {
+            if (l.Stat.Compacted != r.Stat.Compacted) {
+                return r.Stat.Compacted;
+            }
+
+            return l.Stat.GarbageIgnoringZeroed() >
+                   r.Stat.GarbageIgnoringZeroed();
+        });
+
+        result.crop(count);
+        return result;
+    }
+
+    ui32 GetNonEmptyRangeCount() const
+    {
+        ui32 count = 0;
+        for (const auto& [_, stat] : Stats) {
+            if (stat.BlobCount > 0) {
+                ++count;
+            }
+        }
+        return count;
+    }
+};
+
+void AssertRangeStatEqual(const TRangeStat& expected, const TRangeStat& actual)
+{
+    UNIT_ASSERT_VALUES_EQUAL(expected.BlobCount, actual.BlobCount);
+    UNIT_ASSERT_VALUES_EQUAL(expected.BlockCount, actual.BlockCount);
+    UNIT_ASSERT_VALUES_EQUAL(expected.UsedBlockCount, actual.UsedBlockCount);
+    UNIT_ASSERT_VALUES_EQUAL(
+        expected.ReadRequestCount,
+        actual.ReadRequestCount);
+    UNIT_ASSERT_VALUES_EQUAL(
+        expected.ReadRequestBlobCount,
+        actual.ReadRequestBlobCount);
+    UNIT_ASSERT_VALUES_EQUAL(
+        expected.ReadRequestBlockCount,
+        actual.ReadRequestBlockCount);
+    UNIT_ASSERT_VALUES_EQUAL(
+        expected.NewlyZeroedBlocks,
+        actual.NewlyZeroedBlocks);
+    UNIT_ASSERT_VALUES_EQUAL(expected.Compacted, actual.Compacted);
+    UNIT_ASSERT_DOUBLES_EQUAL(
+        expected.CompactionScore.Score,
+        actual.CompactionScore.Score,
+        1e-6);
+    UNIT_ASSERT_VALUES_EQUAL(
+        static_cast<int>(expected.CompactionScore.Type),
+        static_cast<int>(actual.CompactionScore.Type));
 }
 
 }   // namespace
@@ -332,6 +542,107 @@ Y_UNIT_TEST_SUITE(TCompactionMapTest)
             const auto nonEmptyCount = map.GetNonEmptyRanges().size();
             UNIT_ASSERT_VALUES_EQUAL(nonEmptyCount, map.GetNonEmptyRangeCount());
             UNIT_ASSERT_VALUES_EQUAL(nonEmptyCount, 99);
+        }
+    }
+
+    Y_UNIT_TEST(RandomizedUpdates)
+    {
+        const TVector<ui32> blockIndices = {
+            GetGroupIndex(0),
+            GetGroupIndex(0) + RangeSize,
+            GetGroupIndex(0) + 2 * RangeSize,
+            GetGroupIndex(1),
+            GetGroupIndex(1) + 3 * RangeSize,
+            GetGroupIndex(3),
+        };
+
+        const auto policy = BuildDefaultCompactionPolicy(5);
+        TCompactionMap map(RangeSize, policy);
+        TReferenceImplementation ref(RangeSize, policy);
+
+        const ui32 iterationsCount = 1000;
+
+        for (size_t i = 0; i < iterationsCount; ++i) {
+            const ui32 blockIndex =
+                blockIndices[
+                    RandomNumber<ui32>(blockIndices.size())];
+            const ui32 blobCount = RandomNumber<ui32>(4);
+            const ui32 blockCount = RandomNumber<ui32>(6);
+            const bool compacted = RandomNumber<ui32>(10) >= 8;
+            const ui32 usedBlockCount = compacted ? blockCount :
+                RandomNumber<ui32>(blockCount + 1);
+            const ui32 maxNewlyZeroedBlocks = blockCount - usedBlockCount;
+            const ui32 newlyZeroedBlocks = compacted ? 0 :
+                RandomNumber<ui32>(maxNewlyZeroedBlocks + 1);
+
+            map.Update(
+                blockIndex,
+                blobCount,
+                blockCount,
+                usedBlockCount,
+                newlyZeroedBlocks,
+                compacted);
+            ref.Update(
+                blockIndex,
+                blobCount,
+                blockCount,
+                usedBlockCount,
+                newlyZeroedBlocks,
+                compacted);
+
+            for (ui32 index : blockIndices) {
+                auto refStat = ref.Get(index);
+                if (refStat) {
+                    AssertRangeStatEqual(map.Get(index), *refStat);
+                }
+            }
+
+            UNIT_ASSERT_DOUBLES_EQUAL(
+                map.GetTop().Stat.CompactionScore.Score,
+                ref.GetTop().Stat.CompactionScore.Score,
+                1e-6);
+            UNIT_ASSERT_VALUES_EQUAL(
+                map.GetTopByGarbageBlockCount().Stat.GarbageBlockCount(),
+                ref.GetTopByGarbageBlockCount().Stat.GarbageBlockCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                map.GetTopByGarbageIgnoringZeroed().Stat.GarbageIgnoringZeroed(),
+                ref.GetTopByGarbageIgnoringZeroed().Stat.GarbageIgnoringZeroed());
+
+            {
+                const auto mapTops = map.GetTop(3);
+                const auto refTops = ref.GetTop(3);
+                UNIT_ASSERT_VALUES_EQUAL(mapTops.size(), refTops.size());
+                for (size_t j = 0; j < mapTops.size(); ++j) {
+                    UNIT_ASSERT_DOUBLES_EQUAL(
+                        mapTops[j].Stat.CompactionScore.Score,
+                        refTops[j].Stat.CompactionScore.Score,
+                        1e-6);
+                }
+            }
+            {
+                const auto mapTops = map.GetTopByGarbageBlockCount(3);
+                const auto refTops = ref.GetTopByGarbageBlockCount(3);
+                UNIT_ASSERT_VALUES_EQUAL(mapTops.size(), refTops.size());
+                for (size_t j = 0; j < mapTops.size(); ++j) {
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        mapTops[j].Stat.GarbageBlockCount(),
+                        refTops[j].Stat.GarbageBlockCount());
+                }
+            }
+            {
+                const auto mapTops = map.GetTopByGarbageIgnoringZeroed(3);
+                const auto refTops = ref.GetTopByGarbageIgnoringZeroed(3);
+                UNIT_ASSERT_VALUES_EQUAL(mapTops.size(), refTops.size());
+                for (size_t j = 0; j < mapTops.size(); ++j) {
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        mapTops[j].Stat.GarbageIgnoringZeroed(),
+                        refTops[j].Stat.GarbageIgnoringZeroed());
+                }
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                map.GetNonEmptyRangeCount(),
+                ref.GetNonEmptyRangeCount());
         }
     }
 }

--- a/cloud/blockstore/libs/storage/core/compaction_policy.h
+++ b/cloud/blockstore/libs/storage/core/compaction_policy.h
@@ -36,6 +36,7 @@ struct TRangeStat
     ui16 ReadRequestCount = 0;
     ui16 ReadRequestBlobCount = 0;
     ui16 ReadRequestBlockCount = 0;
+    ui16 NewlyZeroedBlocks = 0;
     bool Compacted = false;
     TCompactionScore CompactionScore;
 
@@ -71,6 +72,20 @@ struct TRangeStat
         }
 
         return BlockCount - UsedBlockCount;
+    }
+
+    ui16 GarbageIgnoringZeroed() const
+    {
+        const auto garbageBlockCount = GarbageBlockCount();
+        if (garbageBlockCount < NewlyZeroedBlocks) {
+            return 0;
+        }
+        return garbageBlockCount - NewlyZeroedBlocks;
+    }
+
+    ui16 UsedBlocksIgnoringZeroed() const
+    {
+        return UsedBlockCount + NewlyZeroedBlocks;
     }
 };
 

--- a/cloud/blockstore/libs/storage/core/compaction_policy.h
+++ b/cloud/blockstore/libs/storage/core/compaction_policy.h
@@ -36,7 +36,7 @@ struct TRangeStat
     ui16 ReadRequestCount = 0;
     ui16 ReadRequestBlobCount = 0;
     ui16 ReadRequestBlockCount = 0;
-    ui16 NewlyZeroedBlocks = 0;
+    ui16 NewlyZeroedBlocks = 0; // In-memory only.
     bool Compacted = false;
     TCompactionScore CompactionScore;
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -510,25 +510,29 @@ private:
         for (const auto& kv: CompactionCounters) {
             const auto usedBlockCount = State.GetUsedBlocks().Count(
                 kv.first,
-                Min(
-                    static_cast<ui64>(
-                        kv.first + State.GetCompactionMap().GetRangeSize()
-                    ),
-                    State.GetUsedBlocks().Capacity()
-                )
-            );
+                Min(static_cast<ui64>(
+                        kv.first + State.GetCompactionMap().GetRangeSize()),
+                    State.GetUsedBlocks().Capacity()));
+
+            ui32 newlyZeroedBlocks = 0;
+
+            if (Args.Mode != ADD_COMPACTION_RESULT) {
+                newlyZeroedBlocks =
+                    State.CalculateNewlyZeroedBlocks(kv.first, usedBlockCount);
+            }
+
             db.WriteCompactionMap(
                 kv.first,
                 kv.second.Stat.BlobCount + kv.second.BlobsSkippedByCompaction,
-                kv.second.Stat.BlockCount + kv.second.BlocksSkippedByCompaction
-            );
+                kv.second.Stat.BlockCount +
+                    kv.second.BlocksSkippedByCompaction);
             State.GetCompactionMap().Update(
                 kv.first,
                 kv.second.Stat.BlobCount + kv.second.BlobsSkippedByCompaction,
                 kv.second.Stat.BlockCount + kv.second.BlocksSkippedByCompaction,
                 usedBlockCount,
-                Args.Mode == ADD_COMPACTION_RESULT
-            );
+                newlyZeroedBlocks,
+                Args.Mode == ADD_COMPACTION_RESULT);
         }
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -661,6 +661,20 @@ void TPartitionState::UnsetUsedBlocks(
     }
 }
 
+ui32 TPartitionState::CalculateNewlyZeroedBlocks(
+    ui32 blockIndex,
+    ui64 usedBlockCount) const
+{
+    const auto& prevRangeStat = CompactionMap.Get(blockIndex);
+    const i64 usedBlockCountDiff =
+        static_cast<i64>(usedBlockCount) - prevRangeStat.UsedBlockCount;
+
+    return static_cast<ui32>(std::max(
+        static_cast<i64>(prevRangeStat.NewlyZeroedBlocks) -
+            usedBlockCountDiff,
+        static_cast<i64>(0)));
+}
+
 void TPartitionState::WriteUsedBlocksToDB(
     TPartitionDatabase& db,
     ui32 begin,

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -669,10 +669,9 @@ ui32 TPartitionState::CalculateNewlyZeroedBlocks(
     const i64 usedBlockCountDiff =
         static_cast<i64>(usedBlockCount) - prevRangeStat.UsedBlockCount;
 
-    return static_cast<ui32>(std::max(
-        static_cast<i64>(prevRangeStat.NewlyZeroedBlocks) -
-            usedBlockCountDiff,
-        static_cast<i64>(0)));
+    return SafeIntegerCast<ui32>(std::max(
+        static_cast<i64>(prevRangeStat.NewlyZeroedBlocks) - usedBlockCountDiff,
+        0L));
 }
 
 void TPartitionState::WriteUsedBlocksToDB(

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -721,6 +721,8 @@ public:
         return BlockMaskReadDuringCompaction;
     }
 
+    ui32 CalculateNewlyZeroedBlocks(ui32 blockIndex, ui64 usedBlockCount) const;
+
 private:
     void WriteUsedBlocksToDB(TPartitionDatabase& db, ui32 begin, ui32 end);
 

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -127,7 +127,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         UNIT_ASSERT_VALUES_EQUAL(1, initialBackpressure.CleanupScore);
 
         state.IncrementUnflushedFreshBlobByteCount(100 * 4_KB);
-        state.GetCompactionMap().Update(0, 10, 10, 10, false);
+        state.GetCompactionMap().Update(0, 10, 10, 10, 0, false);
         state.GetCleanupQueue().Add({{1, 1, 4, 4_MB, 0, 0}, 111});
 
         const auto marginalBackpressure = state.CalculateCurrentBackpressure();
@@ -144,7 +144,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         }
 
         state.IncrementUnflushedFreshBlobByteCount(300 * 4_KB);
-        state.GetCompactionMap().Update(0, 30, 30, 30, false);
+        state.GetCompactionMap().Update(0, 30, 30, 30, 0, false);
         state.GetCleanupQueue().Add({{1, 2, 4, 4_MB, 0, 0}, 111});
 
         const auto maxBackpressure = state.CalculateCurrentBackpressure();
@@ -152,7 +152,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         UNIT_ASSERT_DOUBLES_EQUAL(10, maxBackpressure.CompactionScore, 1e-5);
         UNIT_ASSERT_DOUBLES_EQUAL(10, maxBackpressure.CleanupScore, 1e-5);
 
-        state.GetCompactionMap().Update(0, 100, 100, 100, false);
+        state.GetCompactionMap().Update(0, 100, 100, 100, 0, false);
 
         const auto maxBackpressure2 = state.CalculateCurrentBackpressure();
         UNIT_ASSERT_DOUBLES_EQUAL(10, maxBackpressure2.CompactionScore, 1e-5);
@@ -190,7 +190,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             threadSafeState
         );
 
-        state.GetCompactionMap().Update(0, 30, 30, 30, false);
+        state.GetCompactionMap().Update(0, 30, 30, 30, 0, false);
 
         const auto bp = state.CalculateCurrentBackpressure();
         UNIT_ASSERT_VALUES_EQUAL(0, bp.CompactionScore);
@@ -549,6 +549,66 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             state.GetCleanupQueue().GetQueueBlocks());
+    }
+
+    Y_UNIT_TEST(ShouldCalculateNewlyZeroedBlocks)
+    {
+        auto threadSafeState =
+            std::make_shared<TPartitionThreadSafeState>();
+        TPartitionState state(
+            DefaultConfig(1, DefaultBlockCount),
+            BuildDefaultCompactionPolicy(5),
+            0,  // compactionScoreHistorySize
+            0,  // cleanupScoreHistorySize
+            DefaultBPConfig(),
+            DefaultFreeSpaceConfig(),
+            Max(),  // maxIORequestsInFlight
+            0,      // reassignChannelsPercentageThreshold
+            100,    // reassignFreshChannelsPercentageThreshold
+            100,    // reassignMixedChannelsPercentageThreshold
+            false,  // reassignSystemChannelsImmediately
+            5,      // channelCount
+            0,      // mixedIndexCacheSize
+            10000,  // allocationUnit
+            100,    // maxBlobsPerUnit
+            10,     // maxBlobsPerRange,
+            1,      // compactionRangeCountPerRun
+            threadSafeState
+        );
+
+        const ui32 blockIndex = 0;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0u,
+            state.CalculateNewlyZeroedBlocks(blockIndex, 0));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0u,
+            state.CalculateNewlyZeroedBlocks(blockIndex, 10));
+
+        state.GetCompactionMap().Update(
+            blockIndex,
+            1 /*blobCount=*/,
+            15 /*blockCount=*/,
+            10 /*usedBlockCount=*/,
+            5 /*newlyZeroedBlocks=*/,
+            false /*compacted=*/);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            5u,
+            state.CalculateNewlyZeroedBlocks(blockIndex, 10));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            2u,
+            state.CalculateNewlyZeroedBlocks(blockIndex, 13));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            7u,
+            state.CalculateNewlyZeroedBlocks(blockIndex, 8));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0u,
+            state.CalculateNewlyZeroedBlocks(blockIndex, 30));
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition2/part2_state.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_state.cpp
@@ -1634,6 +1634,7 @@ void TPartitionState::UpdateCompactionMap(
                 stat.BlobCount,
                 stat.BlockCount,
                 Min(static_cast<ui32>(stat.BlockCount), GetMaxBlocksInBlob()),
+                0,
                 false
             );
             db.WriteCompactionMap(prevBlockIndex, stat.BlobCount, stat.BlockCount);
@@ -1673,6 +1674,7 @@ void TPartitionState::ResetCompactionMap(
                 1 + blobsSkipped,
                 blockCount + blocksSkipped,
                 blockCount + blocksSkipped,
+                0,
                 true
             );
             db.WriteCompactionMap(

--- a/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_state_ut.cpp
@@ -1416,7 +1416,7 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             freshBlocks.emplace_back(TBlock{i, 1, 1, false}, ToString(i));
         }
         state.InitFreshBlocks(freshBlocks);
-        state.GetCompactionMap().Update(0, 10, 10, 10, false);
+        state.GetCompactionMap().Update(0, 10, 10, 10, 0, false);
         state.AddBlobUpdateByFresh({TBlockRange32::WithLength(0, 1024), 1, 1});
 
         const auto marginalBackpressure = state.CalculateCurrentBackpressure();
@@ -1429,7 +1429,7 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             freshBlocks.emplace_back(TBlock{i, 1, 1, false}, ToString(i));
         }
         state.InitFreshBlocks(freshBlocks);
-        state.GetCompactionMap().Update(0, 30, 30, 30, false);
+        state.GetCompactionMap().Update(0, 30, 30, 30, 0, false);
         state.AddBlobUpdateByFresh({TBlockRange32::WithLength(1024, 1024), 2, 2});
 
         const auto maxBackpressure = state.CalculateCurrentBackpressure();
@@ -1437,7 +1437,7 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
         UNIT_ASSERT_DOUBLES_EQUAL(10, maxBackpressure.CompactionScore, 1e-5);
         UNIT_ASSERT_DOUBLES_EQUAL(10, maxBackpressure.CleanupScore, 1e-5);
 
-        state.GetCompactionMap().Update(0, 100, 100, 100, false);
+        state.GetCompactionMap().Update(0, 100, 100, 100, 0, false);
 
         const auto maxBackpressure2 = state.CalculateCurrentBackpressure();
         UNIT_ASSERT_DOUBLES_EQUAL(10, maxBackpressure2.CompactionScore, 1e-5);
@@ -1459,7 +1459,7 @@ Y_UNIT_TEST_SUITE(TPartition2StateTest)
             DefaultIndexCachingConfig()
         );
 
-        state.GetCompactionMap().Update(0, 30, 30, 30, false);
+        state.GetCompactionMap().Update(0, 30, 30, 30, 0, false);
 
         const auto bp = state.CalculateCurrentBackpressure();
         UNIT_ASSERT_VALUES_EQUAL(0, bp.CompactionScore);


### PR DESCRIPTION
### Notes

We want to add new compaction type to avoid burst of compaction after discards of large ranges: #5815. This is the first step for it.

In this pr:
- Introduce NewlyZeroedBlocks parameter (per compaction range)
- In compaction map, make possible to get top range by garbage blocks count ignoring newly zeroed blocks.

See details in the issue description.

### Issue

#5815
