### PR TITLE
[Filestore] make blob with EvPut error deterministic in ShouldProfileCancelAddDataAsSeparateRequestType test

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
@@ -13,6 +13,7 @@
 #include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/tablet/blob_id.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
 
@@ -611,8 +612,11 @@ Y_UNIT_TEST_SUITE(TWriteDataUnconfirmedTest)
             profileLog);
         auto& runtime = setup.GetRuntime();
 
+        NActors::TActorId worker;
         bool enableWriteBlobErrorInjection = false;
         bool writeBlobErrorInjected = false;
+        bool targetCommitIdCaptured = false;
+        ui64 targetCommitId = 0;
         const ui32 confirmAddDataType =
             static_cast<ui32>(EFileStoreRequest::ConfirmAddData);
         const ui32 cancelAddDataType =
@@ -622,10 +626,32 @@ Y_UNIT_TEST_SUITE(TWriteDataUnconfirmedTest)
             {
                 Y_UNUSED(runtime);
                 switch (event->GetTypeRewrite()) {
+                    case TEvIndexTablet::EvGenerateBlobIdsRequest: {
+                        if (enableWriteBlobErrorInjection && !worker) {
+                            worker = event->Sender;
+                        }
+                        break;
+                    }
+                    case TEvIndexTablet::EvGenerateBlobIdsResponse: {
+                        if (enableWriteBlobErrorInjection &&
+                            !targetCommitIdCaptured)
+                        {
+                            auto* msg = event->template Get<
+                                TEvIndexTablet::TEvGenerateBlobIdsResponse>();
+                            targetCommitId = msg->Record.GetCommitId();
+                            targetCommitIdCaptured = true;
+                        }
+                        break;
+                    }
+                    // Ensure that we corrupt needed Put and not random one.
                     case NKikimr::TEvBlobStorage::EvPutResult: {
                         auto* msg = event->template Get<
                             NKikimr::TEvBlobStorage::TEvPutResult>();
                         if (enableWriteBlobErrorInjection &&
+                            event->Recipient == worker &&
+                            targetCommitIdCaptured &&
+                            MakePartialBlobId(msg->Id).CommitId() ==
+                                targetCommitId &&
                             !writeBlobErrorInjected)
                         {
                             msg->Status = NKikimrProto::ERROR;


### PR DESCRIPTION
### Notes
Under the suffering system, we have many intertwined EvPuts. In the test, we need to surgically make our EvPut from unconfirmed data fail. We leverage knowledge of the sender ID and the intercepted commit ID for this purpose, narrowing down the conditions for the failed EvPut.

### Fixed test
ShouldProfileCancelAddDataAsSeparateRequestType

