### PR TITLE
issue-2674: E_FS_NOTDIR from shard upon UnlinkNode shouldn't trigger crit event

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -173,29 +173,33 @@ void TUnlinkNodeInShardActor::HandleUnlinkNodeResponse(
         }
 
         const auto message = Sprintf(
-            "Shard node unlinking failed for %s, %s with error %s"
+            "%s Shard node unlinking failed for %s, %s with error %s"
             ", will not retry",
+            LogTag.c_str(),
             Request.GetFileSystemId().c_str(),
             Request.GetName().c_str(),
             FormatError(msg->GetError()).Quote().c_str());
 
-        if (ShouldUnlockUponCompletion &&
-            msg->GetError().GetCode() == E_FS_NOTEMPTY)
+        const ui32 code = msg->GetError().GetCode();
+        if (ShouldUnlockUponCompletion && (code == E_FS_NOTEMPTY
+            || Request.GetUnlinkDirectory() && code == E_FS_NOTDIR))
         {
-            // The response from shard E_FS_NOTEMPTY is expected for directories
-            // and should not be considered erroneous
-            LOG_DEBUG(
+            //
+            // These errors may happen during normal operation.
+            //
+
+            LOG_INFO(
                 ctx,
                 TFileStoreComponents::TABLET_WORKER,
-                "%s %s",
-                LogTag.c_str(),
                 message.c_str());
         } else {
+            //
+            // Other non-retriable errors are not expected.
+            //
+
             LOG_ERROR(
                 ctx,
                 TFileStoreComponents::TABLET_WORKER,
-                "%s %s",
-                LogTag.c_str(),
                 message.c_str());
             ReportReceivedNodeOpErrorFromShard(message);
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -2250,6 +2250,54 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
             response->GetStatus(),
             FormatError(response->GetError()));
     }
+
+    TABLET_TEST_4K_ONLY(ShouldReturnErrorUponFileUnlinkWithUnlinkDirectoryFlag)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetDirectoryCreationInShardsEnabled(true);
+        TTestEnv env({}, storageConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        OverrideDescribeFileStore(env.GetRuntime(), nodeIdx, tabletId);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+
+        auto nodeOpErrorFromShardCounter = counters->GetCounter(
+            "AppCriticalEvents/ReceivedNodeOpErrorFromShard",
+            true);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.ConfigureShards(true);
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        tablet.InitSession("client", "session");
+
+        const TString shardId1 = "shard1";
+        const TString name1 = "name1";
+        const TString uuid1 = CreateGuidAsString();
+
+        CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, uuid1));
+        CreateExternalRef(tablet, RootNodeId, name1, shardId1, uuid1);
+
+        tablet.SendUnlinkNodeRequest(
+            RootNodeId,
+            name1,
+            true /* unlinkDirectory */);
+        auto response = tablet.RecvUnlinkNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_FS_NOTDIR,
+            response->GetStatus(),
+            FormatError(response->GetError()));
+
+        UNIT_ASSERT_VALUES_EQUAL(0, nodeOpErrorFromShardCounter->Val());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Notes
`E_FS_NOTDIR` can be legitimately returned by shards if the client incorrectly sets up `UnlinkDirectory` flag

### Issue
follow-up for https://github.com/ydb-platform/nbs/issues/2674
