### PR TITLE
issue-5942: decrypt reads on separate threads for local disks

### DIFF
--- a/cloud/blockstore/config/server.proto
+++ b/cloud/blockstore/config/server.proto
@@ -288,6 +288,9 @@ message TServerConfig
 
     // Drop all discard requests without processing them.
     optional bool DropDiscardRequests = 132;
+
+    // Size of the thread pool for the external vhost server.
+    optional uint32 ExternalVhostServerThreadPoolSize = 133;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -1128,9 +1128,11 @@ private:
             }
         }
 
-        args.emplace_back("--thread-pool-size");
-        args.emplace_back(
-            ToString(ServerConfig->GetExternalVhostServerThreadPoolSize()));
+        if (ServerConfig->GetExternalVhostServerThreadPoolSize()) {
+            args.emplace_back("--thread-pool-size");
+            args.emplace_back(
+                ToString(ServerConfig->GetExternalVhostServerThreadPoolSize()));
+        }
 
         TVector<TString> cgroups(
             request.GetClientCGroups().begin(),

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -1128,11 +1128,13 @@ private:
             }
         }
 
+        args.emplace_back("--thread-pool-size");
+        args.emplace_back(
+            ToString(ServerConfig->GetExternalVhostServerThreadPoolSize()));
+
         TVector<TString> cgroups(
             request.GetClientCGroups().begin(),
-            request.GetClientCGroups().end()
-        );
-
+            request.GetClientCGroups().end());
 
         auto ep = EndpointFactory(
             clientId,

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -946,6 +946,84 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
             UNIT_ASSERT_C(stop, "actual entry: " << History[0].index());
         }
     }
+
+    Y_UNIT_TEST_F(ShoultPassThreadPoolSize, TFixture)
+    {
+        UNIT_ASSERT_VALUES_EQUAL(0, History.size());
+        {
+            const ui64 threadPoolSize = RandInt<ui64>() % 10 + 1;
+            NProto::TServerConfig serverConfig;
+            serverConfig.SetExternalVhostServerThreadPoolSize(threadPoolSize);
+            Listener = CreateEndpointListener(false, serverConfig);
+            auto request = CreateDefaultStartEndpointRequest();
+
+            auto error = Listener->StartEndpoint(request, Volume, Session)
+                             .GetValueSync();
+            UNIT_ASSERT_C(!HasError(error), error);
+
+            UNIT_ASSERT_VALUES_EQUAL(3, History.size());
+
+            auto* create = std::get_if<TCreateExternalEndpoint>(&History[0]);
+            UNIT_ASSERT_C(create, "actual entry: " << History[0].index());
+
+            UNIT_ASSERT_VALUES_EQUAL(Volume.GetDiskId(), create->DiskId);
+
+            /*
+                --serial local0                     2
+                --disk-id vol0                      2
+                --block-size 512                    2
+                --socket-path /tmp/socket.vhost     2
+                --socket-access-mode ...            2
+                -q 2                                2
+                --device ...                        2
+                --device ...                        2
+                --read-only                         1
+                --wait-after-parent-exit ...        2
+                --thread-pool-size  ...             2
+                                                   19
+            */
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                21,
+                create->CmdArgs.size(),
+                JoinStrings(create->CmdArgs, " "));
+            UNIT_ASSERT_VALUES_EQUAL("local0", GetArg(create->CmdArgs, "--serial"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "vol0",
+                GetArg(create->CmdArgs, "--disk-id"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "512",
+                GetArg(create->CmdArgs, "--block-size"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                "30",
+                GetArg(create->CmdArgs, "--wait-after-parent-exit"));
+            UNIT_ASSERT_VALUES_EQUAL(
+                ToString(threadPoolSize),
+                GetArg(create->CmdArgs, "--thread-pool-size"));
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                "/tmp/socket.vhost",
+                GetArg(create->CmdArgs, "--socket-path"));
+
+            UNIT_ASSERT_VALUES_EQUAL("2", GetArg(create->CmdArgs, "-q"));
+            UNIT_ASSERT(FindPtr(create->CmdArgs, "--read-only"));
+
+            auto devices = GetArgN(create->CmdArgs, "--device");
+            UNIT_ASSERT_VALUES_EQUAL(2, devices.size());
+
+            History.clear();
+        }
+
+        {
+            auto error = Listener->StopEndpoint(SocketPath).GetValueSync();
+            UNIT_ASSERT_C(!HasError(error), error);
+
+            UNIT_ASSERT_VALUES_EQUAL(1, History.size());
+            auto* stop = std::get_if<TStopExternalEndpoint>(&History[0]);
+            UNIT_ASSERT_C(stop, "actual entry: " << History[0].index());
+        }
+    }
+
 }
 
 }   // namespace NCloud::NBlockStore::NServer

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -947,7 +947,7 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
         }
     }
 
-    Y_UNIT_TEST_F(ShoultPassThreadPoolSize, TFixture)
+    Y_UNIT_TEST_F(ShouldPassThreadPoolSize, TFixture)
     {
         UNIT_ASSERT_VALUES_EQUAL(0, History.size());
         {

--- a/cloud/blockstore/libs/server/config.cpp
+++ b/cloud/blockstore/libs/server/config.cpp
@@ -118,6 +118,7 @@ constexpr TDuration Seconds(int s)
     xxx(AutomaticNbdDeviceManagement,bool,                   false            )\
     xxx(EnableOverlappingRequestsGuard,  bool,               false            )\
     xxx(EnableRequestSplitter,       bool,                   false            )\
+    xxx(ExternalVhostServerThreadPoolSize, ui64,             0                )\
 // BLOCKSTORE_SERVER_CONFIG
 
 // clang-format on

--- a/cloud/blockstore/libs/server/config.h
+++ b/cloud/blockstore/libs/server/config.h
@@ -148,6 +148,7 @@ public:
     bool GetAutomaticNbdDeviceManagement() const;
     bool GetEnableOverlappingRequestsGuard() const;
     bool GetEnableRequestSplitter() const;
+    ui64 GetExternalVhostServerThreadPoolSize() const;
 
     void Dump(IOutputStream& out) const override;
     void DumpHtml(IOutputStream& out) const override;

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -142,6 +142,9 @@ private:
 
     ITaskQueuePtr ThreadPool;
 
+    std::shared_ptr<std::atomic<ui64>> InflightTasksInThreadPool =
+        std::make_shared<std::atomic<ui64>>(0);
+
 public:
     TAioBackend(
         IEncryptorPtr encryptor,
@@ -356,6 +359,11 @@ void TAioBackend::Stop()
     pthread_kill(CompletionThread.native_handle(), SIGUSR2);
     CompletionThread.join();
 
+    TSpinWait spinWait;
+    while (InflightTasksInThreadPool->load() > 0) {
+        spinWait.Sleep();
+    }
+
     io_destroy(Io);
     Devices.clear();
 }
@@ -465,12 +473,15 @@ void TAioBackend::CompleteCompoundRequest(
         vhd_get_bdev_io(sub->GetParentRequest()->Io)->type == VHD_BDEV_READ &&
         result == VHD_BDEV_SUCCESS && ThreadPool;
 
-    auto completeCompoundRequest = [log = SharedLog,
-                                    encryptor = Encryptor,
-                                    sub = std::move(sub),
-                                    result,
-                                    stats,
-                                    now]() mutable
+    InflightTasksInThreadPool->fetch_add(1);
+    auto completeCompoundRequest =
+        [log = SharedLog,
+         encryptor = Encryptor,
+         inflightTasksInThreadPool = InflightTasksInThreadPool,
+         sub = std::move(sub),
+         result,
+         stats,
+         now]() mutable
     {
         CompleteCompoundRequestImpl(
             *log,
@@ -480,6 +491,7 @@ void TAioBackend::CompleteCompoundRequest(
             *stats,
             now);
         stats->Completed += 1;
+        inflightTasksInThreadPool->fetch_sub(1);
     };
 
     if (needToPostOnAnotherThread) {
@@ -501,12 +513,15 @@ void TAioBackend::CompleteRequest(
         Encryptor && bio->type == VHD_BDEV_READ && result == VHD_BDEV_SUCCESS &&
         ThreadPool;
 
-    auto completeRequest = [log = SharedLog,
-                            encryptor = Encryptor,
-                            req = std::move(req),
-                            result,
-                            stats,
-                            now]() mutable
+    InflightTasksInThreadPool->fetch_add(1);
+    auto completeRequest =
+        [log = SharedLog,
+         encryptor = Encryptor,
+         inflightTasksInThreadPool = InflightTasksInThreadPool,
+         req = std::move(req),
+         result,
+         stats,
+         now]() mutable
     {
         CompleteRequestImpl(
             *log,
@@ -516,6 +531,7 @@ void TAioBackend::CompleteRequest(
             *stats,
             now);
         stats->Completed += 1;
+        inflightTasksInThreadPool->fetch_sub(1);
     };
 
     if (needToPostOnAnotherThread) {

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -6,6 +6,7 @@
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread.h>
+#include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
@@ -124,8 +125,7 @@ class TAioBackend final: public IBackend
 {
 private:
     const ILoggingServicePtr Logging;
-    std::shared_ptr<TLog> SharedLog;
-    TLog& Log = *SharedLog;
+    TLog Log;
 
     IEncryptorPtr Encryptor;
     TVector<TAioDevice> Devices;
@@ -142,14 +142,13 @@ private:
 
     ITaskQueuePtr ThreadPool;
 
-    std::shared_ptr<std::atomic<ui64>> InflightTasksInThreadPool =
-        std::make_shared<std::atomic<ui64>>(0);
+    std::atomic<ui64> InflightTasksInThreadPool = 0;
 
 public:
     TAioBackend(
         IEncryptorPtr encryptor,
         ILoggingServicePtr logging,
-        ITaskQueuePtr threadPool);
+        ui64 threadPoolSize);
 
     vhd_bdev_info Init(const TOptions& options) override;
     void Start() override;
@@ -191,14 +190,16 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TAioBackend::TAioBackend(
-        IEncryptorPtr encryptor,
-        ILoggingServicePtr logging,
-        ITaskQueuePtr threadPool)
+    IEncryptorPtr encryptor,
+    ILoggingServicePtr logging,
+    ui64 threadPoolSize)
     : Logging{std::move(logging)}
-    , SharedLog(std::make_shared<TLog>(Logging->CreateLog("AIO")))
+    , Log(Logging->CreateLog("AIO"))
     , Encryptor(std::move(encryptor))
     , CompletionStats(CreateCompletionStats())
-    , ThreadPool(std::move(threadPool))
+    , ThreadPool(
+          threadPoolSize > 0 ? CreateThreadPool("ENCRYPTION", threadPoolSize)
+                             : nullptr)
 {}
 
 void TAioBackend::IoSetup()
@@ -349,6 +350,10 @@ void TAioBackend::Start()
 {
     STORAGE_INFO("Starting AIO backend");
 
+    if (ThreadPool) {
+        ThreadPool->Start();
+    }
+
     CompletionThread = std::thread([this] { CompletionThreadFunc(); });
 }
 
@@ -360,8 +365,12 @@ void TAioBackend::Stop()
     CompletionThread.join();
 
     TSpinWait spinWait;
-    while (InflightTasksInThreadPool->load() > 0) {
+    while (InflightTasksInThreadPool.load() > 0) {
         spinWait.Sleep();
+    }
+
+    if (ThreadPool) {
+        ThreadPool->Stop();
     }
 
     io_destroy(Io);
@@ -473,25 +482,19 @@ void TAioBackend::CompleteCompoundRequest(
         vhd_get_bdev_io(sub->GetParentRequest()->Io)->type == VHD_BDEV_READ &&
         result == VHD_BDEV_SUCCESS && ThreadPool;
 
-    InflightTasksInThreadPool->fetch_add(1);
+    InflightTasksInThreadPool.fetch_add(1);
     auto completeCompoundRequest =
-        [log = SharedLog,
-         encryptor = Encryptor,
-         inflightTasksInThreadPool = InflightTasksInThreadPool,
-         sub = std::move(sub),
-         result,
-         stats,
-         now]() mutable
+        [this, sub = std::move(sub), result, stats, now]() mutable
     {
         CompleteCompoundRequestImpl(
-            *log,
-            encryptor.get(),
+            Log,
+            Encryptor.get(),
             std::move(sub),
             result,
             *stats,
             now);
         stats->Completed += 1;
-        inflightTasksInThreadPool->fetch_sub(1);
+        InflightTasksInThreadPool.fetch_sub(1);
     };
 
     if (needToPostOnAnotherThread) {
@@ -513,25 +516,23 @@ void TAioBackend::CompleteRequest(
         Encryptor && bio->type == VHD_BDEV_READ && result == VHD_BDEV_SUCCESS &&
         ThreadPool;
 
-    InflightTasksInThreadPool->fetch_add(1);
+    InflightTasksInThreadPool.fetch_add(1);
     auto completeRequest =
-        [log = SharedLog,
-         encryptor = Encryptor,
-         inflightTasksInThreadPool = InflightTasksInThreadPool,
+        [this,
          req = std::move(req),
          result,
-         stats,
+         stats = std::move(stats),
          now]() mutable
     {
         CompleteRequestImpl(
-            *log,
-            encryptor.get(),
+            Log,
+            Encryptor.get(),
             std::move(req),
             result,
             *stats,
             now);
         stats->Completed += 1;
-        inflightTasksInThreadPool->fetch_sub(1);
+        InflightTasksInThreadPool.fetch_sub(1);
     };
 
     if (needToPostOnAnotherThread) {
@@ -636,12 +637,12 @@ void TAioBackend::CompletionThreadFunc()
 IBackendPtr CreateAioBackend(
     IEncryptorPtr encryptor,
     ILoggingServicePtr logging,
-    ITaskQueuePtr threadPool)
+    ui64 threadPoolSize)
 {
     return std::make_shared<TAioBackend>(
         std::move(encryptor),
         std::move(logging),
-        std::move(threadPool));
+        threadPoolSize);
 }
 
 }   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -3,11 +3,13 @@
 #include "backend.h"
 #include "request_aio.h"
 
-#include <cloud/contrib/vhost/include/vhost/server.h>
 #include <cloud/storage/core/libs/common/format.h>
+#include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/common/verify.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+
+#include <cloud/contrib/vhost/include/vhost/server.h>
 
 #include <util/stream/file.h>
 #include <util/system/sanitizers.h>
@@ -25,12 +27,13 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void CompleteRequest(
+template <typename TStats>
+void CompleteRequestImpl(
     TLog& log,
     IEncryptor* encryptor,
     TAioRequestHolder req,
     vhd_bdev_io_result status,
-    TSimpleStats& stats,
+    TStats& stats,
     TCpuCycles now)
 {
     auto* bio = vhd_get_bdev_io(req->Io);
@@ -66,12 +69,13 @@ void CompleteRequest(
     vhd_complete_bio(req->Io, status);
 }
 
-void CompleteCompoundRequest(
+template <typename TStats>
+void CompleteCompoundRequestImpl(
     TLog& log,
     IEncryptor* encryptor,
     TAioSubRequestHolder sub,
     vhd_bdev_io_result status,
-    TSimpleStats& stats,
+    TStats& stats,
     TCpuCycles now)
 {
     auto* req = sub->GetParentRequest();
@@ -120,7 +124,8 @@ class TAioBackend final: public IBackend
 {
 private:
     const ILoggingServicePtr Logging;
-    TLog Log;
+    std::shared_ptr<TLog> SharedLog;
+    TLog& Log = *SharedLog;
 
     IEncryptorPtr Encryptor;
     TVector<TAioDevice> Devices;
@@ -135,8 +140,13 @@ private:
 
     ICompletionStatsPtr CompletionStats;
 
+    ITaskQueuePtr ThreadPool;
+
 public:
-    TAioBackend(IEncryptorPtr encryptor, ILoggingServicePtr logging);
+    TAioBackend(
+        IEncryptorPtr encryptor,
+        ILoggingServicePtr logging,
+        ITaskQueuePtr threadPool);
 
     vhd_bdev_info Init(const TOptions& options) override;
     void Start() override;
@@ -158,6 +168,18 @@ private:
         TCpuCycles now,
         TSimpleStats& queueStats);
 
+    void CompleteCompoundRequest(
+        TAioSubRequestHolder sub,
+        vhd_bdev_io_result result,
+        TCpuCycles now,
+        std::shared_ptr<TAtomicStats> stats);
+
+    void CompleteRequest(
+        TAioRequestHolder req,
+        vhd_bdev_io_result result,
+        TCpuCycles now,
+        std::shared_ptr<TAtomicStats> stats);
+
     void CompletionThreadFunc();
 
     void IoSetup();
@@ -167,13 +189,14 @@ private:
 
 TAioBackend::TAioBackend(
         IEncryptorPtr encryptor,
-        ILoggingServicePtr logging)
+        ILoggingServicePtr logging,
+        ITaskQueuePtr threadPool)
     : Logging{std::move(logging)}
+    , SharedLog(std::make_shared<TLog>(Logging->CreateLog("AIO")))
     , Encryptor(std::move(encryptor))
     , CompletionStats(CreateCompletionStats())
-{
-    Log = Logging->CreateLog("AIO");
-}
+    , ThreadPool(std::move(threadPool))
+{}
 
 void TAioBackend::IoSetup()
 {
@@ -374,7 +397,7 @@ void TAioBackend::ProcessQueue(
             ++queueStats.SubFailed;
 
             if (batch[0]->data) {
-                CompleteCompoundRequest(
+                CompleteCompoundRequestImpl(
                     Log,
                     Encryptor.get(),
                     TAioSubRequest::FromIocb(batch[0]),
@@ -382,7 +405,7 @@ void TAioBackend::ProcessQueue(
                     queueStats,
                     now);
             } else {
-                CompleteRequest(
+                CompleteRequestImpl(
                     Log,
                     Encryptor.get(),
                     TAioRequest::FromIocb(batch[0]),
@@ -431,6 +454,77 @@ size_t TAioBackend::PrepareBatch(
     return batch.size() - initialSize;
 }
 
+void TAioBackend::CompleteCompoundRequest(
+    TAioSubRequestHolder sub,
+    vhd_bdev_io_result result,
+    TCpuCycles now,
+    std::shared_ptr<TAtomicStats> stats)
+{
+    const bool needToPostOnAnotherThread =
+        Encryptor &&
+        vhd_get_bdev_io(sub->GetParentRequest()->Io)->type == VHD_BDEV_READ &&
+        result == VHD_BDEV_SUCCESS && ThreadPool;
+
+    auto completeCompoundRequest = [log = SharedLog,
+                                    encryptor = Encryptor,
+                                    sub = std::move(sub),
+                                    result,
+                                    stats,
+                                    now]() mutable
+    {
+        CompleteCompoundRequestImpl(
+            *log,
+            encryptor.get(),
+            std::move(sub),
+            result,
+            *stats,
+            now);
+        stats->Completed += 1;
+    };
+
+    if (needToPostOnAnotherThread) {
+        ThreadPool->ExecuteSimple(std::move(completeCompoundRequest));
+    } else {
+        completeCompoundRequest();
+    }
+}
+
+void TAioBackend::CompleteRequest(
+    TAioRequestHolder req,
+    vhd_bdev_io_result result,
+    TCpuCycles now,
+    std::shared_ptr<TAtomicStats> stats)
+{
+    auto* bio = vhd_get_bdev_io(req->Io);
+
+    const bool needToPostOnAnotherThread =
+        Encryptor && bio->type == VHD_BDEV_READ && result == VHD_BDEV_SUCCESS &&
+        ThreadPool;
+
+    auto completeRequest = [log = SharedLog,
+                            encryptor = Encryptor,
+                            req = std::move(req),
+                            result,
+                            stats,
+                            now]() mutable
+    {
+        CompleteRequestImpl(
+            *log,
+            encryptor.get(),
+            std::move(req),
+            result,
+            *stats,
+            now);
+        stats->Completed += 1;
+    };
+
+    if (needToPostOnAnotherThread) {
+        ThreadPool->ExecuteSimple(std::move(completeRequest));
+    } else {
+        completeRequest();
+    }
+}
+
 void TAioBackend::CompletionThreadFunc()
 {
     NCloud::SetCurrentThreadName("AIO");
@@ -443,7 +537,8 @@ void TAioBackend::CompletionThreadFunc()
 
     TVector<io_event> events(BatchSize);
 
-    TSimpleStats stats;
+    auto stats = std::make_shared<TAtomicStats>();
+
     timespec timeout{.tv_sec = 1, .tv_nsec = 0};
 
     for (;;) {
@@ -455,7 +550,7 @@ void TAioBackend::CompletionThreadFunc()
             Y_ABORT("io_getevents: %s", strerror(-ret));
         }
 
-        CompletionStats->Sync(stats);
+        CompletionStats->Sync(*stats);
 
         if (shouldStop) {
             break;
@@ -474,7 +569,7 @@ void TAioBackend::CompletionThreadFunc()
                 vhd_bdev_io_result result = VHD_BDEV_SUCCESS;
 
                 if (events[i].res2 != 0 || events[i].res != sub->u.c.nbytes) {
-                    stats.CompFailed += 1;
+                    stats->CompFailed += 1;
                     result = VHD_BDEV_IOERR;
                     STORAGE_ERROR(
                         "IO request: opcode=%d, offset=%lld size=%lu, res=%lu, "
@@ -487,13 +582,7 @@ void TAioBackend::CompletionThreadFunc()
                         strerror(-events[i].res));
                 }
 
-                CompleteCompoundRequest(
-                    Log,
-                    Encryptor.get(),
-                    std::move(sub),
-                    result,
-                    stats,
-                    now);
+                CompleteCompoundRequest(std::move(sub), result, now, stats);
 
                 continue;
             }
@@ -506,7 +595,7 @@ void TAioBackend::CompletionThreadFunc()
             if (events[i].res2 != 0 ||
                 events[i].res != bio->total_sectors * VHD_SECTOR_SIZE)
             {
-                stats.CompFailed += 1;
+                stats->CompFailed += 1;
                 result = VHD_BDEV_IOERR;
                 STORAGE_ERROR(
                     "IO request: opcode=%d, offset=%lld, size=%llu, res=%lu, "
@@ -519,16 +608,8 @@ void TAioBackend::CompletionThreadFunc()
                     strerror(-events[i].res));
             }
 
-            CompleteRequest(
-                Log,
-                Encryptor.get(),
-                std::move(req),
-                result,
-                stats,
-                now);
+            CompleteRequest(std::move(req), result, now, stats);
         }
-
-        stats.Completed += ret;
     }
 }
 
@@ -538,11 +619,13 @@ void TAioBackend::CompletionThreadFunc()
 
 IBackendPtr CreateAioBackend(
     IEncryptorPtr encryptor,
-    ILoggingServicePtr logging)
+    ILoggingServicePtr logging,
+    ITaskQueuePtr threadPool)
 {
     return std::make_shared<TAioBackend>(
         std::move(encryptor),
-        std::move(logging));
+        std::move(logging),
+        std::move(threadPool));
 }
 
 }   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -33,8 +33,7 @@ void CompleteRequestImpl(
     IEncryptor* encryptor,
     TAioRequestHolder req,
     vhd_bdev_io_result status,
-    TAtomicStats& stats,
-    TCpuCycles now)
+    TAtomicStats& stats)
 {
     auto* bio = vhd_get_bdev_io(req->Io);
     const ui64 bytes = bio->total_sectors * VHD_SECTOR_SIZE;
@@ -44,11 +43,6 @@ void CompleteRequestImpl(
     requestStat.Count += status == VHD_BDEV_SUCCESS;
     requestStat.Bytes += bytes;
     requestStat.Unaligned += req->Unaligned;
-
-    if (status == VHD_BDEV_SUCCESS) {
-        stats.Times[bio->type].Increment(now - req->SubmitTs);
-        stats.Sizes[bio->type].Increment(bytes);
-    }
 
     if (req->BufferAllocated || encryptor) {
         if (bio->type == VHD_BDEV_READ && status == VHD_BDEV_SUCCESS) {
@@ -66,6 +60,14 @@ void CompleteRequestImpl(
             }
         }
     }
+
+    const TCpuCycles now = GetCycleCount();
+
+    if (status == VHD_BDEV_SUCCESS) {
+        stats.Times[bio->type].Increment(now - req->SubmitTs);
+        stats.Sizes[bio->type].Increment(bytes);
+    }
+
     vhd_complete_bio(req->Io, status);
 }
 
@@ -74,8 +76,7 @@ void CompleteCompoundRequestImpl(
     IEncryptor* encryptor,
     TAioSubRequestHolder sub,
     vhd_bdev_io_result status,
-    TAtomicStats& stats,
-    TCpuCycles now)
+    TAtomicStats& stats)
 {
     auto* req = sub->GetParentRequest();
 
@@ -94,11 +95,6 @@ void CompleteCompoundRequestImpl(
         requestStat.Count += 1;
         requestStat.Bytes += bytes;
 
-        if (status == VHD_BDEV_SUCCESS) {
-            stats.Times[bio->type].Increment(now - req->SubmitTs);
-            stats.Sizes[bio->type].Increment(bytes);
-        }
-
         if (bio->type == VHD_BDEV_READ && status == VHD_BDEV_SUCCESS) {
             TBlockDataRef data = req->GetData();
             NSan::Unpoison(data.data(), data.size());
@@ -113,6 +109,14 @@ void CompleteCompoundRequestImpl(
                 stats.EncryptorErrors++;
             }
         }
+
+        const TCpuCycles now = GetCycleCount();
+
+        if (status == VHD_BDEV_SUCCESS) {
+            stats.Times[bio->type].Increment(now - req->SubmitTs);
+            stats.Sizes[bio->type].Increment(bytes);
+        }
+
         vhd_complete_bio(req->Io, status);
     }
 }
@@ -169,13 +173,11 @@ private:
     void CompleteCompoundRequest(
         TAioSubRequestHolder sub,
         vhd_bdev_io_result result,
-        TCpuCycles now,
         TAtomicStats& stats);
 
     void CompleteRequest(
         TAioRequestHolder req,
         vhd_bdev_io_result result,
-        TCpuCycles now,
         TAtomicStats& stats);
 
     void CompletionThreadFunc();
@@ -412,16 +414,14 @@ void TAioBackend::ProcessQueue(
                     Encryptor.get(),
                     TAioSubRequest::FromIocb(batch[0]),
                     VHD_BDEV_IOERR,
-                    stats,
-                    now);
+                    stats);
             } else {
                 CompleteRequestImpl(
                     Log,
                     Encryptor.get(),
                     TAioRequest::FromIocb(batch[0]),
                     VHD_BDEV_IOERR,
-                    stats,
-                    now);
+                    stats);
             }
 
             queueStats += stats;
@@ -469,7 +469,6 @@ size_t TAioBackend::PrepareBatch(
 void TAioBackend::CompleteCompoundRequest(
     TAioSubRequestHolder sub,
     vhd_bdev_io_result result,
-    TCpuCycles now,
     TAtomicStats& stats)
 {
     const bool needToPostOnAnotherThread =
@@ -478,15 +477,14 @@ void TAioBackend::CompleteCompoundRequest(
         result == VHD_BDEV_SUCCESS && ThreadPool;
 
     auto completeCompoundRequest =
-        [this, sub = std::move(sub), result, &stats, now]() mutable
+        [this, sub = std::move(sub), result, &stats]() mutable
     {
         CompleteCompoundRequestImpl(
             Log,
             Encryptor.get(),
             std::move(sub),
             result,
-            stats,
-            now);
+            stats);
         stats.Completed += 1;
     };
 
@@ -500,7 +498,6 @@ void TAioBackend::CompleteCompoundRequest(
 void TAioBackend::CompleteRequest(
     TAioRequestHolder req,
     vhd_bdev_io_result result,
-    TCpuCycles now,
     TAtomicStats& stats)
 {
     auto* bio = vhd_get_bdev_io(req->Io);
@@ -513,16 +510,14 @@ void TAioBackend::CompleteRequest(
         [this,
          req = std::move(req),
          result,
-         &stats,
-         now]() mutable
+         &stats]() mutable
     {
         CompleteRequestImpl(
             Log,
             Encryptor.get(),
             std::move(req),
             result,
-            stats,
-            now);
+            stats);
         stats.Completed += 1;
     };
 
@@ -570,8 +565,6 @@ void TAioBackend::CompletionThreadFunc()
             continue;
         }
 
-        const TCpuCycles now = GetCycleCount();
-
         ioFinishedCount += ret;
 
         for (int i = 0; i != ret; ++i) {
@@ -594,7 +587,7 @@ void TAioBackend::CompletionThreadFunc()
                         strerror(-events[i].res));
                 }
 
-                CompleteCompoundRequest(std::move(sub), result, now, stats);
+                CompleteCompoundRequest(std::move(sub), result, stats);
 
                 continue;
             }
@@ -620,7 +613,7 @@ void TAioBackend::CompletionThreadFunc()
                     strerror(-events[i].res));
             }
 
-            CompleteRequest(std::move(req), result, now, stats);
+            CompleteRequest(std::move(req), result, stats);
         }
     }
 

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -142,8 +142,6 @@ private:
 
     ITaskQueuePtr ThreadPool;
 
-    std::atomic<ui64> InflightTasksInThreadPool = 0;
-
 public:
     TAioBackend(
         IEncryptorPtr encryptor,
@@ -364,11 +362,6 @@ void TAioBackend::Stop()
     pthread_kill(CompletionThread.native_handle(), SIGUSR2);
     CompletionThread.join();
 
-    TSpinWait spinWait;
-    while (InflightTasksInThreadPool.load() > 0) {
-        spinWait.Sleep();
-    }
-
     if (ThreadPool) {
         ThreadPool->Stop();
     }
@@ -482,7 +475,6 @@ void TAioBackend::CompleteCompoundRequest(
         vhd_get_bdev_io(sub->GetParentRequest()->Io)->type == VHD_BDEV_READ &&
         result == VHD_BDEV_SUCCESS && ThreadPool;
 
-    InflightTasksInThreadPool.fetch_add(1);
     auto completeCompoundRequest =
         [this, sub = std::move(sub), result, stats, now]() mutable
     {
@@ -494,7 +486,6 @@ void TAioBackend::CompleteCompoundRequest(
             *stats,
             now);
         stats->Completed += 1;
-        InflightTasksInThreadPool.fetch_sub(1);
     };
 
     if (needToPostOnAnotherThread) {
@@ -516,7 +507,6 @@ void TAioBackend::CompleteRequest(
         Encryptor && bio->type == VHD_BDEV_READ && result == VHD_BDEV_SUCCESS &&
         ThreadPool;
 
-    InflightTasksInThreadPool.fetch_add(1);
     auto completeRequest =
         [this,
          req = std::move(req),
@@ -532,7 +522,6 @@ void TAioBackend::CompleteRequest(
             *stats,
             now);
         stats->Completed += 1;
-        InflightTasksInThreadPool.fetch_sub(1);
     };
 
     if (needToPostOnAnotherThread) {
@@ -558,6 +547,8 @@ void TAioBackend::CompletionThreadFunc()
 
     timespec timeout{.tv_sec = 1, .tv_nsec = 0};
 
+    ui64 ioFinishedCount = 0;
+
     for (;;) {
         // TODO: try AIO_RING_MAGIC trick
         // (https://github.com/axboe/fio/blob/master/engines/libaio.c#L272)
@@ -578,6 +569,8 @@ void TAioBackend::CompletionThreadFunc()
         }
 
         const TCpuCycles now = GetCycleCount();
+
+        ioFinishedCount += ret;
 
         for (int i = 0; i != ret; ++i) {
             if (events[i].data) {
@@ -627,6 +620,11 @@ void TAioBackend::CompletionThreadFunc()
 
             CompleteRequest(std::move(req), result, now, stats);
         }
+    }
+
+    TSpinWait spinWait;
+    while (ioFinishedCount != stats->Completed.load()) {
+        spinWait.Sleep();
     }
 }
 

--- a/cloud/blockstore/vhost-server/backend_aio.cpp
+++ b/cloud/blockstore/vhost-server/backend_aio.cpp
@@ -28,13 +28,12 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename TStats>
 void CompleteRequestImpl(
     TLog& log,
     IEncryptor* encryptor,
     TAioRequestHolder req,
     vhd_bdev_io_result status,
-    TStats& stats,
+    TAtomicStats& stats,
     TCpuCycles now)
 {
     auto* bio = vhd_get_bdev_io(req->Io);
@@ -70,13 +69,12 @@ void CompleteRequestImpl(
     vhd_complete_bio(req->Io, status);
 }
 
-template <typename TStats>
 void CompleteCompoundRequestImpl(
     TLog& log,
     IEncryptor* encryptor,
     TAioSubRequestHolder sub,
     vhd_bdev_io_result status,
-    TStats& stats,
+    TAtomicStats& stats,
     TCpuCycles now)
 {
     auto* req = sub->GetParentRequest();
@@ -172,13 +170,13 @@ private:
         TAioSubRequestHolder sub,
         vhd_bdev_io_result result,
         TCpuCycles now,
-        std::shared_ptr<TAtomicStats> stats);
+        TAtomicStats& stats);
 
     void CompleteRequest(
         TAioRequestHolder req,
         vhd_bdev_io_result result,
         TCpuCycles now,
-        std::shared_ptr<TAtomicStats> stats);
+        TAtomicStats& stats);
 
     void CompletionThreadFunc();
 
@@ -406,13 +404,15 @@ void TAioBackend::ProcessQueue(
 
             ++queueStats.SubFailed;
 
+            TAtomicStats stats;
+
             if (batch[0]->data) {
                 CompleteCompoundRequestImpl(
                     Log,
                     Encryptor.get(),
                     TAioSubRequest::FromIocb(batch[0]),
                     VHD_BDEV_IOERR,
-                    queueStats,
+                    stats,
                     now);
             } else {
                 CompleteRequestImpl(
@@ -420,9 +420,11 @@ void TAioBackend::ProcessQueue(
                     Encryptor.get(),
                     TAioRequest::FromIocb(batch[0]),
                     VHD_BDEV_IOERR,
-                    queueStats,
+                    stats,
                     now);
             }
+
+            queueStats += stats;
 
             ret = 1;
         }
@@ -468,7 +470,7 @@ void TAioBackend::CompleteCompoundRequest(
     TAioSubRequestHolder sub,
     vhd_bdev_io_result result,
     TCpuCycles now,
-    std::shared_ptr<TAtomicStats> stats)
+    TAtomicStats& stats)
 {
     const bool needToPostOnAnotherThread =
         Encryptor &&
@@ -476,16 +478,16 @@ void TAioBackend::CompleteCompoundRequest(
         result == VHD_BDEV_SUCCESS && ThreadPool;
 
     auto completeCompoundRequest =
-        [this, sub = std::move(sub), result, stats, now]() mutable
+        [this, sub = std::move(sub), result, &stats, now]() mutable
     {
         CompleteCompoundRequestImpl(
             Log,
             Encryptor.get(),
             std::move(sub),
             result,
-            *stats,
+            stats,
             now);
-        stats->Completed += 1;
+        stats.Completed += 1;
     };
 
     if (needToPostOnAnotherThread) {
@@ -499,7 +501,7 @@ void TAioBackend::CompleteRequest(
     TAioRequestHolder req,
     vhd_bdev_io_result result,
     TCpuCycles now,
-    std::shared_ptr<TAtomicStats> stats)
+    TAtomicStats& stats)
 {
     auto* bio = vhd_get_bdev_io(req->Io);
 
@@ -511,7 +513,7 @@ void TAioBackend::CompleteRequest(
         [this,
          req = std::move(req),
          result,
-         stats = std::move(stats),
+         &stats,
          now]() mutable
     {
         CompleteRequestImpl(
@@ -519,9 +521,9 @@ void TAioBackend::CompleteRequest(
             Encryptor.get(),
             std::move(req),
             result,
-            *stats,
+            stats,
             now);
-        stats->Completed += 1;
+        stats.Completed += 1;
     };
 
     if (needToPostOnAnotherThread) {
@@ -543,7 +545,7 @@ void TAioBackend::CompletionThreadFunc()
 
     TVector<io_event> events(BatchSize);
 
-    auto stats = std::make_shared<TAtomicStats>();
+    TAtomicStats stats;
 
     timespec timeout{.tv_sec = 1, .tv_nsec = 0};
 
@@ -558,7 +560,7 @@ void TAioBackend::CompletionThreadFunc()
             Y_ABORT("io_getevents: %s", strerror(-ret));
         }
 
-        CompletionStats->Sync(*stats);
+        CompletionStats->Sync(stats);
 
         if (shouldStop) {
             break;
@@ -579,7 +581,7 @@ void TAioBackend::CompletionThreadFunc()
                 vhd_bdev_io_result result = VHD_BDEV_SUCCESS;
 
                 if (events[i].res2 != 0 || events[i].res != sub->u.c.nbytes) {
-                    stats->CompFailed += 1;
+                    stats.CompFailed += 1;
                     result = VHD_BDEV_IOERR;
                     STORAGE_ERROR(
                         "IO request: opcode=%d, offset=%lld size=%lu, res=%lu, "
@@ -605,7 +607,7 @@ void TAioBackend::CompletionThreadFunc()
             if (events[i].res2 != 0 ||
                 events[i].res != bio->total_sectors * VHD_SECTOR_SIZE)
             {
-                stats->CompFailed += 1;
+                stats.CompFailed += 1;
                 result = VHD_BDEV_IOERR;
                 STORAGE_ERROR(
                     "IO request: opcode=%d, offset=%lld, size=%llu, res=%lu, "
@@ -623,7 +625,7 @@ void TAioBackend::CompletionThreadFunc()
     }
 
     TSpinWait spinWait;
-    while (ioFinishedCount != stats->Completed.load()) {
+    while (ioFinishedCount != stats.Completed.load()) {
         spinWait.Sleep();
     }
 }

--- a/cloud/blockstore/vhost-server/backend_aio.h
+++ b/cloud/blockstore/vhost-server/backend_aio.h
@@ -11,6 +11,7 @@ namespace NCloud::NBlockStore::NVHostServer {
 
 IBackendPtr CreateAioBackend(
     IEncryptorPtr encryptor,
-    ILoggingServicePtr logging);
+    ILoggingServicePtr logging,
+    ITaskQueuePtr threadPool);
 
 }   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/vhost-server/backend_aio.h
+++ b/cloud/blockstore/vhost-server/backend_aio.h
@@ -12,6 +12,6 @@ namespace NCloud::NBlockStore::NVHostServer {
 IBackendPtr CreateAioBackend(
     IEncryptorPtr encryptor,
     ILoggingServicePtr logging,
-    ITaskQueuePtr threadPool);
+    ui64 threadPoolSize);
 
 }   // namespace NCloud::NBlockStore::NVHostServer

--- a/cloud/blockstore/vhost-server/histogram.h
+++ b/cloud/blockstore/vhost-server/histogram.h
@@ -3,24 +3,49 @@
 #include <util/system/types.h>
 #include <util/system/yassert.h>
 
+#include <atomic>
 #include <type_traits>
 
 namespace NCloud::NBlockStore::NVHostServer {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <ui32 BucketShift = 7>
+template <typename T, ui32 BucketShift = 7>
 class THistogram
 {
+    static_assert(
+        std::is_same_v<T, ui64> || std::is_same_v<T, std::atomic<ui64>>,
+        "T must be ui64 or std::atomic<ui64>");
+
     static constexpr ui32 BucketLsb = 64 - BucketShift;
     static constexpr ui32 NumBucketsPerRange = 1ULL << BucketShift;
     static constexpr ui32 BucketMask = NumBucketsPerRange - 1;
     static constexpr ui32 NumBucketRanges = BucketLsb + 1;
     static constexpr ui32 NumBuckets = NumBucketsPerRange * NumBucketRanges;
 
-    ui64 Buckets[NumBuckets] = {};
+    T Buckets[NumBuckets] = {};
 
 public:
+    THistogram() = default;
+
+    template <typename U>
+    explicit THistogram(const THistogram<U, BucketShift>& rhs) noexcept
+    {
+        for (ui64 i = 0; i != NumBuckets; ++i) {
+            Buckets[i] = rhs.GetBucketValue(i);
+        }
+    }
+
+    template <typename U>
+    THistogram& operator=(const THistogram<U, BucketShift>& rhs) noexcept
+    {
+        for (ui64 i = 0; i != NumBuckets; ++i) {
+            Buckets[i] = rhs.GetBucketValue(i);
+        }
+
+        return *this;
+    }
+
     void Increment(ui64 value, ui64 count = 1) noexcept
     {
         const ui32 range = GetBucketRange(value);
@@ -29,24 +54,35 @@ public:
         Buckets[(range << BucketShift) + index] += count;
     }
 
-    THistogram& operator += (const THistogram& rhs) noexcept
+    template <typename U>
+    THistogram& operator+=(const THistogram<U, BucketShift>& rhs) noexcept
     {
         for (ui64 i = 0; i != THistogram::NumBuckets; ++i) {
-            Buckets[i] += rhs.Buckets[i];
+            Buckets[i] += rhs.GetBucketValue(i);
         }
 
         return *this;
     }
 
-    THistogram& operator -= (const THistogram& rhs) noexcept
+    template <typename U>
+    THistogram& operator-=(const THistogram<U, BucketShift>& rhs) noexcept
     {
         for (ui64 i = 0; i != THistogram::NumBuckets; ++i) {
-            if (Buckets[i]) {
-                Buckets[i] -= rhs.Buckets[i];
+            if (GetBucketValue(i)) {
+                Buckets[i] -= rhs.GetBucketValue(i);
             }
         }
 
         return *this;
+    }
+
+    [[nodiscard]] ui64 GetBucketValue(size_t index) const noexcept
+    {
+        if constexpr (std::is_same_v<T, std::atomic<ui64>>) {
+            return Buckets[index].load();
+        } else {
+            return Buckets[index];
+        }
     }
 
     template <typename F>
@@ -94,7 +130,7 @@ public:
 private:
     [[nodiscard]] ui64 GetCount(ui32 range, ui32 index) const noexcept
     {
-        return Buckets[(range << BucketShift) + index];
+        return GetBucketValue((range << BucketShift) + index);
     }
 
     [[nodiscard]] static ui32 GetBucketRange(ui64 value) noexcept

--- a/cloud/blockstore/vhost-server/histogram.h
+++ b/cloud/blockstore/vhost-server/histogram.h
@@ -11,12 +11,9 @@ namespace NCloud::NBlockStore::NVHostServer {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T, ui32 BucketShift = 7>
+    requires std::is_same_v<T, ui64> || std::is_same_v<T, std::atomic<ui64>>
 class THistogram
 {
-    static_assert(
-        std::is_same_v<T, ui64> || std::is_same_v<T, std::atomic<ui64>>,
-        "T must be ui64 or std::atomic<ui64>");
-
     static constexpr ui32 BucketLsb = 64 - BucketShift;
     static constexpr ui32 NumBucketsPerRange = 1ULL << BucketShift;
     static constexpr ui32 BucketMask = NumBucketsPerRange - 1;

--- a/cloud/blockstore/vhost-server/histogram_ut.cpp
+++ b/cloud/blockstore/vhost-server/histogram_ut.cpp
@@ -14,7 +14,7 @@ Y_UNIT_TEST_SUITE(THistogrmTest)
 {
     Y_UNIT_TEST(ShouldCollectEmptyBuckets)
     {
-        THistogram<> hist;
+        THistogram<ui64> hist;
 
         int count = 0;
         hist.IterateBuckets([&count] (auto, auto, auto) {
@@ -30,7 +30,7 @@ Y_UNIT_TEST_SUITE(THistogrmTest)
 
         const ui64 dt = 1ull << 63;
 
-        THistogram<> hist;
+        THistogram<ui64> hist;
 
         hist.Increment(dt);
 
@@ -53,7 +53,7 @@ Y_UNIT_TEST_SUITE(THistogrmTest)
     {
         using TBucket = std::tuple<ui64, ui64, ui64>;
 
-        THistogram<> hist;
+        THistogram<ui64> hist;
 
         for (int i = 0; i != 1000; ++i) {
             hist.Increment(1000);
@@ -99,7 +99,7 @@ Y_UNIT_TEST_SUITE(THistogrmTest)
     {
         using TBucket = std::pair<ui64, ui64>;
 
-        THistogram<> hist;
+        THistogram<ui64> hist;
 
         hist.Increment(1);
         hist.Increment(1_KB, 2);
@@ -120,7 +120,7 @@ Y_UNIT_TEST_SUITE(THistogrmTest)
             UNIT_ASSERT_EQUAL(TBucket(1_GB, 4), buckets[3]);
         }
 
-        THistogram<> newHist = hist;
+        THistogram<ui64> newHist = hist;
 
         {
             TVector<TBucket> buckets;

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -333,5 +333,9 @@ int main(int argc, char** argv)
 
     server->Stop();
 
+    if (threadPool) {
+        threadPool->Stop();
+    }
+
     return 0;
 }

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -8,6 +8,8 @@
 #include <cloud/blockstore/libs/encryption/encryptor.h>
 
 #include <cloud/storage/core/libs/common/future_helper.h>
+#include <cloud/storage/core/libs/common/task_queue.h>
+#include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <library/cpp/json/json_writer.h>
@@ -147,12 +149,16 @@ IEncryptorPtr CreateEncryptor(
 
 IBackendPtr CreateBackend(
     const TOptions& options,
-    NCloud::ILoggingServicePtr logging)
+    NCloud::ILoggingServicePtr logging,
+    ITaskQueuePtr threadPool)
 {
     auto encryptor = CreateEncryptor(options, logging);
 
     if (options.DeviceBackend == "aio") {
-        return CreateAioBackend(std::move(encryptor), logging);
+        return CreateAioBackend(
+            std::move(encryptor),
+            logging,
+            std::move(threadPool));
     } else if (options.DeviceBackend == "rdma") {
         return CreateRdmaBackend(logging);
     } else if (options.DeviceBackend == "null") {
@@ -225,10 +231,19 @@ int main(int argc, char** argv)
     pthread_sigmask(SIG_BLOCK, &sigset, nullptr);
 
     auto logService = CreateLogService(options);
-    auto backend = CreateBackend(options, logService);
+    NCloud::ITaskQueuePtr threadPool;
+    if (options.ThreadPoolSize > 0) {
+        threadPool =
+            NCloud::CreateThreadPool("Encryption", options.ThreadPoolSize);
+    }
+    auto backend = CreateBackend(options, logService, threadPool);
     auto server = CreateServer(logService, backend);
     auto Log = logService->CreateLog("SERVER");
     SetCriticalEventsLog(Log);
+
+    if (threadPool) {
+        threadPool->Start();
+    }
 
     server->Start(options);
 

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -149,8 +149,7 @@ IEncryptorPtr CreateEncryptor(
 
 IBackendPtr CreateBackend(
     const TOptions& options,
-    NCloud::ILoggingServicePtr logging,
-    ITaskQueuePtr threadPool)
+    NCloud::ILoggingServicePtr logging)
 {
     auto encryptor = CreateEncryptor(options, logging);
 
@@ -158,7 +157,7 @@ IBackendPtr CreateBackend(
         return CreateAioBackend(
             std::move(encryptor),
             logging,
-            std::move(threadPool));
+            options.ThreadPoolSize);
     } else if (options.DeviceBackend == "rdma") {
         return CreateRdmaBackend(logging);
     } else if (options.DeviceBackend == "null") {
@@ -231,19 +230,10 @@ int main(int argc, char** argv)
     pthread_sigmask(SIG_BLOCK, &sigset, nullptr);
 
     auto logService = CreateLogService(options);
-    NCloud::ITaskQueuePtr threadPool;
-    if (options.ThreadPoolSize > 0) {
-        threadPool =
-            NCloud::CreateThreadPool("USER_POOL", options.ThreadPoolSize);
-    }
-    auto backend = CreateBackend(options, logService, threadPool);
+    auto backend = CreateBackend(options, logService);
     auto server = CreateServer(logService, backend);
     auto Log = logService->CreateLog("SERVER");
     SetCriticalEventsLog(Log);
-
-    if (threadPool) {
-        threadPool->Start();
-    }
 
     server->Start(options);
 

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char** argv)
     NCloud::ITaskQueuePtr threadPool;
     if (options.ThreadPoolSize > 0) {
         threadPool =
-            NCloud::CreateThreadPool("UserPool", options.ThreadPoolSize);
+            NCloud::CreateThreadPool("USER_POOL", options.ThreadPoolSize);
     }
     auto backend = CreateBackend(options, logService, threadPool);
     auto server = CreateServer(logService, backend);

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char** argv)
     NCloud::ITaskQueuePtr threadPool;
     if (options.ThreadPoolSize > 0) {
         threadPool =
-            NCloud::CreateThreadPool("Encryption", options.ThreadPoolSize);
+            NCloud::CreateThreadPool("UserPool", options.ThreadPoolSize);
     }
     auto backend = CreateBackend(options, logService, threadPool);
     auto server = CreateServer(logService, backend);

--- a/cloud/blockstore/vhost-server/main.cpp
+++ b/cloud/blockstore/vhost-server/main.cpp
@@ -323,9 +323,5 @@ int main(int argc, char** argv)
 
     server->Stop();
 
-    if (threadPool) {
-        threadPool->Stop();
-    }
-
     return 0;
 }

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -165,6 +165,10 @@ void TOptions::Parse(int argc, char** argv)
         .RequiredArgument("INT")
         .StoreResult(&BlockstoreServicePid);
 
+    opts.AddLongOption("thread-pool-size", "thread pool size")
+        .RequiredArgument("INT")
+        .StoreResult(&ThreadPoolSize);
+
     TOptsParseResultException res(&opts, argc, argv);
 
     if (res.FindLongOptParseResult("verbose") && VerboseLevel.empty()) {

--- a/cloud/blockstore/vhost-server/options.cpp
+++ b/cloud/blockstore/vhost-server/options.cpp
@@ -166,7 +166,8 @@ void TOptions::Parse(int argc, char** argv)
         .StoreResult(&BlockstoreServicePid);
 
     opts.AddLongOption("thread-pool-size", "thread pool size")
-        .RequiredArgument("INT")
+        .OptionalArgument("INT")
+        .DefaultValue(0)
         .StoreResult(&ThreadPoolSize);
 
     TOptsParseResultException res(&opts, argc, argv);

--- a/cloud/blockstore/vhost-server/options.h
+++ b/cloud/blockstore/vhost-server/options.h
@@ -35,6 +35,7 @@ struct TOptions
     ui32 QueueCount = 0;
     ui64 PteFlushByteThreshold = 0;
     ui32 SocketAccessMode = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
+    ui64 ThreadPoolSize = 0;
 
     TString LogType = "json";
     TString VerboseLevel = "info";

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -174,13 +174,14 @@ public:
             Encryptor =
                 CreateAesXtsEncryptor(TEncryptionKey(DefaultEncryptionKey));
         }
-        if (ThreadCount > 0) {
-            ThreadPool = CreateThreadPool("Encryptor", ThreadCount);
-        }
     }
 
     void StartServer(bool addNonExistingDevice = false)
     {
+        if (ThreadCount > 0) {
+            ThreadPool = CreateThreadPool("Encryptor", ThreadCount);
+        }
+
         Server = CreateServer(Logging, CreateAioBackend(Encryptor, Logging, ThreadPool));
 
         Options.Layout.reserve(ChunkCount);
@@ -216,6 +217,10 @@ public:
 
     void StartServerWithSplitDevices()
     {
+        if (ThreadCount > 0) {
+            ThreadPool = CreateThreadPool("Encryptor", ThreadCount);
+        }
+
         Server = CreateServer(
             Logging,
             CreateAioBackend(Encryptor, Logging, ThreadPool));
@@ -299,6 +304,10 @@ public:
             Client.DeInit();
             Server->Stop();
             Server.reset();
+        }
+        if (ThreadPool) {
+            ThreadPool->Stop();
+            ThreadPool.reset();
         }
         Files.clear();
         Options.Layout.clear();

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1436,6 +1436,78 @@ TEST_P(TSlowEncryptorServerTest, ShouldDecryptDataInParallel)
     }
 }
 
+TEST_P(TSlowEncryptorServerTest, ShouldWaitForAllThreadPoolTasksBeforeStop)
+{
+    StartServer();
+
+    const ui64 requestCount = ThreadCount * 5;
+
+    auto makePattern = [&](size_t block) -> TString
+    {
+        return TString(BlockSize, GetFillChar(block));
+    };
+
+    // Write blocks directly to the underlying devices. Encrypt them first so
+    // that when the server reads + decrypts, we get the original plaintext.
+    {
+        SetSleepTime(TDuration::Zero());
+
+        TString encrypted;
+        encrypted.resize(BlockSize);
+        for (ui64 i = 0; i < requestCount; ++i) {
+            const TString plaintext = makePattern(i);
+            const auto err = Encryptor->Encrypt(
+                TBlockDataRef(plaintext.data(), BlockSize),
+                TBlockDataRef(encrypted.data(), BlockSize),
+                i * SectorsPerBlock);
+            ASSERT_FALSE(HasError(err));
+            ASSERT_TRUE(SaveRawBlock(i, encrypted));
+        }
+    }
+
+    SetSleepTime(TDuration::MilliSeconds(100));
+
+    TVector<std::span<char>> readBuffers;
+    TVector<std::span<char>> statuses;
+    TVector<NThreading::TFuture<ui32>> futures;
+    for (ui64 i = 0; i < requestCount; ++i) {
+        std::span hdr = Hdr(
+            Memory,
+            {.type = VIRTIO_BLK_T_IN, .sector = i * SectorsPerBlock});
+        std::span readBuffer =
+            Memory.Allocate(BlockSize, Unaligned ? 1 : BlockSize);
+        std::span status = Memory.Allocate(1);
+        readBuffers.push_back(readBuffer);
+        statuses.push_back(status);
+        futures.push_back(
+            Client.WriteAsync(i % QueueCount, {hdr}, {readBuffer, status}));
+    }
+
+    // Give AIO time to complete the reads and enqueue decryption tasks onto
+    // the thread pool. Each decryption sleeps 100ms, so most tasks remain
+    // queued at this point.
+    Sleep(TDuration::MilliSeconds(200));
+
+    Server->Stop();
+
+    EXPECT_EQ(
+        TDuration::MilliSeconds(requestCount * 100),
+        GetTotalSleepTime());
+
+    for (size_t i = 0; i < futures.size(); ++i) {
+        ASSERT_TRUE(futures[i].HasValue())
+            << "future " << i << " did not resolve";
+        const ui32 len = futures[i].GetValueSync();
+        EXPECT_EQ(statuses[i].size() + readBuffers[i].size(), len);
+        EXPECT_EQ(VIRTIO_BLK_S_OK, statuses[i][0]);
+        TString readData(readBuffers[i].data(), readBuffers[i].size());
+        EXPECT_EQ(makePattern(i), readData);
+    }
+
+    Client.DeInit();
+    Server.reset();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ,
     TSlowEncryptorServerTest,

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1281,30 +1281,32 @@ INSTANTIATE_TEST_SUITE_P(
 class TSlowEncryptor: public IEncryptor
 {
 private:
-    TDuration SleepTime;
+    std::atomic<ui64> SleepTimeMillis;
     std::atomic<ui64> TotalSleepTimeMillis;
 
     IEncryptorPtr Encryptor;
 
 public:
     explicit TSlowEncryptor(TDuration sleepTime, IEncryptorPtr encryptor)
-        : SleepTime(sleepTime)
+        : SleepTimeMillis(sleepTime.MilliSeconds())
         , Encryptor(std::move(encryptor))
     {}
 
     NProto::TError
     Encrypt(TBlockDataRef src, TBlockDataRef dst, ui64 blockIndex) override
     {
-        Sleep(SleepTime);
-        TotalSleepTimeMillis += SleepTime.MilliSeconds();
+        const auto sleepTime = SleepTimeMillis.load();
+        Sleep(TDuration::MilliSeconds(sleepTime));
+        TotalSleepTimeMillis += sleepTime;
         return Encryptor->Encrypt(src, dst, blockIndex);
     }
 
     NProto::TError
     Decrypt(TBlockDataRef src, TBlockDataRef dst, ui64 blockIndex) override
     {
-        Sleep(SleepTime);
-        TotalSleepTimeMillis += SleepTime.MilliSeconds();
+        const auto sleepTime = SleepTimeMillis.load();
+        Sleep(TDuration::MilliSeconds(sleepTime));
+        TotalSleepTimeMillis += sleepTime;
         return Encryptor->Decrypt(src, dst, blockIndex);
     }
 
@@ -1315,7 +1317,7 @@ public:
 
     void SetSleepTime(TDuration sleepTime)
     {
-        SleepTime = sleepTime;
+        SleepTimeMillis.store(sleepTime.MilliSeconds());
     }
 };
 
@@ -1437,6 +1439,9 @@ TEST_P(TSlowEncryptorServerTest, ShouldDecryptDataInParallel)
 #if !defined(__SANITIZE_MEMORY__) && !defined(__SANITIZE_ADDRESS__) && \
     !defined(__SANITIZE_THREAD__) && !UBSAN_BUILD
         EXPECT_LT(duration, expectedSleepTime);
+#else
+    Y_UNUSED(duration);
+    Y_UNUSED(expectedSleepTime);
 #endif
     }
 

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1410,19 +1410,11 @@ TEST_P(TSlowEncryptorServerTest, ShouldDecryptDataInParallel)
 
         auto expectedSleepTime = (GetTotalSleepTime() / ThreadCount) * 1.1;
 
-#if (defined(__has_feature) && __has_feature(undefined_behavior_sanitizer)) || \
-    (defined(__SANITIZE_UNDEFINED__) && __SANITIZE_UNDEFINED__)
-#define UBSAN_BUILD 1
-#else
-#define UBSAN_BUILD 0
-#endif
-
-#if !defined(__SANITIZE_MEMORY__) && !defined(__SANITIZE_ADDRESS__) && \
-    !defined(__SANITIZE_THREAD__) && !UBSAN_BUILD
+#if !defined(_san_enabled_)
         EXPECT_LT(duration, expectedSleepTime);
 #else
-    Y_UNUSED(duration);
-    Y_UNUSED(expectedSleepTime);
+        Y_UNUSED(duration);
+        Y_UNUSED(expectedSleepTime);
 #endif
     }
 

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -152,7 +152,6 @@ public:
     std::shared_ptr<IServer> Server;
     TVector<TTempFileHandle> Files;
     IEncryptorPtr Encryptor;
-    ITaskQueuePtr ThreadPool;
 
     TOptions Options {
         .SocketPath = SocketPath,
@@ -178,11 +177,9 @@ public:
 
     void StartServer(bool addNonExistingDevice = false)
     {
-        if (ThreadCount > 0) {
-            ThreadPool = CreateThreadPool("Encryptor", ThreadCount);
-        }
-
-        Server = CreateServer(Logging, CreateAioBackend(Encryptor, Logging, ThreadPool));
+        Server = CreateServer(
+            Logging,
+            CreateAioBackend(Encryptor, Logging, ThreadCount));
 
         Options.Layout.reserve(ChunkCount);
         Files.reserve(ChunkCount);
@@ -204,10 +201,6 @@ public:
             file.Resize(ChunkByteCount);
         }
 
-        if (ThreadPool) {
-            ThreadPool->Start();
-        }
-
         Server->Start(Options);
 
         ASSERT_TRUE(Client.Init());
@@ -217,13 +210,9 @@ public:
 
     void StartServerWithSplitDevices()
     {
-        if (ThreadCount > 0) {
-            ThreadPool = CreateThreadPool("Encryptor", ThreadCount);
-        }
-
         Server = CreateServer(
             Logging,
-            CreateAioBackend(Encryptor, Logging, ThreadPool));
+            CreateAioBackend(Encryptor, Logging, ThreadCount));
 
         // H - header
         // D - device
@@ -279,10 +268,6 @@ public:
             });
         }
 
-        if (ThreadPool) {
-            ThreadPool->Start();
-        }
-
         Server->Start(Options);
 
         ASSERT_TRUE(Client.Init());
@@ -304,10 +289,6 @@ public:
             Client.DeInit();
             Server->Stop();
             Server.reset();
-        }
-        if (ThreadPool) {
-            ThreadPool->Stop();
-            ThreadPool.reset();
         }
         Files.clear();
         Options.Layout.clear();

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -5,10 +5,14 @@
 #include <cloud/blockstore/libs/common/iovector.h>
 #include <cloud/blockstore/libs/encryption/encryption_key.h>
 #include <cloud/blockstore/libs/encryption/encryptor.h>
-#include <cloud/contrib/vhost/virtio/virtio_blk_spec.h>
+
+#include <cloud/storage/core/libs/common/task_queue.h>
+#include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/vhost-client/monotonic_buffer_resource.h>
 #include <cloud/storage/core/libs/vhost-client/vhost-client.h>
+
+#include <cloud/contrib/vhost/virtio/virtio_blk_spec.h>
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/writer/json_value.h>
@@ -61,8 +65,13 @@ const TString DefaultEncryptionKey("1234567890123456789012345678901");
 using TBlocksPerRequest = size_t;
 using TBlockSize = ui32;
 using TUnaligned = bool;
-using TTestParams = std::
-    tuple<NProto::EEncryptionMode, TBlocksPerRequest, TBlockSize, TUnaligned>;
+using TThreadCount = size_t;
+using TTestParams = std::tuple<
+    NProto::EEncryptionMode,
+    TBlocksPerRequest,
+    TBlockSize,
+    TUnaligned,
+    TThreadCount>;
 
 class TMockEncryptor: public IEncryptor
 {
@@ -129,6 +138,7 @@ public:
     const NProto::EEncryptionMode EncryptionMode = std::get<0>(GetParam());
     const size_t BlocksPerRequest = std::get<1>(GetParam());
     const ui32 BlockSize = std::get<2>(GetParam());
+    const size_t ThreadCount = std::get<4>(GetParam());
     const ui64 BlocksPerChunk = ChunkByteCount / BlockSize;
     const ui32 SectorsPerBlock = BlockSize / SectorSize;
     const size_t SectorsPerRequest = SectorsPerBlock * BlocksPerRequest;
@@ -142,6 +152,7 @@ public:
     std::shared_ptr<IServer> Server;
     TVector<TTempFileHandle> Files;
     IEncryptorPtr Encryptor;
+    ITaskQueuePtr ThreadPool;
 
     TOptions Options {
         .SocketPath = SocketPath,
@@ -163,11 +174,14 @@ public:
             Encryptor =
                 CreateAesXtsEncryptor(TEncryptionKey(DefaultEncryptionKey));
         }
+        if (ThreadCount > 0) {
+            ThreadPool = CreateThreadPool("Encryptor", ThreadCount);
+        }
     }
 
     void StartServer(bool addNonExistingDevice = false)
     {
-        Server = CreateServer(Logging, CreateAioBackend(Encryptor, Logging));
+        Server = CreateServer(Logging, CreateAioBackend(Encryptor, Logging, ThreadPool));
 
         Options.Layout.reserve(ChunkCount);
         Files.reserve(ChunkCount);
@@ -189,6 +203,10 @@ public:
             file.Resize(ChunkByteCount);
         }
 
+        if (ThreadPool) {
+            ThreadPool->Start();
+        }
+
         Server->Start(Options);
 
         ASSERT_TRUE(Client.Init());
@@ -198,7 +216,9 @@ public:
 
     void StartServerWithSplitDevices()
     {
-        Server = CreateServer(Logging, CreateAioBackend(Encryptor, Logging));
+        Server = CreateServer(
+            Logging,
+            CreateAioBackend(Encryptor, Logging, ThreadPool));
 
         // H - header
         // D - device
@@ -252,6 +272,10 @@ public:
                 .ByteCount = ChunkByteCount,
                 .Offset = offsets[i]
             });
+        }
+
+        if (ThreadPool) {
+            ThreadPool->Start();
         }
 
         Server->Start(Options);
@@ -1232,15 +1256,204 @@ INSTANTIATE_TEST_SUITE_P(
             NProto::EEncryptionMode::ENCRYPTION_AES_XTS),
         testing::Values(1, 2, 4),       // Blocks per request
         testing::Values(512_B, 4_KB),   // Block size
-        testing::Values(true, false)    // Unaligned
+        testing::Values(true, false),   // Unaligned
+        testing::Values(0, 2)),
+    [](const testing::TestParamInfo<TTestParams>& info)
+    {
+        const auto name = TStringBuilder()
+                          << std::get<0>(info.param) << "_bc"
+                          << std::get<1>(info.param) << "_bs"
+                          << std::get<2>(info.param) << "_"
+                          << (std::get<3>(info.param) ? "unaligned" : "aligned")
+                          << "_tc" << std::get<4>(info.param);
+        return std::string(name);
+    });
+
+class TSlowEncryptor: public IEncryptor
+{
+private:
+    TDuration SleepTime;
+    std::atomic<ui64> TotalSleepTimeMillis;
+
+    IEncryptorPtr Encryptor;
+
+public:
+    explicit TSlowEncryptor(TDuration sleepTime, IEncryptorPtr encryptor)
+        : SleepTime(sleepTime)
+        , Encryptor(std::move(encryptor))
+    {}
+
+    NProto::TError
+    Encrypt(TBlockDataRef src, TBlockDataRef dst, ui64 blockIndex) override
+    {
+        Y_UNUSED(src);
+        Y_UNUSED(blockIndex);
+        Sleep(SleepTime);
+        TotalSleepTimeMillis += SleepTime.MilliSeconds();
+        return Encryptor->Encrypt(src, dst, blockIndex);
+    }
+
+    NProto::TError
+    Decrypt(TBlockDataRef src, TBlockDataRef dst, ui64 blockIndex) override
+    {
+        Y_UNUSED(src);
+        Y_UNUSED(blockIndex);
+
+        Sleep(SleepTime);
+        TotalSleepTimeMillis += SleepTime.MilliSeconds();
+        return Encryptor->Decrypt(src, dst, blockIndex);
+    }
+
+    TDuration GetTotalSleepTime() const
+    {
+        return TDuration::MilliSeconds(TotalSleepTimeMillis.load());
+    }
+
+    void SetSleepTime(TDuration sleepTime)
+    {
+        SleepTime = sleepTime;
+    }
+};
+
+class TSlowEncryptorServerTest: public TServerTest
+{
+public:
+    TSlowEncryptorServerTest()
+    {
+        Encryptor = std::make_shared<TSlowEncryptor>(
+            TDuration::MilliSeconds(100),
+            Encryptor);
+    }
+
+    TDuration GetTotalSleepTime() const
+    {
+        auto* slowEncryptor = dynamic_cast<TSlowEncryptor*>(Encryptor.get());
+        EXPECT_TRUE(slowEncryptor != nullptr);
+        return slowEncryptor->GetTotalSleepTime();
+    }
+
+    void SetSleepTime(TDuration sleepTime)
+    {
+        auto* slowEncryptor = dynamic_cast<TSlowEncryptor*>(Encryptor.get());
+        EXPECT_TRUE(slowEncryptor != nullptr);
+        slowEncryptor->SetSleepTime(sleepTime);
+    }
+};
+
+TEST_P(TSlowEncryptorServerTest, ShouldDecryptDataInParallel)
+{
+    StartServer();
+
+    auto makePatten = [&](size_t startBlock) -> TString
+    {
+        TString result;
+        result.resize(RequestSize);
+        for (size_t i = 0; i < BlocksPerRequest; ++i) {
+            memset(
+                const_cast<char*>(result.data()) + BlockSize * i,
+                GetFillChar(startBlock + i),
+                BlockSize);
+        }
+        return result;
+    };
+
+    SetSleepTime(TDuration::Zero());
+
+    {
+        std::span hdr = Hdr(Memory, {.type = VIRTIO_BLK_T_OUT});
+        std::span writeBuffer =
+            Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize);
+        std::span status = Memory.Allocate(1);
+
+        for (ui64 i = 0; i < ui64(ThreadCount); ++i) {
+            reinterpret_cast<virtio_blk_req_hdr*>(hdr.data())->sector =
+                i * SectorsPerBlock;
+            TString expectedData = makePatten(i);
+            memcpy(
+                writeBuffer.data(),
+                expectedData.data(),
+                expectedData.size());
+            auto writeOp =
+                Client.WriteAsync(QueueIndex, {hdr, writeBuffer}, {status});
+            EXPECT_EQ(status.size(), writeOp.GetValueSync());
+            EXPECT_EQ(VIRTIO_BLK_S_OK, status[0]);
+        }
+    }
+
+    SetSleepTime(TDuration::MilliSeconds(100));
+
+    // read data
+    {
+        TVector<std::span<char>> hdrs;
+        TVector<std::span<char>> readBuffers;
+        TVector<std::span<char>> statuses;
+        TVector<NThreading::TFuture<ui32>> readOpsResult;
+
+        for (ui64 i = 0; i < ui64(ThreadCount); ++i) {
+            hdrs.push_back(Hdr(Memory, {.type = VIRTIO_BLK_T_IN}));
+            readBuffers.push_back(
+                Memory.Allocate(RequestSize, Unaligned ? 1 : BlockSize));
+            statuses.push_back(Memory.Allocate(1));
+
+            reinterpret_cast<virtio_blk_req_hdr*>(hdrs.back().data())->sector =
+                i * SectorsPerBlock;
+            auto readOp = Client.WriteAsync(
+                QueueIndex,
+                {hdrs.back()},
+                {readBuffers.back(), statuses.back()});
+            readOpsResult.push_back(readOp);
+        }
+
+        auto before = TInstant::Now();
+
+        auto waitResult = NThreading::WaitAll(readOpsResult);
+
+        waitResult.Wait();
+
+        auto after = TInstant::Now();
+        auto duration = after - before;
+
+        for (size_t i = 0; i < readOpsResult.size(); ++i) {
+            auto readOpResult = readOpsResult[i].GetValueSync();
+            EXPECT_EQ(statuses[i].size() + readBuffers[i].size(), readOpResult);
+            EXPECT_EQ(VIRTIO_BLK_S_OK, statuses[i][0]);
+            TString readData(readBuffers[i].data(), readBuffers[i].size());
+            EXPECT_EQ(makePatten(i), readData);
+        }
+
+        auto expectedSleepTime = (GetTotalSleepTime() / ThreadCount) * 1.1;
+
+        EXPECT_LT(duration, expectedSleepTime);
+    }
+
+    SetSleepTime(TDuration::Zero());
+
+    // validate storage
+    for (ui64 i = 0; i < ui64(ThreadCount); ++i) {
+        const TString expectedData(BlockSize, GetFillChar(i));
+        const TString realData = LoadBlockAndDecrypt(i);
+        EXPECT_EQ(expectedData, realData);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    TSlowEncryptorServerTest,
+    testing::Combine(
+        testing::Values(NProto::EEncryptionMode::ENCRYPTION_AES_XTS),
+        testing::Values(1, 2, 4),       // Blocks per request
+        testing::Values(512_B),         // Block size
+        testing::Values(true, false),   // Unaligned
+        testing::Values(2, 4)           // Thread Count
         ),
     [](const testing::TestParamInfo<TTestParams>& info)
     {
-        const auto name =
-            TStringBuilder()
-            << std::get<0>(info.param) << "_bc" << std::get<1>(info.param)
-            << "_bs" << std::get<2>(info.param) << "_"
-            << (std::get<3>(info.param) ? "unaligned" : "aligned");
+        const auto name = TStringBuilder()
+                          << std::get<0>(info.param) << "_bc"
+                          << std::get<1>(info.param) << "_bs"
+                          << std::get<2>(info.param) << "_"
+                          << (std::get<3>(info.param) ? "unaligned" : "aligned")
+                          << "_tc" << std::get<4>(info.param);
         return std::string(name);
     });
 

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1418,7 +1418,17 @@ TEST_P(TSlowEncryptorServerTest, ShouldDecryptDataInParallel)
 
         auto expectedSleepTime = (GetTotalSleepTime() / ThreadCount) * 1.1;
 
+#if (defined(__has_feature) && __has_feature(undefined_behavior_sanitizer)) || \
+    (defined(__SANITIZE_UNDEFINED__) && __SANITIZE_UNDEFINED__)
+#define UBSAN_BUILD 1
+#else
+#define UBSAN_BUILD 0
+#endif
+
+#if !defined(__SANITIZE_MEMORY__) && !defined(__SANITIZE_ADDRESS__) && \
+    !defined(__SANITIZE_THREAD__) && !UBSAN_BUILD
         EXPECT_LT(duration, expectedSleepTime);
+#endif
     }
 
     SetSleepTime(TDuration::Zero());

--- a/cloud/blockstore/vhost-server/server_ut.cpp
+++ b/cloud/blockstore/vhost-server/server_ut.cpp
@@ -1286,8 +1286,6 @@ public:
     NProto::TError
     Encrypt(TBlockDataRef src, TBlockDataRef dst, ui64 blockIndex) override
     {
-        Y_UNUSED(src);
-        Y_UNUSED(blockIndex);
         Sleep(SleepTime);
         TotalSleepTimeMillis += SleepTime.MilliSeconds();
         return Encryptor->Encrypt(src, dst, blockIndex);
@@ -1296,9 +1294,6 @@ public:
     NProto::TError
     Decrypt(TBlockDataRef src, TBlockDataRef dst, ui64 blockIndex) override
     {
-        Y_UNUSED(src);
-        Y_UNUSED(blockIndex);
-
         Sleep(SleepTime);
         TotalSleepTimeMillis += SleepTime.MilliSeconds();
         return Encryptor->Decrypt(src, dst, blockIndex);

--- a/cloud/blockstore/vhost-server/stats.cpp
+++ b/cloud/blockstore/vhost-server/stats.cpp
@@ -60,6 +60,24 @@ public:
         NeedUpdateCompletionStats = false;
         CompletionStatsEvent.Signal();
     }
+
+    void Sync(const TAtomicStats& stats) override
+    {
+        if (!NeedUpdateCompletionStats) {
+            return;
+        }
+
+        CompletionStats.Completed = stats.Completed;
+        CompletionStats.CompFailed = stats.CompFailed;
+        CompletionStats.EncryptorErrors = stats.EncryptorErrors;
+
+        std::ranges::copy(stats.Requests, CompletionStats.Requests.begin());
+        std::ranges::copy(stats.Times, CompletionStats.Times.begin());
+        std::ranges::copy(stats.Sizes, CompletionStats.Sizes.begin());
+
+        NeedUpdateCompletionStats = false;
+        CompletionStatsEvent.Signal();
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/vhost-server/stats.h
+++ b/cloud/blockstore/vhost-server/stats.h
@@ -163,6 +163,8 @@ struct ICompletionStats
     virtual std::optional<TSimpleStats> Get(TDuration timeout) = 0;
 
     virtual void Sync(const TSimpleStats& stats) = 0;
+
+    virtual void Sync(const TAtomicStats& stats) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/vhost-server/stats.h
+++ b/cloud/blockstore/vhost-server/stats.h
@@ -19,8 +19,12 @@ namespace NCloud::NBlockStore::NVHostServer {
 ////////////////////////////////////////////////////////////////////////////////
 
 using TCpuCycles = ui64;
-using TTimeHistogram = THistogram<7>;
-using TSizeHistogram = THistogram<3>;
+
+template <typename T>
+using TTimeHistogram = THistogram<T, 7>;
+
+template <typename T>
+using TSizeHistogram = THistogram<T, 3>;
 
 template <typename T>
 struct TRequestStats
@@ -85,8 +89,8 @@ struct TStats
     T EncryptorErrors = {};
 
     std::array<TRequestStats<T>, 2> Requests = {};
-    std::array<TTimeHistogram, 2> Times = {};
-    std::array<TSizeHistogram, 2> Sizes = {};
+    std::array<TTimeHistogram<T>, 2> Times = {};
+    std::array<TSizeHistogram<T>, 2> Sizes = {};
 
     TStats() = default;
 


### PR DESCRIPTION
### Notes
ran ```sudo fio --rw=randread --filename=/dev/disk/by-id/virtio-local-encrypted-disk --direct=1 --bs=8k --ioengine=libaio --iodepth=64 --time_based --runtime 600 --numjobs=3 --group_reporting --size=184GB```
iops without and with separate thread pool for decryption:
<img width="1852" height="512" alt="image" src="https://github.com/user-attachments/assets/74a31269-3b3e-4c16-95cb-3347cad744e6" />
With separate TP, we can achieve twice the I/OPS for encrypted local disks and come close to disk performance with no encryption
### Issue
#5942