### PR TITLE
fix: trying to fix concurrent comment update

### DIFF
--- a/.github/scripts/tests/finalize_workload_comments.py
+++ b/.github/scripts/tests/finalize_workload_comments.py
@@ -28,6 +28,7 @@ def iter_build_presets(matrix_include: str) -> list[str]:
 
 def main() -> None:
     setup_logger(name=__name__, fmt="%(levelname)s %(message)s")
+    setup_logger(name=gs.__name__, fmt="%(levelname)s %(message)s")
     parser = argparse.ArgumentParser()
     parser.add_argument("--matrix-include", required=True)
     parser.add_argument(

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -3,16 +3,19 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import functools
 import json
 import logging
 import os
+import random
 import re
 import sys
+import time
 from contextlib import contextmanager
 from enum import Enum
 from operator import attrgetter
 from pathlib import Path
-from typing import IO, Iterable, Protocol, TypeAlias
+from typing import IO, Callable, Iterable, Protocol, TypeAlias
 from xml.etree import ElementTree as ET
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
@@ -28,6 +31,22 @@ WORKLOAD_STATUS_START = "<!-- workload-status -->"
 WORKLOAD_STATUS_END = "<!-- /workload-status -->"
 WORKLOAD_CHECKS_START = "<!-- workload-checks -->"
 WORKLOAD_CHECKS_END = "<!-- /workload-checks -->"
+WORKLOAD_COMMENT_EDIT_ATTEMPTS = 5
+WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS = float(
+    os.environ.get("WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS", "1.0")
+)
+WORKLOAD_CHECK_STATUS_ICONS = {
+    "pending": ":white_circle:",
+    "running": ":hourglass_flowing_sand:",
+    "completed": ":white_check_mark:",
+    "failed_build": ":red_circle:",
+}
+WORKLOAD_CHECK_STATUS_ORDER = {
+    "pending": 0,
+    "running": 1,
+    "completed": 2,
+    "failed_build": 3,
+}
 
 
 class IssueCommentLike(Protocol):
@@ -47,6 +66,10 @@ class PullRequestLike(Protocol):
 
     def get_issue_comments(self) -> Iterable[IssueCommentLike]: ...
     def create_issue_comment(self, body: str) -> None: ...  # noqa: U100
+
+
+class CommentEditConflict(Exception):
+    pass
 
 
 @contextmanager
@@ -535,11 +558,62 @@ def get_comment_header(
     run_number: int,
     build_preset: str,
     is_dry_run: bool,
+    revision: int = 0,
 ) -> str:
     return (
         f"<!-- status pr={pr_number}, run={run_number}, "
-        f"build_preset={build_preset}, dry_run={is_dry_run} -->"
+        f"build_preset={build_preset}, dry_run={is_dry_run}, "
+        f"revision={revision} -->"
     )
+
+
+def get_comment_header_prefix(
+    pr_number: int,
+    run_number: int,
+    build_preset: str,
+    is_dry_run: bool,
+) -> str:
+    return (
+        f"<!-- status pr={pr_number}, run={run_number}, "
+        f"build_preset={build_preset}, dry_run={is_dry_run}, revision="
+    )
+
+
+def get_comment_revision(body: str) -> int:
+    header = body.splitlines()[0] if body else ""
+    match = re.search(r", revision=(?P<revision>\d+) -->$", header)
+    if match is None:
+        return 0
+    return int(match.group("revision"))
+
+
+def bump_comment_revision(body: str) -> str:
+    lines = body.splitlines()
+    if not lines:
+        return body
+
+    revision = get_comment_revision(body) + 1
+    if re.search(r", revision=\d+ -->$", lines[0]):
+        lines[0] = re.sub(
+            r", revision=\d+ -->$",
+            f", revision={revision} -->",
+            lines[0],
+        )
+    elif lines[0].startswith("<!-- status ") and lines[0].endswith(" -->"):
+        lines[0] = lines[0].removesuffix(" -->") + f", revision={revision} -->"
+
+    return "\n".join(lines)
+
+
+def comment_body_starts_with_header(
+    body: str,
+    header_prefix: str,
+) -> bool:
+    if body.startswith(header_prefix):
+        return True
+
+    legacy_header = header_prefix.removesuffix(", revision=") + " -->"
+    return body.startswith(legacy_header)
 
 
 def get_workload_label(component: str) -> str:
@@ -559,12 +633,6 @@ def get_workload_check_line(
     status: str,
     job_url: str = "",
 ) -> str:
-    icons = {
-        "pending": ":white_circle:",
-        "running": ":hourglass_flowing_sand:",
-        "completed": ":white_check_mark:",
-        "failed_build": ":red_circle:",
-    }
     suffixes = {
         "pending": "",
         "running": "",
@@ -575,7 +643,7 @@ def get_workload_check_line(
     if job_url:
         label = f"[{label}]({job_url})"
     return (
-        f"- {icons[status]} {label}{suffixes[status]} "
+        f"- {WORKLOAD_CHECK_STATUS_ICONS[status]} {label}{suffixes[status]} "
         f"{get_workload_check_marker(component)}"
     )
 
@@ -658,20 +726,75 @@ def replace_workload_checks_block(
     )
 
 
+def get_workload_check_line_match(
+    body: str,
+    component: str,
+) -> re.Match[str] | None:
+    marker = get_workload_check_marker(component)
+    pattern = re.compile(rf"^.*{re.escape(marker)}$", re.MULTILINE)
+    return pattern.search(body)
+
+
+def get_workload_check_status(
+    body: str,
+    component: str,
+) -> str | None:
+    match = get_workload_check_line_match(body, component)
+    if match is None:
+        return None
+
+    line = match.group(0)
+    for status, icon in WORKLOAD_CHECK_STATUS_ICONS.items():
+        if icon in line:
+            return status
+
+    return None
+
+
+def is_workload_check_update_applied(
+    body: str,
+    component: str,
+    status: str,
+) -> bool:
+    current_status = get_workload_check_status(body, component)
+    if current_status is None:
+        return False
+
+    return (
+        WORKLOAD_CHECK_STATUS_ORDER[current_status]
+        >= WORKLOAD_CHECK_STATUS_ORDER[status]
+    )
+
+
 def update_workload_check_block(
     body: str,
     component: str,
     status: str,
     job_url: str = "",
 ) -> str:
-    marker = get_workload_check_marker(component)
-    pattern = re.compile(rf"^.*{re.escape(marker)}$", re.MULTILINE)
-    match = pattern.search(body)
+    match = get_workload_check_line_match(body, component)
     if match is None:
         return body
+
+    current_status = get_workload_check_status(body, component)
+    if current_status is not None and (
+        WORKLOAD_CHECK_STATUS_ORDER[current_status]
+        > WORKLOAD_CHECK_STATUS_ORDER[status]
+    ):
+        LOGGER.info(
+            "Keeping workload check %s at %s instead of applying stale %s",
+            component,
+            current_status,
+            status,
+        )
+        return body
+
     if not job_url:
         job_url_match = re.search(r"\]\((?P<url>[^)]+)\)", match.group(0))
         job_url = job_url_match.group("url") if job_url_match else ""
+
+    marker = get_workload_check_marker(component)
+    pattern = re.compile(rf"^.*{re.escape(marker)}$", re.MULTILINE)
     return pattern.sub(
         get_workload_check_line(component, status, job_url),
         body,
@@ -698,13 +821,75 @@ def complete_workload_checks_block(body: str) -> str:
 
 def find_pr_comment(
     pr: PullRequestLike,
-    header: str,
+    header_prefix: str,
 ) -> IssueCommentLike | None:
     for comment in pr.get_issue_comments():
-        if comment.body.startswith(header):
+        if comment_body_starts_with_header(comment.body, header_prefix):
             LOGGER.info("Found comment with id=%s", comment.id)
             return comment
     return None
+
+
+def retry_pr_comment_edit(func: Callable[..., None]) -> Callable[..., None]:
+    @functools.wraps(func)
+    def wrapper(*args: object, operation: str, **kwargs: object) -> None:
+        for attempt in range(1, WORKLOAD_COMMENT_EDIT_ATTEMPTS + 1):
+            if WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS > 0:
+                time.sleep(
+                    random.uniform(0, WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS / 2)
+                )
+
+            try:
+                return func(*args, operation=operation, **kwargs)
+            except CommentEditConflict:
+                if attempt == WORKLOAD_COMMENT_EDIT_ATTEMPTS:
+                    break
+                LOGGER.warning(
+                    "Comment edit for %s was overwritten, retrying attempt %s/%s",
+                    operation,
+                    attempt,
+                    WORKLOAD_COMMENT_EDIT_ATTEMPTS,
+                )
+
+        LOGGER.warning("Comment edit for %s did not stick after retries", operation)
+
+    return wrapper
+
+
+@retry_pr_comment_edit
+def edit_pr_comment(
+    *,
+    pr: PullRequestLike,
+    header_prefix: str,
+    update_body: Callable[[str], str],
+    is_applied: Callable[[str], bool],
+    operation: str,
+) -> None:
+    comment = find_pr_comment(pr, header_prefix)
+    if comment is None:
+        LOGGER.info("Comment disappeared before %s", operation)
+        return
+
+    updated_body = update_body(comment.body)
+    if updated_body == comment.body:
+        LOGGER.info("No comment edit needed for %s", operation)
+        return
+
+    updated_body = bump_comment_revision(updated_body)
+    comment.edit(updated_body)
+
+    if WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS > 0:
+        time.sleep(WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS)
+
+    refreshed_comment = find_pr_comment(pr, header_prefix)
+    if refreshed_comment is None:
+        LOGGER.info("Comment disappeared after %s", operation)
+        return
+
+    if is_applied(refreshed_comment.body):
+        return
+
+    raise CommentEditConflict(operation)
 
 
 def get_base_comment_body(
@@ -751,7 +936,13 @@ def update_pr_comment(
     workload_status: str,
 ) -> None:
     header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
-    comment = find_pr_comment(pr, header)
+    header_prefix = get_comment_header_prefix(
+        pr.number,
+        run_number,
+        build_preset,
+        is_dry_run,
+    )
+    comment = find_pr_comment(pr, header_prefix)
 
     if comment is None:
         body = get_base_comment_body(
@@ -789,7 +980,7 @@ def update_pr_comment(
         pr.create_issue_comment(body)
     else:
         LOGGER.info("Updating existing comment")
-        comment.edit(body)
+        comment.edit(bump_comment_revision(body))
 
 
 def update_pr_comment_workload_status(
@@ -799,8 +990,13 @@ def update_pr_comment_workload_status(
     is_dry_run: bool,
     workload_status: str,
 ) -> None:
-    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
-    comment = find_pr_comment(pr, header)
+    header_prefix = get_comment_header_prefix(
+        pr.number,
+        run_number,
+        build_preset,
+        is_dry_run,
+    )
+    comment = find_pr_comment(pr, header_prefix)
 
     if comment is None:
         LOGGER.info("No existing comment found for workload status update")
@@ -808,10 +1004,12 @@ def update_pr_comment_workload_status(
 
     LOGGER.info("Updating workload status for comment id=%s", comment.id)
     comment.edit(
-        replace_workload_status_block(
-            comment.body,
-            build_preset,
-            workload_status,
+        bump_comment_revision(
+            replace_workload_status_block(
+                comment.body,
+                build_preset,
+                workload_status,
+            )
         )
     )
 
@@ -825,7 +1023,13 @@ def initialize_pr_comment(
     workload_components: list[str],
 ) -> None:
     header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
-    comment = find_pr_comment(pr, header)
+    header_prefix = get_comment_header_prefix(
+        pr.number,
+        run_number,
+        build_preset,
+        is_dry_run,
+    )
+    comment = find_pr_comment(pr, header_prefix)
 
     if comment is None:
         LOGGER.info("Creating new pre-run comment")
@@ -845,7 +1049,7 @@ def initialize_pr_comment(
     LOGGER.info("Refreshing existing pre-run comment id=%s", comment.id)
     body = replace_workload_status_block(comment.body, build_preset, workload_status)
     body = replace_workload_checks_block(body, build_preset, workload_components)
-    comment.edit(body)
+    comment.edit(bump_comment_revision(body))
 
 
 def update_pr_comment_workload_check(
@@ -857,21 +1061,34 @@ def update_pr_comment_workload_check(
     workload_check_status: str,
     job_url: str = "",
 ) -> None:
-    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
-    comment = find_pr_comment(pr, header)
+    header_prefix = get_comment_header_prefix(
+        pr.number,
+        run_number,
+        build_preset,
+        is_dry_run,
+    )
+    comment = find_pr_comment(pr, header_prefix)
 
     if comment is None:
         LOGGER.info("No existing comment found for workload check update")
         return
 
     LOGGER.info("Updating workload check for comment id=%s", comment.id)
-    comment.edit(
-        update_workload_check_block(
-            comment.body,
+    edit_pr_comment(
+        pr=pr,
+        header_prefix=header_prefix,
+        update_body=lambda body: update_workload_check_block(
+            body,
             component,
             workload_check_status,
             job_url,
-        )
+        ),
+        is_applied=lambda body: is_workload_check_update_applied(
+            body,
+            component,
+            workload_check_status,
+        ),
+        operation=f"workload check {component} -> {workload_check_status}",
     )
 
 
@@ -881,15 +1098,20 @@ def complete_pr_comment_workload_checks(
     build_preset: str,
     is_dry_run: bool,
 ) -> None:
-    header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
-    comment = find_pr_comment(pr, header)
+    header_prefix = get_comment_header_prefix(
+        pr.number,
+        run_number,
+        build_preset,
+        is_dry_run,
+    )
+    comment = find_pr_comment(pr, header_prefix)
 
     if comment is None:
         LOGGER.info("No existing comment found for workload checks completion")
         return
 
     LOGGER.info("Completing workload checks for comment id=%s", comment.id)
-    comment.edit(complete_workload_checks_block(comment.body))
+    comment.edit(bump_comment_revision(complete_workload_checks_block(comment.body)))
 
 
 def parse_title_html_path_args(args: list[str]) -> list[TitlePathTriplet]:

--- a/.github/scripts/tests/generate_summary_test.py
+++ b/.github/scripts/tests/generate_summary_test.py
@@ -214,7 +214,9 @@ def test_update_pr_comment_creates_new_comment(monkeypatch) -> None:
 
     assert len(pr.created) == 1
     body = pr.created[0]
-    assert "<!-- status pr=77, run=12, build_preset=linux, dry_run=True -->" in body
+    assert (
+        "<!-- status pr=77, run=12, build_preset=linux, dry_run=True, " "revision=0 -->"
+    ) in body
     assert "This is a simulation, not a real result" in body
     assert "<!-- workload-status -->" in body
     assert "Workload for **linux** is not finished yet" in body
@@ -250,7 +252,10 @@ def test_update_pr_comment_updates_existing_comment() -> None:
         def create_issue_comment(self, body: str) -> None:
             self.created.append(body)
 
-    header = "<!-- status pr=77, run=12, build_preset=linux, dry_run=False -->"
+    header = (
+        "<!-- status pr=77, run=12, build_preset=linux, dry_run=False, "
+        "revision=3 -->"
+    )
     existing = FakeComment(
         "\n".join(
             [
@@ -293,6 +298,7 @@ def test_update_pr_comment_updates_existing_comment() -> None:
     assert "Workload for **linux** is not finished yet" in existing.body
     assert "old text" in existing.body
     assert "some tests FAILED for commit abc123." in existing.body
+    assert gs.get_comment_revision(existing.body) == 4
 
 
 def test_update_pr_comment_workload_status_only_preserves_existing_body() -> None:
@@ -326,7 +332,10 @@ def test_update_pr_comment_workload_status_only_preserves_existing_body() -> Non
     existing = FakeComment(
         "\n".join(
             [
-                "<!-- status pr=77, run=12, build_preset=linux, dry_run=False -->",
+                (
+                    "<!-- status pr=77, run=12, build_preset=linux, "
+                    "dry_run=False, revision=7 -->"
+                ),
                 "> [!NOTE]",
                 "> This is an automated comment that will be appended during run.",
                 "",
@@ -352,8 +361,65 @@ def test_update_pr_comment_workload_status_only_preserves_existing_body() -> Non
     assert len(existing.edits) == 1
     assert "Workload for **linux** is not finished yet" not in existing.body
     assert "All workloads for **linux** have completed." in existing.body
+    assert gs.get_comment_revision(existing.body) == 8
     assert (
         ":green_circle: **linux**: all tests PASSED for commit abc123." in existing.body
+    )
+
+
+def test_update_pr_comment_workload_status_upgrades_legacy_header() -> None:
+    class FakeHead:
+        sha = "abc123"
+
+    class FakeComment:
+        id = 1001
+
+        def __init__(self, body: str) -> None:
+            self.body = body
+            self.edits = []
+
+        def edit(self, body: str) -> None:
+            self.body = body
+            self.edits.append(body)
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self, comment: FakeComment) -> None:
+            self._comment = comment
+
+        def get_issue_comments(self) -> list[FakeComment]:
+            return [self._comment]
+
+        def create_issue_comment(self, body: str) -> None:  # noqa: U100
+            raise AssertionError("should not create a new comment")
+
+    existing = FakeComment(
+        "\n".join(
+            [
+                "<!-- status pr=77, run=12, build_preset=linux, dry_run=False -->",
+                gs.WORKLOAD_STATUS_START,
+                "> [!IMPORTANT]",
+                "> Workload for **linux** is not finished yet.",
+                gs.WORKLOAD_STATUS_END,
+            ]
+        )
+    )
+    pr = FakePR(existing)
+
+    gs.update_pr_comment_workload_status(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        is_dry_run=False,
+        workload_status="completed",
+    )
+
+    assert len(existing.edits) == 1
+    assert existing.body.startswith(
+        "<!-- status pr=77, run=12, build_preset=linux, dry_run=False, "
+        "revision=1 -->"
     )
 
 
@@ -423,7 +489,10 @@ def test_update_pr_comment_workload_check_preserves_existing_job_url() -> None:
     existing = FakeComment(
         "\n".join(
             [
-                "<!-- status pr=77, run=12, build_preset=linux, dry_run=False -->",
+                (
+                    "<!-- status pr=77, run=12, build_preset=linux, "
+                    "dry_run=False, revision=0 -->"
+                ),
                 gs.WORKLOAD_CHECKS_START,
                 gs.get_workload_check_line(
                     "blockstore",
@@ -448,6 +517,96 @@ def test_update_pr_comment_workload_check_preserves_existing_job_url() -> None:
     assert len(existing.edits) == 1
     assert ":white_check_mark:" in existing.body
     assert "https://github.example/job/123" in existing.body
+    assert gs.get_comment_revision(existing.body) == 1
+
+
+def test_update_pr_comment_workload_check_retries_lost_concurrent_edit(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gs, "WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS", 0)
+
+    class FakeHead:
+        sha = "abc123"
+
+    class FakeComment:
+        id = 1001
+
+        def __init__(self, body: str) -> None:
+            self.body = body
+            self.edits = []
+
+        def edit(self, body: str) -> None:
+            self.edits.append(body)
+            self.body = body
+            if len(self.edits) == 1:
+                self.body = gs.bump_comment_revision(
+                    gs.update_workload_check_block(
+                        initial_body,
+                        "filestore",
+                        "completed",
+                    )
+                )
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self, comment: FakeComment) -> None:
+            self._comment = comment
+
+        def get_issue_comments(self) -> list[FakeComment]:
+            return [self._comment]
+
+        def create_issue_comment(self, body: str) -> None:  # noqa: U100
+            raise AssertionError("should not create a new comment")
+
+    initial_body = "\n".join(
+        [
+            (
+                "<!-- status pr=77, run=12, build_preset=linux, "
+                "dry_run=False, revision=0 -->"
+            ),
+            gs.WORKLOAD_CHECKS_START,
+            gs.get_workload_check_line("blockstore", "running"),
+            gs.get_workload_check_line("filestore", "running"),
+            gs.WORKLOAD_CHECKS_END,
+        ]
+    )
+    existing = FakeComment(initial_body)
+    pr = FakePR(existing)
+
+    gs.update_pr_comment_workload_check(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        component="blockstore",
+        is_dry_run=False,
+        workload_check_status="completed",
+    )
+
+    assert len(existing.edits) == 2
+    assert gs.get_workload_check_status(existing.body, "blockstore") == "completed"
+    assert gs.get_workload_check_status(existing.body, "filestore") == "completed"
+    assert gs.get_comment_revision(existing.body) == 2
+
+
+def test_update_workload_check_block_does_not_downgrade_completed_status() -> None:
+    body = "\n".join(
+        [
+            gs.WORKLOAD_CHECKS_START,
+            gs.get_workload_check_line("blockstore", "completed"),
+            gs.WORKLOAD_CHECKS_END,
+        ]
+    )
+
+    updated = gs.update_workload_check_block(
+        body,
+        "blockstore",
+        "running",
+        "https://github.example/job/123",
+    )
+
+    assert updated == body
 
 
 def test_complete_workload_checks_block_preserves_failed_build_rows() -> None:

--- a/.github/scripts/tests/workload_comment.py
+++ b/.github/scripts/tests/workload_comment.py
@@ -102,6 +102,7 @@ def write_output(path: str, value: str) -> None:
 
 def main() -> None:
     setup_logger(name=__name__, fmt="%(levelname)s %(message)s")
+    setup_logger(name=gs.__name__, fmt="%(levelname)s %(message)s")
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
 


### PR DESCRIPTION
During testing of different PR I found out when workload comments enter race condition, and overwrite messages.

https://github.com/ydb-platform/nbs/pull/5908#issuecomment-4406572460

There should be 4 tables with status messages, but there are only 3. This is because here
* https://github.com/ydb-platform/nbs/actions/runs/25556731181/job/75018088094
* https://github.com/ydb-platform/nbs/actions/runs/25556731181/job/75018084110 
Step `mark workload as completed` happened exactly at `Fri, 08 May 2026 13:08:43 GMT` for blockstore and filestore workloads.

Since Github API doesn't provide any way mitigate this concurrent modification in pull requests I added revision to comment header and update comment function will retry if it reads comment before update and finds out that its generation is different than comment's.

Real fix would require some changes in Github API, or can be somewhat mitigated by having some db where lock can be taken.
