### PR TITLE
[Filestore] Release barrier in case of early return for unconfirmed data flow in GenerateBlobIds

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -379,15 +379,6 @@ void TIndexTabletActor::HandleGenerateBlobIds(
         return;
     }
 
-    if (!canUseUnconfirmed) {
-        // We schedule this event for the case if the client does not call
-        // AddData. Thus we ensure that the collect barrier will be released
-        // eventually.
-        ctx.Schedule(
-            Config->GetGenerateBlobIdsReleaseCollectBarrierTimeout(),
-            new TEvIndexTabletPrivate::TEvReleaseCollectBarrier(commitId, 1));
-    }
-
     AcquireCollectBarrier(commitId);
 
     auto response =
@@ -401,6 +392,8 @@ void TIndexTabletActor::HandleGenerateBlobIds(
             GenerateBlobId(commitId, length, blobIndex, &partialBlobId);
         if (!ok) {
             ReassignDataChannelsIfNeeded(ctx);
+
+            TABLET_VERIFY(TryReleaseCollectBarrier(commitId));
 
             auto response =
                 std::make_unique<TEvIndexTablet::TEvGenerateBlobIdsResponse>(
@@ -418,6 +411,15 @@ void TIndexTabletActor::HandleGenerateBlobIds(
             partialBlobId.Channel(),
             partialBlobId.Generation()));
         offset += length;
+    }
+
+    if (!canUseUnconfirmed) {
+        // We schedule this event for the case if the client does not call
+        // AddData. Thus we ensure that the collect barrier will be released
+        // eventually.
+        ctx.Schedule(
+            Config->GetGenerateBlobIdsReleaseCollectBarrierTimeout(),
+            new TEvIndexTabletPrivate::TEvReleaseCollectBarrier(commitId, 1));
     }
 
     response->Record.SetCommitId(commitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1253,6 +1253,81 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         TIndexTabletClient observer(runtime, nodeIdx, tabletId);
         AssertStorageStats(observer, 0, 0);
     }
+
+    Y_UNIT_TEST(ShouldReleaseCollectBarrierOnGenerateBlobIdsChannelError)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({.ChannelCount = 4}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            TFileSystemConfig{.ChannelCount = 4});
+        tablet.InitSession("client", "session");
+
+        auto& runtime = env.GetRuntime();
+
+        bool yellowStopInjected = false;
+        runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() != TEvBlobStorage::EvPutResult) {
+                    return false;
+                }
+
+                auto* msg = event->Get<TEvBlobStorage::TEvPutResult>();
+                if (msg->Id.TabletID() != tabletId ||
+                    msg->Id.Channel() < TIndexTabletSchema::DataChannel)
+                {
+                    return false;
+                }
+
+                const auto flags =
+                    ui32(NKikimrBlobStorage::StatusIsValid) |
+                    ui32(NKikimrBlobStorage::StatusDiskSpaceYellowStop);
+                const_cast<TStorageStatusFlags&>(msg->StatusFlags).Merge(flags);
+                yellowStopInjected = true;
+                return false;
+            });
+
+        auto gcNode =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "gc"));
+        ui64 gcHandle = CreateHandle(tablet, gcNode);
+        tablet.WriteData(gcHandle, 0, block, 'a');
+        UNIT_ASSERT(yellowStopInjected);
+
+        auto id =
+            CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "target"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto failedGenerateBlobIds =
+            tablet.AssertGenerateBlobIdsFailed(id, handle, 0, block);
+        UNIT_ASSERT_VALUES_EQUAL(
+            E_FS_OUT_OF_SPACE,
+            failedGenerateBlobIds->GetStatus());
+
+        const ui64 commitIdAfterFailedGenerateBlobIds =
+            tablet.GenerateCommitId()->CommitId;
+
+        tablet.DestroyHandle(gcHandle);
+        tablet.UnlinkNode(RootNodeId, "gc", false);
+        tablet.CollectGarbage();
+
+        UNIT_ASSERT_GT(
+            tablet.GetStorageStats()
+                ->Record.GetStats()
+                .GetLastCollectCommitId(),
+            commitIdAfterFailedGenerateBlobIds);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Notes
If GenerateBlobId fails, GenerateBlobIds returns early for unconfirmed data flow, so the barrier must be released in that path.

Moved the barrier-release scheduling for the regular three-stage write to after blob ID generation.
Added a barrier release on GenerateBlobIds error.

### Issue
#2293
