### PR TITLE
[NBS] Local NVMe service: resolve vfio-dev when acquiring NVMe device

### DIFF
--- a/cloud/blockstore/libs/local_nvme/service.cpp
+++ b/cloud/blockstore/libs/local_nvme/service.cpp
@@ -31,13 +31,14 @@ public:
     }
 
     [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> final
+        -> TFuture<TResultOrError<NProto::TNVMeDevice>> final
     {
         if (!serialNumber) {
-            return MakeFuture(MakeError(E_ARGUMENT, "Serial number is empty"));
+            return MakeFuture<TResultOrError<NProto::TNVMeDevice>>(
+                MakeError(E_ARGUMENT, "Serial number is empty"));
         }
 
-        return MakeFuture(MakeError(
+        return MakeFuture<TResultOrError<NProto::TNVMeDevice>>(MakeError(
             E_NOT_FOUND,
             TStringBuilder()
                 << "Device " << serialNumber.Quote() << " not found"));

--- a/cloud/blockstore/libs/local_nvme/service.h
+++ b/cloud/blockstore/libs/local_nvme/service.h
@@ -24,7 +24,7 @@ struct ILocalNVMeService: public IStartable
         TResultOrError<TVector<NProto::TNVMeDevice>>> = 0;
 
     [[nodiscard]] virtual auto AcquireNVMeDevice(const TString& serialNumber)
-        -> NThreading::TFuture<NProto::TError> = 0;
+        -> NThreading::TFuture<TResultOrError<NProto::TNVMeDevice>> = 0;
 
     [[nodiscard]] virtual auto ReleaseNVMeDevice(const TString& serialNumber)
         -> NThreading::TFuture<NProto::TError> = 0;

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -32,6 +32,8 @@ const TErrorResponse ServiceDestroyedError =
     MakeError(E_REJECTED, "Local NVMe service is destroyed");
 
 const TDuration SanitizeStatusProbeTimeout = TDuration::MilliSeconds(100);
+const TDuration VfioDeviceRetryDelay = TDuration::MilliSeconds(100);
+const ui32 VfioDeviceMaxRetries = 100;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -76,6 +78,7 @@ private:
 
     TLog Log;
     TFuture<NProto::TError> Ready;
+    bool IsVfioDevSupported = false;
 
     THashMap<TString, NProto::TNVMeDevice> Devices;
     THashSet<TString> AcquiredDevices;
@@ -124,6 +127,8 @@ private:
     auto BindDeviceToDriver(
         const NProto::TNVMeDevice& device,
         const TString& driverName) -> NProto::TError;
+    auto GetVfioDevName(TCont* c, const TString& pciAddress)
+        -> TResultOrError<TString>;
 
     // Spawn a coroutine with a name `name` to execute `fn`
     template <typename R, typename TSelf, typename F, typename... TArgs>
@@ -174,6 +179,15 @@ TLocalNVMeService::TLocalNVMeService(
 void TLocalNVMeService::Start()
 {
     Log = Logging->CreateLog("BLOCKSTORE_LOCAL_NVME");
+
+    auto [supported, error] = SafeExecute<TResultOrError<bool>>(
+        [&] { return SysFs->IsVfioDevSupported(); });
+    if (HasError(error)) {
+        STORAGE_ERROR(
+            "Failed to check for vfio-dev support: " << FormatError(error));
+    } else {
+        IsVfioDevSupported = supported;
+    }
 
     Ready = Executor->Execute(
         [weakSelf = weak_from_this()]() -> NProto::TError
@@ -414,8 +428,6 @@ auto TLocalNVMeService::BindDeviceToDriver(
 auto TLocalNVMeService::AcquireDevice(TCont* c, const TString& serialNumber)
     -> TResultOrError<NProto::TNVMeDevice>
 {
-    Y_UNUSED(c);
-
     const auto* device = Devices.FindPtr(serialNumber);
 
     if (!device) {
@@ -435,12 +447,58 @@ auto TLocalNVMeService::AcquireDevice(TCont* c, const TString& serialNumber)
 
     UpdateStateCache();
 
-    auto error = BindDeviceToDriver(*device, "vfio-pci");
-    if (HasError(error)) {
+    if (auto error = BindDeviceToDriver(*device, "vfio-pci"); HasError(error)) {
         return error;
     }
 
-    return *device;
+    NProto::TNVMeDevice r = *device;
+
+    if (!IsVfioDevSupported) {
+        return r;
+    }
+
+    auto [vfioDev, error] = GetVfioDevName(c, r.GetPCIAddress());
+    if (HasError(error)) {
+        STORAGE_ERROR(
+            "Failed to get vfio device for " << r << ": "
+                                             << FormatError(error));
+    } else {
+        r.SetVfioDevName(std::move(vfioDev));
+    }
+
+    return r;
+}
+
+auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
+    -> TResultOrError<TString>
+{
+    // Binding to vfio-pci completes before the vfio-dev sysfs entry may
+    // appear.
+    // Retry to avoid racing with asynchronous vfio<N> creation.
+
+    for (ui32 attempt = 0;; ++attempt) {
+        auto [vfioDevice, error] = SafeExecute<TResultOrError<TString>>(
+            [&] { return SysFs->GetVfioDeviceForPCIDevice(pciAddress); });
+
+        if (HasError(error)) {
+            return error;
+        }
+
+        if (!vfioDevice && attempt < VfioDeviceMaxRetries) {
+            c->SleepT(VfioDeviceRetryDelay);
+            continue;
+        }
+
+        if (!vfioDevice) {
+            return MakeError(
+                E_NOT_FOUND,
+                TStringBuilder() << "vfio device for PCI address " << pciAddress
+                                 << " was not found after "
+                                 << VfioDeviceMaxRetries << " retries");
+        }
+
+        return vfioDevice;
+    }
 }
 
 auto TLocalNVMeService::GetNVMeCtrlPath(const NProto::TNVMeDevice& device)

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -485,6 +485,10 @@ auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
         }
 
         if (!vfioDevice && attempt < VfioDeviceMaxRetries) {
+            STORAGE_DEBUG(
+                "vfio device for PCI address "
+                << pciAddress << " was not found, retry (attempts: "
+                << attempt + 1 << "/" << VfioDeviceMaxRetries << ")");
             c->SleepT(VfioDeviceRetryDelay);
             continue;
         }

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -99,13 +99,14 @@ public:
     [[nodiscard]] auto ListNVMeDevices() -> TFuture<TListDevicesResult> final;
 
     [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> final;
+        -> TFuture<TResultOrError<NProto::TNVMeDevice>> final;
 
     [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
         -> TFuture<NProto::TError> final;
 
 private:
-    auto AcquireDevice(TCont* c, const TString& serialNumber) -> NProto::TError;
+    auto AcquireDevice(TCont* c, const TString& serialNumber)
+        -> TResultOrError<NProto::TNVMeDevice>;
     auto ReleaseDevice(TCont* c, const TString& serialNumber) -> NProto::TError;
     auto ListDevices(TCont* c) const -> TVector<NProto::TNVMeDevice>;
 
@@ -203,15 +204,15 @@ auto TLocalNVMeService::ListNVMeDevices() -> TFuture<TListDevicesResult>
 }
 
 auto TLocalNVMeService::AcquireNVMeDevice(const TString& serialNumber)
-    -> TFuture<NProto::TError>
+    -> TFuture<TResultOrError<NProto::TNVMeDevice>>
 {
     STORAGE_INFO("Acquire NVMe device " << serialNumber.Quote());
 
     if (auto error = EnsureIsReady(); HasError(error)) {
-        return MakeFuture(error);
+        return MakeFuture(TResultOrError<NProto::TNVMeDevice>(error));
     }
 
-    return ExecuteAsync<NProto::TError>(
+    return ExecuteAsync<TResultOrError<NProto::TNVMeDevice>>(
         *this,
         "acquire",
         &TLocalNVMeService::AcquireDevice,
@@ -411,7 +412,7 @@ auto TLocalNVMeService::BindDeviceToDriver(
 }
 
 auto TLocalNVMeService::AcquireDevice(TCont* c, const TString& serialNumber)
-    -> NProto::TError
+    -> TResultOrError<NProto::TNVMeDevice>
 {
     Y_UNUSED(c);
 
@@ -434,7 +435,12 @@ auto TLocalNVMeService::AcquireDevice(TCont* c, const TString& serialNumber)
 
     UpdateStateCache();
 
-    return BindDeviceToDriver(*device, "vfio-pci");
+    auto error = BindDeviceToDriver(*device, "vfio-pci");
+    if (HasError(error)) {
+        return error;
+    }
+
+    return *device;
 }
 
 auto TLocalNVMeService::GetNVMeCtrlPath(const NProto::TNVMeDevice& device)

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -202,6 +202,18 @@ struct TTestSysFs final: ISysFs
         Y_ENSURE(device);
         return *device;
     }
+
+    auto GetVfioDeviceForPCIDevice(const TString& pciAddr) -> TString final
+    {
+        Y_UNUSED(pciAddr);
+
+        return {};
+    }
+
+    [[nodiscard]] auto IsVfioDevSupported() const -> bool final
+    {
+        return false;
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -178,6 +178,8 @@ struct TTestSysFs final: ISysFs
     THashMap<TString, TString> DeviceToCtrl;
     THashMap<TString, NProto::TNVMeDevice> AddrToDevice;
 
+    std::function<TString(const TString&)> GetVfioDeviceForPCIDeviceImpl;
+
     auto GetDriverForPCIDevice(const TString& pciAddr) -> TString final
     {
         return AddrToDriver.Value(pciAddr, TString());
@@ -205,14 +207,14 @@ struct TTestSysFs final: ISysFs
 
     auto GetVfioDeviceForPCIDevice(const TString& pciAddr) -> TString final
     {
-        Y_UNUSED(pciAddr);
-
-        return {};
+        return GetVfioDeviceForPCIDeviceImpl
+                   ? GetVfioDeviceForPCIDeviceImpl(pciAddr)
+                   : TString{};
     }
 
     [[nodiscard]] auto IsVfioDevSupported() const -> bool final
     {
-        return false;
+        return true;
     }
 };
 
@@ -280,7 +282,6 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
                 SerialNumber: "NVME_0"
                 PCIAddress: "0000:f1:00.0"
                 IOMMUGroup: 10
-                VfioDevName: "vfio0"
                 VendorId: 0x100
                 DeviceId: 0x200
                 Model: "Test NVMe 1"
@@ -494,6 +495,47 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
     }
 
+    Y_UNIT_TEST_F(ShouldRetryGetVfioDevName, TFixture)
+    {
+        SetProviderReady();
+
+        {
+            auto [devices, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        const TString vfioDev = "vfio0";
+        const auto& device = Devices[0];
+
+        const ui32 successfulAttempt = 3;
+        std::atomic<ui32> attempts = 0;
+        SysFs->GetVfioDeviceForPCIDeviceImpl =
+            [&](const TString& pciAddr) mutable -> TString
+        {
+            if (device.GetPCIAddress() != pciAddr) {
+                return {};
+            }
+
+            if (attempts != successfulAttempt) {
+                ++attempts;
+                return {};
+            }
+
+            return vfioDev;
+        };
+
+        auto future = Service->AcquireNVMeDevice(device.GetSerialNumber());
+
+        const auto& [r, error] = future.GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), FormatError(error));
+        UNIT_ASSERT_VALUES_EQUAL(device.GetSerialNumber(), r.GetSerialNumber());
+        UNIT_ASSERT_VALUES_EQUAL(vfioDev, r.GetVfioDevName());
+        UNIT_ASSERT_VALUES_EQUAL(successfulAttempt, attempts.load());
+    }
+
     Y_UNIT_TEST_F(ShouldAcquireAndReleaseDevice, TFixture)
     {
         const auto& device = Devices[0];
@@ -523,11 +565,15 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         SetProviderReady();
 
         {
-            auto [_, error] = ListNVMeDevices();
+            auto [devices, error] = ListNVMeDevices();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),
                 FormatError(error));
+
+            for (const auto& device: devices) {
+                UNIT_ASSERT_VALUES_EQUAL("", device.GetVfioDevName());
+            }
         }
 
         {
@@ -551,6 +597,17 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         UNIT_ASSERT_VALUES_EQUAL("nvme", SysFs->AddrToDriver[pciAddr]);
 
         {
+            const TString vfioDev = "vfio0";
+
+            SysFs->GetVfioDeviceForPCIDeviceImpl =
+                [&](const TString& pciAddr) -> TString
+            {
+                if (pciAddr == device.GetPCIAddress()) {
+                    return vfioDev;
+                }
+                return {};
+            };
+
             auto future = Service->AcquireNVMeDevice(serialNumber);
             const auto& [device, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
@@ -559,6 +616,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 FormatError(error));
 
             UNIT_ASSERT_VALUES_EQUAL(serialNumber, device.GetSerialNumber());
+            UNIT_ASSERT_VALUES_EQUAL(vfioDev, device.GetVfioDevName());
         }
 
         const TString ctrlPath = "/dev/nvme0";

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -491,7 +491,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         for (const auto& sn: {serialNumber, TString("UNK")}) {
             {
                 auto future = Service->AcquireNVMeDevice(sn);
-                const auto& error = future.GetValueSync();
+                const auto& [_, error] = future.GetValueSync();
                 UNIT_ASSERT_VALUES_EQUAL_C(
                     E_REJECTED,
                     error.GetCode(),
@@ -520,7 +520,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         {
             auto future = Service->AcquireNVMeDevice("UNK");
-            const auto& error = future.GetValueSync();
+            const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_NOT_FOUND,
                 error.GetCode(),
@@ -540,11 +540,13 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         {
             auto future = Service->AcquireNVMeDevice(serialNumber);
-            const auto& error = future.GetValueSync();
+            const auto& [device, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),
                 FormatError(error));
+
+            UNIT_ASSERT_VALUES_EQUAL(serialNumber, device.GetSerialNumber());
         }
 
         const TString ctrlPath = "/dev/nvme0";
@@ -623,7 +625,10 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                     TVector<TFuture<NProto::TError>> futures;
 
                     for (int i = 0; i != requestNum; ++i) {
-                        futures.push_back(Service->AcquireNVMeDevice("UNK"));
+                        futures.push_back(
+                            Service->AcquireNVMeDevice("UNK").Apply(
+                                [](const auto& future)
+                                { return future.GetValue().GetError(); }));
                         futures.push_back(Service->ReleaseNVMeDevice("UNK"));
                         Sleep(10ms);
                     }
@@ -682,20 +687,22 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         {
             auto future = Service->AcquireNVMeDevice("NVME_0");
-            const auto& error = future.GetValueSync();
+            const auto& [device, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),
                 FormatError(error));
+            UNIT_ASSERT_VALUES_EQUAL("NVME_0", device.GetSerialNumber());
         }
 
         {
             auto future = Service->AcquireNVMeDevice("NVME_2");
-            const auto& error = future.GetValueSync();
+            const auto& [device, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),
                 FormatError(error));
+            UNIT_ASSERT_VALUES_EQUAL("NVME_2", device.GetSerialNumber());
         }
 
         {
@@ -789,7 +796,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         {
             auto future =
                 Service->AcquireNVMeDevice(Devices[0].GetSerialNumber());
-            const auto& error = future.GetValueSync();
+            const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_ARGUMENT,
                 error.GetCode(),
@@ -799,7 +806,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         {
             auto future =
                 Service->AcquireNVMeDevice(Devices[1].GetSerialNumber());
-            const auto& error = future.GetValueSync();
+            const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),
@@ -809,7 +816,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         {
             auto future =
                 Service->AcquireNVMeDevice(Devices[2].GetSerialNumber());
-            const auto& error = future.GetValueSync();
+            const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_ARGUMENT,
                 error.GetCode(),

--- a/cloud/blockstore/libs/local_nvme/service_proxy.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_proxy.cpp
@@ -12,6 +12,27 @@ using namespace NThreading;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+auto GetDeviceDesc(const NProto::TNVMeDevice& device)
+{
+    NProto::TNVMeDeviceDesc desc;
+
+    desc.SetSerialNumber(device.GetSerialNumber());
+    desc.SetPCIAddress(device.GetPCIAddress());
+    if (device.HasIOMMUGroup()) {
+        desc.SetIOMMUGroup(device.GetIOMMUGroup());
+    }
+    if (device.HasVfioDevName()) {
+        desc.SetVfioDevName(device.GetVfioDevName());
+    }
+    if (device.HasNumaNode()) {
+        desc.SetNumaNode(device.GetNumaNode());
+    }
+
+    return desc;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TLocalNVMeServiceProxy
     : public TBlockStoreImpl<TLocalNVMeServiceProxy, IBlockStore>
 {
@@ -67,19 +88,8 @@ public:
 
                 NProto::TListNVMeDevicesResponse response;
                 response.MutableError()->CopyFrom(error);
-                for (const auto& src: devices) {
-                    auto* dst = response.AddDevices();
-                    dst->SetSerialNumber(src.GetSerialNumber());
-                    dst->SetPCIAddress(src.GetPCIAddress());
-                    if (src.HasIOMMUGroup()) {
-                        dst->SetIOMMUGroup(src.GetIOMMUGroup());
-                    }
-                    if (src.HasVfioDevName()) {
-                        dst->SetVfioDevName(src.GetVfioDevName());
-                    }
-                    if (src.HasNumaNode()) {
-                        dst->SetNumaNode(src.GetNumaNode());
-                    }
+                for (const auto& device: devices) {
+                    *response.AddDevices() = GetDeviceDesc(device);
                 }
 
                 return response;
@@ -101,7 +111,7 @@ public:
                     NProto::TAcquireNVMeDeviceResponse response;
                     response.MutableError()->CopyFrom(error);
                     if (!HasError(error)) {
-                        response.MutableDevice()->CopyFrom(device);
+                        *response.MutableDevice() = GetDeviceDesc(device);
                     }
                     return response;
                 });

--- a/cloud/blockstore/libs/local_nvme/service_proxy.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_proxy.cpp
@@ -96,8 +96,13 @@ public:
             .Apply(
                 [](const auto& future)
                 {
+                    const auto& [device, error] = future.GetValue();
+
                     NProto::TAcquireNVMeDeviceResponse response;
-                    response.MutableError()->CopyFrom(future.GetValue());
+                    response.MutableError()->CopyFrom(error);
+                    if (!HasError(error)) {
+                        response.MutableDevice()->CopyFrom(device);
+                    }
                     return response;
                 });
     }

--- a/cloud/blockstore/libs/local_nvme/service_proxy_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_proxy_ut.cpp
@@ -62,11 +62,11 @@ struct TTestLocalNVMeService: public ILocalNVMeService
     }
 
     [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> override
+        -> TFuture<TResultOrError<NProto::TNVMeDevice>> override
     {
         Y_UNUSED(serialNumber);
 
-        return MakeFuture(MakeError(S_OK));
+        return MakeFuture<TResultOrError<NProto::TNVMeDevice>>(MakeError(S_OK));
     }
 
     [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
@@ -187,7 +187,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceProxyTest)
         auto future = BlockStore->AcquireNVMeDevice(
             MakeIntrusive<TCallContext>(),
             request);
-        auto response = future.GetValueSync();
+        const auto& response = future.GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response.GetError().GetCode());
     }
 
@@ -198,7 +198,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceProxyTest)
         auto future = BlockStore->ReleaseNVMeDevice(
             MakeIntrusive<TCallContext>(),
             request);
-        auto response = future.GetValueSync();
+        const auto& response = future.GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response.GetError().GetCode());
     }
 }

--- a/cloud/blockstore/libs/local_nvme/service_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_ut.cpp
@@ -25,7 +25,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceStubTest)
 
         {
             auto future = service->AcquireNVMeDevice("foo");
-            const auto& error = future.GetValueSync();
+            const auto& [_, error] = future.GetValueSync();
 
             UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, error.GetCode());
         }

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
@@ -63,10 +63,6 @@ auto GetVFioDeviceName(const TFsPath& pciDevicePath) -> TString
         devName = child;
     }
 
-    Y_ENSURE(
-        !devName.empty(),
-        "no vfio<N> entry found in " << vfioDevDir.GetPath().Quote());
-
     return devName;
 }
 
@@ -191,6 +187,16 @@ public:
         }
 
         return device;
+    }
+
+    auto GetVfioDeviceForPCIDevice(const TString& pciAddr) -> TString final
+    {
+        return GetVFioDeviceName(SysFsRoot / "bus/pci/devices" / pciAddr);
+    }
+
+    [[nodiscard]] auto IsVfioDevSupported() const -> bool final
+    {
+        return NFs::Exists(SysFsRoot / "class/vfio-dev");
     }
 };
 

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.h
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.h
@@ -31,6 +31,11 @@ struct ISysFs
 
     virtual auto GetNVMeDeviceFromPCIAddr(const TString& pciAddr)
         -> NProto::TNVMeDevice = 0;
+
+    virtual auto GetVfioDeviceForPCIDevice(const TString& pciAddr)
+        -> TString = 0;
+
+    [[nodiscard]] virtual auto IsVfioDevSupported() const -> bool = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_local_nvme.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_local_nvme.cpp
@@ -65,9 +65,12 @@ void TDiskAgentActor::HandleAcquireNVMeDevice(
              replyFrom = ctx.SelfID,
              cookie = ev->Cookie](const auto& future)
             {
+                const auto& [device, error] = future.GetValue();
+
                 auto response = std::make_unique<
                     TEvDiskAgentPrivate::TEvAcquireNVMeDeviceResponse>(
-                    future.GetValue());
+                    error,
+                    device);
 
                 actorSystem->Send(new IEventHandle{
                     replyTo,

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_private.h
@@ -276,7 +276,9 @@ struct TEvDiskAgentPrivate
     };
 
     struct TAcquireNVMeDeviceResponse
-    {};
+    {
+        NProto::TNVMeDevice NVMeDevice;
+    };
 
     //
     // ReleaseNVMeDevice

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_local_nvme.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_local_nvme.cpp
@@ -137,6 +137,13 @@ void TLocalNVMeDeviceOpsActor::HandleAcquireNVMeDeviceResponse(
 
     auto response =
         std::make_unique<TEvService::TEvExecuteActionResponse>(msg->GetError());
+
+    if (!HasError(msg->GetError())) {
+        google::protobuf::util::MessageToJsonString(
+            msg->NVMeDevice,
+            response->Record.MutableOutput());
+    }
+
     NCloud::Reply(ctx, *RequestInfo, std::move(response));
 
     Die(ctx);
@@ -247,8 +254,7 @@ STFUNC(TLocalNVMeDeviceOpsActor::StateWork)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TListNVMeDevicesActor final
-    : public TLocalNVMeDeviceOpsActor
+class TListNVMeDevicesActor final: public TLocalNVMeDeviceOpsActor
 {
 public:
     using TLocalNVMeDeviceOpsActor::TLocalNVMeDeviceOpsActor;
@@ -269,8 +275,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TAcquireNVMeDeviceActor final
-    : public TLocalNVMeDeviceOpsActor
+class TAcquireNVMeDeviceActor final: public TLocalNVMeDeviceOpsActor
 {
 public:
     using TLocalNVMeDeviceOpsActor::TLocalNVMeDeviceOpsActor;
@@ -306,8 +311,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TReleaseNVMeDeviceActor final
-    : public TLocalNVMeDeviceOpsActor
+class TReleaseNVMeDeviceActor final: public TLocalNVMeDeviceOpsActor
 {
 public:
     using TLocalNVMeDeviceOpsActor::TLocalNVMeDeviceOpsActor;

--- a/cloud/blockstore/libs/storage/testlib/disk_agent_mock.cpp
+++ b/cloud/blockstore/libs/storage/testlib/disk_agent_mock.cpp
@@ -47,9 +47,12 @@ void TDiskAgentMock::HandleAcquireNVMeDevice(
              replyFrom = ctx.SelfID,
              cookie = ev->Cookie](const auto& future)
             {
+                const auto& [device, error] = future.GetValue();
+
                 auto response = std::make_unique<
                     TEvDiskAgentPrivate::TEvAcquireNVMeDeviceResponse>(
-                    future.GetValue());
+                    error,
+                    device);
 
                 actorSystem->Send(new IEventHandle{
                     replyTo,

--- a/cloud/blockstore/libs/storage/testlib/local_nvme_mock.cpp
+++ b/cloud/blockstore/libs/storage/testlib/local_nvme_mock.cpp
@@ -37,7 +37,7 @@ public:
     }
 
     [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> final
+        -> TFuture<TResultOrError<NProto::TNVMeDevice>> final
     {
         const auto* disk = FindIfPtr(
             Devices,
@@ -45,10 +45,11 @@ public:
             { return disk.GetSerialNumber() == serialNumber; });
 
         if (disk) {
-            return MakeFuture(NProto::TError());
+            return MakeFuture<TResultOrError<NProto::TNVMeDevice>>(
+                NProto::TError());
         }
 
-        return MakeFuture(MakeError(
+        return MakeFuture<TResultOrError<NProto::TNVMeDevice>>(MakeError(
             E_NOT_FOUND,
             TStringBuilder()
                 << "Disk " << serialNumber.Quote() << " not found"));

--- a/cloud/blockstore/public/api/protos/local_nvme.proto
+++ b/cloud/blockstore/public/api/protos/local_nvme.proto
@@ -57,6 +57,9 @@ message TAcquireNVMeDeviceResponse
 {
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
+
+    // Acquired device.
+    TNVMeDeviceDesc Device = 2;
 }
 
 message TReleaseNVMeDeviceRequest


### PR DESCRIPTION
Resolving vfio-dev for an NVMe device has been moved into `AcquireNVMeDevice`, since vfioN only becomes available after the device has been rebound to the vfio-pci driver.