### PR TITLE
filestore: implemented CollectGarbageThresholdForBackpressure

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -759,4 +759,7 @@ message TStorageConfig
 
     // Use ListNodesInternal API for internal ListNodes calls.
     optional bool UseListNodesInternal = 494;
+
+    // Thresholds which enable backpressure - part 2.
+    optional uint64 CollectGarbageThresholdForBackpressure = 495;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -97,6 +97,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(CompactionThresholdForBackpressure, ui32,      200                    )\
     xxx(FlushBytesThresholdForBackpressure, ui64,      128_MB                 )\
     xxx(FlushBytesItemCountThresholdForBackpressure,   ui64,    500'000       )\
+    xxx(CollectGarbageThresholdForBackpressure,        ui64,    1_TB          )\
     xxx(BackpressureThresholdPercentageForBackgroundOpsPriority,  ui32,   90  )\
                                                                                \
     xxx(HDDSystemChannelPoolKind,      TString,   "rot"                       )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -110,6 +110,7 @@ public:
     ui32 GetCompactionThresholdForBackpressure() const;
     ui64 GetFlushBytesThresholdForBackpressure() const;
     ui64 GetFlushBytesItemCountThresholdForBackpressure() const;
+    ui64 GetCollectGarbageThresholdForBackpressure() const;
     ui32 GetBackpressureThresholdPercentageForBackgroundOpsPriority() const;
 
     TString GetHDDSystemChannelPoolKind() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -308,18 +308,24 @@ TThresholds TIndexTabletActor::BuildBackpressureThresholds() const
         .CompactionScore = ScaleCompactionThreshold(
             Config->GetCompactionThresholdForBackpressure()),
         .CleanupScore = Config->GetCleanupThresholdForBackpressure(),
+        .CollectGarbage = Config->GetCollectGarbageThresholdForBackpressure(),
     };
 }
 
 TIndexTabletState::TBackpressureValues
 TIndexTabletActor::GetBackpressureValues() const
 {
+    // explicitly checking this because CollectGarbageThresholdForBackpressure
+    // can be really big
+    static_assert(sizeof(GetGarbageQueueSize()) == sizeof(ui64));
+
     return {
         .Flush = GetFreshBlocksCount() * GetBlockSize(),
         .FlushBytes = GetFreshBytesCount(),
         .FlushBytesItemCount = GetFreshBytesItemCount(),
         .CompactionScore = GetRangeToCompact().Score,
         .CleanupScore = GetRangeToCleanup().Score,
+        .CollectGarbage = GetGarbageQueueSize(),
     };
 }
 
@@ -701,6 +707,9 @@ TBackgroundOpsBackpressureStatus
         .Cleanup = GetBackgroundOpBackpressureStatus(
             bpThresholds.CleanupScore,
             bpValues.CleanupScore),
+        .CollectGarbage = GetBackgroundOpBackpressureStatus(
+            bpThresholds.CollectGarbage,
+            bpValues.CollectGarbage),
     };
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -377,6 +377,12 @@ void TIndexTabletActor::UpdateMetrics(
     Store(
         Metrics.CleanupBackpressureThreshold,
         backpressureThresholds.CleanupScore);
+    Store(
+        Metrics.CollectGarbageBackpressureValue,
+        backpressureValues.CollectGarbage);
+    Store(
+        Metrics.CollectGarbageBackpressureThreshold,
+        backpressureThresholds.CollectGarbage);
 
     Store(Metrics.MaxReadIops, performanceProfile.GetMaxReadIops());
     Store(Metrics.MaxWriteIops, performanceProfile.GetMaxWriteIops());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1194,6 +1194,7 @@ void TIndexTabletActor::HandleHttpInfo_Default(
             DUMP_BACKPRESSURE_FIELD(FlushBytesItemCount);
             DUMP_BACKPRESSURE_FIELD(CompactionScore);
             DUMP_BACKPRESSURE_FIELD(CleanupScore);
+            DUMP_BACKPRESSURE_FIELD(CollectGarbage);
 
 #undef DUMP_BACKPRESSURE_FIELD
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -272,6 +272,10 @@ void TTabletMetrics::Register(
     REGISTER_LOCAL(CompactionBackpressureThreshold, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(CleanupBackpressureValue, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(CleanupBackpressureThreshold, EMetricType::MT_ABSOLUTE);
+    REGISTER_LOCAL(CollectGarbageBackpressureValue, EMetricType::MT_ABSOLUTE);
+    REGISTER_LOCAL(
+        CollectGarbageBackpressureThreshold,
+        EMetricType::MT_ABSOLUTE);
 
     REGISTER_AGGREGATABLE_SUM(IdleTime, EMetricType::MT_DERIVATIVE);
     REGISTER_AGGREGATABLE_SUM(BusyTime, EMetricType::MT_DERIVATIVE);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -212,6 +212,8 @@ struct TTabletMetrics
     std::atomic<i64> CompactionBackpressureThreshold{0};
     std::atomic<i64> CleanupBackpressureValue{0};
     std::atomic<i64> CleanupBackpressureThreshold{0};
+    std::atomic<i64> CollectGarbageBackpressureValue{0};
+    std::atomic<i64> CollectGarbageBackpressureThreshold{0};
 
     // Throttling
     std::atomic<i64> MaxReadBandwidth{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -186,6 +186,7 @@ struct TBackgroundOpsBackpressureStatus
     const EBackgroundOpBackpressureStatus FlushBytesItemCount;
     const EBackgroundOpBackpressureStatus Compaction;
     const EBackgroundOpBackpressureStatus Cleanup;
+    const EBackgroundOpBackpressureStatus CollectGarbage;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -964,6 +965,7 @@ public:
         const ui64 FlushBytesItemCount;
         const ui64 CompactionScore;
         const ui64 CleanupScore;
+        const ui64 CollectGarbage;
     };
 
     using TBackpressureValues = TBackpressureThresholds;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -312,6 +312,12 @@ bool TIndexTabletState::IsWriteAllowed(
         return false;
     }
 
+    if (values.CollectGarbage >= thresholds.CollectGarbage) {
+        *message =
+            TStringBuilder() << "collectGarbage: " << values.CollectGarbage;
+        return false;
+    }
+
     return true;
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2598,14 +2598,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCompactionThreshold(999'999);
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetFlushBytesThreshold(1_GB);
+        storageConfig.SetCollectGarbageThreshold(1_GB);
         storageConfig.SetFlushThresholdForBackpressure(2 * block);
         storageConfig.SetCompactionThresholdForBackpressure(
             8 * DefaultBlockSize / block);
         storageConfig.SetCleanupThresholdForBackpressure(20);
         storageConfig.SetFlushBytesThresholdForBackpressure(block / 2);
         storageConfig.SetFlushBytesItemCountThresholdForBackpressure(10);
+        storageConfig.SetCollectGarbageThresholdForBackpressure(64 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env({}, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2710,6 +2712,23 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             });
         };
 
+        auto checkCollectGarbageBackpressureValues =
+            [&](i64 value, i64 threshold)
+        {
+            TTestRegistryVisitor visitor;
+            tablet.SendRequest(tablet.CreateUpdateCounters());
+            env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+            env.GetRegistry()->Visit(TInstant::Zero(), visitor);
+            visitor.ValidateExpectedCounters({
+                {{{"sensor", "CollectGarbageBackpressureValue"},
+                  {"filesystem", "test"}},
+                 value},
+                {{{"sensor", "CollectGarbageBackpressureThreshold"},
+                  {"filesystem", "test"}},
+                 threshold},
+            });
+        };
+
         checkIsWriteAllowed(true);
         checkFlushBackpressureValues(0, 2 * block);
 
@@ -2751,6 +2770,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         ui32 rangeId = GetMixedRangeIndex(id, 0);
         tablet.Compaction(rangeId);
+        tablet.CollectGarbage();
 
         // no backpressure after Compaction
         tablet.WriteData(handle, 0, 2 * block, '0'); // 2 blobs, 1 fresh block, 19 markers
@@ -2758,6 +2778,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.WriteData(handle, 0, block, '0'); // 2 blobs, 2 fresh blocks, 20 markers
         tablet.Flush(); // 3 blobs, 10 markers
         tablet.Compaction(rangeId); // 1 blob, 10 markers
+        tablet.CollectGarbage();
 
         // backpressure due to CleanupScoreThresholdForBackpressure
         tablet.SendWriteDataRequest(handle, 0, block, '0');
@@ -2769,6 +2790,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
 
         tablet.Cleanup(rangeId); // 1 blob
+        tablet.CollectGarbage();
 
         // no backpressure after Cleanup
         tablet.WriteData(handle, 0, block / 4, '0'); // 1 blob, block / 4 fresh bytes
@@ -2784,6 +2806,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
 
         tablet.FlushBytes(); // 2 blobs
+        tablet.CollectGarbage();
 
         for (ui32 i = 0; i < 10; i++) {
             tablet.WriteData(handle, i * 2, 1, '0');
@@ -2799,6 +2822,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
 
         tablet.FlushBytes();
+        tablet.CollectGarbage();
 
         // no backpressure after FlushBytes
         tablet.WriteData(handle, 0, block / 4, '0'); // 2 blobs, block / 4 fresh bytes
@@ -2812,6 +2836,32 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             const auto& buffer = response->Record.GetBuffer();
             UNIT_ASSERT_VALUES_EQUAL(expected, buffer);
         }
+
+        tablet.Cleanup(rangeId); // cleaning up our index
+        tablet.CollectGarbage(); // and flushing our garbage queue
+        const ui64 requestSize =
+            storageConfig.GetCollectGarbageThresholdForBackpressure();
+        tablet.WriteData(handle, 0, requestSize, '0'); // large blob
+        tablet.Cleanup(rangeId); // preventing Cleanup backpressure
+
+        // backpressure due to CollectGarbageThresholdForBackpressure
+        tablet.SendWriteDataRequest(handle, 100, 1, '0');
+        {
+            auto response = tablet.RecvWriteDataResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+
+            checkIsWriteAllowed(false);
+            const ui64 garbageSize = 13 * block;
+            const ui64 newDataSize = requestSize;
+            checkCollectGarbageBackpressureValues(
+                garbageSize + newDataSize,
+                storageConfig.GetCollectGarbageThresholdForBackpressure());
+        }
+
+        tablet.CollectGarbage();
+        // no backpressure after CollectGarbage
+        checkIsWriteAllowed(true);
+        tablet.SendWriteDataRequest(handle, 100, 1, '0');
 
         tablet.DestroyHandle(handle);
     }


### PR DESCRIPTION
### Notes
#### Problem
`CollectGarbage` progress may get stuck - either because of bugs in our code (barrier calculation, EvCollectGarbage scheduling, etc) or because of bugs in ydb code. If it's stuck for a long time but we keep writing new blobs, then the number of keep and dontkeep flags might become so large that the next `EvCollectGarbage` event that we send won't fit into the IC event size limit: https://github.com/ydb-platform/nbs/blob/0ff8e8244bfa8b767714be51824e940e1eb0ec84/contrib/ydb/library/actors/core/event_pb.h#L145 - we want to prevent that.

#### Solution
Just added `GarbageQueueSize` as yet another backpressure feature. Works exactly the same as our other backpressure features. The default threshold is very high - 1TiB - but it's still low enough to prevent running into the aforementioned message size limit.

### Issue
None
