### PR TITLE
issue-5590: Don't read block masks only if mixed blob fully available for compaction

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1083,15 +1083,18 @@ private:
     TTxPartition::TRangeCompaction& Args;
     const ui64 MaxCommitId;
     const TCompactionMap& CompactionMap;
+    const ui64 TabletId;
 
 public:
     TCompactionBlockVisitor(
             TTxPartition::TRangeCompaction& args,
             ui64 maxCommitId,
-            const TCompactionMap& compactionMap)
+            const TCompactionMap& compactionMap,
+            ui64 tabletId)
         : Args(args)
         , MaxCommitId(maxCommitId)
         , CompactionMap(compactionMap)
+        , TabletId(tabletId)
     {}
 
     bool Visit(const TFreshBlock& block) override
@@ -1131,11 +1134,27 @@ public:
         ui16 blobOffset,
         ui8 compactionRangeCount) override
     {
+        auto& ab = Args.AffectedBlobs[blobId];
+
+        ab.MaxCommitIdInCompactionRange =
+            std::max(commitId, ab.MaxCommitIdInCompactionRange);
+        ab.MinCommitIdInCompactionRange =
+            std::min(commitId, ab.MinCommitIdInCompactionRange);
+
         if (commitId > MaxCommitId) {
             return true;
         }
 
-        auto& ab = Args.AffectedBlobs[blobId];
+        STORAGE_VERIFY_C(
+            ab.CompactionRangeCount == 0 ||
+                ab.CompactionRangeCount == compactionRangeCount,
+            TWellKnownEntityTypes::TABLET,
+            TabletId,
+            TStringBuilder()
+                << "Compaction range count mismatch, BlobId: " << blobId
+                << ", expected: " << ab.CompactionRangeCount
+                << ", actual: " << compactionRangeCount);
+
         ab.CompactionRangeCount = compactionRangeCount;
 
         Args.MarkBlock(
@@ -1150,9 +1169,27 @@ public:
     bool Visit(TBlockRange32 blockRange, const TPartialBlobId& blobId) override
     {
         auto& ab = Args.AffectedBlobs[blobId];
-        ab.CompactionRangeCount = CompactionMap.GetRangeIndex(blockRange.End) -
+        ab.MaxCommitIdInCompactionRange = blobId.CommitId();
+        ab.MinCommitIdInCompactionRange = blobId.CommitId();
+        ab.CompactionRangeCount =
+            CompactionMap.GetRangeIndex(blockRange.End) -
             CompactionMap.GetRangeIndex(blockRange.Start) + 1;
         return true;
+    }
+
+    void Finish()
+    {
+        TVector<TPartialBlobId> blobIdsToDelete;
+
+        for (const auto& [blobId, ab]: Args.AffectedBlobs) {
+            if (ab.MinCommitIdInCompactionRange > MaxCommitId) {
+                blobIdsToDelete.push_back(blobId);
+            }
+        }
+
+        for (const auto& blobId: blobIdsToDelete) {
+            Args.AffectedBlobs.erase(blobId);
+        }
     }
 };
 
@@ -1816,7 +1853,11 @@ void PrepareRangeCompaction(
     TTxPartition::TRangeCompaction& args,
     const TString& logTitle)
 {
-    TCompactionBlockVisitor visitor(args, commitId, state.GetCompactionMap());
+    TCompactionBlockVisitor visitor(
+        args,
+        commitId,
+        state.GetCompactionMap(),
+        tabletId);
     state.FindFreshBlocks(visitor, args.BlockRange, commitId);
     visitor.KeepTrackOfAffectedBlocks = true;
     ready &= state.FindMixedBlocksForCompaction(db, visitor, args.RangeIdx);
@@ -1828,6 +1869,8 @@ void PrepareRangeCompaction(
         true,   // precharge
         state.GetMaxBlocksInBlob(),
         commitId);
+
+    visitor.Finish();
 
     if (ready && maxSkippedBlobs > 0) {
         THashMap<TPartialBlobId, ui32, TPartialBlobIdHash> liveBlocks;
@@ -1931,7 +1974,11 @@ void PrepareRangeCompaction(
         const bool blobOnlyInOneCompactRange =
             kv.second.CompactionRangeCount == 1;
 
-        if (!blobOnlyInOneCompactRange ||
+        const bool blobFullyAvailableForRangeCompaction =
+            kv.second.MaxCommitIdInCompactionRange <= commitId &&
+            blobOnlyInOneCompactRange;
+
+        if (!blobFullyAvailableForRangeCompaction ||
             !readBlockMaskOnCompactionOptimizationEnabled)
         {
             state.IncrementBlockMaskReadDuringCompaction();

--- a/cloud/blockstore/libs/storage/partition/part_events_private.h
+++ b/cloud/blockstore/libs/storage/partition/part_events_private.h
@@ -125,6 +125,8 @@ struct TWriteFreshBlocksRequest
 struct TAffectedBlob
 {
     ui8 CompactionRangeCount = 0;
+    ui64 MaxCommitIdInCompactionRange = 0;
+    ui64 MinCommitIdInCompactionRange = Max<ui64>();
     TVector<ui16> Offsets;
     TMaybe<TBlockMask> BlockMask;
     TVector<ui32> AffectedBlockIndices;

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -13762,6 +13762,77 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
         }
     }
+
+    Y_UNIT_TEST(
+        ShouldNotDeleteBlobsThatAreNotFullyAvailableForCompactionWithoutReadingBlockMasks)
+    {
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 'A');
+
+        partition.WriteBlocks(0, '0');
+
+        std::unique_ptr<IEventHandle> writeBlobRequest;
+
+        bool interceptWriteBlobRequest = true;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvWriteBlobRequest &&
+                    interceptWriteBlobRequest)
+                {
+                    writeBlobRequest.reset(event.Release());
+
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendWriteBlocksRequest(1, '1');
+
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(writeBlobRequest);
+        interceptWriteBlobRequest = false;
+
+        partition.SendCompactionRequest();
+
+        runtime->DispatchEvents({}, 10ms);
+
+        partition.WriteBlocks(2, '2');
+
+        partition.Flush();
+        partition.TrimFreshLog();
+
+        runtime->SendAsync(writeBlobRequest.release());
+
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(response->GetStatus(), S_OK);
+
+        partition.Cleanup();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('0'),
+            GetBlockContent(partition.ReadBlocks(0)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1'),
+            GetBlockContent(partition.ReadBlocks(1)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('2'),
+            GetBlockContent(partition.ReadBlocks(2)));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -117,6 +117,13 @@ def storage_config_with_fresh_blocks_writer_enabled(enabled):
     return storage
 
 
+def storage_config_with_read_block_mask_on_compaction_optimization_enabled(enabled):
+    storage = default_storage_config()
+    storage.ReadBlockMaskOnCompactionOptimizationEnabled = enabled
+
+    return storage
+
+
 def storage_config_with_mixed_index_cache_enabled():
     storage = default_storage_config()
     storage.MixedIndexCacheV1Enabled = True
@@ -296,6 +303,19 @@ TESTS = [
             ordinary_prod_storage_config(),
             storage_config_with_compaction_merged_blob_threshold_hdd(),
             ordinary_prod_storage_config(),
+        ],
+        None,
+    ),
+    TestCase(
+        "version1-read-block-mask-on-compaction-optimization-enabled",
+        "cloud/blockstore/tests/loadtest/local-newfeatures/local-tablet-version-1-multiple-ranges.txt",
+        [
+            storage_config_with_read_block_mask_on_compaction_optimization_enabled(
+                False
+            ),
+            storage_config_with_read_block_mask_on_compaction_optimization_enabled(
+                True
+            ),
         ],
         None,
     ),


### PR DESCRIPTION
### Notes
Now such situation is possible:

1. WriteBlock Started commitId == 1 blockIndex == 0 content == '0'
2. WriteBlock Ended commitId == 1 blockIndex == 0 content == '0'
3. WriteBlock Started commitId == 2 blockIndex == 1 content == '1'
4. Received Compaction Request commitId == 3
5. WriteBlock Started commitId == 4 blockIndex == 2 content == '2'
6. WriteBlock Ended commitId == 4 blockIndex == 2 content == '2'
7. Flushed blobs from 1-2 and 5-6 points with blob-id-1
8. WriteBlock Ended commitId == 2 blockIndex == 1 content == '1'

Compaction will ignore writes with commitId == 4, but it will mark the blob containing this write for cleanup and lose data.

In this pr i added ignoring optimization for blobs that are not fully available for compaction.

### Issue
#5590