### PR TITLE
filestore: not returning TFileStore from shards to main tablet upon session creation

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -193,11 +193,37 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         TShardedFileSystemConfig fsConfig;
         CREATE_ENV_AND_SHARDED_FILESYSTEM();
 
+        TVector<NProtoPrivate::TCreateSessionResponse> responses;
+
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& e) {
+                Y_UNUSED(runtime);
+                if (e->GetTypeRewrite() ==
+                        TEvIndexTablet::EvCreateSessionResponse)
+                {
+                    const auto* msg =
+                        e->Get<TEvIndexTablet::TEvCreateSessionResponse>();
+                    responses.push_back(msg->Record);
+                }
+                return false;
+            });
+
         auto headers = service.InitSession(fsConfig.FsId, "client");
         auto headers1 = headers;
         headers1.FileSystemId = fsConfig.Shard1Id;
         auto headers2 = headers;
         headers2.FileSystemId = fsConfig.Shard2Id;
+
+        UNIT_ASSERT_C(3 <= responses.size(), responses.size());
+        for (ui32 i = 0; i < responses.size() - 1; ++i) {
+            UNIT_ASSERT_C(
+                !responses[i].HasFileStore(),
+                responses[i].ShortUtf8DebugString());
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            fsConfig.FsId,
+            responses.back().GetFileStore().GetFileSystemId(),
+            responses.back().ShortUtf8DebugString());
 
         ui64 nodeId1 =
             service

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -418,16 +418,18 @@ void TIndexTabletActor::CompleteTx_CreateSession(
     auto response = std::make_unique<TResponse>(args.Error);
     response->Record.SetSessionId(std::move(args.SessionId));
     response->Record.SetSessionState(session->GetSessionState());
-    auto& fileStore = *response->Record.MutableFileStore();
-    Convert(GetFileSystem(), fileStore);
-    FillFeatures(GetFileSystem(), GetFileSystemStats(), *Config, fileStore);
+    if (!args.Request.GetNoFileStoreInfo()) {
+        auto& fileStore = *response->Record.MutableFileStore();
+        Convert(GetFileSystem(), fileStore);
+        FillFeatures(GetFileSystem(), GetFileSystemStats(), *Config, fileStore);
 
-    LOG_DEBUG(
-        ctx,
-        TFileStoreComponents::TABLET,
-        "%s New session TFileStoreFeatures '%s'",
-        LogTag.c_str(),
-        fileStore.GetFeatures().ShortDebugString().c_str());
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s New session TFileStoreFeatures '%s'",
+            LogTag.c_str(),
+            fileStore.GetFeatures().ShortDebugString().c_str());
+    }
 
     TVector<TString> shardIds;
     // there's no point in returning shard list unless it's main filesystem
@@ -506,6 +508,7 @@ void TIndexTabletActor::CreateSessionsInShards(
         logTag.c_str(),
         JoinSeq(",", shardIds).c_str());
 
+    request.SetNoFileStoreInfo(true);
     auto actor = std::make_unique<TCreateShardSessionsActor>(
         std::move(logTag),
         SelfId(),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -508,7 +508,15 @@ void TIndexTabletActor::CreateSessionsInShards(
         logTag.c_str(),
         JoinSeq(",", shardIds).c_str());
 
+    //
+    // The returned FileStore structure can be huge for filesystems with many
+    // shards. At the same time it's actually not used at all - it's only needed
+    // by the storage service layer, not by other tablets. And the storage
+    // service layer gets it from the main tablet.
+    //
+
     request.SetNoFileStoreInfo(true);
+
     auto actor = std::make_unique<TCreateShardSessionsActor>(
         std::move(logTag),
         SelfId(),

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -51,6 +51,9 @@ message TCreateSessionRequest
     bool ReadOnly = 5;
 
     uint64 MountSeqNumber = 6;
+
+    // Don't return FileStore in the response.
+    bool NoFileStoreInfo = 7;
 }
 
 message TCreateSessionResponse


### PR DESCRIPTION
### Notes
Otherwise the total number of bytes that needs to be transferred is quadratic relative to the total number of shards which is a huge issue for filesystems with thousands of shards 

Tablets don't use the contents of `TCreateSessionResponse`s anyway - they're needed only in the storage service layer

### Issue
None - it's just a small tweak to tablet<->tablet `TCreateSessionResponse`s
