### PR TITLE
[Filestore] Resolve race in TFileSystemTest::ShouldRecoverSession

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -612,15 +612,17 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             return MakeFuture(result);
         };
 
-        bool called = false;
-        auto promise = NewPromise<NProto::TCreateHandleResponse>();
-        bootstrap.Service->CreateHandleHandler = [&] (auto callContext, auto request) {
+        std::atomic<int> called = 0;
+        bootstrap.Service->CreateHandleHandler =
+            [&](auto callContext, auto request)
+        {
             UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
 
+            called++;
             NProto::TCreateHandleResponse result;
-            if (!called) {
-                called = true;
-                return promise.GetFuture();
+            if (!recovered) {
+                result =
+                    TErrorResponse(E_FS_INVALID_SESSION, "invalid session");
             } else if (GetSessionId(*request) != sessionId) {
                 result = TErrorResponse(E_ARGUMENT, "");
             } else {
@@ -637,19 +639,18 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             bootstrap.Stop();
         };
 
-        auto future1 = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file1", RootNodeId);
-        UNIT_ASSERT(!future1.HasValue());
+        auto future1 = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
+            "/file1",
+            RootNodeId);
 
-        auto future2 = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file2", RootNodeId);
-        UNIT_ASSERT(!future2.HasValue());
-
-        NProto::TCreateHandleResponse result;
-        result = TErrorResponse(E_FS_INVALID_SESSION, "invalid session");
-        promise.SetValue(result);
+        auto future2 = bootstrap.Fuse->SendRequest<TCreateHandleRequest>(
+            "/file2",
+            RootNodeId);
 
         UNIT_ASSERT(IsIn(expected, future1.GetValue(WaitTimeout)));
         UNIT_ASSERT(IsIn(expected, future2.GetValue(WaitTimeout)));
         UNIT_ASSERT(recovered);
+        UNIT_ASSERT_LT(2, called.load());
     }
 
     Y_UNIT_TEST(ShouldFailRequestIfFailedToRecoverSession)


### PR DESCRIPTION
### Notes
Resolve
```
Uncaught exception: (NUnitTest::TAssertException) 
??+0 (0x16E4421)
std::terminate()+41 (0x1886D79)
??+0 (0x16DE19E)
??+0 (0x175E0BB)
NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()::operator()() const+71 (0x17F7A57)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+127 (0x19DC46F)
NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()+436 (0x17F7414)
NUnitTest::TTestFactory::Execute()+780 (0x19DCBCC)
NUnitTest::RunMain(int, char**)+3005 (0x19EC08D)
??+0 (0x7F7165A29D90)
__libc_start_main+128 (0x7F7165A29E40)
??+0 (0x16DE029)
```

caused by
```
        auto future2 = bootstrap.Fuse->SendRequest<TCreateHandleRequest>("/file2", RootNodeId);
        UNIT_ASSERT(!future2.HasValue());
```

Assert condition was wrong - it didn't check the test scenario. Requests are sent in a thread pool so the condition was met just because the pool thread hasn't started yet. The test randomly failed when the request was processed before going to the next line.

Also, the second call to TCreateHandleRequest was completed successfully unconditionally even if the session hasn't restored yet.