### PR TITLE
Cool down timeout before secure erase devices

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1554,4 +1554,7 @@ message TStorageServiceConfig
 
     // Max skipped blobs during range compaction for HDD disks.
     optional uint32 MaxSkippedBlobsDuringCompactionHDD = 493;
+
+    // Cool down timeout before secure erase devices (in milliseconds).
+    optional uint32 CoolDownTimeoutBeforeSecureErase = 494;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -509,6 +509,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MaxWriteBlobErrorsBeforeSuicide,           ui32,      1               )\
     xxx(RejectMountOnAddClientTimeout,             bool,      false           )\
     xxx(NonReplicatedVolumeNotificationTimeout,    TDuration, Seconds(30)     )\
+                                                                               \
+    xxx(CoolDownTimeoutBeforeSecureErase,          TDuration, Seconds(0)      )\
     xxx(NonReplicatedSecureEraseTimeout,           TDuration, Minutes(10)     )\
     xxx(MaxDevicesToErasePerDeviceNameForDefaultPoolKind,   ui32,   100       )\
     xxx(MaxDevicesToErasePerDeviceNameForLocalPoolKind,     ui32,   100       )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -546,6 +546,7 @@ public:
 
     TDuration GetNonReplicatedVolumeNotificationTimeout() const;
 
+    TDuration GetCoolDownTimeoutBeforeSecureErase() const;
     TDuration GetNonReplicatedSecureEraseTimeout() const;
     ui32 GetMaxDevicesToErasePerDeviceNameForDefaultPoolKind() const;
     ui32 GetMaxDevicesToErasePerDeviceNameForLocalPoolKind() const;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -22,18 +22,21 @@ constexpr size_t MaxDeviceCountToPrintInLog = 100;
 TString MakeDevicesNamesString(const TVector<NProto::TDeviceConfig>& devices)
 {
     TStringBuilder sb;
+    sb << "[";
 
     size_t count = 0;
     for (const auto& device: devices) {
-        if (count++ > MaxDeviceCountToPrintInLog) {
+        if (count++ >= MaxDeviceCountToPrintInLog) {
             sb << "...";
             break;
         }
-        if (!sb.empty()) {
+        if (count > 1) {
             sb << ", ";
         }
         sb << device.GetDeviceUUID();
     }
+
+    sb << "](" << devices.size() << ")";
     return sb;
 }
 
@@ -408,7 +411,7 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
             LOG_INFO(
                 ctx,
                 TBlockStoreComponents::DISK_REGISTRY,
-                "%s Scheduled secure erase for pool: %s, devices: [%s], after: %s",
+                "%s Scheduled secure erase for pool: %s, devices: %s, after: %s",
                 LogTitle.GetWithTime().c_str(),
                 poolName.Quote().c_str(),
                 MakeDevicesNamesString(request->DirtyDevices).c_str(),
@@ -421,7 +424,7 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
             LOG_INFO(
                 ctx,
                 TBlockStoreComponents::DISK_REGISTRY,
-                "%s Sending secure erase request for pool: %s, devices: [%s]",
+                "%s Sending secure erase request for pool: %s, devices: %s",
                 LogTitle.GetWithTime().c_str(),
                 poolName.Quote().c_str(),
                 MakeDevicesNamesString(request->DirtyDevices).c_str());
@@ -444,10 +447,9 @@ void TDiskRegistryActor::HandleSecureErase(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::DISK_REGISTRY,
-        "%s Received SecureErase request: DirtyDevices=%s %lu",
+        "%s Received SecureErase request. DirtyDevices: %s",
         LogTitle.GetWithTime().c_str(),
-        MakeDevicesNamesString(msg->DirtyDevices).c_str(),
-        msg->DirtyDevices.size());
+        MakeDevicesNamesString(msg->DirtyDevices).c_str());
 
     auto actor = NCloud::Register<TSecureEraseActor>(
         ctx,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -4,6 +4,8 @@
 #include <cloud/blockstore/libs/storage/api/disk_agent.h>
 #include <cloud/blockstore/libs/storage/disk_registry/model/device_list.h>
 
+#include <cloud/storage/core/libs/common/format.h>
+
 namespace NCloud::NBlockStore::NStorage {
 
 using namespace NActors;
@@ -12,6 +14,28 @@ using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr size_t MaxDeviceCountToPrintInLog = 100;
+
+TString MakeDevicesNamesString(const TVector<NProto::TDeviceConfig>& devices)
+{
+    TStringBuilder sb;
+
+    size_t count = 0;
+    for (const auto& device: devices) {
+        if (count++ > MaxDeviceCountToPrintInLog) {
+            sb << "...";
+            break;
+        }
+        if (!sb.empty()) {
+            sb << ", ";
+        }
+        sb << device.GetDeviceUUID();
+    }
+    return sb;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -376,16 +400,19 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
 
         auto deadline =
             Min(SecureEraseStartTs, ctx.Now()) + TDuration::Seconds(5);
-        if (deadline > ctx.Now()) {
+
+        if (deadline > ctx.Now() || Config->GetCoolDownTimeoutBeforeSecureErase()) {
+            deadline =
+                Max(deadline,
+                    ctx.Now() + Config->GetCoolDownTimeoutBeforeSecureErase());
             LOG_INFO(
                 ctx,
                 TBlockStoreComponents::DISK_REGISTRY,
-                "%s Scheduled secure erase for pool: %s, now: %lu, "
-                "deadline: %lu",
+                "%s Scheduled secure erase for pool: %s, devices: [%s], after: %s",
                 LogTitle.GetWithTime().c_str(),
-                poolName.c_str(),
-                ctx.Now().MicroSeconds(),
-                deadline.MicroSeconds());
+                poolName.Quote().c_str(),
+                MakeDevicesNamesString(request->DirtyDevices).c_str(),
+                FormatDuration(deadline - ctx.Now()).c_str());
 
             ctx.Schedule(
                 deadline,
@@ -394,9 +421,10 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
             LOG_INFO(
                 ctx,
                 TBlockStoreComponents::DISK_REGISTRY,
-                "%s Sending secure erase request for pool: %s",
+                "%s Sending secure erase request for pool: %s, devices: [%s]",
                 LogTitle.GetWithTime().c_str(),
-                poolName.c_str());
+                poolName.Quote().c_str(),
+                MakeDevicesNamesString(request->DirtyDevices).c_str());
 
             NCloud::Send(ctx, ctx.SelfID, std::move(request));
         }
@@ -416,8 +444,9 @@ void TDiskRegistryActor::HandleSecureErase(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::DISK_REGISTRY,
-        "%s Received SecureErase request: DirtyDevices=%lu",
+        "%s Received SecureErase request: DirtyDevices=%s %lu",
         LogTitle.GetWithTime().c_str(),
+        MakeDevicesNamesString(msg->DirtyDevices).c_str(),
         msg->DirtyDevices.size());
 
     auto actor = NCloud::Register<TSecureEraseActor>(
@@ -457,9 +486,9 @@ void TDiskRegistryActor::HandleCleanupDevices(
     LOG_INFO(
         ctx,
         TBlockStoreComponents::DISK_REGISTRY,
-        "%s Received CleanupDevices request: Devices=%lu %s",
+        "%s Received CleanupDevices request: Devices=[%s] %s",
         LogTitle.GetWithTime().c_str(),
-        msg->Devices.size(),
+        JoinStrings(msg->Devices, ", ").c_str(),
         TransactionTimeTracker.GetInflightInfo(GetCycleCount()).c_str());
 
     ExecuteTx<TCleanupDevices>(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -938,6 +938,84 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         UNIT_ASSERT_VALUES_EQUAL("uuid-4", cleanDevices[1]);
     }
 
+    Y_UNIT_TEST(ShouldHandleCoolDownBeforeSecureErase)
+    {
+        auto config = CreateDefaultStorageConfig();
+        config.SetCoolDownTimeoutBeforeSecureErase(TDuration::Seconds(30).MilliSeconds());
+
+        const auto agentConfig1 = CreateAgentConfig("agent-1", {
+            Device("dev-1", "uuid-1", "rack-1", 10_GB),
+            Device("dev-2", "uuid-2", "rack-1", 10_GB)
+        });
+
+        auto runtime = TTestRuntimeBuilder()
+            .With(config)
+            .WithAgents({  CreateTestDiskAgent(agentConfig1) })
+            .Build();
+
+        TDiskRegistryClient diskRegistry(*runtime);
+        diskRegistry.WaitReady();
+        diskRegistry.SetWritableState(true);
+
+        diskRegistry.UpdateConfig(
+            CreateRegistryConfig(0, { agentConfig1,  }));
+
+        RegisterAgents(*runtime, 1);
+        WaitForAgents(*runtime, 1);
+
+        // secure erase
+
+        TVector<TString> cleanDevices;
+
+        runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvDiskRegistryPrivate::EvCleanupDevicesRequest: {
+                    auto& msg = *event->Get<TEvDiskRegistryPrivate::TEvCleanupDevicesRequest>();
+                    cleanDevices = msg.Devices;
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        TVector<NProto::TDeviceConfig> devices;
+
+        {
+            auto& device = devices.emplace_back();
+            device.SetNodeId(runtime->GetNodeId(0));
+            device.SetDeviceUUID("uuid-1");
+        }
+
+        {
+            auto& device = devices.emplace_back();
+            device.SetNodeId(runtime->GetNodeId(0));
+            device.SetDeviceUUID("uuid-2");
+        }
+
+        // Should not get secure erases during cool down timeout.
+        runtime->AdvanceCurrentTime(28s);
+        runtime->DispatchEvents({}, 100ms);
+        UNIT_ASSERT_VALUES_EQUAL(0, cleanDevices.size());
+
+        // Will get secure erases after cool down timeout passed.
+        runtime->AdvanceCurrentTime(1s);
+        {
+            TDispatchOptions options;
+            options.FinalEvents = {
+                TDispatchOptions::TFinalEventCondition(
+                    TEvDiskRegistryPrivate::EvCleanupDevicesResponse)
+            };
+
+            runtime->DispatchEvents(options);
+        }
+
+        Sort(cleanDevices);
+        UNIT_ASSERT_VALUES_EQUAL(2, cleanDevices.size());
+        UNIT_ASSERT_VALUES_EQUAL("uuid-1", cleanDevices[0]);
+        UNIT_ASSERT_VALUES_EQUAL("uuid-2", cleanDevices[1]);
+    }
+
     Y_UNIT_TEST(ShouldUpdateNodeId)
     {
         auto agent = CreateAgentConfig("agent-1", {

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_lifecycle.cpp
@@ -979,20 +979,6 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             return TTestActorRuntime::DefaultObserverFunc(event);
         });
 
-        TVector<NProto::TDeviceConfig> devices;
-
-        {
-            auto& device = devices.emplace_back();
-            device.SetNodeId(runtime->GetNodeId(0));
-            device.SetDeviceUUID("uuid-1");
-        }
-
-        {
-            auto& device = devices.emplace_back();
-            device.SetNodeId(runtime->GetNodeId(0));
-            device.SetDeviceUUID("uuid-2");
-        }
-
         // Should not get secure erases during cool down timeout.
         runtime->AdvanceCurrentTime(28s);
         runtime->DispatchEvents({}, 100ms);

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -6,6 +6,7 @@ ManuallyPreemptedVolumesFile: "backups.1/nbs-preempted-volumes.json"
 AllocationUnitMirror2SSD: 1
 AllocationUnitMirror3SSD: 1
 AllocationUnitNonReplicatedSSD: 1
+CoolDownTimeoutBeforeSecureErase: 30000
 EnableToChangeErrorStatesFromDiskRegistryMonpage: true
 EnableToChangeStatesFromDiskRegistryMonpage: true
 MirroredMigrationStartAllowed: true

--- a/example/nbs/nbs-storage2.txt
+++ b/example/nbs/nbs-storage2.txt
@@ -6,6 +6,7 @@ ManuallyPreemptedVolumesFile: "backups.2/nbs-preempted-volumes.json"
 AllocationUnitMirror2SSD: 1
 AllocationUnitMirror3SSD: 1
 AllocationUnitNonReplicatedSSD: 1
+CoolDownTimeoutBeforeSecureErase: 30000
 EnableToChangeErrorStatesFromDiskRegistryMonpage: true
 EnableToChangeStatesFromDiskRegistryMonpage: true
 MirroredMigrationStartAllowed: true


### PR DESCRIPTION
### Notes
Added a cool down timeout before starting device erasing. This avoids a race when a late request from a destroyed volume arrives at a device that has already started to be secure erased.
Most often, late requests are generated by migrations.
`CRITICAL_EVENT:DiskAgentCriticalEvents/DiskAgentIoDuringSecureErase:device="xxx"; client="migration"; start=16039936; blocks=1024; isWrite=1; isRdma=0`

