### PR TITLE
[Filestore] Forbid modification of TFileRingBuffer when IsCorrupted flag is set

### DIFF
--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -383,6 +383,7 @@ private:
 
         if (front.IsInvalid() || front.ActualPos != Header()->ReadPos) {
             SetCorrupted();
+            return;
         }
 
         while (cur.HasValue()) {
@@ -392,15 +393,6 @@ private:
 
         if (cur.IsInvalid() || cur.ActualPos != Header()->WritePos) {
             SetCorrupted();
-        }
-
-        if (front.HasValue()) {
-            Y_ABORT_UNLESS(back.HasValue());
-            Header()->ReadPos = front.ActualPos;
-            Header()->WritePos = back.GetNextEntryPos();
-        } else {
-            Header()->ReadPos = 0;
-            Header()->WritePos = 0;
         }
     }
 
@@ -553,7 +545,9 @@ public:
                 }
             });
 
-        EraseFreeEntriesFromFront();
+        if (!IsCorrupted()) {
+            EraseFreeEntriesFromFront();
+        }
     }
 
     bool PushBack(TStringBuf data)
@@ -672,6 +666,10 @@ public:
 
     bool Free(const void* ptr)
     {
+        if (IsCorrupted()) {
+            return false;
+        }
+
         auto it = EntryMap.find(ptr);
         if (it == EntryMap.end()) {
             return false;

--- a/cloud/storage/core/libs/common/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer.cpp
@@ -377,17 +377,14 @@ private:
 
     void ValidateDataStructure()
     {
-        TEntryInfo front = GetFrontEntry();
-        TEntryInfo back = front;
-        TEntryInfo cur = front;
+        TEntryInfo cur = GetFrontEntry();
 
-        if (front.IsInvalid() || front.ActualPos != Header()->ReadPos) {
+        if (cur.IsInvalid() || cur.ActualPos != Header()->ReadPos) {
             SetCorrupted();
             return;
         }
 
         while (cur.HasValue()) {
-            back = cur;
             cur = GetNextEntry(cur);
         }
 

--- a/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/common/file_ring_buffer_ut.cpp
@@ -588,28 +588,21 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb.PushBack("12345678"));
     }
 
-    Y_UNIT_TEST(VisitAndPopBackShouldProduceSameResults)
+    Y_UNIT_TEST(ForbidModificationOfCorruptedBuffer)
     {
-        for (int i = 0; i <= 32; i++) {
-            TStateWithCorruptedEntryLength s(i);
-            TFileRingBuffer rb(s.FileHandle.GetName(), s.Len);
+        TStateWithCorruptedEntryLength s(13);
+        TFileRingBuffer rb(s.FileHandle.GetName(), s.Len);
+        auto state = Dump(rb);
 
-            TVector<TString> afterVisit;
-            rb.Visit([&] (ui32 checksum, TStringBuf entry)
-            {
-                Y_UNUSED(checksum);
-                afterVisit.push_back(TString(entry));
-            });
+        const char* ptr = rb.Front().data();
+        UNIT_ASSERT(!rb.Free(ptr));
+        UNIT_ASSERT_VALUES_EQUAL(state, Dump(rb));
 
-            TVector<TString> afterPopBack;
-            while (!rb.Empty())
-            {
-                afterPopBack.push_back(TString(rb.Front()));
-                rb.PopFront();
-            }
+        rb.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(state, Dump(rb));
 
-            UNIT_ASSERT_EQUAL(Dump(afterVisit), Dump(afterPopBack));
-        }
+        UNIT_ASSERT(!rb.PushBack("1"));
+        UNIT_ASSERT_VALUES_EQUAL(state, Dump(rb));
     }
 
     Y_UNIT_TEST(ShouldGetRawCapacity)


### PR DESCRIPTION
### Notes
Corruption in `TFileRingBuffer` is no more a recoverable state. Previously, restoration of read and write position happened and alloc/free was allowed. Now the strategy is changed from 'try to restore whatever is possible' to the strategy 'halt and wait for a manual resolution'.
