### PR TITLE
[Filestore] increase the default timeout for FilestoreCliClient used in tests

### DIFF
--- a/cloud/filestore/tests/python/lib/client.py
+++ b/cloud/filestore/tests/python/lib/client.py
@@ -25,7 +25,7 @@ class FilestoreCliClient:
         vhost_port=None,
         verbose=False,
         cwd=".",
-        timeout=60,
+        timeout=200,
         config_path=None,
         auth_token=None,
         check_exit_code=True,


### PR DESCRIPTION
### Notes
Example of mount-recipe start-up failure:
```
Errors:
...rary/python/testing/recipe/__init__.py", line 107, in declare_recipe
    start(argv[1:])
  File "cloud/filestore/tests/recipes/mount/__main__.py", line 52, in start
    pids.append(client.mount(args.filesystem, path))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "cloud/filestore/tests/python/lib/client.py", line 121, in mount
    raise RuntimeError("failed to mount {} at {} in {}".format(
RuntimeError: failed to mount nfs_share at /home/github/.ya/build/build_root/iefr/001957/cloud/filestore/tests/fio/mount-local-test/test-results/py3test/chunk5/nfs_mount in 60
contrib/tools/python3/Lib/subprocess.py:1127: ResourceWarning: subprocess 66489 is still running
```

But CreateSession requests actually manage to finish successfully:
```
2026-04-28T00:01:11.107956Z :NFS_SERVER WARN: cloud/filestore/libs/diagnostics/request_stats.cpp:138: CreateSession #17949571959168815760 [f:nfs_share] RESPONSE request too slow(total_time: 2m 20s, execution_time: 2m 20s, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2026-04-28T00:01:11.107996Z :NFS_SERVER WARN: cloud/filestore/libs/diagnostics/request_stats.cpp:138: CreateSession #11552592721225718860 [f:nfs_share] RESPONSE request too slow(total_time: 1m 19s, execution_time: 1m 19s, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
2026-04-28T00:01:11.108011Z :NFS_SERVER WARN: cloud/filestore/libs/diagnostics/request_stats.cpp:138: CreateSession #13969603463917354699 [f:nfs_share] RESPONSE request too slow(total_time: 1m 50s, execution_time: 1m 50s, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
```
Increase the timeout from 60 to 200 seconds to tolerate such failures, which may be caused by CPU stalls

### Issue
Put links to the related issues here
