### PR TITLE
issue-5811: [Filestore] Fix race between almost simultaneous CreateHandle/UnlinkNode requests

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -8119,7 +8119,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             listNodesResponse.GetNodes(0).GetId());
     }
 
-    SERVICE_TEST(ShouldReproRaceWhileCreatingHandle)
+    SERVICE_TEST(ShouldLockNodeRefWhileCreatingHandle)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
@@ -8168,9 +8168,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT(createNodeInShard);
 
         // At this point a NodeRef is created in the main filesystem but a node
-        // is not created in the shard.
-        // The next CreateHandleRequest actually creates a node in the shards
-        // that corresponds to the already created NodeRef.
+        // is not created in the shard. The NodeRef in the main filesystem is
+        // locked.
 
         intercept = false;
         service.SendCreateHandleRequest(
@@ -8182,37 +8181,23 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             "",
             ++requestId);
 
-        auto createHandleResponse = service.RecvCreateHandleResponse();
+        // An attempt to create a handle or to unlink the node should fail as
+        // the NodeRef is locked.
+        const auto createHandleResponse = service.RecvCreateHandleResponse();
         UNIT_ASSERT_VALUES_EQUAL_C(
-            S_OK,
+            E_REJECTED,
             createHandleResponse->GetError().GetCode(),
             createHandleResponse->GetError().GetMessage());
 
-        const auto nodeId = createHandleResponse->Record.GetNodeAttr().GetId();
+        service.SendUnlinkNodeRequest(headers, RootNodeId, "file1");
+        const auto unlinkNodeResponse = service.RecvUnlinkNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            unlinkNodeResponse->GetError().GetCode(),
+            unlinkNodeResponse->GetError().GetMessage());
 
-        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId));
-
-        bool createNodeResponseCaught = false;
-        env.GetRuntime().SetEventFilter(
-            [&](auto& runtime, TAutoPtr<IEventHandle>& e)
-            {
-                Y_UNUSED(runtime);
-                if (!createNodeResponseCaught &&
-                    e->GetTypeRewrite() == TEvService::EvCreateNodeResponse)
-                {
-                    const auto* msg =
-                        e->Get<TEvService::TEvCreateNodeResponse>();
-                    UNIT_ASSERT_VALUES_EQUAL_C(
-                        E_FS_EXIST,
-                        msg->GetStatus(),
-                        msg->GetErrorReason());
-                }
-                return false;
-            });
-
-        // Send stolen createNodeInShard event and get E_FS_EXIST from the
-        // shard. After a planned fix the previous CreateHandle should get
-        // E_REJECTED.
+        // Sending stolen createNodeInShard event should create a node in the
+        // shard and unlock the NodeRef.
         env.GetRuntime().Send(createNodeInShard.Release(), nodeIdx);
 
         auto createHandleResponse1 = service.RecvCreateHandleResponse();
@@ -8221,9 +8206,23 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             createHandleResponse1->GetStatus(),
             createHandleResponse1->GetErrorReason());
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            nodeId,
-            createHandleResponse->Record.GetNodeAttr().GetId());
+        const auto nodeId1 =
+            createHandleResponse1->Record.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId1));
+
+        // As the NodeRef is unlocked now we should be able to create a handle
+        auto createHandleResponse2 = service.CreateHandle(
+            headers,
+            fsConfig.FsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::RDWR,
+            "",
+            ++requestId);
+
+        const auto nodeId2 =
+            createHandleResponse2->Record.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId2));
 
         TTestRegistryVisitor visitor;
         auto registry = env.GetRegistry();
@@ -8232,7 +8231,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         visitor.ValidateExpectedCounters(
             {{{{"sensor", "NodeExistsWhileCreatingInShardCount"},
                {"filesystem", "test"}},
-              1},
+              0},
              {{{"sensor", "NodeExistsWhileCreatingInShardCount"},
                {"filesystem", "test_s1"}},
               0},
@@ -8241,7 +8240,127 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
               0}});
     }
 
-    SERVICE_TEST(ShouldReplayOpLog)
+    SERVICE_TEST(ShouldLockNodeRefWhileCreatingNode)
+    {
+        config.SetMultiTabletForwardingEnabled(true);
+        config.SetStrictFileSystemSizeEnforcementEnabled(true);
+        config.SetShardBalancerPolicy(NProto::SBP_ROUND_ROBIN);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        THeaders headers = service.InitSession(fsConfig.FsId, "client");
+
+        TAutoPtr<IEventHandle> createNodeInShard;
+        TString name;
+        bool intercept = true;
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, TAutoPtr<IEventHandle>& e) {
+                Y_UNUSED(runtime);
+                if (e->GetTypeRewrite() == TEvService::EvCreateNodeRequest) {
+                    const auto* msg =
+                        e->Get<TEvService::TEvCreateNodeRequest>();
+                    if (intercept && msg->Record.GetFileSystemId()
+                            == fsConfig.Shard1Id)
+                    {
+                        name = msg->Record.GetName();
+                        createNodeInShard = e;
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::File(RootNodeId, "file1"));
+
+        ui32 iterations = 0;
+        while (!createNodeInShard && iterations++ < 100) {
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT(createNodeInShard);
+
+        // At this point a NodeRef is created in the main filesystem but a node
+        // is not created in the shard.
+
+        ui64 requestId = 111;
+        intercept = false;
+        service.SendCreateHandleRequest(
+            headers,
+            fsConfig.FsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::CREATE,
+            "",
+            ++requestId);
+
+        // An attempt to create a handle or to unlink the node should fail as
+        // the NodeRef is locked.
+        const auto createHandleResponse = service.RecvCreateHandleResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            createHandleResponse->GetError().GetCode(),
+            createHandleResponse->GetError().GetMessage());
+
+        service.SendUnlinkNodeRequest(headers, RootNodeId, "file1");
+        const auto unlinkNodeResponse = service.RecvUnlinkNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            unlinkNodeResponse->GetError().GetCode(),
+            unlinkNodeResponse->GetError().GetMessage());
+
+        // Sending stolen createNodeInShard event should create a node in the
+        // shard and unlock the NodeRef.
+        env.GetRuntime().Send(createNodeInShard.Release(), nodeIdx);
+
+        const auto createNodeResponse = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createNodeResponse->GetStatus(),
+            createNodeResponse->GetErrorReason());
+
+        const auto nodeId = createNodeResponse->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId));
+
+        // The NodeRef is unlocked now and we should be able to create a handle.
+        const auto createHandleResponse1 = service.CreateHandle(
+            headers,
+            fsConfig.FsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::RDWR,
+            "",
+            ++requestId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createHandleResponse1->GetStatus(),
+            createHandleResponse1->GetErrorReason());
+
+        const auto nodeId1 =
+            createHandleResponse1->Record.GetNodeAttr().GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId1));
+
+        TTestRegistryVisitor visitor;
+        auto registry = env.GetRegistry();
+        registry->Visit(TInstant::Zero(), visitor);
+
+        visitor.ValidateExpectedCounters(
+            {{{{"sensor", "NodeExistsWhileCreatingInShardCount"},
+               {"filesystem", "test"}},
+              0},
+             {{{"sensor", "NodeExistsWhileCreatingInShardCount"},
+               {"filesystem", "test_s1"}},
+              0},
+             {{{"sensor", "NodeExistsWhileCreatingInShardCount"},
+               {"filesystem", "test_s2"}},
+              0}});
+    }
+
+    SERVICE_TEST(ShouldReplayCreateNodeInShardFromOpLog)
     {
         config.SetMultiTabletForwardingEnabled(true);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
@@ -8289,33 +8408,35 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT(createNodeInShard);
 
         intercept = false;
-        service.SendCreateHandleRequest(
-            headers,
-            fsConfig.FsId,
-            RootNodeId,
-            "file1",
-            TCreateHandleArgs::CREATE,
-            "",
-            ++requestId);
-
-        auto createHandleResponse = service.RecvCreateHandleResponse();
-        UNIT_ASSERT_VALUES_EQUAL_C(
-            S_OK,
-            createHandleResponse->GetError().GetCode(),
-            createHandleResponse->GetError().GetMessage());
-
-        const auto nodeId = createHandleResponse->Record.GetNodeAttr().GetId();
-
-        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId));
-
-        // OpLog should be replayed upon RebootTablet.
-        // As we already created 'file1', we should get E_FS_EXIST during
-        // replay.
         TIndexTabletClient tablet(
             env.GetRuntime(),
             nodeIdx,
             fsInfo.MainTabletId);
         tablet.RebootTablet();
+
+        const auto createHandleResponse = service.RecvCreateHandleResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            createHandleResponse->GetError().GetCode(),
+            createHandleResponse->GetError().GetMessage());
+
+        headers = service.InitSession(fsConfig.FsId, "client");
+
+        // After the tablet is restated "file1" creation is completed and
+        // CreateHandle should be seccessful.
+        const auto createHandleResponse1 = service.CreateHandle(
+            headers,
+            fsConfig.FsId,
+            RootNodeId,
+            "file1",
+            TCreateHandleArgs::RDWR,
+            "",
+            ++requestId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            createHandleResponse1->GetError().GetCode(),
+            createHandleResponse1->GetError().GetMessage());
 
         TTestRegistryVisitor visitor;
         auto registry = env.GetRegistry();
@@ -8333,7 +8454,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
               0},
              {{{"sensor", "NodeExistsWhileCreatingInShardCount"},
                {"filesystem", "test"}},
-              1},
+              0},
              {{{"sensor", "NodeExistsWhileCreatingInShardCount"},
                {"filesystem", "test_s1"}},
               0},

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -8422,8 +8422,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         headers = service.InitSession(fsConfig.FsId, "client");
 
-        // After the tablet is restated "file1" creation is completed and
-        // CreateHandle should be seccessful.
+        // After the tablet is restarted "file1" creation is completed and
+        // CreateHandle should be successful.
         const auto createHandleResponse1 = service.CreateHandle(
             headers,
             fsConfig.FsId,

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -665,6 +665,8 @@ struct TEvIndexTabletPrivate
         NProto::TProfileLogRequestInfo ProfileLogRequest;
         const bool NodeAlreadyExists;
         const ui32 CreateNodeRetryCount;
+        const ui64 OriginalNodeId;
+        const TString OriginalName;
 
         TNodeCreatedInShard(
                 TRequestInfoPtr requestInfo,
@@ -675,7 +677,9 @@ struct TEvIndexTabletPrivate
                 TCreateNodeInShardResult result,
                 NProto::TProfileLogRequestInfo profileLogRequest,
                 bool nodeAlreadyExists,
-                ui32 createNodeRetryCount)
+                ui32 createNodeRetryCount,
+                ui64 originalNodeId,
+                TString originalName)
             : RequestInfo(std::move(requestInfo))
             , SessionId(std::move(sessionId))
             , RequestId(requestId)
@@ -685,6 +689,8 @@ struct TEvIndexTabletPrivate
             , ProfileLogRequest(std::move(profileLogRequest))
             , NodeAlreadyExists(nodeAlreadyExists)
             , CreateNodeRetryCount(createNodeRetryCount)
+            , OriginalNodeId(originalNodeId)
+            , OriginalName(std::move(originalName))
         {
         }
     };

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -9,6 +9,7 @@
 #include <cloud/filestore/libs/storage/model/public.h>
 #include <cloud/filestore/libs/storage/tablet/model/blob.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
+#include <cloud/filestore/libs/storage/tablet/model/node_ref.h>
 #include <cloud/filestore/libs/storage/tablet/model/shard_balancer.h>
 #include <cloud/filestore/libs/storage/tablet/protos/tablet.pb.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
@@ -665,8 +666,7 @@ struct TEvIndexTabletPrivate
         NProto::TProfileLogRequestInfo ProfileLogRequest;
         const bool NodeAlreadyExists;
         const ui32 CreateNodeRetryCount;
-        const ui64 OriginalNodeId;
-        const TString OriginalName;
+        const TNodeRefKey OriginalNodeRefKey;
 
         TNodeCreatedInShard(
                 TRequestInfoPtr requestInfo,
@@ -678,8 +678,7 @@ struct TEvIndexTabletPrivate
                 NProto::TProfileLogRequestInfo profileLogRequest,
                 bool nodeAlreadyExists,
                 ui32 createNodeRetryCount,
-                ui64 originalNodeId,
-                TString originalName)
+                TNodeRefKey originalNodeRefKey)
             : RequestInfo(std::move(requestInfo))
             , SessionId(std::move(sessionId))
             , RequestId(requestId)
@@ -689,8 +688,7 @@ struct TEvIndexTabletPrivate
             , ProfileLogRequest(std::move(profileLogRequest))
             , NodeAlreadyExists(nodeAlreadyExists)
             , CreateNodeRetryCount(createNodeRetryCount)
-            , OriginalNodeId(originalNodeId)
-            , OriginalName(std::move(originalName))
+            , OriginalNodeRefKey(std::move(originalNodeRefKey))
         {
         }
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -453,6 +453,17 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
     } else {
         args.Response.SetShardFileSystemId(args.ShardId);
         args.Response.SetShardNodeName(args.ShardNodeName);
+
+        // When the NodeRef references a node in a shard we need to lock it to
+        // prevent the node from being unlinked and to avoid races with other
+        // concurrent CreateHandle/CreateNode requests.
+        args.IsNodeRefLocked = TryLockNodeRef({args.NodeId, args.Name});
+        if (!args.IsNodeRefLocked) {
+            args.Error = MakeError(E_REJECTED, TStringBuilder()
+                << "node ref " << args.NodeId << " " << args.Name
+                << " is locked for CreateNode");
+            return;
+        }
     }
 
     if (args.IsNewShardNode) {
@@ -468,6 +479,8 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         shardRequest->SetNodeId(RootNodeId);
         shardRequest->SetName(args.ShardNodeName);
         shardRequest->ClearShardFileSystemId();
+        shardRequest->SetOriginalNodeId(args.NodeId);
+        shardRequest->SetOriginalName(args.Name);
         const bool serialized = args.ProfileLogRequest.SerializeToString(
             args.OpLogEntry.MutableProfileLogRequest());
         if (!serialized) {
@@ -527,6 +540,13 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
     }
 
     RemoveInFlightRequest(*args.RequestInfo);
+
+    // If the node is to be created in the shard the NodeRef will be unlocked in
+    // TIndexTabletActor::HandleNodeCreatedInShard, otherwise it should be
+    // unlocked here.
+    if (args.IsNodeRefLocked) {
+        UnlockNodeRef({args.NodeId, args.Name});
+    }
 
     auto response =
         std::make_unique<TEvService::TEvCreateHandleResponse>(args.Error);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -461,7 +461,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         if (!args.IsNodeRefLocked) {
             args.Error = MakeError(E_REJECTED, TStringBuilder()
                 << "node ref " << args.NodeId << " " << args.Name
-                << " is locked for CreateNode");
+                << " is locked for CreateHandle");
             return;
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -411,7 +411,9 @@ void TCreateNodeInShardActor::ReplyAndDie(
         std::move(Result),
         std::move(ProfileLogRequest),
         NodeAlreadyExists,
-        CreateNodeRetryCount));
+        CreateNodeRetryCount,
+        Request.GetOriginalNodeId(),
+        Request.GetOriginalName()));
 
     Die(ctx);
 }
@@ -756,6 +758,16 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
                 InvalidCommitId
             };
         } else {
+            // When the NodeRef references a node in a shard we need to lock it
+            // to prevent the node from being unlinked and to avoid races with
+            // other concurrent CreateHandle/CreateNode requests.
+            if (!TryLockNodeRef({args.ParentNodeId, args.Name})) {
+                args.Error = MakeError(E_REJECTED, TStringBuilder()
+                        << "node ref " << args.ParentNodeId << " " << args.Name
+                        << " is locked for CreateHandle");
+                return;
+            }
+
             // OpLogEntryId doesn't have to be a CommitId - it's just convenient to
             // use CommitId here in order not to generate some other unique ui64
             args.OpLogEntry.SetEntryId(args.CommitId);
@@ -767,6 +779,8 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             shardRequest->SetNodeId(RootNodeId);
             shardRequest->SetName(args.ShardNodeName);
             shardRequest->ClearShardFileSystemId();
+            shardRequest->SetOriginalNodeId(args.ParentNodeId);
+            shardRequest->SetOriginalName(args.Name);
             const bool serialized = args.ProfileLogRequest.SerializeToString(
                 args.OpLogEntry.MutableProfileLogRequest());
             if (!serialized) {
@@ -954,6 +968,8 @@ void TIndexTabletActor::HandleNodeCreatedInShard(
     WorkerActors.erase(ev->Sender);
 
     EndNodeCreateInShard(msg->NodeName);
+
+    UnlockNodeRef({msg->OriginalNodeId, msg->OriginalName});
 
     Metrics.NodeExistsWhileCreatingInShardCount.fetch_add(
         msg->NodeAlreadyExists,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -412,8 +412,7 @@ void TCreateNodeInShardActor::ReplyAndDie(
         std::move(ProfileLogRequest),
         NodeAlreadyExists,
         CreateNodeRetryCount,
-        Request.GetOriginalNodeId(),
-        Request.GetOriginalName()));
+        TNodeRefKey{Request.GetOriginalNodeId(), Request.GetOriginalName()}));
 
     Die(ctx);
 }
@@ -764,7 +763,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             if (!TryLockNodeRef({args.ParentNodeId, args.Name})) {
                 args.Error = MakeError(E_REJECTED, TStringBuilder()
                         << "node ref " << args.ParentNodeId << " " << args.Name
-                        << " is locked for CreateHandle");
+                        << " is locked for CreateNode");
                 return;
             }
 
@@ -969,7 +968,7 @@ void TIndexTabletActor::HandleNodeCreatedInShard(
 
     EndNodeCreateInShard(msg->NodeName);
 
-    UnlockNodeRef({msg->OriginalNodeId, msg->OriginalName});
+    UnlockNodeRef(msg->OriginalNodeRefKey);
 
     Metrics.NodeExistsWhileCreatingInShardCount.fetch_add(
         msg->NodeAlreadyExists,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -37,6 +37,15 @@ void TIndexTabletActor::ReplayOpLog(
         }
 
         if (op.HasCreateNodeRequest()) {
+            const auto& request = op.GetCreateNodeRequest();
+            if (!TryLockNodeRef(
+                    {request.GetOriginalNodeId(), request.GetOriginalName()}))
+            {
+                ReportFailedToLockNodeRef(
+                    TStringBuilder() << "CreateNodeInShardRequset: "
+                                     << request.ShortUtf8DebugString().Quote());
+            }
+
             Metrics.ReplayedCreateNodeInShardRequestsCount.fetch_add(
                 1,
                 std::memory_order_relaxed);

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1878,6 +1878,7 @@ struct TTxIndexTablet
         TString ShardId;
         TString ShardNodeName;
         bool IsNewShardNode = false;
+        bool IsNodeRefLocked = false;
         TMaybe<IIndexTabletDatabase::TNode> TargetNode;
         TMaybe<IIndexTabletDatabase::TNode> ParentNode;
         TVector<ui64> UpdatedNodes;

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -188,6 +188,14 @@ message TCreateNodeRequest
 
     // Umask of the calling process
     uint32 Umask = 16;
+
+    // If a node is created by TCreateNodeInShardActor, the following fields
+    // contain the Name and NodeId from the original request that identify
+    // NodeRef in the IndexTabletActor managing the directory.
+
+    uint64 OriginalNodeId = 17;
+
+    bytes OriginalName = 18;
 }
 
 message TCreateNodeResponse


### PR DESCRIPTION
### Notes
If a CreateHandle request creates a node in a shard the NodeRef in the fs that owns the directory 
is locked till the node in the shard is created.

### Issue
#5811
