### PR TITLE
issue-5643: MemFileSystemShard and tablet Adapter mode ut - fixed uninit mem

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/mem/memshard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/mem/memshard.cpp
@@ -425,7 +425,14 @@ public:
         const ui64 end = request.GetOffset()
             + request.GetBuffer().size() - request.GetBufferOffset();
         if (f.Data.size() < end) {
+            const ui64 prevEnd = f.Data.size();
             f.Data.Resize(end);
+            if (request.GetOffset() > prevEnd) {
+                memset(
+                    f.Data.data() + prevEnd,
+                    0,
+                    request.GetOffset() - prevEnd);
+            }
         }
 
         if (a.GetSize() < end) {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
@@ -177,7 +177,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
         }
 
         TString expected;
-        expected.ReserveAndResize(6_KB);
+        expected.resize(6_KB, 0);
 
         {
             auto response = tablet.SendAndRecvWriteData(


### PR DESCRIPTION
### Notes
Fixing uninitialized memory in `MemFileSystemShard` and tablet Adapter mode unit tests that was left in the unwritten file regions and that caused msan complaints

### Issue
https://github.com/ydb-platform/nbs/issues/5643
