### PR TITLE
fixed DirectoryHandlesInitialDataSize in local debug cfg

### DIFF
--- a/cloud/filestore/bin/nfs/nfs-vhost.txt
+++ b/cloud/filestore/bin/nfs/nfs-vhost.txt
@@ -11,7 +11,7 @@ VhostServiceConfig {
   HandleOpsQueuePath: "/run/qemu/filestore-vhost"
   WriteBackCachePath: "/run/qemu/filestore-vhost"
   DirectoryHandlesStoragePath: "/run/qemu/filestore-vhost"
-  DirectoryHandlesInitialDataSize: 10485760
+  DirectoryHandlesInitialDataSize: 1048576
   PermanentActorCount: 4
 }
 


### PR DESCRIPTION
### Notes
Otherwise filestore-vhost can't start - it wants `DirectoryHandlesInitialDataSize` to be a power of 2

### Issue
None