### PR TITLE
[Filestore] unconfirmed three stage write cache bypass

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -191,9 +191,18 @@ private:
 
         Execute_AddBlob_Write(ctx, db, args);
 
-        if (args.CommitId == InvalidCommitId) {
-            return;
-        }
+        TABLET_VERIFY_C(
+            args.WriteRanges.size() == 1,
+            "WriteRanges.size(): " << args.WriteRanges.size());
+
+        // We shouldn't have errors other than CommitIdOverflow at this place
+        TABLET_VERIFY_C(
+            !HasError(args.Error) || args.CommitIdOverflow,
+            "Error: " << FormatError(args.Error));
+
+        Tablet.ActivateInMemoryIndexStateBypass(
+            args.WriteRanges.front().NodeId,
+            args.CommitId);
 
         if (HasError(args.Error)) {
             return;
@@ -573,9 +582,12 @@ void TIndexTabletActor::CompleteTx_AddBlob(
         args.RequestInfo->CallContext,
         "AddBlob");
 
-    // For ConfirmedData we already Released barrier and Answered to the client,
-    // nothing left to do and we can skip event
-    if (args.ConfirmedDataRefCommitId != InvalidCommitId) {
+    // For unconfirmed data we already released the barrier and answered to
+    // the client, nothing left to do and we can skip event.
+    if (args.Mode == EAddBlobMode::WriteUnconfirmed) {
+        DeactivateInMemoryIndexStateBypass(
+            args.WriteRanges.front().NodeId,
+            args.CommitId);
         EnqueueCollectGarbageIfNeeded(ctx);
         EnqueueBlobIndexOpIfNeeded(ctx);
         return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
@@ -335,7 +335,7 @@ void TIndexTabletActor::BlobsConfirmed(const TActorContext& ctx)
         "%s ConfirmBlobs: recovery confirmation completed",
         LogTag.c_str());
 
-    UnconfirmedRecoveryReady = true;
+    SetUnconfirmedRecoveryReady(true);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -84,6 +84,7 @@ TIndexTabletState::~TIndexTabletState() = default;
 void TIndexTabletState::UpdateLogTag(TString tag)
 {
     Impl->FreshBytes.UpdateLogTag(tag);
+    Impl->InMemoryIndexState.UpdateLogTag(tag);
     LogTag = std::move(tag);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -266,6 +266,9 @@ protected:
     // has completed recovery confirmation.
     bool UnconfirmedRecoveryReady = false;
 
+protected:
+    void SetUnconfirmedRecoveryReady(bool value);
+
 public:
     TIndexTabletState();
     ~TIndexTabletState();
@@ -988,6 +991,9 @@ public:
     bool HasDataOverlapWithUnconfirmed(
         ui64 nodeId,
         const TByteRange& requestRange) const;
+
+    void ActivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
+    void DeactivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
 
     //
     // FreshBytes

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -1,5 +1,7 @@
 #include "tablet_state_cache.h"
 
+#include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
 #include <cloud/storage/core/libs/tablet/model/commit.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -7,9 +9,10 @@ namespace NCloud::NFileStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 TInMemoryIndexState::TInMemoryIndexState(IAllocator* allocator)
-    : Nodes(0), NodeAttrs(0), NodeRefs(allocator)
-{
-}
+    : Nodes(0)
+    , NodeAttrs(0)
+    , NodeRefs(allocator)
+{}
 
 void TInMemoryIndexState::Reset(
     ui64 nodesCapacity,
@@ -48,6 +51,11 @@ void TInMemoryIndexState::MarkNodeRefsExhaustive(ui64 nodeId)
     NodeRefsExhaustivenessInfo.MarkNodeRefsExhaustive(nodeId);
 }
 
+void TInMemoryIndexState::UpdateLogTag(TString logTag)
+{
+    LogTag = std::move(logTag);
+}
+
 TInMemoryIndexStateStats TInMemoryIndexState::GetStats() const
 {
     return TInMemoryIndexStateStats{
@@ -63,6 +71,71 @@ TInMemoryIndexStateStats TInMemoryIndexState::GetStats() const
         .IsNodeRefsExhaustive = NodeRefsExhaustivenessInfo.IsExhaustive()};
 }
 
+void TInMemoryIndexState::ActivateInMemoryIndexStateBypass(
+    ui64 nodeId,
+    ui64 commitId)
+{
+    CacheBypassCommitIdsByNodeId[nodeId].push_back(commitId);
+}
+
+void TInMemoryIndexState::DeactivateInMemoryIndexStateBypass(
+    ui64 nodeId,
+    ui64 commitId)
+{
+    auto nodeIt = CacheBypassCommitIdsByNodeId.find(nodeId);
+    TABLET_VERIFY_C(
+        nodeIt != CacheBypassCommitIdsByNodeId.end(),
+        "nodeId: " << nodeId << ", commitId: " << commitId);
+    TABLET_VERIFY_C(
+        !nodeIt->second.empty(),
+        "nodeId: " << nodeId << ", commitId: " << commitId);
+    TABLET_VERIFY_C(
+        nodeIt->second.front() == commitId,
+        "nodeId: " << nodeId << ", expected commitId: " << commitId
+                   << ", actual commitId: " << nodeIt->second.front()
+                   << ", queue size: " << nodeIt->second.size());
+
+    nodeIt->second.pop_front();
+    if (nodeIt->second.empty()) {
+        CacheBypassCommitIdsByNodeId.erase(nodeIt);
+    }
+}
+
+void TInMemoryIndexState::SetUnconfirmedRecoveryReady(
+    bool unconfirmedRecoveryReady)
+{
+    UnconfirmedRecoveryReady = unconfirmedRecoveryReady;
+}
+
+bool TInMemoryIndexState::ShouldBypassCacheRead(
+    ui64 nodeId,
+    ui64 commitId) const
+{
+    // If recovery is in progress, reading from the cache is not possible.
+    if (!UnconfirmedRecoveryReady) {
+        return true;
+    }
+
+    // No records at all. The map is always empty after the recovery phase if
+    // unconfirmed data is disabled, as it is the only client of this API for
+    // now.
+    if (CacheBypassCommitIdsByNodeId.empty()) {
+        return false;
+    }
+
+    // If there are no records for the given node, we can read from the cache.
+    const auto it = CacheBypassCommitIdsByNodeId.find(nodeId);
+    if (it == CacheBypassCommitIdsByNodeId.end() || it->second.empty()) {
+        return false;
+    }
+
+    // Otherwise, ensure that all writes with commit ids up to the current
+    // commit are already in the cache.
+    const ui64 frontCommitId = it->second.front();
+    // The InvalidCommitId comparison handles the CommitIdOverflow case.
+    return frontCommitId == InvalidCommitId || frontCommitId <= commitId;
+}
+
 //
 // Nodes
 //
@@ -72,6 +145,11 @@ bool TInMemoryIndexState::ReadNode(
     ui64 commitId,
     TMaybe<TNode>& node)
 {
+    // TODO (#5912) use waiting queue instead of going full TX flow
+    if (ShouldBypassCacheRead(nodeId, commitId)) {
+        return false;
+    }
+
     auto it = Nodes.Find(nodeId);
     if (it == Nodes.End()) {
         return false;
@@ -142,6 +220,11 @@ bool TInMemoryIndexState::ReadNodeAttr(
     const TString& name,
     TMaybe<TNodeAttr>& attr)
 {
+    // TODO (#5912) use waiting queue instead of going full TX flow
+    if (ShouldBypassCacheRead(nodeId, commitId)) {
+        return false;
+    }
+
     auto it = NodeAttrs.Find(TNodeAttrsKey(nodeId, name));
     if (it == NodeAttrs.End()) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -8,6 +8,9 @@
 
 #include <cloud/storage/core/libs/common/lru_cache.h>
 
+#include <util/generic/deque.h>
+#include <util/generic/hash.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,10 +53,33 @@ public:
 
     [[nodiscard]] TInMemoryIndexStateStats GetStats() const;
 
+    void UpdateLogTag(TString logTag);
+
+private:
+    TString LogTag;
+
+    //
+    // Cache bypass
+    //
+
+public:
+    void ActivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
+
+    void DeactivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
+
+    void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady);
+
+private:
+    bool ShouldBypassCacheRead(ui64 nodeId, ui64 commitId) const;
+
+    bool UnconfirmedRecoveryReady = false;
+    THashMap<ui64, TDeque<ui64>> CacheBypassCommitIdsByNodeId;
+
     //
     // Nodes
     //
 
+public:
     bool ReadNode(
         ui64 nodeId,
         ui64 commitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -421,6 +421,30 @@ bool TIndexTabletState::HasDataOverlapWithUnconfirmed(
     return hasDataOverlap(UnconfirmedData) || hasDataOverlap(ConfirmedData);
 }
 
+void TIndexTabletState::ActivateInMemoryIndexStateBypass(
+    ui64 nodeId,
+    ui64 commitId)
+{
+    Impl->InMemoryIndexState.ActivateInMemoryIndexStateBypass(
+        nodeId,
+        commitId);
+}
+
+void TIndexTabletState::DeactivateInMemoryIndexStateBypass(
+    ui64 nodeId,
+    ui64 commitId)
+{
+    Impl->InMemoryIndexState.DeactivateInMemoryIndexStateBypass(
+        nodeId,
+        commitId);
+}
+
+void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
+{
+    UnconfirmedRecoveryReady = value;
+    Impl->InMemoryIndexState.SetUnconfirmedRecoveryReady(value);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // FreshBytes
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -97,7 +97,8 @@ struct TIndexTabletState::TImpl
         , CompactionMap(registry.GetAllocator(EAllocatorTag::CompactionMap))
         , GarbageQueue(registry.GetAllocator(EAllocatorTag::GarbageQueue))
         , ReadAheadCache(registry.GetAllocator(EAllocatorTag::ReadAheadCache))
-        , InMemoryIndexState(registry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache))
+        , InMemoryIndexState(
+              registry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache))
         , ThrottlingPolicy(TThrottlerConfig())
     {}
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -25,6 +25,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
@@ -58,6 +59,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
             {TInMemoryIndexState::TWriteNodeRequest{
@@ -83,6 +85,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
@@ -103,6 +106,91 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(node.Empty());
     }
 
+    Y_UNIT_TEST(ShouldBypassCacheReads)
+    {
+        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        state.Reset(1, 0, 0, 0);
+        state.SetUnconfirmedRecoveryReady(true);
+
+        state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
+            .NodeId = nodeId1,
+            .Row = {
+                .CommitId = commitId1,
+                .Node = nodeAttrs1,
+            }}});
+
+        TMaybe<IIndexTabletDatabase::TNode> node;
+        UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
+        UNIT_ASSERT(node.Defined());
+
+        state.ActivateInMemoryIndexStateBypass(nodeId1, commitId2);
+
+        node.Clear();
+        UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
+        UNIT_ASSERT(node.Defined());
+
+        node.Clear();
+        UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
+        UNIT_ASSERT(node.Empty());
+
+        state.DeactivateInMemoryIndexStateBypass(nodeId1, commitId2);
+
+        node.Clear();
+        UNIT_ASSERT(state.ReadNode(nodeId1, commitId2, node));
+        UNIT_ASSERT(node.Defined());
+
+        state.ActivateInMemoryIndexStateBypass(
+            nodeId1,
+            InvalidCommitId);
+
+        node.Clear();
+        UNIT_ASSERT(!state.ReadNode(nodeId1, commitId1, node));
+        UNIT_ASSERT(node.Empty());
+
+        node.Clear();
+        UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
+        UNIT_ASSERT(node.Empty());
+
+        state.DeactivateInMemoryIndexStateBypass(
+            nodeId1,
+            InvalidCommitId);
+
+        node.Clear();
+        UNIT_ASSERT(state.ReadNode(nodeId1, commitId2, node));
+        UNIT_ASSERT(node.Defined());
+    }
+
+    Y_UNIT_TEST(ShouldBypassCacheReadsUntilUnconfirmedWritesComplete)
+    {
+        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        state.Reset(1, 0, 0, 0);
+
+        state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
+            .NodeId = nodeId1,
+            .Row = {
+                .CommitId = commitId1,
+                .Node = nodeAttrs1,
+            }}});
+
+        state.ActivateInMemoryIndexStateBypass(nodeId1, commitId2);
+
+        TMaybe<IIndexTabletDatabase::TNode> node;
+        UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
+        UNIT_ASSERT(node.Empty());
+
+        state.SetUnconfirmedRecoveryReady(true);
+
+        node.Clear();
+        UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
+        UNIT_ASSERT(node.Empty());
+
+        state.DeactivateInMemoryIndexStateBypass(nodeId1, commitId2);
+
+        node.Clear();
+        UNIT_ASSERT(state.ReadNode(nodeId1, commitId2, node));
+        UNIT_ASSERT(node.Defined());
+    }
+
     const TString attrName1 = "name1";
     const TString attrName2 = "name2";
 
@@ -119,6 +207,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 1, 0, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId2, attrName1, attr));
@@ -155,6 +244,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 1, 0, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
             {TInMemoryIndexState::TWriteNodeAttrsRequest{
@@ -175,6 +265,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 1, 0, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({TInMemoryIndexState::TWriteNodeAttrsRequest{
             .NodeAttrsKey = {nodeId1, attrName1},
@@ -256,6 +347,7 @@ namespace {
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 0, 1, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
         UNIT_ASSERT(
@@ -306,6 +398,7 @@ namespace {
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 0, 3, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         const TVector<TInMemoryIndexState::TWriteNodeRefsRequest> requests = {
             {
@@ -417,6 +510,7 @@ namespace {
     {
         TInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 0, 1, 0);
+        state.SetUnconfirmedRecoveryReady(true);
 
         TInMemoryIndexState::TWriteNodeRefsRequest request = {
             .NodeRefsKey = {rootNodeIds[0], nodeNames[0]},

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1549,6 +1549,95 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
                 .GetLastCollectCommitId(),
             commitIdAfterFailedGenerateBlobIds);
     }
+
+    Y_UNIT_TEST(ShouldBlockGetNodeAttrUntilAddBlobUnconfirmedCommits)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(2);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(1);
+        storageConfig.SetInMemoryIndexCacheNodeAttrsCapacity(2);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        const ui64 initialCommitId =
+            GenerateBlobIdsAndPutBlob(env, tablet, id, handle, 0, block, 'a');
+        WaitForTabletCommit(env);
+        tablet.ConfirmAddData(initialCommitId);
+        WaitForTabletCommit(env);
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+        UNIT_ASSERT_VALUES_EQUAL(
+            block,
+            tablet.GetNodeAttr(id)->Record.GetNode().GetSize());
+
+        const ui64 commitId = GenerateBlobIdsAndPutBlob(
+            env,
+            tablet,
+            id,
+            handle,
+            block,
+            block,
+            'b');
+        WaitForTabletCommit(env);
+        AssertStorageStats(tablet, 1, 0);
+
+        TAutoPtr<IEventHandle> addBlobCommitResult;
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvTablet::EvCommitResult &&
+                    !addBlobCommitResult)
+                {
+                    addBlobCommitResult = event.Release();
+                    return true;
+                }
+                return false;
+            });
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]()
+                { return !!addBlobCommitResult; }},
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(
+            addBlobCommitResult,
+            "Expected AddBlob commit result to be held by the test");
+
+        tablet.AssertConfirmAddDataResponse(S_OK);
+
+        tablet.SendGetNodeAttrRequest(id);
+
+        // With cache bypass we will not receive response until release of Commit
+        // event
+        tablet.AssertGetNodeAttrNoResponse();
+
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        runtime.Send(addBlobCommitResult.Release(), nodeIdx);
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            2 * block,
+            tablet.GetNodeAttr(id)->Record.GetNode().GetSize());
+        AssertStorageStats(tablet, 0, 0);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Problem
Currently with unconfirmed writes, we respond from tablet at ExecuteTx stage. At the same time, InMemoryIndexState updates at CompleteTx stage. During this window some requests, that require file metadata can    obtain stale values from that cache. The solution is simple, track all commit ids of inflight unconfirmed writes and if  some TXes that clash with our inflight writes we force them to bypass the cache and go full TX flow instead of quick reply from cache.

### Implemented Solution
Introduced cache bypass mechanic for inflight TXes of unconfirmed writes
Added relevant ut

### Issue
#2293
