### PR TITLE
VolumeBalancer: Add IO cost calculation

### DIFF
--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -276,6 +276,38 @@ TDuration GetDowntimeThreshold(
     }
 }
 
+TVolumePerfSettings GetPerfSettings(
+    const TDiagnosticsConfig& config,
+    const NCloud::NProto::EStorageMediaKind kind)
+{
+    switch (kind) {
+        case NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED: {
+            return config.GetNonreplPerfSettings();
+        }
+        case NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED: {
+            return config.GetHddNonreplPerfSettings();
+        }
+        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2: {
+            return config.GetMirror2PerfSettings();
+        }
+        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3: {
+            return config.GetMirror3PerfSettings();
+        }
+        case NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL: {
+            return config.GetLocalSSDPerfSettings();
+        }
+        case NCloud::NProto::STORAGE_MEDIA_HDD_LOCAL: {
+            return config.GetLocalHDDPerfSettings();
+        }
+        case NCloud::NProto::STORAGE_MEDIA_SSD: {
+            return config.GetSsdPerfSettings();
+        }
+        default: {
+            return config.GetHddPerfSettings();
+        }
+    }
+}
+
 }   // namespace NCloud::NBlockStore
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -202,4 +202,9 @@ TDuration GetDowntimeThreshold(
     const TDiagnosticsConfig& config,
     NCloud::NProto::EStorageMediaKind kind);
 
+// Returns the PerfSettings corresponding to the media kind.
+TVolumePerfSettings GetPerfSettings(
+    const TDiagnosticsConfig& config,
+    NCloud::NProto::EStorageMediaKind kind);
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/volume_perf.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf.cpp
@@ -39,44 +39,11 @@ template <typename T>
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVolumePerfSettings TVolumePerformanceCalculator::GetConfigSettings(
-    TDiagnosticsConfigPtr diagnosticsConfig) const
-{
-    switch (MediaKind) {
-        case NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED: {
-            return diagnosticsConfig->GetNonreplPerfSettings();
-        }
-        case NCloud::NProto::STORAGE_MEDIA_HDD_NONREPLICATED: {
-            return diagnosticsConfig->GetHddNonreplPerfSettings();
-        }
-        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR2: {
-            return diagnosticsConfig->GetMirror2PerfSettings();
-        }
-        case NCloud::NProto::STORAGE_MEDIA_SSD_MIRROR3: {
-            return diagnosticsConfig->GetMirror3PerfSettings();
-        }
-        case NCloud::NProto::STORAGE_MEDIA_SSD_LOCAL: {
-            return diagnosticsConfig->GetLocalSSDPerfSettings();
-        }
-        case NCloud::NProto::STORAGE_MEDIA_HDD_LOCAL: {
-            return diagnosticsConfig->GetLocalHDDPerfSettings();
-        }
-        case NCloud::NProto::STORAGE_MEDIA_SSD: {
-            return diagnosticsConfig->GetSsdPerfSettings();
-        }
-        default: {
-            return diagnosticsConfig->GetHddPerfSettings();
-        }
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 TVolumePerformanceCalculator::TVolumePerformanceCalculator(
         const NProto::TVolume& volume,
         TDiagnosticsConfigPtr diagnosticsConfig)
     : MediaKind(volume.GetStorageMediaKind())
-    , ConfigSettings(GetConfigSettings(diagnosticsConfig))
+    , ConfigSettings(GetPerfSettings(*diagnosticsConfig, MediaKind))
     , ExpectedIoParallelism(diagnosticsConfig->GetExpectedIoParallelism())
 {
     TIntrusivePtr<TVolumePerfSettings> settings =

--- a/cloud/blockstore/libs/diagnostics/volume_perf.h
+++ b/cloud/blockstore/libs/diagnostics/volume_perf.h
@@ -50,8 +50,6 @@ private:
     TAtomic CriticalSufferCount = 0;
 
 private:
-    TVolumePerfSettings GetConfigSettings(
-        TDiagnosticsConfigPtr diagnosticsConfig) const;
     bool DidSuffer(long expectedScore, long actualScore) const;
 
 public:

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -326,6 +326,7 @@ public:
 
         auto volumeBalancerService = CreateVolumeBalancerActor(
             Args.StorageConfig,
+            Args.DiagnosticsConfig,
             Args.VolumeStats,
             Args.StatsFetcher,
             Args.VolumeBalancerSwitch,

--- a/cloud/blockstore/libs/storage/protos/volume.proto
+++ b/cloud/blockstore/libs/storage/protos/volume.proto
@@ -468,6 +468,11 @@ message TVolumeBalancerDiskStats
     string FolderId = 11;
 
     NCloud.NProto.EStorageMediaKind StorageMediaKind = 12;
+
+    uint64 ReadBlobCount = 13;
+    uint64 WriteBlobCount = 14;
+    uint64 ReadBlobBytes = 15;
+    uint64 WriteBlobBytes = 16;
 }
 
 message TGetVolumeLoadInfoRequest

--- a/cloud/blockstore/libs/storage/stats_service/stats_service_volume_stats.cpp
+++ b/cloud/blockstore/libs/storage/stats_service/stats_service_volume_stats.cpp
@@ -146,8 +146,14 @@ void TStatsServiceActor::HandleGetVolumeStats(
 {
     for (auto& v: ev->Get()->VolumeStats) {
         if (v.GetHost()) {
-            const auto* volume = State.GetVolume(v.GetDiskId());
-            if (!volume) {
+            if (const auto* volume = State.GetVolume(v.GetDiskId())) {
+                const auto& counters =
+                    volume->PerfCounters.YdbDiskCounters.RequestCounters;
+                v.SetReadBlobCount(counters.ReadBlob.GetCount());
+                v.SetWriteBlobCount(counters.WriteBlob.GetCount());
+                v.SetReadBlobBytes(counters.ReadBlob.GetRequestBytes());
+                v.SetWriteBlobBytes(counters.WriteBlob.GetRequestBytes());
+            } else {
                 v.SetIsLocal(false);
             }
         }

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer.cpp
@@ -10,6 +10,7 @@ using namespace NActors;
 
 IActorPtr CreateVolumeBalancerActor(
     TStorageConfigPtr storageConfig,
+    TDiagnosticsConfigPtr diagnosticsConfig,
     IVolumeStatsPtr volumeStats,
     NCloud::NStorage::IStatsFetcherPtr statFetcher,
     IVolumeBalancerSwitchPtr volumeBalancerSwitch,
@@ -17,6 +18,7 @@ IActorPtr CreateVolumeBalancerActor(
 {
     return std::make_unique<TVolumeBalancerActor>(
         std::move(storageConfig),
+        std::move(diagnosticsConfig),
         std::move(volumeStats),
         std::move(statFetcher),
         std::move(volumeBalancerSwitch),

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer.h
@@ -19,6 +19,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 NActors::IActorPtr CreateVolumeBalancerActor(
     TStorageConfigPtr storageConfig,
+    TDiagnosticsConfigPtr diagnosticsConfig,
     IVolumeStatsPtr volumeStats,
     NCloud::NStorage::IStatsFetcherPtr cgroupStatFetcher,
     IVolumeBalancerSwitchPtr volumeBalancerSwitch,

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -142,16 +142,21 @@ STFUNC(TRemoteVolumeStatActor::StateWork)
 
 TVolumeBalancerActor::TVolumeBalancerActor(
         TStorageConfigPtr storageConfig,
+        TDiagnosticsConfigPtr diagnosticsConfig,
         IVolumeStatsPtr volumeStats,
         NCloud::NStorage::IStatsFetcherPtr statsFetcher,
         IVolumeBalancerSwitchPtr volumeBalancerSwitch,
         TActorId serviceActorId)
     : StorageConfig(std::move(storageConfig))
+    , DiagnosticsConfig(std::move(diagnosticsConfig))
     , VolumeStats(std::move(volumeStats))
     , StatsFetcher(std::move(statsFetcher))
     , VolumeBalancerSwitch(std::move(volumeBalancerSwitch))
     , ServiceActorId(serviceActorId)
-    , State(std::make_unique<TVolumeBalancerState>(StorageConfig))
+    , State(
+          std::make_unique<TVolumeBalancerState>(
+              StorageConfig,
+              DiagnosticsConfig))
 {
 }
 

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.h
@@ -34,6 +34,7 @@ class TVolumeBalancerActor final
 
 private:
     const TStorageConfigPtr StorageConfig;
+    const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IVolumeStatsPtr VolumeStats;
     const NCloud::NStorage::IStatsFetcherPtr StatsFetcher;
     const IVolumeBalancerSwitchPtr VolumeBalancerSwitch;
@@ -55,6 +56,7 @@ private:
 public:
     TVolumeBalancerActor(
         TStorageConfigPtr storageConfig,
+        TDiagnosticsConfigPtr diagnosticsConfig,
         IVolumeStatsPtr volumeStats,
         NCloud::NStorage::IStatsFetcherPtr statsFetcher,
         IVolumeBalancerSwitchPtr volumeBalancerSwitch,

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 
 #include <cloud/storage/core/libs/common/media.h>
+#include "cloud/storage/core/libs/throttling/helpers.h"
 
 #include <library/cpp/monlib/service/pages/templates.h>
 
@@ -79,6 +80,27 @@ void TVolumeBalancerState::UpdateVolumeStats(
         if (auto perfIt = perfMap.find(it->first); perfIt != perfMap.end()) {
             info.SufferCount = perfIt->second;
         }
+
+        info.Cost = {};
+
+        if (info.IsLocal) {
+            TYdbDiskLoadCounters currentLoadCounters{
+                v.GetReadBlobCount(),
+                v.GetWriteBlobCount(),
+                v.GetReadBlobBytes(),
+                v.GetWriteBlobBytes(),
+            };
+
+            if (info.LoadCountersUpdateTs) {
+                info.Cost = CalculateCost(info, currentLoadCounters);
+            }
+            info.LoadCounters = currentLoadCounters;
+            info.LoadCountersUpdateTs = now;
+        } else {
+            info.LoadCounters = {};
+            info.LoadCountersUpdateTs = {};
+        }
+
         knownDisks.erase(v.GetDiskId());
     }
 
@@ -116,6 +138,7 @@ void TVolumeBalancerState::RenderLocalVolumes(TStringStream& out) const
                     TABLEH() { out << "Volume"; }
                     TABLEH() { out << "Preemption allowed"; }
                     TABLEH() { out << "Suffer Count"; }
+                    TABLEH() { out << "IO Cost"; }
                 }
             }
             for (const auto& v: Volumes) {
@@ -129,6 +152,9 @@ void TVolumeBalancerState::RenderLocalVolumes(TStringStream& out) const
                         }
                         TABLED() {
                             out << v.second.SufferCount;
+                        }
+                        TABLED() {
+                            out << v.second.Cost;
                         }
                     }
                 }
@@ -296,6 +322,37 @@ bool TVolumeBalancerState::IsVolumePreemptible(
         balancerEnabled &&
         isSuitableMediaKind &&
         !VolumesInProgress.count(diskId);
+}
+
+TDuration TVolumeBalancerState::CalculateCost(
+        const TVolumeInfo& info,
+        const TYdbDiskLoadCounters& currentLoad) const
+{
+    const auto& last = info.LoadCounters;
+
+    const auto perfSettings =
+        GetPerfSettings(*DiagnosticsConfig, info.MediaKind);
+
+    const ui32 expectedParallelism =
+        DiagnosticsConfig->GetExpectedIoParallelism();
+
+    const TDuration writeCost =
+        expectedParallelism *
+        CostPerIO(
+            perfSettings.WriteIops,
+            perfSettings.WriteBandwidth,
+            currentLoad.WriteBlobBytes - last.WriteBlobBytes,
+            currentLoad.WriteBlobCount - last.WriteBlobCount);
+
+    const TDuration readCost =
+        expectedParallelism *
+        CostPerIO(
+            perfSettings.ReadIops,
+            perfSettings.ReadBandwidth,
+            currentLoad.ReadBlobBytes - last.ReadBlobBytes,
+            currentLoad.WriteBlobCount - last.WriteBlobCount);
+
+    return writeCost + readCost;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -3,7 +3,7 @@
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 
 #include <cloud/storage/core/libs/common/media.h>
-#include "cloud/storage/core/libs/throttling/helpers.h"
+#include <cloud/storage/core/libs/throttling/helpers.h>
 
 #include <library/cpp/monlib/service/pages/templates.h>
 
@@ -147,7 +147,7 @@ void TVolumeBalancerState::RenderLocalVolumes(TStringStream& out) const
                             out << (enabled ? "Yes" : "No");
                         }
                         TABLED() {
-                            out <<info.SufferCount;
+                            out << info.SufferCount;
                         }
                         TABLED() {
                             out
@@ -337,7 +337,7 @@ TResultOrError<TDuration> TVolumeBalancerState::CalculateCost(
     if (currentLoad.WriteBlobBytes < last.WriteBlobBytes ||
         currentLoad.WriteBlobCount < last.WriteBlobCount ||
         currentLoad.ReadBlobBytes < last.ReadBlobBytes ||
-        currentLoad.WriteBlobCount < last.WriteBlobCount)
+        currentLoad.ReadBlobCount < last.ReadBlobCount)
     {
         // Unable to calculate cost: Negative counters diff
         return MakeError(E_FAIL, "Negative counters diff");
@@ -368,7 +368,7 @@ TResultOrError<TDuration> TVolumeBalancerState::CalculateCost(
             perfSettings.ReadIops,
             perfSettings.ReadBandwidth,
             currentLoad.ReadBlobBytes - last.ReadBlobBytes,
-            currentLoad.WriteBlobCount - last.WriteBlobCount);
+            currentLoad.ReadBlobCount - last.ReadBlobCount);
 
     return writeCost + readCost;
 }

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -81,8 +81,6 @@ void TVolumeBalancerState::UpdateVolumeStats(
             info.SufferCount = perfIt->second;
         }
 
-        info.Cost = {};
-
         if (info.IsLocal) {
             TYdbDiskLoadCounters currentLoadCounters{
                 v.GetReadBlobCount(),
@@ -91,14 +89,12 @@ void TVolumeBalancerState::UpdateVolumeStats(
                 v.GetWriteBlobBytes(),
             };
 
-            if (info.LoadCountersUpdateTs) {
-                info.Cost = CalculateCost(info, currentLoadCounters);
-            }
+            info.Cost = CalculateCost(info, currentLoadCounters);
+
             info.LoadCounters = currentLoadCounters;
-            info.LoadCountersUpdateTs = now;
         } else {
-            info.LoadCounters = {};
-            info.LoadCountersUpdateTs = {};
+            info.Cost = MakeError(E_FAIL, "Volume is preempted");
+            info.LoadCounters = std::nullopt;
         }
 
         knownDisks.erase(v.GetDiskId());
@@ -141,20 +137,23 @@ void TVolumeBalancerState::RenderLocalVolumes(TStringStream& out) const
                     TABLEH() { out << "IO Cost"; }
                 }
             }
-            for (const auto& v: Volumes) {
-                if (v.second.IsLocal) {
+            for (const auto& [diskId, info]: Volumes) {
+                if (info.IsLocal) {
                     TABLER() {
-                        TABLED() { out << v.first; }
+                        TABLED() { out << diskId; }
                         TABLED() {
                             const bool enabled =
-                                IsVolumePreemptible(v.first, v.second);
+                                IsVolumePreemptible(diskId, info);
                             out << (enabled ? "Yes" : "No");
                         }
                         TABLED() {
-                            out << v.second.SufferCount;
+                            out <<info.SufferCount;
                         }
                         TABLED() {
-                            out << v.second.Cost;
+                            out
+                                << (HasError(info.Cost.GetError())
+                                        ? info.Cost.GetError().GetMessage()
+                                        : info.Cost.GetResult().ToString());
                         }
                     }
                 }
@@ -324,14 +323,33 @@ bool TVolumeBalancerState::IsVolumePreemptible(
         !VolumesInProgress.count(diskId);
 }
 
-TDuration TVolumeBalancerState::CalculateCost(
+TResultOrError<TDuration> TVolumeBalancerState::CalculateCost(
         const TVolumeInfo& info,
         const TYdbDiskLoadCounters& currentLoad) const
 {
-    const auto& last = info.LoadCounters;
+    if (!info.LoadCounters.has_value()) {
+        // Unable to calculate cost: No counters from previous iteration
+        return MakeError(E_FAIL, "No counters from previous iteration");
+    }
+
+    const auto& last = info.LoadCounters.value();
+
+    if (currentLoad.WriteBlobBytes < last.WriteBlobBytes ||
+        currentLoad.WriteBlobCount < last.WriteBlobCount ||
+        currentLoad.ReadBlobBytes < last.ReadBlobBytes ||
+        currentLoad.WriteBlobCount < last.WriteBlobCount)
+    {
+        // Unable to calculate cost: Negative counters diff
+        return MakeError(E_FAIL, "Negative counters diff");
+    }
 
     const auto perfSettings =
         GetPerfSettings(*DiagnosticsConfig, info.MediaKind);
+
+    if (!perfSettings.WriteIops || !perfSettings.ReadIops) {
+        // Unable to calculate cost: CostPerIO is undefined for 0 maxIops
+        return MakeError(E_FAIL, "Perf settings not configured");
+    }
 
     const ui32 expectedParallelism =
         DiagnosticsConfig->GetExpectedIoParallelism();

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -25,8 +25,11 @@ TVolumeBalancerState::TVolumeInfo::TVolumeInfo(TDuration pullInterval)
     , LastSuccessfulPull(TInstant::Now())
 {}
 
-TVolumeBalancerState::TVolumeBalancerState(TStorageConfigPtr storageConfig)
+TVolumeBalancerState::TVolumeBalancerState(
+    TStorageConfigPtr storageConfig,
+    TDiagnosticsConfigPtr diagnosticsConfig)
     : StorageConfig(std::move(storageConfig))
+    , DiagnosticsConfig(std::move(diagnosticsConfig))
     , InitialVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
     , OverridenVolumePreemptionType(StorageConfig->GetVolumePreemptionType())
     , PullDelayResetTimespan(StorageConfig->GetInitialPullDelay())

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -90,10 +90,9 @@ void TVolumeBalancerState::UpdateVolumeStats(
             };
 
             info.Cost = CalculateCost(info, currentLoadCounters);
-
             info.LoadCounters = currentLoadCounters;
         } else {
-            info.Cost = MakeError(E_FAIL, "Volume is preempted");
+            info.Cost = std::nullopt;
             info.LoadCounters = std::nullopt;
         }
 
@@ -150,10 +149,11 @@ void TVolumeBalancerState::RenderLocalVolumes(TStringStream& out) const
                             out << info.SufferCount;
                         }
                         TABLED() {
-                            out
-                                << (HasError(info.Cost.GetError())
-                                        ? info.Cost.GetError().GetMessage()
-                                        : info.Cost.GetResult().ToString());
+                            if (info.Cost.has_value()) {
+                                out << info.Cost.value().GetValue();
+                            } else {
+                                out << "-";
+                            }
                         }
                     }
                 }
@@ -323,13 +323,13 @@ bool TVolumeBalancerState::IsVolumePreemptible(
         !VolumesInProgress.count(diskId);
 }
 
-TResultOrError<TDuration> TVolumeBalancerState::CalculateCost(
-        const TVolumeInfo& info,
-        const TYdbDiskLoadCounters& currentLoad) const
+std::optional<TDuration> TVolumeBalancerState::CalculateCost(
+    const TVolumeInfo& info,
+    const TYdbDiskLoadCounters& currentLoad) const
 {
     if (!info.LoadCounters.has_value()) {
         // Unable to calculate cost: No counters from previous iteration
-        return MakeError(E_FAIL, "No counters from previous iteration");
+        return std::nullopt;
     }
 
     const auto& last = info.LoadCounters.value();
@@ -340,7 +340,7 @@ TResultOrError<TDuration> TVolumeBalancerState::CalculateCost(
         currentLoad.ReadBlobCount < last.ReadBlobCount)
     {
         // Unable to calculate cost: Negative counters diff
-        return MakeError(E_FAIL, "Negative counters diff");
+        return std::nullopt;
     }
 
     const auto perfSettings =
@@ -348,7 +348,7 @@ TResultOrError<TDuration> TVolumeBalancerState::CalculateCost(
 
     if (!perfSettings.WriteIops || !perfSettings.ReadIops) {
         // Unable to calculate cost: CostPerIO is undefined for 0 maxIops
-        return MakeError(E_FAIL, "Perf settings not configured");
+        return std::nullopt;
     }
 
     const ui32 expectedParallelism =

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <cloud/blockstore/libs/diagnostics/config.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 
@@ -47,6 +48,7 @@ public:
 
 private:
     TStorageConfigPtr StorageConfig;
+    const TDiagnosticsConfigPtr DiagnosticsConfig;
 
     ui64 CpuLack = 0;
 
@@ -66,7 +68,9 @@ private:
     TDuration PullDelayResetTimespan;
 
 public:
-    TVolumeBalancerState(TStorageConfigPtr storageConfig);
+    TVolumeBalancerState(
+        TStorageConfigPtr storageConfig,
+        TDiagnosticsConfigPtr diagnosticsConfig);
 
     TString GetVolumeToPush() const;
     TString GetVolumeToPull() const;

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -48,11 +48,9 @@ class TVolumeBalancerState
 
         ui32 SufferCount = 0;
 
-        TInstant LoadCountersUpdateTs = {};
+        std::optional<TYdbDiskLoadCounters> LoadCounters = {};
 
-        TYdbDiskLoadCounters LoadCounters = {};
-
-        TDuration Cost = {};
+        TResultOrError<TDuration> Cost = MakeError(E_ABORTED, "Uninitialized");
 
         TVolumeInfo(TDuration pullInterval);
     };
@@ -152,7 +150,7 @@ private:
         const TString& diskId,
         const TVolumeInfo& volume) const;
 
-    TDuration CalculateCost(
+    TResultOrError<TDuration> CalculateCost(
         const TVolumeInfo& info,
         const TYdbDiskLoadCounters& currentLoad) const;
 };

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -23,6 +23,14 @@ namespace NCloud::NBlockStore::NStorage {
 
 class TVolumeBalancerState
 {
+    struct TYdbDiskLoadCounters
+    {
+        ui64 ReadBlobCount = 0;
+        ui64 WriteBlobCount = 0;
+        ui64 ReadBlobBytes = 0;
+        ui64 WriteBlobBytes = 0;
+    };
+
     struct TVolumeInfo
     {
         TString CloudId;
@@ -39,6 +47,12 @@ class TVolumeBalancerState
         TInstant LastSuccessfulPull;
 
         ui32 SufferCount = 0;
+
+        TInstant LoadCountersUpdateTs = {};
+
+        TYdbDiskLoadCounters LoadCounters = {};
+
+        TDuration Cost = {};
 
         TVolumeInfo(TDuration pullInterval);
     };
@@ -137,6 +151,10 @@ private:
     bool IsVolumePreemptible(
         const TString& diskId,
         const TVolumeInfo& volume) const;
+
+    TDuration CalculateCost(
+        const TVolumeInfo& info,
+        const TYdbDiskLoadCounters& currentLoad) const;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -48,9 +48,9 @@ class TVolumeBalancerState
 
         ui32 SufferCount = 0;
 
-        std::optional<TYdbDiskLoadCounters> LoadCounters = {};
+        std::optional<TYdbDiskLoadCounters> LoadCounters;
 
-        TResultOrError<TDuration> Cost = MakeError(E_ABORTED, "Uninitialized");
+        std::optional<TDuration> Cost;
 
         TVolumeInfo(TDuration pullInterval);
     };
@@ -150,7 +150,7 @@ private:
         const TString& diskId,
         const TVolumeInfo& volume) const;
 
-    TResultOrError<TDuration> CalculateCost(
+    std::optional<TDuration> CalculateCost(
         const TVolumeInfo& info,
         const TYdbDiskLoadCounters& currentLoad) const;
 };

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state_ut.cpp
@@ -1,6 +1,7 @@
 #include <cloud/blockstore/libs/storage/testlib/test_env.h>
 
 #include <cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h>
+#include <cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.h>
 
 #include <cloud/storage/core/libs/features/features_config.h>
 
@@ -126,9 +127,8 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             CreateStorageConfig(
                 NProto::PREEMPTION_MOVE_MOST_HEAVY,
                 70,
-                CreateFeatureConfig("Balancer", {}, true)
-            )
-        );
+                CreateFeatureConfig("Balancer", {}, true)),
+            CreateDiagnosticsConfig());
         TInstant now = TInstant::Seconds(0);
 
         TVector<NProto::TVolumeBalancerDiskStats> vols {
@@ -151,9 +151,8 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             CreateStorageConfig(
                 NProto::PREEMPTION_MOVE_LEAST_HEAVY,
                 70,
-                CreateFeatureConfig("Balancer", {}, true)
-            )
-        );
+                CreateFeatureConfig("Balancer", {}, true)),
+            CreateDiagnosticsConfig());
         TInstant now = TInstant::Seconds(0);
 
         TVector<NProto::TVolumeBalancerDiskStats> vols {
@@ -176,9 +175,8 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             CreateStorageConfig(
                 NProto::PREEMPTION_MOVE_MOST_HEAVY,
                 70,
-                CreateFeatureConfig("Balancer", {}, true)
-            )
-        );
+                CreateFeatureConfig("Balancer", {}, true)),
+            CreateDiagnosticsConfig());
         TInstant now = TInstant::Seconds(0);
 
         TVector<NProto::TVolumeBalancerDiskStats> vols {
@@ -202,7 +200,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             70,
             CreateFeatureConfig("Balancer", {}, true));
 
-        TVolumeBalancerState state(storageConfig);
+        TVolumeBalancerState state(storageConfig, CreateDiagnosticsConfig());
         TInstant now = TInstant::Seconds(0);
 
         {
@@ -249,7 +247,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             70,
             CreateFeatureConfig("Balancer", {{"cloudid1", "folderid1"}}, true));
 
-        TVolumeBalancerState state(storageConfig);
+        TVolumeBalancerState state(storageConfig, CreateDiagnosticsConfig());
 
         TInstant now = TInstant::Seconds(0);
 
@@ -275,7 +273,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             70,
             CreateFeatureConfig("Balancer", {}, true));
 
-        TVolumeBalancerState state(storageConfig);
+        TVolumeBalancerState state(storageConfig, CreateDiagnosticsConfig());
         TInstant now = TInstant::Seconds(0);
 
         {
@@ -340,7 +338,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
         auto overlappingPullDelay =
             storageConfig->GetInitialPullDelay() + TDuration::Seconds(10);
 
-        TVolumeBalancerState state(storageConfig);
+        TVolumeBalancerState state(storageConfig, CreateDiagnosticsConfig());
         TInstant now = TInstant::Seconds(0);
 
         // Push vol0
@@ -401,9 +399,8 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             CreateStorageConfig(
                 NProto::PREEMPTION_MOVE_MOST_HEAVY,
                 70,
-                CreateFeatureConfig("Balancer", {}, true)
-            )
-        );
+                CreateFeatureConfig("Balancer", {}, true)),
+            CreateDiagnosticsConfig());
         TInstant now = TInstant::Seconds(0);
 
         {
@@ -450,9 +447,8 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             CreateStorageConfig(
                 NProto::PREEMPTION_MOVE_MOST_HEAVY,
                 70,
-                CreateFeatureConfig("Balancer", {}, true)
-            )
-        );
+                CreateFeatureConfig("Balancer", {}, true)),
+            CreateDiagnosticsConfig());
 
         for (ui32 i = 0; i < kinds.size(); ++i) {
             TInstant now = TInstant::Seconds(0);

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -7,6 +7,7 @@
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/testlib/test_env.h>
 #include <cloud/blockstore/libs/storage/volume_balancer/volume_balancer.h>
+#include <cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.h>
 
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
@@ -441,6 +442,7 @@ IActorPtr CreateVolumeBalancerActor(
         std::make_shared<TStorageConfig>(
             config.Build(),
             CreateFeatureConfig("Balancer", {})),
+        CreateDiagnosticsConfig(),
         std::move(volumeStats),
         std::move(statsFetcher),
         std::move(volumeBalancerSwitch),
@@ -850,6 +852,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerTest)
             std::make_shared<TStorageConfig>(
                 config.Build(),
                 CreateFeatureConfig("Balancer", {})),
+            CreateDiagnosticsConfig(),
             testEnv.VolumeStats,
             testEnv.Fetcher,
             CreateVolumeBalancerSwitch(),

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "cloud/storage/core/libs/common/proto_helpers.h"
+
+#include <cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+namespace {
+
+TDiagnosticsConfigPtr CreateDiagnosticsConfig()
+{
+    NProto::TDiagnosticsConfig config;
+    ParseProtoTextFromString(
+        R"(
+        SsdPerfSettings {
+          Write {
+            Iops: 100
+            Bandwidth: 409600
+          }
+          Read {
+            Iops: 100
+            Bandwidth: 409600
+          }
+        })",
+        config);
+    return std::make_shared<TDiagnosticsConfig>(config);
+}
+
+}   // namespace
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/storage/core/libs/throttling/helpers.cpp
+++ b/cloud/storage/core/libs/throttling/helpers.cpp
@@ -45,11 +45,15 @@ TDuration SecondsToDuration(double seconds)
     return TDuration::MicroSeconds(ceil(1e6 * seconds));
 }
 
-TDuration CostPerIO(ui64 maxIops, ui64 maxBandwidth, ui64 byteCount)
+TDuration CostPerIO(
+    const ui64 maxIops,
+    const ui64 maxBandwidth,
+    const ui64 byteCount,
+    const ui64 ioCount)
 {
     Y_DEBUG_ABORT_UNLESS(maxIops);
 
-    double cost = 1.0 / static_cast<double>(maxIops);
+    double cost = ioCount / static_cast<double>(maxIops);
 
     // 0 is special value which disables throttling by byteCount
     if (maxBandwidth) {

--- a/cloud/storage/core/libs/throttling/helpers.cpp
+++ b/cloud/storage/core/libs/throttling/helpers.cpp
@@ -45,6 +45,12 @@ TDuration SecondsToDuration(double seconds)
     return TDuration::MicroSeconds(ceil(1e6 * seconds));
 }
 
+TDuration
+CostPerIO(const ui64 maxIops, const ui64 maxBandwidth, const ui64 byteCount)
+{
+    return CostPerIO(maxIops, maxBandwidth, byteCount, 1);
+}
+
 TDuration CostPerIO(
     const ui64 maxIops,
     const ui64 maxBandwidth,
@@ -57,8 +63,8 @@ TDuration CostPerIO(
 
     // 0 is special value which disables throttling by byteCount
     if (maxBandwidth) {
-        cost += static_cast<double>(byteCount)
-            / static_cast<double>(maxBandwidth);
+        cost +=
+            static_cast<double>(byteCount) / static_cast<double>(maxBandwidth);
     }
 
     return SecondsToDuration(cost);

--- a/cloud/storage/core/libs/throttling/helpers.h
+++ b/cloud/storage/core/libs/throttling/helpers.h
@@ -17,6 +17,8 @@ ui64 CalculateThrottlerC1(double maxIops, double maxBandwidth);
 ui64 CalculateThrottlerC2(double maxIops, double maxBandwidth);
 
 TDuration SecondsToDuration(double seconds);
-TDuration CostPerIO(ui64 maxIops, ui64 maxBandwidth, ui64 byteCount);
+
+TDuration
+CostPerIO(ui64 maxIops, ui64 maxBandwidth, ui64 byteCount, ui64 ioCount = 1);
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/throttling/helpers.h
+++ b/cloud/storage/core/libs/throttling/helpers.h
@@ -18,7 +18,9 @@ ui64 CalculateThrottlerC2(double maxIops, double maxBandwidth);
 
 TDuration SecondsToDuration(double seconds);
 
+TDuration CostPerIO(ui64 maxIops, ui64 maxBandwidth, ui64 byteCount);
+
 TDuration
-CostPerIO(ui64 maxIops, ui64 maxBandwidth, ui64 byteCount, ui64 ioCount = 1);
+CostPerIO(ui64 maxIops, ui64 maxBandwidth, ui64 byteCount, ui64 ioCount);
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/throttling/helpers_ut.cpp
+++ b/cloud/storage/core/libs/throttling/helpers_ut.cpp
@@ -114,6 +114,17 @@ Y_UNIT_TEST_SUITE(THelpersTest)
             SecondsToDuration(1. / 128),
             CostPerIO(128, 0, 64));
     }
+
+    Y_UNIT_TEST(ShouldCorrectlyCalculateCostPerMultipleIO)
+    {
+        UNIT_ASSERT_VALUES_EQUAL(
+            SecondsToDuration(10. / 128),
+            CostPerIO(128, 1024, 64, 2));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            SecondsToDuration(2. / 128),
+            CostPerIO(128, 0, 64, 2));
+    }
 }
 
 }   // namespace NCloud


### PR DESCRIPTION
This PR is a preparation of load-based volume push prioritization

It's made as a separate PR to simplify the review process

The point for using Blob-level requests instead of Block-level is to cover background YDB processes such as compaction
Although `*PerfSettings` are intended for Block-level IO, they provide cost relations between reads and writes and are expected to work well enough for _relative_ comparison of disks load.