### PR TITLE
issue-5715: EXDEV from shard shouldn't trigger crit events

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -134,7 +134,8 @@ void TRenameNodeInDestinationActor::HandleRenameNodeInDestinationResponse(
         if (msg->GetError().GetCode() == E_FS_ISDIR
                 || msg->GetError().GetCode() == E_FS_NOTEMPTY
                 || msg->GetError().GetCode() == E_FS_NOENT
-                || msg->GetError().GetCode() == E_FS_EXIST)
+                || msg->GetError().GetCode() == E_FS_EXIST
+                || msg->GetError().GetCode() == E_FS_XDEV)
         {
             //
             // These errors may happen during normal operation.


### PR DESCRIPTION
### Notes
`EXDEV` from shard can happen during normal `RenameNodeInDestination` operation, it shouldn't trigger `ReceivedNodeOpErrorFromShard` crit events

### Issue
https://github.com/ydb-platform/nbs/issues/5715
