### PR TITLE
[Filestore] track pipeId for unconfirmed data to invalidate them upon pipe destruction

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -78,15 +78,6 @@ NProtoPrivate::TChangeStorageConfigResponse ExecuteChangeStorageConfig(
     return response;
 }
 
-void WaitForTabletStart(TServiceClient& service)
-{
-    TDispatchOptions options;
-    options.FinalEvents = {
-        TDispatchOptions::TFinalEventCondition(
-            TEvIndexTabletPrivate::EvLoadCompactionMapChunkRequest)};
-    service.AccessRuntime().DispatchEvents(options);
-}
-
 NProtoPrivate::TGetStorageStatsResponse GetStorageStats(
     TServiceClient& service,
     const NProtoPrivate::TGetStorageStatsRequest& request)

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -57,16 +57,6 @@ NProtoPrivate::TChangeStorageConfigResponse ExecuteChangeStorageConfig(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void WaitForTabletStart(TServiceClient& service)
-{
-    TDispatchOptions options;
-    options.FinalEvents = {TDispatchOptions::TFinalEventCondition(
-        TEvIndexTabletPrivate::EvLoadCompactionMapChunkRequest)};
-    service.AccessRuntime().DispatchEvents(options);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 NProtoPrivate::TSetHasXAttrsResponse ExecuteSetHasXAttrs(
     TServiceClient& service,
     bool value = true)

--- a/cloud/filestore/libs/storage/service/service_ut_helpers.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_helpers.cpp
@@ -1,10 +1,15 @@
 #include "service_ut_helpers.h"
 
+#include <cloud/filestore/libs/storage/tablet/events/tablet_private.h>
+#include <cloud/filestore/libs/storage/testlib/service_client.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <utility>
 
 namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
 
 void TTestProfileLog::Start()
 {}
@@ -30,6 +35,15 @@ TString GenerateValidateData(ui32 size, ui32 seed)
         data[i] = 'A' + ((i + seed) % ('Z' - 'A' + 1));
     }
     return data;
+}
+
+void WaitForTabletStart(TServiceClient& service)
+{
+    TDispatchOptions options;
+    options.FinalEvents = {
+        TDispatchOptions::TFinalEventCondition(
+            TEvIndexTabletPrivate::EvLoadCompactionMapChunkRequest)};
+    service.AccessRuntime().DispatchEvents(options, TDuration::Seconds(5));
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut_helpers.h
+++ b/cloud/filestore/libs/storage/service/service_ut_helpers.h
@@ -9,6 +9,8 @@
 
 namespace NCloud::NFileStore::NStorage {
 
+class TServiceClient;
+
 class TTestProfileLog
     : public IProfileLog
 {
@@ -25,5 +27,7 @@ public:
 };
 
 TString GenerateValidateData(ui32 size, ui32 seed = 0);
+
+void WaitForTabletStart(TServiceClient& service);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -146,14 +146,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     const auto StartupEventType =
         TEvIndexTabletPrivate::EvLoadCompactionMapChunkRequest;
 
-    void WaitForTabletStart(TServiceClient& service)
-    {
-        TDispatchOptions options;
-        options.FinalEvents = {
-            TDispatchOptions::TFinalEventCondition(StartupEventType)};
-        service.AccessRuntime().DispatchEvents(options);
-    }
-
     void CatchActorIds(TServiceClient& service, TVector<TActorId>& ids)
     {
         service.AccessRuntime().SetEventFilter(

--- a/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
@@ -4,6 +4,7 @@
 #include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/model/utils.h>
 #include <cloud/filestore/libs/storage/testlib/service_client.h>
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
@@ -16,11 +17,14 @@
 #include <cloud/storage/core/libs/tablet/blob_id.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
+#include <contrib/ydb/core/base/tablet.h>
+#include <contrib/ydb/core/testlib/tablet_helpers.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/digest/city.h>
+#include <util/generic/map.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -28,6 +32,16 @@ using namespace NActors;
 using namespace NKikimr;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TShardedFileSystemConfig
+{
+    const TString FsId = "test";
+    const TString Shard1Id = FsId + "_s1";
+    const ui64 ShardBlockCount = 1'000;
+    const ui64 MainFsBlockCount = ShardBlockCount;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -155,6 +169,302 @@ ReadData(TTestSetup& setup, ui64 offset, ui64 bytes)
         setup.Handle,
         offset,
         bytes);
+}
+
+enum class EShardPipeToDisconnect
+{
+    Session,
+    Write,
+};
+
+void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
+    EShardPipeToDisconnect pipeToDisconnect)
+{
+    TShardedFileSystemConfig fsConfig;
+
+    NProto::TStorageConfig storageConfig;
+    storageConfig.SetAutomaticShardCreationEnabled(true);
+    storageConfig.SetAutomaticallyCreatedShardSize(1_GB);
+    storageConfig.SetShardAllocationUnit(1_GB);
+    storageConfig.SetShardBalancerPolicy(NProto::SBP_ROUND_ROBIN);
+    storageConfig.SetAddingUnconfirmedDataEnabled(true);
+    storageConfig.SetUnconfirmedDataCountHardLimit(100);
+    storageConfig.SetWriteBlobThreshold(128_KB);
+    storageConfig.SetThreeStageWriteEnabled(true);
+    storageConfig.SetUnalignedThreeStageWriteEnabled(true);
+
+    TTestEnvConfig envConfig;
+    envConfig.DynamicNodes = 2;
+    TTestEnv env(envConfig, storageConfig);
+
+    const ui32 fsNodeIdx = env.AddDynamicNode();
+
+    TServiceClient fsService(env.GetRuntime(), fsNodeIdx);
+    fsService.CreateFileStore(fsConfig.FsId, fsConfig.MainFsBlockCount);
+
+    auto& runtime = env.GetRuntime();
+    ui64 shardTabletId = 0;
+    const TString targetClientId = "client";
+
+    TMap<TActorId, TActorId> shardPipeClientsByServer;
+    TActorId shardSessionPipeServer;
+    TActorId shardSessionClient;
+    TActorId shardWritePipeServer;
+    TActorId shardWriteClient;
+    TActorId writeActor;
+    TString shardSessionId;
+    TString shardWriteSessionId;
+    TAutoPtr<IEventHandle> blockedPutResult;
+
+    // Capture the shard session pipe and the independent shard write pipe.
+    // The blob put result is held to keep the write actor alive while the test
+    // disconnects one of those pipes.
+    auto prevFilter = runtime.SetEventFilter(
+        [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvTabletPipe::EvClientConnected: {
+                    const auto* msg =
+                        event->Get<TEvTabletPipe::TEvClientConnected>();
+                    if (msg->Status == NKikimrProto::OK) {
+                        shardPipeClientsByServer[msg->ServerId] = msg->ClientId;
+                    }
+                    break;
+                }
+
+                case TEvTabletPipe::EvServerConnected: {
+                    const auto* msg =
+                        event->Get<TEvTabletPipe::TEvServerConnected>();
+                    shardPipeClientsByServer[msg->ServerId] = msg->ClientId;
+                    break;
+                }
+
+                case TEvIndexTablet::EvCreateSessionRequest: {
+                    if (event->Recipient == MakeIndexTabletProxyServiceId()) {
+                        break;
+                    }
+
+                    const auto* msg =
+                        event->Get<TEvIndexTablet::TEvCreateSessionRequest>();
+                    if (msg->Record.GetFileSystemId() == fsConfig.Shard1Id &&
+                        msg->Record.GetHeaders().GetClientId() ==
+                            targetClientId &&
+                        !shardSessionPipeServer)
+                    {
+                        shardSessionPipeServer = event->Recipient;
+                        shardSessionClient = event->Sender;
+                        shardSessionId =
+                            msg->Record.GetHeaders().GetSessionId();
+                    }
+
+                    break;
+                }
+
+                case TEvIndexTablet::EvGenerateBlobIdsRequest: {
+                    const auto* msg =
+                        event->Get<TEvIndexTablet::TEvGenerateBlobIdsRequest>();
+                    if (msg->Record.GetFileSystemId() != fsConfig.Shard1Id ||
+                        msg->Record.GetHeaders().GetClientId() !=
+                            targetClientId)
+                    {
+                        break;
+                    }
+
+                    if (event->Recipient == MakeIndexTabletProxyServiceId()) {
+                        writeActor = event->Sender;
+                        break;
+                    }
+
+                    shardWritePipeServer = event->Recipient;
+                    shardWriteClient = event->Sender;
+                    shardWriteSessionId =
+                        msg->Record.GetHeaders().GetSessionId();
+                    break;
+                }
+
+                case TEvBlobStorage::EvPutResult: {
+                    if (writeActor && event->Recipient == writeActor &&
+                        !blockedPutResult)
+                    {
+                        blockedPutResult = event.Release();
+                        return true;
+                    }
+                    break;
+                }
+            }
+
+            return false;
+        });
+
+    fsService.ResizeFileStore(
+        fsConfig.FsId,
+        fsConfig.MainFsBlockCount,
+        false /* force */,
+        1 /* shardCount */);
+    WaitForTabletStart(fsService);
+
+    const auto mainTabletId = fsService.GetFileStoreInfo(fsConfig.FsId)
+                                  ->Record.GetFileStore()
+                                  .GetMainTabletId();
+    const auto mainTabletActorId = ResolveTablet(runtime, mainTabletId);
+
+    shardTabletId = fsService.GetFileStoreInfo(fsConfig.Shard1Id)
+                        ->Record.GetFileStore()
+                        .GetMainTabletId();
+    UNIT_ASSERT(shardTabletId);
+
+    // Create a file on the shard and write through the service. The write
+    // service is placed on a node different from the main tablet node, so the
+    // write uses a different tablet pipe than the shard session creation path.
+    const ui32 serviceNodeIdx = env.AddDynamicNode();
+    UNIT_ASSERT_VALUES_UNEQUAL(
+        mainTabletActorId.NodeId(),
+        runtime.GetNodeId(serviceNodeIdx));
+    TServiceClient service(env.GetRuntime(), serviceNodeIdx);
+    auto headers = service.InitSession(fsConfig.FsId, targetClientId);
+
+    const auto nodeId =
+        service.CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+            ->Record.GetNode()
+            .GetId();
+    UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId));
+
+    const auto handle = service
+                            .CreateHandle(
+                                headers,
+                                fsConfig.FsId,
+                                nodeId,
+                                "",
+                                TCreateHandleArgs::RDWR)
+                            ->Record.GetHandle();
+
+    service.SendWriteDataRequest(
+        headers,
+        fsConfig.FsId,
+        nodeId,
+        handle,
+        0,
+        GenerateValidateData(256_KB));
+
+    UNIT_ASSERT_C(
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition =
+                    [&]()
+                {
+                    return !!blockedPutResult && !!shardSessionPipeServer &&
+                           !!shardWritePipeServer;
+                }},
+            TDuration::Seconds(5)),
+        "Timed out waiting for blocked write and shard pipe capture");
+
+    // Verify that the test captured the exact two-pipe situation it is about to
+    // use: same logical session, different tablet pipe servers.
+    UNIT_ASSERT_C(blockedPutResult, "Write blob result was not blocked");
+    UNIT_ASSERT_C(
+        shardSessionPipeServer,
+        "Shard session creation request to tablet pipe was not observed");
+    UNIT_ASSERT_C(
+        shardWritePipeServer,
+        "Shard WriteData GenerateBlobIds request was not observed");
+    UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, shardSessionId);
+    UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, shardWriteSessionId);
+    UNIT_ASSERT_C(
+        shardSessionPipeServer != shardWritePipeServer,
+        TStringBuilder()
+            << "Shard session creation and WriteData used the same pipe "
+            << "server: " << shardSessionPipeServer);
+    UNIT_ASSERT_VALUES_EQUAL(
+        mainTabletActorId.NodeId(),
+        shardSessionClient.NodeId());
+    UNIT_ASSERT_VALUES_EQUAL(
+        runtime.GetNodeId(serviceNodeIdx),
+        shardWriteClient.NodeId());
+
+    const auto sessionPipeClientIt =
+        shardPipeClientsByServer.find(shardSessionPipeServer);
+    UNIT_ASSERT_C(
+        sessionPipeClientIt != shardPipeClientsByServer.end(),
+        TStringBuilder()
+            << "Pipe client for shard session pipe server was not observed: "
+            << shardSessionPipeServer);
+
+    const auto writePipeClientIt =
+        shardPipeClientsByServer.find(shardWritePipeServer);
+    UNIT_ASSERT_C(
+        writePipeClientIt != shardPipeClientsByServer.end(),
+        TStringBuilder()
+            << "Pipe client for shard write pipe server was not observed: "
+            << shardWritePipeServer);
+
+    TIndexTabletClient shardTablet(
+        runtime,
+        serviceNodeIdx,
+        shardTabletId,
+        {},
+        false /* updateConfig */);
+
+    // At this point the write actor is blocked on blob storage, so the
+    // unconfirmed entry must stay visible until either the write pipe or the
+    // session pipe is disconnected.
+    UNIT_ASSERT_VALUES_EQUAL(
+        1,
+        GetStorageStats(shardTablet).GetUnconfirmedDataCount());
+
+    // Select either the shard session pipe or the active write pipe.
+    struct TPipeToDisconnect
+    {
+        TActorId Server;
+        TActorId Client;
+        ui32 NodeIdx = 0;
+    };
+
+    const TPipeToDisconnect sessionPipeToDisconnect{
+        shardSessionPipeServer,
+        sessionPipeClientIt->second,
+        fsNodeIdx};
+    const TPipeToDisconnect writePipeToDisconnect{
+        shardWritePipeServer,
+        writePipeClientIt->second,
+        serviceNodeIdx};
+
+    const TPipeToDisconnect pipeToDisconnectInfo =
+        pipeToDisconnect == EShardPipeToDisconnect::Session
+            ? sessionPipeToDisconnect
+            : writePipeToDisconnect;
+
+    runtime.ClosePipe(
+        pipeToDisconnectInfo.Client,
+        TActorId(),
+        pipeToDisconnectInfo.NodeIdx);
+
+    // Wait until the shard observes the selected tablet pipe server
+    // disconnect.
+    TDispatchOptions disconnectOptions;
+    disconnectOptions.FinalEvents = {TDispatchOptions::TFinalEventCondition(
+        [server = pipeToDisconnectInfo.Server](IEventHandle& event)
+        {
+            if (event.GetTypeRewrite() != TEvTabletPipe::EvServerDisconnected) {
+                return false;
+            }
+
+            const auto* msg = event.Get<TEvTabletPipe::TEvServerDisconnected>();
+            return msg->ServerId == server;
+        })};
+    UNIT_ASSERT_C(
+        runtime.DispatchEvents(disconnectOptions, TDuration::Seconds(5)),
+        TStringBuilder() << "Timed out waiting for shard pipe disconnect "
+                         << pipeToDisconnectInfo.Server);
+
+    // The disconnect dispatch can already execute and commit the cleanup tx.
+    // Querying stats after it is the synchronization point for the assertion.
+    UNIT_ASSERT_VALUES_EQUAL(
+        0,
+        GetStorageStats(shardTablet).GetUnconfirmedDataCount());
+
+    runtime.SetEventFilter(prevFilter);
 }
 
 }   // namespace
@@ -1040,6 +1350,22 @@ Y_UNIT_TEST_SUITE(TWriteDataUnconfirmedTest)
             CityHash64(data),
             CityHash64(actual),
             "Data mismatch");
+    }
+
+    // =========================================================================
+    // Sharding tests
+    // =========================================================================
+
+    Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceWritePipeDisconnect)
+    {
+        DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
+            EShardPipeToDisconnect::Write);
+    }
+
+    Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceSessionPipeDisconnect)
+    {
+        DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
+            EShardPipeToDisconnect::Session);
     }
 
     // =========================================================================

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -763,20 +763,24 @@ void TIndexTabletActor::HandleSessionDisconnectedInWork(
 {
     const auto& msg = *ev->Get();
 
+    // TODO (#4962) use proper session id
+    const auto& sessionIds = FindSessionIdsByPipeServer(msg.ServerId);
+
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET,
-        "%s Server disconnected, sender: %s, client: %s, server: %s",
+        "%s Server disconnected, sender: %s, client: %s, server: %s, "
+        "matchedSessions: %zu",
         LogTag.c_str(),
         ev->Sender.ToString().c_str(),
         msg.ClientId.ToString().c_str(),
-        msg.ServerId.ToString().c_str());
+        msg.ServerId.ToString().c_str(),
+        sessionIds.size());
 
-    // TODO (#4962) use proper session id
-    const auto& sessionIds = FindSessionIdsByPipeServer(msg.ServerId);
     for (const auto& sessionId: sessionIds) {
         DeleteUnconfirmedDataForSession(sessionId, ctx);
     }
+    DeleteUnconfirmedDataForPipeServer(msg.ServerId, ctx);
     RemoveSessionByPipeServer(msg.ServerId);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -761,8 +761,19 @@ private:
         const NActors::TActorContext& ctx);
     void BlobsConfirmed(const NActors::TActorContext& ctx);
 
+    void DeleteUnconfirmedData(
+        const NActors::TActorContext& ctx,
+        const char* deletionEntity,
+        const TString& entityId,
+        const std::function<bool(const TTrackedUnconfirmedData&)>&
+            shouldDelete);
+
     void DeleteUnconfirmedDataForSession(
         const TString& sessionId,
+        const NActors::TActorContext& ctx);
+
+    void DeleteUnconfirmedDataForPipeServer(
+        const NActors::TActorId& pipeServerId,
         const NActors::TActorContext& ctx);
 
     void SendMetricsToExecutor(const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -462,7 +462,8 @@ void TIndexTabletActor::HandleGenerateBlobIds(
             commitId,
             TTrackedUnconfirmedData{
                 .Data = std::move(unconfirmedData),
-                .SessionId = GetSessionId(msg->Record)});
+                .SessionId = GetSessionId(msg->Record),
+                .PipeServerId = ev->Recipient});
         TABLET_VERIFY(inserted);
 
         NProto::TProfileLogRequestInfo profileLogRequest;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -388,16 +388,18 @@ void TIndexTabletActor::ConfirmData(ui64 commitId, const TActorContext& ctx)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TIndexTabletActor::DeleteUnconfirmedDataForSession(
-    const TString& sessionId,
-    const TActorContext& ctx)
+void TIndexTabletActor::DeleteUnconfirmedData(
+    const TActorContext& ctx,
+    const char* deletionEntity,
+    const TString& entityId,
+    const std::function<bool(const TTrackedUnconfirmedData&)>& shouldDelete)
 {
     TVector<ui64> commitIdsToDelete;
 
     auto enqueueCommitIdsToDelete = [&](const auto& data)
     {
         for (const auto& [commitId, trackedData]: data) {
-            if (trackedData.SessionId != sessionId) {
+            if (!shouldDelete(trackedData)) {
                 continue;
             }
 
@@ -412,28 +414,54 @@ void TIndexTabletActor::DeleteUnconfirmedDataForSession(
     enqueueCommitIdsToDelete(UnconfirmedData);
     enqueueCommitIdsToDelete(UnconfirmedDataInProgress);
 
-    if (!commitIdsToDelete.empty()) {
-        LOG_INFO(
-            ctx,
-            TFileStoreComponents::TABLET,
-            "%s Deleting unconfirmed data: sessionId=%s, "
-            "deleteNow=%zu",
-            LogTag.c_str(),
-            sessionId.Quote().c_str(),
-            commitIdsToDelete.size());
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s Deleting unconfirmed data: %s=%s, deleteNow=%zu",
+        LogTag.c_str(),
+        deletionEntity,
+        entityId.c_str(),
+        commitIdsToDelete.size());
 
-        // Session cleanup has the same ordering requirement as CancelAddData:
-        // once commitIds are placed into DeletionQueue, DeleteUnconfirmedData
-        // must be executed before any later AddBlob execute. For that reason it
-        // should be also page-fault-free.
-        ExecuteTx<TDeleteUnconfirmedData>(
-            ctx,
-            CreateRequestInfo(
-                SelfId(),
-                0 /* cookie */,
-                MakeIntrusive<TCallContext>()),
-            std::move(commitIdsToDelete));
+    if (commitIdsToDelete.empty()) {
+        return;
     }
+
+    // Cleanup has the same ordering requirement as CancelAddData: once
+    // commitIds are placed into DeletionQueue, DeleteUnconfirmedData must be
+    // executed before any later AddBlob execute. For that reason it should be
+    // also page-fault-free.
+    ExecuteTx<TDeleteUnconfirmedData>(
+        ctx,
+        CreateRequestInfo(
+            SelfId(),
+            0 /* cookie */,
+            MakeIntrusive<TCallContext>()),
+        std::move(commitIdsToDelete));
+}
+
+void TIndexTabletActor::DeleteUnconfirmedDataForSession(
+    const TString& sessionId,
+    const TActorContext& ctx)
+{
+    DeleteUnconfirmedData(
+        ctx,
+        "sessionId",
+        sessionId.Quote(),
+        [&sessionId](const TTrackedUnconfirmedData& trackedData)
+        { return trackedData.SessionId == sessionId; });
+}
+
+void TIndexTabletActor::DeleteUnconfirmedDataForPipeServer(
+    const TActorId& pipeServerId,
+    const TActorContext& ctx)
+{
+    DeleteUnconfirmedData(
+        ctx,
+        "pipeServer",
+        pipeServerId.ToString(),
+        [&pipeServerId](const TTrackedUnconfirmedData& trackedData)
+        { return trackedData.PipeServerId == pipeServerId; });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -208,6 +208,7 @@ struct TTrackedUnconfirmedData
 {
     NProto::TUnconfirmedData Data;
     TString SessionId;
+    NActors::TActorId PipeServerId;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1475,6 +1475,50 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         AssertStorageStats(observer, 0, 0);
     }
 
+    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataOnWritePipeDisconnection)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient sessionClient(runtime, nodeIdx, tabletId);
+        sessionClient.InitSession("client", "session");
+
+        auto id = CreateNode(
+            sessionClient,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(sessionClient, id);
+
+        TIndexTabletClient writeClient(
+            runtime,
+            nodeIdx,
+            tabletId,
+            {},
+            false /* updateConfig */);
+        writeClient.SetHeaders("client", "session", 0 /* sessionSeqNo */);
+
+        auto gbi = writeClient.GenerateBlobIds(id, handle, 0, block);
+        Y_UNUSED(gbi);
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        AssertStorageStats(sessionClient, 1, 0);
+
+        writeClient.DisconnectPipe();
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        TIndexTabletClient observer(runtime, nodeIdx, tabletId);
+        AssertStorageStats(observer, 0, 0);
+    }
+
     Y_UNIT_TEST(ShouldReleaseCollectBarrierOnGenerateBlobIdsChannelError)
     {
         constexpr ui32 block = 4_KB;


### PR DESCRIPTION
### Notes
This fixes cleanup for the direct write-pipe case.

During sharded WriteData, GenerateBlobIds can reach the shard through a pipe that
was created by the service write actor, not through the pipe that created the
shard session:

Before this change, cleanup was session-based only. If the direct write pipe to a shard disconnected, the shard could not resolve that pipe back to a session, so its unconfirmed write could stay behind. Now the tablet stores the pipe server id from GenerateBlobIds with each unconfirmed entry and, on EvServerDisconnected, also removes entries owned by that pipe. So, now "write pipe disconnect -> delete unconfirmed data owned by that pipe"

Added service test for direct pipe disconnection (not created by CreateSession)
Added service test for pipe from session creation
Added ut to cover correct deletion by pipe


### Issue
#2293
