### PR TITLE
[Filestore] introducing memory controller for dynamic persistent table

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
@@ -24,7 +24,8 @@ TDirectoryHandleStorage::TDirectoryHandleStorage(
             .InitialDataAreaSize = initialDataAreaSize,
             .MaxDataAreaStepSize = maxDataAreaStepSize,
             .InitialDataMoveBufferSize = initialDataMoveBufferSize,
-        });
+        },
+        nullptr);
 }
 
 void TDirectoryHandleStorage::StoreHandle(
@@ -255,11 +256,12 @@ TDirectoryHandleChunkPair TDirectoryHandleStorage::DeserializeHandleChunk(
 
 ui64 TDirectoryHandleStorage::CreateRecord(const TBuffer& record)
 {
-    ui64 index = Table->AllocRecord(record.Size());
-    if (index == TDirectoryHandleTable::InvalidIndex) {
+    auto result = Table->AllocRecord(record.Size());
+    if (HasError(result)) {
         return TDirectoryHandleTable::InvalidIndex;
     }
 
+    const ui64 index = result.GetResult();
     if (!Table->WriteRecordData(index, record.Data(), record.Size())) {
         return TDirectoryHandleTable::InvalidIndex;
     }

--- a/cloud/storage/core/libs/common/dynamic_persistent_table.h
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "error.h"
+#include "memory_controller.h"
 #include "numeric.h"
 
 #include <library/cpp/digest/crc32c/crc32c.h>
@@ -11,6 +13,7 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 #include <util/stream/mem.h>
+#include <util/string/builder.h>
 #include <util/system/align.h>
 #include <util/system/file.h>
 #include <util/system/filemap.h>
@@ -142,6 +145,7 @@ private:
 
     TString FileName;
     const TDynamicPersistentTableConfig Config;
+    const IMemoryControllerPtr MemoryController;
     ui64 MaxRecords = 0;
     ui64 LowMemoryOps = 0;
 
@@ -258,9 +262,11 @@ public:
 public:
     TDynamicPersistentTable(
         const TString& fileName,
-        const TDynamicPersistentTableConfig& config)
+        const TDynamicPersistentTableConfig& config,
+        IMemoryControllerPtr memoryController)
         : FileName(fileName)
         , Config(config)
+        , MemoryController(memoryController)
         , MaxRecords(config.MaxRecords)
         , DataAreaSize(config.InitialDataAreaSize)
     {
@@ -278,6 +284,11 @@ public:
         Init();
     }
 
+    ~TDynamicPersistentTable()
+    {
+        UpdateFileMapSize(GetFileMapSize(), 0);
+    }
+
     H* HeaderData()
     {
         return &HeaderPtr->Data;
@@ -293,33 +304,39 @@ public:
         return GetRecord(index, EDataRetrievalMode::WithValidation);
     }
 
-    ui64 AllocRecord(ui64 dataSize)
+    TResultOrError<ui64> AllocRecord(ui64 dataSize)
     {
-        ui64 index = InvalidIndex;
         if (dataSize == 0) {
-            return InvalidIndex;
+            return MakeError(E_ARGUMENT, "Data size should be nonzero");
         }
 
+        ui64 index = InvalidIndex;
         if (!FreeRecordIndexes.empty()) {
             index = FreeRecordIndexes.front();
             FreeRecordIndexes.pop_front();
         } else if (NextFreeRecordIndex < MaxRecords) {
             index = NextFreeRecordIndex++;
         } else {
-            ExpandRecordArea();
+            if (auto error = ExpandRecordArea(); HasError(error)) {
+                return error;
+            }
             index = NextFreeRecordIndex++;
         }
 
         if (index == InvalidIndex) {
-            return InvalidIndex;
+            return MakeError(E_FAIL, "Invalid record index");
         }
 
         HeaderPtr->NextFreeRecordIndex = NextFreeRecordIndex;
 
         if (NextDataOffset + dataSize > DataAreaSize) {
             TryCompactDataArea(dataSize);
-            if (NextDataOffset + dataSize > DataAreaSize) {
-                ExpandDataArea(dataSize);
+            const ui64 requiredSize = NextDataOffset + dataSize;
+            if (requiredSize > DataAreaSize) {
+                if (auto error = ExpandDataArea(requiredSize); HasError(error)) {
+                    FreeRecordIndexes.push_back(index);
+                    return error;
+                }
             }
         }
 
@@ -387,6 +404,8 @@ public:
 
     void Clear()
     {
+        UpdateFileMapSize(GetFileMapSize(), 0);
+
         NextFreeRecordIndex = 0;
         NextDataOffset = 0;
         GapSpaceSize = 0;
@@ -534,7 +553,7 @@ private:
         TailDataIndex = index;
     }
 
-    void ExpandRecordArea()
+    NProto::TError ExpandRecordArea()
     {
         if (GapSpaceSize != 0) {
             CompactDataArea();
@@ -553,14 +572,15 @@ private:
             movedBytes += DescriptorsPtr[currentIndex].DataSize;
         }
 
-        if (NextDataOffset < expansionBytes) {
-            NextDataOffset = expansionBytes;
+        const ui64 nextDataOffset = Max(NextDataOffset, expansionBytes);
+        const ui64 requiredSize = nextDataOffset + movedBytes;
+        if (requiredSize > DataAreaSize) {
+            if (auto error = ExpandDataArea(requiredSize); HasError(error)) {
+                return error;
+            }
         }
 
-        if (NextDataOffset + movedBytes > DataAreaSize) {
-            ExpandDataArea(movedBytes);
-        }
-
+        NextDataOffset = nextDataOffset;
         ui64 nextAppendOffset = DataAreaOffset + NextDataOffset;
 
         while (HeadDataIndex != InvalidIndex &&
@@ -584,8 +604,13 @@ private:
         HeaderPtr->MaxRecords = targetMaxRecords;
         MaxRecords = targetMaxRecords;
         DataAreaOffset = targetDataAreaOffset;
-        ResizeAndRemap();
+        // The expanded record area consumes the reserved data-area prefix.
+        DataAreaSize -= expansionBytes;
+        HeaderPtr->DataAreaSize = DataAreaSize;
+        RefreshPointers();
         NextDataOffset -= expansionBytes;
+
+        return {};
     }
 
     void PrepareAddRecord(ui64 index)
@@ -700,6 +725,9 @@ private:
 
         FileMap = std::make_unique<TFileMap>(FileName, TMemoryMapCommon::oRdWr);
         FileMap->Map(0, sizeof(THeader));
+        // Startup/restore mappings are always accounted but are not rejected by
+        // the memory controller. The limit is applied only to later growth.
+        UpdateFileMapSize(0, GetFileMapSize());
 
         HeaderPtr = reinterpret_cast<THeader*>(FileMap->Ptr());
         if (HeaderPtr->MaxRecords == 0) {
@@ -1000,10 +1028,10 @@ private:
         HeaderPtr->DataMoveBufferSize = Config.InitialDataMoveBufferSize;
     }
 
-    void ExpandDataArea(ui64 requiredRecordDataSize)
+    NProto::TError ExpandDataArea(ui64 requiredSize)
     {
         ui64 newDataAreaSize = DataAreaSize;
-        while (NextDataOffset + requiredRecordDataSize > newDataAreaSize) {
+        while (requiredSize > newDataAreaSize) {
             const ui64 dataAreaStepSize =
                 newDataAreaSize < Config.MaxDataAreaStepSize
                     ? newDataAreaSize
@@ -1012,12 +1040,60 @@ private:
             newDataAreaSize += dataAreaStepSize;
         }
 
+        const ui64 newFileMapSize = CalcFileSize(newDataAreaSize);
+        // This is intentionally a growth admission check, not a reservation.
+        // Usage is charged after ResizeAndRemap() succeeds.
+        if (auto error = CanResizeFileMap(newFileMapSize); HasError(error)) {
+            return error;
+        }
+
         DataAreaSize = newDataAreaSize;
         HeaderPtr->DataAreaSize = DataAreaSize;
 
         ResizeAndRemap();
 
         ResetShrinkState();
+
+        return {};
+    }
+
+    NProto::TError CanResizeFileMap(ui64 newFileMapSize) const
+    {
+        const ui64 fileMapSize = GetFileMapSize();
+        if (!MemoryController || newFileMapSize <= fileMapSize) {
+            return {};
+        }
+
+        const ui64 increaseSize = newFileMapSize - fileMapSize;
+        if (MemoryController->CanIncreaseFileMapUsage(increaseSize)) {
+            return {};
+        }
+
+        return MakeError(
+            E_REJECTED,
+            TStringBuilder()
+                << "MemoryNotEnough: failed to increase file map size by "
+                << increaseSize << " bytes");
+    }
+
+    void UpdateFileMapSize(ui64 oldFileMapSize, ui64 newFileMapSize)
+    {
+        if (!MemoryController) {
+            return;
+        }
+
+        if (newFileMapSize > oldFileMapSize) {
+            MemoryController->IncreaseFileMapUsage(
+                newFileMapSize - oldFileMapSize);
+        } else if (newFileMapSize < oldFileMapSize) {
+            MemoryController->DecreaseFileMapUsage(
+                oldFileMapSize - newFileMapSize);
+        }
+    }
+
+    ui64 GetFileMapSize() const
+    {
+        return FileMap ? FileMap->MappedSize() : 0;
     }
 
     ui64 GetLiveDataSize() const
@@ -1041,7 +1117,14 @@ private:
 
     void ResizeAndRemap()
     {
+        const ui64 oldFileMapSize = GetFileMapSize();
         FileMap->ResizeAndRemap(0, CalcFileSize(DataAreaSize));
+        RefreshPointers();
+        UpdateFileMapSize(oldFileMapSize, GetFileMapSize());
+    }
+
+    void RefreshPointers()
+    {
         HeaderPtr = reinterpret_cast<THeader*>(FileMap->Ptr());
         FilePtr = reinterpret_cast<char*>(FileMap->Ptr());
         DescriptorsPtr =

--- a/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/common/dynamic_persistent_table_ut.cpp
@@ -109,9 +109,12 @@ struct TTestData
 using TTable = TDynamicPersistentTable<TTestHeader>;
 using TTableConfig = TDynamicPersistentTableConfig;
 
-TTable CreateTable(const TString& fileName, const TTableConfig& config)
+TTable CreateTable(
+    const TString& fileName,
+    const TTableConfig& config,
+    IMemoryControllerPtr memoryController = nullptr)
 {
-    return TTable(fileName, config);
+    return TTable(fileName, config, memoryController);
 }
 
 TTable
@@ -126,6 +129,29 @@ CreateTable(const TString& fileName, ui64 maxRecords, ui64 initialDataAreaSize)
             .InitialDataMoveBufferSize = 100,
         });
 }
+
+struct TTestMemoryController final: public IMemoryController
+{
+    ui64 Current = 0;
+    bool CanIncreaseResult = true;
+
+    bool CanIncreaseFileMapUsage(ui64 value) const override
+    {
+        Y_UNUSED(value);
+        return CanIncreaseResult;
+    }
+
+    void IncreaseFileMapUsage(ui64 value) override
+    {
+        Current += value;
+    }
+
+    void DecreaseFileMapUsage(ui64 value) override
+    {
+        UNIT_ASSERT(Current >= value);
+        Current -= value;
+    }
+};
 
 // Helper functions for accessing internal table structures
 TTable::THeader* GetTableHeader(TTable& table)
@@ -155,9 +181,16 @@ ui64 CalcDataAreaOffset(const TTable::THeader* tableHeader)
            tableHeader->MaxRecords * tableHeader->RecordDescriptorSize;
 }
 
+ui64 AllocRecord(TTable& table, ui64 dataSize)
+{
+    auto result = table.AllocRecord(dataSize);
+    UNIT_ASSERT(!HasError(result));
+    return result.GetResult();
+}
+
 ui64 AllocAndCommitRecord(TTable& table, const TString& data)
 {
-    ui64 index = table.AllocRecord(data.size());
+    const ui64 index = AllocRecord(table, data.size());
     UNIT_ASSERT_VALUES_UNEQUAL(TTable::InvalidIndex, index);
     UNIT_ASSERT(table.WriteRecordData(index, data.data(), data.size()));
     UNIT_ASSERT(table.CommitRecord(index));
@@ -308,6 +341,110 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldTrackFileMapSizeLifecycle)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "test.table";
+
+        auto fileMapSizeController =
+            std::make_shared<TTestMemoryController>();
+        ui64 initialFileMapSize = 0;
+        {
+            auto table = CreateTable(
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = 32,
+                    .InitialDataAreaSize = 128,
+                    .MaxDataAreaStepSize = 128,
+                    .InitialDataMoveBufferSize = 100,
+                },
+                fileMapSizeController);
+
+            const auto* tableHeader = GetTableHeader(table);
+            initialFileMapSize = CalcDataAreaOffset(tableHeader) +
+                                 tableHeader->DataAreaSize +
+                                 tableHeader->DataMoveBufferSize;
+            UNIT_ASSERT_VALUES_EQUAL(
+                initialFileMapSize,
+                fileMapSizeController->Current);
+
+            const TString data(96, 'a');
+
+            ui64 firstIndex = AllocRecord(table, data.size());
+            UNIT_ASSERT(
+                table.WriteRecordData(firstIndex, data.data(), data.size()));
+            UNIT_ASSERT(table.CommitRecord(firstIndex));
+            UNIT_ASSERT_VALUES_EQUAL(
+                initialFileMapSize,
+                fileMapSizeController->Current);
+
+            ui64 secondIndex = AllocRecord(table, data.size());
+            UNIT_ASSERT(
+                table.WriteRecordData(secondIndex, data.data(), data.size()));
+            UNIT_ASSERT(table.CommitRecord(secondIndex));
+            UNIT_ASSERT_VALUES_EQUAL(
+                initialFileMapSize + 128,
+                fileMapSizeController->Current);
+
+            UNIT_ASSERT(table.DeleteRecord(firstIndex));
+            UNIT_ASSERT(table.DeleteRecord(secondIndex));
+            table.TryDeallocateMemory();
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                initialFileMapSize,
+                fileMapSizeController->Current);
+        }
+
+        UNIT_ASSERT_VALUES_UNEQUAL(0, initialFileMapSize);
+        UNIT_ASSERT_VALUES_EQUAL(0, fileMapSizeController->Current);
+    }
+
+    Y_UNIT_TEST(ShouldReturnErrorWhenFileMapSizeCannotIncrease)
+    {
+        TTempDir tempDir;
+        TString tablePath = tempDir.Path() / "test.table";
+
+        auto fileMapSizeController =
+            std::make_shared<TTestMemoryController>();
+
+        auto table = CreateTable(
+            tablePath,
+            TTableConfig{
+                .MaxRecords = 1,
+                .InitialDataAreaSize = 128,
+                .MaxDataAreaStepSize = 128,
+                .InitialDataMoveBufferSize = 100,
+            },
+            fileMapSizeController);
+
+        fileMapSizeController->CanIncreaseResult = false;
+
+        auto result = table.AllocRecord(256);
+        UNIT_ASSERT(HasError(result));
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, result.GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(0, table.CountRecords());
+
+        fileMapSizeController->CanIncreaseResult = true;
+        const TString payload(32, 'r');
+        AllocAndCommitRecord(table, payload);
+        UNIT_ASSERT_VALUES_EQUAL(1, table.CountRecords());
+
+        fileMapSizeController->CanIncreaseResult = false;
+        result = table.AllocRecord(payload.size());
+        UNIT_ASSERT(HasError(result));
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, result.GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(1, table.CountRecords());
+        UNIT_ASSERT_VALUES_EQUAL(1, GetTableHeader(table)->MaxRecords);
+
+        fileMapSizeController->CanIncreaseResult = true;
+        result = table.AllocRecord(payload.size());
+        UNIT_ASSERT(!HasError(result));
+        UNIT_ASSERT_VALUES_EQUAL(2, table.CountRecords());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1 + TTable::RecordAreaExpansionStep,
+            GetTableHeader(table)->MaxRecords);
+    }
+
     Y_UNIT_TEST(ShouldAllocAndStoreVariableSizeRecords)
     {
         TTempDir tempDir;
@@ -324,7 +461,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TString smallSerialized = smallData.Serialize();
         TString largeSerialized = largeData.Serialize();
 
-        ui64 smallIndex = table.AllocRecord(smallSerialized.size());
+        ui64 smallIndex = AllocRecord(table, smallSerialized.size());
         UNIT_ASSERT(
             smallIndex != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
         UNIT_ASSERT(table.WriteRecordData(
@@ -333,7 +470,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             smallSerialized.size()));
         table.CommitRecord(smallIndex);
 
-        ui64 largeIndex = table.AllocRecord(largeSerialized.size());
+        ui64 largeIndex = AllocRecord(table, largeSerialized.size());
         UNIT_ASSERT(
             largeIndex != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
         UNIT_ASSERT(table.WriteRecordData(
@@ -372,7 +509,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TVector<ui64> indices;
         for (const auto& testData: testRecords) {
             TString serialized = testData.Serialize();
-            ui64 index = table.AllocRecord(serialized.size());
+            ui64 index = AllocRecord(table, serialized.size());
             UNIT_ASSERT(
                 index != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
             UNIT_ASSERT(table.WriteRecordData(
@@ -413,14 +550,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TString serialized1 = data1.Serialize();
         TString serialized2 = data2.Serialize();
 
-        ui64 index1 = table.AllocRecord(serialized1.size());
+        ui64 index1 = AllocRecord(table, serialized1.size());
         UNIT_ASSERT(table.WriteRecordData(
             index1,
             serialized1.data(),
             serialized1.size()));
         table.CommitRecord(index1);
 
-        ui64 index2 = table.AllocRecord(serialized2.size());
+        ui64 index2 = AllocRecord(table, serialized2.size());
         UNIT_ASSERT(table.WriteRecordData(
             index2,
             serialized2.data(),
@@ -450,7 +587,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
                 TStringBuilder() << "item" << i,
                 {static_cast<ui32>(i)}};
             TString serialized = data.Serialize();
-            ui64 index = table.AllocRecord(serialized.size());
+            ui64 index = AllocRecord(table, serialized.size());
             UNIT_ASSERT(
                 index != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
             UNIT_ASSERT(table.WriteRecordData(
@@ -468,7 +605,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         TTestData extraData{999, "extra", {999}};
         TString extraSerialized = extraData.Serialize();
-        ui64 newIndex = table.AllocRecord(extraSerialized.size());
+        ui64 newIndex = AllocRecord(table, extraSerialized.size());
         UNIT_ASSERT(
             newIndex != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
         UNIT_ASSERT_VALUES_EQUAL(indices[1], newIndex);
@@ -489,7 +626,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
-                ui64 index = table.AllocRecord(serialized.size());
+                ui64 index = AllocRecord(table, serialized.size());
                 UNIT_ASSERT(table.WriteRecordData(
                     index,
                     serialized.data(),
@@ -595,7 +732,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             table.HeaderData()->Val = 123;
 
             TString serialized = testData[0].Serialize();
-            index1 = table.AllocRecord(serialized.size());
+            index1 = AllocRecord(table, serialized.size());
             UNIT_ASSERT(table.WriteRecordData(
                 index1,
                 serialized.data(),
@@ -603,7 +740,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             table.CommitRecord(index1);
 
             serialized = testData[1].Serialize();
-            index2 = table.AllocRecord(serialized.size());
+            index2 = AllocRecord(table, serialized.size());
             UNIT_ASSERT(table.WriteRecordData(
                 index2,
                 serialized.data(),
@@ -613,7 +750,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             table.DeleteRecord(index1);
 
             serialized = testData[2].Serialize();
-            ui64 index3 = table.AllocRecord(serialized.size());
+            ui64 index3 = AllocRecord(table, serialized.size());
             UNIT_ASSERT(table.WriteRecordData(
                 index3,
                 serialized.data(),
@@ -659,7 +796,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
                 TVector<ui32>(100, i)};
 
             TString serialized = data.Serialize();
-            ui64 index = table.AllocRecord(serialized.size());
+            ui64 index = AllocRecord(table, serialized.size());
             UNIT_ASSERT(
                 index != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
             UNIT_ASSERT(table.WriteRecordData(
@@ -699,7 +836,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
                 {static_cast<ui32>(i)}};
             TString serialized = data.Serialize();
 
-            ui64 index = table.AllocRecord(serialized.size());
+            ui64 index = AllocRecord(table, serialized.size());
             if (index == TDynamicPersistentTable<TTestHeader>::InvalidIndex) {
                 break;
             }
@@ -740,7 +877,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}};
         TString originalSerialized = originalData.Serialize();
 
-        ui64 index = table.AllocRecord(originalSerialized.size());
+        ui64 index = AllocRecord(table, originalSerialized.size());
         UNIT_ASSERT_VALUES_UNEQUAL(
             TDynamicPersistentTable<TTestHeader>::InvalidIndex,
             index);
@@ -789,7 +926,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
                 {static_cast<ui32>(i), static_cast<ui32>(i + 1)}};
             TString serialized = data.Serialize();
 
-            ui64 index = table.AllocRecord(serialized.size());
+            ui64 index = AllocRecord(table, serialized.size());
             if (index == TDynamicPersistentTable<TTestHeader>::InvalidIndex) {
                 break;
             }
@@ -820,7 +957,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             TVector<ui32>(20, 999)};
         TString largeSerialized = largeData.Serialize();
 
-        ui64 newIndex = table.AllocRecord(largeSerialized.size());
+        ui64 newIndex = AllocRecord(table, largeSerialized.size());
         UNIT_ASSERT(
             newIndex != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
         UNIT_ASSERT(table.WriteRecordData(
@@ -921,14 +1058,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
         auto table = CreateTable(tablePath, 32, 1024);
 
-        ui64 index = table.AllocRecord(0);
-        UNIT_ASSERT(
-            index == TDynamicPersistentTable<TTestHeader>::InvalidIndex);
+        auto result = table.AllocRecord(0);
+        UNIT_ASSERT(HasError(result));
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, result.GetError().GetCode());
 
         TTestData emptyData{42, "", {}};
         TString emptySerialized = emptyData.Serialize();
 
-        ui64 emptyIndex = table.AllocRecord(emptySerialized.size());
+        ui64 emptyIndex = AllocRecord(table, emptySerialized.size());
         UNIT_ASSERT(
             emptyIndex != TDynamicPersistentTable<TTestHeader>::InvalidIndex);
         UNIT_ASSERT(table.WriteRecordData(
@@ -948,7 +1085,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         TTestData normalData{99, "normal", {1, 2, 3}};
         TString normalSerialized = normalData.Serialize();
 
-        ui64 normalIndex = table.AllocRecord(normalSerialized.size());
+        ui64 normalIndex = AllocRecord(table, normalSerialized.size());
         UNIT_ASSERT(!table.WriteRecordData(
             normalIndex,
             nullptr,
@@ -1505,7 +1642,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
-                ui64 index = table.AllocRecord(serialized.size());
+                ui64 index = AllocRecord(table, serialized.size());
                 UNIT_ASSERT(table.WriteRecordData(
                     index,
                     serialized.data(),
@@ -1610,7 +1747,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
-                ui64 index = table.AllocRecord(serialized.size());
+                ui64 index = AllocRecord(table, serialized.size());
                 UNIT_ASSERT(table.WriteRecordData(
                     index,
                     serialized.data(),
@@ -1693,7 +1830,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
-                ui64 index = table.AllocRecord(serialized.size());
+                ui64 index = AllocRecord(table, serialized.size());
                 UNIT_ASSERT(table.WriteRecordData(
                     index,
                     serialized.data(),
@@ -1783,7 +1920,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
-                ui64 index = table.AllocRecord(serialized.size());
+                ui64 index = AllocRecord(table, serialized.size());
                 UNIT_ASSERT(table.WriteRecordData(
                     index,
                     serialized.data(),
@@ -1880,7 +2017,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
-                ui64 index = table.AllocRecord(serialized.size());
+                ui64 index = AllocRecord(table, serialized.size());
                 UNIT_ASSERT(table.WriteRecordData(
                     index,
                     serialized.data(),
@@ -2126,7 +2263,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
             auto table = CreateTable(tablePath, 32, 1024);
 
             TString serialized1 = testData1.Serialize();
-            ui64 index1 = table.AllocRecord(serialized1.size());
+            ui64 index1 = AllocRecord(table, serialized1.size());
             UNIT_ASSERT(table.WriteRecordData(
                 index1,
                 serialized1.data(),
@@ -2137,7 +2274,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             // Simulate crash during add operation before state change, but
             // after index list was set
-            ui64 index2 = table.AllocRecord(serialized2.size());
+            ui64 index2 = AllocRecord(table, serialized2.size());
 
             auto [tableHeader, descriptorsPtr, _] = GetTableInternals(table);
 
@@ -2187,7 +2324,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
 
             for (const auto& data: testData) {
                 TString serialized = data.Serialize();
-                ui64 index = table.AllocRecord(serialized.size());
+                ui64 index = AllocRecord(table, serialized.size());
                 UNIT_ASSERT(table.WriteRecordData(
                     index,
                     serialized.data(),
@@ -2264,7 +2401,14 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         auto restore = [&]()
         {
             table = std::make_unique<TTable>(
-                CreateTable(tablePath, tableSize, 1024));
+                tablePath,
+                TTableConfig{
+                    .MaxRecords = tableSize,
+                    .InitialDataAreaSize = 1024,
+                    .MaxDataAreaStepSize = 1_GB,
+                    .InitialDataMoveBufferSize = 100,
+                },
+                nullptr);
         };
 
         restore();
@@ -2285,7 +2429,7 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
                 }
 
                 TString serialized = testData.Serialize();
-                ui64 tableIndex = table->AllocRecord(serialized.size());
+                ui64 tableIndex = AllocRecord(*table, serialized.size());
                 ui64 riIndex = ri.AllocRecord(serialized.size());
 
                 UNIT_ASSERT_VALUES_EQUAL(riIndex, tableIndex);

--- a/cloud/storage/core/libs/common/memory_controller.cpp
+++ b/cloud/storage/core/libs/common/memory_controller.cpp
@@ -1,0 +1,92 @@
+#include "memory_controller.h"
+
+#include "numeric.h"
+#include "verify.h"
+
+#include <util/generic/strbuf.h>
+
+#include <atomic>
+#include <memory>
+#include <utility>
+
+namespace NCloud {
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TStringBuf MemoryControllerEntityType = "MemoryController";
+constexpr TStringBuf MemoryControllerEntityId = "file_map";
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TMemoryController final: public IMemoryController
+{
+private:
+    const TMemoryControllerConfig Config;
+    const ui64 FileMapLimit;
+    std::atomic<ui64> FileMapMemoryUsage = 0;
+
+public:
+    explicit TMemoryController(TMemoryControllerConfig config)
+        : Config(std::move(config))
+        , FileMapLimit(CalcFileMapLimit(Config))
+    {}
+
+    [[nodiscard]] bool CanIncreaseFileMapUsage(ui64 increaseSize) const override
+    {
+        const ui64 current = FileMapMemoryUsage.load(std::memory_order_acquire);
+        return current <= FileMapLimit &&
+               increaseSize <= FileMapLimit - current;
+    }
+
+    void IncreaseFileMapUsage(ui64 diffSize) override
+    {
+        if (!diffSize) {
+            return;
+        }
+
+        FileMapMemoryUsage.fetch_add(diffSize, std::memory_order_release);
+    }
+
+    void DecreaseFileMapUsage(ui64 diffSize) override
+    {
+        if (!diffSize) {
+            return;
+        }
+
+        const ui64 previous =
+            FileMapMemoryUsage.fetch_sub(diffSize, std::memory_order_release);
+        STORAGE_VERIFY(
+            previous >= diffSize,
+            MemoryControllerEntityType,
+            MemoryControllerEntityId);
+    }
+
+private:
+    static ui64 CalcFileMapLimit(const TMemoryControllerConfig& config)
+    {
+        STORAGE_VERIFY(
+            config.MemoryLimit,
+            MemoryControllerEntityType,
+            MemoryControllerEntityId);
+
+        return PercentOf(config.MemoryLimit, config.TmpfsMemoryLimitPercent);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IMemoryControllerPtr CreateMemoryController(TMemoryControllerConfig config)
+{
+    if (!config.MemoryLimit) {
+        return nullptr;
+    }
+
+    return std::make_shared<TMemoryController>(std::move(config));
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/memory_controller.h
+++ b/cloud/storage/core/libs/common/memory_controller.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <util/system/types.h>
+
+#include <memory>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IMemoryController
+{
+    virtual ~IMemoryController() = default;
+
+    // The check is advisory, not a reservation. Callers account memory only
+    // after a file mapping actually grows, so concurrent growth can temporarily
+    // overshoot the limit; the limit gates future growth attempts.
+    [[nodiscard]] virtual bool CanIncreaseFileMapUsage(
+        ui64 increaseSize) const = 0;
+    virtual void IncreaseFileMapUsage(ui64 diffSize) = 0;
+    virtual void DecreaseFileMapUsage(ui64 diffSize) = 0;
+};
+
+using IMemoryControllerPtr = std::shared_ptr<IMemoryController>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TMemoryControllerConfig
+{
+    ui64 MemoryLimit = 0;
+    ui32 TmpfsMemoryLimitPercent = 0;
+};
+
+// Returns nullptr when memory limiting is disabled.
+IMemoryControllerPtr CreateMemoryController(
+    TMemoryControllerConfig config = {});
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/memory_controller_ut.cpp
+++ b/cloud/storage/core/libs/common/memory_controller_ut.cpp
@@ -1,0 +1,54 @@
+#include "memory_controller.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TMemoryControllerTest)
+{
+    Y_UNIT_TEST(ShouldReturnNullptrWhenMemoryLimitDisabled)
+    {
+        UNIT_ASSERT(!CreateMemoryController(
+            {.MemoryLimit = 0, .TmpfsMemoryLimitPercent = 25}));
+    }
+
+    Y_UNIT_TEST(ShouldUseZeroLimitWhenTmpfsPercentDisabled)
+    {
+        auto controller = CreateMemoryController(
+            {.MemoryLimit = 1024, .TmpfsMemoryLimitPercent = 0});
+        UNIT_ASSERT(controller);
+
+        UNIT_ASSERT(!controller->CanIncreaseFileMapUsage(1));
+    }
+
+    Y_UNIT_TEST(ShouldLimitMemoryConsumption)
+    {
+        auto controller = CreateMemoryController(
+            {.MemoryLimit = 100, .TmpfsMemoryLimitPercent = 25});
+        UNIT_ASSERT(controller);
+
+        UNIT_ASSERT(controller->CanIncreaseFileMapUsage(25));
+        UNIT_ASSERT(!controller->CanIncreaseFileMapUsage(26));
+
+        controller->IncreaseFileMapUsage(20);
+        UNIT_ASSERT(controller->CanIncreaseFileMapUsage(5));
+        UNIT_ASSERT(!controller->CanIncreaseFileMapUsage(6));
+
+        controller->DecreaseFileMapUsage(10);
+        UNIT_ASSERT(controller->CanIncreaseFileMapUsage(15));
+        UNIT_ASSERT(!controller->CanIncreaseFileMapUsage(16));
+    }
+
+    Y_UNIT_TEST(ShouldUseRoundedDownLimitForSmallPercent)
+    {
+        auto controller = CreateMemoryController(
+            {.MemoryLimit = 1, .TmpfsMemoryLimitPercent = 1});
+        UNIT_ASSERT(controller);
+
+        UNIT_ASSERT(!controller->CanIncreaseFileMapUsage(1));
+    }
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/common/ut/ya.make
+++ b/cloud/storage/core/libs/common/ut/ya.make
@@ -39,6 +39,7 @@ SRCS(
     history_ut.cpp
     lru_cache_ut.cpp
     dynamic_persistent_table_ut.cpp
+    memory_controller_ut.cpp
     persistent_table_ut.cpp
     ring_buffer_ut.cpp
     scheduler_ut.cpp

--- a/cloud/storage/core/libs/common/ya.make
+++ b/cloud/storage/core/libs/common/ya.make
@@ -27,6 +27,7 @@ SRCS(
     hostname.cpp
     lru_cache.cpp
     media.cpp
+    memory_controller.cpp
     numeric.cpp
     page_size.cpp
     dynamic_persistent_table.cpp


### PR DESCRIPTION
### Notes
Added shared memory accounting for tmpfs-backed file maps used by directory handle storage.

The main idea is that TDynamicPersistentTable now accounts mapped file size through this controller and rejects later storage growth when the tmpfs memory limit is exceeded.

What changed:

Added a memory controller with file-map usage tracking.
Updated TDynamicPersistentTable to check file-map growth against the memory controller.
Changed table allocation to return errors instead of only InvalidIndex.
Added tests.

### Issue
#5763
