### PR TITLE
Allow to skip volume performance profile for suffer calculation

### DIFF
--- a/cloud/blockstore/config/diagnostics.proto
+++ b/cloud/blockstore/config/diagnostics.proto
@@ -47,6 +47,16 @@ message TVolumePerfSettings
     optional NCloud.NProto.TPerformanceProfile Write = 1;
     optional NCloud.NProto.TPerformanceProfile Read = 2;
     optional uint32 CriticalFactor = 3;
+
+    // Multiplier that applies to volume's performance profile limits.
+    optional double ThrottlerOvercommit = 4;
+
+    // Minimum effective limits for write/read. After applying clamping by the
+    // volume performance profile (optionally scaled by ThrottlerOvercommit),
+    // the resulting IOPS/BW will not go below these values.
+    optional NCloud.NProto.TPerformanceProfile MinWrite = 5;
+    optional NCloud.NProto.TPerformanceProfile MinRead = 6;
+
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -299,6 +299,11 @@ void Out<NCloud::NBlockStore::TVolumePerfSettings>(
     v.MutableWrite()->SetIops(value.Write.Iops);
     v.MutableWrite()->SetBandwidth(value.Write.Bandwidth);
     v.SetCriticalFactor(value.CriticalFactor);
+    v.SetThrottlerOvercommit(value.ThrottlerOvercommit);
+    v.MutableMinRead()->SetIops(value.MinRead.Iops);
+    v.MutableMinRead()->SetBandwidth(value.MinRead.Bandwidth);
+    v.MutableMinWrite()->SetIops(value.MinWrite.Iops);
+    v.MutableMinWrite()->SetBandwidth(value.MinWrite.Bandwidth);
 
     SerializeToTextFormat(v, out);
 }

--- a/cloud/blockstore/libs/diagnostics/config.cpp
+++ b/cloud/blockstore/libs/diagnostics/config.cpp
@@ -294,10 +294,10 @@ void Out<NCloud::NBlockStore::TVolumePerfSettings>(
     const NCloud::NBlockStore::TVolumePerfSettings& value)
 {
     NCloud::NBlockStore::NProto::TVolumePerfSettings v;
-    v.MutableRead()->SetIops(value.ReadIops);
-    v.MutableRead()->SetBandwidth(value.ReadBandwidth);
-    v.MutableWrite()->SetIops(value.WriteIops);
-    v.MutableWrite()->SetBandwidth(value.WriteBandwidth);
+    v.MutableRead()->SetIops(value.Read.Iops);
+    v.MutableRead()->SetBandwidth(value.Read.Bandwidth);
+    v.MutableWrite()->SetIops(value.Write.Iops);
+    v.MutableWrite()->SetBandwidth(value.Write.Bandwidth);
     v.SetCriticalFactor(value.CriticalFactor);
 
     SerializeToTextFormat(v, out);

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -15,56 +15,72 @@ namespace NCloud::NBlockStore {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TVolumePerfSettings:
-    public TAtomicRefCount<TVolumePerfSettings>
+struct TVolumePerfSettings: public TAtomicRefCount<TVolumePerfSettings>
 {
-    ui32 ReadIops = 0;
-    ui64 ReadBandwidth = 0;
+    struct TPerformanceProfile {
+        ui32 Iops = 0;
+        ui64 Bandwidth = 0;
 
-    ui32 WriteIops = 0;
-    ui64 WriteBandwidth = 0;
+        bool operator==(const TPerformanceProfile& rhs) const = default;
+
+        [[nodiscard]] bool IsValid() const
+        {
+            return Iops != 0 && Bandwidth != 0;
+        }
+    };
+
+    TPerformanceProfile Read;
+    TPerformanceProfile Write;
 
     ui32 CriticalFactor = 0;
+    double ThrottlerOvercommit = 1.0;
+
+    TPerformanceProfile MinRead;
+    TPerformanceProfile MinWrite;
 
     TVolumePerfSettings() = default;
     TVolumePerfSettings(const TVolumePerfSettings& rhs) = default;
 
     TVolumePerfSettings(
-            ui32 readIops,
-            ui64 readBandwidth,
-            ui32 writeIops,
-            ui64 writeBandwidth,
-            ui32 criticalFactor)
-        : ReadIops(readIops)
-        , ReadBandwidth(readBandwidth)
-        , WriteIops(writeIops)
-        , WriteBandwidth(writeBandwidth)
+        ui32 readIops,
+        ui64 readBandwidth,
+        ui32 writeIops,
+        ui64 writeBandwidth,
+        ui32 criticalFactor,
+        double throttlerOvercommit)
+        : Read(readIops, readBandwidth)
+        , Write(writeIops, writeBandwidth)
         , CriticalFactor(criticalFactor)
+        , ThrottlerOvercommit(throttlerOvercommit)
     {}
 
     TVolumePerfSettings(const NProto::TVolumePerfSettings& settings)
-        : ReadIops(settings.GetRead().GetIops())
-        , ReadBandwidth(settings.GetRead().GetBandwidth())
-        , WriteIops(settings.GetWrite().GetIops())
-        , WriteBandwidth(settings.GetWrite().GetBandwidth())
+        : Read(settings.GetRead().GetIops(), settings.GetRead().GetBandwidth())
+        , Write(
+              settings.GetWrite().GetIops(),
+              settings.GetWrite().GetBandwidth())
         , CriticalFactor(settings.GetCriticalFactor())
+        , ThrottlerOvercommit(
+              settings.HasThrottlerOvercommit()
+                  ? settings.GetThrottlerOvercommit()
+                  : 1.0)
+        , MinRead(
+              settings.GetMinRead().GetIops(),
+              settings.GetMinRead().GetBandwidth())
+        , MinWrite(
+              settings.GetMinWrite().GetIops(),
+              settings.GetMinWrite().GetBandwidth())
     {}
 
     bool IsValid() const
     {
-        return ReadIops != 0
-            && ReadBandwidth != 0
-            && WriteIops != 0
-            && WriteBandwidth != 0;
+        return Read.IsValid() && Write.IsValid();
     }
 
-    bool operator == (const TVolumePerfSettings& rhs) const
+    bool operator==(const TVolumePerfSettings& rhs) const
     {
-        return ReadIops == rhs.ReadIops
-            && ReadBandwidth == rhs.ReadBandwidth
-            && WriteIops == rhs.WriteIops
-            && WriteBandwidth == rhs.WriteBandwidth
-            && CriticalFactor == rhs.CriticalFactor;
+        return Read == rhs.Read && Write == rhs.Write &&
+               CriticalFactor == rhs.CriticalFactor;
     }
 
     bool operator != (const TVolumePerfSettings& rhs) const = default;

--- a/cloud/blockstore/libs/diagnostics/config.h
+++ b/cloud/blockstore/libs/diagnostics/config.h
@@ -17,7 +17,8 @@ namespace NCloud::NBlockStore {
 
 struct TVolumePerfSettings: public TAtomicRefCount<TVolumePerfSettings>
 {
-    struct TPerformanceProfile {
+    struct TPerformanceProfile
+    {
         ui32 Iops = 0;
         ui64 Bandwidth = 0;
 

--- a/cloud/blockstore/libs/diagnostics/volume_perf.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf.cpp
@@ -14,9 +14,26 @@
 #include <util/generic/hash.h>
 #include <util/system/rwlock.h>
 
+#include <limits>
+#include <type_traits>
+
 namespace NCloud::NBlockStore {
 
 using namespace NMonitoring;
+
+namespace {
+
+template <typename T>
+    requires(std::is_integral_v<T> && std::is_unsigned_v<T>)
+[[nodiscard]] T SafeMultiply(T a, double m)
+{
+    if (m >= 1.0 && static_cast<T>(std::numeric_limits<T>::max() / m) <= a) {
+        return std::numeric_limits<T>::max();
+    }
+    return a * m;
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -68,29 +85,40 @@ TVolumePerformanceCalculator::TVolumePerformanceCalculator(
 void TVolumePerformanceCalculator::Register(const NProto::TVolume& volume)
 {
     const auto old = *PerfSettings.AtomicLoad();
-    if (old.IsValid()) {
-        const auto& profile = volume.GetPerformanceProfile();
-        TVolumePerfSettings clientSettings(
-            Min(ConfigSettings.ReadIops, profile.GetMaxReadIops()),
-            Min(ConfigSettings.ReadBandwidth, profile.GetMaxReadBandwidth()),
-            Min(ConfigSettings.WriteIops, profile.GetMaxWriteIops()),
-            Min(ConfigSettings.WriteBandwidth, profile.GetMaxWriteBandwidth()),
-            ConfigSettings.CriticalFactor);
-
-        TIntrusivePtr<TVolumePerfSettings> newSettings;
-
-        if (clientSettings.IsValid() && old != clientSettings) {
-            newSettings = new TVolumePerfSettings(
-                Min(ConfigSettings.ReadIops, profile.GetMaxReadIops()),
-                Min(ConfigSettings.ReadBandwidth, profile.GetMaxReadBandwidth()),
-                Min(ConfigSettings.WriteIops, profile.GetMaxWriteIops()),
-                Min(ConfigSettings.WriteBandwidth, profile.GetMaxWriteBandwidth()),
-                ConfigSettings.CriticalFactor);
-
-            PerfSettings.AtomicStore(newSettings);
-        }
-        IsEnabled = true;
+    if (!old.IsValid()) {
+        return;
     }
+
+    const auto& profile = volume.GetPerformanceProfile();
+    TVolumePerfSettings clientSettings(
+        Max(Min(ConfigSettings.Read.Iops,
+                SafeMultiply(
+                    profile.GetMaxReadIops(),
+                    ConfigSettings.ThrottlerOvercommit)),
+            ConfigSettings.MinRead.Iops),
+        Max(Min(ConfigSettings.Read.Bandwidth,
+                SafeMultiply(
+                    profile.GetMaxReadBandwidth(),
+                    ConfigSettings.ThrottlerOvercommit)),
+            ConfigSettings.MinRead.Bandwidth),
+        Max(Min(ConfigSettings.Write.Iops,
+                SafeMultiply(
+                    profile.GetMaxWriteIops(),
+                    ConfigSettings.ThrottlerOvercommit)),
+            ConfigSettings.MinWrite.Iops),
+        Max(Min(ConfigSettings.Write.Bandwidth,
+                SafeMultiply(
+                    profile.GetMaxWriteBandwidth(),
+                    ConfigSettings.ThrottlerOvercommit)),
+            ConfigSettings.MinWrite.Bandwidth),
+        ConfigSettings.CriticalFactor,
+        ConfigSettings.ThrottlerOvercommit);
+
+    if (clientSettings.IsValid() && old != clientSettings) {
+        PerfSettings.AtomicStore(new TVolumePerfSettings(clientSettings));
+    }
+
+    IsEnabled = true;
 }
 
 void TVolumePerformanceCalculator::Register(
@@ -258,8 +286,8 @@ TDuration TVolumePerformanceCalculator::GetExpectedReadCost(
 {
     auto perf = PerfSettings.AtomicLoad();
     return ExpectedIoParallelism * CostPerIO(
-        perf->ReadIops,
-        perf->ReadBandwidth,
+        perf->Read.Iops,
+        perf->Read.Bandwidth,
         requestBytes);
 }
 
@@ -268,8 +296,8 @@ TDuration TVolumePerformanceCalculator::GetExpectedWriteCost(
 {
     auto perf = PerfSettings.AtomicLoad();
     return ExpectedIoParallelism * CostPerIO(
-        perf->WriteIops,
-        perf->WriteBandwidth,
+        perf->Write.Iops,
+        perf->Write.Bandwidth,
         requestBytes);
 }
 
@@ -282,6 +310,5 @@ TDuration TVolumePerformanceCalculator::GetCurrentCost() const
 {
     return TDuration::MicroSeconds(AtomicGet(CurrentScore));
 }
-
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/volume_perf.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf.cpp
@@ -23,6 +23,8 @@ using namespace NMonitoring;
 
 namespace {
 
+////////////////////////////////////////////////////////////////////////////////
+
 template <typename T>
     requires(std::is_integral_v<T> && std::is_unsigned_v<T>)
 [[nodiscard]] T SafeMultiply(T a, double m)

--- a/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
+#include <cloud/storage/core/libs/throttling/helpers.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -184,21 +185,33 @@ NProto::TDiagnosticsConfig CreateDefaultPerformanceSettings(
 
 NProto::TDiagnosticsConfig CreatePerformanceSettings(
     NCloud::NProto::EStorageMediaKind type,
-    ui64 readIops,
+    ui32 readIops,
     ui64 readBandwidth,
-    ui64 writeIops,
-    ui64 writeBandwidth)
+    ui32 writeIops,
+    ui64 writeBandwidth,
+    ui32 minReadIops,
+    ui64 minReadBandwidth,
+    ui32 minWriteIops,
+    ui64 minWriteBandwidth)
 {
     NProto::TDiagnosticsConfig config;
     NProto::TVolumePerfSettings settings;
+
     auto& read = *settings.MutableRead();
     auto& write = *settings.MutableWrite();
-
     read.SetIops(readIops);
     read.SetBandwidth(readBandwidth);
-
     write.SetIops(writeIops);
     write.SetBandwidth(writeBandwidth);
+
+    settings.SetThrottlerOvercommit(1);
+
+    auto& minRead = *settings.MutableMinRead();
+    auto& minWrite = *settings.MutableMinWrite();
+    minRead.SetIops(minReadIops);
+    minRead.SetBandwidth(minReadBandwidth);
+    minWrite.SetIops(minWriteIops);
+    minWrite.SetBandwidth(minWriteBandwidth);
 
     switch (type) {
         case NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED: {
@@ -579,8 +592,11 @@ Y_UNIT_TEST_SUITE(TVolumePerfTest)
             0,
             0,
             0,
-            0
-        );
+            0,
+            0,
+            0,
+            0,
+            0);
 
         auto volume = CreateVolume(
             "test1",
@@ -778,6 +794,194 @@ Y_UNIT_TEST_SUITE(TVolumePerfTest)
             0,
             0,
             0);
+    }
+
+    Y_UNIT_TEST(ShouldOverridePerformanceProfileLimitsWithMinLimits)
+    {
+        constexpr ui32 ConfigReadIops = 10000;
+        constexpr ui32 ConfigWriteIops = 10000;
+        constexpr ui32 ConfigReadBw = 300_MB;
+        constexpr ui32 ConfigWriteBw = 300_MB;
+
+        constexpr ui32 ProfileReadIops = 100;
+        constexpr ui32 ProfileWriteIops = 100;
+        constexpr ui32 ProfileReadBw = 1_MB;
+        constexpr ui32 ProfileWriteBw = 1_MB;
+
+        const auto config = CreatePerformanceSettings(
+            NProto::STORAGE_MEDIA_SSD,
+            ConfigReadIops,    // readIops
+            ConfigReadBw,      // readBandwidth
+            ConfigWriteIops,   // writeIops
+            ConfigWriteBw,     // writeBandwidth
+            0,                 // minReadIops
+            0,                 // minReadBandwidth
+            0,                 // minWriteIops
+            0                  // minWriteBandwidth
+        );
+
+        // Create a config that overrides the performance profile limits.
+        const auto configWithMin = CreatePerformanceSettings(
+            NProto::STORAGE_MEDIA_SSD,
+            ConfigReadIops,    // readIops
+            ConfigReadBw,      // readBandwidth
+            ConfigWriteIops,   // writeIops
+            ConfigWriteBw,     // writeBandwidth
+            ConfigReadIops,    // minReadIops
+            ConfigReadBw,      // minReadBandwidth
+            ConfigWriteIops,   // minWriteIops
+            ConfigWriteBw      // minWriteBandwidth
+        );
+
+        constexpr ui32 RequestBytes = 1024 * 1024;
+
+        {
+            auto monitoring = CreateMonitoringServiceStub();
+            auto counters = monitoring->GetCounters();
+
+            auto volume = CreateVolume(
+                "test_clamped",
+                NProto::STORAGE_MEDIA_SSD,
+                ProfileReadIops,
+                ProfileReadBw,
+                ProfileWriteIops,
+                ProfileWriteBw);
+            auto volumeCounters =
+                CreateVolumeCounters(counters, volume.GetDiskId());
+
+            TVolumePerformanceCalculator calc(
+                volume,
+                std::make_shared<TDiagnosticsConfig>(config));
+            calc.Register(*volumeCounters, volume);
+
+            // Since config is clamped by profile limits, expectedScore becomes
+            // too large and DidSuffer() returns false even for "slow" requests.
+            TestSuffer(
+                calc,
+                volumeCounters,
+                TDuration::Seconds(15),
+                true,   // slowRequest
+                0,      // expected Suffer
+                0,      // expected SmoothSuffer
+                0);     // expected CriticalSuffer
+        }
+
+        {
+            auto monitoring = CreateMonitoringServiceStub();
+            auto counters = monitoring->GetCounters();
+
+            auto volume = CreateVolume(
+                "test_ignore",
+                NProto::STORAGE_MEDIA_SSD,
+                ProfileReadIops,
+                ProfileReadBw,
+                ProfileWriteIops,
+                ProfileWriteBw);
+            auto volumeCounters =
+                CreateVolumeCounters(counters, volume.GetDiskId());
+
+            TVolumePerformanceCalculator calc(
+                volume,
+                std::make_shared<TDiagnosticsConfig>(std::move(configWithMin)));
+
+            const auto before = calc.GetExpectedWriteCost(RequestBytes);
+            calc.Register(*volumeCounters, volume);
+            const auto after = calc.GetExpectedWriteCost(RequestBytes);
+
+            UNIT_ASSERT_VALUES_EQUAL(before, after);
+
+            TestSuffer(
+                calc,
+                volumeCounters,
+                TDuration::Seconds(15),
+                true,   // slowRequest
+                1,      // expected Suffer
+                1,      // expected SmoothSuffer
+                0);     // expected CriticalSuffer
+        }
+    }
+
+    Y_UNIT_TEST(ShouldApplyThrottlerOvercommitToPerformanceProfileLimits)
+    {
+        constexpr double NoOvercommit = 1.0;
+        constexpr double Overcommit = 2.0;
+
+        constexpr ui32 ConfigReadIops = 10000;
+        constexpr ui32 ConfigWriteIops = 20000;
+        constexpr ui64 ConfigReadBw = 300_MB;
+        constexpr ui64 ConfigWriteBw = 400_MB;
+
+        constexpr ui32 ProfileReadIops = 100;
+        constexpr ui32 ProfileWriteIops = 200;
+        constexpr ui32 ProfileReadBw = 5_MB;
+        constexpr ui32 ProfileWriteBw = 10_MB;
+
+        constexpr ui32 RequestBytes = 1024 * 1024;
+
+        auto baseConfig = CreatePerformanceSettings(
+            NProto::STORAGE_MEDIA_SSD,
+            ConfigReadIops,    // readIops
+            ConfigReadBw,      // readBandwidth
+            ConfigWriteIops,   // writeIops
+            ConfigWriteBw,     // writeBandwidth
+            0,                 // minReadIops
+            0,                 // minReadBandwidth
+            0,                 // minWriteIops
+            0                  // minWriteBandwidth
+        );
+        baseConfig.SetExpectedIoParallelism(1);
+
+        auto overcommit1Config = baseConfig;
+        overcommit1Config.MutableSsdPerfSettings()->SetThrottlerOvercommit(
+            NoOvercommit);
+
+        auto overcommit2Config = baseConfig;
+        overcommit2Config.MutableSsdPerfSettings()->SetThrottlerOvercommit(
+            Overcommit);
+
+        const auto volume = CreateVolume(
+            "test_overcommit",
+            NProto::STORAGE_MEDIA_SSD,
+            ProfileReadIops,
+            ProfileReadBw,
+            ProfileWriteIops,
+            ProfileWriteBw);
+
+        TVolumePerformanceCalculator calcOvercommit1(
+            volume,
+            std::make_shared<TDiagnosticsConfig>(overcommit1Config));
+        calcOvercommit1.Register(volume);
+
+        TVolumePerformanceCalculator calcOvercommit2(
+            volume,
+            std::make_shared<TDiagnosticsConfig>(overcommit2Config));
+        calcOvercommit2.Register(volume);
+
+        // With overcommit=1, perf settings are clamped by profile limits.
+        UNIT_ASSERT_VALUES_EQUAL(
+            CostPerIO(ProfileReadIops, ProfileReadBw, RequestBytes),
+            calcOvercommit1.GetExpectedReadCost(RequestBytes));
+        UNIT_ASSERT_VALUES_EQUAL(
+            CostPerIO(ProfileWriteIops, ProfileWriteBw, RequestBytes),
+            calcOvercommit1.GetExpectedWriteCost(RequestBytes));
+
+        // With overcommit=2, profile limits are scaled up before clamping.
+        UNIT_ASSERT_VALUES_EQUAL(
+            CostPerIO(
+                static_cast<ui64>(ProfileReadIops) * 2,
+                static_cast<ui64>(ProfileReadBw) * 2,
+                RequestBytes),
+            calcOvercommit2.GetExpectedReadCost(RequestBytes));
+        UNIT_ASSERT_VALUES_EQUAL(
+            CostPerIO(
+                static_cast<ui64>(ProfileWriteIops) * 2,
+                static_cast<ui64>(ProfileWriteBw) * 2,
+                RequestBytes),
+            calcOvercommit2.GetExpectedWriteCost(RequestBytes));
+
+        UNIT_ASSERT(
+            calcOvercommit2.GetExpectedWriteCost(RequestBytes) <
+            calcOvercommit1.GetExpectedWriteCost(RequestBytes));
     }
 
     Y_UNIT_TEST(ShouldCorrectlyUpdatePerformanceSettingsIfClientPerfSettingsIncreased)

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -807,8 +807,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
 
         auto requestDuration = TDuration::MilliSeconds(400) +
             diagConfig->GetExpectedIoParallelism() * CostPerIO(
-                diagConfig->GetSsdPerfSettings().WriteIops,
-                diagConfig->GetSsdPerfSettings().WriteBandwidth,
+                diagConfig->GetSsdPerfSettings().Write.Iops,
+                diagConfig->GetSsdPerfSettings().Write.Bandwidth,
                 1_MB);
         auto durationInCycles = DurationToCyclesSafe(requestDuration);
         auto now = GetCycleCount();


### PR DESCRIPTION
### Notes
Small volumes have low performance profile values. However, "execution time" (without any waiting time) does not really differ much between small and large volumes. This PR allows to override the volume's throttling settings and rely only on the performance profile set in the diagnostic config to calculate the `Suffer`/`SmoothSuffer`/`CriticalSuffer`.


