### PR TITLE
issue-5715: returning E_FS_XDEV instead of E_ARGUMENT for unsupported RenameNode ops regardless of ForceDirectoryCreationInShards

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5875,6 +5875,181 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(1, counter->GetAtomic());
     }
 
+    SERVICE_TEST(ShouldReturnXDevRegardlessOfForceFlag)
+    {
+        config.SetAutomaticShardCreationEnabled(true);
+
+        const TString fsId = "test";
+        const ui64 blockCount = 1'000;
+
+        TTestEnv env({}, config);
+        ui32 nodeIdx = env.AddDynamicNode();
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        //
+        // Creating a single-tablet filesystem. No shards yet - default
+        // AutomaticallyCreatedShardSize is 5TB, so none are created.
+        //
+        service.CreateFileStore(fsId, blockCount);
+
+        auto headers = service.InitSession(fsId, "client");
+
+        //
+        // Dir and file are created before shards exist — they live in the main
+        // tablet, shardNo == 0 even after shards are added later.
+        //
+        const auto dir1Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir1")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(0, ExtractShardNo(dir1Id));
+
+        const auto file1Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(dir1Id, "file1")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(0, ExtractShardNo(file1Id));
+
+        //
+        // Adding a shard and enabling DirectoryCreationInShards.
+        //
+        service.ResizeFileStore(
+            fsId,
+            blockCount,
+            false /* force */,
+            1 /* shardCount */,
+            false /* enableStrictSizeMode */,
+            true /* directoryCreationInShards */,
+            false /* forceDirectoryCreationInShards */);
+        WaitForTabletStart(service);
+
+        headers = service.InitSession(fsId, "client");
+
+        //
+        // Creating a dir directly in shard - it's not possible to create it
+        // via the API of the main filesystem because it checks whether there
+        // are any nodes created in the main tablet.
+        //
+        // But situations like the one tested here were possible before some of
+        // the recent changes - that's why we have this test.
+        //
+        const auto shardId = fsId + "_s1";
+        auto shardHeaders = service.InitSession(shardId, "client");
+        const auto uuid = CreateGuidAsString();
+
+        const auto dir2Id =service.CreateNode(
+            shardHeaders,
+            TCreateNodeArgs::Directory(RootNodeId, uuid)
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(dir2Id));
+
+        //
+        // This node ref is not going to be used directly but let's still create
+        // it to make the directory structure similar to what we would have in
+        // real clusters.
+        //
+        {
+            NProtoPrivate::TUnsafeCreateNodeRefRequest request;
+            request.SetFileSystemId(fsId);
+            request.SetParentId(RootNodeId);
+            request.SetName("dir2");
+            request.SetShardId(shardId);
+            request.SetShardNodeName(uuid);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("UnsafeCreateNodeRef", buf);
+        }
+
+        //
+        // Creating a file in the new dir.
+        //
+        const auto fileId2 = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(dir2Id, "file2")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(fileId2));
+
+        //
+        // Trying to move file1 into dir2. Can't be done because dir1/file1
+        // NodeRef is not external.
+        //
+        {
+            auto response = service.SendAndRecvRenameNode(
+                headers,
+                dir1Id,
+                "file1",
+                dir2Id,
+                "file1",
+                0 /* flags */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FS_XDEV,
+                response->GetError().GetCode(),
+                response->GetError().GetMessage());
+        }
+
+        //
+        // Trying to move file2 into dir1. Should be possible.
+        //
+        {
+            auto response = service.SendAndRecvRenameNode(
+                headers,
+                dir2Id,
+                "file2",
+                dir1Id,
+                "file2",
+                0 /* flags */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetError().GetCode(),
+                response->GetError().GetMessage());
+        }
+
+        //
+        // file1 can be renamed in dir1.
+        //
+        {
+            auto response = service.SendAndRecvRenameNode(
+                headers,
+                dir1Id,
+                "file1",
+                dir1Id,
+                "file1.new",
+                0 /* flags */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetError().GetCode(),
+                response->GetError().GetMessage());
+        }
+
+        //
+        // Creating a file in the new dir.
+        //
+        const auto fileId3 = service.CreateNode(
+            headers,
+            TCreateNodeArgs::File(dir2Id, "file3")
+        )->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(fileId3));
+
+        //
+        // Can't move file3 on top of file1.new because dir1/file1.new is not an
+        // external NodeRef. Technically such an op can be implemented but right
+        // now it's not.
+        //
+        {
+            auto response = service.SendAndRecvRenameNode(
+                headers,
+                dir2Id,
+                "file3",
+                dir1Id,
+                "file1.new",
+                0 /* flags */);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FS_XDEV,
+                response->GetError().GetCode(),
+                response->GetError().GetMessage());
+        }
+    }
+
     SERVICE_TEST(ShouldListNodesAndGetNodeAttrInDirectoryInShard)
     {
         config.SetDirectoryCreationInShardsEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -98,18 +98,6 @@ NProto::TError TIndexTabletActor::HandleCrossShardRenameNodeImpl(
         return MakeError(E_ARGUMENT, std::move(message));
     }
 
-    if (newParentShardNo == 0
-            && record.GetNewParentId() != RootNodeId
-            && !GetFileSystem().GetForceDirectoryCreationInShards())
-    {
-        auto message = ReportInvalidShardNo(
-            TStringBuilder() << "RenameNode: "
-                << record.ShortDebugString() << " newParentShardNo"
-                << ": " << newParentShardNo << ", NewParentId: "
-                << record.GetNewParentId());
-        return MakeError(E_ARGUMENT, std::move(message));
-    }
-
     ExecuteTx<TPrepareRenameNodeInSource>(
         ctx,
         std::move(requestInfo),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -558,21 +558,13 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
         }
 
         if (!args.NewChildRef->IsExternal()) {
-            if (GetFileSystem().GetForceDirectoryCreationInShards()) {
-                Metrics.RenameNotSupportedErrorCount.fetch_add(
-                    1,
-                    std::memory_order_relaxed);
+            Metrics.RenameNotSupportedErrorCount.fetch_add(
+                1,
+                std::memory_order_relaxed);
 
-                args.Error = ErrorRenameNotSupported(
-                    args.Request.GetOriginalRequest().GetNodeId(),
-                    args.Request.GetNewParentId());
-            } else {
-                auto message = ReportRenameNodeRequestForLocalNode(
-                    TStringBuilder() << "RenameNodeInDestination: "
-                        << args.Request.ShortDebugString());
-                args.Error = MakeError(E_ARGUMENT, std::move(message));
-            }
-
+            args.Error = ErrorRenameNotSupported(
+                args.Request.GetOriginalRequest().GetNodeId(),
+                args.Request.GetNewParentId());
             return true;
         }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -460,21 +460,13 @@ bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
     }
 
     if (!args.ChildRef->IsExternal()) {
-        if (GetFileSystem().GetForceDirectoryCreationInShards()) {
-            Metrics.RenameNotSupportedErrorCount.fetch_add(
-                1,
-                std::memory_order_relaxed);
+        Metrics.RenameNotSupportedErrorCount.fetch_add(
+            1,
+            std::memory_order_relaxed);
 
-            args.Error = ErrorRenameNotSupported(
-                args.ParentNodeId,
-                args.Request.GetNewParentId());
-        } else {
-            auto message = ReportRenameNodeRequestForLocalNode(TStringBuilder()
-                << "PrepareRenameNodeInSource: "
-                << args.Request.ShortDebugString());
-            args.Error = MakeError(E_ARGUMENT, std::move(message));
-        }
-
+        args.Error = ErrorRenameNotSupported(
+            args.ParentNodeId,
+            args.Request.GetNewParentId());
         return true;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -986,7 +986,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
             CreateGuidAsString());
         auto response = tablet.RecvRenameNodeInDestinationResponse();
         UNIT_ASSERT_VALUES_EQUAL_C(
-            E_ARGUMENT,
+            E_FS_XDEV,
             response->GetStatus(),
             FormatError(response->GetError()));
     }


### PR DESCRIPTION
### Notes
In some rare cases we can have filesystems which have both directories in shards and directories in the main tablet but which do not have the `ForceDirectoryCreationInShards` flag. Simplifying the code to just return `E_FS_XDEV` for the unsupported `RenameNode` ops regardless of the `ForceDirectoryCreationInShards` flag. Added a unit test which tests various kinds of moves for such filesystems.

### Issue
https://github.com/ydb-platform/nbs/issues/5715