### PR TITLE
issue-5953: [Filestore] track GuestKeepCache hit rate via CreateHandle.GuestKeepCacheSet metric

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -437,11 +437,16 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         {
             // We set the GuestKeepCache to tell the client not to bother
             // invalidating the caches upon opening a read-only handle
-            args.Response.SetGuestKeepCache(
+            const bool keepCache =
                 session->HandleStatsByNode.IsAllowedToKeepCache(
                     *node,
                     // isFirstReadAllowed
-                    Config->GetGuestCachingType() == NProto::GCT_ANY_READ));
+                    Config->GetGuestCachingType() == NProto::GCT_ANY_READ);
+            args.Response.SetGuestKeepCache(keepCache);
+
+            Metrics.CreateHandleExtra.GuestKeepCacheSet.fetch_add(
+                keepCache,
+                std::memory_order_relaxed);
         }
 
         // We can remember the last time that the cache was invalidated by a

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -381,6 +381,11 @@ void TTabletMetrics::Register(
         EMetricType::MT_DERIVATIVE);
 
     REGISTER_AGGREGATABLE_SUM_EXT(
+        CreateHandleExtra.GuestKeepCacheSet,
+        "CreateHandle.GuestKeepCacheSet",
+        EMetricType::MT_DERIVATIVE);
+
+    REGISTER_AGGREGATABLE_SUM_EXT(
         CompactionExtra.DudCount,
         "Compaction.DudCount",
         EMetricType::MT_DERIVATIVE);

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -276,6 +276,11 @@ struct TTabletMetrics
         std::atomic<i64> ResponseNodeRefs{0};
     } ListNodesExtra;
 
+    struct TExtraCreateHandleMetrics
+    {
+        std::atomic<i64> GuestKeepCacheSet{0};
+    } CreateHandleExtra;
+
     struct TExtraConfirmAddDataMetrics
     {
         std::atomic<i64> DeferredCount{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
@@ -58,6 +58,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
         tablet.DestroyHandle(writeHandle);
         UNIT_ASSERT(tablet.CreateHandle(id, TCreateHandleArgs::RDNLY)
                         ->Record.GetGuestKeepCache());
+
+        tablet.SendRequest(tablet.CreateUpdateCounters());
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+        TTestRegistryVisitor visitor;
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {{{"filesystem", "test"},
+              {"sensor", "CreateHandle.GuestKeepCacheSet"}},
+             2},
+        });
     }
 
     Y_UNIT_TEST(ShouldSetGuestKeepCacheBasedOnMtime)
@@ -113,7 +123,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
         tablet.InitSession("client", "session");
 
-#define CHECK_HANDLE_STATS(maxSize, sumSize, maxTotalSize, sumTotalSize)       \
+#define CHECK_HANDLE_STATS(maxSize, sumSize, maxTotalSize, sumTotalSize,       \
+                           keepCacheSet)                                       \
     {                                                                          \
         tablet.SendRequest(tablet.CreateUpdateCounters());                     \
         env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));            \
@@ -132,6 +143,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
             {{{"filesystem", "test"},                                          \
               {"sensor", "HandleStatsByNodeSumTotalSize"}},                    \
              sumTotalSize},                                                    \
+            {{{"filesystem", "test"},                                          \
+              {"sensor", "CreateHandle.GuestKeepCacheSet"}},                   \
+             keepCacheSet},                                                    \
         });                                                                    \
     }
 
@@ -144,10 +158,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
             tablet.CreateHandle(id, TCreateHandleArgs::RDNLY);
         UNIT_ASSERT(!createHandleResponse->Record.GetGuestKeepCache());
         // Stats={test}, Offloaded={}
-        CHECK_HANDLE_STATS(1, 1, 1, 1);
+        CHECK_HANDLE_STATS(1, 1, 1, 1, 0);
         tablet.DestroyHandle(createHandleResponse->Record.GetHandle());
         // Stats={}, Offloaded={test}
-        CHECK_HANDLE_STATS(0, 0, 1, 1);
+        CHECK_HANDLE_STATS(0, 0, 1, 1, 0);
 
         // Create handle again, should have GuestKeepCache set
         createHandleResponse =
@@ -166,7 +180,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
             tablet.DestroyHandle(createHandleResponse->Record.GetHandle());
         }
         // Stats={}, Offloaded={test0, test1} ("test" was evicted by LRU)
-        CHECK_HANDLE_STATS(0, 0, 2, 2);
+        CHECK_HANDLE_STATS(0, 0, 2, 2, 1);
 
         // Create handle for the first file again, will not have the
         // GuestKeepCache set because this node was evicted from the cache
@@ -174,7 +188,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
             tablet.CreateHandle(id, TCreateHandleArgs::RDNLY);
         UNIT_ASSERT(!createHandleResponse->Record.GetGuestKeepCache());
         // Stats={test}, Offloaded={test0, test1}
-        CHECK_HANDLE_STATS(1, 1, 3, 3);
+        CHECK_HANDLE_STATS(1, 1, 3, 3, 1);
 
         tablet.DestroyHandle(createHandleResponse->Record.GetHandle());
 


### PR DESCRIPTION
### Notes
Second step mentioned in the issue: _"Sensors about the fraction of CreateHandle responses with this cache populated"_

### Issue
#5953 