### PR TITLE
filestore: logging error + incrementing a counter upon shard balancer update failure instead of aborting

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
@@ -2,6 +2,7 @@
 
 #include <util/generic/algorithm.h>
 #include <util/random/random.h>
+#include <util/string/builder.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -79,7 +80,7 @@ TShardBalancerBase::TShardBalancerBase(
     }
 }
 
-void TShardBalancerBase::Update(
+NProto::TError TShardBalancerBase::Update(
     const TVector<TShardStats>& stats,
     std::optional<ui64> desiredFreeSpaceReserve,
     std::optional<ui64> minFreeSpaceReserve)
@@ -91,11 +92,16 @@ void TShardBalancerBase::Update(
         MinFreeSpaceReserve = minFreeSpaceReserve.value();
     }
 
-    Y_ABORT_UNLESS(stats.size() == Metas.size());
+    if (stats.size() != Metas.size()) {
+        return MakeError(E_ARGUMENT, TStringBuilder() << "stats.size() "
+            << stats.size() << " != Metas.size() " << Metas.size());
+    }
+
     for (ui32 i = 0; i < stats.size(); ++i) {
         Metas[i] = TShardMeta(i, stats[i]);
     }
     Sort(Metas.begin(), Metas.end(), TShardMetaComp(PrecisionBytes, BlockSize));
+    return {};
 }
 
 size_t TShardBalancerBase::FindUpperBoundAmongAllShardsToFitFile(
@@ -189,16 +195,21 @@ void TShardBalancerWeightedRandom::UpdateWeightPrefixSums()
     }
 }
 
-void TShardBalancerWeightedRandom::Update(
+NProto::TError TShardBalancerWeightedRandom::Update(
     const TVector<TShardStats>& stats,
     std::optional<ui64> desiredFreeSpaceReserve,
     std::optional<ui64> minFreeSpaceReserve)
 {
-    TShardBalancerBase::Update(
+    auto e = TShardBalancerBase::Update(
         stats,
         desiredFreeSpaceReserve,
         minFreeSpaceReserve);
+    if (HasError(e)) {
+        return e;
+    }
+
     UpdateWeightPrefixSums();
+    return {};
 }
 
 NProto::TError TShardBalancerWeightedRandom::SelectShard(

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
@@ -51,11 +51,16 @@ public:
 
     virtual ~IShardBalancer() = default;
 
-    virtual void Update(
+    virtual NProto::TError Update(
         const TVector<TShardStats>& stats,
         std::optional<ui64> desiredFreeSpaceReserve,
         std::optional<ui64> minFreeSpaceReserve) = 0;
     virtual NProto::TError SelectShard(ui64 fileSize, TString* shardId) = 0;
+
+    NProto::TError Update(const TVector<TShardStats>& stats)
+    {
+        return Update(stats, {}, {});
+    }
 
     /**
      * @brief Builds and returns the shard list ordered from best to worst.
@@ -109,10 +114,12 @@ protected:
         ui64 fileSize) const;
 
 public:
-    void Update(
+    using IShardBalancer::Update;
+
+    NProto::TError Update(
         const TVector<TShardStats>& stats,
-        std::optional<ui64> desiredFreeSpaceReserve = {},
-        std::optional<ui64> minFreeSpaceReserve = {}) override;
+        std::optional<ui64> desiredFreeSpaceReserve,
+        std::optional<ui64> minFreeSpaceReserve) override;
 
     [[nodiscard]] TVector<TShardDescr> MakeOrderedShardList() const override;
 };
@@ -159,10 +166,15 @@ public:
         ui64 desiredFreeSpaceReserve,
         ui64 minFreeSpaceReserve,
         TVector<TString> shardIds);
-    void Update(
+
+public:
+    using IShardBalancer::Update;
+
+    NProto::TError Update(
         const TVector<TShardStats>& stats,
-        std::optional<ui64> desiredFreeSpaceReserve = {},
-        std::optional<ui64> minFreeSpaceReserve = {}) final;
+        std::optional<ui64> desiredFreeSpaceReserve,
+        std::optional<ui64> minFreeSpaceReserve) final;
+
     NProto::TError SelectShard(ui64 fileSize, TString* shardId) final;
 };
 

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
@@ -31,9 +31,13 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
 }                                                                              \
 // ASSERT_ERROR
 
-constexpr ui32 BlockSize = 4_KB;
-constexpr ui64 PrecisionBytes = 1_GB;
-constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
+#define ASSERT_NO_ERROR(error)                                                 \
+    UNIT_ASSERT_C(!HasError(error), FormatError(error));                       \
+// ASSERT_NO_ERROR
+
+    constexpr ui32 BlockSize = 4_KB;
+    constexpr ui64 PrecisionBytes = 1_GB;
+    constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
 
     Y_UNIT_TEST(ShouldBalanceShardsRoundRobin)
     {
@@ -55,13 +59,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
         ASSERT_NO_SB_ERROR(0, "s4");
         ASSERT_NO_SB_ERROR(0, "s5");
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 3_TB / 4_KB, 0, 0},
-        });
+        }));
 
         // order changed: s1, s3, s4, s2, s5
 
@@ -78,13 +82,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
 
         // order changed: s1, s2, s3, s4, s5
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 4_TB / 4_KB, 0, 0},
-        });
+        }));
 
         ASSERT_NO_SB_ERROR(0, "s1");
         ASSERT_NO_SB_ERROR(0, "s2");
@@ -100,13 +104,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
         // one of the shards has less than desired free space
         // order changed: s1, s2, s3, s4
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
-        });
+        }));
 
         ASSERT_NO_SB_ERROR(0, "s3");
         ASSERT_NO_SB_ERROR(0, "s4");
@@ -123,13 +127,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
         // order changed: s1, s4
         // tier 2: s3, s5
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
-        });
+        }));
 
         ASSERT_NO_SB_ERROR(0, "s1");
         ASSERT_NO_SB_ERROR(0, "s4");
@@ -139,13 +143,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
         // 3 close to full shards, 2 full shards
         // order changed: s3, s1, s5
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, (4_TB + 400_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
-        });
+        }));
 
         ASSERT_NO_SB_ERROR(0, "s5");
         ASSERT_NO_SB_ERROR(0, "s3");
@@ -157,26 +161,26 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
 
         // 1 close to full shard left: s3
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, (5_TB - 512_KB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-        });
+        }));
 
         ASSERT_NO_SB_ERROR(0, "s3");
         ASSERT_NO_SB_ERROR(0, "s3");
 
         // out of space
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, (5_TB - 512_KB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB + 300_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-        });
+        }));
 
         ASSERT_SB_ERROR(0, E_FS_NOSPC);
         ASSERT_SB_ERROR(0, E_FS_NOSPC);
@@ -257,13 +261,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
             1_GB /* minFreeSpaceReserve */,
             {"s1", "s2", "s3", "s4", "s5"});
 
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, 512_GB / 4_KB, 0, 0},
             {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, 3_TB / 4_KB, 0, 0},
-        });
+        }));
 
         // 1 TiB can fit in any shard
 
@@ -336,13 +340,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
         UNIT_ASSERT_LE(count, iterations / shardCount + rangeToleration);
 
         // Now let's fill up last 3 shards to their limits
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, 0, 0, 0},
             {5_TB / 4_KB, 0, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-        });
+        }));
 
         // 1 TiB can now fit only in s1 or s2
         hitCount.clear();
@@ -404,13 +408,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
 
         // Now let's fill up last 2 shards to their limits and leave first 3
         // shards 1:2:3 free space
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, (5_TB - 1_TB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB - 2_TB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB - 3_TB) / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
             {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-        });
+        }));
 
         // It is expected that s1, s2, s3 will be selected with 1:2:3 ratio
         hitCount.clear();
@@ -443,14 +447,14 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
 
         // If we fill up all the shards with less than 1 TiB left it should not
         // be possible to select any shard
-        balancer.Update(
+        ASSERT_NO_ERROR(balancer.Update(
             TVector<TShardStats>(
                 shardCount,
                 TShardStats{
                     .TotalBlocksCount = 5_TB / 4_KB,
                     .UsedBlocksCount = (5_TB - 500_GB) / 4_KB,
                     .CurrentLoad = 0,
-                    .Suffer = 0}));
+                    .Suffer = 0})));
         for (ui64 i = 0; i < iterations; ++i) {
             ASSERT_SB_ERROR(1_TB, E_FS_NOSPC);
         }
@@ -461,13 +465,13 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
 
         // For a situation where in every shard there is less than 1 TiB left,
         // we should disregard additional 1 TiB reserve
-        balancer.Update({
+        ASSERT_NO_ERROR(balancer.Update({
             {5_TB / 4_KB, (5_TB - 1_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB - 2_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB - 3_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB - 4_GB) / 4_KB, 0, 0},
             {5_TB / 4_KB, (5_TB - 5_GB) / 4_KB, 0, 0},
-        });
+        }));
         // Trying to allocate 3 GiB should result in s3, s4, s5 being selected
         // in a 3:4:5 ratio
         hitCount.clear();
@@ -518,9 +522,33 @@ constexpr ui32 MaxFileBlocks = 300_GB / BlockSize;
                 error.GetMessage());
         }
     }
+
+    Y_UNIT_TEST(ShouldReturnErrorUponUpdate)
+    {
+        TShardBalancerRoundRobin balancer(
+            BlockSize,
+            PrecisionBytes,
+            MaxFileBlocks,
+            1_TB /* desiredFreeSpaceReserve */,
+            1_GB /* minFreeSpaceReserve */,
+            {"s1", "s2", "s3", "s4", "s5"});
+
+        auto e = balancer.Update({
+            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+        });
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_ARGUMENT,
+            e.GetCode(),
+            FormatError(e));
+    }
 }
 
 #undef ASSERT_NO_SB_ERROR
 #undef ASSERT_SB_ERROR
+#undef ASSERT_NO_ERROR
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -853,14 +853,27 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
         }
         CachedAggregateStats = std::move(msg->AggregateStats);
         CachedShardStats = std::move(msg->ShardStats);
-        UpdateShardBalancer(CachedShardStats);
 
-        LOG_DEBUG(
-            ctx,
-            TFileStoreComponents::TABLET,
-            "%s Updated shard balancer: %s",
-            LogTag.c_str(),
-            DescribeShardList(MakeOrderedShardList()).c_str());
+        auto error = UpdateShardBalancer(CachedShardStats);
+        if (HasError(error)) {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::TABLET,
+                "%s Failed to updated shard balancer: %s",
+                LogTag.c_str(),
+                FormatError(error).Quote().c_str());
+
+            Metrics.ShardBalancerUpdateErrorCount.fetch_add(
+                1,
+                std::memory_order_relaxed);
+        } else {
+            LOG_DEBUG(
+                ctx,
+                TFileStoreComponents::TABLET,
+                "%s Updated shard balancer: %s",
+                LogTag.c_str(),
+                DescribeShardList(MakeOrderedShardList()).c_str());
+        }
 
         Store(
             Metrics.AggregateUsedBytesCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -393,6 +393,10 @@ void TTabletMetrics::Register(
         RenameNotSupportedErrorCount,
         EMetricType::MT_DERIVATIVE);
 
+    REGISTER_AGGREGATABLE_SUM(
+        ShardBalancerUpdateErrorCount,
+        EMetricType::MT_DERIVATIVE);
+
 #undef REGISTER_LOCAL
 #undef REGISTER_AGGREGATABLE_SUM
 #undef REGISTER

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -295,6 +295,8 @@ struct TTabletMetrics
 
     std::atomic<i64> RenameNotSupportedErrorCount{0};
 
+    std::atomic<i64> ShardBalancerUpdateErrorCount{0};
+
     const NMetrics::IMetricsRegistryPtr StorageRegistry;
     const NMetrics::IMetricsRegistryPtr StorageFsRegistry;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -416,7 +416,7 @@ public:
 
     NProto::TError SelectShard(ui64 fileSize, TString* shardId);
 
-    void UpdateShardBalancer(const TVector<TShardStats>& stats);
+    NProto::TError UpdateShardBalancer(const TVector<TShardStats>& stats);
 
     TVector<IShardBalancer::TShardDescr> MakeOrderedShardList() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1545,7 +1545,8 @@ NProto::TError TIndexTabletState::SelectShard(ui64 fileSize, TString* shardId)
     return e;
 }
 
-void TIndexTabletState::UpdateShardBalancer(const TVector<TShardStats>& stats)
+NProto::TError TIndexTabletState::UpdateShardBalancer(
+    const TVector<TShardStats>& stats)
 {
     std::optional<ui64> desiredFreeSpaceReserve;
     std::optional<ui64> minFreeSpaceReserve;
@@ -1557,7 +1558,7 @@ void TIndexTabletState::UpdateShardBalancer(const TVector<TShardStats>& stats)
         minFreeSpaceReserve = 0;
     }
 
-    Impl->ShardBalancer->Update(
+    return Impl->ShardBalancer->Update(
         stats,
         desiredFreeSpaceReserve,
         minFreeSpaceReserve);


### PR DESCRIPTION
### Notes
Fixing a crash that happens in the following scenario:
1. shard_list = {s1, s2, ..., sk}
2. `TAggregateStatsActor` is registered with this shard list
3. `ConfigureAsShardRequest` is received with a new shard_list = {s1, s2, ..., sk+1, ..., sn}
4. `IShardBalancer` state is updated and it now has n items in `Metas`
5. `TAggregateStatsActor` finishes execution, notifies `TIndexTabletActor`, which triggers `IShardBalancer::Update(stats)` and `stats.size()` == k < n => we crash

Changed this behaviour to simply logging such cases and incrementing a counter.

### Issue
None