### PR TITLE
issue-1751: [Filestore] Allow deletion from TFileRingBuffer from any position

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -103,18 +103,18 @@ public:
         return Storage.Alloc(size);
     }
 
-    bool Commit() override
+    void Commit() override
     {
-        auto res = Storage.Commit();
+        bool success = Storage.Commit();
+        Y_ENSURE(success, "Failed to commit allocation");
         SetCounters();
-        return res;
     }
 
-    bool Free(const void* ptr) override
+    void Free(const void* ptr) override
     {
-        bool removed = Storage.Free(ptr);
+        bool success = Storage.Free(ptr);
+        Y_ENSURE(success, "Failed to free pointer " << ptr);
         SetCounters();
-        return removed;
     }
 
     void UpdateStats() const override

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -21,7 +21,6 @@ class TFileRingBufferStorage: public IPersistentStorage
 private:
     const IPersistentStorageStatsPtr Stats;
     TFileRingBuffer Storage;
-    THashSet<const void*> DeletedEntries;
     const TPersistentStorageConfig Config;
     const TLog Log;
     const TString LogTag;
@@ -85,12 +84,10 @@ public:
     void Visit(const TVisitor& visitor) override
     {
         Storage.Visit(
-            [this, &visitor](ui32 checksum, TStringBuf entry)
+            [&visitor](ui32 checksum, TStringBuf entry)
             {
                 Y_UNUSED(checksum);
-                if (!DeletedEntries.contains(entry.data())) {
-                    visitor({entry.data(), entry.size()});
-                }
+                visitor({entry.data(), entry.size()});
             });
 
         SetCounters();
@@ -113,27 +110,11 @@ public:
         return res;
     }
 
-    void Free(const void* ptr) override
+    bool Free(const void* ptr) override
     {
-        auto [it, inserted] = DeletedEntries.insert(ptr);
-        Y_ENSURE(inserted, "Double free detected");
-
-        while (!Storage.Empty()) {
-            const char* front = Storage.Front().data();
-            if (DeletedEntries.erase(front) != 0) {
-                Storage.PopFront();
-            } else {
-                break;
-            }
-        }
-
-        if (Storage.Empty()) {
-            Y_ENSURE(
-                DeletedEntries.empty(),
-                "Orphaned deleted entries detected");
-        }
-
+        bool removed = Storage.Free(ptr);
         SetCounters();
+        return removed;
     }
 
     void UpdateStats() const override
@@ -147,7 +128,7 @@ private:
         Stats->SetPersistentStorageCounters(
             /* rawCapacityBytesCount = */ Storage.GetRawCapacity(),
             /* rawUsedBytesCount = */ Storage.GetRawUsedBytesCount(),
-            /* entryCount = */ Storage.Size() - DeletedEntries.size(),
+            /* entryCount = */ Storage.Size(),
             /* isCorrupted = */ Storage.IsCorrupted());
     }
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -43,7 +43,7 @@ struct IPersistentStorage
      *
      * Returns an error if allocation is not possible due to other reasons.
      */
-    virtual TResultOrError<char*> Alloc(size_t size) = 0;
+    [[nodiscard]] virtual TResultOrError<char*> Alloc(size_t size) = 0;
 
     /**
      * Commits previous memory allocation
@@ -54,10 +54,10 @@ struct IPersistentStorage
      * Returns true if the commit was successful.
      * Returns false if Alloc was not called.
      */
-    virtual bool Commit() = 0;
+    [[nodiscard]] virtual bool Commit() = 0;
 
     // Frees a previously allocated buffer.
-    virtual void Free(const void* ptr) = 0;
+    [[nodiscard]] virtual bool Free(const void* ptr) = 0;
 
     virtual void UpdateStats() const = 0;
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -54,10 +54,10 @@ struct IPersistentStorage
      * Returns true if the commit was successful.
      * Returns false if Alloc was not called.
      */
-    [[nodiscard]] virtual bool Commit() = 0;
+    virtual void Commit() = 0;
 
     // Frees a previously allocated buffer.
-    [[nodiscard]] virtual bool Free(const void* ptr) = 0;
+    virtual void Free(const void* ptr) = 0;
 
     virtual void UpdateStats() const = 0;
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -72,12 +72,14 @@ struct TBootstrap
     const char* Alloc(const TString& data) const
     {
         auto allocationResult = Storage->Alloc(data.size());
-        UNIT_ASSERT(!HasError(allocationResult));
+        if (HasError(allocationResult)) {
+            return nullptr;
+        }
 
         char* ptr = allocationResult.GetResult();
         if (ptr != nullptr) {
             data.copy(ptr, data.size());
-            UNIT_ASSERT(Storage->Commit());
+            Storage->Commit();
         }
         return ptr;
     }
@@ -88,9 +90,9 @@ struct TBootstrap
         return HasError(allocationResult);
     }
 
-    bool Free(const void* ptr) const
+    void Free(const void* ptr) const
     {
-        return Storage->Free(ptr);
+        Storage->Free(ptr);
     }
 
     TString Dump() const
@@ -155,7 +157,7 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         UNIT_ASSERT_VALUES_EQUAL(0, stats.EntryCount->Get());
     }
 
-    Y_UNIT_TEST(ShouldNotAllowDoubleFree)
+    Y_UNIT_TEST(ShouldThrowOnDoubleFree)
     {
         TBootstrap b;
 
@@ -168,11 +170,11 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         const auto* ptr2 = b.Alloc("567890");
         UNIT_ASSERT(ptr2);
 
-        UNIT_ASSERT(b.Free(ptr2));
-        UNIT_ASSERT(!b.Free(ptr2));
+        b.Free(ptr2);
+        UNIT_ASSERT_EXCEPTION(b.Free(ptr2), yexception);
 
         b.Free(ptr1);
-        UNIT_ASSERT(!b.Free(ptr1));
+        UNIT_ASSERT_EXCEPTION(b.Free(ptr1), yexception);
     }
 
     Y_UNIT_TEST(ShouldValidateAllocationSize)

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -88,9 +88,9 @@ struct TBootstrap
         return HasError(allocationResult);
     }
 
-    void Free(const void* ptr) const
+    bool Free(const void* ptr) const
     {
-        Storage->Free(ptr);
+        return Storage->Free(ptr);
     }
 
     TString Dump() const
@@ -155,7 +155,7 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         UNIT_ASSERT_VALUES_EQUAL(0, stats.EntryCount->Get());
     }
 
-    Y_UNIT_TEST(ShouldThrowOnDoubleFree)
+    Y_UNIT_TEST(ShouldNotAllowDoubleFree)
     {
         TBootstrap b;
 
@@ -168,11 +168,11 @@ Y_UNIT_TEST_SUITE(TPersistentStorageTest)
         const auto* ptr2 = b.Alloc("567890");
         UNIT_ASSERT(ptr2);
 
-        b.Free(ptr2);
-        UNIT_ASSERT_EXCEPTION(b.Free(ptr2), yexception);
+        UNIT_ASSERT(b.Free(ptr2));
+        UNIT_ASSERT(!b.Free(ptr2));
 
         b.Free(ptr1);
-        UNIT_ASSERT_EXCEPTION(b.Free(ptr1), yexception);
+        UNIT_ASSERT(!b.Free(ptr1));
     }
 
     Y_UNIT_TEST(ShouldValidateAllocationSize)

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
@@ -43,23 +43,17 @@ TResultOrError<char*> TTestStorage::Alloc(size_t size)
     return res;
 }
 
-bool TTestStorage::Commit()
-{
-    return true;
-}
+void TTestStorage::Commit()
+{}
 
-bool TTestStorage::Free(const void* ptr)
+void TTestStorage::Free(const void* ptr)
 {
     auto it = Data.find(ptr);
-    if (it == Data.end()) {
-        return false;
-    }
+    Y_ENSURE(it != Data.end(), "Double free detected");
 
     Data.erase(it);
 
     SetStats();
-
-    return true;
 }
 
 void TTestStorage::UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
@@ -48,14 +48,18 @@ bool TTestStorage::Commit()
     return true;
 }
 
-void TTestStorage::Free(const void* ptr)
+bool TTestStorage::Free(const void* ptr)
 {
     auto it = Data.find(ptr);
-    Y_ENSURE(it != Data.end(), "Double free detected");
+    if (it == Data.end()) {
+        return false;
+    }
 
     Data.erase(it);
 
     SetStats();
+
+    return true;
 }
 
 void TTestStorage::UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
@@ -32,7 +32,7 @@ public:
     ui64 GetMaxSupportedAllocationByteCount() const override;
     TResultOrError<char*> Alloc(size_t size) override;
     bool Commit() override;
-    void Free(const void* ptr) override;
+    bool Free(const void* ptr) override;
     void UpdateStats() const override;
 
     void SetCapacity(size_t capacity);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
@@ -31,8 +31,8 @@ public:
     void Visit(const TVisitor& visitor) override;
     ui64 GetMaxSupportedAllocationByteCount() const override;
     TResultOrError<char*> Alloc(size_t size) override;
-    bool Commit() override;
-    bool Free(const void* ptr) override;
+    void Commit() override;
+    void Free(const void* ptr) override;
     void UpdateStats() const override;
 
     void SetCapacity(size_t capacity);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -805,13 +805,6 @@ struct TStatsCalculator
 
     void Flush(ui32 nodeId)
     {
-        for (auto& stats: Queue) {
-            if (stats.NodeId != nodeId || stats.Flushed) {
-                continue;
-            }
-            stats.Flushed = true;
-        }
-
         auto it = UnflushedRequestCount.find(nodeId);
         if (it != UnflushedRequestCount.end()) {
             WriteDataFlushCount += it->second;
@@ -819,9 +812,9 @@ struct TStatsCalculator
             UnflushedRequestCount.erase(it);
         }
 
-        while (!Queue.empty() && Queue.front().Flushed) {
-            Queue.pop_front();
-        }
+        EraseIf(
+            Queue,
+            [nodeId](const auto& stats) { return stats.NodeId == nodeId; });
     }
 
     void FlushAll()
@@ -833,16 +826,6 @@ struct TStatsCalculator
 
         Queue.clear();
         UnflushedRequestCount.clear();
-    }
-
-    void Unflush()
-    {
-        for (auto& stats: Queue) {
-            if (stats.Flushed) {
-                stats.Flushed = false;
-                UnflushedRequestCount[stats.NodeId]++;
-            }
-        }
     }
 
     ui64 GetUnflushedQueueRequestCount() const
@@ -1131,7 +1114,6 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
             if (args.WithCacheRecreation && RandomNumber(20u) == 0) {
                 b.RecreateCache();
-                stats.Unflush();
                 // Stats are reset on cache recreation
                 stats.FlushCount = 0;
             }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -787,19 +787,10 @@ struct TStatsCalculator
 {
     ui64 WriteDataFlushCount = 0;
     ui64 FlushCount = 0;
-
-    struct TState
-    {
-        ui32 NodeId = 0;
-        bool Flushed = false;
-    };
-
-    TDeque<TState> Queue;
     THashMap<ui32, ui64> UnflushedRequestCount;
 
     void Write(ui32 nodeId)
     {
-        Queue.push_back({.NodeId = nodeId, .Flushed = false});
         UnflushedRequestCount[nodeId]++;
     }
 
@@ -811,10 +802,6 @@ struct TStatsCalculator
             FlushCount++;
             UnflushedRequestCount.erase(it);
         }
-
-        EraseIf(
-            Queue,
-            [nodeId](const auto& stats) { return stats.NodeId == nodeId; });
     }
 
     void FlushAll()
@@ -824,17 +811,14 @@ struct TStatsCalculator
             WriteDataFlushCount += pair.second;
         }
 
-        Queue.clear();
         UnflushedRequestCount.clear();
     }
 
     ui64 GetUnflushedQueueRequestCount() const
     {
         ui64 res = 0;
-        for (const auto& stats: Queue) {
-            if (!stats.Flushed) {
-                res++;
-            }
+        for (auto [nodeId, count]: UnflushedRequestCount) {
+            res += count;
         }
         return res;
     }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -256,7 +256,6 @@ void TWriteDataRequestManager::Evict(
     std::unique_ptr<TCachedWriteDataRequest> request)
 {
     FlushedRequestsRemove(request.get());
-
     PersistentStorage->Free(request->GetAllocationPtr());
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -69,7 +69,11 @@ std::unique_ptr<TCachedWriteDataRequest> TryStoreRequestInPersistentStorage(
         memoryOutput.Exhausted(),
         "Buffer is expected to be written completely");
 
-    storage.Commit();
+    bool committed = storage.Commit();
+
+    Y_ABORT_UNLESS(
+        committed,
+        "Failed to commit allocation in the persistent storage");
 
     return std::make_unique<TCachedWriteDataRequest>(
         sequenceId,
@@ -256,7 +260,12 @@ void TWriteDataRequestManager::Evict(
     std::unique_ptr<TCachedWriteDataRequest> request)
 {
     FlushedRequestsRemove(request.get());
-    PersistentStorage->Free(request->GetAllocationPtr());
+
+    bool success = PersistentStorage->Free(request->GetAllocationPtr());
+
+    Y_ABORT_UNLESS(
+        success,
+        "Failed to free allocation in the persistent storage");
 }
 
 void TWriteDataRequestManager::UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -69,11 +69,7 @@ std::unique_ptr<TCachedWriteDataRequest> TryStoreRequestInPersistentStorage(
         memoryOutput.Exhausted(),
         "Buffer is expected to be written completely");
 
-    bool committed = storage.Commit();
-
-    Y_ABORT_UNLESS(
-        committed,
-        "Failed to commit allocation in the persistent storage");
+    storage.Commit();
 
     return std::make_unique<TCachedWriteDataRequest>(
         sequenceId,
@@ -261,11 +257,7 @@ void TWriteDataRequestManager::Evict(
 {
     FlushedRequestsRemove(request.get());
 
-    bool success = PersistentStorage->Free(request->GetAllocationPtr());
-
-    Y_ABORT_UNLESS(
-        success,
-        "Failed to free allocation in the persistent storage");
+    PersistentStorage->Free(request->GetAllocationPtr());
 }
 
 void TWriteDataRequestManager::UpdateStats() const

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -28,18 +28,15 @@ constexpr ui64 HeaderReserveSize = 256;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct THeaderPrev
+struct THeader
 {
     ui32 Version = 0;
     ui32 HeaderSize = 0;
     ui64 DataCapacity = 0;
     ui64 ReadPos = 0;
     ui64 WritePos = 0;
-    ui64 LastEntrySize = 0;
-};
-
-struct THeader: THeaderPrev
-{
+    // Previously was: LastEntrySize
+    ui64 Unused = 0;
     ui64 DataOffset = 0;
     ui64 MetadataCapacity = 0;
     ui64 MetadataOffset = 0;
@@ -106,7 +103,6 @@ public:
 //    - ReadPos != WritePos
 //    - ReadPos points to the first byte of the first valid entry
 //    - WritePos points to the first byte right after the last valid entry
-//    - LastEntrySize is the size of the last valid entry
 //
 //  3. Valid entry:
 //    - Size > 0
@@ -400,17 +396,11 @@ private:
 
         if (front.HasValue()) {
             Y_ABORT_UNLESS(back.HasValue());
-
             Header()->ReadPos = front.ActualPos;
             Header()->WritePos = back.GetNextEntryPos();
-            // Updating WritePos and LastEntrySize is not performed atomically
-            // It may happen that only one field was updated before crash - need
-            // to correct the value.
-            Header()->LastEntrySize = back.GetNextEntryPos() - back.ActualPos;
         } else {
             Header()->ReadPos = 0;
             Header()->WritePos = 0;
-            Header()->LastEntrySize = 0;
         }
     }
 
@@ -446,6 +436,7 @@ private:
                      { Y_ABORT_UNLESS(!e.GetFreeFlag()); });
 
         Header()->Version = VERSION;
+        Header()->Unused = 0;
     }
 
     void ResizeMetadata(ui64 desiredMetadataCapacity)
@@ -673,7 +664,6 @@ public:
         auto sz = sizeof(TEntryHeader) + CurrentAllocation->GetDataSize();
 
         Header()->WritePos = writePos + sz;
-        Header()->LastEntrySize = sz;
         EntryMap[ptr] = writePos;
 
         CurrentAllocation = nullptr;

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -5,6 +5,7 @@
 #include <util/generic/hash.h>
 #include <util/generic/size_literals.h>
 #include <util/stream/mem.h>
+#include <util/string/builder.h>
 #include <util/system/align.h>
 #include <util/system/compiler.h>
 #include <util/system/filemap.h>
@@ -51,8 +52,8 @@ static_assert(sizeof(THeader) <= HeaderReserveSize);
 struct Y_PACKED TEntryHeader
 {
 private:
-    static constexpr ui32 SkipFlagMask = 1U << 31U;
-    static constexpr ui32 SizeMask = SkipFlagMask - 1;
+    static constexpr ui32 FreeFlagMask = 1U << 31U;
+    static constexpr ui32 SizeMask = FreeFlagMask - 1;
 
     ui32 DataSize = 0;
     ui32 Checksum = 0;
@@ -70,17 +71,17 @@ public:
         DataSize = (DataSize & ~SizeMask) | (value & SizeMask);
     }
 
-    bool GetSkipFlag() const
+    bool GetFreeFlag() const
     {
-        return (DataSize & SkipFlagMask) != 0;
+        return (DataSize & FreeFlagMask) != 0;
     }
 
-    void SetSkipFlag(bool value)
+    void SetFreeFlag(bool value)
     {
         if (value) {
-            DataSize |= SkipFlagMask;
+            DataSize |= FreeFlagMask;
         } else {
-            DataSize &= ~SkipFlagMask;
+            DataSize &= ~FreeFlagMask;
         }
     }
 
@@ -214,9 +215,9 @@ struct TEntryInfo
         return ActualPos == INVALID_POS;
     }
 
-    bool GetSkipFlag() const
+    bool GetFreeFlag() const
     {
-        return Header->GetSkipFlag();
+        return Header->GetFreeFlag();
     }
 
     TStringBuf GetData() const
@@ -287,7 +288,7 @@ private:
 
     TEntryHeader* CurrentAllocation = nullptr;
 
-    // Map of non-skipped entries: data ptr -> pos
+    // Map of non-free entries: data ptr -> pos
     THashMap<const void*, ui64> EntryMap;
 
 private:
@@ -440,10 +441,10 @@ private:
 
     void Migrate()
     {
-        // In the new version, the highest bit of the entry size is used as a
-        // skip flag - need to ensure that nobody use it
+        // In the new version, the highest bit of the entry size is treated as a
+        // free flag - need to ensure that nobody use it
         VisitEntries([](const TEntryInfo& e)
-                     { Y_ABORT_UNLESS(!e.GetSkipFlag()); });
+                     { Y_ABORT_UNLESS(!e.GetFreeFlag()); });
 
         Header()->Version = VERSION;
     }
@@ -509,16 +510,17 @@ private:
         }
     }
 
-    void PopFrontSkippedEntries()
+    void EraseFreeEntriesFromFront()
     {
         auto front = GetFrontEntry();
-        while (front.HasValue() && front.GetSkipFlag()) {
+        while (front.HasValue() && front.GetFreeFlag()) {
             front = GetNextEntry(front);
         }
 
         if (front.HasValue()) {
             Header()->ReadPos = front.ActualPos;
         } else {
+            // All entries deleted, ring buffer should be emptied
             Header()->ReadPos = 0;
             Header()->WritePos = 0;
         }
@@ -556,12 +558,12 @@ public:
         VisitEntries(
             [&](const TEntryInfo& e)
             {
-                if (!e.GetSkipFlag()) {
+                if (!e.GetFreeFlag()) {
                     EntryMap[e.Data] = e.ActualPos;
                 }
             });
 
-        PopFrontSkippedEntries();
+        EraseFreeEntriesFromFront();
     }
 
     bool PushBack(TStringBuf data)
@@ -597,11 +599,20 @@ public:
         }
 
         if (size > TEntryHeader::MaxDataSize) {
-            return nullptr;
+            return MakeError(
+                E_ARGUMENT,
+                TStringBuilder() << "Allocation data size (" << size
+                                 << ") exceeds maximum allowed size ("
+                                 << TEntryHeader::MaxDataSize << ")");
         }
 
         const auto sz = size + sizeof(TEntryHeader);
         if (sz > Header()->DataCapacity) {
+            return MakeError(
+                E_ARGUMENT,
+                TStringBuilder() << "Allocation entry size (" << sz
+                                 << ") exceeds DataCapacity ("
+                                 << Header()->DataCapacity << ")");
             return nullptr;
         }
         auto writePos = Header()->WritePos;
@@ -637,7 +648,7 @@ public:
 
         CurrentAllocation = Data.GetEntryHeader(writePos);
         CurrentAllocation->SetDataSize(size);
-        CurrentAllocation->SetSkipFlag(false);
+        CurrentAllocation->SetFreeFlag(false);
 
         char* ptr = Data.GetEntryData(CurrentAllocation);
         Y_ABORT_UNLESS(ptr != nullptr);
@@ -679,10 +690,10 @@ public:
         }
 
         auto* eh = Data.GetEntryHeader(it->second);
-        eh->SetSkipFlag(true);
+        eh->SetFreeFlag(true);
         EntryMap.erase(it);
 
-        PopFrontSkippedEntries();
+        EraseFreeEntriesFromFront();
 
         return true;
     }
@@ -744,7 +755,7 @@ public:
         VisitEntries(
             [&](const TEntryInfo& e)
             {
-                if (!e.GetSkipFlag()) {
+                if (!e.GetFreeFlag()) {
                     visitor(e.Header->GetChecksum(), e.GetData());
                 }
             });

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -2,6 +2,7 @@
 
 #include <library/cpp/digest/crc32c/crc32c.h>
 
+#include <util/generic/hash.h>
 #include <util/generic/size_literals.h>
 #include <util/stream/mem.h>
 #include <util/system/align.h>
@@ -16,8 +17,8 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr ui32 VERSION_PREV = 2;
-constexpr ui32 VERSION = 3;
+constexpr ui32 VERSION_PREV = 3;
+constexpr ui32 VERSION = 4;
 constexpr ui64 INVALID_POS = Max<ui64>();
 
 // Reserve some space after header so adding new fields will not require data
@@ -49,8 +50,49 @@ static_assert(sizeof(THeader) <= HeaderReserveSize);
 
 struct Y_PACKED TEntryHeader
 {
+private:
+    static constexpr ui32 SkipFlagMask = 1U << 31U;
+    static constexpr ui32 SizeMask = SkipFlagMask - 1;
+
     ui32 DataSize = 0;
     ui32 Checksum = 0;
+
+public:
+    static constexpr ui32 MaxDataSize = SizeMask;
+
+    ui32 GetDataSize() const
+    {
+        return DataSize & SizeMask;
+    }
+
+    void SetDataSize(ui32 value)
+    {
+        DataSize = (DataSize & ~SizeMask) | (value & SizeMask);
+    }
+
+    bool GetSkipFlag() const
+    {
+        return (DataSize & SkipFlagMask) != 0;
+    }
+
+    void SetSkipFlag(bool value)
+    {
+        if (value) {
+            DataSize |= SkipFlagMask;
+        } else {
+            DataSize &= ~SkipFlagMask;
+        }
+    }
+
+    ui32 GetChecksum() const
+    {
+        return Checksum;
+    }
+
+    void SetChecksum(ui32 value)
+    {
+        Checksum = value;
+    }
 };
 
 //  Structure contract:
@@ -99,10 +141,10 @@ private:
     char* DoGetEntryData(const TEntryHeader* eh) const
     {
         Y_ABORT_UNLESS(eh != nullptr);
-        Y_ABORT_UNLESS(eh->DataSize != 0);
+        Y_ABORT_UNLESS(eh->GetDataSize() != 0);
 
-        ui64 pos = reinterpret_cast<const char*>(eh) - Data.data();
-        return GetPtr(pos + sizeof(eh), eh->DataSize);
+        ui64 pos = GetEntryPos(eh);
+        return GetPtr(pos + sizeof(eh), eh->GetDataSize());
     }
 
 public:
@@ -122,6 +164,12 @@ public:
         return GetPtr<TEntryHeader>(pos);
     }
 
+    ui64 GetEntryPos(const TEntryHeader* eh) const
+    {
+        Y_ABORT_UNLESS(eh != nullptr);
+        return reinterpret_cast<const char*>(eh) - Data.data();
+    }
+
     char* GetEntryData(TEntryHeader* eh)
     {
         return DoGetEntryData(eh);
@@ -137,8 +185,10 @@ public:
         auto* eh = GetEntryHeader(pos);
         Y_ABORT_UNLESS(eh != nullptr);
 
-        eh->DataSize = data.size();
-        eh->Checksum = Crc32c(data.data(), data.size());
+        eh->SetDataSize(data.size());
+        Y_ABORT_UNLESS(eh->GetDataSize() == data.size());
+
+        eh->SetChecksum(Crc32c(data.data(), data.size()));
 
         auto* dst = GetEntryData(eh);
         Y_ABORT_UNLESS(dst != nullptr);
@@ -164,15 +214,21 @@ struct TEntryInfo
         return ActualPos == INVALID_POS;
     }
 
+    bool GetSkipFlag() const
+    {
+        return Header->GetSkipFlag();
+    }
+
     TStringBuf GetData() const
     {
-        return HasValue() ? TStringBuf(Data, Header->DataSize) : TStringBuf();
+        return HasValue() ? TStringBuf(Data, Header->GetDataSize())
+                          : TStringBuf();
     }
 
     ui64 GetNextEntryPos() const
     {
-        return Header != nullptr && Header->DataSize > 0
-            ? ActualPos + sizeof(TEntryHeader) + Header->DataSize
+        return Header != nullptr && Header->GetDataSize() > 0
+            ? ActualPos + sizeof(TEntryHeader) + Header->GetDataSize()
             : INVALID_POS;
     }
 
@@ -183,7 +239,7 @@ struct TEntryInfo
     {
         Y_ABORT_UNLESS(pos != INVALID_POS);
         Y_ABORT_UNLESS(header != nullptr);
-        Y_ABORT_UNLESS(header->DataSize > 0);
+        Y_ABORT_UNLESS(header->GetDataSize() > 0);
         Y_ABORT_UNLESS(data != nullptr);
 
         return TEntryInfo{.ActualPos = pos, .Header = header, .Data = data};
@@ -227,12 +283,12 @@ private:
     TFileMap Map;
 
     TEntriesData Data;
-    ui64 Count = 0;
     bool Corrupted = false;
 
     TEntryHeader* CurrentAllocation = nullptr;
-    ui64 WritePosAfterCommit = 0;
-    ui64 LastEntrySizeAfterCommit = 0;
+
+    // Map of non-skipped entries: data ptr -> pos
+    THashMap<const void*, ui64> EntryMap;
 
 private:
     THeader* Header()
@@ -258,7 +314,7 @@ private:
             }
 
             const auto* eh = Data.GetEntryHeader(pos);
-            if (eh != nullptr && eh->DataSize != 0) {
+            if (eh != nullptr && eh->GetDataSize() != 0) {
                 const auto* data = Data.GetEntryData(eh);
                 return data != nullptr
                     ? TEntryInfo::Create(pos, eh, data)
@@ -280,7 +336,7 @@ private:
         }
 
         const auto* eh = Data.GetEntryHeader(pos);
-        if (eh == nullptr || eh->DataSize == 0) {
+        if (eh == nullptr || eh->GetDataSize() == 0) {
             return TEntryInfo::CreateInvalid();
         }
 
@@ -334,7 +390,6 @@ private:
         }
 
         while (cur.HasValue()) {
-            Count++;
             back = cur;
             cur = GetNextEntry(cur);
         }
@@ -383,36 +438,17 @@ private:
         MemCopy(dst.data(), src.data(), size);
     }
 
-    void Migrate(const THeader& header)
+    void Migrate()
     {
-        Y_ABORT_UNLESS(Header()->DataCapacity == header.DataCapacity);
-        Y_ABORT_UNLESS(sizeof(THeaderPrev) <= header.DataOffset);
+        // In the new version, the highest bit of the entry size is used as a
+        // skip flag - need to ensure that nobody use it
+        Visit([](auto checksum, auto data)
+        {
+            Y_UNUSED(checksum);
+            Y_ABORT_UNLESS(data.size() <= TEntryHeader::MaxDataSize);
+        });
 
-        const ui64 newFileSize = header.DataOffset + header.DataCapacity;
-
-        // Make a copy of all data in the end of the file
-        // Then copy it to the right place
-        ResizeAndRemap(newFileSize + header.DataCapacity);
-
-        if (Header()->HeaderSize == 0) {
-            CopyMappedData(
-                newFileSize,
-                sizeof(THeaderPrev),
-                header.DataCapacity);
-            // Indicate that the data has been copied
-            Header()->HeaderSize = sizeof(THeader);
-        }
-
-        Y_ABORT_UNLESS(Header()->HeaderSize == sizeof(THeader));
-        CopyMappedData(header.DataOffset, newFileSize, header.DataCapacity);
-
-        Header()->DataOffset = header.DataOffset;
-        Header()->MetadataOffset = header.MetadataOffset;
-        Header()->MetadataCapacity = header.MetadataCapacity;
-        Header()->MetadataSize = 0;
         Header()->Version = VERSION;
-
-        ResizeAndRemap(newFileSize);
     }
 
     void ResizeMetadata(ui64 desiredMetadataCapacity)
@@ -462,6 +498,37 @@ private:
         Header()->MetadataCapacity = newMetadataCapacity;
     }
 
+    void VisitNonSkippedEntries(auto visitor)
+    {
+        auto e = GetFrontEntry();
+
+        while (e.HasValue()) {
+            if (!e.GetSkipFlag()) {
+                visitor(e);
+            }
+            e = GetNextEntry(e);
+        }
+
+        if (e.IsInvalid()) {
+            SetCorrupted();
+        }
+    }
+
+    void PopFrontSkippedEntries()
+    {
+        auto front = GetFrontEntry();
+        while (front.HasValue() && front.GetSkipFlag()) {
+            front = GetNextEntry(front);
+        }
+
+        if (front.HasValue()) {
+            Header()->ReadPos = front.ActualPos;
+        } else {
+            Header()->ReadPos = 0;
+            Header()->WritePos = 0;
+        }
+    }
+
 public:
     TImpl(const TString& filePath, ui64 dataCapacity, ui64 metadataCapacity)
         : Map(filePath, TMemoryMapCommon::oRdWr)
@@ -477,8 +544,7 @@ public:
         }
 
         if (Header()->Version == VERSION_PREV) {
-            auto header = InitHeader(Header()->DataCapacity, metadataCapacity);
-            Migrate(header);
+            Migrate();
         }
 
         ValidateStructure();
@@ -491,6 +557,11 @@ public:
             GetMappedData(Header()->DataOffset, Header()->DataCapacity));
 
         ValidateDataStructure();
+
+        VisitNonSkippedEntries([&](const TEntryInfo& e)
+                               { EntryMap[e.Data] = e.ActualPos; });
+
+        PopFrontSkippedEntries();
     }
 
     bool PushBack(TStringBuf data)
@@ -525,6 +596,10 @@ public:
                 "Zero size allocations are not allowed");
         }
 
+        if (size > TEntryHeader::MaxDataSize) {
+            return nullptr;
+        }
+
         const auto sz = size + sizeof(TEntryHeader);
         if (sz > Header()->DataCapacity) {
             return nullptr;
@@ -545,7 +620,7 @@ public:
                     }
                     auto* eh = Data.GetEntryHeader(Header()->WritePos);
                     if (eh != nullptr) {
-                        eh->DataSize = 0;
+                        eh->SetDataSize(0);
                     }
                     writePos = 0;
                 }
@@ -561,10 +636,8 @@ public:
         }
 
         CurrentAllocation = Data.GetEntryHeader(writePos);
-        CurrentAllocation->DataSize = size;
-
-        WritePosAfterCommit = writePos + sz;
-        LastEntrySizeAfterCommit = sz;
+        CurrentAllocation->SetDataSize(size);
+        CurrentAllocation->SetSkipFlag(false);
 
         char* ptr = Data.GetEntryData(CurrentAllocation);
         Y_ABORT_UNLESS(ptr != nullptr);
@@ -580,17 +653,37 @@ public:
         char* ptr = Data.GetEntryData(CurrentAllocation);
         Y_ABORT_UNLESS(ptr != nullptr);
 
-        CurrentAllocation->Checksum = Crc32c(ptr, CurrentAllocation->DataSize);
+        CurrentAllocation->SetChecksum(
+            Crc32c(ptr, CurrentAllocation->GetDataSize()));
 
         // We need to ensure that all previous writes are visible before
         // updating the write position
         std::atomic_thread_fence(std::memory_order_release);
 
-        Header()->WritePos = WritePosAfterCommit;
-        Header()->LastEntrySize = LastEntrySizeAfterCommit;
-        ++Count;
+        auto writePos = Data.GetEntryPos(CurrentAllocation);
+        auto sz = sizeof(TEntryHeader) + CurrentAllocation->GetDataSize();
+
+        Header()->WritePos = writePos + sz;
+        Header()->LastEntrySize = sz;
+        EntryMap[ptr] = writePos;
 
         CurrentAllocation = nullptr;
+        return true;
+    }
+
+    bool Free(const void* ptr)
+    {
+        auto it = EntryMap.find(ptr);
+        if (it == EntryMap.end()) {
+            return false;
+        }
+
+        auto* eh = Data.GetEntryHeader(it->second);
+        eh->SetSkipFlag(true);
+        EntryMap.erase(it);
+
+        PopFrontSkippedEntries();
+
         return true;
     }
 
@@ -639,26 +732,18 @@ public:
             return;
         }
 
-        auto next = GetNextEntry(cur);
-        if (next.HasValue()) {
-            Header()->ReadPos = next.ActualPos;
-        } else {
-            Header()->ReadPos = 0;
-            Header()->WritePos = 0;
-        }
-
-        --Count;
+        Free(cur.GetData().data());
     }
 
     ui64 Size() const
     {
-        return Count;
+        return EntryMap.size();
     }
 
     bool Empty() const
     {
         const bool result = Header()->ReadPos == Header()->WritePos;
-        Y_DEBUG_ABORT_UNLESS(result == (Count == 0));
+        Y_DEBUG_ABORT_UNLESS(result == (EntryMap.size() == 0));
         return result;
     }
 
@@ -681,16 +766,9 @@ public:
 
     void Visit(const TVisitor& visitor)
     {
-        auto e = GetFrontEntry();
-
-        while (e.HasValue()) {
-            visitor(e.Header->Checksum, e.GetData());
-            e = GetNextEntry(e);
-        }
-
-        if (e.IsInvalid()) {
-            SetCorrupted();
-        }
+        VisitNonSkippedEntries(
+            [&](const TEntryInfo& e)
+            { visitor(e.Header->GetChecksum(), e.GetData()); });
     }
 
     bool IsCorrupted() const
@@ -809,6 +887,11 @@ TResultOrError<char*> TFileRingBuffer::Alloc(size_t size)
 bool TFileRingBuffer::Commit()
 {
     return Impl->Commit();
+}
+
+bool TFileRingBuffer::Free(const void* ptr)
+{
+    return Impl->Free(ptr);
 }
 
 TStringBuf TFileRingBuffer::Front() const

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -66,9 +66,10 @@ public:
         return DataSize & SizeMask;
     }
 
-    void SetDataSize(ui32 value)
+    void SetDataSize(size_t value)
     {
-        DataSize = (DataSize & ~SizeMask) | (value & SizeMask);
+        Y_ABORT_UNLESS(value <= MaxDataSize);
+        DataSize = (DataSize & ~SizeMask) | static_cast<ui32>(value);
     }
 
     bool GetFreeFlag() const
@@ -187,8 +188,6 @@ public:
         Y_ABORT_UNLESS(eh != nullptr);
 
         eh->SetDataSize(data.size());
-        Y_ABORT_UNLESS(eh->GetDataSize() == data.size());
-
         eh->SetChecksum(Crc32c(data.data(), data.size()));
 
         auto* dst = GetEntryData(eh);

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -144,7 +144,7 @@ private:
         Y_ABORT_UNLESS(eh->GetDataSize() != 0);
 
         ui64 pos = GetEntryPos(eh);
-        return GetPtr(pos + sizeof(eh), eh->GetDataSize());
+        return GetPtr(pos + sizeof(TEntryHeader), eh->GetDataSize());
     }
 
 public:
@@ -442,11 +442,8 @@ private:
     {
         // In the new version, the highest bit of the entry size is used as a
         // skip flag - need to ensure that nobody use it
-        Visit([](auto checksum, auto data)
-        {
-            Y_UNUSED(checksum);
-            Y_ABORT_UNLESS(data.size() <= TEntryHeader::MaxDataSize);
-        });
+        VisitEntries([](const TEntryInfo& e)
+                     { Y_ABORT_UNLESS(!e.GetSkipFlag()); });
 
         Header()->Version = VERSION;
     }
@@ -498,14 +495,12 @@ private:
         Header()->MetadataCapacity = newMetadataCapacity;
     }
 
-    void VisitNonSkippedEntries(auto visitor)
+    void VisitEntries(auto&& visitor)
     {
         auto e = GetFrontEntry();
 
         while (e.HasValue()) {
-            if (!e.GetSkipFlag()) {
-                visitor(e);
-            }
+            visitor(e);
             e = GetNextEntry(e);
         }
 
@@ -558,8 +553,13 @@ public:
 
         ValidateDataStructure();
 
-        VisitNonSkippedEntries([&](const TEntryInfo& e)
-                               { EntryMap[e.Data] = e.ActualPos; });
+        VisitEntries(
+            [&](const TEntryInfo& e)
+            {
+                if (!e.GetSkipFlag()) {
+                    EntryMap[e.Data] = e.ActualPos;
+                }
+            });
 
         PopFrontSkippedEntries();
     }
@@ -766,9 +766,13 @@ public:
 
     void Visit(const TVisitor& visitor)
     {
-        VisitNonSkippedEntries(
+        VisitEntries(
             [&](const TEntryInfo& e)
-            { visitor(e.Header->GetChecksum(), e.GetData()); });
+            {
+                if (!e.GetSkipFlag()) {
+                    visitor(e.Header->GetChecksum(), e.GetData());
+                }
+            });
     }
 
     bool IsCorrupted() const

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -613,7 +613,6 @@ public:
                 TStringBuilder() << "Allocation entry size (" << sz
                                  << ") exceeds DataCapacity ("
                                  << Header()->DataCapacity << ")");
-            return nullptr;
         }
         auto writePos = Header()->WritePos;
 

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -700,31 +700,6 @@ public:
         return e.GetData();
     }
 
-    TStringBuf Back() const
-    {
-        if (Empty()) {
-            return {};
-        }
-
-        if (Header()->WritePos < Header()->LastEntrySize) {
-            // corruption
-            // TODO: report?
-            return {};
-        }
-        auto pos = Header()->WritePos - Header()->LastEntrySize;
-        const auto e = GetEntry(pos);
-
-        if (!e.HasValue() || e.ActualPos != pos ||
-            e.GetNextEntryPos() != Header()->WritePos)
-        {
-            // corruption
-            // TODO: report?
-            return {};
-        }
-
-        return e.GetData();
-    }
-
     void PopFront()
     {
         auto cur = GetFrontEntry();
@@ -901,11 +876,6 @@ bool TFileRingBuffer::Free(const void* ptr)
 TStringBuf TFileRingBuffer::Front() const
 {
     return Impl->Front();
-}
-
-TStringBuf TFileRingBuffer::Back() const
-{
-    return Impl->Back();
 }
 
 void TFileRingBuffer::PopFront()

--- a/cloud/storage/core/libs/common/file_ring_buffer.h
+++ b/cloud/storage/core/libs/common/file_ring_buffer.h
@@ -63,7 +63,6 @@ public:
 
     // Free memory block previously allocated with Alloc.
     // It is possible to free memory blocks in any order.
-    // If a block is in the front of the queue, it will be removed via PopFront.
     // Otherwise, it will be marked for deletion and removed later.
     // Returns true if the pointer was correct and hasn't been freed yet.
     bool Free(const void* ptr);

--- a/cloud/storage/core/libs/common/file_ring_buffer.h
+++ b/cloud/storage/core/libs/common/file_ring_buffer.h
@@ -61,8 +61,18 @@ public:
     // and advance the write pointer.
     bool Commit();
 
+    // Free memory block previously allocated with Alloc.
+    // It is possible to free memory blocks in any order.
+    // If a block is in the front of the queue, it will be removed via PopFront.
+    // Otherwise, it will be marked for deletion and removed later.
+    // Returns true if the pointer was correct and hasn't been freed yet.
+    bool Free(const void* ptr);
+
     TStringBuf Front() const;
+
+    // Note: this method doesn't take into consideration Skip flag
     TStringBuf Back() const;
+
     void PopFront();
     ui64 Size() const;
     bool Empty() const;

--- a/cloud/storage/core/libs/common/file_ring_buffer.h
+++ b/cloud/storage/core/libs/common/file_ring_buffer.h
@@ -69,10 +69,6 @@ public:
     bool Free(const void* ptr);
 
     TStringBuf Front() const;
-
-    // Note: this method doesn't take into consideration Skip flag
-    TStringBuf Back() const;
-
     void PopFront();
     ui64 Size() const;
     bool Empty() const;

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -46,6 +46,31 @@ TString Dump(const TVector<TString>& entries)
     return sb;
 }
 
+TString Dump(TFileRingBuffer& rb)
+{
+    TVector<TString> entries;
+
+    rb.Visit([&](ui32, TStringBuf entry)
+             { entries.push_back(TString(entry)); });
+
+    return Dump(entries);
+}
+
+TStringBuf Find(TFileRingBuffer& rb, TStringBuf entry)
+{
+    TStringBuf result;
+
+    rb.Visit(
+        [&](ui32, TStringBuf e)
+        {
+            if (e == entry) {
+                result = e;
+            }
+        });
+
+    return result;
+}
+
 TString PopAll(TFileRingBuffer& rb)
 {
     TStringBuilder sb;
@@ -721,26 +746,31 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb->ValidateMetadata());
     }
 
-    Y_UNIT_TEST(ShouldBackwardSupportFileFormat)
+    Y_UNIT_TEST(ShouldBackwardSupportFileFormat_V3_to_V4)
     {
         const auto f = TTempFileHandle();
-        const ui32 len = 36;
+        const ui32 dataLen = 36;
+        const ui32 metadataLen = 8;
 
-        const TString fileDumpVer2 =
-            "AgAAAAAAAAAkAAAAAAAAAAAAAAAAAAAACwAAAAAAAAALAAAAAAAAAAMAAAARceVdQU"
-            "FBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+        const TString fileDumpVer3 =
+            "BAAAAEgAAAAkAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAAgBAAAAAAAACA"
+            "AAAAAAAAAAAQAAAAAAAAgAAAASj+ZzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAEZvcm1hdFYzCAAAABcbOq5Tb21lRGF0YQAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAA";
 
         {
-            TString decoded;
-            Base64Decode(fileDumpVer2, decoded);
-
+            TString decoded = Base64Decode(fileDumpVer3);
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.ResizeAndRemap(0, decoded.size());
             decoded.copy(reinterpret_cast<char*>(m.Ptr()), decoded.size());
         }
 
-        TFileRingBuffer rb(f.GetName(), len);
-        UNIT_ASSERT_VALUES_EQUAL("AAA", rb.Front());
+        TFileRingBuffer rb(f.GetName(), dataLen, metadataLen);
+        UNIT_ASSERT_VALUES_EQUAL("FormatV3", rb.GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL("SomeData", rb.Front());
     }
 
     Y_UNIT_TEST(ShouldResizeMetadata)
@@ -947,6 +977,70 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         auto alloc5 = rb.Alloc(2);
         UNIT_ASSERT(HasError(alloc5));
+    }
+
+    Y_UNIT_TEST(ShouldSupportRandomDeletion)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 64;
+        auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        TString data1 = "hello";
+        TString data2 = "abc";
+        TString data3 = "meow";
+        TString data4 = "ok";
+
+        auto alloc = [&](TString data)
+        {
+            auto res = rb->Alloc(data.size());
+            UNIT_ASSERT(!HasError(res));
+            data.copy(res.GetResult(), data.size());
+            UNIT_ASSERT(rb->Commit());
+            return res.GetResult();
+        };
+
+        const char* alloc1 = alloc(data1);
+        const char* alloc2 = alloc(data2);
+        const char* alloc3 = alloc(data3);
+        const char* alloc4 = alloc(data4);
+
+        UNIT_ASSERT(rb->Free(alloc2));
+        UNIT_ASSERT(!rb->Free(alloc2));
+        UNIT_ASSERT(!rb->Free(nullptr));
+
+        UNIT_ASSERT_VALUES_EQUAL("hello, meow, ok", Dump(*rb));
+        UNIT_ASSERT_VALUES_EQUAL(3, rb->Size());
+
+        // Recreate buffer - information about entry skip should be persisted
+        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        UNIT_ASSERT_VALUES_EQUAL("hello, meow, ok", Dump(*rb));
+
+        alloc3 = Find(*rb, "meow").data();
+        UNIT_ASSERT(rb->Free(alloc3));
+
+        UNIT_ASSERT_VALUES_EQUAL("hello, ok", Dump(*rb));
+        UNIT_ASSERT_VALUES_EQUAL(2, rb->Size());
+
+        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        alloc1 = Find(*rb, "hello").data();
+        alloc4 = Find(*rb, "ok").data();
+
+        UNIT_ASSERT(rb->Free(alloc1));
+
+        UNIT_ASSERT_VALUES_EQUAL("ok", Dump(*rb));
+        UNIT_ASSERT_VALUES_EQUAL(1, rb->Size());
+
+        UNIT_ASSERT(rb->Free(alloc4));
+
+        UNIT_ASSERT_VALUES_EQUAL("", Dump(*rb));
+        UNIT_ASSERT_VALUES_EQUAL(0, rb->Size());
+
+        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        UNIT_ASSERT_VALUES_EQUAL("", Dump(*rb));
+        UNIT_ASSERT_VALUES_EQUAL(0, rb->Size());
     }
 }
 

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -149,15 +149,6 @@ struct TReferenceImplementation
         return Q.front();
     }
 
-    TStringBuf Back() const
-    {
-        if (!Q) {
-            return {};
-        }
-
-        return Q.back();
-    }
-
     void PopFront()
     {
         if (!Q) {
@@ -199,6 +190,18 @@ struct TReferenceImplementation
     }
 };
 
+TString Dump(const TReferenceImplementation& ri)
+{
+    TStringBuilder sb;
+    for (const auto& entry: ri.Q) {
+        if (!sb.empty()) {
+            sb << ", ";
+        }
+        sb << entry;
+    }
+    return sb;
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -224,14 +227,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(!rb.PushBack(""));              // empty
 
         UNIT_ASSERT(rb.PushBack("vasya"));
-        UNIT_ASSERT_VALUES_EQUAL("vasya", rb.Back());
-
         UNIT_ASSERT(rb.PushBack("petya"));
-        UNIT_ASSERT_VALUES_EQUAL("petya", rb.Back());
-
         UNIT_ASSERT(rb.PushBack("vasya2"));
-        UNIT_ASSERT_VALUES_EQUAL("vasya2", rb.Back());
-
         UNIT_ASSERT(rb.PushBack("petya2"));
         UNIT_ASSERT(!rb.PushBack("vasya3"));        // out of space
 
@@ -403,7 +400,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
                                         "GetMaxAllocationBytesCount "
                                      << maxAllocationSize
                                      << " for a successful PushBack");
-                    UNIT_ASSERT_VALUES_EQUAL(ri.Back(), rb->Back());
+                    UNIT_ASSERT_VALUES_EQUAL(Dump(ri), Dump(*rb));
                     remainingBytes -= entrySize;
                     // Cerr << "PUSH\t" << data << Endl;
                 } else {
@@ -416,8 +413,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
                                      << " for a unsuccessful PushBack");
                 }
             } else {
-                UNIT_ASSERT_VALUES_EQUAL(ri.Back(), rb->Back());
-                UNIT_ASSERT_VALUES_EQUAL(ri.Front(), rb->Front());
+                UNIT_ASSERT_VALUES_EQUAL(Dump(ri), Dump(*rb));
                 // Cerr << "POP\t" << ri.Front() << Endl;
                 ri.PopFront();
                 rb->PopFront();

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -953,8 +953,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         TFileRingBuffer rb(f.GetName(), len);
 
         auto alloc1 = rb.Alloc(128);
-        UNIT_ASSERT(!HasError(alloc1));
-        UNIT_ASSERT(alloc1.GetResult() == nullptr);
+        UNIT_ASSERT(HasError(alloc1));
 
         auto alloc2 = rb.Alloc(0);
         UNIT_ASSERT(HasError(alloc2));


### PR DESCRIPTION
### Notes

`TFileRingBuffer` supports entry removal only from head of the ring buffer but `TWriteBackCache` needs to be able to randomly allocate and free memory.

Previously, this was managed at `TWriteBackCache` side — it stored deleted entries but its actial deletion occured when they become front entries.

The problem was that information about deleted entries was not persisted — after nfs-vhost restart deleted entries could be resurrected and flushed again. This didn't break data consistency but handles associated with the resurrected requests could be destroyed and the cache could become stuck (infinite `E_FS_BADHANDLE` at flush).

In this PR, the logic is moved from `TWriteBackCache` to `TFileRingBuffer` and deletion flag is persisted.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
