### PR TITLE
[Filestore] cleanup: remove (SS|Hive|IndexTablet)Proxy initialization for static node in TTestEnv::AddDynamicNode; add a comment

### DIFF
--- a/cloud/filestore/libs/daemon/common/options.h
+++ b/cloud/filestore/libs/daemon/common/options.h
@@ -11,6 +11,8 @@ namespace NCloud::NFileStore::NDaemon {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// IMPORTANT: do not delete "null", "local", or "kikimr" annotations as they are
+// used for enum serialization
 enum class EServiceKind
 {
     Null   /* "null"   */ ,

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -127,15 +127,17 @@ TString GetBufferFromIovecs(const TVector<TString>& iovecs, size_t length)
 
 TTabletStorageInfoPtr GetTabletStorageInfo(
     TTestActorRuntime& runtime,
-    ui64 tabletId)
+    ui64 tabletId,
+    ui32 nodeIdx)
 {
     using TEvHiveProxy = NCloud::NStorage::TEvHiveProxy;
 
-    auto sender = runtime.AllocateEdgeActor();
+    auto sender = runtime.AllocateEdgeActor(nodeIdx);
     runtime.Send(new IEventHandle(
         NCloud::NStorage::MakeHiveProxyServiceId(),
         sender,
-        new TEvHiveProxy::TEvGetStorageInfoRequest(tabletId)));
+        new TEvHiveProxy::TEvGetStorageInfoRequest(tabletId)),
+        nodeIdx);
 
     TAutoPtr<IEventHandle> handle;
     auto* event =
@@ -2659,7 +2661,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         TVector<ui32> channelsToReassign = {1, 4};
         TVector<ui32> groupsToReassign;
 
-        auto storageInfo = GetTabletStorageInfo(runtime, tabletId);
+        auto storageInfo = GetTabletStorageInfo(runtime, tabletId, nodeIdx);
         UNIT_ASSERT(storageInfo->Channels.size() > channelsToReassign.size());
 
         // Find which groups correspond to the channels being reassigned
@@ -2742,7 +2744,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
 
         ui32 reassignedToGroupId = 0;
 
-        storageInfo = GetTabletStorageInfo(runtime, tabletId);
+        storageInfo = GetTabletStorageInfo(runtime, tabletId, nodeIdx);
         UNIT_ASSERT(storageInfo->Channels.size() > reassignedChannels.size());
 
         // Ensure that the reassign did happen
@@ -2782,7 +2784,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
             UNIT_ASSERT(event == nullptr);
         }
 
-        storageInfo = GetTabletStorageInfo(runtime, tabletId);
+        storageInfo = GetTabletStorageInfo(runtime, tabletId, nodeIdx);
         UNIT_ASSERT(storageInfo->Channels.size() > reassignedChannels.size());
         {
             auto channel = storageInfo->Channels[reassignedToChannel];

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -275,54 +275,6 @@ ui32 TTestEnv::AddDynamicNode()
         hiveProxyId,
         nodeIdx);
 
-    // we need node-local proxies as well
-    auto localTabletProxy = CreateIndexTabletProxy(StorageConfig);
-    auto localTabletProxyId = Runtime.Register(
-        localTabletProxy.release(),
-        0,
-        appData.UserPoolId,
-        TMailboxType::Simple,
-        0);
-    Runtime.EnableScheduleForActor(localTabletProxyId);
-    Runtime.RegisterService(
-        MakeIndexTabletProxyServiceId(),
-        localTabletProxyId,
-        0);
-
-    auto localSsProxy = CreateSSProxy(StorageConfig);
-    auto localSsProxyId = Runtime.Register(
-        localSsProxy.release(),
-        0,
-        appData.UserPoolId,
-        TMailboxType::Simple,
-        0);
-    Runtime.EnableScheduleForActor(localSsProxyId);
-    Runtime.RegisterService(
-        MakeSSProxyServiceId(),
-        localSsProxyId,
-        0);
-
-    auto localHiveProxy = CreateHiveProxy({
-        StorageConfig->GetPipeClientRetryCount(),
-        StorageConfig->GetPipeClientMinRetryTime(),
-        TDuration::Seconds(1),  // HiveLockExpireTimeout - does not matter
-        TFileStoreComponents::HIVE_PROXY,
-        /*TabletBootInfoBackupFilePath=*/"",
-        /*UseBinaryFormatForTabletBootInfoBackup=*/false,
-        /*FallbackMode=*/false,
-    });
-    auto localHiveProxyId = Runtime.Register(
-        localHiveProxy.release(),
-        0,
-        appData.UserPoolId,
-        TMailboxType::Simple,
-        0);
-    Runtime.EnableScheduleForActor(localHiveProxyId);
-    Runtime.RegisterService(
-        MakeHiveProxyServiceId(),
-        localHiveProxyId,
-        0);
-
     return nodeIdx;
 }
 


### PR DESCRIPTION
### Notes
No need to create proxies for the static node when adding a new dynamic node. 
(SS|Hive|IndexTablet)Proxy actors should exist only for each dynamic node and should not exist for static nodes

### Issue
Put links to the related issues here
