### PR TITLE
issue-4664: update shared memory client parameters to accept the base path and target file separately

### DIFF
--- a/cloud/filestore/bin/nfs/log.txt
+++ b/cloud/filestore/bin/nfs/log.txt
@@ -1,3 +1,2 @@
 SysLog: false
 DefaultLevel: 3
-

--- a/cloud/filestore/bin/nfs/nfs-log.txt
+++ b/cloud/filestore/bin/nfs/nfs-log.txt
@@ -41,4 +41,3 @@ Entry {
 SysLog: false
 DefaultLevel: 3
 SysLogService: "NFS_SERVER"
-

--- a/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/datashard-like-read-write.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/datashard-like-read-write.txt
@@ -20,7 +20,8 @@ Tests {
             ReadBytes: 4096
             WriteBytes: 4096
             InitialFileSize: 4194304
-            SharedMemoryFilePath: "{output_path}/shm/shm-loadtest.bin"
+            SharedMemoryBaseDir: "{output_path}/shm"
+            SharedMemoryFilePath: "shm-loadtest.bin"
             SharedMemorySizeBytes: 33554432
         }
         IODepth: 4

--- a/cloud/filestore/tools/testing/loadtest/lib/shm_client.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/shm_client.cpp
@@ -35,7 +35,8 @@ class TSharedMemoryClient final
     , public std::enable_shared_from_this<TSharedMemoryClient>
 {
 private:
-    const TString FullPath;
+    const TString BaseDir;
+    const TString FilePath;
     const ui64 ShmSize;
     const ui64 SlotSize;
 
@@ -54,14 +55,16 @@ private:
 
 public:
     TSharedMemoryClient(
-            TString fullPath,
+            TString baseDir,
+            TString filePath,
             ui64 shmSize,
             ui64 slotSize,
             IShmControlPtr shmControl,
             ISchedulerPtr scheduler,
             ITimerPtr timer,
             ILoggingServicePtr logging)
-        : FullPath(std::move(fullPath))
+        : BaseDir(std::move(baseDir))
+        , FilePath(std::move(filePath))
         , ShmSize(shmSize)
         , SlotSize(slotSize)
         , Scheduler(std::move(scheduler))
@@ -141,20 +144,21 @@ public:
 private:
     void SetupSharedMemory()
     {
-        TFile file(FullPath, CreateAlways | RdWr);
+        TFsPath fullPath = TFsPath(BaseDir) / TFsPath(FilePath);
+        TFile file(fullPath, CreateAlways | RdWr);
         file.Resize(ShmSize);
         int fd = file.GetHandle();
 
         LocalAddr =
             ::mmap(nullptr, ShmSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
         if (LocalAddr == MAP_FAILED) {
-            ythrow TSystemError() << "mmap failed for " << FullPath;
+            ythrow TSystemError() << "mmap failed for " << fullPath;
         }
         file.Close();
 
         auto ctx = MakeIntrusive<TCallContext>();
         auto req = std::make_shared<NProto::TMmapRequest>();
-        req->SetFilePath(TFsPath(FullPath).GetName());
+        req->SetFilePath(FilePath);
         req->SetSize(ShmSize);
 
         auto response = ShmControl->Mmap(std::move(ctx), std::move(req)).GetValueSync();
@@ -166,7 +170,7 @@ private:
 
         STORAGE_INFO(
             "Shared memory region registered: id=" << RegionId
-            << ", file=" << FullPath
+            << ", file=" << fullPath
             << ", size=" << ShmSize);
     }
 
@@ -232,7 +236,8 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 IShmDataClientPtr CreateSharedMemoryClient(
-    TString fullFilePath,
+    TString baseDir,
+    TString filePath,
     ui64 shmSize,
     ui64 slotSize,
     IShmControlPtr shmControl,
@@ -241,7 +246,8 @@ IShmDataClientPtr CreateSharedMemoryClient(
     ILoggingServicePtr logging)
 {
     return std::make_shared<TSharedMemoryClient>(
-        std::move(fullFilePath),
+        std::move(baseDir),
+        std::move(filePath),
         shmSize,
         slotSize,
         std::move(shmControl),

--- a/cloud/filestore/tools/testing/loadtest/lib/shm_client.h
+++ b/cloud/filestore/tools/testing/loadtest/lib/shm_client.h
@@ -53,7 +53,8 @@ using IShmDataClientPtr = std::shared_ptr<IShmDataClient>;
 ////////////////////////////////////////////////////////////////////////////////
 
 IShmDataClientPtr CreateSharedMemoryClient(
-    TString fullFilePath,
+    TString baseDir,
+    TString filePath,
     ui64 shmSize,
     ui64 slotSize,
     IShmControlPtr shmControl,

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -560,8 +560,11 @@ private:
                 break;
             case NProto::TLoadTest::kDatashardLikeLoadSpec: {
                 const auto& spec = Config.GetDatashardLikeLoadSpec();
-                if (!spec.GetSharedMemoryFilePath().empty()) {
+                if (!spec.GetSharedMemoryBaseDir().empty() &&
+                    !spec.GetSharedMemoryFilePath().empty())
+                {
                     ShmClient = CreateSharedMemoryClient(
+                        spec.GetSharedMemoryBaseDir(),
                         spec.GetSharedMemoryFilePath(),
                         spec.GetSharedMemorySizeBytes(),
                         Max(static_cast<ui64>(spec.GetReadBytes()),

--- a/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
+++ b/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
@@ -135,12 +135,12 @@ message TDatashardLikeLoadSpec
     uint64 InitialFileSize = 4;
     repeated TAction Actions = 5;
 
-    // If set, use shared-memory transport for data IO.
-    // Full path to the shared memory file (must be accessible to the server).
-    string SharedMemoryFilePath = 6;
+    // If both set, use shared-memory transport for data IO.
+    string SharedMemoryBaseDir = 6;
+    string SharedMemoryFilePath = 7;
 
     // Size of the shared memory region in bytes (used when SharedMemoryFilePath is set).
-    uint64 SharedMemorySizeBytes = 7;
+    uint64 SharedMemorySizeBytes = 8;
 }
 
 message TMigrationSpec


### PR DESCRIPTION
### Notes
Slight follow-up for #5528

### Issue
#4664
