### PR TITLE
Add various parameters to the RDMA configs

### DIFF
--- a/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
@@ -65,6 +65,8 @@ void TBootstrap::Init()
             std::make_unique<NCloud::NStorage::NRdma::TServerConfig>();
         config->Backlog = Options->Backlog;
         config->QueueSize = Options->QueueSize;
+        config->SendQueueSize = Options->SendQueueSize;
+        config->RecvQueueSize = Options->RecvQueueSize;
         config->PollerThreads = Options->PollerThreads;
         config->WaitMode =
             NCloud::NStorage::NRdma::EWaitMode(Options->WaitMode);
@@ -72,6 +74,10 @@ void TBootstrap::Init()
         config->SourceInterface = Options->SourceInterface;
         config->VerbsQP = Options->VerbsQP;
         config->BufferPool = Options->BufferPool;
+        config->QpRetryCount = Options->QpRetryCount;
+        config->QpRnrRetryCount = Options->QpRnrRetryCount;
+        config->QpTimeout = Options->QpTimeout;
+        config->QpMinRnrTimer = Options->QpMinRnrTimer;
 
         Server = NCloud::NBlockStore::NRdma::CreateRdmaServer(
             Logging,
@@ -81,6 +87,8 @@ void TBootstrap::Init()
         auto config =
             std::make_unique<NCloud::NStorage::NRdma::TClientConfig>();
         config->QueueSize = Options->QueueSize;
+        config->SendQueueSize = Options->SendQueueSize;
+        config->RecvQueueSize = Options->RecvQueueSize;
         config->PollerThreads = Options->PollerThreads;
         config->WaitMode =
             NCloud::NStorage::NRdma::EWaitMode(Options->WaitMode);
@@ -88,6 +96,13 @@ void TBootstrap::Init()
         config->SourceInterface = Options->SourceInterface;
         config->VerbsQP = Options->VerbsQP;
         config->BufferPool = Options->BufferPool;
+        config->ResolveTimeout =
+            TDuration::MilliSeconds(Options->ResolveTimeout);
+        config->FlushTimeout = TDuration::MilliSeconds(Options->FlushTimeout);
+        config->QpRetryCount = Options->QpRetryCount;
+        config->QpRnrRetryCount = Options->QpRnrRetryCount;
+        config->QpTimeout = Options->QpTimeout;
+        config->QpMinRnrTimer = Options->QpMinRnrTimer;
 
         Client = NCloud::NBlockStore::NRdma::CreateRdmaClient(
             Logging,

--- a/cloud/blockstore/tools/testing/rdma-test/options.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/options.cpp
@@ -47,6 +47,16 @@ void TOptions::Parse(int argc, char** argv)
         .DefaultValue(ToString(QueueSize))
         .StoreResult(&QueueSize);
 
+    opts.AddLongOption("send-queue-size")
+        .RequiredArgument("NUM")
+        .DefaultValue(SendQueueSize)
+        .StoreResult(&SendQueueSize);
+
+    opts.AddLongOption("recv-queue-size")
+        .RequiredArgument("NUM")
+        .DefaultValue(RecvQueueSize)
+        .StoreResult(&RecvQueueSize);
+
     opts.AddLongOption("poller-threads")
         .RequiredArgument("NUM")
         .DefaultValue(ToString(PollerThreads))
@@ -74,6 +84,36 @@ void TOptions::Parse(int argc, char** argv)
 
     opts.AddLongOption("verbs-qp")
         .StoreTrue(&VerbsQP);
+
+    opts.AddLongOption("resolve-timeout")
+        .RequiredArgument("MSEC")
+        .DefaultValue(ResolveTimeout)
+        .StoreResult(&ResolveTimeout);
+
+    opts.AddLongOption("flush-timeout")
+        .RequiredArgument("MSEC")
+        .DefaultValue(FlushTimeout)
+        .StoreResult(&FlushTimeout);
+
+    opts.AddLongOption("qp-retry-count")
+        .RequiredArgument("NUM")
+        .DefaultValue(QpRetryCount)
+        .StoreResult(&QpRetryCount);
+
+    opts.AddLongOption("qp-rnr-retry-count")
+        .RequiredArgument("NUM")
+        .DefaultValue(QpRnrRetryCount)
+        .StoreResult(&QpRnrRetryCount);
+
+    opts.AddLongOption("qp-timeout")
+        .RequiredArgument("NUM")
+        .DefaultValue(QpTimeout)
+        .StoreResult(&QpTimeout);
+
+    opts.AddLongOption("qp-min-rnr-timer")
+        .RequiredArgument("NUM")
+        .DefaultValue(QpMinRnrTimer)
+        .StoreResult(&QpMinRnrTimer);
 
     // device geometry
     opts.AddLongOption("storage")

--- a/cloud/blockstore/tools/testing/rdma-test/options.h
+++ b/cloud/blockstore/tools/testing/rdma-test/options.h
@@ -50,12 +50,20 @@ struct TOptions
     ui32 Port = 1234;
     ui32 Backlog = 10;
     ui32 QueueSize = 256;
+    ui32 SendQueueSize = 256;
+    ui32 RecvQueueSize = 256;
     ui32 PollerThreads = 1;
     EWaitMode WaitMode = EWaitMode::Poll;
     ui32 ConnectTimeout = 5;
     ui8 Tos = 0;
     TString SourceInterface;
     bool VerbsQP = false;
+    ui32 ResolveTimeout = 10000;
+    ui32 FlushTimeout = 10000;
+    ui8 QpRetryCount = 7;
+    ui8 QpRnrRetryCount = 7;
+    ui8 QpTimeout = 0;
+    ui8 QpMinRnrTimer = 0;
 
     // storage options
     EStorageKind StorageKind = EStorageKind::Null;

--- a/cloud/storage/core/libs/rdma/iface/client.cpp
+++ b/cloud/storage/core/libs/rdma/iface/client.cpp
@@ -1,7 +1,5 @@
 #include "client.h"
 
-#include <cloud/storage/core/protos/rdma.pb.h>
-
 #include <library/cpp/monlib/service/pages/templates.h>
 
 namespace NCloud::NStorage::NRdma {
@@ -22,6 +20,36 @@ TClientConfig::TClientConfig()
 void TClientConfig::Validate(TLog& log)
 {
     BufferPool.Validate(log);
+    constexpr ui8 ThreeBitsMax = 7;
+    constexpr ui8 FiveBitsMax = 31;
+    if (QpRetryCount > ThreeBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpRetryCount=" << QpRetryCount
+                            << " is greater than 7, set QpRetryCount=7");
+        QpRetryCount = ThreeBitsMax;
+    }
+    if (QpRnrRetryCount > ThreeBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpRnrRetryCount=" << QpRnrRetryCount
+                               << " is greater than 7, set QpRnrRetryCount=7");
+        QpRnrRetryCount = ThreeBitsMax;
+    }
+    if (QpTimeout > FiveBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpTimeout=" << QpTimeout
+                         << " is greater than 31, set QpTimeout=31");
+        QpTimeout = FiveBitsMax;
+    }
+    if (QpMinRnrTimer > FiveBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpMinRnrTimer=" << QpMinRnrTimer
+                             << " is greater than 31, set QpMinRnrTimer=31");
+        QpMinRnrTimer = FiveBitsMax;
+    }
 }
 
 void TClientConfig::DumpHtml(IOutputStream& out) const
@@ -52,6 +80,12 @@ void TClientConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(BufferPool.ChunkSize, BufferPool.ChunkSize);
                 ENTRY(BufferPool.MaxChunkAlloc, BufferPool.MaxChunkAlloc);
                 ENTRY(BufferPool.MaxFreeChunks, BufferPool.MaxFreeChunks);
+                ENTRY(ResolveTimeout, ResolveTimeout.ToString());
+                ENTRY(FlushTimeout, FlushTimeout.ToString());
+                ENTRY(QpRetryCount, static_cast<ui32>(QpRetryCount));
+                ENTRY(QpRnrRetryCount, static_cast<ui32>(QpRnrRetryCount));
+                ENTRY(QpTimeout, static_cast<ui32>(QpTimeout));
+                ENTRY(QpMinRnrTimer, static_cast<ui32>(QpMinRnrTimer));
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/iface/client.h
+++ b/cloud/storage/core/libs/rdma/iface/client.h
@@ -4,8 +4,8 @@
 
 #include "buffer.h"
 
-#include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/common/startable.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
 
@@ -42,6 +42,12 @@ struct TClientConfig
     TBufferPoolConfig BufferPool;
     ui32 SendQueueSize = 0;
     ui32 RecvQueueSize = 0;
+    TDuration ResolveTimeout = TDuration::Seconds(10);
+    TDuration FlushTimeout = TDuration::Seconds(10);
+    ui8 QpRetryCount = 7;
+    ui8 QpRnrRetryCount = 7;
+    ui8 QpTimeout = 0;
+    ui8 QpMinRnrTimer = 0;
 
     TClientConfig();
 

--- a/cloud/storage/core/libs/rdma/iface/config.h
+++ b/cloud/storage/core/libs/rdma/iface/config.h
@@ -60,6 +60,12 @@ inline TClientConfig CreateClientConfig(const NProto::TRdmaClient& config)
     SET(VerbsQP);
     SET(SendQueueSize);
     SET(RecvQueueSize);
+    SET(ResolveTimeout, TDuration::MilliSeconds);
+    SET(FlushTimeout, TDuration::MilliSeconds);
+    SET(QpRetryCount);
+    SET(QpRnrRetryCount);
+    SET(QpTimeout);
+    SET(QpMinRnrTimer);
 
     SET_NESTED(BufferPool, ChunkSize);
     SET_NESTED(BufferPool, MaxChunkAlloc);
@@ -115,6 +121,10 @@ inline TServerConfig CreateServerConfig(const NProto::TRdmaServer& config)
     SET(SendQueueSize);
     SET(RecvQueueSize);
     SET(StrictValidation);
+    SET(QpRetryCount);
+    SET(QpRnrRetryCount);
+    SET(QpTimeout);
+    SET(QpMinRnrTimer);
 
     SET_NESTED(BufferPool, ChunkSize);
     SET_NESTED(BufferPool, MaxChunkAlloc);

--- a/cloud/storage/core/libs/rdma/iface/server.cpp
+++ b/cloud/storage/core/libs/rdma/iface/server.cpp
@@ -20,6 +20,36 @@ TServerConfig::TServerConfig()
 void TServerConfig::Validate(TLog& log)
 {
     BufferPool.Validate(log);
+    constexpr ui8 ThreeBitsMax = 7;
+    constexpr ui8 FiveBitsMax = 31;
+    if (QpRetryCount > ThreeBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpRetryCount=" << QpRetryCount
+                            << " is greater than 7, set QpRetryCount=7");
+        QpRetryCount = ThreeBitsMax;
+    }
+    if (QpRnrRetryCount > ThreeBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpRnrRetryCount=" << QpRnrRetryCount
+                               << " is greater than 7, set QpRnrRetryCount=7");
+        QpRnrRetryCount = ThreeBitsMax;
+    }
+    if (QpTimeout > FiveBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpTimeout=" << QpTimeout
+                         << " is greater than 31, set QpTimeout=31");
+        QpTimeout = FiveBitsMax;
+    }
+    if (QpMinRnrTimer > FiveBitsMax) {
+        RDMA_WARN(
+            log,
+            "QpMinRnrTimer=" << QpMinRnrTimer
+                             << " is greater than 31, set QpMinRnrTimer=31");
+        QpMinRnrTimer = FiveBitsMax;
+    }
 }
 
 void TServerConfig::DumpHtml(IOutputStream& out) const
@@ -51,6 +81,10 @@ void TServerConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(BufferPool.MaxChunkAlloc, BufferPool.MaxChunkAlloc);
                 ENTRY(BufferPool.MaxFreeChunks, BufferPool.MaxFreeChunks);
                 ENTRY(StrictValidation, StrictValidation);
+                ENTRY(QpRetryCount, static_cast<ui32>(QpRetryCount));
+                ENTRY(QpRnrRetryCount, static_cast<ui32>(QpRnrRetryCount));
+                ENTRY(QpTimeout, static_cast<ui32>(QpTimeout));
+                ENTRY(QpMinRnrTimer, static_cast<ui32>(QpMinRnrTimer));
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/iface/server.h
+++ b/cloud/storage/core/libs/rdma/iface/server.h
@@ -34,6 +34,10 @@ struct TServerConfig
     TBufferPoolConfig BufferPool;
     ui32 SendQueueSize = 0;
     ui32 RecvQueueSize = 0;
+    ui8 QpRetryCount = 7;
+    ui8 QpRnrRetryCount = 7;
+    ui8 QpTimeout = 0;
+    ui8 QpMinRnrTimer = 0;
 
     TServerConfig();
 

--- a/cloud/storage/core/libs/rdma/iface/ya.make
+++ b/cloud/storage/core/libs/rdma/iface/ya.make
@@ -4,11 +4,11 @@ SRCS(
     buffer.cpp
     client.cpp
     config.cpp
+    log.cpp
     probes.cpp
     protobuf.cpp
     protocol.cpp
     server.cpp
-    log.cpp
 )
 
 PEERDIR(

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -52,9 +52,7 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr TDuration POLL_TIMEOUT = TDuration::Seconds(1);
-constexpr TDuration RESOLVE_TIMEOUT = TDuration::Seconds(10);
 constexpr TDuration MIN_CONNECT_TIMEOUT = TDuration::Seconds(1);
-constexpr TDuration FLUSH_TIMEOUT = TDuration::Seconds(10);
 constexpr TDuration MIN_RECONNECT_DELAY = TDuration::MilliSeconds(10);
 constexpr TDuration INSTANT_RECONNECT_DELAY = TDuration::MicroSeconds(1);
 
@@ -521,6 +519,7 @@ public:
 
     // called from CM thread
     void CreateQP();
+    void SetupQP();
     void DestroyQP() noexcept;
     void StartReceive() noexcept;
     void SetConnection(NVerbs::TConnectionPtr connection) noexcept;
@@ -739,6 +738,23 @@ void TClientEndpoint::CreateQP()
 
         RecvQueue.Push(&wr);
         responseMsg += sizeof(TResponseMessage);
+    }
+}
+
+void TClientEndpoint::SetupQP()
+{
+    ibv_qp_attr qpAttr{};
+    int mask = 0;
+    if (Config.QpTimeout > 0) {
+        qpAttr.timeout = Config.QpTimeout;
+        mask |= IBV_QP_TIMEOUT;
+    }
+    if (Config.QpMinRnrTimer > 0) {
+        qpAttr.min_rnr_timer = Config.QpMinRnrTimer;
+        mask |= IBV_QP_MIN_RNR_TIMER;
+    }
+    if (mask != 0) {
+        Verbs->ModifyQP(Connection->qp, &qpAttr, mask);
     }
 }
 
@@ -1362,7 +1378,7 @@ bool TClientEndpoint::FlushHanging() const
 {
     auto start = FlushStartCycles.load();
     return start &&
-           CyclesToDurationSafe(GetCycleCount() - start) >= FLUSH_TIMEOUT;
+           CyclesToDurationSafe(GetCycleCount() - start) >= Config.FlushTimeout;
 }
 
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
@@ -2177,7 +2193,7 @@ void TClient::BeginResolveAddress(TClientEndpoint* endpoint) noexcept
         RDMA_DEBUG(endpoint->Log, "resolve address");
 
         Verbs->ResolveAddress(endpoint->Connection.get(), addrinfo->ai_src_addr,
-            addrinfo->ai_dst_addr, RESOLVE_TIMEOUT);
+            addrinfo->ai_dst_addr, Config->ResolveTimeout);
 
     } catch (const TServiceError& e) {
         RDMA_ERROR(endpoint->Log, e.what());
@@ -2195,7 +2211,7 @@ void TClient::BeginResolveRoute(TClientEndpoint* endpoint) noexcept
         EEndpointState::ResolvingRoute);
 
     try {
-        Verbs->ResolveRoute(endpoint->Connection.get(), RESOLVE_TIMEOUT);
+        Verbs->ResolveRoute(endpoint->Connection.get(), Config->ResolveTimeout);
 
     } catch (const TServiceError& e) {
         RDMA_ERROR(endpoint->Log, e.what());
@@ -2232,8 +2248,8 @@ void TClient::BeginConnect(TClientEndpoint* endpoint) noexcept
             .responder_resources = RDMA_MAX_RESP_RES,
             .initiator_depth = RDMA_MAX_INIT_DEPTH,
             .flow_control = 1,
-            .retry_count = 7,
-            .rnr_retry_count = 7,
+            .retry_count = Config->QpRetryCount,
+            .rnr_retry_count = Config->QpRnrRetryCount,
         };
 
         Verbs->Connect(endpoint->Connection.get(), &param);
@@ -2277,6 +2293,14 @@ void TClient::HandleConnected(
         EEndpointState::Connected);
 
     endpoint->Reconnect.Cancel();
+    try {
+        endpoint->SetupQP();
+    } catch (const TServiceError& e) {
+        RDMA_ERROR(endpoint->Log, e.what());
+        Counters->Error();
+        endpoint->Disconnect();
+        return;
+    }
     endpoint->StartReceive();
 
     RDMA_INFO(endpoint->Log, "connected");

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -1769,12 +1769,15 @@ private:
                 DurationToCyclesSafe(Config->MaxResponseDelay));
 
             for (auto& request: requests) {
-                RDMA_DEBUG(endpoint->Log, "request " << request->ReqId << " timed out");
+                const ui32 reqId = request->ReqId;
+                RDMA_DEBUG(endpoint->Log, "request " << reqId << " timed out");
                 endpoint->Counters->RequestAborted();
                 endpoint->AbortRequest(
                     std::move(request),
                     E_TIMEOUT,
-                    "request timeout");
+                    TStringBuilder() << "request " << reqId << " timed out "
+                                     << "[peer=" << endpoint->Host << ":"
+                                     << endpoint->Port << "]");
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -113,33 +113,130 @@ TEST(TRdmaClientTest, ShouldStartEndpoint)
 
 TEST(TRdmaClientTest, ShouldStartEndpointWithToS)
 {
-        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
-        auto verbs =
-            NVerbs::CreateTestVerbs(testContext);
-        auto monitoring = CreateMonitoringServiceStub();
-        auto clientConfig = std::make_shared<TClientConfig>();
-        clientConfig->IpTypeOfService = 42;
-        ASSERT_NE(42, testContext->ToS);
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto clientConfig = std::make_shared<TClientConfig>();
+    clientConfig->IpTypeOfService = 42;
+    ASSERT_NE(42, testContext->ToS);
 
-        auto logging = CreateLoggingService(
-            "console",
-            TLogSettings{TLOG_RESOURCES});
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
 
-        auto client = CreateTestClient(
-            verbs,
-            logging,
-            monitoring,
-            clientConfig);
+    auto client = CreateTestClient(verbs, logging, monitoring, clientConfig);
 
-        client->Start();
-        Y_DEFER {
-            client->Stop();
-        };
+    client->Start();
+    Y_DEFER
+    {
+        client->Stop();
+    };
 
-        auto clientEndpoint = client->StartEndpoint("::", 10020);
-        Y_UNUSED(clientEndpoint);
-        ASSERT_EQ(42, testContext->ToS);
-    }
+    auto clientEndpoint = client->StartEndpoint("::", 10020);
+    Y_UNUSED(clientEndpoint);
+    ASSERT_EQ(42, testContext->ToS);
+}
+
+TEST(TRdmaClientTest, ShouldUseConfiguredResolveTimeoutAndQpParamsOnConnect)
+{
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+    auto monitoring = CreateMonitoringServiceStub();
+
+    auto clientConfig = std::make_shared<TClientConfig>();
+    clientConfig->ResolveTimeout = TDuration::MilliSeconds(123);
+    clientConfig->QpRetryCount = 3;
+    clientConfig->QpRnrRetryCount = 5;
+    clientConfig->QpTimeout = 7;
+    clientConfig->QpMinRnrTimer = 9;
+
+    std::atomic<bool> resolveAddressCalled = false;
+    std::atomic<bool> resolveRouteCalled = false;
+    std::atomic<ui64> resolveAddressTimeoutUs = 0;
+    std::atomic<ui64> resolveRouteTimeoutUs = 0;
+
+    std::atomic<bool> connectCalled = false;
+    std::atomic<int> connectRetryCount = -1;
+    std::atomic<int> connectRnrRetryCount = -1;
+
+    std::atomic<bool> modifyCalled = false;
+
+    testContext->HandleResolveAddress =
+        [&](rdma_cm_id* id, sockaddr* srcAddr, sockaddr* dstAddr, TDuration t)
+    {
+        Y_UNUSED(id);
+        Y_UNUSED(srcAddr);
+        Y_UNUSED(dstAddr);
+
+        resolveAddressTimeoutUs.store(t.MicroSeconds());
+        resolveAddressCalled.store(true);
+    };
+
+    testContext->HandleResolveRoute = [&](rdma_cm_id* id, TDuration t)
+    {
+        Y_UNUSED(id);
+
+        resolveRouteTimeoutUs.store(t.MicroSeconds());
+        resolveRouteCalled.store(true);
+    };
+
+    testContext->ModifyQP = [&](ibv_qp* qp, ibv_qp_attr* attr, int mask)
+    {
+        Y_UNUSED(qp);
+
+        const int expectedMask = IBV_QP_TIMEOUT | IBV_QP_MIN_RNR_TIMER;
+
+        EXPECT_EQ(expectedMask, mask);
+        EXPECT_EQ(clientConfig->QpTimeout, attr->timeout);
+        EXPECT_EQ(clientConfig->QpMinRnrTimer, attr->min_rnr_timer);
+
+        modifyCalled.store(true);
+    };
+
+    testContext->HandleConnect = [&](rdma_cm_id* id, rdma_conn_param* param)
+    {
+        connectRetryCount.store(param->retry_count);
+        connectRnrRetryCount.store(param->rnr_retry_count);
+        connectCalled.store(true);
+
+        TAcceptMessage acceptMsg{};
+        InitMessageHeader(&acceptMsg, RDMA_PROTO_VERSION);
+
+        NVerbs::EnqueueAcceptEvent(
+            testContext,
+            id,
+            &acceptMsg,
+            sizeof(acceptMsg));
+    };
+
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+    auto client = CreateTestClient(verbs, logging, monitoring, clientConfig);
+
+    client->Start();
+    Y_DEFER
+    {
+        client->Stop();
+    };
+
+    auto ep = client->StartEndpoint("::", 10020).GetValue(5s);
+    ASSERT_TRUE(ep);
+
+    ASSERT_TRUE(resolveAddressCalled.load());
+    ASSERT_TRUE(resolveRouteCalled.load());
+    ASSERT_EQ(
+        clientConfig->ResolveTimeout.MicroSeconds(),
+        resolveAddressTimeoutUs.load());
+    ASSERT_EQ(
+        clientConfig->ResolveTimeout.MicroSeconds(),
+        resolveRouteTimeoutUs.load());
+
+    ASSERT_TRUE(connectCalled.load());
+    ASSERT_EQ(clientConfig->QpRetryCount, connectRetryCount.load());
+    ASSERT_EQ(clientConfig->QpRnrRetryCount, connectRnrRetryCount.load());
+
+    ASSERT_TRUE(modifyCalled.load());
+}
 
 TEST(TRdmaClientTest, ShouldDetachFromPoller)
 {

--- a/cloud/storage/core/libs/rdma/impl/server.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server.cpp
@@ -317,6 +317,7 @@ public:
 
     // called from CM thread
     void CreateQP();
+    void SetupQP();
     void Start() noexcept;
     void Stop() noexcept;
     void Flush() noexcept;
@@ -501,6 +502,23 @@ TServerSession::~TServerSession()
 
     SendQueue.Clear();
     RecvQueue.Clear();
+}
+
+void TServerSession::SetupQP()
+{
+    ibv_qp_attr qpAttr{};
+    int mask = 0;
+    if (Config->QpTimeout > 0) {
+        qpAttr.timeout = Config->QpTimeout;
+        mask |= IBV_QP_TIMEOUT;
+    }
+    if (Config->QpMinRnrTimer > 0) {
+        qpAttr.min_rnr_timer = Config->QpMinRnrTimer;
+        mask |= IBV_QP_MIN_RNR_TIMER;
+    }
+    if (mask != 0) {
+        Verbs->ModifyQP(Connection->qp, &qpAttr, mask);
+    }
 }
 
 void TServerSession::Start() noexcept
@@ -1905,8 +1923,8 @@ void TServer::Accept(
             .responder_resources = RDMA_MAX_RESP_RES,
             .initiator_depth = RDMA_MAX_INIT_DEPTH,
             .flow_control = 1,
-            .retry_count = 7,
-            .rnr_retry_count = 7,
+            .retry_count = Config->QpRetryCount,
+            .rnr_retry_count = Config->QpRnrRetryCount,
         };
 
         RDMA_DEBUG("accept " << Verbs->GetPeer(event->id));
@@ -1925,6 +1943,7 @@ void TServer::Accept(
 void TServer::HandleConnected(TServerSession* session) noexcept
 {
     try {
+        session->SetupQP();
         session->Start();
         session->CompletionPoller->Attach(session);
         RDMA_INFO(session->Log, "connected");

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -146,6 +146,75 @@ TEST(TRdmaServerTest, ShouldStartEndpointWithToS)
     server->Stop();
 }
 
+TEST(TRdmaServerTest, ShouldUseConfiguredQpParamsOnAcceptAndSetupQp)
+{
+    auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+    auto verbs = NVerbs::CreateTestVerbs(testContext);
+
+    auto monitoring = CreateMonitoringServiceStub();
+    auto serverConfig = std::make_shared<TServerConfig>();
+    serverConfig->QpRetryCount = 2;
+    serverConfig->QpRnrRetryCount = 4;
+    serverConfig->QpTimeout = 6;
+    serverConfig->QpMinRnrTimer = 8;
+
+    std::atomic<bool> acceptCalled = false;
+    std::atomic<int> acceptRetryCount = -1;
+    std::atomic<int> acceptRnrRetryCount = -1;
+    std::atomic<bool> modifyCalled = false;
+
+    testContext->HandleAccept = [&](rdma_cm_id* id, rdma_conn_param* param)
+    {
+        Y_UNUSED(id);
+        acceptRetryCount.store(param->retry_count);
+        acceptRnrRetryCount.store(param->rnr_retry_count);
+        acceptCalled.store(true);
+    };
+
+    testContext->ModifyQP = [&](ibv_qp* qp, ibv_qp_attr* attr, int mask)
+    {
+        Y_UNUSED(qp);
+
+        const int expectedMask = IBV_QP_TIMEOUT | IBV_QP_MIN_RNR_TIMER;
+
+        EXPECT_EQ(expectedMask, mask);
+        EXPECT_EQ(serverConfig->QpTimeout, attr->timeout);
+        EXPECT_EQ(serverConfig->QpMinRnrTimer, attr->min_rnr_timer);
+
+        modifyCalled.store(true);
+    };
+
+    auto logging =
+        CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+    auto server = CreateTestServer(verbs, logging, monitoring, serverConfig);
+    server->Start();
+    Y_DEFER
+    {
+        server->Stop();
+    };
+
+    auto endpoint =
+        server->StartEndpoint("::", 10020, std::make_shared<TServerHandler>());
+    Y_UNUSED(endpoint);
+
+    NVerbs::CreateConnection(testContext);
+
+    auto start = GetCycleCount();
+    while ((!acceptCalled.load() || !modifyCalled.load()) &&
+           CyclesToDurationSafe(GetCycleCount() - start) <
+               TDuration::Seconds(5))
+    {
+        SpinLockPause();
+    }
+
+    ASSERT_TRUE(acceptCalled.load());
+    ASSERT_EQ(serverConfig->QpRetryCount, acceptRetryCount.load());
+    ASSERT_EQ(serverConfig->QpRnrRetryCount, acceptRnrRetryCount.load());
+
+    ASSERT_TRUE(modifyCalled.load());
+}
+
 TEST(TRdmaServerTest, StartEndpointShouldNotThrow)
 {
     auto context = MakeIntrusive<NVerbs::TTestContext>();

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -381,7 +381,7 @@ struct TTestVerbs
             void* context,
             rdma_port_space ps)
         {
-            memset(this, 0, sizeof(rdma_cm_id));
+            *static_cast<rdma_cm_id*>(this) = {};
 
             Y_UNUSED(channel);
             Y_UNUSED(context);
@@ -423,7 +423,9 @@ struct TTestVerbs
         sockaddr* dstAddr,
         TDuration timeout) override
     {
-        Y_UNUSED(timeout);
+        if (TestContext->HandleResolveAddress) {
+            TestContext->HandleResolveAddress(id, srcAddr, dstAddr, timeout);
+        }
 
         static_assert(sizeof(sockaddr) <= sizeof(sockaddr_storage));
         memcpy(&id->route.addr.src_storage, srcAddr, sizeof(sockaddr));
@@ -434,7 +436,9 @@ struct TTestVerbs
 
     void ResolveRoute(rdma_cm_id* id, TDuration timeout) override
     {
-        Y_UNUSED(timeout);
+        if (TestContext->HandleResolveRoute) {
+            TestContext->HandleResolveRoute(id, timeout);
+        }
 
         EnqueueConnectionEvent(TestContext, RDMA_CM_EVENT_ROUTE_RESOLVED, id);
     }
@@ -511,6 +515,9 @@ struct TTestVerbs
 
     void Accept(rdma_cm_id* id, rdma_conn_param* param) override
     {
+        if (TestContext->HandleAccept) {
+            TestContext->HandleAccept(id, param);
+        }
         EnqueueConnectionEvent(
             TestContext,
             RDMA_CM_EVENT_ESTABLISHED,

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -45,11 +45,22 @@ struct TTestContext: TAtomicRefCount<TTestContext>
     std::function<void(ibv_pd* pd, void* addr, size_t length, int flags)>
         RegisterMemoryRegion;
 
+    // If set, called when TTestVerbs resolves address/route.
+    std::function<void(
+        rdma_cm_id* id,
+        sockaddr* srcAddr,
+        sockaddr* dstAddr,
+        TDuration timeout)> HandleResolveAddress;
+    std::function<void(rdma_cm_id* id, TDuration timeout)> HandleResolveRoute;
+
     // If set, overrides the default behavior of TTestVerbs::Connect. The test
     // can use it together with EnqueueAcceptEvent / EnqueueRejectEvent helpers
     // to simulate custom server-side responses (e.g. specific reject messages
     // or accept messages with a particular protocol version).
     std::function<void(rdma_cm_id* id, rdma_conn_param* param)> HandleConnect;
+
+    // If set, called when server Accept() is invoked.
+    std::function<void(rdma_cm_id* id, rdma_conn_param* param)> HandleAccept;
 };
 
 using TTestContextPtr = TIntrusivePtr<TTestContext>;

--- a/cloud/storage/core/protos/rdma.proto
+++ b/cloud/storage/core/protos/rdma.proto
@@ -53,6 +53,21 @@ message TRdmaServer
     uint32 SendQueueSize = 15;
     uint32 RecvQueueSize = 16;
     bool StrictValidation = 17;
+
+    // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 7].
+    uint32 QpRetryCount = 18;
+    // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 7].
+    uint32 QpRnrRetryCount = 19;
+    // Sets the "timeout" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 31].
+    // The resulting timeout is calculated as 4096*2^{QpTimeout} microseconds.
+    // 0 means infinite timeout.
+    uint32 QpTimeout = 20;
+    // Sets the "min_rnr_timer" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 31].
+    uint32 QpMinRnrTimer = 21;
 }
 
 message TRdmaClient
@@ -80,4 +95,27 @@ message TRdmaClient
 
     uint32 SendQueueSize = 14;
     uint32 RecvQueueSize = 15;
+
+    // Timeout for address/route resolution during connect:
+    // rdma_resolve_addr + rdma_resolve_route. (in milliseconds)
+    uint64 ResolveTimeout = 16;
+
+    // Maximum time we wait for in-flight requests to drain during endpoint
+    // flush/shutdown before considering flush "hung". (in milliseconds)
+    uint64 FlushTimeout = 17;
+
+    // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 7].
+    uint32 QpRetryCount = 18;
+    // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 7].
+    uint32 QpRnrRetryCount = 19;
+    // Sets the "timeout" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 31].
+    // The resulting timeout is calculated as 4096*2^{QpTimeout} microseconds.
+    // 0 means infinite timeout.
+    uint32 QpTimeout = 20;
+    // Sets the "min_rnr_timer" parameter in the "ibv_qp_attr" for
+    // "ibv_modify_qp()" function. Valid values are in range [0, 31].
+    uint32 QpMinRnrTimer = 21;
 }


### PR DESCRIPTION
### Notes

1) Previously hardcoded `ResolveTimeout` and `FlushTimeout`  are now configurable.
2) Added 4 QP parameters that are applied after connect/accept. 
`QpRetryCount` and  `QpRnrRetryCount` configure the amount of retries before the QP reconnects
`QpTimeout` and `QpMinRnrTimer ` configure the timeouts between retries.

### Issue
#5729
#2258
