### PR TITLE
[Filestore] Prevent modification of TFileRingBuffer if corruption is detected; do not report false positives

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -3599,7 +3599,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                     sessionId / "write_back_cache";
 
         {
-            TFileRingBuffer ringBuffer(path, WriteBackCacheCapacity);
+            TFileRingBuffer ringBuffer(path, {}, "", WriteBackCacheCapacity);
             UNIT_ASSERT(!ringBuffer.Empty());
         }
 
@@ -3640,7 +3640,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         }
 
         {
-            TFileRingBuffer ringBuffer(path, WriteBackCacheCapacity);
+            TFileRingBuffer ringBuffer(path, {}, "", WriteBackCacheCapacity);
             UNIT_ASSERT(ringBuffer.Empty());
         }
 

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
@@ -4,8 +4,12 @@ namespace NCloud::NFileStore::NFuse {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-THandleOpsQueue::THandleOpsQueue(const TString& filePath, ui32 size)
-    : RequestsToProcess(filePath, size)
+THandleOpsQueue::THandleOpsQueue(
+    const TString& filePath,
+    ui32 size,
+    TLog log,
+    TString logTag)
+    : RequestsToProcess(filePath, std::move(log), std::move(logTag), size)
 {}
 
 THandleOpsQueue::EResult THandleOpsQueue::AddDestroyRequest(
@@ -59,9 +63,15 @@ ui64 THandleOpsQueue::Size() const
 
 THandleOpsQueuePtr CreateHandleOpsQueue(
     const TString& filePath,
-    ui32 size)
+    ui32 size,
+    TLog log,
+    TString logTag)
 {
-    return std::make_unique<THandleOpsQueue>(filePath, size);
+    return std::make_unique<THandleOpsQueue>(
+        filePath,
+        size,
+        std::move(log),
+        std::move(logTag));
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.h
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.h
@@ -5,6 +5,7 @@
 #include <cloud/filestore/libs/vfs_fuse/protos/queue_entry.pb.h>
 
 #include <cloud/storage/core/libs/common/file_ring_buffer.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
 
 namespace NCloud::NFileStore::NFuse {
 
@@ -23,7 +24,11 @@ public:
         SerializationError,
     };
 
-    explicit THandleOpsQueue(const TString& filePath, ui32 size);
+    THandleOpsQueue(
+        const TString& filePath,
+        ui32 size,
+        TLog log,
+        TString logTags);
 
     EResult AddDestroyRequest(ui64 nodeId, ui64 handle);
     std::optional<NProto::TQueueEntry> Front();
@@ -34,6 +39,10 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-THandleOpsQueuePtr CreateHandleOpsQueue(const TString& filePath, ui32 size);
+THandleOpsQueuePtr CreateHandleOpsQueue(
+    const TString& filePath,
+    ui32 size,
+    TLog log,
+    TString logTag);
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1002,7 +1002,12 @@ private:
 
                     handleOpsQueue = CreateHandleOpsQueue(
                         path / HandleOpsQueueFileName,
-                        Config->GetHandleOpsQueueSize());
+                        Config->GetHandleOpsQueueSize(),
+                        Log,
+                        Sprintf(
+                            "[f:%s][c:%s]",
+                            Config->GetFileSystemId().Quote().c_str(),
+                            Config->GetClientId().Quote().c_str()));
                     HandleOpsQueueInitialized = true;
                 } else {
                     ReportHandleOpsQueueCreatingOrDeletingError(Sprintf(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -32,7 +32,12 @@ public:
         TLog log,
         TString logTag)
         : Stats(std::move(stats))
-        , Storage(config.FilePath, config.DataCapacity, config.MetadataCapacity)
+        , Storage(
+              config.FilePath,
+              log,
+              logTag,
+              config.DataCapacity,
+              config.MetadataCapacity)
         , Config(std::move(config))
         , Log(std::move(log))
         , LogTag(std::move(logTag))

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -97,7 +97,7 @@ public:
 //  Structure contract:
 //
 //  1. Empty buffer:
-//    - ReadPos = WritePos = 0
+//    - ReadPos == WritePos (any position)
 //
 //  2. Non-empty buffer:
 //    - ReadPos != WritePos
@@ -277,6 +277,8 @@ class TFileRingBuffer::TImpl
 {
 private:
     TFileMap Map;
+    TLog Log;
+    const TString LogTag;
 
     TEntriesData Data;
     bool Corrupted = false;
@@ -381,8 +383,17 @@ private:
         TEntryInfo back = front;
         TEntryInfo cur = front;
 
-        if (front.IsInvalid() || front.ActualPos != Header()->ReadPos) {
+        if (front.IsInvalid()) {
             SetCorrupted();
+            return;
+        }
+
+        if (front.ActualPos != Header()->ReadPos) {
+            STORAGE_WARN(
+                LogTag
+                << " TFileRingBuffer: Front entry position mismatch, ReadPos = "
+                << Header()->ReadPos
+                << ", front.ActualPos = " << front.ActualPos);
         }
 
         while (cur.HasValue()) {
@@ -390,17 +401,17 @@ private:
             cur = GetNextEntry(cur);
         }
 
-        if (cur.IsInvalid() || cur.ActualPos != Header()->WritePos) {
+        if (cur.IsInvalid()) {
             SetCorrupted();
+            return;
         }
 
-        if (front.HasValue()) {
-            Y_ABORT_UNLESS(back.HasValue());
-            Header()->ReadPos = front.ActualPos;
-            Header()->WritePos = back.GetNextEntryPos();
-        } else {
-            Header()->ReadPos = 0;
-            Header()->WritePos = 0;
+        if (back.GetNextEntryPos() != Header()->WritePos) {
+            STORAGE_WARN(
+                LogTag
+                << " TFileRingBuffer: Back entry position mismatch, WritePos = "
+                << Header()->WritePos
+                << ", back.GetNextEntryPos() = " << back.GetNextEntryPos());
         }
     }
 
@@ -507,18 +518,31 @@ private:
             front = GetNextEntry(front);
         }
 
-        if (front.HasValue()) {
-            Header()->ReadPos = front.ActualPos;
+        if (front.IsInvalid()) {
+            SetCorrupted();
         } else {
-            // All entries deleted, ring buffer should be emptied
-            Header()->ReadPos = 0;
-            Header()->WritePos = 0;
+            Header()->ReadPos = front.ActualPos;
+        }
+    }
+
+    void WriteSlackSpaceMarker(ui64 pos)
+    {
+        auto* eh = Data.GetEntryHeader(pos);
+        if (eh != nullptr) {
+            eh->SetDataSize(0);
         }
     }
 
 public:
-    TImpl(const TString& filePath, ui64 dataCapacity, ui64 metadataCapacity)
+    TImpl(
+        const TString& filePath,
+        TLog log,
+        TString logTag,
+        ui64 dataCapacity,
+        ui64 metadataCapacity)
         : Map(filePath, TMemoryMapCommon::oRdWr)
+        , Log(std::move(log))
+        , LogTag(std::move(logTag))
     {
         Y_ABORT_UNLESS(sizeof(TEntryHeader) <= dataCapacity);
 
@@ -553,7 +577,10 @@ public:
                 }
             });
 
-        EraseFreeEntriesFromFront();
+        if (!IsCorrupted()) {
+            // This call also skips slack space
+            EraseFreeEntriesFromFront();
+        }
     }
 
     bool PushBack(TStringBuf data)
@@ -618,10 +645,7 @@ public:
                         // out of space
                         return nullptr;
                     }
-                    auto* eh = Data.GetEntryHeader(Header()->WritePos);
-                    if (eh != nullptr) {
-                        eh->SetDataSize(0);
-                    }
+                    WriteSlackSpaceMarker(Header()->WritePos);
                     writePos = 0;
                 }
             } else {
@@ -633,6 +657,19 @@ public:
                     return nullptr;
                 }
             }
+        } else if (Header()->WritePos != 0) {
+            // In order to fully utilize space when the buffer is empty,
+            // we need to reset read and write positions and ensure that
+            // the state can be restored from the intermediate state
+            WriteSlackSpaceMarker(Header()->WritePos);
+            // Ensure ordering of write operations
+            std::atomic_thread_fence(std::memory_order_release);
+            Header()->WritePos = 0;
+            // If crash happens here, EraseFreeEntriesFromFront() called in
+            // constructor will skip slack space
+            std::atomic_thread_fence(std::memory_order_release);
+            Header()->ReadPos = 0;
+            writePos = 0;
         }
 
         CurrentAllocation = Data.GetEntryHeader(writePos);
@@ -672,6 +709,10 @@ public:
 
     bool Free(const void* ptr)
     {
+        if (IsCorrupted()) {
+            return false;
+        }
+
         auto it = EntryMap.find(ptr);
         if (it == EntryMap.end()) {
             return false;
@@ -845,9 +886,16 @@ public:
 
 TFileRingBuffer::TFileRingBuffer(
         const TString& filePath,
+        TLog log,
+        TString logTag,
         ui64 dataCapacity,
         ui64 metadataCapacity)
-    : Impl(new TImpl(filePath, dataCapacity, metadataCapacity))
+    : Impl(new TImpl(
+          filePath,
+          std::move(log),
+          std::move(logTag),
+          dataCapacity,
+          metadataCapacity))
 {}
 
 TFileRingBuffer::~TFileRingBuffer() = default;

--- a/cloud/storage/core/libs/common/file_ring_buffer.h
+++ b/cloud/storage/core/libs/common/file_ring_buffer.h
@@ -2,6 +2,8 @@
 
 #include "error.h"
 
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
@@ -43,6 +45,8 @@ public:
     */
     TFileRingBuffer(
         const TString& filePath,
+        TLog log,
+        TString logTag,
         ui64 dataCapacity,
         ui64 metadataCapacity = 0);
 

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -9,7 +9,7 @@
 #include <util/system/filemap.h>
 #include <util/system/tempfile.h>
 
-namespace NCloud {
+namespace NCloud::NTesting {
 
 namespace {
 
@@ -87,6 +87,22 @@ TString PopAll(TFileRingBuffer& rb)
     return sb;
 }
 
+class TFileRingBuffer: public NCloud::TFileRingBuffer
+{
+public:
+    TFileRingBuffer(
+        const TString& filePath,
+        ui64 dataCapacity,
+        ui64 metadataCapacity = 0)
+        : NCloud::TFileRingBuffer(
+              filePath,
+              TLog(),
+              "[tag]",
+              dataCapacity,
+              metadataCapacity)
+    {}
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TReferenceImplementation
@@ -115,24 +131,24 @@ struct TReferenceImplementation
         }
 
         if (!Empty()) {
-            if (ReadPos < WritePos) {
-                const auto avail = MaxWeight - WritePos;
-                if (avail < sz) {
-                    if (ReadPos <= sz) {
-                        // out of space
-                        return false;
-                    }
-
-                    SlackSpace = avail;
-                    WritePos = 0;
-                }
-            } else {
-                const auto avail = ReadPos - WritePos;
-                if (avail <= sz) {
+        if (ReadPos < WritePos) {
+            const auto avail = MaxWeight - WritePos;
+            if (avail < sz) {
+                if (ReadPos <= sz) {
                     // out of space
                     return false;
                 }
+
+                SlackSpace = avail;
+                WritePos = 0;
             }
+        } else {
+            const auto avail = ReadPos - WritePos;
+            if (avail <= sz) {
+                // out of space
+                return false;
+            }
+        }
         }
 
         WritePos += sz;
@@ -588,28 +604,18 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb.PushBack("12345678"));
     }
 
-    Y_UNIT_TEST(VisitAndPopBackShouldProduceSameResults)
+    Y_UNIT_TEST(ForbidModificationOfCorruptedBuffer)
     {
-        for (int i = 0; i <= 32; i++) {
-            TStateWithCorruptedEntryLength s(i);
-            TFileRingBuffer rb(s.FileHandle.GetName(), s.Len);
+        TStateWithCorruptedEntryLength s(13);
+        TFileRingBuffer rb(s.FileHandle.GetName(), s.Len);
 
-            TVector<TString> afterVisit;
-            rb.Visit([&] (ui32 checksum, TStringBuf entry)
-            {
-                Y_UNUSED(checksum);
-                afterVisit.push_back(TString(entry));
-            });
-
-            TVector<TString> afterPopBack;
-            while (!rb.Empty())
-            {
-                afterPopBack.push_back(TString(rb.Front()));
-                rb.PopFront();
-            }
-
-            UNIT_ASSERT_EQUAL(Dump(afterVisit), Dump(afterPopBack));
-        }
+        auto state1 = Dump(rb);
+        rb.PopFront();
+        auto state2 = Dump(rb);
+        UNIT_ASSERT_VALUES_EQUAL(state1, state2);
+        rb.PushBack("1");
+        auto state3 = Dump(rb);
+        UNIT_ASSERT_VALUES_EQUAL(state1, state3);
     }
 
     Y_UNIT_TEST(ShouldGetRawCapacity)
@@ -1036,6 +1042,32 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         UNIT_ASSERT_VALUES_EQUAL("", Dump(*rb));
         UNIT_ASSERT_VALUES_EQUAL(0, rb->Size());
+    }
+
+    Y_UNIT_TEST(ShouldSupportFreeBetweenAllocAndCommit)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 36;
+        auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        const TString data = "efgh";
+
+        UNIT_ASSERT(rb->PushBack("abcd"));   // 12 bytes
+
+        auto alloc = rb->Alloc(4);
+        UNIT_ASSERT(!HasError(alloc));
+        data.copy(alloc.GetResult(), data.size());
+
+        rb->PopFront();
+
+        UNIT_ASSERT(rb->Commit());
+
+        UNIT_ASSERT_VALUES_EQUAL(data, rb->Front());
+
+        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        UNIT_ASSERT(!rb->IsCorrupted());
+        UNIT_ASSERT_VALUES_EQUAL(data, rb->Front());
     }
 }
 

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -131,24 +131,24 @@ struct TReferenceImplementation
         }
 
         if (!Empty()) {
-        if (ReadPos < WritePos) {
-            const auto avail = MaxWeight - WritePos;
-            if (avail < sz) {
-                if (ReadPos <= sz) {
+            if (ReadPos < WritePos) {
+                const auto avail = MaxWeight - WritePos;
+                if (avail < sz) {
+                    if (ReadPos <= sz) {
+                        // out of space
+                        return false;
+                    }
+
+                    SlackSpace = avail;
+                    WritePos = 0;
+                }
+            } else {
+                const auto avail = ReadPos - WritePos;
+                if (avail <= sz) {
                     // out of space
                     return false;
                 }
-
-                SlackSpace = avail;
-                WritePos = 0;
             }
-        } else {
-            const auto avail = ReadPos - WritePos;
-            if (avail <= sz) {
-                // out of space
-                return false;
-            }
-        }
         }
 
         WritePos += sz;


### PR DESCRIPTION
### Notes
An attempt to resolve the problem:
```
NFS_VHOST INFO: CRITICAL_EVENT:AppCriticalEvents/WriteBackCacheCorruptionError:[f:computefilesystem-e02atffgtkhmza0dmv][c:nbs.csi.nebius.ai-node-0082.compute-prod.ik8s.kef.nbhost.net-computeinstance-e02nv0v47ze2khqhw6] WriteBackCache persistent storage initialization failed: { Code: 2147483648 Message: "Data structure is corrupted" }
```

Changes in the PR:

1. Corruption is no more a recoverable state. Previously, restoration of read and write position happened and alloc/free was allowed. Now the strategy is changed from 'try to restore whatever is possible' to the strategy 'halt and wait for a manual action'.

2. Some states that are not expected normally but could appear on interruption are no more treated as corruption. For example, pointing to a slack space marker. Now this is reported to log as a warning message.

3. Setting ReadPos = WritePos = 0 in Free/PopFront when the buffer is empty is fragile. Now is it managed in `Alloc` in a more safe way.
