### PR TITLE
[Filestore] Make cloud/storage/core/libs/common tests medium under sanitizers

### DIFF
--- a/cloud/storage/core/libs/common/ut/ya.make
+++ b/cloud/storage/core/libs/common/ut/ya.make
@@ -15,10 +15,12 @@ IF (SANITIZER_TYPE != "thread")
     )
 ENDIF()
 
-# TFileRingBufferTest::RandomizedPushPopRestore tests may take longer time
-IF (SANITIZER_TYPE == "memory")
-    SIZE(MEDIUM)
-    TIMEOUT(120)
+# TFileRingBufferTest::RandomizedPushPopRestore tests may need more time
+# under sanitizers
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 ENDIF()
 
 SRCS(

--- a/cloud/storage/core/libs/common/ut/ya.make
+++ b/cloud/storage/core/libs/common/ut/ya.make
@@ -15,6 +15,12 @@ IF (SANITIZER_TYPE != "thread")
     )
 ENDIF()
 
+# TFileRingBufferTest::RandomizedPushPopRestore tests may take longer time
+IF (SANITIZER_TYPE == "memory")
+    SIZE(MEDIUM)
+    TIMEOUT(120)
+ENDIF()
+
 SRCS(
     aligned_buffer_ut.cpp
     backoff_delay_provider_ut.cpp


### PR DESCRIPTION
### Notes
```
Traceback (most recent call last):
  File "library/python/testing/yatest_common/yatest/common/process.py", line 384, in wait
    wait_for(
  File "library/python/testing/yatest_common/yatest/common/process.py", line 764, in wait_for
    raise TimeoutError(truncate(message, MAX_MESSAGE_LEN))
yatest.common.process.TimeoutError: 60 second(s) wait timeout has expired: Command '['/home/github/.ya/tools/v4/8580453620/test_tool', 'run_ut', '@/home/github/.ya/build/build_root/c6s6/0008a4/cloud/storage/core/libs/common/ut/test-results/unittest/testing_out_stuff/test_tool.args']' stopped by 60 seconds timeout
```

Use `medium.inc` recipe (600s timeout) when sanitizers are used and `small.inc` by default.
