### PR TITLE
[Blockstore] optimize compaction map: do not recalculate score/garbage of the group when not needed

### DIFF
--- a/cloud/blockstore/libs/storage/core/compaction_map.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map.cpp
@@ -234,15 +234,12 @@ struct TCompactionMap::TImpl
                 : Policy->CalculateScore(group->Stats[index]);
             group->Stats[index].CompactionScore = newScore;
 
-            if (prev.CompactionScore.Score < newScore.Score) {
+            if (prev.CompactionScore.Score <= newScore.Score) {
                 if (group->Score < newScore.Score) {
                     group->Score = newScore.Score;
                     group->Range = index;
                 }
-            } else if (
-                index == group->Range &&
-                newScore.Score < prev.CompactionScore.Score)
-            {
+            } else if (index == group->Range) {
                 // Score in the top range has decreased, need to recalculate the
                 // maximal score.
                 RecalculateGroupScore(group);
@@ -251,14 +248,11 @@ struct TCompactionMap::TImpl
             const auto newGarbageBlockCount =
                 compacted ? 0 : group->Stats[index].GarbageBlockCount();
 
-            if (prev.GarbageBlockCount() < newGarbageBlockCount) {
+            if (prev.GarbageBlockCount() <= newGarbageBlockCount) {
                 if (GetGarbageBlockCount(*group) < newGarbageBlockCount) {
                     group->GarbageBlockCount = newGarbageBlockCount;
                 }
-            } else if (
-                prev.GarbageBlockCount() == group->GarbageBlockCount &&
-                newGarbageBlockCount < prev.GarbageBlockCount())
-            {
+            } else if (prev.GarbageBlockCount() == GetGarbageBlockCount(*group)) {
                 // Garbage block count in the top range has decreased, need to
                 // recalculate the maximal garbage block count.
                 RecalculateGroupGarbageBlockCount(group);
@@ -293,7 +287,7 @@ struct TCompactionMap::TImpl
             auto newScore = Policy->CalculateScore(group->Stats[index]);
             group->Stats[index].CompactionScore = newScore;
 
-            if (prev.CompactionScore.Score < newScore.Score) {
+            if (prev.CompactionScore.Score <= newScore.Score) {
                 if (group->Score < newScore.Score) {
                     group->Score = newScore.Score;
                     group->Range = index;

--- a/cloud/blockstore/libs/storage/core/compaction_map.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map.cpp
@@ -239,19 +239,28 @@ struct TCompactionMap::TImpl
                     group->Score = newScore.Score;
                     group->Range = index;
                 }
-            } else if (index == group->Range) {
+            } else if (
+                index == group->Range &&
+                newScore.Score < prev.CompactionScore.Score)
+            {
+                // Score in the top range has decreased, need to recalculate the
+                // maximal score.
                 RecalculateGroupScore(group);
             }
 
-            const auto newGarbageBlockCount = compacted
-                ? 0
-                : group->Stats[index].GarbageBlockCount();
+            const auto newGarbageBlockCount =
+                compacted ? 0 : group->Stats[index].GarbageBlockCount();
 
             if (prev.GarbageBlockCount() < newGarbageBlockCount) {
                 if (GetGarbageBlockCount(*group) < newGarbageBlockCount) {
                     group->GarbageBlockCount = newGarbageBlockCount;
                 }
-            } else if (prev.GarbageBlockCount() == group->GarbageBlockCount) {
+            } else if (
+                prev.GarbageBlockCount() == group->GarbageBlockCount &&
+                newGarbageBlockCount < prev.GarbageBlockCount())
+            {
+                // Garbage block count in the top range has decreased, need to
+                // recalculate the maximal garbage block count.
                 RecalculateGroupGarbageBlockCount(group);
             }
         }

--- a/cloud/blockstore/libs/storage/core/compaction_map.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map.cpp
@@ -293,6 +293,8 @@ struct TCompactionMap::TImpl
                     group->Range = index;
                 }
             } else if (index == group->Range) {
+                // Score in the top range has decreased, need to recalculate the
+                // maximal score.
                 RecalculateGroupScore(group);
             }
         }

--- a/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/testing/gbenchmark/benchmark.h>
 
 #include <util/generic/size_literals.h>
+#include <util/random/random.h>
 
 namespace NCloud::NBlockStore::NStorage {
 
@@ -16,17 +17,6 @@ void DoUpdate(ui64 diskSize, benchmark::State& state)
     constexpr size_t BlockSize = 4096;
     const ui64 blockCount = diskSize / BlockSize;
     const ui64 rangeCount = blockCount / RangeSize;
-
-    TCompactionMap compactionMap(
-        RangeSize,
-        BuildLoadOptimizationCompactionPolicy(
-            {.MaxBlobSize = 4_MB,
-             .BlockSize = 4_KB,
-             .MaxReadIops = 400,
-             .MaxReadBandwidth = 15_MB,
-             .MaxWriteIops = 1000,
-             .MaxWriteBandwidth = 15_MB,
-             .MaxBlobsPerRange = 70}));
 
     TCompressedBitmap usedBlocks(rangeCount * RangeSize);
     usedBlocks.Set(0, rangeCount * RangeSize);
@@ -48,6 +38,81 @@ void DoUpdate(ui64 diskSize, benchmark::State& state)
     }
 
     for (const auto _: state) {
+        TCompactionMap compactionMap(
+            RangeSize,
+            BuildLoadOptimizationCompactionPolicy(
+                {.MaxBlobSize = 4_MB,
+                 .BlockSize = 4_KB,
+                 .MaxReadIops = 400,
+                 .MaxReadBandwidth = 15_MB,
+                 .MaxWriteIops = 1000,
+                 .MaxWriteBandwidth = 15_MB,
+                 .MaxBlobsPerRange = 70}));
+
+        compactionMap.Update(counters, &usedBlocks);
+    }
+}
+
+ui16 RandomUsedBlockCount(ui16 blockCount)
+{
+    const ui32 bucket = RandomNumber<ui32>(4);
+    if (bucket == 0) {
+        return blockCount;
+    }
+    if (bucket == 1) {
+        return 0;
+    }
+    return static_cast<ui16>(RandomNumber<ui32>(blockCount - 1) + 1);
+}
+
+void DoUpdateRandomized(ui64 diskSize, benchmark::State& state)
+{
+    constexpr size_t RangeSize = 1024;
+    constexpr size_t BlockSize = 4096;
+    const ui64 blockCount = diskSize / BlockSize;
+    const ui64 rangeCount = blockCount / RangeSize;
+
+    TCompressedBitmap usedBlocks(rangeCount * RangeSize);
+
+    TVector<TCompactionCounter> counters(Reserve(rangeCount));
+    for (size_t i = 0; i < rangeCount; ++i) {
+        const ui16 blobCount =
+            static_cast<ui16>(RandomNumber<ui32>(5) + 1);
+        const ui16 statBlockCount =
+            static_cast<ui16>(RandomNumber<ui32>(901) + 100);
+        const ui16 usedBlockCount = RandomUsedBlockCount(statBlockCount);
+        const float score = 0.1f + 0.1f * RandomNumber<float>();
+
+        auto rangeStat = TRangeStat(
+            blobCount,
+            statBlockCount,
+            usedBlockCount,
+            0,
+            0,
+            0,
+            false,
+            score);
+
+        counters.emplace_back(i * RangeSize, rangeStat);
+
+        const ui64 rangeBase = i * RangeSize;
+        if (usedBlockCount != 0) {
+            usedBlocks.Set(rangeBase, rangeBase + usedBlockCount);
+        }
+    }
+
+    for (const auto _: state) {
+        TCompactionMap compactionMap(
+            RangeSize,
+            BuildLoadOptimizationCompactionPolicy(
+                {.MaxBlobSize = 4_MB,
+                 .BlockSize = 4_KB,
+                 .MaxReadIops = 400,
+                 .MaxReadBandwidth = 15_MB,
+                 .MaxWriteIops = 1000,
+                 .MaxWriteBandwidth = 15_MB,
+                 .MaxBlobsPerRange = 70}));
+
         compactionMap.Update(counters, &usedBlocks);
     }
 }
@@ -67,5 +132,19 @@ DECLARE_BENCH(10_TB)
 DECLARE_BENCH(50_TB)
 DECLARE_BENCH(100_TB)
 DECLARE_BENCH(500_TB)
+
+#define DECLARE_BENCH_RANDOMIZED(diskSize)                   \
+    void UpdateRandomized_##diskSize(benchmark::State& state)  \
+    {                                                        \
+        DoUpdateRandomized(diskSize, state);                 \
+    }                                                        \
+    BENCHMARK(UpdateRandomized_##diskSize);
+
+DECLARE_BENCH_RANDOMIZED(1_TB)
+DECLARE_BENCH_RANDOMIZED(5_TB)
+DECLARE_BENCH_RANDOMIZED(10_TB)
+DECLARE_BENCH_RANDOMIZED(50_TB)
+DECLARE_BENCH_RANDOMIZED(100_TB)
+DECLARE_BENCH_RANDOMIZED(500_TB)
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
@@ -13,13 +13,13 @@ namespace {
 
 void DoUpdate(ui64 diskSize, benchmark::State& state)
 {
-    constexpr size_t RangeSize = 1024;
+    constexpr size_t BlocksInRange = 1024;
     constexpr size_t BlockSize = 4096;
     const ui64 blockCount = diskSize / BlockSize;
-    const ui64 rangeCount = blockCount / RangeSize;
+    const ui64 rangeCount = blockCount / BlocksInRange;
 
-    TCompressedBitmap usedBlocks(rangeCount * RangeSize);
-    usedBlocks.Set(0, rangeCount * RangeSize);
+    TCompressedBitmap usedBlocks(rangeCount * BlocksInRange);
+    usedBlocks.Set(0, rangeCount * BlocksInRange);
 
     TVector<TCompactionCounter> counters(Reserve(rangeCount));
     for (size_t i = 0; i < rangeCount; ++i) {
@@ -34,12 +34,12 @@ void DoUpdate(ui64 diskSize, benchmark::State& state)
             0.1      // score
         );
 
-        counters.emplace_back(i * RangeSize, rangeStat);
+        counters.emplace_back(i * BlocksInRange, rangeStat);
     }
 
     for (const auto _: state) {
         TCompactionMap compactionMap(
-            RangeSize,
+            BlocksInRange,
             BuildLoadOptimizationCompactionPolicy(
                 {.MaxBlobSize = 4_MB,
                  .BlockSize = 4_KB,
@@ -73,15 +73,14 @@ ui16 RandomUsedBlockCount(ui16 blockCount)
 
 void DoUpdateRandomized(ui64 diskSize, benchmark::State& state)
 {
-    constexpr size_t RangeSize = 1024;
+    constexpr size_t BlocksInRange = 1024;
     constexpr size_t BlockSize = 4096;
     const ui64 blockCount = diskSize / BlockSize;
-    const ui64 rangeCount = blockCount / RangeSize;
+    const ui64 rangeCount = blockCount / BlocksInRange;
 
-    TCompressedBitmap usedBlocks(rangeCount * RangeSize);
+    TCompressedBitmap usedBlocks(rangeCount * BlocksInRange);
     TVector<TCompactionCounter> counters(Reserve(rangeCount));
 
-    constexpr ui16 BlocksInRange = 1024;
 
     for (size_t i = 0; i < rangeCount; ++i) {
         const ui16 blobCount =
@@ -101,17 +100,17 @@ void DoUpdateRandomized(ui64 diskSize, benchmark::State& state)
             false,
             score);
 
-        counters.emplace_back(i * RangeSize, rangeStat);
+        counters.emplace_back(i * BlocksInRange, rangeStat);
 
-        const ui64 rangeBase = i * RangeSize;
+        const ui64 rangeBlockOffset = i * BlocksInRange;
         if (usedBlockCount != 0) {
-            usedBlocks.Set(rangeBase, rangeBase + usedBlockCount);
+            usedBlocks.Set(rangeBlockOffset, rangeBlockOffset + usedBlockCount);
         }
     }
 
     for (const auto _: state) {
         TCompactionMap compactionMap(
-            RangeSize,
+            BlocksInRange,
             BuildLoadOptimizationCompactionPolicy(
                 {.MaxBlobSize = 4_MB,
                  .BlockSize = 4_KB,

--- a/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
@@ -57,10 +57,16 @@ ui16 RandomUsedBlockCount(ui16 blockCount)
 {
     const ui32 bucket = RandomNumber<ui32>(4);
     if (bucket == 0) {
+        // No garbage with probability 25%.
         return blockCount;
     }
     if (bucket == 1) {
+        // Everything is garbage with probability 25%.
         return 0;
+    }
+
+    if (blockCount <= 1) {
+        return blockCount;
     }
     return static_cast<ui16>(RandomNumber<ui32>(blockCount - 1) + 1);
 }
@@ -73,15 +79,17 @@ void DoUpdateRandomized(ui64 diskSize, benchmark::State& state)
     const ui64 rangeCount = blockCount / RangeSize;
 
     TCompressedBitmap usedBlocks(rangeCount * RangeSize);
-
     TVector<TCompactionCounter> counters(Reserve(rangeCount));
+
+    constexpr ui16 BlocksInRange = 1024;
+
     for (size_t i = 0; i < rangeCount; ++i) {
         const ui16 blobCount =
-            static_cast<ui16>(RandomNumber<ui32>(5) + 1);
+            static_cast<ui16>(RandomNumber<ui32>(6)); // [0, 5]
         const ui16 statBlockCount =
-            static_cast<ui16>(RandomNumber<ui32>(901) + 100);
+            static_cast<ui16>(RandomNumber<ui32>(BlocksInRange + 1)); // [0, BlocksInRange]
         const ui16 usedBlockCount = RandomUsedBlockCount(statBlockCount);
-        const float score = 0.1f + 0.1f * RandomNumber<float>();
+        const float score = 0.1f * RandomNumber<float>(); // [0.0, 0.1]
 
         auto rangeStat = TRangeStat(
             blobCount,

--- a/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/core/compaction_map_benchmark.cpp
@@ -81,7 +81,6 @@ void DoUpdateRandomized(ui64 diskSize, benchmark::State& state)
     TCompressedBitmap usedBlocks(rangeCount * BlocksInRange);
     TVector<TCompactionCounter> counters(Reserve(rangeCount));
 
-
     for (size_t i = 0; i < rangeCount; ++i) {
         const ui16 blobCount =
             static_cast<ui16>(RandomNumber<ui32>(6)); // [0, 5]


### PR DESCRIPTION
### Notes

- Optimize the performance of the compaction map in some scenarios
- Improve the compaction map benchmark

---

Compaction map optimization:

`RecalculateGroupScore` and `RecalculateGroupGarbageBlockCount` are quite expensive because they iterate over all ranges in the group. However, we only need this recalculation when the score/garbage value in the top range of the group decreases. Before this fix, we also performed this recalculation when the top range changed and the score/garbage value did not change.

For example, if we fill the entire compaction map with ranges that have `0` garbage, we call `RecalculateGroupGarbageBlockCount` for each range. This is inefficient.

---

Benchmark modifications:

1. Create a new compaction map object for each iteration. If we do not do this, all iterations after the first one are much faster (they just don't dive into this `if` https://github.com/ydb-platform/nbs/blob/main/cloud/blockstore/libs/storage/core/compaction_map.cpp#L207). This leads to strange results like this -- avarage for 18 iteration is much better then expected:

```
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
Update_1_TB              29805000 ns     29802429 ns           18
Update_5_TB            2015158198 ns   2015002645 ns            1
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
Update_1_TB             679578910 ns    679552834 ns            1
Update_5_TB            3473159005 ns   3472999281 ns            1
```

2. Added new benchmarks that try to simulate real load better. Old benchmarks represent a special case when garbage in all ranges is 0.

---

Benchmark results:

Without the fix:

```
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
Update_1_TB              401368067 ns    401338871 ns            2
Update_5_TB             2063699893 ns   2063571520 ns            1
Update_10_TB            4178160549 ns   4177690753 ns            1
Update_50_TB            7114521451 ns   7114163624 ns            1
Update_100_TB           7650246420 ns   7649679902 ns            1
Update_500_TB           1.1903e+10 ns   1.1902e+10 ns            1
UpdateRandomized_1_TB     17984053 ns     17982492 ns           39
UpdateRandomized_5_TB    131754655 ns    131745974 ns            6
UpdateRandomized_10_TB   285124737 ns    285108213 ns            3
UpdateRandomized_50_TB  1301530570 ns   1301425944 ns            1
UpdateRandomized_100_TB 2547280139 ns   2547114097 ns            1
UpdateRandomized_500_TB 1.2384e+10 ns   1.2383e+10 ns            1
```

With the fix:

```
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
Update_1_TB              139999779 ns    139998215 ns            5
Update_5_TB              763097292 ns    763067559 ns            1
Update_10_TB            1600163868 ns   1600088125 ns            1
Update_50_TB            2943275623 ns   2943165508 ns            1
Update_100_TB           3470560086 ns   3470379386 ns            1
Update_500_TB           7601042094 ns   7600382811 ns            1
UpdateRandomized_1_TB     18083756 ns     18082438 ns           40
UpdateRandomized_5_TB    126521303 ns    126512374 ns            6
UpdateRandomized_10_TB   268469964 ns    268464845 ns            3
UpdateRandomized_50_TB  1283381287 ns   1283216432 ns            1
UpdateRandomized_100_TB 2541680311 ns   2541274731 ns            1
UpdateRandomized_500_TB 1.2210e+10 ns   1.2210e+10 ns            1
```

Old benchmarks performance improved significantly.