### PR TITLE
[Filestore] fix a possible debug abort when the tablet wakes up before the throttler has something to flush

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -721,7 +721,9 @@ void TIndexTabletActor::HandleWakeup(
 {
     Y_UNUSED(ev);
 
-    Throttler->StartFlushing(ctx);
+    if (Throttler) {
+        Throttler->StartFlushing(ctx);
+    }
 }
 
 void TIndexTabletActor::HandlePoisonPill(

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -8439,6 +8439,33 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             "got "
                 << rebootTracker.GetGenerationCount());
     }
+
+    // See #5975 for details
+    TABLET_TEST(ShouldNotCrashIfWakeupHappensBeforeThrottlerHasSomethingToFlush)
+    {
+        // Otherwise compilation error is possible
+        Y_UNUSED(tabletConfig);
+
+        TTestEnv env;
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        auto& runtime = env.GetRuntime();
+
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        // Need tablet to load its state
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        const auto sender = runtime.AllocateEdgeActor(nodeIdx);
+
+        runtime.SendToPipe(
+            tabletId,
+            sender,
+            new TEvents::TEvWakeup(),
+            nodeIdx,
+            GetPipeConfigWithRetries());
+
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/storage/core/libs/throttling/tablet_throttler.cpp
+++ b/cloud/storage/core/libs/throttling/tablet_throttler.cpp
@@ -84,7 +84,11 @@ public:
 
     void StartFlushing(const NActors::TActorContext& ctx) override
     {
-        Y_DEBUG_ABORT_UNLESS(PostponedQueueFlushScheduled);
+        if (!PostponedQueueFlushScheduled) {
+            // Nothing to flush
+            return;
+        }
+
         PostponedQueueFlushScheduled = false;
         PostponedQueueFlushInProgress = true;
 

--- a/cloud/storage/core/libs/throttling/tablet_throttler_ut.cpp
+++ b/cloud/storage/core/libs/throttling/tablet_throttler_ut.cpp
@@ -195,6 +195,30 @@ Y_UNIT_TEST_SUITE(TTabletThrottlerTest)
                 senderId,
                 new NActors::TEvents::TEvFlushLog())));
     }
+
+    Y_UNIT_TEST(ShouldIgnoreFlushIfNoPostponedRequests)
+    {
+        TTabletThrottlerLoggerStub logger;
+        TTabletThrottlerPolicyAlwaysPostpone policy;
+
+        std::unique_ptr<TSampleActorWithThrottler> actor =
+            std::make_unique<TSampleActorWithThrottler>();
+        auto throttler = CreateTabletThrottler(*actor, logger, policy);
+        actor->ResetThrottler(std::move(throttler));
+
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        auto senderId = runtime.AllocateEdgeActor();
+
+        auto actorId = runtime.Register(actor.release());
+
+        runtime.Send(
+            TAutoPtr<IEventHandle>(new IEventHandle(
+                actorId,
+                senderId,
+                new NActors::TEvents::TEvFlushLog())));
+    }
 }
 
 }   // namespace NCloud


### PR DESCRIPTION
### Notes
```
2026-05-14T19:07:44.425657Z node 2 :NFS_TABLET DEBUG: [f:test][t:72075186223972353] Sending OK response for UpdateConfig with version=0
VERIFY failed (2026-05-14T21:07:44.426313+0200):
  cloud/storage/core/libs/throttling/tablet_throttler.cpp:87
  StartFlushing(): requirement PostponedQueueFlushScheduled failed
BackTrace(void**, unsigned long)+29 (0x28636E4D)
FormatBackTrace(IOutputStream*)+32 (0x28637320)
PrintBackTrace()+17 (0x28637371)
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char>>, char const*, unsigned long)+995 (0x286666D3)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+418 (0x2865BD02)
NCloud::TTabletThrottler::StartFlushing(NActors::TActorContext const&)+220 (0x40484AFC)
NCloud::NFileStore::NStorage::TIndexTabletActor::HandleWakeup(TAutoPtr<NActors::TEventHandle<NActors::TEvents::TEvWakeup>, TDelete> const&, NActors::TActorContext const&)+57 (0x40147AC9)
NCloud::NFileStore::NStorage::TIndexTabletActor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&)+2971 (0x4014024B)
NActors::TActorCallbackBehaviour::Receive(NActors::IActor*, TAutoPtr<NActors::IEventHandle, TDelete>&)+110 (0x2A3AAD9E)
NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&)+99 (0x2A428B53)
NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool)+1963 (0x3CA59C0B)
NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant)+5048 (0x3CA56E98)
NActors::TTestActorRuntimeBase::DispatchEvents(NActors::TDispatchOptions const&, TInstant)+69 (0x3CA55A25)
NActors::TTestActorRuntimeBase::DispatchEvents(NActors::TDispatchOptions const&, TDuration)+86 (0x3CA55AC6)
NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TestImplShouldIgnoreWakeupBeforeThrottlerInitialized(NCloud::NFileStore::NStorage::TFileSystemConfig)+991 (0x28130CBF)
NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TTestCaseShouldIgnoreWakeupBeforeThrottlerInitialized::Execute_(NUnitTest::TTestContext&)+276 (0x28130854)
NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()::operator()() const+131 (0x28137313)
decltype(std::declval<NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()&>()()) std::__y1::__invoke[abi:v180000]<NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()&>(NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()&)+21 (0x28137285)
void std::__y1::__invoke_void_return_wrapper<void, true>::__call[abi:v180000]<NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()&>(NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()&)+21 (0x28137245)
std::__y1::__function::__alloc_func<NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()[abi:v180000]()+29 (0x2813721D)
std::__y1::__function::__func<NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()()+25 (0x28136609)
std::__y1::__function::__value_func<void ()>::operator()[abi:v180000]() const+50 (0x26AB1F92)
std::__y1::function<void ()>::operator()() const+21 (0x26AA9955)
TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+142 (0x287B1A4E)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+134 (0x28786336)
NCloud::NFileStore::NStorage::NTestSuiteTIndexTabletTest_Data::TCurrentTest::Execute()+498 (0x28135B22)
NUnitTest::TTestFactory::Execute()+711 (0x28786BF7)
NUnitTest::RunMain(int, char**)+4248 (0x287AF728)
main+34 (0x287AE652)
??+0 (0x7F67C1E8BD90)
__libc_start_main+128 (0x7F67C1E8BE40)
??+0 (0x26846029)
```

Also add `if (Throttler)` by analogy with other code. The current code is fragile and depends on ResetThrottlingPolicy being called after RunRegularTasks, which schedules Wakeup https://github.com/ydb-platform/nbs/blob/148e5afc840cb9571923f663f55c6945e070d1c2/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp#L486

### Issue
Put links to the related issues here
