### PR TITLE
issue-5640: CPUUsageRate should use CPUUsageMicros values, not executor pool ElapsedByActivity

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -578,24 +578,17 @@ void TIndexTabletActor::SendMetricsToExecutor(const TActorContext& ctx)
 
 void TIndexTabletActor::CalculateActorCPUUsage(const TActorContext& ctx)
 {
-    TExecutorPoolStats poolStats;
-    TVector<TExecutorThreadStats> threadStats;
-    auto& actorSystem = *ctx.ExecutorThread.ActorSystem;
-    const ui32 poolId = ctx.SelfID.PoolID();
-    actorSystem.GetPoolStats(poolId, poolStats, threadStats);
-    i64 ticks = 0;
-    for (ui64 i = 0; i < threadStats.size(); ++i) {
-        ticks += threadStats[i].ElapsedTicksByActivity[GetActivityType()];
-    }
-
-    const i64 curUsageMicros = ::NHPTimer::GetSeconds(ticks) * 1'000'000;
+    const i64 curUsageMicros =
+        Metrics.CPUUsageMicros.load(std::memory_order_relaxed);
     const TInstant ts = ctx.Now();
     if (Metrics.PrevCPUUsageMicrosTs) {
         const auto timeDiff = ts - Metrics.PrevCPUUsageMicrosTs;
         if (timeDiff) {
             const double usageDiff =
                 curUsageMicros - Metrics.PrevCPUUsageMicros;
-            Metrics.CPUUsageRate = 100 * (usageDiff / timeDiff.MicroSeconds());
+            Metrics.CPUUsageRate.store(
+                100 * (usageDiff / timeDiff.MicroSeconds()),
+                std::memory_order_relaxed);
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -389,6 +389,7 @@ void TTabletMetrics::Register(
     //
 
     REGISTER_AGGREGATABLE_SUM(CPUUsageMicros, EMetricType::MT_DERIVATIVE);
+    REGISTER_LOCAL(CPUUsageRate, EMetricType::MT_ABSOLUTE);
 
     REGISTER_LOCAL(OpLogEntryCount, EMetricType::MT_ABSOLUTE);
     REGISTER_LOCAL(ResponseLogEntryCount, EMetricType::MT_ABSOLUTE);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -290,7 +290,7 @@ struct TTabletMetrics
     TInstant PrevCPUUsageMicrosTs;
     i64 PrevCPUUsageMicros{0};
     std::atomic<i64> CPUUsageMicros{0};
-    i64 CPUUsageRate = 0;
+    std::atomic<i64> CPUUsageRate{0};
 
     std::atomic<i64> OpLogEntryCount{0};
     std::atomic<i64> ResponseLogEntryCount{0};


### PR DESCRIPTION
### Notes
Fixing a brain fart - previously I changed `CPUUsageMicros` calculation code so that it would:
* calculate the time spent in all `TIndexTabletActor`'s methods - including tx code
* calculate values for different tablets separately
But I forgot to fix `CPUUsageRate` calculation - it's still calculated via `ElapsedByActivity` actor system counters. And it's hard to catch that in tests because:
* values depend on timing
* the values calculated by the current code are actually more or less correct in most of the cases

In this PR I fixed `CPUUsageRate` calculation to use `CPUUsageMicros` values and also exposed it as a separate counter to be able to see its values on the monitoring dashboards.

### Issue
https://github.com/ydb-platform/nbs/issues/5640
