### PR TITLE
issue-5590: split flushed blobs by compaction range borders

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1564,4 +1564,10 @@ message TStorageServiceConfig
 
     // Timeout for gentle preemption (ms).
     optional uint32 VolumeBalancerGentlePreemptionTimeout = 496;
+
+    // When flushing fresh blocks into mixed blobs, if the number of distinct
+    // compaction ranges in a candidate blob does not exceed this value,
+    // the blob may be split at compaction range
+    // borders to eliminate reading block masks. Zero disables splitting.
+    optional uint64 SplitByCompactionRangeMaxBlobCount = 497;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -698,6 +698,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
                                                                                \
     xxx(VolumeBalancerGentlePreemptionEnabled,      bool,       false         )\
     xxx(VolumeBalancerGentlePreemptionTimeout,      TDuration,  Hours(72)     )\
+                                                                               \
+    xxx(SplitByCompactionRangeMaxBlobCount,   ui64,        0                  )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -816,6 +816,8 @@ public:
     [[nodiscard]] bool GetVolumeBalancerGentlePreemptionEnabled() const;
 
     [[nodiscard]] TDuration GetVolumeBalancerGentlePreemptionTimeout() const;
+
+    [[nodiscard]] ui64 GetSplitByCompactionRangeMaxBlobCount() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
@@ -1,7 +1,5 @@
 #include "flush_blocks_visitor.h"
 
-#include "library/cpp/containers/stack_vector/stack_vec.h"
-
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 
 #include <cloud/storage/core/libs/common/verify.h>

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
@@ -208,8 +208,8 @@ void TFlushBlocksVisitor::FlushBlob(
         (dataRefs.size() == blocks.size()) || (!dataRefs),
         TWellKnownEntityTypes::TABLET,
         TabletId,
-        "dataRefs.size():" << dataRefs.size() << ", blocks.size(): %lu"
-                           << blocks.size());
+        "dataRefs.size(): " << dataRefs.size()
+                            << ", blocks.size(): " << blocks.size());
 
     for (const auto& [start, end]: blocksByRanges) {
         TVector<TBlock> pieceBlocks(

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
@@ -1,12 +1,55 @@
 #include "flush_blocks_visitor.h"
 
+#include "library/cpp/containers/stack_vector/stack_vec.h"
+
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 
 #include <cloud/storage/core/libs/common/verify.h>
 
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
+namespace {
+
+constexpr size_t MaxOnStackTmpVectorSize = 128;
+
 ////////////////////////////////////////////////////////////////////////////////
+
+template <typename TOutputContainer>
+TOutputContainer SplitBlocksByCompactionRangeBorders(
+    const TVector<TBlock>& blocks,
+    const TCompactionMap& compactionMap)
+{
+    TOutputContainer blocksByRanges;
+    size_t start = 0;
+    while (start < blocks.size()) {
+        size_t end = start + 1;
+        while (end < blocks.size() &&
+               compactionMap.GetRangeStart(blocks[end - 1].BlockIndex) ==
+                   compactionMap.GetRangeStart(blocks[end].BlockIndex))
+        {
+            ++end;
+        }
+
+        blocksByRanges.emplace_back(start, end);
+        start = end;
+    }
+    return blocksByRanges;
+}
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TFlushBlocksVisitor::TBlob::TBlob(
+        TBlockBuffer blobContent,
+        TVector<TBlock> blocks,
+        TVector<ui32> checksums,
+        ui8 compactionRangeCount)
+    : BlobContent(std::move(blobContent))
+    , Blocks(std::move(blocks))
+    , Checksums(std::move(checksums))
+    , CompactionRangeCount(compactionRangeCount)
+{}
 
 TFlushBlocksVisitor::TFlushBlocksVisitor(
         ui32 blockSize,
@@ -16,6 +59,8 @@ TFlushBlocksVisitor::TFlushBlocksVisitor(
         ui64 diskPrefixLengthWithBlockChecksumsInBlobs,
         const TCompactionMap& compactionMap,
         bool readBlockMaskOnCompactionOptimizationEnabled,
+        ui64 splitByCompactionRangeMaxBlobCount,
+        ui64 tabletId,
         TVector<TBlob>& blobs)
     : BlockSize(blockSize)
     , FlushBlobSizeThreshold(flushBlobSizeThreshold)
@@ -26,6 +71,8 @@ TFlushBlocksVisitor::TFlushBlocksVisitor(
     , CompactionMap(compactionMap)
     , ReadBlockMaskOnCompactionOptimizationEnabled(
           readBlockMaskOnCompactionOptimizationEnabled)
+    , SplitByCompactionRangeMaxBlobCount(splitByCompactionRangeMaxBlobCount)
+    , TabletId(tabletId)
     , Blobs(blobs)
 {}
 
@@ -113,12 +160,7 @@ ui8 TFlushBlocksVisitor::CalculateCompactionRangeCount(
     return compactionRangeCount <= Max<ui8>() ? compactionRangeCount : 0;
 }
 
-void TFlushBlocksVisitor::FlushZeroBlob(TVector<TBlock> blocks)
-{
-    FlushBlob({}, std::move(blocks), {});
-}
-
-void TFlushBlocksVisitor::FlushBlob(
+void TFlushBlocksVisitor::AppendDataBlob(
     TBlockBuffer blobContent,
     TVector<TBlock> blocks,
     TVector<ui32> checksums)
@@ -132,6 +174,103 @@ void TFlushBlocksVisitor::FlushBlob(
         std::move(blocks),
         std::move(checksums),
         compactionRangeCount);
+}
+
+void TFlushBlocksVisitor::FlushZeroBlob(TVector<TBlock> blocks)
+{
+    FlushBlob({}, std::move(blocks), {});
+}
+
+void TFlushBlocksVisitor::FlushBlob(
+    TBlockBuffer blobContent,
+    TVector<TBlock> blocks,
+    TVector<ui32> checksums)
+{
+    const size_t maxCompactionRangeCountPerBlob =
+        MaxBlobRangeSize / CompactionMap.GetRangeSize();
+
+    // With standard compaction range size and max blob range size
+    // the number of compaction ranges per blob will not exceed
+    // MaxOnStackTmpVectorSize
+    if (Y_LIKELY(maxCompactionRangeCountPerBlob <= MaxOnStackTmpVectorSize)) {
+        FlushBlobImpl<
+            TStackVec<std::pair<size_t, size_t>, MaxOnStackTmpVectorSize>>(
+            std::move(blobContent),
+            std::move(blocks),
+            std::move(checksums));
+    } else {
+        FlushBlobImpl<TVector<std::pair<size_t, size_t>>>(
+            std::move(blobContent),
+            std::move(blocks),
+            std::move(checksums));
+    }
+}
+
+template <typename TTmpContainerType>
+void TFlushBlocksVisitor::FlushBlobImpl(
+    TBlockBuffer blobContent,
+    TVector<TBlock> blocks,
+    TVector<ui32> checksums)
+{
+    STORAGE_VERIFY(blocks, TWellKnownEntityTypes::TABLET, TabletId);
+
+    if (!SplitByCompactionRangeMaxBlobCount ||
+        !ReadBlockMaskOnCompactionOptimizationEnabled)
+    {
+        AppendDataBlob(
+            std::move(blobContent),
+            std::move(blocks),
+            std::move(checksums));
+        return;
+    }
+
+    auto blocksByRanges =
+        SplitBlocksByCompactionRangeBorders<TTmpContainerType>(
+            blocks,
+            CompactionMap);
+
+    const ui64 compactionRangeCount = blocksByRanges.size();
+    const bool splitByCompactionBorders =
+        compactionRangeCount <= SplitByCompactionRangeMaxBlobCount;
+
+    if (!splitByCompactionBorders || compactionRangeCount == 1) {
+        AppendDataBlob(
+            std::move(blobContent),
+            std::move(blocks),
+            std::move(checksums));
+        return;
+    }
+
+    const auto& dataRefs = blobContent.GetBlocks();
+    Y_DEBUG_ABORT_UNLESS((dataRefs.size() == blocks.size()) || (!dataRefs));
+
+    for (const auto& [start, end]: blocksByRanges) {
+        TVector<TBlock> pieceBlocks(
+            blocks.begin() + start,
+            blocks.begin() + end);
+
+        TBlockBuffer pieceBuf{TProfilingAllocator::Instance()};
+        if (dataRefs) {
+            for (size_t i = start; i < end; ++i) {
+                pieceBuf.AddBlock(dataRefs[i]);
+            }
+        }
+
+        TVector<ui32> pieceChecksums;
+        if (checksums) {
+            size_t checksumsStart = Min(start, checksums.size());
+            size_t checksumsEnd = Min(end, checksums.size());
+
+            pieceChecksums = TVector<ui32>(
+                checksums.begin() + checksumsStart,
+                checksums.begin() + checksumsEnd);
+        }
+
+        AppendDataBlob(
+            std::move(pieceBuf),
+            std::move(pieceBlocks),
+            std::move(pieceChecksums));
+    }
 }
 
 ui32 TFlushBlocksVisitor::GetBlobRangeSize(

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
@@ -10,16 +10,19 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 namespace {
 
-constexpr size_t MaxOnStackTmpVectorSize = 128;
-
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename TOutputContainer>
-TOutputContainer SplitBlocksByCompactionRangeBorders(
+struct TVectorRange
+{
+    size_t Start;
+    size_t End;
+};
+
+TVector<TVectorRange> SplitBlocksByCompactionRangeBorders(
     const TVector<TBlock>& blocks,
     const TCompactionMap& compactionMap)
 {
-    TOutputContainer blocksByRanges;
+    TVector<TVectorRange> blocksByRanges;
     size_t start = 0;
     while (start < blocks.size()) {
         size_t end = start + 1;
@@ -36,20 +39,9 @@ TOutputContainer SplitBlocksByCompactionRangeBorders(
     return blocksByRanges;
 }
 
-} // namespace
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
-
-TFlushBlocksVisitor::TBlob::TBlob(
-        TBlockBuffer blobContent,
-        TVector<TBlock> blocks,
-        TVector<ui32> checksums,
-        ui8 compactionRangeCount)
-    : BlobContent(std::move(blobContent))
-    , Blocks(std::move(blocks))
-    , Checksums(std::move(checksums))
-    , CompactionRangeCount(compactionRangeCount)
-{}
 
 TFlushBlocksVisitor::TFlushBlocksVisitor(
         ui32 blockSize,
@@ -186,32 +178,6 @@ void TFlushBlocksVisitor::FlushBlob(
     TVector<TBlock> blocks,
     TVector<ui32> checksums)
 {
-    const size_t maxCompactionRangeCountPerBlob =
-        MaxBlobRangeSize / CompactionMap.GetRangeSize();
-
-    // With standard compaction range size and max blob range size
-    // the number of compaction ranges per blob will not exceed
-    // MaxOnStackTmpVectorSize
-    if (Y_LIKELY(maxCompactionRangeCountPerBlob <= MaxOnStackTmpVectorSize)) {
-        FlushBlobImpl<
-            TStackVec<std::pair<size_t, size_t>, MaxOnStackTmpVectorSize>>(
-            std::move(blobContent),
-            std::move(blocks),
-            std::move(checksums));
-    } else {
-        FlushBlobImpl<TVector<std::pair<size_t, size_t>>>(
-            std::move(blobContent),
-            std::move(blocks),
-            std::move(checksums));
-    }
-}
-
-template <typename TTmpContainerType>
-void TFlushBlocksVisitor::FlushBlobImpl(
-    TBlockBuffer blobContent,
-    TVector<TBlock> blocks,
-    TVector<ui32> checksums)
-{
     STORAGE_VERIFY(blocks, TWellKnownEntityTypes::TABLET, TabletId);
 
     if (!SplitByCompactionRangeMaxBlobCount ||
@@ -224,10 +190,8 @@ void TFlushBlocksVisitor::FlushBlobImpl(
         return;
     }
 
-    auto blocksByRanges =
-        SplitBlocksByCompactionRangeBorders<TTmpContainerType>(
-            blocks,
-            CompactionMap);
+    const auto blocksByRanges =
+        SplitBlocksByCompactionRangeBorders(blocks, CompactionMap);
 
     const ui64 compactionRangeCount = blocksByRanges.size();
     const bool splitByCompactionBorders =

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.cpp
@@ -204,7 +204,12 @@ void TFlushBlocksVisitor::FlushBlob(
     }
 
     const auto& dataRefs = blobContent.GetBlocks();
-    Y_DEBUG_ABORT_UNLESS((dataRefs.size() == blocks.size()) || (!dataRefs));
+    STORAGE_VERIFY_C(
+        (dataRefs.size() == blocks.size()) || (!dataRefs),
+        TWellKnownEntityTypes::TABLET,
+        TabletId,
+        "dataRefs.size():" << dataRefs.size() << ", blocks.size(): %lu"
+                           << blocks.size());
 
     for (const auto& [start, end]: blocksByRanges) {
         TVector<TBlock> pieceBlocks(

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.h
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.h
@@ -29,6 +29,8 @@ private:
     const ui64 DiskPrefixLengthWithBlockChecksumsInBlobs;
     const TCompactionMap& CompactionMap;
     const bool ReadBlockMaskOnCompactionOptimizationEnabled;
+    const ui64 SplitByCompactionRangeMaxBlobCount;
+    const ui64 TabletId;
 
     TVector<TBlob>& Blobs;
 
@@ -47,6 +49,8 @@ public:
         ui64 diskPrefixLengthWithBlockChecksumsInBlobs,
         const TCompactionMap& compactionMap,
         bool readBlockMaskOnCompactionOptimizationEnabled,
+        ui64 splitByCompactionRangeMaxBlobCount,
+        ui64 tabletId,
         TVector<TBlob>& blobs);
 
     bool Visit(const TFreshBlock& block) override;
@@ -57,9 +61,20 @@ private:
     [[nodiscard]] ui8 CalculateCompactionRangeCount(
         const TVector<TBlock>& blocks) const;
 
+    void AppendDataBlob(
+        TBlockBuffer blobContent,
+        TVector<TBlock> blocks,
+        TVector<ui32> checksums);
+
     void FlushZeroBlob(TVector<TBlock> blocks);
 
     void FlushBlob(
+        TBlockBuffer blobContent,
+        TVector<TBlock> blocks,
+        TVector<ui32> checksums);
+
+    template <typename TTmpContainerType>
+    void FlushBlobImpl(
         TBlockBuffer blobContent,
         TVector<TBlock> blocks,
         TVector<ui32> checksums);

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.h
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor.h
@@ -73,12 +73,6 @@ private:
         TVector<TBlock> blocks,
         TVector<ui32> checksums);
 
-    template <typename TTmpContainerType>
-    void FlushBlobImpl(
-        TBlockBuffer blobContent,
-        TVector<TBlock> blocks,
-        TVector<ui32> checksums);
-
     static ui32 GetBlobRangeSize(
         const TVector<TBlock>& blocks,
         ui32 blockIndex);

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor_ut.cpp
@@ -1,5 +1,9 @@
 #include "flush_blocks_visitor.h"
 
+#include <cloud/blockstore/libs/diagnostics/block_digest.h>
+
+#include <cloud/storage/core/libs/common/block_data_ref.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NCloud::NBlockStore::NStorage::NPartition {
@@ -15,12 +19,26 @@ constexpr ui32 MaxBlobRangeSize = 32 * CompactionRangeSize;
 constexpr ui32 MaxBlocksInBlob = MaxBlobRangeSize;
 constexpr ui64 TabletId = 1;
 
-void VisitDataBlock(TFlushBlocksVisitor& visitor, ui32 blockIndex, char fill)
+TString MakeBlockContent(size_t visitOrderIndex)
 {
-    TString content(BlockSize, fill);
+    const char fill = static_cast<char>('a' + (visitOrderIndex % 26));
+    return TString(BlockSize, fill);
+}
+
+ui32 ExpectedChecksum(size_t visitOrderIndex)
+{
+    const TString content = MakeBlockContent(visitOrderIndex);
+    return ComputeDefaultDigest(TBlockDataRef(content.data(), content.size()));
+}
+
+void VisitDataBlock(
+    TFlushBlocksVisitor& visitor,
+    ui32 blockIndex,
+    const TString& content)
+{
     const TFreshBlock block{
         TBlock(blockIndex, 1, false),
-        TStringBuf(content)
+        content
     };
 
     visitor.Visit(block);
@@ -29,7 +47,8 @@ void VisitDataBlock(TFlushBlocksVisitor& visitor, ui32 blockIndex, char fill)
 TVector<TFlushBlocksVisitor::TBlob> BuildBlobs(
     const TVector<ui32>& blockIndices,
     bool readBlockMaskOnCompactionOptimizationEnabled,
-    ui64 splitByCompactionRangeMaxBlobCount)
+    ui64 splitByCompactionRangeMaxBlobCount,
+    ui64 diskPrefixLengthWithBlockChecksumsInBlobs = 0)
 {
     TCompactionMap compactionMap(
         CompactionRangeSize,
@@ -41,7 +60,7 @@ TVector<TFlushBlocksVisitor::TBlob> BuildBlobs(
         /*flushBlobSizeThreshold*/ 1,
         MaxBlobRangeSize,
         MaxBlocksInBlob,
-        /*diskPrefixLengthWithBlockChecksumsInBlobs*/ 0,
+        diskPrefixLengthWithBlockChecksumsInBlobs,
         compactionMap,
         readBlockMaskOnCompactionOptimizationEnabled,
         splitByCompactionRangeMaxBlobCount,
@@ -49,8 +68,8 @@ TVector<TFlushBlocksVisitor::TBlob> BuildBlobs(
         blobs);
 
     for (size_t i = 0; i < blockIndices.size(); ++i) {
-        const char fill = static_cast<char>('a' + (i % 26));
-        VisitDataBlock(visitor, blockIndices[i], fill);
+        const TString content = MakeBlockContent(i);
+        VisitDataBlock(visitor, blockIndices[i], content);
     }
 
     visitor.Finish();
@@ -171,6 +190,110 @@ Y_UNIT_TEST_SUITE(TFlushBlocksVisitorTest)
         UNIT_ASSERT_VALUES_EQUAL(1, blobs.size());
         UNIT_ASSERT_VALUES_EQUAL(5, blobs[0].Blocks.size());
         UNIT_ASSERT_VALUES_EQUAL(0, blobs[0].CompactionRangeCount);
+    }
+
+    Y_UNIT_TEST(ShouldSplitChecksumsByCompactionRangeBorders)
+    {
+        // All 5 blocks are below the checksum boundary => Checksums.size() ==
+        // Blocks.size(). After the split into 3 compaction-range pieces the
+        // checksums of each block must remain attached to that block.
+        const auto blobs = BuildBlobs(
+            {1, 2, 10, 11, 20},
+            /*splitOptimizationEnabled*/ true,
+            /*splitByCompactionRangeMaxBlobCount*/ 3,
+            /*diskPrefixLengthWithBlockChecksumsInBlobs*/ 100 * BlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, blobs.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Checksums.size());
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(0), blobs[0].Checksums[0]);
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(1), blobs[0].Checksums[1]);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[1].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[1].Checksums.size());
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(2), blobs[1].Checksums[0]);
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(3), blobs[1].Checksums[1]);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[2].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[2].Checksums.size());
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(4), blobs[2].Checksums[0]);
+    }
+
+    Y_UNIT_TEST(ShouldSplitBlobWithPartialChecksumsAcrossRangeBoundary)
+    {
+        // Checksum boundary = 15 blocks => blocks {1, 2, 10, 11} are
+        // checksummed and Checksums.size() == 4, but block 20 is above the
+        // boundary so the trailing piece must end up with an empty Checksums
+        // vector while still preserving the checksums for the earlier pieces.
+        const auto blobs = BuildBlobs(
+            {1, 2, 10, 11, 20},
+            /*splitOptimizationEnabled*/ true,
+            /*splitByCompactionRangeMaxBlobCount*/ 3,
+            /*diskPrefixLengthWithBlockChecksumsInBlobs*/ 15 * BlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, blobs.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Checksums.size());
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(0), blobs[0].Checksums[0]);
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(1), blobs[0].Checksums[1]);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[1].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[1].Checksums.size());
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(2), blobs[1].Checksums[0]);
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(3), blobs[1].Checksums[1]);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[2].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, blobs[2].Checksums.size());
+    }
+
+    Y_UNIT_TEST(ShouldSplitBlobWithChecksumBoundaryInsidePiece)
+    {
+        // Checksum boundary = 11 blocks => blocks {1, 2, 10} are checksummed
+        // (Checksums.size() == 3), block 11 lies inside the second
+        // compaction-range piece but is above the boundary, and block 20 is
+        // also above the boundary. The middle piece must therefore receive
+        // exactly one checksum (for block 10) and the last piece must end up
+        // with no checksums.
+        const auto blobs = BuildBlobs(
+            {1, 2, 10, 11, 20},
+            /*splitOptimizationEnabled*/ true,
+            /*splitByCompactionRangeMaxBlobCount*/ 3,
+            /*diskPrefixLengthWithBlockChecksumsInBlobs*/ 11 * BlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, blobs.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Checksums.size());
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(0), blobs[0].Checksums[0]);
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(1), blobs[0].Checksums[1]);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[1].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[1].Checksums.size());
+        UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(2), blobs[1].Checksums[0]);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[2].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, blobs[2].Checksums.size());
+    }
+
+    Y_UNIT_TEST(ShouldKeepChecksumsTogetherWhenBlobIsNotSplit)
+    {
+        // splitByCompactionRangeMaxBlobCount = 2 is below the 3 compaction
+        // ranges spanned by the visited blocks, so the blob must NOT be split.
+        // All checksums should remain in a single blob in visit order.
+        const auto blobs = BuildBlobs(
+            {1, 2, 10, 11, 20},
+            /*splitOptimizationEnabled*/ true,
+            /*splitByCompactionRangeMaxBlobCount*/ 2,
+            /*diskPrefixLengthWithBlockChecksumsInBlobs*/ 100 * BlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs.size());
+        UNIT_ASSERT_VALUES_EQUAL(5, blobs[0].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(5, blobs[0].Checksums.size());
+        for (size_t i = 0; i < 5; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(ExpectedChecksum(i), blobs[0].Checksums[i]);
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor_ut.cpp
@@ -85,7 +85,8 @@ Y_UNIT_TEST_SUITE(TFlushBlocksVisitorTest)
                  2 * MaxBlobRangeSize,
                  2 * MaxBlobRangeSize + CompactionRangeSize,
                  2 * MaxBlobRangeSize + 2 * CompactionRangeSize},
-                /*readBlockMaskOnCompactionOptimizationEnabled*/ true);
+                /*readBlockMaskOnCompactionOptimizationEnabled*/ true,
+                /*splitByCompactionRangeMaxBlobCount*/ 0);
 
             UNIT_ASSERT_VALUES_EQUAL(3, blobs.size());
 
@@ -108,7 +109,8 @@ Y_UNIT_TEST_SUITE(TFlushBlocksVisitorTest)
                  2 * MaxBlobRangeSize,
                  2 * MaxBlobRangeSize + CompactionRangeSize,
                  2 * MaxBlobRangeSize + 2 * CompactionRangeSize},
-                /*readBlockMaskOnCompactionOptimizationEnabled*/ false);
+                /*readBlockMaskOnCompactionOptimizationEnabled*/ false,
+                /*splitByCompactionRangeMaxBlobCount*/ 0);
 
             UNIT_ASSERT_VALUES_EQUAL(3, blobs.size());
 

--- a/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/flush_blocks_visitor_ut.cpp
@@ -13,6 +13,7 @@ constexpr ui32 CompactionRangeSize = 8;
 constexpr ui32 CompactionThreshold = 8;
 constexpr ui32 MaxBlobRangeSize = 32 * CompactionRangeSize;
 constexpr ui32 MaxBlocksInBlob = MaxBlobRangeSize;
+constexpr ui64 TabletId = 1;
 
 void VisitDataBlock(TFlushBlocksVisitor& visitor, ui32 blockIndex, char fill)
 {
@@ -27,7 +28,8 @@ void VisitDataBlock(TFlushBlocksVisitor& visitor, ui32 blockIndex, char fill)
 
 TVector<TFlushBlocksVisitor::TBlob> BuildBlobs(
     const TVector<ui32>& blockIndices,
-    bool readBlockMaskOnCompactionOptimizationEnabled)
+    bool readBlockMaskOnCompactionOptimizationEnabled,
+    ui64 splitByCompactionRangeMaxBlobCount)
 {
     TCompactionMap compactionMap(
         CompactionRangeSize,
@@ -42,6 +44,8 @@ TVector<TFlushBlocksVisitor::TBlob> BuildBlobs(
         /*diskPrefixLengthWithBlockChecksumsInBlobs*/ 0,
         compactionMap,
         readBlockMaskOnCompactionOptimizationEnabled,
+        splitByCompactionRangeMaxBlobCount,
+        TabletId,
         blobs);
 
     for (size_t i = 0; i < blockIndices.size(); ++i) {
@@ -64,7 +68,8 @@ Y_UNIT_TEST_SUITE(TFlushBlocksVisitorTest)
         {
             const auto blobs = BuildBlobs(
                 {1, 2, 10, 11, 20},
-                /*readBlockMaskOnCompactionOptimizationEnabled*/ true);
+                /*readBlockMaskOnCompactionOptimizationEnabled*/ true,
+                /*splitByCompactionRangeMaxBlobCount*/ 0);
 
             UNIT_ASSERT_VALUES_EQUAL(1, blobs.size());
             UNIT_ASSERT_VALUES_EQUAL(5, blobs[0].Blocks.size());
@@ -116,6 +121,54 @@ Y_UNIT_TEST_SUITE(TFlushBlocksVisitorTest)
             UNIT_ASSERT_VALUES_EQUAL(3, blobs[2].Blocks.size());
             UNIT_ASSERT_VALUES_EQUAL(0, blobs[2].CompactionRangeCount);
         }
+    }
+
+    Y_UNIT_TEST(ShouldSplitBlobByCompactionRangeBorders)
+    {
+        const auto blobs = BuildBlobs(
+            {1, 2, 10, 11, 20},
+            /*splitOptimizationEnabled*/ true,
+            /*splitByCompactionRangeMaxBlobCount*/ 3);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, blobs.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[0].Blocks[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[0].Blocks[1].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[0].CompactionRangeCount);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, blobs[1].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(10, blobs[1].Blocks[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(11, blobs[1].Blocks[1].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[1].CompactionRangeCount);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[2].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(20, blobs[2].Blocks[0].BlockIndex);
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs[2].CompactionRangeCount);
+    }
+
+    Y_UNIT_TEST(ShouldNotSplitBlobIfRangeCountIsGreaterThanLimit)
+    {
+        const auto blobs = BuildBlobs(
+            {1, 2, 10, 11, 20},
+            /*splitOptimizationEnabled*/ true,
+            /*splitByCompactionRangeMaxBlobCount*/ 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs.size());
+        UNIT_ASSERT_VALUES_EQUAL(5, blobs[0].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(3, blobs[0].CompactionRangeCount);
+    }
+
+    Y_UNIT_TEST(ShouldNotSplitBlobIfOptimizationIsDisabled)
+    {
+        const auto blobs = BuildBlobs(
+            {1, 2, 10, 11, 20},
+            /*splitOptimizationEnabled*/ false,
+            /*splitByCompactionRangeMaxBlobCount*/ 3);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, blobs.size());
+        UNIT_ASSERT_VALUES_EQUAL(5, blobs[0].Blocks.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, blobs[0].CompactionRangeCount);
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ut/ya.make
@@ -12,6 +12,7 @@ SRCS(
     compaction_map_load_state_ut.cpp
     flush_blocks_visitor_ut.cpp
     fresh_blob_ut.cpp
+    flush_blocks_visitor_ut.cpp
     garbage_queue_ut.cpp
     group_downtimes_ut.cpp
     mixed_index_cache_ut.cpp

--- a/cloud/blockstore/libs/storage/partition/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ut/ya.make
@@ -12,7 +12,6 @@ SRCS(
     compaction_map_load_state_ut.cpp
     flush_blocks_visitor_ut.cpp
     fresh_blob_ut.cpp
-    flush_blocks_visitor_ut.cpp
     garbage_queue_ut.cpp
     group_downtimes_ut.cpp
     mixed_index_cache_ut.cpp

--- a/cloud/blockstore/libs/storage/partition/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ya.make
@@ -18,6 +18,7 @@ SRCS(
     compaction_map_load_state.cpp
     flush_blocks_visitor.cpp
     fresh_blob.cpp
+    flush_blocks_visitor.cpp
     garbage_queue.cpp
     group_downtimes.cpp
     mixed_index_cache.cpp
@@ -28,6 +29,7 @@ SRCS(
 
 PEERDIR(
     cloud/blockstore/libs/common
+    cloud/blockstore/libs/diagnostics
     cloud/blockstore/libs/storage/core
     cloud/blockstore/libs/storage/protos
 

--- a/cloud/blockstore/libs/storage/partition/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ya.make
@@ -18,7 +18,6 @@ SRCS(
     compaction_map_load_state.cpp
     flush_blocks_visitor.cpp
     fresh_blob.cpp
-    flush_blocks_visitor.cpp
     garbage_queue.cpp
     group_downtimes.cpp
     mixed_index_cache.cpp

--- a/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_flush.cpp
@@ -566,6 +566,8 @@ void TPartitionActor::HandleFlush(
             Config->GetDiskPrefixLengthWithBlockChecksumsInBlobs(),
             State->GetCompactionMap(),
             IsReadBlockMaskOnCompactionOptimizationEnabled(),
+            Config->GetSplitByCompactionRangeMaxBlobCount(),
+            TabletID(),
             blobs);
 
         State->FindFreshBlocks(visitor, TBlockRange32::Max(), commitId);

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13833,6 +13833,261 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             GetBlockContent('2'),
             GetBlockContent(partition.ReadBlocks(2)));
     }
+
+    Y_UNIT_TEST(ShouldSplitFlushBlobsByCompactionRangeBoundaries)
+    {
+        constexpr ui32 rangeSize = 1024;
+        constexpr ui32 blockCount = rangeSize * 3;
+
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetSplitByCompactionRangeMaxBlobCount(3);
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            partition.WriteBlocks(i, 1);
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            partition.WriteBlocks(i, 2);
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            partition.WriteBlocks(i, 3);
+        }
+
+        ui32 mixedBlobsCount = 0;
+        TVector<TVector<ui32>> blobIndexes;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                            mixedBlobsCount = msg->FreshBlobs.size();
+
+                            for (const auto& blob: msg->FreshBlobs) {
+                                blobIndexes.emplace_back();
+                                for (const auto& block: blob.Blocks) {
+                                    blobIndexes.back().push_back(
+                                        block.BlockIndex);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Flush();
+
+        // Expect 3 blobs: [1022-1023], [1024-1025] + [1500-1504] + [2045-2047],
+        // [2048-2049]
+        UNIT_ASSERT_VALUES_EQUAL(3, mixedBlobsCount);
+
+        for (const auto& blobBlocks: blobIndexes) {
+            ui32 rangeIndex = blobBlocks.front() / rangeSize;
+            for (auto blockIdx: blobBlocks) {
+                UNIT_ASSERT_VALUES_EQUAL(rangeIndex, blockIdx / rangeSize);
+            }
+        }
+
+        partition.Compaction();
+        partition.Compaction();
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                3,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldSplitFlushZeroBlobsByCompactionRangeBoundaries)
+    {
+        constexpr ui32 rangeSize = 1024;
+        constexpr ui32 blockCount = rangeSize * 3;
+
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetSplitByCompactionRangeMaxBlobCount(3);
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 'A');
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024), 'B');
+        partition.WriteBlocks(TBlockRange32::WithLength(2048, 1024), 'C');
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            partition.ZeroBlocks(i);
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            partition.ZeroBlocks(i);
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            partition.ZeroBlocks(i);
+        }
+
+        ui32 mixedBlobsCount = 0;
+        TVector<TVector<ui32>> blobIndexes;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                            mixedBlobsCount = msg->FreshBlobs.size();
+
+                            for (const auto& blob: msg->FreshBlobs) {
+                                blobIndexes.emplace_back();
+                                for (const auto& block: blob.Blocks) {
+                                    blobIndexes.back().push_back(
+                                        block.BlockIndex);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Flush();
+
+        UNIT_ASSERT_VALUES_EQUAL(3, mixedBlobsCount);
+
+        for (const auto& blobBlocks: blobIndexes) {
+            ui32 rangeIndex = blobBlocks.front() / rangeSize;
+            for (auto blockIdx: blobBlocks) {
+                UNIT_ASSERT_VALUES_EQUAL(rangeIndex, blockIdx / rangeSize);
+            }
+        }
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        partition.Compaction();
+        partition.Compaction();
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                6,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldSkipCompactionRangeSplitInFlushWhenRunCountExceedsLimit)
+    {
+        constexpr ui32 rangeSize = 1024;
+        constexpr ui32 blockCount = rangeSize * 3;
+
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetSplitByCompactionRangeMaxBlobCount(2);
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            partition.WriteBlocks(i, 1);
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            partition.WriteBlocks(i, 2);
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            partition.WriteBlocks(i, 3);
+        }
+
+        ui32 mixedBlobsCount = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                            mixedBlobsCount = msg->FreshBlobs.size();
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+
+        for (ui32 i = 1022; i < 1024; ++i) {
+            partition.WriteBlocks(i, 1);
+        }
+
+        for (ui32 i = 2048; i < 2050; ++i) {
+            partition.WriteBlocks(i, 3);
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                2,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition


### PR DESCRIPTION
### Notes
When flushing fresh blocks into mixed blobs, if the number of distinct compaction ranges in a candidate blob does not exceed `SplitByCompactionRangeMaxBlobCount` value, the blob may be split at compaction range borders to eliminate reading block masks for such blobs. Zero disables splitting.

### Issue
#5590 