### PR TITLE
[Filestore] issue-5948: FsyncQueue multi-threaded benchmark

### DIFF
--- a/cloud/filestore/libs/vfs/bench/fsync_queue_bench.cpp
+++ b/cloud/filestore/libs/vfs/bench/fsync_queue_bench.cpp
@@ -1,0 +1,857 @@
+#include <cloud/filestore/libs/vfs/fsync_queue.h>
+
+#include <library/cpp/histogram/hdr/histogram.h>
+#include <library/cpp/testing/benchmark/bench.h>
+
+#include <util/datetime/cputimer.h>
+#include <util/generic/singleton.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/stream/format.h>
+#include <util/stream/output.h>
+#include <util/stream/str.h>
+#include <util/system/datetime.h>
+#include <util/system/mutex.h>
+#include <util/system/rusage.h>
+#include <util/system/yassert.h>
+
+#include <atomic>
+#include <cstddef>
+#include <latch>
+#include <memory>
+#include <thread>
+#include <utility>
+
+namespace NCloud::NFileStore::NVFS {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const TString FileSystemId = "fsync_queue_bench";
+constexpr ui32 MaxPendingRequests = 64;
+constexpr ui64 IdsPerThread = 1'000'000;
+const TDuration MaxTrackedLatency = TDuration::Minutes(10);
+
+enum class EScenario
+{
+    DataEnqDeq,
+    MetaEnqDeq,
+    DataMixedEnqDeqLocalWait,
+    MetaMixedEnqDeqLocalWait,
+    DataMixedEnqDeqGlobalWait,
+    MetaMixedEnqDeqGlobalWait,
+};
+
+struct TBenchmarkRuntime
+{
+    ILoggingServicePtr Logging = CreateLoggingService("console", {TLOG_INFO});
+};
+
+ILoggingServicePtr GetLogging()
+{
+    return Singleton<TBenchmarkRuntime>()->Logging;
+}
+
+ui64 GetMaxTrackedNanoseconds()
+{
+    static const ui64 nanoseconds = MaxTrackedLatency.NanoSeconds();
+    return nanoseconds;
+}
+
+long double GetCyclesPerNanosecond()
+{
+    static const long double cyclesPerNanosecond =
+        static_cast<long double>(GetCyclesPerMillisecond()) / 1'000'000.0L;
+    return cyclesPerNanosecond;
+}
+
+ui64 CyclesToNanoseconds(ui64 cycles)
+{
+    return static_cast<ui64>(
+        // Add 0.5 before truncating to round to the nearest nanosecond.
+        static_cast<long double>(cycles) / GetCyclesPerNanosecond() + 0.5L);
+}
+
+struct TLatencyStats
+{
+    ui64 Count = 0;
+    NHdr::THistogram Nanoseconds =
+        NHdr::THistogram(static_cast<i64>(GetMaxTrackedNanoseconds()), 3);
+
+    void RecordCycles(ui64 cycles)
+    {
+        auto nanoseconds = CyclesToNanoseconds(cycles);
+        if (nanoseconds == 0) {
+            nanoseconds = 1;
+        }
+        if (nanoseconds > GetMaxTrackedNanoseconds()) {
+            nanoseconds = GetMaxTrackedNanoseconds();
+        }
+
+        ++Count;
+        Y_ABORT_UNLESS(Nanoseconds.RecordValue(static_cast<i64>(nanoseconds)));
+    }
+
+    void Add(const TLatencyStats& stats)
+    {
+        Count += stats.Count;
+        Y_ABORT_UNLESS(Nanoseconds.Add(stats.Nanoseconds) == 0);
+    }
+};
+
+struct TThreadStats
+{
+    TLatencyStats Enqueue;
+    TLatencyStats Dequeue;
+    TLatencyStats Wait;
+};
+
+struct TRunStats
+{
+    TLatencyStats Enqueue;
+    TLatencyStats Dequeue;
+    TLatencyStats Wait;
+
+    void Add(const TThreadStats& stats)
+    {
+        Enqueue.Add(stats.Enqueue);
+        Dequeue.Add(stats.Dequeue);
+        Wait.Add(stats.Wait);
+    }
+
+    void Add(const TRunStats& stats)
+    {
+        Enqueue.Add(stats.Enqueue);
+        Dequeue.Add(stats.Dequeue);
+        Wait.Add(stats.Wait);
+    }
+};
+
+void PrintShortDurationValue(IOutputStream& out, double value)
+{
+    int digits = 0;
+    if (value < 10) {
+        digits = 2;
+    } else if (value < 100) {
+        digits = 1;
+    }
+
+    out << Prec(value, PREC_POINT_DIGITS_STRIP_ZEROES, digits);
+}
+
+void PrintHumanNanoseconds(IOutputStream& out, ui64 nanoseconds)
+{
+    constexpr ui64 Microsecond = 1'000;
+    constexpr ui64 Millisecond = 1'000 * Microsecond;
+    constexpr ui64 Second = 1'000 * Millisecond;
+
+    if (nanoseconds < Microsecond) {
+        out << nanoseconds << "ns";
+        return;
+    }
+
+    if (nanoseconds < Millisecond) {
+        PrintShortDurationValue(
+            out,
+            static_cast<double>(nanoseconds) / Microsecond);
+        out << "us";
+        return;
+    }
+
+    if (nanoseconds < Second) {
+        PrintShortDurationValue(
+            out,
+            static_cast<double>(nanoseconds) / Millisecond);
+        out << "ms";
+        return;
+    }
+
+    if (nanoseconds < 60 * Second) {
+        PrintShortDurationValue(out, static_cast<double>(nanoseconds) / Second);
+        out << 's';
+        return;
+    }
+
+    out << HumanReadable(TDuration::MicroSeconds(nanoseconds / Microsecond));
+}
+
+void PrintLatencyStats(
+    IOutputStream& out,
+    const char* name,
+    const TLatencyStats& stats)
+{
+    const auto printValue = [&](const char* suffix, i64 nanoseconds)
+    {
+        out << ' ' << suffix << '=';
+        if (stats.Count) {
+            PrintHumanNanoseconds(out, static_cast<ui64>(nanoseconds));
+        } else {
+            out << '-';
+        }
+    };
+
+    out << "  " << name << "_latency:";
+    printValue("p50", stats.Nanoseconds.GetValueAtPercentile(50));
+    printValue("p95", stats.Nanoseconds.GetValueAtPercentile(95));
+    printValue("p99", stats.Nanoseconds.GetValueAtPercentile(99));
+    printValue("max", stats.Nanoseconds.GetMax());
+    out << Endl;
+}
+
+struct TCollectedRun
+{
+    ui64 Iterations = 0;
+    ui64 Samples = 0;
+    bool WarmupSkipped = false;
+    TRunStats Stats;
+    TDuration UserCpu;
+    TDuration SystemCpu;
+    ui64 WallCycles = 0;
+
+    void Add(
+        ui64 iterations,
+        const TRunStats& stats,
+        const TRusage& startedUsage,
+        const TRusage& finishedUsage,
+        ui64 startedCycles,
+        ui64 finishedCycles)
+    {
+        Iterations += iterations;
+        ++Samples;
+        Stats.Add(stats);
+        UserCpu = UserCpu + (finishedUsage.Utime - startedUsage.Utime);
+        SystemCpu = SystemCpu + (finishedUsage.Stime - startedUsage.Stime);
+        WallCycles += finishedCycles - startedCycles;
+    }
+};
+
+TString FormatRunStats(const char* name, const TCollectedRun& run)
+{
+    const auto totalCpu = run.UserCpu + run.SystemCpu;
+    const auto wall = CyclesToDurationSafe(run.WallCycles);
+
+    const auto wallUs = wall.MicroSeconds();
+    const auto cpuUtil =
+        wallUs ? static_cast<double>(totalCpu.MicroSeconds()) / wallUs : 0.0;
+
+    TStringStream out;
+    out << "FSyncQueueBench" << " name=" << name << Endl
+        << "  iterations=" << run.Iterations << Endl
+        << "  operations:" << " enqueues=" << run.Stats.Enqueue.Count
+        << " dequeues=" << run.Stats.Dequeue.Count
+        << " waits=" << run.Stats.Wait.Count << Endl;
+
+    PrintLatencyStats(out, "enqueue", run.Stats.Enqueue);
+    PrintLatencyStats(out, "dequeue", run.Stats.Dequeue);
+    PrintLatencyStats(out, "wait", run.Stats.Wait);
+
+    out << "  cpu_time:";
+    out << " user=";
+    PrintHumanNanoseconds(out, run.UserCpu.NanoSeconds());
+    out << " system=";
+    PrintHumanNanoseconds(out, run.SystemCpu.NanoSeconds());
+    out << " total=";
+    PrintHumanNanoseconds(out, totalCpu.NanoSeconds());
+    out << Endl;
+
+    out << "  wall_time=";
+    PrintHumanNanoseconds(out, wall.NanoSeconds());
+    out << " cpu_util=" << cpuUtil;
+
+    return out.Str();
+}
+
+struct TStatsCollector
+{
+    TMutex Lock;
+    TString CurrentName;
+    std::unique_ptr<TCollectedRun> CurrentRun;
+
+    ~TStatsCollector()
+    {
+        PrintCurrentRun();
+    }
+
+    void Add(
+        TString name,
+        ui64 iterations,
+        const TRunStats& stats,
+        const TRusage& startedUsage,
+        const TRusage& finishedUsage,
+        ui64 startedCycles,
+        ui64 finishedCycles)
+    {
+        with_lock (Lock) {
+            if (!CurrentRun || CurrentName != name) {
+                PrintCurrentRun();
+                CurrentName = std::move(name);
+                CurrentRun = std::make_unique<TCollectedRun>();
+            }
+
+            if (!CurrentRun->WarmupSkipped) {
+                CurrentRun->WarmupSkipped = true;
+                return;
+            }
+
+            CurrentRun->Add(
+                iterations,
+                stats,
+                startedUsage,
+                finishedUsage,
+                startedCycles,
+                finishedCycles);
+        }
+    }
+
+private:
+    void PrintCurrentRun()
+    {
+        if (CurrentRun && CurrentRun->Samples) {
+            Cerr << FormatRunStats(CurrentName.data(), *CurrentRun) << Endl;
+        }
+        CurrentRun.reset();
+    }
+};
+
+void CollectRunStats(
+    const char* name,
+    ui64 iterations,
+    const TRunStats& stats,
+    const TRusage& startedUsage,
+    const TRusage& finishedUsage,
+    ui64 startedCycles,
+    ui64 finishedCycles)
+{
+    Singleton<TStatsCollector>()->Add(
+        name,
+        iterations,
+        stats,
+        startedUsage,
+        finishedUsage,
+        startedCycles,
+        finishedCycles);
+}
+
+TNodeId GetNodeId(ui32 threadIndex, ui64 offset = 0)
+{
+    return TNodeId{1 + threadIndex * IdsPerThread + offset};
+}
+
+THandle GetHandle(ui32 threadIndex, ui64 offset = 0)
+{
+    return THandle{1 + threadIndex * IdsPerThread + offset};
+}
+
+ui64 GetThreadIterations(ui64 iterations, ui32 threadIndex, ui32 threadCount)
+{
+    // Split the benchmark framework iteration count evenly across workers while
+    // preserving the exact total number of iterations.
+    const ui64 base = iterations / threadCount;
+    const ui64 extra = threadIndex < iterations % threadCount ? 1 : 0;
+    return base + extra;
+}
+
+void WaitFuture(
+    NThreading::TFuture<NProto::TError> future,
+    ui64 startedCycles,
+    TThreadStats& stats)
+{
+    const auto error = future.GetValueSync();
+    Y_ABORT_UNLESS(!HasError(error));
+    stats.Wait.RecordCycles(GetCycleCount() - startedCycles);
+}
+
+struct TPendingRequest
+{
+    IFSyncQueue::TRequestId ReqId = 0;
+    TNodeId NodeId;
+    THandle Handle;
+};
+
+TPendingRequest EnqueueDataRequest(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    TNodeId nodeId,
+    THandle handle)
+{
+    const auto reqId = requestId.fetch_add(1, std::memory_order_relaxed);
+
+    const auto startedCycles = GetCycleCount();
+    queue.Enqueue(reqId, nodeId, handle);
+    stats.Enqueue.RecordCycles(GetCycleCount() - startedCycles);
+
+    return {
+        .ReqId = reqId,
+        .NodeId = nodeId,
+        .Handle = handle,
+    };
+}
+
+TPendingRequest EnqueueMetaRequest(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    TNodeId nodeId)
+{
+    const auto reqId = requestId.fetch_add(1, std::memory_order_relaxed);
+
+    const auto startedCycles = GetCycleCount();
+    queue.Enqueue(reqId, nodeId);
+    stats.Enqueue.RecordCycles(GetCycleCount() - startedCycles);
+
+    return {
+        .ReqId = reqId,
+        .NodeId = nodeId,
+    };
+}
+
+void DequeueRequest(
+    TFSyncQueue& queue,
+    const TPendingRequest& request,
+    TThreadStats& stats)
+{
+    const auto startedCycles = GetCycleCount();
+    queue.Dequeue(request.ReqId, {}, request.NodeId, request.Handle);
+    stats.Dequeue.RecordCycles(GetCycleCount() - startedCycles);
+}
+
+void CompleteLastRequest(
+    TFSyncQueue& queue,
+    TVector<TPendingRequest>& pending,
+    TThreadStats& stats)
+{
+    auto request = pending.back();
+    pending.pop_back();
+
+    DequeueRequest(queue, request, stats);
+}
+
+void CompletePendingRequests(
+    TFSyncQueue& queue,
+    TVector<TPendingRequest>& pending,
+    TThreadStats& stats)
+{
+    while (!pending.empty()) {
+        CompleteLastRequest(queue, pending, stats);
+    }
+}
+
+void RunDataEnqDeq(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    ui32 threadIndex,
+    ui64 iterations)
+{
+    const auto nodeId = GetNodeId(threadIndex);
+    const auto handle = GetHandle(threadIndex);
+
+    for (ui64 i = 0; i < iterations; ++i) {
+        auto request =
+            EnqueueDataRequest(queue, requestId, stats, nodeId, handle);
+        DequeueRequest(queue, request, stats);
+    }
+}
+
+void RunMetaEnqDeq(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    ui32 threadIndex,
+    ui64 iterations)
+{
+    const auto nodeId = GetNodeId(threadIndex);
+
+    for (ui64 i = 0; i < iterations; ++i) {
+        auto request = EnqueueMetaRequest(queue, requestId, stats, nodeId);
+        DequeueRequest(queue, request, stats);
+    }
+}
+
+void RunDataMixedEnqDeqLocalWait(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    ui32 threadIndex,
+    ui64 iterations,
+    ui32 iterationsBeforeWait)
+{
+    Y_ABORT_UNLESS(iterationsBeforeWait);
+
+    const auto nodeId = GetNodeId(threadIndex);
+    const auto handle = GetHandle(threadIndex);
+
+    TVector<TPendingRequest> pending;
+    pending.reserve(MaxPendingRequests);
+
+    for (ui64 i = 0; i < iterations; ++i) {
+        const bool shouldWait = (i + 1) % iterationsBeforeWait == 0;
+
+        if (shouldWait) {
+            const auto reqId =
+                requestId.fetch_add(1, std::memory_order_relaxed);
+            const auto startedCycles = GetCycleCount();
+            auto future = queue.WaitForDataRequests(reqId, nodeId, handle);
+
+            CompletePendingRequests(queue, pending, stats);
+            WaitFuture(std::move(future), startedCycles, stats);
+
+            continue;
+        }
+
+        pending.push_back(
+            EnqueueDataRequest(queue, requestId, stats, nodeId, handle));
+
+        if (pending.size() == MaxPendingRequests) {
+            CompleteLastRequest(queue, pending, stats);
+        }
+    }
+
+    CompletePendingRequests(queue, pending, stats);
+}
+
+void RunMetaMixedEnqDeqLocalWait(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    ui32 threadIndex,
+    ui64 iterations,
+    ui32 iterationsBeforeWait)
+{
+    Y_ABORT_UNLESS(iterationsBeforeWait);
+
+    const auto nodeId = GetNodeId(threadIndex);
+
+    TVector<TPendingRequest> pending;
+    pending.reserve(MaxPendingRequests);
+
+    for (ui64 i = 0; i < iterations; ++i) {
+        const bool shouldWait = (i + 1) % iterationsBeforeWait == 0;
+
+        if (shouldWait) {
+            const auto reqId =
+                requestId.fetch_add(1, std::memory_order_relaxed);
+            const auto startedCycles = GetCycleCount();
+            auto future = queue.WaitForRequests(reqId, nodeId);
+
+            CompletePendingRequests(queue, pending, stats);
+            WaitFuture(std::move(future), startedCycles, stats);
+
+            continue;
+        }
+
+        pending.push_back(EnqueueMetaRequest(queue, requestId, stats, nodeId));
+
+        if (pending.size() == MaxPendingRequests) {
+            CompleteLastRequest(queue, pending, stats);
+        }
+    }
+
+    CompletePendingRequests(queue, pending, stats);
+}
+
+void RunDataMixedEnqDeqGlobalWait(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    ui32 threadIndex,
+    ui64 iterations,
+    ui32 iterationsBeforeWait)
+{
+    Y_ABORT_UNLESS(iterationsBeforeWait);
+
+    TVector<TPendingRequest> pending;
+    pending.reserve(MaxPendingRequests);
+
+    for (ui64 i = 0; i < iterations; ++i) {
+        const bool shouldWait = (i + 1) % iterationsBeforeWait == 0;
+
+        if (shouldWait) {
+            const auto reqId =
+                requestId.fetch_add(1, std::memory_order_relaxed);
+            const auto startedCycles = GetCycleCount();
+            auto future = queue.WaitForDataRequests(reqId);
+
+            CompletePendingRequests(queue, pending, stats);
+            WaitFuture(std::move(future), startedCycles, stats);
+
+            continue;
+        }
+
+        const ui64 idOffset = 1 + i % MaxPendingRequests;
+        pending.push_back(EnqueueDataRequest(
+            queue,
+            requestId,
+            stats,
+            GetNodeId(threadIndex, idOffset),
+            GetHandle(threadIndex, idOffset)));
+
+        if (pending.size() == MaxPendingRequests) {
+            CompleteLastRequest(queue, pending, stats);
+        }
+    }
+
+    CompletePendingRequests(queue, pending, stats);
+}
+
+void RunMetaMixedEnqDeqGlobalWait(
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    ui32 threadIndex,
+    ui64 iterations,
+    ui32 iterationsBeforeWait)
+{
+    Y_ABORT_UNLESS(iterationsBeforeWait);
+
+    TVector<TPendingRequest> pending;
+    pending.reserve(MaxPendingRequests);
+
+    for (ui64 i = 0; i < iterations; ++i) {
+        const bool shouldWait = (i + 1) % iterationsBeforeWait == 0;
+
+        if (shouldWait) {
+            const auto reqId =
+                requestId.fetch_add(1, std::memory_order_relaxed);
+            const auto startedCycles = GetCycleCount();
+            auto future = queue.WaitForRequests(reqId);
+
+            CompletePendingRequests(queue, pending, stats);
+            WaitFuture(std::move(future), startedCycles, stats);
+
+            continue;
+        }
+
+        const ui64 idOffset = 1 + i % MaxPendingRequests;
+        pending.push_back(EnqueueMetaRequest(
+            queue,
+            requestId,
+            stats,
+            GetNodeId(threadIndex, idOffset)));
+
+        if (pending.size() == MaxPendingRequests) {
+            CompleteLastRequest(queue, pending, stats);
+        }
+    }
+
+    CompletePendingRequests(queue, pending, stats);
+}
+
+void RunWorker(
+    EScenario scenario,
+    TFSyncQueue& queue,
+    std::atomic<IFSyncQueue::TRequestId>& requestId,
+    TThreadStats& stats,
+    ui32 threadIndex,
+    ui64 iterations,
+    ui32 iterationsBeforeWait)
+{
+    switch (scenario) {
+        case EScenario::DataEnqDeq:
+            RunDataEnqDeq(queue, requestId, stats, threadIndex, iterations);
+            break;
+
+        case EScenario::MetaEnqDeq:
+            RunMetaEnqDeq(queue, requestId, stats, threadIndex, iterations);
+            break;
+
+        case EScenario::DataMixedEnqDeqLocalWait:
+            RunDataMixedEnqDeqLocalWait(
+                queue,
+                requestId,
+                stats,
+                threadIndex,
+                iterations,
+                iterationsBeforeWait);
+            break;
+
+        case EScenario::MetaMixedEnqDeqLocalWait:
+            RunMetaMixedEnqDeqLocalWait(
+                queue,
+                requestId,
+                stats,
+                threadIndex,
+                iterations,
+                iterationsBeforeWait);
+            break;
+
+        case EScenario::DataMixedEnqDeqGlobalWait:
+            RunDataMixedEnqDeqGlobalWait(
+                queue,
+                requestId,
+                stats,
+                threadIndex,
+                iterations,
+                iterationsBeforeWait);
+            break;
+
+        case EScenario::MetaMixedEnqDeqGlobalWait:
+            RunMetaMixedEnqDeqGlobalWait(
+                queue,
+                requestId,
+                stats,
+                threadIndex,
+                iterations,
+                iterationsBeforeWait);
+            break;
+    }
+}
+
+void RunFSyncQueueBench(
+    const char* name,
+    ui64 iterations,
+    ui32 threadCount,
+    EScenario scenario,
+    ui32 iterationsBeforeWait = 0)
+{
+    if (iterations == 0) {
+        return;
+    }
+
+    TFSyncQueue queue(FileSystemId, GetLogging());
+    std::atomic<IFSyncQueue::TRequestId> requestId = 1;
+
+    std::latch start{static_cast<std::ptrdiff_t>(threadCount + 1)};
+    TVector<std::thread> threads;
+    threads.reserve(threadCount);
+    TVector<std::unique_ptr<TThreadStats>> threadStats;
+    threadStats.reserve(threadCount);
+
+    for (ui32 threadIndex = 0; threadIndex < threadCount; ++threadIndex) {
+        threadStats.emplace_back(std::make_unique<TThreadStats>());
+        auto* stats = threadStats.back().get();
+
+        threads.emplace_back(
+            [&queue,
+             &requestId,
+             &start,
+             stats,
+             scenario,
+             threadIndex,
+             iterationsBeforeWait,
+             threadIterations =
+                 GetThreadIterations(iterations, threadIndex, threadCount)]
+            {
+                start.arrive_and_wait();
+
+                RunWorker(
+                    scenario,
+                    queue,
+                    requestId,
+                    *stats,
+                    threadIndex,
+                    threadIterations,
+                    iterationsBeforeWait);
+            });
+    }
+
+    GetMaxTrackedNanoseconds();
+    GetCyclesPerNanosecond();
+    const auto startedUsage = TRusage::Get();
+    const auto startedCycles = GetCycleCount();
+
+    start.arrive_and_wait();
+
+    for (auto& thread: threads) {
+        thread.join();
+    }
+
+    const auto finishedCycles = GetCycleCount();
+    const auto finishedUsage = TRusage::Get();
+
+    TRunStats stats;
+    for (const auto& threadStat: threadStats) {
+        stats.Add(*threadStat);
+    }
+
+    CollectRunStats(
+        name,
+        iterations,
+        stats,
+        startedUsage,
+        finishedUsage,
+        startedCycles,
+        finishedCycles);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define FSYNC_QUEUE_BENCHMARK(name, scenario, threadCount)     \
+    Y_CPU_BENCHMARK(TFSyncQueue_##name##_##threadCount, iface) \
+    {                                                          \
+        RunFSyncQueueBench(                                    \
+            "TFSyncQueue_" #name "_" #threadCount,             \
+            iface.Iterations(),                                \
+            threadCount,                                       \
+            EScenario::scenario);                              \
+    }                                                          \
+    // FSYNC_QUEUE_BENCHMARK
+
+#define FSYNC_QUEUE_MIXED_BENCHMARK(                                               \
+    name,                                                                          \
+    scenario,                                                                      \
+    iterationsBeforeWait,                                                          \
+    threadCount)                                                                   \
+    Y_CPU_BENCHMARK(                                                               \
+        TFSyncQueue_##name##After##iterationsBeforeWait##Iterations_##threadCount, \
+        iface)                                                                     \
+    {                                                                              \
+        RunFSyncQueueBench(                                                        \
+            "TFSyncQueue_" #name "After" #iterationsBeforeWait                     \
+            "Iterations_" #threadCount,                                            \
+            iface.Iterations(),                                                    \
+            threadCount,                                                           \
+            EScenario::scenario,                                                   \
+            iterationsBeforeWait);                                                 \
+    }                                                                              \
+    // FSYNC_QUEUE_MIXED_BENCHMARK
+
+#define FSYNC_QUEUE_BENCHMARK_SET(name, scenario) \
+    FSYNC_QUEUE_BENCHMARK(name, scenario, 1)      \
+    FSYNC_QUEUE_BENCHMARK(name, scenario, 2)      \
+    FSYNC_QUEUE_BENCHMARK(name, scenario, 4)      \
+    FSYNC_QUEUE_BENCHMARK(name, scenario, 8)      \
+    FSYNC_QUEUE_BENCHMARK(name, scenario, 16)     \
+    // FSYNC_QUEUE_BENCHMARK_SET
+
+#define FSYNC_QUEUE_MIXED_BENCHMARK_SET(name, scenario, iterationsBeforeWait) \
+    FSYNC_QUEUE_MIXED_BENCHMARK(name, scenario, iterationsBeforeWait, 1)      \
+    FSYNC_QUEUE_MIXED_BENCHMARK(name, scenario, iterationsBeforeWait, 2)      \
+    FSYNC_QUEUE_MIXED_BENCHMARK(name, scenario, iterationsBeforeWait, 4)      \
+    FSYNC_QUEUE_MIXED_BENCHMARK(name, scenario, iterationsBeforeWait, 8)      \
+    FSYNC_QUEUE_MIXED_BENCHMARK(name, scenario, iterationsBeforeWait, 16)     \
+    // FSYNC_QUEUE_MIXED_BENCHMARK_SET
+
+FSYNC_QUEUE_BENCHMARK_SET(DataEnqDeq, DataEnqDeq)
+FSYNC_QUEUE_BENCHMARK_SET(MetaEnqDeq, MetaEnqDeq)
+
+FSYNC_QUEUE_MIXED_BENCHMARK_SET(
+    DataMixedEnqDeqLocalWait,
+    DataMixedEnqDeqLocalWait,
+    64)
+
+FSYNC_QUEUE_MIXED_BENCHMARK_SET(
+    MetaMixedEnqDeqLocalWait,
+    MetaMixedEnqDeqLocalWait,
+    64)
+
+FSYNC_QUEUE_MIXED_BENCHMARK_SET(
+    DataMixedEnqDeqGlobalWait,
+    DataMixedEnqDeqGlobalWait,
+    64)
+
+FSYNC_QUEUE_MIXED_BENCHMARK_SET(
+    MetaMixedEnqDeqGlobalWait,
+    MetaMixedEnqDeqGlobalWait,
+    64)
+
+#undef FSYNC_QUEUE_MIXED_BENCHMARK_SET
+#undef FSYNC_QUEUE_BENCHMARK_SET
+#undef FSYNC_QUEUE_MIXED_BENCHMARK
+#undef FSYNC_QUEUE_BENCHMARK
+
+}   // namespace NCloud::NFileStore::NVFS

--- a/cloud/filestore/libs/vfs/bench/ya.make
+++ b/cloud/filestore/libs/vfs/bench/ya.make
@@ -1,0 +1,17 @@
+Y_BENCHMARK()
+
+IF (SANITIZER_TYPE)
+    TAG(ya:manual)
+ENDIF()
+
+SRCS(
+    fsync_queue_bench.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/diagnostics
+    cloud/filestore/libs/vfs
+    library/cpp/histogram/hdr
+)
+
+END()

--- a/cloud/filestore/libs/vfs/ya.make
+++ b/cloud/filestore/libs/vfs/ya.make
@@ -22,8 +22,8 @@ RECURSE(
 )
 
 RECURSE_FOR_TESTS(
+    bench
     tests
     ut
 )
-
 


### PR DESCRIPTION
#5948
Running example:
```
$ ya make -rT cloud/filestore/libs/vfs/bench && cloud/filestore/libs/vfs/bench/bench --budget=300
Configuring dependencies for platform default-linux-x86_64-release-FORCE_STATIC_LINKING=yes
Configuring dependencies for platform tools
Configuring local and dist store caches
Configuration done. Preparing for execution
|33.3%| COMPACTING CACHE 134.0GiB
|66.7%| CLEANING SYMRES
|83.3%| [LD] {RESULT} $(B)/cloud/filestore/libs/vfs/bench/bench
|99.9%| CLEANING BUILD ROOT
Ok
----------- TFSyncQueue_DataEnqDeq_1 ---------------
 samples:       6907
 iterations:    29456650
 iterations hr:    29.5M
 run time:      10.00162916
 per iteration: 724.4488814 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_1
  iterations=29456650
  operations: enqueues=29456650 dequeues=29456650 waits=0
  enqueue_latency: p50=90ns p95=110ns p99=120ns max=46.2us
  dequeue_latency: p50=90ns p95=100ns p99=120ns max=49.2us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=8.71s system=639ms total=9.35s
  wall_time=9.17s cpu_util=1.019863098
----------- TFSyncQueue_DataEnqDeq_2 ---------------
 samples:       3641
 iterations:    8187081
 iterations hr:    8.19M
 run time:      10.00307825
 per iteration: 1826.113643 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_2
  iterations=8187081
  operations: enqueues=8187081 dequeues=8187081 waits=0
  enqueue_latency: p50=621ns p95=2.16us p99=2.58us max=48.2us
  dequeue_latency: p50=871ns p95=3.69us p99=4.61us max=74.3us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=17.2s system=878ms total=18.1s
  wall_time=9.06s cpu_util=1.992995965
----------- TFSyncQueue_DataEnqDeq_4 ---------------
 samples:       2984
 iterations:    5499586
 iterations hr:    5.5M
 run time:      10.004191
 per iteration: 3617.546021 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_4
  iterations=5499586
  operations: enqueues=5499586 dequeues=5499586 waits=0
  enqueue_latency: p50=1.22us p95=6.37us p99=22.1us max=5.15ms
  dequeue_latency: p50=1.26us p95=6.36us p99=20.7us max=7.78ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=24.3s system=1.39s total=25.7s
  wall_time=8.27s cpu_util=3.110946035
----------- TFSyncQueue_DataEnqDeq_8 ---------------
 samples:       2534
 iterations:    3966336
 iterations hr:    3.97M
 run time:      10.00539216
 per iteration: 3870.550192 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_8
  iterations=3966336
  operations: enqueues=3966336 dequeues=3966336 waits=0
  enqueue_latency: p50=1.35us p95=8.89us p99=31.2us max=7.53ms
  dequeue_latency: p50=1.39us p95=8.92us p99=24.8us max=5.22ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=23.8s system=2.39s total=26.2s
  wall_time=7.02s cpu_util=3.733005172
----------- TFSyncQueue_DataEnqDeq_16 ---------------
 samples:       1961
 iterations:    2375110
 iterations hr:    2.38M
 run time:      10.00250542
 per iteration: 3805.653855 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_16
  iterations=2375110
  operations: enqueues=2375110 dequeues=2375110 waits=0
  enqueue_latency: p50=1.73us p95=13.3us p99=115us max=5.23ms
  dequeue_latency: p50=1.61us p95=11.7us p99=29.5us max=4.92ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=21s system=3.58s total=24.6s
  wall_time=5.44s cpu_util=4.520118635
----------- TFSyncQueue_MetaEnqDeq_1 ---------------
 samples:       8237
 iterations:    41893281
 iterations hr:    41.9M
 run time:      10.0020835
 per iteration: 505.8548253 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_1
  iterations=41893281
  operations: enqueues=41893281 dequeues=41893281 waits=0
  enqueue_latency: p50=50ns p95=50ns p99=60ns max=44.1us
  dequeue_latency: p50=50ns p95=60ns p99=60ns max=100us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=8.68s system=657ms total=9.34s
  wall_time=9.1s cpu_util=1.026189445
----------- TFSyncQueue_MetaEnqDeq_2 ---------------
 samples:       5706
 iterations:    20100970
 iterations hr:    20.1M
 run time:      10.00101609
 per iteration: 826.0374389 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_2
  iterations=20100970
  operations: enqueues=20100970 dequeues=20100970 waits=0
  enqueue_latency: p50=310ns p95=1us p99=1.7us max=694us
  dequeue_latency: p50=330ns p95=561ns p99=2.13us max=579us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=16.2s system=1.15s total=17.3s
  wall_time=8.7s cpu_util=1.993360449
----------- TFSyncQueue_MetaEnqDeq_4 ---------------
 samples:       4522
 iterations:    12627825
 iterations hr:    12.6M
 run time:      10.00066596
 per iteration: 1181.372488 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_4
  iterations=12627825
  operations: enqueues=12627825 dequeues=12627825 waits=0
  enqueue_latency: p50=641ns p95=2.69us p99=6.22us max=3.01ms
  dequeue_latency: p50=401ns p95=2.3us p99=5.81us max=3.16ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=22.2s system=1.53s total=23.8s
  wall_time=7.76s cpu_util=3.063439111
----------- TFSyncQueue_MetaEnqDeq_8 ---------------
 samples:       3447
 iterations:    7336365
 iterations hr:    7.34M
 run time:      10.00316518
 per iteration: 1629.289202 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_8
  iterations=7336365
  operations: enqueues=7336365 dequeues=7336365 waits=0
  enqueue_latency: p50=701ns p95=3.97us p99=8.26us max=3.2ms
  dequeue_latency: p50=451ns p95=3.5us p99=7.13us max=3.2ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=18.6s system=2.98s total=21.5s
  wall_time=6.28s cpu_util=3.429257547
----------- TFSyncQueue_MetaEnqDeq_16 ---------------
 samples:       2437
 iterations:    3667986
 iterations hr:    3.67M
 run time:      10.0031135
 per iteration: 1991.438892 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_16
  iterations=3667986
  operations: enqueues=3667986 dequeues=3667986 waits=0
  enqueue_latency: p50=761ns p95=5.64us p99=27.2us max=3.39ms
  dequeue_latency: p50=330ns p95=4.14us p99=10.2us max=3.36ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=15.2s system=3.82s total=19.1s
  wall_time=4.84s cpu_util=3.940250419
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_1 ---------------
 samples:       6106
 iterations:    23021505
 iterations hr:    23M
 run time:      10.00295185
 per iteration: 893.2944821 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_1
  iterations=23021505
  operations: enqueues=22665133 dequeues=22665133 waits=356372
  enqueue_latency: p50=110ns p95=150ns p99=230ns max=81us
  dequeue_latency: p50=150ns p95=200ns p99=280ns max=48us
  wait_latency: p50=12.2us p95=16us p99=20.4us max=63.3us
  cpu_time: user=8.63s system=502ms total=9.13s
  wall_time=8.98s cpu_util=1.017282732
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_2 ---------------
 samples:       2862
 iterations:    5057790
 iterations hr:    5.06M
 run time:      10.00497385
 per iteration: 3460.772484 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_2
  iterations=5057790
  operations: enqueues=4981878 dequeues=4981878 waits=75912
  enqueue_latency: p50=1.11us p95=5.19us p99=6.54us max=584us
  dequeue_latency: p50=1us p95=3.88us p99=5.51us max=50.2us
  wait_latency: p50=76.9us p95=166us p99=200us max=301us
  cpu_time: user=17.3s system=561ms total=17.8s
  wall_time=8.96s cpu_util=1.992113239
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_4 ---------------
 samples:       2750
 iterations:    4671096
 iterations hr:    4.67M
 run time:      10.00231571
 per iteration: 3841.559836 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_4
  iterations=4671096
  operations: enqueues=4604106 dequeues=4604106 waits=66990
  enqueue_latency: p50=1.44us p95=9.34us p99=19.4us max=4.85ms
  dequeue_latency: p50=1.12us p95=7.23us p99=15.6us max=1.75ms
  wait_latency: p50=140us p95=336us p99=865us max=3.23ms
  cpu_time: user=23.7s system=1.14s total=24.9s
  wall_time=7.88s cpu_util=3.155030822
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_8 ---------------
 samples:       2319
 iterations:    3321753
 iterations hr:    3.32M
 run time:      10.00092278
 per iteration: 4337.47732 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_8
  iterations=3321753
  operations: enqueues=3279933 dequeues=3279933 waits=41820
  enqueue_latency: p50=1.66us p95=10.3us p99=29us max=5.3ms
  dequeue_latency: p50=1.14us p95=6.98us p99=14.8us max=4.42ms
  wait_latency: p50=139us p95=357us p99=1.08ms max=5.07ms
  cpu_time: user=19.7s system=2.04s total=21.7s
  wall_time=6.69s cpu_util=3.249623157
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_16 ---------------
 samples:       1805
 iterations:    2013021
 iterations hr:    2.01M
 run time:      10.00559524
 per iteration: 5526.0071 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_16
  iterations=2013021
  operations: enqueues=1997173 dequeues=1997173 waits=15848
  enqueue_latency: p50=2.3us p95=16.2us p99=656us max=5.22ms
  dequeue_latency: p50=1.24us p95=8.93us p99=20.9us max=5.1ms
  wait_latency: p50=198us p95=712us p99=1.67ms max=5.15ms
  cpu_time: user=18.2s system=3.2s total=21.4s
  wall_time=5.41s cpu_util=3.954743386
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_1 ---------------
 samples:       7273
 iterations:    32663403
 iterations hr:    32.7M
 run time:      10.00128762
 per iteration: 629.575127 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_1
  iterations=32663403
  operations: enqueues=32157009 dequeues=32157009 waits=506394
  enqueue_latency: p50=60ns p95=80ns p99=120ns max=53.8us
  dequeue_latency: p50=80ns p95=110ns p99=150ns max=95.9us
  wait_latency: p50=8.21us p95=9.89us p99=14.1us max=108us
  cpu_time: user=8.43s system=644ms total=9.07s
  wall_time=8.87s cpu_util=1.022871394
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_2 ---------------
 samples:       4526
 iterations:    12647935
 iterations hr:    12.6M
 run time:      10.00191262
 per iteration: 1420.891696 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_2
  iterations=12647935
  operations: enqueues=12455236 dequeues=12455236 waits=192699
  enqueue_latency: p50=601ns p95=771ns p99=1.44us max=537us
  dequeue_latency: p50=441ns p95=831ns p99=2.11us max=587us
  wait_latency: p50=33.2us p95=77.6us p99=105us max=620us
  cpu_time: user=16s system=946ms total=16.9s
  wall_time=8.5s cpu_util=1.992899348
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_4 ---------------
 samples:       3926
 iterations:    9520066
 iterations hr:    9.52M
 run time:      10.00086564
 per iteration: 1674.259813 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_4
  iterations=9520066
  operations: enqueues=9379884 dequeues=9379884 waits=140182
  enqueue_latency: p50=691ns p95=2.71us p99=7.19us max=3.2ms
  dequeue_latency: p50=561ns p95=2.27us p99=6.21us max=3.14ms
  wait_latency: p50=61.2us p95=120us p99=182us max=3.17ms
  cpu_time: user=18.9s system=1.47s total=20.4s
  wall_time=7.34s cpu_util=2.77916076
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_8 ---------------
 samples:       2907
 iterations:    5218065
 iterations hr:    5.22M
 run time:      10.00364824
 per iteration: 2328.208484 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_8
  iterations=5218065
  operations: enqueues=5148825 dequeues=5148825 waits=69240
  enqueue_latency: p50=841ns p95=5.48us p99=14us max=3.36ms
  dequeue_latency: p50=561ns p95=4.05us p99=8.49us max=3.2ms
  wait_latency: p50=68.9us p95=212us p99=814us max=3.3ms
  cpu_time: user=16.6s system=2.42s total=19.1s
  wall_time=6.11s cpu_util=3.12145739
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_16 ---------------
 samples:       2090
 iterations:    2699326
 iterations hr:    2.7M
 run time:      10.00282304
 per iteration: 3605.76751 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_16
  iterations=2699326
  operations: enqueues=2673870 dequeues=2673870 waits=25456
  enqueue_latency: p50=1.09us p95=8.8us p99=106us max=6.29ms
  dequeue_latency: p50=591ns p95=5.03us p99=10.9us max=3.3ms
  wait_latency: p50=90.6us p95=304us p99=1.7ms max=3.33ms
  cpu_time: user=14.5s system=3.46s total=17.9s
  wall_time=4.92s cpu_util=3.650492788
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_1 ---------------
 samples:       3727
 iterations:    8580153
 iterations hr:    8.58M
 run time:      10.00236722
 per iteration: 2495.779105 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_1
  iterations=8580153
  operations: enqueues=8448121 dequeues=8448121 waits=132032
  enqueue_latency: p50=441ns p95=721ns p99=891ns max=45.3us
  dequeue_latency: p50=461ns p95=781ns p99=871ns max=57.4us
  wait_latency: p50=32.5us p95=39.6us p99=50.8us max=94.1us
  cpu_time: user=8.96s system=348ms total=9.31s
  wall_time=9.23s cpu_util=1.009219273
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_2 ---------------
 samples:       1815
 iterations:    2035153
 iterations hr:    2.04M
 run time:      10.00803106
 per iteration: 8383.867311 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_2
  iterations=2035153
  operations: enqueues=2005318 dequeues=2005318 waits=29835
  enqueue_latency: p50=1.85us p95=10.7us p99=26.1us max=780us
  dequeue_latency: p50=1.42us p95=4.89us p99=9.83us max=751us
  wait_latency: p50=203us p95=736us p99=849us max=1.11ms
  cpu_time: user=11.1s system=564ms total=11.7s
  wall_time=9.17s cpu_util=1.276976683
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_4 ---------------
 samples:       1669
 iterations:    1721440
 iterations hr:    1.72M
 run time:      10.00550067
 per iteration: 11521.09368 (11.5K) cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_4
  iterations=1721440
  operations: enqueues=1698102 dequeues=1698102 waits=23338
  enqueue_latency: p50=3.63us p95=15.7us p99=36.9us max=11.4ms
  dequeue_latency: p50=2.34us p95=10.6us p99=20.6us max=1.73ms
  wait_latency: p50=398us p95=1.3ms p99=1.59ms max=2.41ms
  cpu_time: user=15.9s system=854ms total=16.7s
  wall_time=8.65s cpu_util=1.936064396
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_8 ---------------
 samples:       1391
 iterations:    1195831
 iterations hr:    1.2M
 run time:      10.00961132
 per iteration: 16247.40247 (16.2K) cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_8
  iterations=1195831
  operations: enqueues=1183195 dequeues=1183195 waits=12636
  enqueue_latency: p50=5.31us p95=28.2us p99=638us max=10.9ms
  dequeue_latency: p50=3.37us p95=17.2us p99=34.1us max=4.78ms
  wait_latency: p50=1.03ms p95=3.12ms p99=3.83ms max=4.99ms
  cpu_time: user=17.8s system=1.48s total=19.3s
  wall_time=7.87s cpu_util=2.455559953
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_16 ---------------
 samples:       1149
 iterations:    816003
 iterations hr:    816K
 run time:      10.00841059
 per iteration: 22918.08784 (22.9K) cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_16
  iterations=816003
  operations: enqueues=811819 dequeues=811819 waits=4184
  enqueue_latency: p50=7.15us p95=41.1us p99=1.63ms max=18.3ms
  dequeue_latency: p50=4.09us p95=21.1us p99=45.2us max=16.5ms
  wait_latency: p50=3.17ms p95=9.21ms p99=12ms max=17.1ms
  cpu_time: user=17.2s system=2.16s total=19.4s
  wall_time=7.06s cpu_util=2.744524798
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_1 ---------------
 samples:       5397
 iterations:    17985003
 iterations hr:    18M
 run time:      10.00192161
 per iteration: 1180.72016 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_1
  iterations=17985003
  operations: enqueues=17706933 dequeues=17706933 waits=278070
  enqueue_latency: p50=170ns p95=280ns p99=330ns max=42.1us
  dequeue_latency: p50=190ns p95=300ns p99=351ns max=52.6us
  wait_latency: p50=15.4us p95=18.2us p99=23.6us max=75.4us
  cpu_time: user=8.75s system=475ms total=9.23s
  wall_time=9.11s cpu_util=1.013541501
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_2 ---------------
 samples:       3177
 iterations:    6235746
 iterations hr:    6.24M
 run time:      10.00258177
 per iteration: 2906.12281 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_2
  iterations=6235746
  operations: enqueues=6141759 dequeues=6141759 waits=93987
  enqueue_latency: p50=1.29us p95=1.88us p99=4.28us max=754us
  dequeue_latency: p50=991ns p95=1.59us p99=2.85us max=743us
  wait_latency: p50=86.5us p95=112us p99=633us max=837us
  cpu_time: user=14.6s system=947ms total=15.6s
  wall_time=8.81s cpu_util=1.768586711
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_4 ---------------
 samples:       2311
 iterations:    3298596
 iterations hr:    3.3M
 run time:      10.0016484
 per iteration: 6096.037591 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_4
  iterations=3298596
  operations: enqueues=3252096 dequeues=3252096 waits=46500
  enqueue_latency: p50=1.84us p95=9.29us p99=24.1us max=5.02ms
  dequeue_latency: p50=1.51us p95=6.02us p99=16us max=1.57ms
  wait_latency: p50=253us p95=665us p99=801us max=1.7ms
  cpu_time: user=17.3s system=1.39s total=18.7s
  wall_time=8.27s cpu_util=2.262784858
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_8 ---------------
 samples:       1875
 iterations:    2172570
 iterations hr:    2.17M
 run time:      10.00599266
 per iteration: 7957.621051 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_8
  iterations=2172570
  operations: enqueues=2146698 dequeues=2146698 waits=25872
  enqueue_latency: p50=1.87us p95=14.6us p99=62.2us max=7.45ms
  dequeue_latency: p50=1.22us p95=8.25us p99=21.3us max=1.73ms
  wait_latency: p50=488us p95=1.57ms p99=2.05ms max=3.03ms
  cpu_time: user=15.1s system=1.81s total=16.9s
  wall_time=7.26s cpu_util=2.330900668
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_16 ---------------
 samples:       1529
 iterations:    1444150
 iterations hr:    1.44M
 run time:      10.00566744
 per iteration: 10927.72093 (10.9K) cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_16
  iterations=1444150
  operations: enqueues=1433214 dequeues=1433214 waits=10936
  enqueue_latency: p50=2.48us p95=23.2us p99=725us max=8ms
  dequeue_latency: p50=1.5us p95=11.8us p99=27.6us max=7.03ms
  wait_latency: p50=1.36ms p95=4.15ms p99=4.99ms max=7.53ms
  cpu_time: user=15.3s system=2.79s total=18.1s
  wall_time=6.08s cpu_util=2.969653773
```