### PR TITLE
[Filestore] should not hang if a Forget request is received before fuse_init

### DIFF
--- a/cloud/contrib/virtiofsd/fuse_lowlevel.c
+++ b/cloud/contrib/virtiofsd/fuse_lowlevel.c
@@ -358,10 +358,14 @@ int fuse_reply_err(fuse_req_t req, int err)
     return send_reply(req, -err, NULL, 0);
 }
 
+/* Implementation should define this function and add completion-specific logic
+ *
+ * See #5897 for details
 void fuse_reply_none(fuse_req_t req)
 {
     fuse_free_req(req);
 }
+*/
 
 static unsigned long calc_timeout_sec(double t)
 {

--- a/cloud/filestore/libs/vfs_fuse/fs.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs.cpp
@@ -23,7 +23,7 @@ int ReplyNone(
     requestStats.ResponseSent(callContext);
     FILESTORE_TRACK(ResponseSent, (&callContext), "None");
 
-    fuse_reply_none_override(req);
+    fuse_reply_none(req);
 
     requestStats.RequestCompleted(log, callContext, error);
 

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -3121,7 +3121,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
     Y_UNIT_TEST(ShouldNotCrashWhileStoppingWhenForgetRequestIsInFlight)
     {
-        TBootstrap bootstrap(CreateWallClockTimer());
+        TBootstrap bootstrap;
 
         bootstrap.Start();
 
@@ -3147,6 +3147,21 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             // has already been destroyed by the time the request reaches the
             // virtio queue, causing a wait timeout in |TFuseVirtioClient|
         }
+    }
+
+    Y_UNIT_TEST(ShouldNotHangIfForgetRequestReceivedBeforeInit)
+    {
+        TBootstrap bootstrap;
+
+        bootstrap.Start(/* sendInitRequest = */ false);
+
+        const ui64 nodeId = 123;
+        const ui64 refCount = 10;
+
+        auto forget = bootstrap.Fuse->SendRequest<TForgetRequest>(
+            nodeId,
+            refCount);
+        UNIT_ASSERT_NO_EXCEPTION(forget.GetValue(WaitTimeout));
     }
 
     Y_UNIT_TEST(ShouldRaiseCritEventWhenErrorWasSentToGuest)

--- a/cloud/filestore/libs/vfs_fuse/fuse.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fuse.cpp
@@ -16,8 +16,3 @@ int fuse_cancel_request(
     (void)code;
     return fuse_reply_err(req, EINTR);
 }
-
-void fuse_reply_none_override(fuse_req_t req)
-{
-    fuse_reply_none(req);
-}

--- a/cloud/filestore/libs/vfs_fuse/fuse.h
+++ b/cloud/filestore/libs/vfs_fuse/fuse.h
@@ -37,12 +37,6 @@ int fuse_cancel_request(
     fuse_req_t req,
     enum fuse_cancelation_code code);
 
-// 'overrides' fuse_reply_none, needed for VIRTIO-specific request completion
-// handling.
-// See https://github.com/ydb-platform/nbs/pull/4283
-// and https://github.com/ydb-platform/nbs/pull/4313
-void fuse_reply_none_override(fuse_req_t req);
-
 #if defined(__cplusplus)
 }   // extern "C"
 #endif

--- a/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
+++ b/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
@@ -410,6 +410,10 @@ int fuse_cancel_request(
     return 0;
 }
 
+// Override for cloud/contrib/virtiofsd/fuse_lowlevel.c:fuse_reply_none.
+// It is important to define it and call complete_request before the default
+// implementation (which only calls fuse_free_req), otherwise the Forget request
+// will hang
 void fuse_reply_none(fuse_req_t req)
 {
     // complete attached fuse virtio request

--- a/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
+++ b/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
@@ -410,19 +410,14 @@ int fuse_cancel_request(
     return 0;
 }
 
-// 'overrides' fuse_reply_none, needed for VIRTIO-specific request completion
-// handling.
-// See https://github.com/ydb-platform/nbs/pull/4283
-// and https://github.com/ydb-platform/nbs/pull/4313
-void fuse_reply_none_override(fuse_req_t req)
+void fuse_reply_none(fuse_req_t req)
 {
     // complete attached fuse virtio request
     struct fuse_chan* ch = req->ch;
     struct fuse_virtio_request* vhd_req = VIRTIO_REQ_FROM_CHAN(ch);
     complete_request(vhd_req, 0);
 
-    // calling 'base' implementation
-    fuse_reply_none(req);
+    fuse_free_req(req);
 }
 
 int virtio_session_mount(struct fuse_session* se)


### PR DESCRIPTION
### Notes
Follow-up for https://github.com/ydb-platform/nbs/pull/4283.

A "Forget" request is not completed if it is received before fuse_init, because the FUSE handler cannot be called in this case 

### Issue
Put links to the related issues here
