### PR TITLE
VolumeBalancer: Prevent volume preemption when all local disks have zero suffer

### DIFF
--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.cpp
@@ -48,6 +48,8 @@ void TVolumeBalancerState::UpdateVolumeStats(
         knownDisks.insert(d.first);
     }
 
+    bool localSufferingDetected = false;
+
     for (auto& v: stats) {
         auto it = Volumes.emplace(v.GetDiskId(), TVolumeInfo(StorageConfig->GetInitialPullDelay())).first;
 
@@ -75,6 +77,9 @@ void TVolumeBalancerState::UpdateVolumeStats(
 
         if (auto perfIt = perfMap.find(it->first); perfIt != perfMap.end()) {
             info.SufferCount = perfIt->second;
+            if (info.IsLocal && info.SufferCount > 0) {
+                localSufferingDetected = true;
+            }
         }
         knownDisks.erase(v.GetDiskId());
     }
@@ -83,12 +88,13 @@ void TVolumeBalancerState::UpdateVolumeStats(
         Volumes.erase(d);
     }
 
-    if (emergencyCpu) {
-        VolumeToPull = {};
-        UpdateVolumeToPush();
-    } else {
-        VolumeToPush = {};
-        UpdateVolumeToPull(now);
+    VolumeToPush = {};
+    VolumeToPull = {};
+
+    if (emergencyCpu && localSufferingDetected) {
+        VolumeToPush = SelectVolumeToPush();
+    } else if (!emergencyCpu) {
+        VolumeToPull = SelectVolumeToPull(now);
     }
 }
 
@@ -227,12 +233,12 @@ void TVolumeBalancerState::RenderHtml(TStringStream& out, TInstant now) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TVolumeBalancerState::UpdateVolumeToPush()
+TString TVolumeBalancerState::SelectVolumeToPush() const
 {
     const bool moveMostHeavy = StorageConfig->GetVolumePreemptionType() ==
-        NProto::PREEMPTION_MOVE_MOST_HEAVY;
+                               NProto::PREEMPTION_MOVE_MOST_HEAVY;
 
-    VolumeToPush = {};
+    TString volumeToPush;
 
     ui64 value = moveMostHeavy ? 0 : Max<ui64>();
     for (auto v = Volumes.begin(); v != Volumes.end(); ++v) {
@@ -241,34 +247,34 @@ void TVolumeBalancerState::UpdateVolumeToPush()
         }
 
         if (moveMostHeavy) {
-            if (value < v->second.SufferCount) {
+            if (value <= v->second.SufferCount) {
                 value = v->second.SufferCount;
-                VolumeToPush = v->first;
+                volumeToPush = v->first;
             }
         } else {
-            if (value > v->second.SufferCount) {
+            if (value >= v->second.SufferCount) {
                 value = v->second.SufferCount;
-                VolumeToPush = v->first;
+                volumeToPush = v->first;
             }
         }
     }
+
+    return volumeToPush;
 }
 
-void TVolumeBalancerState::UpdateVolumeToPull(TInstant now)
+TString TVolumeBalancerState::SelectVolumeToPull(TInstant now) const
 {
-    VolumeToPull = {};
-
     for (const auto& v: Volumes) {
         if (!v.second.IsLocal &&
-            v.second.PreemptionSource == NProto::EPreemptionSource::SOURCE_BALANCER &&
+            v.second.PreemptionSource ==
+                NProto::EPreemptionSource::SOURCE_BALANCER &&
             v.second.NextPullAttempt <= now &&
             !VolumesInProgress.count(v.first))
         {
-            VolumeToPull = v.first;
-            return;
+            return v.first;
         }
     }
-
+    return {};
 }
 
 bool TVolumeBalancerState::IsVolumePreemptible(

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state.h
@@ -127,8 +127,8 @@ private:
     void RenderConfig(TStringStream& out) const;
     void RenderState(TStringStream& out) const;
 
-    void UpdateVolumeToPush();
-    void UpdateVolumeToPull(TInstant now);
+    TString SelectVolumeToPush() const;
+    TString SelectVolumeToPull(TInstant now) const;
 
     bool IsVolumePreemptible(
         const TString& diskId,

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_state_ut.cpp
@@ -470,6 +470,75 @@ Y_UNIT_TEST_SUITE(TVolumeBalancerStateTest)
             UNIT_ASSERT(!state.GetVolumeToPull());
         }
     }
+
+    Y_UNIT_TEST(ShouldNotPreemptVolumeIfLocalSufferIsZero)
+    {
+        TVolumeBalancerState state(CreateStorageConfig(
+            NProto::PREEMPTION_MOVE_MOST_HEAVY,
+            70,
+            CreateFeatureConfig("Balancer", {}, true)));
+        TInstant now = TInstant::Seconds(0);
+
+        const TVector vols{
+            CreateVolumeStats("vol0", "", "", true),
+            CreateVolumeStats("vol1", "", "", true)};
+
+        TVolumeBalancerState::TPerfGuaranteesMap perfMap;
+        perfMap["vol0"] = 0;
+        perfMap["vol1"] = 0;
+
+        state.UpdateVolumeStats(vols, std::move(perfMap), 80, now);
+
+        UNIT_ASSERT_VALUES_EQUAL("", state.GetVolumeToPush());
+        UNIT_ASSERT_VALUES_EQUAL("", state.GetVolumeToPull());
+    }
+
+    Y_UNIT_TEST(ShouldNotReturnVolumeBySufferAlone)
+    {
+        auto storageConfig = CreateStorageConfig(
+            NProto::PREEMPTION_MOVE_MOST_HEAVY,
+            70,
+            CreateFeatureConfig("Balancer", {}, true));
+
+        TVolumeBalancerState state(storageConfig);
+        TInstant now = TInstant::Seconds(0);
+
+        {
+            TVector vols{
+                CreateVolumeStats("vol0", "", "", true),
+                CreateVolumeStats("vol1", "", "", true)};
+
+            TVolumeBalancerState::TPerfGuaranteesMap perfMap;
+            perfMap["vol0"] = 10;
+            perfMap["vol1"] = 1;
+
+            state.UpdateVolumeStats(vols, std::move(perfMap), 80, now);
+
+            UNIT_ASSERT_VALUES_EQUAL("vol0", state.GetVolumeToPush());
+            UNIT_ASSERT(!state.GetVolumeToPull());
+        }
+
+        {
+            TVector vols{
+                CreateVolumeStats("vol0", "", "", false),
+                CreateVolumeStats("vol1", "", "", false)};
+
+            TVolumeBalancerState::TPerfGuaranteesMap perfMap;
+            perfMap["vol0"] = 0;
+            perfMap["vol1"] = 0;
+
+            state.UpdateVolumeStats(vols, std::move(perfMap), 80, now);
+
+            UNIT_ASSERT(!state.GetVolumeToPush());
+            UNIT_ASSERT(!state.GetVolumeToPull());
+
+            now += storageConfig->GetInitialPullDelay();
+
+            state.UpdateVolumeStats(vols, perfMap, 80, now);
+            UNIT_ASSERT(!state.GetVolumeToPush());
+            UNIT_ASSERT(!state.GetVolumeToPull());
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
1. Preventing VolumeBalancer from pushing volumes when no local disk has positive suffer
2. Adjust selection loop condition allowing to select a value from all-zero range (not useful with Suffer, but may be useful later with cost. Also unifies MOST/LEAST beavior)
3. Minor refactoring to explicit data flow