### PR TITLE
issue-5934 [Filestore]: add timestamp attributes to the profile log's SetNodeAttr requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cloud/storage/core/tools/testing/qemu/bin/usr/**
 cloud/storage/core/tools/testing/qemu/bin/qemu-bin.tar.gz
 
 cloud/filestore/bin/pids.txt
+
+# nbs_internal directory
+nbs_internal/**

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,3 @@ cloud/storage/core/tools/testing/qemu/bin/usr/**
 cloud/storage/core/tools/testing/qemu/bin/qemu-bin.tar.gz
 
 cloud/filestore/bin/pids.txt
-
-# nbs_internal directory
-nbs_internal/**

--- a/cloud/filestore/libs/diagnostics/events/profile_events.ev
+++ b/cloud/filestore/libs/diagnostics/events/profile_events.ev
@@ -35,6 +35,9 @@ message TProfileLogNodeInfo {
     optional uint32 Flags = 5;
     optional uint32 Mode = 6;
     optional uint32 Type = 10;
+    optional uint64 ATime = 11;
+    optional uint64 MTime = 12;
+    optional uint64 CTime = 13;
 
     // from response (for private API requests these values can come from the
     // requests as well)

--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -18,6 +18,7 @@
 #include <cloud/filestore/public/api/protos/session.pb.h>
 
 #include <cloud/storage/core/libs/common/byte_range.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 
 #include <library/cpp/digest/crc32c/crc32c.h>
 
@@ -519,10 +520,22 @@ void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
     const NProto::TSetNodeAttrRequest& request)
 {
+    const auto flags = request.GetFlags();
     auto* nodeInfo = profileLogRequest.MutableNodeInfo();
     nodeInfo->SetParentNodeId(request.GetNodeId());
-    nodeInfo->SetFlags(request.GetFlags());
+    nodeInfo->SetFlags(flags);
     nodeInfo->SetMode(request.GetUpdate().GetMode());
+
+    using F = NProto::TSetNodeAttrRequest;
+    if (HasProtoFlag(flags, F::F_SET_ATTR_ATIME)) {
+        nodeInfo->SetATime(request.GetUpdate().GetATime());
+    }
+    if (HasProtoFlag(flags, F::F_SET_ATTR_MTIME)) {
+        nodeInfo->SetMTime(request.GetUpdate().GetMTime());
+    }
+    if (HasProtoFlag(flags, F::F_SET_ATTR_CTIME)) {
+        nodeInfo->SetCTime(request.GetUpdate().GetCTime());
+    }
 }
 
 template <>

--- a/cloud/filestore/libs/diagnostics/profile_log_events_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events_ut.cpp
@@ -8,6 +8,7 @@
 #include <cloud/filestore/public/api/protos/locks.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/protos/error.pb.h>
 
 #include <library/cpp/digest/crc32c/crc32c.h>
@@ -511,7 +512,9 @@ Y_UNIT_TEST_SUITE(TProfileLogEventsTest)
     {
         const auto nodeId = 12;
         const auto mode = 56;
-        const auto flags = 78;
+        ui32 flags = 0;
+        SetProtoFlag(flags, NProto::TSetNodeAttrRequest::F_SET_ATTR_MODE);
+        SetProtoFlag(flags, NProto::TSetNodeAttrRequest::F_SET_ATTR_UID);
 
         NProto::TSetNodeAttrRequest req;
         req.SetNodeId(nodeId);
@@ -534,6 +537,38 @@ Y_UNIT_TEST_SUITE(TProfileLogEventsTest)
         UNIT_ASSERT_VALUES_EQUAL(mode, nodeInfo.GetMode());
         UNIT_ASSERT(!nodeInfo.HasNodeId());
         UNIT_ASSERT(!nodeInfo.HasSize());
+        UNIT_ASSERT(!nodeInfo.HasATime());
+        UNIT_ASSERT(!nodeInfo.HasMTime());
+        UNIT_ASSERT(!nodeInfo.HasCTime());
+    }
+
+    Y_UNIT_TEST(ShouldSetNodeAttrRequestInitializeTimestampsCorrectly)
+    {
+        using F = NProto::TSetNodeAttrRequest;
+        const ui64 atime = 111;
+        const ui64 mtime = 222;
+        const ui64 ctime = 333;
+        ui32 flags = 0;
+        SetProtoFlag(flags, F::F_SET_ATTR_ATIME);
+        SetProtoFlag(flags, F::F_SET_ATTR_MTIME);
+        SetProtoFlag(flags, F::F_SET_ATTR_CTIME);
+
+        NProto::TSetNodeAttrRequest req;
+        req.SetFlags(flags);
+        req.MutableUpdate()->SetATime(atime);
+        req.MutableUpdate()->SetMTime(mtime);
+        req.MutableUpdate()->SetCTime(ctime);
+
+        NProto::TProfileLogRequestInfo profileLogRequest;
+        InitProfileLogRequestInfo(profileLogRequest, req);
+
+        const auto& nodeInfo = profileLogRequest.GetNodeInfo();
+        UNIT_ASSERT(nodeInfo.HasATime());
+        UNIT_ASSERT_VALUES_EQUAL(atime, nodeInfo.GetATime());
+        UNIT_ASSERT(nodeInfo.HasMTime());
+        UNIT_ASSERT_VALUES_EQUAL(mtime, nodeInfo.GetMTime());
+        UNIT_ASSERT(nodeInfo.HasCTime());
+        UNIT_ASSERT_VALUES_EQUAL(ctime, nodeInfo.GetCTime());
     }
 
     Y_UNIT_TEST(ShouldGetNodeAttrRequestInitializeFieldsCorrectly)

--- a/cloud/filestore/libs/diagnostics/profile_log_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_ut.cpp
@@ -51,7 +51,10 @@ TString NodeInfoToString(const NProto::TProfileLogNodeInfo& nodeInfo)
         << "," << nodeInfo.GetNodeId()
         << "," << nodeInfo.GetHandle()
         << "," << nodeInfo.GetSize()
-        << "," << nodeInfo.GetType();
+        << "," << nodeInfo.GetType()
+        << "," << nodeInfo.GetATime()
+        << "," << nodeInfo.GetMTime()
+        << "," << nodeInfo.GetCTime();
 }
 
 TString LockInfoToString(const NProto::TProfileLogLockInfo& lockInfo)
@@ -394,7 +397,7 @@ Y_UNIT_TEST_SUITE(TProfileLogTest)
             EventProcessor.FlatMessages[2]
         );
         UNIT_ASSERT_VALUES_EQUAL(
-            "fs2\t4000000\t11\t800000\t1\t1,node,2,new_node,3,7,12,123,32,2",
+            "fs2\t4000000\t11\t800000\t1\t1,node,2,new_node,3,7,12,123,32,2,0,0,0",
             EventProcessor.FlatMessages[3]
         );
         UNIT_ASSERT_VALUES_EQUAL(

--- a/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
@@ -112,6 +112,9 @@ TString PrintNodeInfo(
     TStringBuf handleLabel,
     TStringBuf sizeLabel,
     TStringBuf typeLabel,
+    TStringBuf aTimeLabel,
+    TStringBuf mTimeLabel,
+    TStringBuf cTimeLabel,
     const NProto::TProfileLogNodeInfo& nodeInfo)
 {
     TStringBuilder out;
@@ -147,6 +150,15 @@ TString PrintNodeInfo(
     }
     if (nodeInfo.HasType()) {
         out << PrintValue(typeLabel, nodeInfo.GetType()) << ", ";
+    }
+    if (nodeInfo.HasATime() && !aTimeLabel.empty()) {
+        out << PrintValue(aTimeLabel, nodeInfo.GetATime()) << ", ";
+    }
+    if (nodeInfo.HasMTime() && !mTimeLabel.empty()) {
+        out << PrintValue(mTimeLabel, nodeInfo.GetMTime()) << ", ";
+    }
+    if (nodeInfo.HasCTime() && !cTimeLabel.empty()) {
+        out << PrintValue(cTimeLabel, nodeInfo.GetCTime()) << ", ";
     }
 
     if (out.empty()) {
@@ -334,6 +346,9 @@ public:
                 "handle",
                 "size",
                 "type",
+                "atime",
+                "mtime",
+                "ctime",
                 request.GetNodeInfo()) << "\t";
         }
 
@@ -411,6 +426,9 @@ public:
                 "",
                 "",
                 "",
+                "",
+                "",
+                "",
                 request.GetNodeInfo());
         }
 
@@ -438,6 +456,9 @@ public:
                 "",
                 "version",
                 "",
+                "",
+                "",
+                "",
                 request.GetNodeInfo());
         }
 
@@ -457,6 +478,9 @@ public:
             return PrintNodeInfo(
                 "node_id",
                 "attr_name",
+                "",
+                "",
+                "",
                 "",
                 "",
                 "",
@@ -492,6 +516,9 @@ public:
                 "",
                 "",
                 "",
+                "",
+                "",
+                "",
                 request.GetNodeInfo());
         }
 
@@ -517,6 +544,9 @@ public:
                 "data_only",
                 "node_id",
                 "handle",
+                "",
+                "",
+                "",
                 "",
                 "",
                 request.GetNodeInfo());


### PR DESCRIPTION
### Notes
Right now, it is impossible to know if the node's time attributes were set by the SetNodeAttr from the profile log 

### Issue
#5934