### PR TITLE
issue-5726: ability to switch between different NodeRefs cache implementations - preparation

### DIFF
--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -90,6 +90,7 @@ namespace NCloud::NFileStore{
     xxx(UnconfirmedDataNotInProgress)                                          \
     xxx(InvalidCommitIdInUnconfirmedAddBlobSafePoint)                          \
     xxx(ListNodesInternalFailedToAddNodeRef)                                   \
+    xxx(InMemoryIndexStateNotInitialized)                                      \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/metadata_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/metadata_cache.cpp
@@ -1,0 +1,7 @@
+#include "metadata_cache.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
+++ b/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
@@ -123,7 +123,7 @@ public:
         return NodeRefs.GetMaxSize();
     }
 
-    TNodeRefsRow* FindInIndex(const TNodeRefsKey& key)
+    TNodeRefsRow* Find(const TNodeRefsKey& key)
     {
         return NodeRefs.FindInIndex(key);
     }

--- a/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
+++ b/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
@@ -1,0 +1,189 @@
+#pragma once
+
+#include <cloud/storage/core/libs/common/lru_cache.h>
+
+#include <util/digest/multi.h>
+#include <util/generic/map.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+#include <optional>
+
+/*
+ * The whole implementation is located in the header to allow inlining.
+ * NodeRef lookup and iteration can be done in hot code paths.
+ */
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TNodeRefsKey
+{
+    TNodeRefsKey(ui64 nodeId, TString name)
+        : NodeId(nodeId)
+        , Name(std::move(name))
+    {}
+
+    ui64 NodeId = 0;
+    TString Name;
+
+    bool operator<(const TNodeRefsKey& rhs) const
+    {
+        return std::tie(NodeId, Name) < std::tie(rhs.NodeId, rhs.Name);
+    }
+
+    bool operator==(const TNodeRefsKey& rhs) const
+    {
+        return std::tie(NodeId, Name) == std::tie(rhs.NodeId, rhs.Name);
+    }
+};
+
+struct TNodeRefsRow
+{
+    ui64 CommitId = 0;
+    ui64 ChildId = 0;
+    TString ShardId;
+    TString ShardNodeName;
+};
+
+struct TNodeRefsKeyHash
+{
+    size_t operator()(const TNodeRefsKey& key) const
+    {
+        return MultiHash(key.NodeId, key.Name);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TStandardNodeRefsCache
+{
+private:
+    using TNodeRefs = NCloud::TLRUCache<
+        TNodeRefsKey,
+        TNodeRefsRow,
+        true /* UseIndexLookup */,
+        TNodeRefsKeyHash,
+        TMap<TNodeRefsKey, TNodeRefsRow, TLess<TNodeRefsKey>, TStlAllocator>>;
+    TNodeRefs NodeRefs;
+
+public:
+    class TIterator
+    {
+    private:
+        TNodeRefs::iterator Impl;
+        TNodeRefs::iterator End;
+        bool Called = false;
+
+    public:
+        TIterator(TNodeRefs::iterator impl, TNodeRefs::iterator end)
+            : Impl(std::move(impl))
+            , End(std::move(end))
+        {}
+
+    public:
+        bool Next(const TNodeRefsKey** key, const TNodeRefsRow** value)
+        {
+            if (Impl != End && Called) {
+                ++Impl;
+            }
+
+            if (Impl == End) {
+                *key = nullptr;
+                *value = nullptr;
+                return false;
+            }
+
+            *key = &Impl->first;
+            *value = &Impl->second;
+            Called = true;
+            return true;
+        }
+    };
+
+public:
+    explicit TStandardNodeRefsCache(IAllocator *allocator)
+        : NodeRefs(allocator)
+    {}
+
+public:
+    TVector<TNodeRefsKey> SetMaxSize(size_t maxSize)
+    {
+        return NodeRefs.SetMaxSize(maxSize);
+    }
+
+    size_t Size() const
+    {
+        return NodeRefs.size();
+    }
+
+    size_t GetMaxSize() const
+    {
+        return NodeRefs.GetMaxSize();
+    }
+
+    TNodeRefsRow* FindInIndex(const TNodeRefsKey& key)
+    {
+        return NodeRefs.FindInIndex(key);
+    }
+
+    bool TouchKey(const TNodeRefsKey& key)
+    {
+        return NodeRefs.TouchKey(key);
+    }
+
+    void Erase(const TNodeRefsKey& key)
+    {
+        NodeRefs.erase(key);
+    }
+
+    std::optional<TNodeRefsKey> Put(
+        const TNodeRefsKey& key,
+        TNodeRefsRow value)
+    {
+        return std::get<2>(NodeRefs.emplace(key, std::move(value)));
+    }
+
+    TIterator LowerBound(const TNodeRefsKey& key)
+    {
+        return {NodeRefs.lower_bound(key), NodeRefs.end()};
+    }
+};
+
+struct TNodeAttrsKey
+{
+    TNodeAttrsKey(ui64 nodeId, TString name)
+        : NodeId(nodeId)
+        , Name(std::move(name))
+    {}
+
+    ui64 NodeId = 0;
+    TString Name;
+
+    bool operator==(const TNodeAttrsKey& rhs) const
+    {
+        return std::tie(NodeId, Name) == std::tie(rhs.NodeId, rhs.Name);
+    }
+};
+
+struct TNodeAttrsRow
+{
+    ui64 CommitId = 0;
+    TString Value;
+    ui64 Version = 0;
+};
+
+}   // namespace NCloud::NFileStore::NStorage
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <>
+struct THash<NCloud::NFileStore::NStorage::TNodeAttrsKey>
+{
+    size_t operator()(const NCloud::NFileStore::NStorage::TNodeAttrsKey& key)
+        const
+    {
+        return MultiHash(key.NodeId, key.Name);
+    }
+};

--- a/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
+++ b/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
@@ -74,7 +74,6 @@ public:
     private:
         TNodeRefs::iterator Impl;
         TNodeRefs::iterator End;
-        bool Called = false;
 
     public:
         TIterator(TNodeRefs::iterator impl, TNodeRefs::iterator end)
@@ -83,12 +82,8 @@ public:
         {}
 
     public:
-        bool Next(const TNodeRefsKey** key, const TNodeRefsRow** value)
+        bool Get(const TNodeRefsKey** key, const TNodeRefsRow** value)
         {
-            if (Impl != End && Called) {
-                ++Impl;
-            }
-
             if (Impl == End) {
                 *key = nullptr;
                 *value = nullptr;
@@ -97,8 +92,16 @@ public:
 
             *key = &Impl->first;
             *value = &Impl->second;
-            Called = true;
             return true;
+        }
+
+        auto& operator++()
+        {
+            if (Impl != End) {
+                ++Impl;
+            }
+
+            return *this;
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
+++ b/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
@@ -106,16 +106,13 @@ public:
     };
 
 public:
-    explicit TStandardNodeRefsCache(IAllocator *allocator)
+    TStandardNodeRefsCache(IAllocator *allocator, size_t maxSize)
         : NodeRefs(allocator)
-    {}
-
-public:
-    TVector<TNodeRefsKey> SetMaxSize(size_t maxSize)
     {
-        return NodeRefs.SetMaxSize(maxSize);
+        NodeRefs.SetMaxSize(maxSize);
     }
 
+public:
     size_t Size() const
     {
         return NodeRefs.size();

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -25,6 +25,7 @@ SRCS(
     group_by.cpp
     internal_request_id.cpp
     large_blocks.cpp
+    metadata_cache.cpp
     mixed_blocks.cpp
     node_ref.cpp
     node_session_stat.cpp

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -376,7 +376,12 @@ private:
 
         // if we can execute the transaction using the in-memory index state,
         // we will do so and return immediately.
-        if (TryExecuteTx(ctx, AccessInMemoryIndexState(), tx)) {
+        auto* indexState = AccessInMemoryIndexState();
+        if (!indexState) {
+            ReportInMemoryIndexStateNotInitialized();
+        }
+
+        if (indexState && TryExecuteTx(ctx, *indexState, tx)) {
             Metrics.InMemoryIndexStateROCacheHitCount.fetch_add(
                 1,
                 std::memory_order_relaxed);

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -2142,7 +2142,7 @@ bool TIndexTabletDatabase::ReadResponseLog(
 
 TIndexTabletDatabaseProxy::TIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
-        TVector<TInMemoryIndexState::TIndexStateRequest>& nodeUpdates)
+        TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates)
     : TIndexTabletDatabase(database)
     , NodeUpdates(nodeUpdates)
 {}
@@ -2156,7 +2156,7 @@ bool TIndexTabletDatabaseProxy::ReadNode(
     if (result && node) {
         // If ReadNode was successful, it is reasonable to update the cache with
         // the value that has just been read.
-        NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRequest{
+        NodeUpdates.emplace_back(IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId,
             .Row = {.CommitId = node->MinCommitId, .Node = node->Attrs}});
     }
@@ -2178,7 +2178,7 @@ bool TIndexTabletDatabaseProxy::ReadNodes(
         // If ReadNodes was successful, it is reasonable to update the cache
         // with the values that have just been read.
         for (const auto& node: nodes) {
-            NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRequest{
+            NodeUpdates.emplace_back(IInMemoryIndexState::TWriteNodeRequest{
                 .NodeId = node.NodeId,
                 .Row = {.CommitId = node.MinCommitId, .Node = node.Attrs}});
         }
@@ -2192,7 +2192,7 @@ void TIndexTabletDatabaseProxy::WriteNode(
     const NProto::TNode& attrs)
 {
     TIndexTabletDatabase::WriteNode(nodeId, commitId, attrs);
-    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRequest{
+    NodeUpdates.emplace_back(IInMemoryIndexState::TWriteNodeRequest{
         .NodeId = nodeId,
         .Row = {.CommitId = commitId, .Node = attrs}});
 }
@@ -2201,7 +2201,7 @@ void TIndexTabletDatabaseProxy::DeleteNode(ui64 nodeId)
 {
     TIndexTabletDatabase::DeleteNode(nodeId);
     NodeUpdates.emplace_back(
-        TInMemoryIndexState::TDeleteNodeRequest{.NodeId = nodeId});
+        IInMemoryIndexState::TDeleteNodeRequest{.NodeId = nodeId});
 }
 
 void TIndexTabletDatabaseProxy::WriteNodeVer(
@@ -2231,7 +2231,7 @@ bool TIndexTabletDatabaseProxy::ReadNodeAttr(
     if (result && attr) {
         // If ReadNodeAttr  was successful, it is reasonable to update the cache
         // with the value that has just been read.
-        NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeAttrsRequest{
+        NodeUpdates.emplace_back(IInMemoryIndexState::TWriteNodeAttrsRequest{
             .NodeAttrsKey = {nodeId, name},
             .NodeAttrsRow = {
                 .CommitId = attr->MinCommitId,
@@ -2249,7 +2249,7 @@ void TIndexTabletDatabaseProxy::WriteNodeAttr(
     ui64 version)
 {
     TIndexTabletDatabase::WriteNodeAttr(nodeId, commitId, name, value, version);
-    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeAttrsRequest{
+    NodeUpdates.emplace_back(IInMemoryIndexState::TWriteNodeAttrsRequest{
         .NodeAttrsKey = {nodeId, name},
         .NodeAttrsRow =
             {.CommitId = commitId, .Value = value, .Version = version}});
@@ -2259,7 +2259,7 @@ void TIndexTabletDatabaseProxy::DeleteNodeAttr(ui64 nodeId, const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeAttr(nodeId, name);
     NodeUpdates.emplace_back(
-        TInMemoryIndexState::TDeleteNodeAttrsRequest{nodeId, name});
+        IInMemoryIndexState::TDeleteNodeAttrsRequest{nodeId, name});
 }
 
 void TIndexTabletDatabaseProxy::WriteNodeAttrVer(
@@ -2347,7 +2347,7 @@ bool TIndexTabletDatabaseProxy::ReadNodeRefs(
         // 2. All refs.size() fit into the underlying cache
         if (next && next->empty() && cookie.empty() && *skippedRefs == 0) {
             NodeUpdates.emplace_back(
-                TInMemoryIndexState::TMarkNodeRefsAsCachedRequest{
+                IInMemoryIndexState::TMarkNodeRefsAsCachedRequest{
                     .NodeId = nodeId,
                     .RefsSize = refs.size()});
         }
@@ -2397,7 +2397,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
         shardId,
         shardNodeName,
         markExhaustive);
-    NodeUpdates.emplace_back(TInMemoryIndexState::TWriteNodeRefsRequest{
+    NodeUpdates.emplace_back(IInMemoryIndexState::TWriteNodeRefsRequest{
         .NodeRefsKey = {nodeId, name},
         .NodeRefsRow = {
             .CommitId = commitId,
@@ -2406,7 +2406,7 @@ void TIndexTabletDatabaseProxy::WriteNodeRef(
             .ShardNodeName = shardNodeName}});
     if (markExhaustive) {
         NodeUpdates.emplace_back(
-            TInMemoryIndexState::TMarkNodeRefsAsCachedRequest{
+            IInMemoryIndexState::TMarkNodeRefsAsCachedRequest{
                 .NodeId = childNode,
                 .RefsSize = 0});
     }
@@ -2416,7 +2416,7 @@ void TIndexTabletDatabaseProxy::DeleteNodeRef(ui64 nodeId, const TString& name)
 {
     TIndexTabletDatabase::DeleteNodeRef(nodeId, name);
     NodeUpdates.emplace_back(
-        TInMemoryIndexState::TDeleteNodeRefsRequest{nodeId, name});
+        IInMemoryIndexState::TDeleteNodeRefsRequest{nodeId, name});
 }
 
 void TIndexTabletDatabaseProxy::WriteNodeRefVer(
@@ -2448,10 +2448,10 @@ void TIndexTabletDatabaseProxy::DeleteNodeRefVer(
     // TODO(#1146): _Ver tables not yet supported
 }
 
-TInMemoryIndexState::TWriteNodeRefsRequest
+IInMemoryIndexState::TWriteNodeRefsRequest
 TIndexTabletDatabaseProxy::ExtractWriteNodeRefsFromNodeRef(const TNodeRef& ref)
 {
-    return TInMemoryIndexState::TWriteNodeRefsRequest{
+    return IInMemoryIndexState::TWriteNodeRefsRequest{
         .NodeRefsKey = {ref.NodeId, ref.Name},
         .NodeRefsRow = {
             .CommitId = ref.MinCommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -107,11 +107,11 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 commitId,
         const NProto::TNode& attrs);
     virtual void DeleteNode(ui64 nodeId);
-    virtual bool ReadNode(
+    bool ReadNode(
         ui64 nodeId,
         ui64 commitId,
         TMaybe<TNode>& node) override;
-    virtual bool ReadNodes(
+    bool ReadNodes(
         ui64 startNodeId,
         ui64 maxNodes,
         ui64& nextNodeId,
@@ -129,7 +129,7 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 
     virtual void DeleteNodeVer(ui64 nodeId, ui64 commitId);
 
-    virtual bool ReadNodeVer(
+    bool ReadNodeVer(
         ui64 nodeId,
         ui64 commitId,
         TMaybe<TNode>& node) override;
@@ -147,13 +147,13 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 
     virtual void DeleteNodeAttr(ui64 nodeId, const TString& name);
 
-    virtual bool ReadNodeAttr(
+    bool ReadNodeAttr(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<TNodeAttr>& attr) override;
 
-    virtual bool ReadNodeAttrs(
+    bool ReadNodeAttrs(
         ui64 nodeId,
         ui64 commitId,
         TVector<TNodeAttr>& attrs) override;
@@ -175,13 +175,13 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
         ui64 commitId,
         const TString& name);
 
-    virtual bool ReadNodeAttrVer(
+    bool ReadNodeAttrVer(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<TNodeAttr>& attr) override;
 
-    virtual bool ReadNodeAttrVers(
+    bool ReadNodeAttrVers(
         ui64 nodeId,
         ui64 commitId,
         TVector<TNodeAttr>& attrs) override;
@@ -201,13 +201,13 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 
     virtual void DeleteNodeRef(ui64 nodeId, const TString& name);
 
-    virtual bool ReadNodeRef(
+    bool ReadNodeRef(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<TNodeRef>& ref) override;
 
-    virtual bool ReadNodeRefs(
+    bool ReadNodeRefs(
         ui64 nodeId,
         ui64 commitId,
         const TString& cookie,
@@ -231,8 +231,7 @@ private:
         NProto::EListNodesSizeMode sizeMode);
 
 public:
-
-    virtual bool ReadNodeRefs(
+    bool ReadNodeRefs(
         ui64 startNodeId,
         const TString& startCookie,
         ui64 maxCount,
@@ -240,7 +239,7 @@ public:
         ui64& nextNodeId,
         TString& nextCookie) override;
 
-    virtual bool PrechargeNodeRefs(
+    bool PrechargeNodeRefs(
         ui64 nodeId,
         const TString& cookie,
         ui64 rowsToPrecharge,
@@ -264,13 +263,13 @@ public:
         ui64 commitId,
         const TString& name);
 
-    virtual bool ReadNodeRefVer(
+    bool ReadNodeRefVer(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         TMaybe<TNodeRef>& ref) override;
 
-    virtual bool ReadNodeRefVers(
+    bool ReadNodeRefVers(
         ui64 nodeId,
         ui64 commitId,
         TVector<TNodeRef>& refs) override;
@@ -593,7 +592,7 @@ class TIndexTabletDatabaseProxy: public TIndexTabletDatabase
 public:
     TIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
-        TVector<TInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
+        TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
 
     //
     // Nodes
@@ -724,9 +723,9 @@ public:
         const TString& name) override;
 
 private:
-    TVector<TInMemoryIndexState::TIndexStateRequest>& NodeUpdates;
+    TVector<IInMemoryIndexState::TIndexStateRequest>& NodeUpdates;
 
-    static TInMemoryIndexState::TWriteNodeRefsRequest
+    static IInMemoryIndexState::TWriteNodeRefsRequest
     ExtractWriteNodeRefsFromNodeRef(const TNodeRef& ref);
 };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -84,7 +84,9 @@ TIndexTabletState::~TIndexTabletState() = default;
 void TIndexTabletState::UpdateLogTag(TString tag)
 {
     Impl->FreshBytes.UpdateLogTag(tag);
-    Impl->InMemoryIndexState.UpdateLogTag(tag);
+    if (Impl->InMemoryIndexState) {
+        Impl->InMemoryIndexState->UpdateLogTag(tag);
+    }
     LogTag = std::move(tag);
 }
 
@@ -188,7 +190,11 @@ void TIndexTabletState::LoadState(
         config.GetReadAheadCacheRangeSize(),
         config.GetReadAheadMaxGapPercentage(),
         config.GetReadAheadCacheMaxHandlesPerNode());
-    Impl->InMemoryIndexState.Reset(
+
+    Impl->InMemoryIndexState = std::make_unique<TStandardInMemoryIndexState>(
+        AllocatorRegistry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache));
+    Impl->InMemoryIndexState->UpdateLogTag(LogTag);
+    Impl->InMemoryIndexState->Reset(
         CalculateInMemoryIndexCacheCapacity(
             config.GetInMemoryIndexCacheNodesCapacity(),
             GetNodesCount(),

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -192,9 +192,7 @@ void TIndexTabletState::LoadState(
         config.GetReadAheadCacheMaxHandlesPerNode());
 
     Impl->InMemoryIndexState = std::make_unique<TStandardInMemoryIndexState>(
-        AllocatorRegistry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache));
-    Impl->InMemoryIndexState->UpdateLogTag(LogTag);
-    Impl->InMemoryIndexState->Reset(
+        AllocatorRegistry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache),
         CalculateInMemoryIndexCacheCapacity(
             config.GetInMemoryIndexCacheNodesCapacity(),
             GetNodesCount(),
@@ -208,6 +206,8 @@ void TIndexTabletState::LoadState(
             GetNodesCount(),
             config.GetInMemoryIndexCacheNodesToNodeRefsCapacityRatio()),
         config.GetInMemoryIndexCacheNodeRefsExhaustivenessCapacity());
+    Impl->InMemoryIndexState->UpdateLogTag(LogTag);
+
     Impl->MixedBlocks.Reset(config.GetMixedBlocksOffloadedRangesCapacity());
 
     for (const auto& deletionMarker: largeDeletionMarkers) {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1552,7 +1552,7 @@ public:
 
     IIndexTabletDatabase& AccessInMemoryIndexState();
     void UpdateInMemoryIndexState(
-        TVector<TInMemoryIndexState::TIndexStateRequest> nodeUpdates);
+        const TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
     void MarkNodeRefsLoadComplete();
     void MarkNodeRefsExhaustive(ui64 nodeId);
     TInMemoryIndexStateStats GetInMemoryIndexStateStats() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1550,7 +1550,7 @@ public:
     // In-memory index state.
     //
 
-    IIndexTabletDatabase& AccessInMemoryIndexState();
+    IIndexTabletDatabase* AccessInMemoryIndexState();
     void UpdateInMemoryIndexState(
         const TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
     void MarkNodeRefsLoadComplete();

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -392,7 +392,7 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRefs(
     ui32 skipped = 0;
     const TNodeRefsKey* key = nullptr;
     const TNodeRefsRow* value = nullptr;
-    while (it.Next(&key, &value) && key->NodeId == nodeId) {
+    while (it.Get(&key, &value) && key->NodeId == nodeId) {
         NodeRefs.TouchKey(*key);
 
         ui64 minCommitId = value->CommitId;
@@ -419,12 +419,14 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRefs(
             ++skipped;
         }
 
+        ++it;
+
         if (maxBytes && bytes >= maxBytes) {
             break;
         }
     }
 
-    if (next && it.Next(&key, &value) && key->NodeId == nodeId) {
+    if (next && it.Get(&key, &value) && key->NodeId == nodeId) {
         *next = key->Name;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -331,7 +331,7 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRef(
     const TString& name,
     TMaybe<TNodeRef>& ref)
 {
-    auto* v = NodeRefs.FindInIndex(TNodeRefsKey(nodeId, name));
+    auto* v = NodeRefs.Find(TNodeRefsKey(nodeId, name));
     if (!v) {
         // If the cache is exhaustive for the node and we did not find the
         // entry, then we are sure that the entry does not exist and we can
@@ -465,7 +465,7 @@ void TInMemoryIndexState<TNodeRefsImpl>::WriteNodeRef(
     const TString& shardNodeName)
 {
     const auto key = TNodeRefsKey(nodeId, name);
-    auto* v = NodeRefs.FindInIndex(key);
+    auto* v = NodeRefs.Find(key);
     TNodeRefsRow value{
         .CommitId = commitId,
         .ChildId = childNode,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -8,13 +8,15 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TInMemoryIndexState::TInMemoryIndexState(IAllocator* allocator)
+template <typename TNodeRefsImpl>
+TInMemoryIndexState<TNodeRefsImpl>::TInMemoryIndexState(IAllocator* allocator)
     : Nodes(0)
     , NodeAttrs(0)
     , NodeRefs(allocator)
 {}
 
-void TInMemoryIndexState::Reset(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::Reset(
     ui64 nodesCapacity,
     ui64 nodeAttrsCapacity,
     ui64 nodeRefsCapacity,
@@ -28,7 +30,9 @@ void TInMemoryIndexState::Reset(
     }
 }
 
-void TInMemoryIndexState::LoadNodeRefs(const TVector<TNodeRef>& nodeRefs)
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::LoadNodeRefs(
+    const TVector<TNodeRef>& nodeRefs)
 {
     for (const auto& nodeRef: nodeRefs) {
         WriteNodeRef(
@@ -41,27 +45,31 @@ void TInMemoryIndexState::LoadNodeRefs(const TVector<TNodeRef>& nodeRefs)
     }
 }
 
-void TInMemoryIndexState::MarkNodeRefsLoadComplete()
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::MarkNodeRefsLoadComplete()
 {
     NodeRefsExhaustivenessInfo.MarkNodeRefsLoadComplete();
 }
 
-void TInMemoryIndexState::MarkNodeRefsExhaustive(ui64 nodeId)
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::MarkNodeRefsExhaustive(ui64 nodeId)
 {
     NodeRefsExhaustivenessInfo.MarkNodeRefsExhaustive(nodeId);
 }
 
-void TInMemoryIndexState::UpdateLogTag(TString logTag)
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::UpdateLogTag(TString logTag)
 {
     LogTag = std::move(logTag);
 }
 
-TInMemoryIndexStateStats TInMemoryIndexState::GetStats() const
+template <typename TNodeRefsImpl>
+TInMemoryIndexStateStats TInMemoryIndexState<TNodeRefsImpl>::GetStats() const
 {
     return TInMemoryIndexStateStats{
         .NodesCount = Nodes.Size(),
         .NodesCapacity = Nodes.GetMaxSize(),
-        .NodeRefsCount = NodeRefs.size(),
+        .NodeRefsCount = NodeRefs.Size(),
         .NodeRefsCapacity = NodeRefs.GetMaxSize(),
         .NodeAttrsCount = NodeAttrs.Size(),
         .NodeAttrsCapacity = NodeAttrs.GetMaxSize(),
@@ -71,14 +79,16 @@ TInMemoryIndexStateStats TInMemoryIndexState::GetStats() const
         .IsNodeRefsExhaustive = NodeRefsExhaustivenessInfo.IsExhaustive()};
 }
 
-void TInMemoryIndexState::ActivateInMemoryIndexStateBypass(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::ActivateInMemoryIndexStateBypass(
     ui64 nodeId,
     ui64 commitId)
 {
     CacheBypassCommitIdsByNodeId[nodeId].push_back(commitId);
 }
 
-void TInMemoryIndexState::DeactivateInMemoryIndexStateBypass(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::DeactivateInMemoryIndexStateBypass(
     ui64 nodeId,
     ui64 commitId)
 {
@@ -101,13 +111,15 @@ void TInMemoryIndexState::DeactivateInMemoryIndexStateBypass(
     }
 }
 
-void TInMemoryIndexState::SetUnconfirmedRecoveryReady(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::SetUnconfirmedRecoveryReady(
     bool unconfirmedRecoveryReady)
 {
     UnconfirmedRecoveryReady = unconfirmedRecoveryReady;
 }
 
-bool TInMemoryIndexState::ShouldBypassCacheRead(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ShouldBypassCacheRead(
     ui64 nodeId,
     ui64 commitId) const
 {
@@ -140,7 +152,8 @@ bool TInMemoryIndexState::ShouldBypassCacheRead(
 // Nodes
 //
 
-bool TInMemoryIndexState::ReadNode(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNode(
     ui64 nodeId,
     ui64 commitId,
     TMaybe<TNode>& node)
@@ -168,7 +181,8 @@ bool TInMemoryIndexState::ReadNode(
     return true;
 }
 
-bool TInMemoryIndexState::ReadNodes(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodes(
     ui64 startNodeId,
     ui64 maxNodes,
     ui64& nextNodeId,
@@ -180,7 +194,8 @@ bool TInMemoryIndexState::ReadNodes(
     return false;
 }
 
-void TInMemoryIndexState::WriteNode(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::WriteNode(
     ui64 nodeId,
     ui64 commitId,
     const NProto::TNode& attrs)
@@ -188,7 +203,8 @@ void TInMemoryIndexState::WriteNode(
     Nodes.Update(nodeId, TNodeRow{.CommitId = commitId, .Node = attrs});
 }
 
-void TInMemoryIndexState::DeleteNode(ui64 nodeId)
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::DeleteNode(ui64 nodeId)
 {
     auto it = Nodes.Find(nodeId);
     if (it != Nodes.End()) {
@@ -200,7 +216,8 @@ void TInMemoryIndexState::DeleteNode(ui64 nodeId)
 // Nodes_Ver
 //
 
-bool TInMemoryIndexState::ReadNodeVer(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeVer(
     ui64 nodeId,
     ui64 commitId,
     TMaybe<TNode>& node)
@@ -214,7 +231,8 @@ bool TInMemoryIndexState::ReadNodeVer(
 // NodeAttrs
 //
 
-bool TInMemoryIndexState::ReadNodeAttr(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeAttr(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -248,7 +266,8 @@ bool TInMemoryIndexState::ReadNodeAttr(
     return true;
 }
 
-bool TInMemoryIndexState::ReadNodeAttrs(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeAttrs(
     ui64 nodeId,
     ui64 commitId,
     TVector<TNodeAttr>& attrs)
@@ -259,7 +278,8 @@ bool TInMemoryIndexState::ReadNodeAttrs(
     return false;
 }
 
-void TInMemoryIndexState::WriteNodeAttr(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::WriteNodeAttr(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -270,7 +290,10 @@ void TInMemoryIndexState::WriteNodeAttr(
     NodeAttrs.Update(key, TNodeAttrsRow{.CommitId = commitId, .Value = value, .Version = version});
 }
 
-void TInMemoryIndexState::DeleteNodeAttr(ui64 nodeId, const TString& name)
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::DeleteNodeAttr(
+    ui64 nodeId,
+    const TString& name)
 {
     auto it = NodeAttrs.Find(TNodeAttrsKey(nodeId, name));
     if (it != NodeAttrs.End()) {
@@ -282,7 +305,8 @@ void TInMemoryIndexState::DeleteNodeAttr(ui64 nodeId, const TString& name)
 // NodeAttrs_Ver
 //
 
-bool TInMemoryIndexState::ReadNodeAttrVer(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeAttrVer(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -293,7 +317,8 @@ bool TInMemoryIndexState::ReadNodeAttrVer(
     return false;
 }
 
-bool TInMemoryIndexState::ReadNodeAttrVers(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeAttrVers(
     ui64 nodeId,
     ui64 commitId,
     TVector<TNodeAttr>& attrs)
@@ -308,7 +333,8 @@ bool TInMemoryIndexState::ReadNodeAttrVers(
 // NodeRefs
 //
 
-bool TInMemoryIndexState::ReadNodeRef(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRef(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -343,7 +369,8 @@ bool TInMemoryIndexState::ReadNodeRef(
     return true;
 }
 
-bool TInMemoryIndexState::ReadNodeRefs(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRefs(
     ui64 nodeId,
     ui64 commitId,
     const TString& cookie,
@@ -359,23 +386,25 @@ bool TInMemoryIndexState::ReadNodeRefs(
         return false;
     }
 
-    auto it = NodeRefs.lower_bound(TNodeRefsKey(nodeId, cookie));
+    auto it = NodeRefs.LowerBound(TNodeRefsKey(nodeId, cookie));
 
     ui32 bytes = 0;
     ui32 skipped = 0;
-    while (it != NodeRefs.end() && it->first.NodeId == nodeId) {
-        NodeRefs.TouchKey(it->first);
+    const TNodeRefsKey* key = nullptr;
+    const TNodeRefsRow* value = nullptr;
+    while (it.Next(&key, &value) && key->NodeId == nodeId) {
+        NodeRefs.TouchKey(*key);
 
-        ui64 minCommitId = it->second.CommitId;
+        ui64 minCommitId = value->CommitId;
         ui64 maxCommitId = InvalidCommitId;
 
         if (VisibleCommitId(commitId, minCommitId, maxCommitId)) {
             refs.emplace_back(TNodeRef{
                 nodeId,
-                it->first.Name,
-                it->second.ChildId,
-                it->second.ShardId,
-                it->second.ShardNodeName,
+                key->Name,
+                value->ChildId,
+                value->ShardId,
+                value->ShardNodeName,
                 minCommitId,
                 maxCommitId});
 
@@ -390,15 +419,13 @@ bool TInMemoryIndexState::ReadNodeRefs(
             ++skipped;
         }
 
-        ++it;
-
         if (maxBytes && bytes >= maxBytes) {
             break;
         }
     }
 
-    if (next && it != NodeRefs.end() && it->first.NodeId == nodeId) {
-        *next = it->first.Name;
+    if (next && it.Next(&key, &value) && key->NodeId == nodeId) {
+        *next = key->Name;
     }
 
     if (skippedRefs) {
@@ -408,7 +435,8 @@ bool TInMemoryIndexState::ReadNodeRefs(
     return true;
 }
 
-bool TInMemoryIndexState::ReadNodeRefs(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRefs(
     ui64 startNodeId,
     const TString& startCookie,
     ui64 maxCount,
@@ -423,7 +451,8 @@ bool TInMemoryIndexState::ReadNodeRefs(
     return false;
 }
 
-bool TInMemoryIndexState::PrechargeNodeRefs(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::PrechargeNodeRefs(
     ui64 nodeId,
     const TString& cookie,
     ui64 rowsToPrecharge,
@@ -433,7 +462,8 @@ bool TInMemoryIndexState::PrechargeNodeRefs(
     return true;
 }
 
-void TInMemoryIndexState::WriteNodeRef(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::WriteNodeRef(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -450,7 +480,7 @@ void TInMemoryIndexState::WriteNodeRef(
         .ShardNodeName = shardNodeName};
 
     if (!v) {
-        const auto [_, inserted, evicted] = NodeRefs.emplace(key, std::move(value));
+        const auto evicted = NodeRefs.Put(key, std::move(value));
         if (evicted) {
             NodeRefsExhaustivenessInfo.NodeRefsEvictionObserved(
                 evicted->NodeId);
@@ -460,16 +490,20 @@ void TInMemoryIndexState::WriteNodeRef(
     }
 }
 
-void TInMemoryIndexState::DeleteNodeRef(ui64 nodeId, const TString& name)
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::DeleteNodeRef(
+    ui64 nodeId,
+    const TString& name)
 {
-    NodeRefs.erase(TNodeRefsKey(nodeId, name));
+    NodeRefs.Erase(TNodeRefsKey(nodeId, name));
 }
 
 //
 // NodeRefs_Ver
 //
 
-bool TInMemoryIndexState::ReadNodeRefVer(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRefVer(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -480,7 +514,8 @@ bool TInMemoryIndexState::ReadNodeRefVer(
     return false;
 }
 
-bool TInMemoryIndexState::ReadNodeRefVers(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRefVers(
     ui64 nodeId,
     ui64 commitId,
     TVector<TNodeRef>& refs)
@@ -495,7 +530,8 @@ bool TInMemoryIndexState::ReadNodeRefVers(
 // CheckpointNodes
 //
 
-bool TInMemoryIndexState::ReadCheckpointNodes(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadCheckpointNodes(
     ui64 checkpointId,
     TVector<ui64>& nodes,
     size_t maxCount)
@@ -510,7 +546,8 @@ bool TInMemoryIndexState::ReadCheckpointNodes(
 // MixedIndex
 //
 
-bool TInMemoryIndexState::ReadMixedBlocks(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadMixedBlocks(
     ui32 rangeId,
     TVector<IIndexTabletDatabase::TMixedBlob>& blobs,
     IAllocator* alloc)
@@ -519,7 +556,8 @@ bool TInMemoryIndexState::ReadMixedBlocks(
     return false;
 }
 
-bool TInMemoryIndexState::ReadDeletionMarkers(
+template <typename TNodeRefsImpl>
+bool TInMemoryIndexState<TNodeRefsImpl>::ReadDeletionMarkers(
     ui32 rangeId,
     TVector<TDeletionMarker>& deletionMarkers)
 {
@@ -529,7 +567,8 @@ bool TInMemoryIndexState::ReadDeletionMarkers(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TInMemoryIndexState::UpdateState(
+template <typename TNodeRefsImpl>
+void TInMemoryIndexState<TNodeRefsImpl>::UpdateState(
     const TVector<TIndexStateRequest>& nodeUpdates)
 {
     for (const auto& update: nodeUpdates) {
@@ -573,7 +612,7 @@ void TInMemoryIndexState::UpdateState(
             const auto* request =
                 std::get_if<TMarkNodeRefsAsCachedRequest>(&update))
         {
-            if (NodeRefs.size() >= request->RefsSize) {
+            if (NodeRefs.Size() >= request->RefsSize) {
                 NodeRefsExhaustivenessInfo.MarkNodeRefsExhaustive(
                     request->NodeId);
             }
@@ -582,5 +621,7 @@ void TInMemoryIndexState::UpdateState(
         }
     }
 }
+
+template class TInMemoryIndexState<TStandardNodeRefsCache>;
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -9,26 +9,17 @@ namespace NCloud::NFileStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TNodeRefsImpl>
-TInMemoryIndexState<TNodeRefsImpl>::TInMemoryIndexState(IAllocator* allocator)
-    : Nodes(0)
-    , NodeAttrs(0)
-    , NodeRefs(allocator)
+TInMemoryIndexState<TNodeRefsImpl>::TInMemoryIndexState(
+        IAllocator* allocator,
+        ui64 nodesCapacity,
+        ui64 nodeAttrsCapacity,
+        ui64 nodeRefsCapacity,
+        ui64 nodeRefsExhaustivenessCapacity)
+    : Nodes(nodesCapacity)
+    , NodeAttrs(nodeAttrsCapacity)
+    , NodeRefs(allocator, nodeRefsCapacity)
+    , NodeRefsExhaustivenessInfo(nodeRefsExhaustivenessCapacity)
 {}
-
-template <typename TNodeRefsImpl>
-void TInMemoryIndexState<TNodeRefsImpl>::Reset(
-    ui64 nodesCapacity,
-    ui64 nodeAttrsCapacity,
-    ui64 nodeRefsCapacity,
-    ui64 nodeRefsExhaustivenessCapacity)
-{
-    Nodes.SetMaxSize(nodesCapacity);
-    NodeAttrs.SetMaxSize(nodeAttrsCapacity);
-    NodeRefsExhaustivenessInfo.SetMaxSize(nodeRefsExhaustivenessCapacity);
-    for (const auto& key: NodeRefs.SetMaxSize(nodeRefsCapacity)) {
-        NodeRefsExhaustivenessInfo.NodeRefsEvictionObserved(key.NodeId);
-    }
-}
 
 template <typename TNodeRefsImpl>
 void TInMemoryIndexState<TNodeRefsImpl>::LoadNodeRefs(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -2,11 +2,12 @@
 
 #include "tablet_state_iface.h"
 
+#include <cloud/filestore/libs/storage/tablet/model/metadata_cache.h>
 #include <cloud/filestore/libs/storage/tablet/tablet_schema.h>
 
-#include <library/cpp/cache/cache.h>
-
 #include <cloud/storage/core/libs/common/lru_cache.h>
+
+#include <library/cpp/cache/cache.h>
 
 #include <util/generic/deque.h>
 #include <util/generic/hash.h>
@@ -30,11 +31,107 @@ struct TInMemoryIndexStateStats
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class IInMemoryIndexState : public IIndexTabletDatabase
+{
+public:
+    virtual void Reset(
+        ui64 nodesCapacity,
+        ui64 nodeAttrsCapacity,
+        ui64 nodeRefsCapacity,
+        ui64 nodeRefsExhaustivenessCapacity) = 0;
+
+    virtual void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs) = 0;
+
+    virtual void MarkNodeRefsLoadComplete() = 0;
+
+    virtual void MarkNodeRefsExhaustive(ui64 nodeId) = 0;
+
+    [[nodiscard]] virtual TInMemoryIndexStateStats GetStats() const = 0;
+
+    virtual void UpdateLogTag(TString logTag) = 0;
+
+    //
+    // Cache bypass
+    //
+
+    virtual void ActivateInMemoryIndexStateBypass(
+        ui64 nodeId,
+        ui64 commitId) = 0;
+
+    virtual void DeactivateInMemoryIndexStateBypass(
+        ui64 nodeId,
+        ui64 commitId) = 0;
+
+    virtual void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady) = 0;
+
+    //
+    // Nodes
+    //
+
+    struct TNodeRow
+    {
+        ui64 CommitId = 0;
+        NProto::TNode Node;
+    };
+
+    struct TWriteNodeRequest
+    {
+        ui64 NodeId = 0;
+        TNodeRow Row;
+    };
+
+    struct TDeleteNodeRequest
+    {
+        ui64 NodeId = 0;
+    };
+
+    struct TWriteNodeAttrsRequest
+    {
+        TNodeAttrsKey NodeAttrsKey;
+        TNodeAttrsRow NodeAttrsRow;
+    };
+
+    using TDeleteNodeAttrsRequest = TNodeAttrsKey;
+
+    struct TWriteNodeRefsRequest
+    {
+        TNodeRefsKey NodeRefsKey;
+        TNodeRefsRow NodeRefsRow;
+    };
+
+    using TDeleteNodeRefsRequest = TNodeRefsKey;
+
+    // This request can be interpreted as follow: "last RefsSize added refs were
+    // children of the NodeId and present the entirety of its children", thus if
+    // we see such request, we can mark the NodeRefs cache as exhaustive for
+    // this particular NodeId
+    struct TMarkNodeRefsAsCachedRequest
+    {
+        ui64 NodeId;
+        ui64 RefsSize;
+    };
+
+    using TIndexStateRequest = std::variant<
+        TWriteNodeRequest,
+        TDeleteNodeRequest,
+        TWriteNodeAttrsRequest,
+        TDeleteNodeAttrsRequest,
+        TWriteNodeRefsRequest,
+        TDeleteNodeRefsRequest,
+        TMarkNodeRefsAsCachedRequest>;
+
+    virtual void UpdateState(
+        const TVector<TIndexStateRequest>& nodeUpdates) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 /**
  * @brief Stores the state of the index tables in memory. Can be used to perform
  * read-only operations.
  */
-class TInMemoryIndexState : public IIndexTabletDatabase
+template <typename TNodeRefsImpl>
+class TInMemoryIndexState : public IInMemoryIndexState
 {
 public:
     explicit TInMemoryIndexState(IAllocator* allocator);
@@ -43,17 +140,17 @@ public:
         ui64 nodesCapacity,
         ui64 nodeAttrsCapacity,
         ui64 nodeRefsCapacity,
-        ui64 nodeRefsExhaustivenessCapacity);
+        ui64 nodeRefsExhaustivenessCapacity) override;
 
-    void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs);
+    void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs) override;
 
-    void MarkNodeRefsLoadComplete();
+    void MarkNodeRefsLoadComplete() override;
 
-    void MarkNodeRefsExhaustive(ui64 nodeId);
+    void MarkNodeRefsExhaustive(ui64 nodeId) override;
 
-    [[nodiscard]] TInMemoryIndexStateStats GetStats() const;
+    [[nodiscard]] TInMemoryIndexStateStats GetStats() const override;
 
-    void UpdateLogTag(TString logTag);
+    void UpdateLogTag(TString logTag) override;
 
 private:
     TString LogTag;
@@ -63,11 +160,13 @@ private:
     //
 
 public:
-    void ActivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
+    void ActivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId) override;
 
-    void DeactivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
+    void DeactivateInMemoryIndexStateBypass(
+        ui64 nodeId,
+        ui64 commitId) override;
 
-    void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady);
+    void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady) override;
 
 private:
     bool ShouldBypassCacheRead(ui64 nodeId, ui64 commitId) const;
@@ -240,95 +339,20 @@ private:
     // Nodes
     //
 
-    struct TNodeRow
-    {
-        ui64 CommitId = 0;
-        NProto::TNode Node;
-    };
-
     ::TLRUCache<ui64, TNodeRow> Nodes;
 
     //
     // NodeAttrs
     //
 
-public:
-    struct TNodeAttrsKey
-    {
-        TNodeAttrsKey(ui64 nodeId, const TString& name)
-            : NodeId(nodeId)
-            , Name(name)
-        {}
-
-        ui64 NodeId = 0;
-        TString Name;
-
-        bool operator==(const TNodeAttrsKey& rhs) const
-        {
-            return std::tie(NodeId, Name) == std::tie(rhs.NodeId, rhs.Name);
-        }
-    };
-
 private:
-    struct TNodeAttrsRow
-    {
-        ui64 CommitId = 0;
-        TString Value;
-        ui64 Version = 0;
-    };
-
     ::TLRUCache<TNodeAttrsKey, TNodeAttrsRow> NodeAttrs;
 
     //
     // NodeRefs
     //
 
-    struct TNodeRefsKey
-    {
-        TNodeRefsKey(ui64 nodeId, const TString& name)
-            : NodeId(nodeId)
-            , Name(name)
-        {}
-
-        ui64 NodeId = 0;
-        TString Name;
-
-        bool operator<(const TNodeRefsKey& rhs) const
-        {
-            return std::tie(NodeId, Name) < std::tie(rhs.NodeId, rhs.Name);
-        }
-
-        bool operator==(const TNodeRefsKey& rhs) const
-        {
-            return std::tie(NodeId, Name) == std::tie(rhs.NodeId, rhs.Name);
-        }
-    };
-
-    struct TNodeRefsKeyHash
-    {
-        size_t operator()(
-            const NCloud::NFileStore::NStorage::TInMemoryIndexState::TNodeRefsKey&
-                key) const
-        {
-            return MultiHash(key.NodeId, key.Name);
-        }
-    };
-
-    struct TNodeRefsRow
-    {
-        ui64 CommitId = 0;
-        ui64 ChildId = 0;
-        TString ShardId;
-        TString ShardNodeName;
-    };
-
-    NCloud::TLRUCache<
-        TNodeRefsKey,
-        TNodeRefsRow,
-        true /* UseIndexLookup */,
-        TNodeRefsKeyHash,
-        TMap<TNodeRefsKey, TNodeRefsRow, TLess<TNodeRefsKey>, TStlAllocator>>
-        NodeRefs;
+    TNodeRefsImpl NodeRefs;
 
     struct TNodeRefsExhaustivenessInfo
     {
@@ -405,66 +429,11 @@ private:
     } NodeRefsExhaustivenessInfo;
 
 public:
-    struct TWriteNodeRequest
-    {
-        ui64 NodeId = 0;
-        TNodeRow Row;
-    };
-
-    struct TDeleteNodeRequest
-    {
-        ui64 NodeId = 0;
-    };
-
-    struct TWriteNodeAttrsRequest
-    {
-        TNodeAttrsKey NodeAttrsKey;
-        TNodeAttrsRow NodeAttrsRow;
-    };
-
-    using TDeleteNodeAttrsRequest = TNodeAttrsKey;
-
-    struct TWriteNodeRefsRequest
-    {
-        TNodeRefsKey NodeRefsKey;
-        TNodeRefsRow NodeRefsRow;
-    };
-
-    using TDeleteNodeRefsRequest = TNodeRefsKey;
-
-    // This request can be interpreted as follow: "last RefsSize added refs were
-    // children of the NodeId and present the entirety of its children", thus if
-    // we see such request, we can mark the NodeRefs cache as exhaustive for
-    // this particular NodeId
-    struct TMarkNodeRefsAsCachedRequest
-    {
-        ui64 NodeId;
-        ui64 RefsSize;
-    };
-
-    using TIndexStateRequest = std::variant<
-        TWriteNodeRequest,
-        TDeleteNodeRequest,
-        TWriteNodeAttrsRequest,
-        TDeleteNodeAttrsRequest,
-        TWriteNodeRefsRequest,
-        TDeleteNodeRefsRequest,
-        TMarkNodeRefsAsCachedRequest>;
-
-    void UpdateState(const TVector<TIndexStateRequest>& nodeUpdates);
+    void UpdateState(const TVector<TIndexStateRequest>& nodeUpdates) override;
 };
-
-}   // namespace NCloud::NFileStore::NStorage
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <>
-struct THash<NCloud::NFileStore::NStorage::TInMemoryIndexState::TNodeAttrsKey>
-{
-    inline size_t operator()(
-        const NCloud::NFileStore::NStorage::TInMemoryIndexState::TNodeAttrsKey&
-            key) const
-    {
-        return MultiHash(key.NodeId, key.Name);
-    }
-};
+using TStandardInMemoryIndexState = TInMemoryIndexState<TStandardNodeRefsCache>;
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -34,12 +34,6 @@ struct TInMemoryIndexStateStats
 class IInMemoryIndexState : public IIndexTabletDatabase
 {
 public:
-    virtual void Reset(
-        ui64 nodesCapacity,
-        ui64 nodeAttrsCapacity,
-        ui64 nodeRefsCapacity,
-        ui64 nodeRefsExhaustivenessCapacity) = 0;
-
     virtual void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs) = 0;
 
     virtual void MarkNodeRefsLoadComplete() = 0;
@@ -134,13 +128,12 @@ template <typename TNodeRefsImpl>
 class TInMemoryIndexState : public IInMemoryIndexState
 {
 public:
-    explicit TInMemoryIndexState(IAllocator* allocator);
-
-    void Reset(
+    TInMemoryIndexState(
+        IAllocator* allocator,
         ui64 nodesCapacity,
         ui64 nodeAttrsCapacity,
         ui64 nodeRefsCapacity,
-        ui64 nodeRefsExhaustivenessCapacity) override;
+        ui64 nodeRefsExhaustivenessCapacity);
 
     void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs) override;
 
@@ -366,14 +359,9 @@ private:
         ::TLRUCache<ui64, bool> IsExhaustivePerNode;
 
     public:
-        TNodeRefsExhaustivenessInfo()
-            : IsExhaustivePerNode(0)
+        explicit TNodeRefsExhaustivenessInfo(size_t size)
+            : IsExhaustivePerNode(size)
         {}
-
-        void SetMaxSize(size_t size)
-        {
-            IsExhaustivePerNode.SetMaxSize(size);
-        }
 
         [[nodiscard]] bool IsExhaustiveForNode(ui64 nodeId)
         {

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -425,7 +425,7 @@ void TIndexTabletState::ActivateInMemoryIndexStateBypass(
     ui64 nodeId,
     ui64 commitId)
 {
-    Impl->InMemoryIndexState.ActivateInMemoryIndexStateBypass(
+    Impl->InMemoryIndexState->ActivateInMemoryIndexStateBypass(
         nodeId,
         commitId);
 }
@@ -434,7 +434,7 @@ void TIndexTabletState::DeactivateInMemoryIndexStateBypass(
     ui64 nodeId,
     ui64 commitId)
 {
-    Impl->InMemoryIndexState.DeactivateInMemoryIndexStateBypass(
+    Impl->InMemoryIndexState->DeactivateInMemoryIndexStateBypass(
         nodeId,
         commitId);
 }
@@ -442,7 +442,7 @@ void TIndexTabletState::DeactivateInMemoryIndexStateBypass(
 void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
 {
     UnconfirmedRecoveryReady = value;
-    Impl->InMemoryIndexState.SetUnconfirmedRecoveryReady(value);
+    Impl->InMemoryIndexState->SetUnconfirmedRecoveryReady(value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -69,7 +69,7 @@ struct TIndexTabletState::TImpl
     TGarbageQueue GarbageQueue;
     TTruncateQueue TruncateQueue;
     TReadAheadCache ReadAheadCache;
-    TInMemoryIndexState InMemoryIndexState;
+    std::unique_ptr<IInMemoryIndexState> InMemoryIndexState;
     TSet<ui64> OrphanNodeIds;
     TSet<TString> PendingNodeCreateInShardNames;
     THashSet<TNodeRefKey, TNodeRefKeyHash> LockedNodeRefs;
@@ -97,8 +97,6 @@ struct TIndexTabletState::TImpl
         , CompactionMap(registry.GetAllocator(EAllocatorTag::CompactionMap))
         , GarbageQueue(registry.GetAllocator(EAllocatorTag::GarbageQueue))
         , ReadAheadCache(registry.GetAllocator(EAllocatorTag::ReadAheadCache))
-        , InMemoryIndexState(
-              registry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache))
         , ThrottlingPolicy(TThrottlerConfig())
     {}
 };

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -612,9 +612,9 @@ void TIndexTabletState::VisitNodeRefLocks(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IIndexTabletDatabase& TIndexTabletState::AccessInMemoryIndexState()
+IIndexTabletDatabase* TIndexTabletState::AccessInMemoryIndexState()
 {
-    return *Impl->InMemoryIndexState;
+    return Impl->InMemoryIndexState.get();
 }
 
 void TIndexTabletState::UpdateInMemoryIndexState(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -614,28 +614,28 @@ void TIndexTabletState::VisitNodeRefLocks(
 
 IIndexTabletDatabase& TIndexTabletState::AccessInMemoryIndexState()
 {
-    return Impl->InMemoryIndexState;
+    return *Impl->InMemoryIndexState;
 }
 
 void TIndexTabletState::UpdateInMemoryIndexState(
-    TVector<TInMemoryIndexState::TIndexStateRequest> nodeUpdates)
+    const TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates)
 {
-    Impl->InMemoryIndexState.UpdateState(nodeUpdates);
+    Impl->InMemoryIndexState->UpdateState(nodeUpdates);
 }
 
 void TIndexTabletState::MarkNodeRefsLoadComplete()
 {
-    Impl->InMemoryIndexState.MarkNodeRefsLoadComplete();
+    Impl->InMemoryIndexState->MarkNodeRefsLoadComplete();
 }
 
 void TIndexTabletState::MarkNodeRefsExhaustive(ui64 nodeId)
 {
-    Impl->InMemoryIndexState.MarkNodeRefsExhaustive(nodeId);
+    Impl->InMemoryIndexState->MarkNodeRefsExhaustive(nodeId);
 }
 
 TInMemoryIndexStateStats TIndexTabletState::GetInMemoryIndexStateStats() const
 {
-    return Impl->InMemoryIndexState.GetStats();
+    return Impl->InMemoryIndexState->GetStats();
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -228,7 +228,7 @@ struct TSessionAware
  */
 struct TIndexStateNodeUpdates
 {
-    TVector<TInMemoryIndexState::TIndexStateRequest> NodeUpdates;
+    TVector<IInMemoryIndexState::TIndexStateRequest> NodeUpdates;
 
     void Clear()
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -23,7 +23,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     //
     Y_UNIT_TEST(ShouldPopulateNodes)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
@@ -32,7 +32,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
         NProto::TNode realNode = nodeAttrs1;
 
-        state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
+        state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
             .Row = {
                 .CommitId = commitId2,
@@ -57,19 +57,19 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldEvictNodes)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
-            {TInMemoryIndexState::TWriteNodeRequest{
+            {IInMemoryIndexState::TWriteNodeRequest{
                  .NodeId = nodeId1,
                  .Row =
                      {
                          .CommitId = commitId1,
                          .Node = nodeAttrs1,
                      }},
-             TInMemoryIndexState::TWriteNodeRequest{
+             IInMemoryIndexState::TWriteNodeRequest{
                  .NodeId = nodeId2,
                  .Row = {
                      .CommitId = commitId1,
@@ -83,11 +83,11 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldDeleteNodes)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
-        state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
+        state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
             .Row = {
                 .CommitId = commitId1,
@@ -99,7 +99,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(node.Defined());
 
         state.UpdateState(
-            {TInMemoryIndexState::TDeleteNodeRequest{.NodeId = nodeId1}});
+            {IInMemoryIndexState::TDeleteNodeRequest{.NodeId = nodeId1}});
 
         node.Clear();
         UNIT_ASSERT(!state.ReadNode(1, commitId1, node));
@@ -108,11 +108,11 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldBypassCacheReads)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
-        state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
+        state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
             .Row = {
                 .CommitId = commitId1,
@@ -162,10 +162,10 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldBypassCacheReadsUntilUnconfirmedWritesComplete)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(1, 0, 0, 0);
 
-        state.UpdateState({TInMemoryIndexState::TWriteNodeRequest{
+        state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
             .Row = {
                 .CommitId = commitId1,
@@ -205,14 +205,14 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     //
     Y_UNIT_TEST(ShouldPopulateNodeAttrs)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 1, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId2, attrName1, attr));
 
-        state.UpdateState({TInMemoryIndexState::TWriteNodeAttrsRequest{
+        state.UpdateState({IInMemoryIndexState::TWriteNodeAttrsRequest{
             .NodeAttrsKey =
                 {
                     nodeId1,
@@ -242,16 +242,16 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldEvictNodeAttrs)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 1, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
-            {TInMemoryIndexState::TWriteNodeAttrsRequest{
+            {IInMemoryIndexState::TWriteNodeAttrsRequest{
                  .NodeAttrsKey = {nodeId1, attrName1},
                  .NodeAttrsRow = {commitId1, attrValue1, attrVersion1},
              },
-             TInMemoryIndexState::TWriteNodeAttrsRequest{
+             IInMemoryIndexState::TWriteNodeAttrsRequest{
                  .NodeAttrsKey = {nodeId2, attrName2},
                  .NodeAttrsRow = {commitId1, attrValue2, attrVersion2},
              }});
@@ -263,11 +263,11 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldDeleteNodeAttrs)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 1, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
-        state.UpdateState({TInMemoryIndexState::TWriteNodeAttrsRequest{
+        state.UpdateState({IInMemoryIndexState::TWriteNodeAttrsRequest{
             .NodeAttrsKey = {nodeId1, attrName1},
             .NodeAttrsRow = {commitId1, attrValue1, attrVersion1},
         }});
@@ -277,7 +277,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(attr.Defined());
 
         state.UpdateState(
-            {TInMemoryIndexState::TDeleteNodeAttrsRequest{nodeId1, attrName1}});
+            {IInMemoryIndexState::TDeleteNodeAttrsRequest{nodeId1, attrName1}});
 
         attr.Clear();
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));
@@ -301,7 +301,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 namespace {
 
     void CheckNodeRef(
-        const TInMemoryIndexState::TWriteNodeRefsRequest& request,
+        const IInMemoryIndexState::TWriteNodeRefsRequest& request,
         IIndexTabletDatabase::TNodeRef& ref)
     {
         UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsKey.NodeId, ref.NodeId);
@@ -316,8 +316,8 @@ namespace {
     }
 
     void ReadAndCheckNodeRef(
-        TInMemoryIndexState& state,
-        const TInMemoryIndexState::TWriteNodeRefsRequest& request)
+        IInMemoryIndexState& state,
+        const IInMemoryIndexState::TWriteNodeRefsRequest& request)
     {
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
         UNIT_ASSERT(state.ReadNodeRef(
@@ -329,8 +329,8 @@ namespace {
     }
 
     void FillStateRequests(
-        TVector<TInMemoryIndexState::TIndexStateRequest>& stateRequests,
-        const TVector<TInMemoryIndexState::TWriteNodeRefsRequest>& requests)
+        TVector<IInMemoryIndexState::TIndexStateRequest>& stateRequests,
+        const TVector<IInMemoryIndexState::TWriteNodeRefsRequest>& requests)
     {
         stateRequests.reserve(requests.size());
         for (const auto& req: requests) {
@@ -345,7 +345,7 @@ namespace {
     //
     Y_UNIT_TEST(ShouldPopulateNodeRefs)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 0, 1, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
@@ -353,7 +353,7 @@ namespace {
         UNIT_ASSERT(
             !state.ReadNodeRef(rootNodeIds[0], commitId1, nodeNames[0], ref));
 
-        TInMemoryIndexState::TWriteNodeRefsRequest request = {
+        IInMemoryIndexState::TWriteNodeRefsRequest request = {
             .NodeRefsKey = {rootNodeIds[0], nodeNames[0]},
             .NodeRefsRow = {
                 .CommitId = commitId2,
@@ -396,11 +396,11 @@ namespace {
 
     Y_UNIT_TEST(ShouldEvictNodeRefs)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 0, 3, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
-        const TVector<TInMemoryIndexState::TWriteNodeRefsRequest> requests = {
+        const TVector<IInMemoryIndexState::TWriteNodeRefsRequest> requests = {
             {
                 .NodeRefsKey = {rootNodeIds[0], nodeNames[0]},
                 .NodeRefsRow = {
@@ -430,7 +430,7 @@ namespace {
             }
         };
 
-        TVector<TInMemoryIndexState::TIndexStateRequest> stateRequests;
+        TVector<IInMemoryIndexState::TIndexStateRequest> stateRequests;
         FillStateRequests(stateRequests, requests);
 
         state.UpdateState(stateRequests);
@@ -460,7 +460,7 @@ namespace {
 
         // here the order should be 2, 1, 0
         // after we add one more ref, 0 should be evicted
-        TInMemoryIndexState::TWriteNodeRefsRequest request3 = {
+        IInMemoryIndexState::TWriteNodeRefsRequest request3 = {
             .NodeRefsKey = {rootNodeIds[3], nodeNames[3]},
             .NodeRefsRow = {
                 .CommitId = commitId1,
@@ -492,7 +492,7 @@ namespace {
             false));
 
         // write a ref with the same key but different value
-        TInMemoryIndexState::TWriteNodeRefsRequest request4 = {
+        IInMemoryIndexState::TWriteNodeRefsRequest request4 = {
             .NodeRefsKey = {rootNodeIds[3], nodeNames[3]},
             .NodeRefsRow = {
                 .CommitId = commitId2,
@@ -508,11 +508,11 @@ namespace {
 
     Y_UNIT_TEST(ShouldDeleteNodeRefs)
     {
-        TInMemoryIndexState state(TDefaultAllocator::Instance());
+        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
         state.Reset(0, 0, 1, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
-        TInMemoryIndexState::TWriteNodeRefsRequest request = {
+        IInMemoryIndexState::TWriteNodeRefsRequest request = {
             .NodeRefsKey = {rootNodeIds[0], nodeNames[0]},
             .NodeRefsRow = {
                 .CommitId = commitId1,
@@ -540,7 +540,7 @@ namespace {
             ref));
         UNIT_ASSERT(ref.Defined());
 
-        state.UpdateState({TInMemoryIndexState::TDeleteNodeRefsRequest{
+        state.UpdateState({IInMemoryIndexState::TDeleteNodeRefsRequest{
             request.NodeRefsKey.NodeId,
             request.NodeRefsKey.Name}});
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -18,13 +18,17 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     const NProto::TNode nodeAttrs1 = CreateRegularAttrs(0666, 1, 2);
     const NProto::TNode nodeAttrs2 = CreateRegularAttrs(0666, 3, 4);
 
+    auto* Alloc()
+    {
+        return TDefaultAllocator::Instance();
+    }
+
     //
     // Nodes
     //
     Y_UNIT_TEST(ShouldPopulateNodes)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNode> node;
@@ -57,8 +61,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldEvictNodes)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
@@ -83,8 +86,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldDeleteNodes)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
@@ -108,8 +110,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldBypassCacheReads)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
@@ -162,8 +163,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldBypassCacheReadsUntilUnconfirmedWritesComplete)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(1, 0, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
@@ -205,8 +205,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     //
     Y_UNIT_TEST(ShouldPopulateNodeAttrs)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 1, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 0, 1, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
@@ -242,8 +241,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldEvictNodeAttrs)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 1, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 0, 1, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
@@ -263,8 +261,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldDeleteNodeAttrs)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 1, 0, 0);
+        TStandardInMemoryIndexState state(Alloc(), 0, 1, 0, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeAttrsRequest{
@@ -345,8 +342,7 @@ namespace {
     //
     Y_UNIT_TEST(ShouldPopulateNodeRefs)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 0, 1, 0);
+        TStandardInMemoryIndexState state(Alloc(), 0, 0, 1, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
@@ -396,8 +392,7 @@ namespace {
 
     Y_UNIT_TEST(ShouldEvictNodeRefs)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 0, 3, 0);
+        TStandardInMemoryIndexState state(Alloc(), 0, 0, 3, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         const TVector<IInMemoryIndexState::TWriteNodeRefsRequest> requests = {
@@ -508,8 +503,7 @@ namespace {
 
     Y_UNIT_TEST(ShouldDeleteNodeRefs)
     {
-        TStandardInMemoryIndexState state(TDefaultAllocator::Instance());
-        state.Reset(0, 0, 1, 0);
+        TStandardInMemoryIndexState state(Alloc(), 0, 0, 1, 0);
         state.SetUnconfirmedRecoveryReady(true);
 
         IInMemoryIndexState::TWriteNodeRefsRequest request = {


### PR DESCRIPTION
### Notes
* moved the definitions of some cache-related types to `tablet/model/metadata_cache.h`
* extracted `IInMemoryIndexState` interface to use an interface instead of a concrete `TInMemoryIndexState` implementation
* extracted current `NodeRefs` cache into `tablet/model/metadata_cache.h` and turned `TInMemoryIndexState` into a template parameterized by the implementation of `NodeRefs` (template param + code in the header because `NodeRefs` iteration code is hot and it's better to let the compiler inline it)
* did some minor cleanup in `TInMemoryIndexState` and related classes here and there

No changes in behaviour are expected in this PR. This is just preparation to support a different implementation of `NodeRefs` (without eviction and with `absl::btree_map` instead of `TMap`)

### Issue
https://github.com/ydb-platform/nbs/issues/5726
