### PR TITLE
[Filestore] Simplify deletion flow for unconfirmed data

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -20,9 +20,9 @@ bool TIndexTabletActor::PrepareTx_AddDataUnconfirmed(
     Y_UNUSED(ctx);
 
     if (!UnconfirmedDataInProgress.contains(args.CommitId)) {
-        ReportUnconfirmedDataNotInProgress(TStringBuilder()
-            << "tabletId: " << TabletID()
-            << ", commitId: " << args.CommitId);
+        ReportUnconfirmedDataNotInProgress(
+            TStringBuilder()
+            << "tabletId: " << TabletID() << ", commitId: " << args.CommitId);
         args.Error = MakeError(E_FAIL, "Unconfirmed data not in progress");
         LOG_ERROR(
             ctx,
@@ -79,10 +79,16 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
     const TActorContext& ctx,
     TTxIndexTablet::TAddDataUnconfirmed& args)
 {
-    ui64 requestBytes = UnconfirmedDataInProgress[args.CommitId].Data.GetLength();
+    auto inProgressIt = UnconfirmedDataInProgress.find(args.CommitId);
+    TABLET_VERIFY(inProgressIt != UnconfirmedDataInProgress.end());
+
+    const ui64 requestBytes = inProgressIt->second.Data.GetLength();
+    const bool deletionInProgress = DeletionQueue.contains(args.CommitId);
 
     Y_DEFER
     {
+        UnconfirmedDataInProgress.erase(inProgressIt);
+
         FinalizeProfileLogRequestInfo(
             std::move(args.ProfileLogRequest),
             ctx.Now(),
@@ -98,8 +104,6 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
         }
     };
 
-    const bool deleteOnTxComplete = DeletionQueue.contains(args.CommitId);
-
     if (HasError(args.Error)) {
         LOG_WARN(
             ctx,
@@ -109,29 +113,11 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
             args.CommitId,
             FormatError(args.Error).c_str());
 
-        DeletionQueue.erase(args.CommitId);
-
-        TABLET_VERIFY(TryReleaseCollectBarrier(args.CommitId));
-    } else {
-        auto inProgressIt = UnconfirmedDataInProgress.find(args.CommitId);
-        TABLET_VERIFY(inProgressIt != UnconfirmedDataInProgress.end());
-        UnconfirmedData.emplace(
-            args.CommitId,
-            std::move(inProgressIt->second));
-        UnconfirmedDataInProgress.erase(inProgressIt);
-
-        if (deleteOnTxComplete) {
-            // Ordering is critical here. Once AddDataUnconfirmed moved the
-            // entry into UnconfirmedData, a cancelled commitId must execute
-            // DeleteUnconfirmedData before any AddBlob. The delete tx itself
-            // must remain page-fault-free, otherwise we can reorder TXes and
-            // crash and that will lead to data corruption.
-            ExecuteTx<TDeleteUnconfirmedData>(
-                ctx,
-                CreateRequestInfo(SelfId(), 0, MakeIntrusive<TCallContext>()),
-                TVector<ui64>{args.CommitId});
+        if (!deletionInProgress) {
+            TABLET_VERIFY(TryReleaseCollectBarrier(args.CommitId));
+            SendPendingConfirmAddDataResponse(ctx, args.CommitId, args.Error);
         }
-
+    } else {
         LOG_TRACE(
             ctx,
             TFileStoreComponents::TABLET,
@@ -139,23 +125,21 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
             LogTag.c_str(),
             args.CommitId,
             args.NodeId);
-    }
 
-    // Check if ConfirmAddData was received while we were executing.
-    auto pendingIt = PendingConfirmation.find(args.CommitId);
-    if (pendingIt != PendingConfirmation.end()) {
-        if (!HasError(args.Error)) {
-            if (deleteOnTxComplete) {
-                // Keep deferred reply until DeleteUnconfirmedData completion.
-                return;
+        // Keep deferred reply until DeleteUnconfirmedData completion if
+        // deletion in progress
+        if (!deletionInProgress) {
+            UnconfirmedData.emplace(
+                args.CommitId,
+                std::move(inProgressIt->second));
+
+            // Check if ConfirmAddData was received while we were executing.
+            auto pendingIt = PendingConfirmation.find(args.CommitId);
+            if (pendingIt != PendingConfirmation.end()) {
+                // AddBlob Execute will send the deferred ConfirmAddData reply.
+                ConfirmData(args.CommitId, ctx);
             }
-
-            // AddBlob Execute will send the deferred ConfirmAddData reply.
-            ConfirmData(args.CommitId, ctx);
-            return;
         }
-
-        SendPendingConfirmAddDataResponse(ctx, args.CommitId, args.Error);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -113,9 +113,9 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
             args.CommitId,
             FormatError(args.Error).c_str());
 
+        SendPendingConfirmAddDataResponse(ctx, args.CommitId, args.Error);
         if (!deletionInProgress) {
             TABLET_VERIFY(TryReleaseCollectBarrier(args.CommitId));
-            SendPendingConfirmAddDataResponse(ctx, args.CommitId, args.Error);
         }
     } else {
         LOG_TRACE(
@@ -126,8 +126,9 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
             args.CommitId,
             args.NodeId);
 
-        // Keep deferred reply until DeleteUnconfirmedData completion if
-        // deletion in progress
+        // If deletion in progress, do nothing. Deferred reply will be triggered
+        // in DeleteUnconfirmedData completion. At this point we could already
+        // pass ExecuteTx for DeleteUnconfirmed.
         if (!deletionInProgress) {
             UnconfirmedData.emplace(
                 args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -60,7 +60,9 @@ void TIndexTabletActor::SendPendingConfirmAddDataResponse(
     auto pending = std::move(pendingIt->second);
     PendingConfirmation.erase(pendingIt);
 
-    Metrics.ConfirmAddData.Update(1, 0, ctx.Now() - pending.DeferredTs);
+    if (!HasError(error)) {
+        Metrics.ConfirmAddData.Update(1, 0, ctx.Now() - pending.DeferredTs);
+    }
 
     SendDeferredConfirmAddDataResponse(ctx, std::move(pending), error);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -73,8 +73,7 @@ void TIndexTabletActor::UnconfirmedAddBlobSafePointReached(
     if (commitId == InvalidCommitId) {
         ReportInvalidCommitIdInUnconfirmedAddBlobSafePoint(
             TStringBuilder()
-                << "tabletId: " << TabletID()
-                << ", commitId: " << commitId);
+            << "tabletId: " << TabletID() << ", commitId: " << commitId);
         return;
     }
 
@@ -391,31 +390,27 @@ void TIndexTabletActor::DeleteUnconfirmedDataForSession(
     const TString& sessionId,
     const TActorContext& ctx)
 {
-    TVector<ui64> commitIdsToDeleteNow;
-    ui64 commitIdsToDeleteOnTx = 0;
+    TVector<ui64> commitIdsToDelete;
 
-    for (const auto& [commitId, trackedData]: UnconfirmedData) {
-        if (trackedData.SessionId != sessionId) {
-            continue;
+    auto enqueueCommitIdsToDelete = [&](const auto& data)
+    {
+        for (const auto& [commitId, trackedData]: data) {
+            if (trackedData.SessionId != sessionId) {
+                continue;
+            }
+
+            if (!DeletionQueue.emplace(commitId).second) {
+                continue;
+            }
+
+            commitIdsToDelete.push_back(commitId);
         }
+    };
 
-        if (!DeletionQueue.emplace(commitId).second) {
-            continue;
-        }
-        commitIdsToDeleteNow.push_back(commitId);
-    }
+    enqueueCommitIdsToDelete(UnconfirmedData);
+    enqueueCommitIdsToDelete(UnconfirmedDataInProgress);
 
-    for (const auto& [commitId, inProgressData]: UnconfirmedDataInProgress) {
-        if (inProgressData.SessionId != sessionId) {
-            continue;
-        }
-
-        if (DeletionQueue.emplace(commitId).second) {
-            ++commitIdsToDeleteOnTx;
-        }
-    }
-
-    if (!commitIdsToDeleteNow.empty()) {
+    if (!commitIdsToDelete.empty()) {
         // Session cleanup has the same ordering requirement as CancelAddData:
         // once commitIds are placed into DeletionQueue, DeleteUnconfirmedData
         // must be executed before any later AddBlob execute. For that reason it
@@ -426,19 +421,16 @@ void TIndexTabletActor::DeleteUnconfirmedDataForSession(
                 SelfId(),
                 0 /* cookie */,
                 MakeIntrusive<TCallContext>()),
-            std::move(commitIdsToDeleteNow));
-    }
+            std::move(commitIdsToDelete));
 
-    if (!commitIdsToDeleteNow.empty() || commitIdsToDeleteOnTx) {
         LOG_INFO(
             ctx,
             TFileStoreComponents::TABLET,
             "%s Deleting unconfirmed data: sessionId=%s, "
-            "deleteNow=%zu, deleteOnTx=%lu",
+            "deleteNow=%zu",
             LogTag.c_str(),
             sessionId.Quote().c_str(),
-            commitIdsToDeleteNow.size(),
-            commitIdsToDeleteOnTx);
+            commitIdsToDelete.size());
     }
 }
 
@@ -469,7 +461,7 @@ void TIndexTabletActor::ExecuteTx_DeleteUnconfirmedData(
     for (ui64 commitId: args.CommitIds) {
         db.DeleteUnconfirmedData(commitId);
         UnconfirmedData.erase(commitId);
-        TryReleaseCollectBarrier(commitId);
+        TABLET_VERIFY(TryReleaseCollectBarrier(commitId));
     }
 
     LOG_DEBUG(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -411,6 +411,15 @@ void TIndexTabletActor::DeleteUnconfirmedDataForSession(
     enqueueCommitIdsToDelete(UnconfirmedDataInProgress);
 
     if (!commitIdsToDelete.empty()) {
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s Deleting unconfirmed data: sessionId=%s, "
+            "deleteNow=%zu",
+            LogTag.c_str(),
+            sessionId.Quote().c_str(),
+            commitIdsToDelete.size());
+
         // Session cleanup has the same ordering requirement as CancelAddData:
         // once commitIds are placed into DeletionQueue, DeleteUnconfirmedData
         // must be executed before any later AddBlob execute. For that reason it
@@ -422,15 +431,6 @@ void TIndexTabletActor::DeleteUnconfirmedDataForSession(
                 0 /* cookie */,
                 MakeIntrusive<TCallContext>()),
             std::move(commitIdsToDelete));
-
-        LOG_INFO(
-            ctx,
-            TFileStoreComponents::TABLET,
-            "%s Deleting unconfirmed data: sessionId=%s, "
-            "deleteNow=%zu",
-            LogTag.c_str(),
-            sessionId.Quote().c_str(),
-            commitIdsToDelete.size());
     }
 }
 
@@ -478,18 +478,9 @@ void TIndexTabletActor::CompleteTx_DeleteUnconfirmedData(
 {
     for (ui64 commitId: args.CommitIds) {
         DeletionQueue.erase(commitId);
-
-        auto pendingIt = PendingConfirmation.find(commitId);
-        if (pendingIt == PendingConfirmation.end()) {
-            continue;
-        }
-
-        auto pending = std::move(pendingIt->second);
-        PendingConfirmation.erase(pendingIt);
-
-        SendDeferredConfirmAddDataResponse(
+        SendPendingConfirmAddDataResponse(
             ctx,
-            std::move(pending),
+            commitId,
             ErrorUnconfirmedDataDeleted());
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
@@ -312,6 +312,10 @@ void TIndexTabletActor::HandleConfirmBlobsCompleted(
             std::move(unrecoverableCommitIds));
     }
 
+    if (recoverableCommitIds.empty()) {
+        return BlobsConfirmed(ctx);
+    }
+
     // Recovery must replay confirmations in commitId order to preserve write
     // order for overlapping ranges.
     Sort(recoverableCommitIds);
@@ -321,8 +325,6 @@ void TIndexTabletActor::HandleConfirmBlobsCompleted(
         // imeadeately
         ConfirmData(commitId, ctx);
     }
-
-    BlobsConfirmed(ctx);
 }
 
 void TIndexTabletActor::BlobsConfirmed(const TActorContext& ctx)

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1,6 +1,7 @@
 #include "tablet_schema.h"
 #include "tablet_tx.h"
 
+#include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
@@ -504,6 +505,217 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         tablet.AssertConfirmAddDataResponse(S_OK);
 
         AssertStorageStats(tablet, 0, 0);
+    }
+
+    Y_UNIT_TEST(ShouldReplyToPendingConfirmOnAddDataUnconfirmedValidationError)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto& runtime = env.GetRuntime();
+        TAutoPtr<IEventHandle> blockedRwPut;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvPut: {
+                        if (!blockedRwPut) {
+                            blockedRwPut = event.Release();
+                            return true;
+                        }
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        tablet.SendSetNodeAttrRequest(TSetNodeAttrArgs(RootNodeId).SetUid(1));
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]() { return !!blockedRwPut; }},
+            TDuration::Seconds(1));
+
+        tablet.AssertSetNodeAttrNoResponse();
+
+        tablet.SendRequest(tablet.CreateUpdateConfigRequest(
+            TFileSystemConfig{.BlockCount = 1}));
+
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, 2 * block);
+        const ui64 commitId = gbi->Record.GetCommitId();
+
+        tablet.SendConfirmAddDataRequest(commitId);
+
+        tablet.AssertConfirmAddDataNoResponse();
+
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        runtime.Send(blockedRwPut.Release(), nodeIdx);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        auto setNodeAttrResponse = tablet.RecvSetNodeAttrResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, setNodeAttrResponse->GetStatus());
+
+        auto updateConfigResponse =
+            tablet
+                .RecvResponse<NKikimr::TEvFileStore::TEvUpdateConfigResponse>();
+        UNIT_ASSERT_C(
+            updateConfigResponse->Record.GetStatus() == NKikimrFileStore::OK,
+            updateConfigResponse->Record.ShortDebugString());
+
+        auto response =
+            tablet.AssertConfirmAddDataResponse(ErrorNoSpaceLeft().GetCode());
+        UNIT_ASSERT_C(
+            response->GetErrorReason().find("no space left") != TString::npos,
+            response->GetErrorReason());
+
+        AssertStorageStats(tablet, 0, 0);
+    }
+
+    Y_UNIT_TEST(
+        ShouldReplyToPendingConfirmOnAddDataUnconfirmedValidationErrorAfterCancel)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto& runtime = env.GetRuntime();
+        TAutoPtr<IEventHandle> blockedRwPut;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvPut: {
+                        if (!blockedRwPut) {
+                            blockedRwPut = event.Release();
+                            return true;
+                        }
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        tablet.SendSetNodeAttrRequest(TSetNodeAttrArgs(RootNodeId).SetUid(1));
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]() { return !!blockedRwPut; }},
+            TDuration::Seconds(1));
+
+        tablet.AssertSetNodeAttrNoResponse();
+
+        tablet.SendRequest(tablet.CreateUpdateConfigRequest(
+            TFileSystemConfig{.BlockCount = 1}));
+
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, 2 * block);
+        const ui64 commitId = gbi->Record.GetCommitId();
+
+        tablet.SendCancelAddDataRequest(commitId);
+        tablet.AssertCancelAddDataResponse(S_OK);
+
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        runtime.Send(blockedRwPut.Release(), nodeIdx);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        auto setNodeAttrResponse = tablet.RecvSetNodeAttrResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, setNodeAttrResponse->GetStatus());
+
+        auto updateConfigResponse =
+            tablet
+                .RecvResponse<NKikimr::TEvFileStore::TEvUpdateConfigResponse>();
+        UNIT_ASSERT_C(
+            updateConfigResponse->Record.GetStatus() == NKikimrFileStore::OK,
+            updateConfigResponse->Record.ShortDebugString());
+
+        AssertStorageStats(tablet, 0, 0);
+    }
+
+    Y_UNIT_TEST(ShouldReleaseCollectBarrierOnAddDataUnconfirmedValidationError)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            TFileSystemConfig{.BlockCount = 1});
+        tablet.InitSession("client", "session");
+
+        UNIT_ASSERT_EQUAL(
+            tablet.GetStorageStats()
+                ->Record.GetStats()
+                .GetLastCollectCommitId(),
+            0);
+
+        auto id =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "overflow"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        const ui64 commitId = tablet.GenerateBlobIds(id, handle, 0, 2 * block)
+                                  ->Record.GetCommitId();
+        WaitForTabletCommit(env);
+
+        AssertStorageStats(tablet, 0, 0);
+
+        auto moveBarrier = [&]
+        {
+            auto node =
+                CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "gc"));
+            ui64 handle = CreateHandle(tablet, node);
+            tablet.WriteData(handle, 0, block, 'a');
+            tablet.Flush();
+            tablet.DestroyHandle(handle);
+            tablet.UnlinkNode(RootNodeId, "gc", false);
+            tablet.CollectGarbage();
+        };
+
+        moveBarrier();
+
+        UNIT_ASSERT_GT(
+            tablet.GetStorageStats()
+                ->Record.GetStats()
+                .GetLastCollectCommitId(),
+            commitId);
     }
 
     Y_UNIT_TEST(ShouldRejectConfirmAddDataForUnknownCommit)


### PR DESCRIPTION


### Notes
Simplified deletion flow for unconfirmed data to avoid barrier management in different places and double deletion
During load phase made UnconfirmedReady flag more tight
Unified deletion flow for CancelUnconfirmedData and SessiondRecovery/Deletion trigger
Added some tests, that cover error flows when executeTx get stuck from multiple TXes
Simplified some code in AddUnconfirmedDataTx
In case of error and pending Confirmed request, made reply earlier.
Tested manually some cases, as not all scenarios can be emulated with current test machinery

### Issue
2293
