### PR TITLE
MAY REQUIRE CONFIG UPDATE! VolumeBalancer: Make IsVolumePreemptible independent of balancer's on/off state

### DIFF
--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -275,12 +275,11 @@ bool TVolumeBalancerState::IsVolumePreemptible(
     const TString& diskId,
     const TVolumeInfo& volume) const
 {
-    const bool isFeatureEnabledForFolder = StorageConfig->IsBalancerFeatureEnabled(
-        volume.CloudId,
-        volume.FolderId,
-        diskId);
-
-    const bool balancerEnabled = isFeatureEnabledForFolder || GetEnabled();
+    const bool isFeatureEnabledForFolder =
+        StorageConfig->IsBalancerFeatureEnabled(
+            volume.CloudId,
+            volume.FolderId,
+            diskId);
 
     // NProto::STORAGE_MEDIA_DEFAULT means that volume mounting
     // is still in progress and will change to something else
@@ -289,10 +288,8 @@ bool TVolumeBalancerState::IsVolumePreemptible(
         (volume.MediaKind != NProto::STORAGE_MEDIA_DEFAULT) &&
         !IsDiskRegistryMediaKind(volume.MediaKind);
 
-    return volume.IsLocal &&
-        balancerEnabled &&
-        isSuitableMediaKind &&
-        !VolumesInProgress.count(diskId);
+    return volume.IsLocal && isFeatureEnabledForFolder && isSuitableMediaKind &&
+           !VolumesInProgress.count(diskId);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state_ut.cpp
@@ -51,11 +51,17 @@ NFeatures::TFeaturesConfigPtr CreateFeatureConfig(
                 *feature->MutableBlacklist()->MutableCloudIds()->Add() = c.first;
                 *feature->MutableBlacklist()->MutableFolderIds()->Add() = c.second;
             }
+            // All but blacklisted
+            feature->SetCloudProbability(1);
+            feature->SetFolderProbability(1);
         } else {
             for (const auto& c: list) {
                 *feature->MutableWhitelist()->MutableCloudIds()->Add() = c.first;
                 *feature->MutableWhitelist()->MutableFolderIds()->Add() = c.second;
             }
+            // None but whitelisted
+            feature->SetCloudProbability(0);
+            feature->SetFolderProbability(0);
         }
     }
     return std::make_shared<NFeatures::TFeaturesConfig>(config);
@@ -245,7 +251,7 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
     Y_UNIT_TEST(ShouldNotSelectVolumeFromBlacklistedCloud)
     {
         auto storageConfig = CreateStorageConfig(
-            NProto::PREEMPTION_NONE,
+            NProto::PREEMPTION_MOVE_MOST_HEAVY,
             70,
             CreateFeatureConfig("Balancer", {{"cloudid1", "folderid1"}}, true));
 

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_ut.cpp
@@ -414,6 +414,9 @@ NFeatures::TFeaturesConfigPtr CreateFeatureConfig(
                 *feature->MutableBlacklist()->MutableFolderIds()->Add() =
                     c.second;
             }
+            // All but blacklisted
+            feature->SetCloudProbability(1);
+            feature->SetFolderProbability(1);
         } else {
             for (const auto& c: list) {
                 *feature->MutableWhitelist()->MutableCloudIds()->Add() =
@@ -421,6 +424,9 @@ NFeatures::TFeaturesConfigPtr CreateFeatureConfig(
                 *feature->MutableWhitelist()->MutableFolderIds()->Add() =
                     c.second;
             }
+            // None but whitelisted
+            feature->SetCloudProbability(0);
+            feature->SetFolderProbability(0);
         }
     }
     return std::make_shared<NFeatures::TFeaturesConfig>(config);


### PR DESCRIPTION
Currently `FeatureConfig::Balancer` does not affect VolumeBalancer's work:

- If VolumeBalancer is enabled (in terms of `State->GetEnabled()`)
  - Feature's status is always overwhelmed by `State->GetEnabled()` at https://github.com/ydb-platform/nbs/commit/3e2d4adac8144b82acb477f5568c88e1c93c0d5c#diff-0d0e0eee72b24144b2ef1bd00a11227d31c2f60c7a0b5cfcd14f7770f3b3d0adL283
- If VolumeBalancer is disabled
  - Feature's status affect volume nomination for push, but balancer is overall disabled, which renders `FeatureConfig::Balancer` practically useless again

Removing `IsVolumePreemptible()`'s dependence from balancer's on/off status we allow `FeatureConfig::Balancer`
to rule balancing whenever `State->GetEnabled()` is true

However, this also means that `FeatureConfig::Balancer` is now **required** to be on for balancer to work