### PR TITLE
[Filestore] issue-5948: shard FSyncQueue by NodeId to remove global lock contention

### DIFF
--- a/cloud/filestore/libs/vfs/fsync_queue.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue.cpp
@@ -2,214 +2,28 @@
 
 #include <util/generic/algorithm.h>
 
+#include <atomic>
+#include <memory>
+
 namespace NCloud::NFileStore::NVFS {
 
 using namespace NThreading;
 
+namespace {
+
 ////////////////////////////////////////////////////////////////////////////////
 
-TFSyncCache::TFSyncCache(TString logTag, ILoggingServicePtr logging)
-    : LogTag(std::move(logTag))
-    , Logging(std::move(logging))
-    // TODO: add vfs log component
-    , Log(Logging->CreateLog("NFS_FUSE"))
-{}
-
-void TFSyncCache::AddRequest(const TRequest& request)
+// Completion tracker for one fanned-out global fsync. The originating
+// WaitFor* inserts one fsync leaf per non empty shard map (keyed by
+// nodeId for meta, (nodeId, handle) for data). Each fired leaf decrements
+// Remaining. Promise fires when it reaches zero.
+struct TGlobalFSyncState
 {
-    Y_ABORT_UNLESS(request.NodeId);
+    std::atomic<size_t> Remaining{0};
+    TPromise<NProto::TError> Promise;
+};
 
-    TItem item{ .Request = request };
-
-    // Meta request.
-    Meta[request.NodeId].emplace(request.ReqId, item);
-    GlobalMeta.emplace(request.ReqId, item);
-
-    STORAGE_TRACE(LogTag << " Request was added to meta maps " << request);
-
-    if (request.Handle) {
-        // Data request.
-        Data[request.NodeId][request.Handle].emplace(request.ReqId, item);
-        GlobalData.emplace(request.ReqId, item);
-
-        STORAGE_TRACE(LogTag << " Request was added to data maps " << request);
-    }
-
-    CheckFSyncNotifications();
-}
-
-TFuture<NProto::TError> TFSyncCache::AddFSyncRequest(const TRequest& request)
-{
-    TItem item{ .Request = request, .Promise = NewPromise<NProto::TError>() };
-    auto future = item.Promise.GetFuture();
-
-    if (request.NodeId) {
-        if (request.Handle) {
-            // Node Data request.
-            Data[request.NodeId][request.Handle]
-                .emplace(request.ReqId, std::move(item));
-
-            STORAGE_TRACE(LogTag
-                << " FSync request was added to local data map " << request);
-        } else {
-            // Node Meta request.
-            Meta[request.NodeId].emplace(request.ReqId, std::move(item));
-
-            STORAGE_TRACE(LogTag
-                << " FSync request was added to local meta map " << request);
-        }
-    } else {
-        if (request.Handle) {
-            // Global Data request.
-            GlobalData.emplace(request.ReqId, std::move(item));
-
-            STORAGE_TRACE(LogTag
-                << " FSync request was added to global data map " << request);
-        } else {
-            // Global Meta request.
-            GlobalMeta.emplace(request.ReqId, std::move(item));
-
-            STORAGE_TRACE(LogTag
-                << " FSync request was added to global meta map " << request);
-        }
-    }
-
-    CheckFSyncNotifications();
-    return future;
-}
-
-void TFSyncCache::RemoveRequest(const TRequest& request)
-{
-    Y_ABORT_UNLESS(request.NodeId);
-
-    {
-        // Meta request.
-        auto nodeIt = Meta.find(request.NodeId);
-        Y_ABORT_UNLESS(nodeIt != Meta.end());
-
-        if (!nodeIt->second.erase(request.ReqId)) {
-            Y_ABORT(
-                "Cannot find requestId: %lu for nodeId: %lu in local meta map",
-                request.ReqId,
-                ToUnderlying(request.NodeId));
-        }
-
-        if (nodeIt->second.empty()) {
-            Meta.erase(nodeIt);
-        }
-
-        STORAGE_TRACE(LogTag
-            << " Request was removed from local meta map " << request);
-
-        // Global meta request.
-        if (!GlobalMeta.erase(request.ReqId)) {
-            Y_ABORT(
-                "Cannot find requestId: %lu in global meta map",
-                request.ReqId);
-        }
-
-        STORAGE_TRACE(LogTag
-            << " Request was removed from global meta map " << request);
-    }
-
-    if (request.Handle) {
-        // Data request.
-        auto nodeIt = Data.find(request.NodeId);
-        Y_ABORT_UNLESS(nodeIt != Data.end());
-
-        auto handleIt = nodeIt->second.find(request.Handle);
-        Y_ABORT_UNLESS(handleIt != nodeIt->second.end());
-
-        if (!handleIt->second.erase(request.ReqId)) {
-            Y_ABORT(
-                "Cannot find requestId: %lu for nodeId: %lu and handle: %lu"
-                " in local data map",
-                request.ReqId,
-                ToUnderlying(request.NodeId),
-                ToUnderlying(request.Handle));
-        }
-
-        if (handleIt->second.empty()) {
-            nodeIt->second.erase(handleIt);
-            if (nodeIt->second.empty()) {
-                Data.erase(nodeIt);
-            }
-        }
-
-        STORAGE_TRACE(LogTag
-            << " Request was removed from local data map " << request);
-
-        // Global data request.
-        if (!GlobalData.erase(request.ReqId)) {
-            Y_ABORT(
-                "Cannot find requestId: %lu in global data map",
-                request.ReqId);
-        }
-
-        STORAGE_TRACE(LogTag
-            << " Request was removed from global data map " << request);
-    }
-
-    CheckFSyncNotifications();
-}
-
-void TFSyncCache::CheckFSyncNotifications()
-{
-    const auto notifyAndErase = [this] (auto& kv) {
-        return NotifyAndEraseLatest(kv.second);
-    };
-
-    // Check in node meta map.
-    EraseNodesIf(Meta, notifyAndErase);
-
-    // Check in global meta map.
-    NotifyAndEraseLatest(GlobalMeta);
-
-    // Check in node data map.
-    EraseNodesIf(Data, [&] (auto& kv) {
-        auto& map = kv.second;
-        EraseNodesIf(map, notifyAndErase);
-        return map.empty();
-    });
-
-    // Check in global data map.
-    NotifyAndEraseLatest(GlobalData);
-}
-
-bool TFSyncCache::NotifyAndEraseLatest(TRequestMap& map)
-{
-    while (!map.empty()) {
-        auto it = map.begin();
-        if (!IsFSync(it->second)) {
-            break;
-        }
-
-        auto item = std::move(it->second);
-        map.erase(it);
-
-        Notify(item.Request, std::move(item.Promise));
-    }
-
-    return map.empty();
-}
-
-void TFSyncCache::Notify(
-    const TRequest& request,
-    TPromise<NProto::TError>&& promise)
-{
-    // TODO: Fsync or flush can finish not only with success
-    // https://man7.org/linux/man-pages/man2/fsync.2.html
-    // https://man7.org/linux/man-pages/man3/fflush.3.html
-    promise.SetValue({});
-
-    STORAGE_TRACE(LogTag
-        << " FSync request was notified and erased " << request);
-}
-
-bool TFSyncCache::IsFSync(const TItem& item) const
-{
-    return item.Promise.Initialized();
-}
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -219,17 +33,69 @@ TFSyncQueue::TFSyncQueue(
     : LogTag("[" + fileSystemId + "][FSYNC]")
     , Logging(std::move(logging))
     , Log(Logging->CreateLog("NFS_FUSE"))
-    , CurrentState(LogTag, Logging)
 {}
+
+TFSyncQueue::TShard& TFSyncQueue::GetShard(TNodeId nodeId)
+{
+    return Shards[ToUnderlying(nodeId) % ShardCount];
+}
+
+bool TFSyncQueue::IsFSync(const TItem& item)
+{
+    return item.Promise.Initialized();
+}
+
+bool TFSyncQueue::NotifyAndEraseLatest(TRequestMap& map)
+{
+    // Fires leading fsyncs in `map` (calls SetValue on their promises).
+    // Returns true if the map is empty afterwards.
+    // SetValue runs subscriber callbacks synchronously, so they execute
+    // while the caller still holds the shard lock.
+    while (!map.empty()) {
+        auto it = map.begin();
+        if (!IsFSync(it->second)) {
+            break;
+        }
+        auto promise = std::move(it->second.Promise);
+        map.erase(it);
+        promise.SetValue({});
+    }
+    return map.empty();
+}
 
 void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
 {
-    TRequest request{ .ReqId = reqId, .NodeId = nodeId, .Handle = handle };
+    Y_ABORT_UNLESS(nodeId);
+
+    TRequest request{.ReqId = reqId, .NodeId = nodeId, .Handle = handle};
 
     STORAGE_TRACE(LogTag << " Request was started " << request);
 
-    with_lock (StateLock) {
-        CurrentState.AddRequest(request);
+    auto& shard = GetShard(nodeId);
+    with_lock (shard.Lock) {
+        TItem item{.Request = request};
+        auto& metaMap = shard.Meta[nodeId];
+        // There is no need to call NotifyAndEraseLatest here since the
+        // head of any map (lowest reqId) is always non-fsync, because
+        // Dequeue and WaitFor* drain leading fsyncs under the shard lock
+        // before releasing it. A non-fsync insert cannot violate this. It
+        // either becomes the new head (still non-fsync) or lands below the
+        // existing head (head unchanged).
+        Y_DEBUG_ABORT_UNLESS(
+            metaMap.empty() || !IsFSync(metaMap.begin()->second),
+            "FSync at head of meta map for nodeId=%lu before Enqueue",
+            ToUnderlying(nodeId));
+        metaMap.emplace(reqId, item);
+        if (handle) {
+            auto& dataMap = shard.Data[nodeId][handle];
+            Y_DEBUG_ABORT_UNLESS(
+                dataMap.empty() || !IsFSync(dataMap.begin()->second),
+                "FSync at head of data map for nodeId=%lu handle=%lu"
+                " before Enqueue",
+                ToUnderlying(nodeId),
+                ToUnderlying(handle));
+            dataMap.emplace(reqId, item);
+        }
     }
 }
 
@@ -241,13 +107,48 @@ void TFSyncQueue::Dequeue(
 {
     // TODO: Request can finish with error
     Y_UNUSED(error);
+    Y_ABORT_UNLESS(nodeId);
 
-    TRequest request{ .ReqId = reqId, .NodeId = nodeId, .Handle = handle };
+    TRequest request{.ReqId = reqId, .NodeId = nodeId, .Handle = handle};
 
     STORAGE_TRACE(LogTag << " Request was finished " << request);
 
-    with_lock (StateLock) {
-        CurrentState.RemoveRequest(request);
+    auto& shard = GetShard(nodeId);
+    with_lock (shard.Lock) {
+        // Local meta map: always present.
+        auto metaNodeIt = shard.Meta.find(nodeId);
+        Y_ABORT_UNLESS(metaNodeIt != shard.Meta.end());
+        if (!metaNodeIt->second.erase(reqId)) {
+            Y_ABORT(
+                "Cannot find requestId: %lu for nodeId: %lu in local meta map",
+                reqId,
+                ToUnderlying(nodeId));
+        }
+        if (NotifyAndEraseLatest(metaNodeIt->second)) {
+            shard.Meta.erase(metaNodeIt);
+        }
+
+        if (handle) {
+            // Local data map: present only for data requests.
+            auto dataNodeIt = shard.Data.find(nodeId);
+            Y_ABORT_UNLESS(dataNodeIt != shard.Data.end());
+            auto handleIt = dataNodeIt->second.find(handle);
+            Y_ABORT_UNLESS(handleIt != dataNodeIt->second.end());
+            if (!handleIt->second.erase(reqId)) {
+                Y_ABORT(
+                    "Cannot find requestId: %lu for nodeId: %lu and handle: %lu"
+                    " in local data map",
+                    reqId,
+                    ToUnderlying(nodeId),
+                    ToUnderlying(handle));
+            }
+            if (NotifyAndEraseLatest(handleIt->second)) {
+                dataNodeIt->second.erase(handleIt);
+                if (dataNodeIt->second.empty()) {
+                    shard.Data.erase(dataNodeIt);
+                }
+            }
+        }
     }
 }
 
@@ -255,20 +156,35 @@ TFuture<NProto::TError> TFSyncQueue::WaitForRequests(
     TRequestId reqId,
     TNodeId nodeId)
 {
-    TRequest request{ .ReqId = reqId, .NodeId = nodeId };
+    TRequest request{.ReqId = reqId, .NodeId = nodeId};
 
-    STORAGE_TRACE(LogTag
-        << " FSync request was received " << request << " meta");
+    STORAGE_TRACE(
+        LogTag << " FSync request was received " << request << " meta");
 
-    with_lock (StateLock) {
-        return CurrentState.AddFSyncRequest(request);
+    if (!nodeId) {
+        return WaitForGlobalMeta(reqId);
     }
+
+    TItem item{
+        .Request = request,
+        .Promise = NewPromise<NProto::TError>(),
+    };
+    auto future = item.Promise.GetFuture();
+
+    auto& shard = GetShard(nodeId);
+    with_lock (shard.Lock) {
+        auto& map = shard.Meta[nodeId];
+        map.emplace(reqId, std::move(item));
+        if (NotifyAndEraseLatest(map)) {
+            shard.Meta.erase(nodeId);
+        }
+    }
+    return future;
 }
 
 TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(TRequestId reqId)
 {
-    // Handle should not be equal to InvalidHandle for global data fsync.
-    return WaitForDataRequests(reqId, TNodeId {InvalidNodeId}, THandle {~InvalidHandle});
+    return WaitForGlobalData(reqId);
 }
 
 TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(
@@ -276,14 +192,158 @@ TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(
     TNodeId nodeId,
     THandle handle)
 {
-    TRequest request{ .ReqId = reqId, .NodeId = nodeId, .Handle = handle };
+    TRequest request{.ReqId = reqId, .NodeId = nodeId, .Handle = handle};
 
-    STORAGE_TRACE(LogTag
-        << " FSync request was received " << request << " data");
+    STORAGE_TRACE(
+        LogTag << " FSync request was received " << request << " data");
 
-    with_lock (StateLock) {
-        return CurrentState.AddFSyncRequest(request);
+    if (!nodeId) {
+        return WaitForGlobalData(reqId);
     }
+
+    TItem item{
+        .Request = request,
+        .Promise = NewPromise<NProto::TError>(),
+    };
+    auto future = item.Promise.GetFuture();
+
+    auto& shard = GetShard(nodeId);
+    with_lock (shard.Lock) {
+        auto& nodeMap = shard.Data[nodeId];
+        auto& map = nodeMap[handle];
+        map.emplace(reqId, std::move(item));
+        if (NotifyAndEraseLatest(map)) {
+            nodeMap.erase(handle);
+            if (nodeMap.empty()) {
+                shard.Data.erase(nodeId);
+            }
+        }
+    }
+    return future;
+}
+
+TFuture<NProto::TError> TFSyncQueue::WaitForGlobalMeta(TRequestId reqId)
+{
+    // Decompose the global meta fsync into one leaf fsync per non-empty
+    // (shard, nodeId) meta map. The shared promise fires when every leaf has
+    // fired. A +1 placeholder prevents premature firing during fan-out.
+    //
+    // Each shard scan is the global fsync's ordering point for that shard.
+    // Requests that enter an already scanned shard later are concurrent from
+    // this queue's point of view even if their fuse_req_unique is lower than
+    // reqId.
+    auto state = std::make_shared<TGlobalFSyncState>();
+    state->Promise = NewPromise<NProto::TError>();
+    state->Remaining.store(1, std::memory_order_relaxed);
+    auto future = state->Promise.GetFuture();
+
+    TVector<TFuture<NProto::TError>> leafFutures;
+
+    for (auto& shard: Shards) {
+        with_lock (shard.Lock) {
+            // Insert a leaf into each non-empty meta map; immediately drain
+            // any leading fsyncs from that map. The leaf may land at the
+            // head (out-of-order reqIds from multi-threaded FUSE loops) and
+            // must fire right away — otherwise the global fsync would wait
+            // for higher-id requests that semantically came *after* it.
+            // Leaf SetValue here only marks the future as complete; the
+            // decrement-Remaining callback is attached later in the
+            // Subscribe loop and will run inline at that point.
+            EraseNodesIf(
+                shard.Meta,
+                [&](auto& kv)
+                {
+                    auto& [nodeId, map] = kv;
+                    TItem item{
+                        .Request = {.ReqId = reqId, .NodeId = nodeId},
+                        .Promise = NewPromise<NProto::TError>(),
+                    };
+                    leafFutures.push_back(item.Promise.GetFuture());
+                    state->Remaining.fetch_add(1, std::memory_order_relaxed);
+                    map.emplace(reqId, std::move(item));
+                    return NotifyAndEraseLatest(map);
+                });
+        }
+    }
+
+    for (auto& f: leafFutures) {
+        f.Subscribe(
+            [state](const auto&)
+            {
+                if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) ==
+                    1) {
+                    state->Promise.SetValue({});
+                }
+            });
+    }
+
+    // Release the placeholder; fires the promise immediately if no shards
+    // had pending requests.
+    if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        state->Promise.SetValue({});
+    }
+    return future;
+}
+
+TFuture<NProto::TError> TFSyncQueue::WaitForGlobalData(TRequestId reqId)
+{
+    // Same contract as WaitForGlobalMeta: each shard is ordered at the moment
+    // it is scanned, not by a single global fuse_req_unique barrier.
+    auto state = std::make_shared<TGlobalFSyncState>();
+    state->Promise = NewPromise<NProto::TError>();
+    state->Remaining.store(1, std::memory_order_relaxed);
+    auto future = state->Promise.GetFuture();
+
+    TVector<TFuture<NProto::TError>> leafFutures;
+
+    for (auto& shard: Shards) {
+        with_lock (shard.Lock) {
+            EraseNodesIf(
+                shard.Data,
+                [&](auto& nodeKv)
+                {
+                    auto& [nodeId, perHandle] = nodeKv;
+                    EraseNodesIf(
+                        perHandle,
+                        [&](auto& handleKv)
+                        {
+                            auto& [handle, map] = handleKv;
+                            TItem item{
+                                .Request =
+                                    {
+                                        .ReqId = reqId,
+                                        .NodeId = nodeId,
+                                        .Handle = handle,
+                                    },
+                                .Promise = NewPromise<NProto::TError>(),
+                            };
+                            leafFutures.push_back(item.Promise.GetFuture());
+                            state->Remaining.fetch_add(
+                                1,
+                                std::memory_order_relaxed);
+                            map.emplace(reqId, std::move(item));
+                            return NotifyAndEraseLatest(map);
+                        });
+                    return perHandle.empty();
+                });
+        }
+    }
+
+    for (auto& f: leafFutures) {
+        f.Subscribe(
+            [state](const auto&)
+            {
+                if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) ==
+                    1) {
+                    state->Promise.SetValue({});
+                }
+            });
+    }
+
+    if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        state->Promise.SetValue({});
+    }
+    return future;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -336,12 +396,10 @@ TFuture<NProto::TError> TFSyncQueueStub::WaitForDataRequests(
 }   // namespace NCloud::NFileStore::NVFS
 
 template <>
-inline void Out<NCloud::NFileStore::NVFS::TFSyncCache::TRequest>(
+inline void Out<NCloud::NFileStore::NVFS::IFSyncQueue::TRequest>(
     IOutputStream& out,
-    const NCloud::NFileStore::NVFS::TFSyncCache::TRequest& request)
+    const NCloud::NFileStore::NVFS::IFSyncQueue::TRequest& request)
 {
-    out
-        << "#" << ToUnderlying(request.NodeId)
-        << " @" << ToUnderlying(request.Handle)
-        << " id:" << request.ReqId;
+    out << "#" << ToUnderlying(request.NodeId) << " @"
+        << ToUnderlying(request.Handle) << " id:" << request.ReqId;
 }

--- a/cloud/filestore/libs/vfs/fsync_queue.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue.cpp
@@ -1,36 +1,22 @@
 #include "fsync_queue.h"
 
-#include <util/generic/algorithm.h>
+#include <cloud/storage/core/libs/common/verify.h>
 
-#include <atomic>
-#include <memory>
+#include <library/cpp/threading/future/wait/wait.h>
+
+#include <util/generic/algorithm.h>
 
 namespace NCloud::NFileStore::NVFS {
 
 using namespace NThreading;
-
-namespace {
-
-////////////////////////////////////////////////////////////////////////////////
-
-// Completion tracker for one fanned-out global fsync. The originating
-// WaitFor* inserts one fsync leaf per non empty shard map (keyed by
-// nodeId for meta, (nodeId, handle) for data). Each fired leaf decrements
-// Remaining. Promise fires when it reaches zero.
-struct TGlobalFSyncState
-{
-    std::atomic<size_t> Remaining{0};
-    TPromise<NProto::TError> Promise;
-};
-
-}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TFSyncQueue::TFSyncQueue(
         const TString& fileSystemId,
         ILoggingServicePtr logging)
-    : LogTag("[" + fileSystemId + "][FSYNC]")
+    : FileSystemId(fileSystemId)
+    , LogTag("[" + fileSystemId + "][FSYNC]")
     , Logging(std::move(logging))
     , Log(Logging->CreateLog("NFS_FUSE"))
 {}
@@ -65,7 +51,7 @@ bool TFSyncQueue::NotifyAndEraseLatest(TRequestMap& map)
 
 void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
 {
-    Y_ABORT_UNLESS(nodeId);
+    STORAGE_VERIFY(nodeId, TWellKnownEntityTypes::FILESYSTEM, FileSystemId);
 
     TRequest request{.ReqId = reqId, .NodeId = nodeId, .Handle = handle};
 
@@ -81,19 +67,22 @@ void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
         // before releasing it. A non-fsync insert cannot violate this. It
         // either becomes the new head (still non-fsync) or lands below the
         // existing head (head unchanged).
-        Y_DEBUG_ABORT_UNLESS(
+        STORAGE_VERIFY_DEBUG_C(
             metaMap.empty() || !IsFSync(metaMap.begin()->second),
-            "FSync at head of meta map for nodeId=%lu before Enqueue",
-            ToUnderlying(nodeId));
+            TWellKnownEntityTypes::FILESYSTEM,
+            FileSystemId,
+            TStringBuilder() << "FSync at head of meta map for nodeId="
+                             << ToUnderlying(nodeId) << " before Enqueue");
         metaMap.emplace(reqId, item);
         if (handle) {
             auto& dataMap = shard.Data[nodeId][handle];
-            Y_DEBUG_ABORT_UNLESS(
+            STORAGE_VERIFY_DEBUG_C(
                 dataMap.empty() || !IsFSync(dataMap.begin()->second),
-                "FSync at head of data map for nodeId=%lu handle=%lu"
-                " before Enqueue",
-                ToUnderlying(nodeId),
-                ToUnderlying(handle));
+                TWellKnownEntityTypes::FILESYSTEM,
+                FileSystemId,
+                TStringBuilder() << "FSync at head of data map for nodeId="
+                                 << ToUnderlying(nodeId) << " handle="
+                                 << ToUnderlying(handle) << " before Enqueue");
             dataMap.emplace(reqId, item);
         }
     }
@@ -107,7 +96,7 @@ void TFSyncQueue::Dequeue(
 {
     // TODO: Request can finish with error
     Y_UNUSED(error);
-    Y_ABORT_UNLESS(nodeId);
+    STORAGE_VERIFY(nodeId, TWellKnownEntityTypes::FILESYSTEM, FileSystemId);
 
     TRequest request{.ReqId = reqId, .NodeId = nodeId, .Handle = handle};
 
@@ -117,13 +106,17 @@ void TFSyncQueue::Dequeue(
     with_lock (shard.Lock) {
         // Local meta map: always present.
         auto metaNodeIt = shard.Meta.find(nodeId);
-        Y_ABORT_UNLESS(metaNodeIt != shard.Meta.end());
-        if (!metaNodeIt->second.erase(reqId)) {
-            Y_ABORT(
-                "Cannot find requestId: %lu for nodeId: %lu in local meta map",
-                reqId,
-                ToUnderlying(nodeId));
-        }
+        STORAGE_VERIFY(
+            metaNodeIt != shard.Meta.end(),
+            TWellKnownEntityTypes::FILESYSTEM,
+            FileSystemId);
+        STORAGE_VERIFY_C(
+            metaNodeIt->second.erase(reqId),
+            TWellKnownEntityTypes::FILESYSTEM,
+            FileSystemId,
+            TStringBuilder() << "Cannot find requestId: " << reqId
+                             << " for nodeId: " << ToUnderlying(nodeId)
+                             << " in local meta map");
         if (NotifyAndEraseLatest(metaNodeIt->second)) {
             shard.Meta.erase(metaNodeIt);
         }
@@ -131,17 +124,23 @@ void TFSyncQueue::Dequeue(
         if (handle) {
             // Local data map: present only for data requests.
             auto dataNodeIt = shard.Data.find(nodeId);
-            Y_ABORT_UNLESS(dataNodeIt != shard.Data.end());
+            STORAGE_VERIFY(
+                dataNodeIt != shard.Data.end(),
+                TWellKnownEntityTypes::FILESYSTEM,
+                FileSystemId);
             auto handleIt = dataNodeIt->second.find(handle);
-            Y_ABORT_UNLESS(handleIt != dataNodeIt->second.end());
-            if (!handleIt->second.erase(reqId)) {
-                Y_ABORT(
-                    "Cannot find requestId: %lu for nodeId: %lu and handle: %lu"
-                    " in local data map",
-                    reqId,
-                    ToUnderlying(nodeId),
-                    ToUnderlying(handle));
-            }
+            STORAGE_VERIFY(
+                handleIt != dataNodeIt->second.end(),
+                TWellKnownEntityTypes::FILESYSTEM,
+                FileSystemId);
+            STORAGE_VERIFY_C(
+                handleIt->second.erase(reqId),
+                TWellKnownEntityTypes::FILESYSTEM,
+                FileSystemId,
+                TStringBuilder() << "Cannot find requestId: " << reqId
+                                 << " for nodeId: " << ToUnderlying(nodeId)
+                                 << " and handle: " << ToUnderlying(handle)
+                                 << " in local data map");
             if (NotifyAndEraseLatest(handleIt->second)) {
                 dataNodeIt->second.erase(handleIt);
                 if (dataNodeIt->second.empty()) {
@@ -165,18 +164,21 @@ TFuture<NProto::TError> TFSyncQueue::WaitForRequests(
         return WaitForGlobalMeta(reqId);
     }
 
-    TItem item{
-        .Request = request,
-        .Promise = NewPromise<NProto::TError>(),
-    };
-    auto future = item.Promise.GetFuture();
-
+    TFuture<NProto::TError> future;
     auto& shard = GetShard(nodeId);
     with_lock (shard.Lock) {
-        auto& map = shard.Meta[nodeId];
-        map.emplace(reqId, std::move(item));
-        if (NotifyAndEraseLatest(map)) {
-            shard.Meta.erase(nodeId);
+        auto it = shard.Meta.find(nodeId);
+        if (it == shard.Meta.end()) {
+            return MakeFuture<NProto::TError>();
+        }
+        TItem item{
+            .Request = request,
+            .Promise = NewPromise<NProto::TError>(),
+        };
+        future = item.Promise.GetFuture();
+        it->second.emplace(reqId, std::move(item));
+        if (NotifyAndEraseLatest(it->second)) {
+            shard.Meta.erase(it);
         }
     }
     return future;
@@ -201,149 +203,123 @@ TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(
         return WaitForGlobalData(reqId);
     }
 
-    TItem item{
-        .Request = request,
-        .Promise = NewPromise<NProto::TError>(),
-    };
-    auto future = item.Promise.GetFuture();
-
+    TFuture<NProto::TError> future;
     auto& shard = GetShard(nodeId);
     with_lock (shard.Lock) {
-        auto& nodeMap = shard.Data[nodeId];
-        auto& map = nodeMap[handle];
-        map.emplace(reqId, std::move(item));
-        if (NotifyAndEraseLatest(map)) {
-            nodeMap.erase(handle);
+        auto nodeIt = shard.Data.find(nodeId);
+        if (nodeIt == shard.Data.end()) {
+            return MakeFuture<NProto::TError>();
+        }
+
+        auto& nodeMap = nodeIt->second;
+        auto handleIt = nodeMap.find(handle);
+        if (handleIt == nodeMap.end()) {
+            return MakeFuture<NProto::TError>();
+        }
+
+        TItem item{
+            .Request = request,
+            .Promise = NewPromise<NProto::TError>(),
+        };
+        future = item.Promise.GetFuture();
+        handleIt->second.emplace(reqId, std::move(item));
+        if (NotifyAndEraseLatest(handleIt->second)) {
+            nodeMap.erase(handleIt);
             if (nodeMap.empty()) {
-                shard.Data.erase(nodeId);
+                shard.Data.erase(nodeIt);
             }
         }
     }
     return future;
 }
 
-TFuture<NProto::TError> TFSyncQueue::WaitForGlobalMeta(TRequestId reqId)
+TFuture<NProto::TError> TFSyncQueue::WaitForShardMeta(
+    TShard& shard,
+    TRequestId reqId)
 {
-    // Decompose the global meta fsync into one leaf fsync per non-empty
-    // (shard, nodeId) meta map. The shared promise fires when every leaf has
-    // fired. A +1 placeholder prevents premature firing during fan-out.
-    //
-    // Each shard scan is the global fsync's ordering point for that shard.
-    // Requests that enter an already scanned shard later are concurrent from
-    // this queue's point of view even if their fuse_req_unique is lower than
-    // reqId.
-    auto state = std::make_shared<TGlobalFSyncState>();
-    state->Promise = NewPromise<NProto::TError>();
-    state->Remaining.store(1, std::memory_order_relaxed);
-    auto future = state->Promise.GetFuture();
-
     TVector<TFuture<NProto::TError>> leafFutures;
-
-    for (auto& shard: Shards) {
-        with_lock (shard.Lock) {
-            // Insert a leaf into each non-empty meta map; immediately drain
-            // any leading fsyncs from that map. The leaf may land at the
-            // head (out-of-order reqIds from multi-threaded FUSE loops) and
-            // must fire right away — otherwise the global fsync would wait
-            // for higher-id requests that semantically came *after* it.
-            // Leaf SetValue here only marks the future as complete; the
-            // decrement-Remaining callback is attached later in the
-            // Subscribe loop and will run inline at that point.
-            EraseNodesIf(
-                shard.Meta,
-                [&](auto& kv)
-                {
-                    auto& [nodeId, map] = kv;
-                    TItem item{
-                        .Request = {.ReqId = reqId, .NodeId = nodeId},
-                        .Promise = NewPromise<NProto::TError>(),
-                    };
-                    leafFutures.push_back(item.Promise.GetFuture());
-                    state->Remaining.fetch_add(1, std::memory_order_relaxed);
-                    map.emplace(reqId, std::move(item));
-                    return NotifyAndEraseLatest(map);
-                });
-        }
-    }
-
-    for (auto& f: leafFutures) {
-        f.Subscribe(
-            [state](const auto&)
+    with_lock (shard.Lock) {
+        leafFutures.reserve(shard.Meta.size());
+        // Insert a leaf into every per-node meta map in the shard; drain
+        // leading fsyncs that may sit at the head (out-of-order reqIds from
+        // multi-threaded FUSE loops would otherwise cause the per-shard fsync
+        // to wait on semantically-later requests).
+        EraseNodesIf(
+            shard.Meta,
+            [&](auto& kv)
             {
-                if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) ==
-                    1) {
-                    state->Promise.SetValue({});
-                }
+                auto& [nodeId, map] = kv;
+                TItem item{
+                    .Request = {.ReqId = reqId, .NodeId = nodeId},
+                    .Promise = NewPromise<NProto::TError>(),
+                };
+                leafFutures.push_back(item.Promise.GetFuture());
+                map.emplace(reqId, std::move(item));
+                return NotifyAndEraseLatest(map);
             });
     }
+    return WaitAll(leafFutures)
+        .Apply([](const auto&) { return NProto::TError{}; });
+}
 
-    // Release the placeholder; fires the promise immediately if no shards
-    // had pending requests.
-    if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        state->Promise.SetValue({});
+TFuture<NProto::TError> TFSyncQueue::WaitForShardData(
+    TShard& shard,
+    TRequestId reqId)
+{
+    TVector<TFuture<NProto::TError>> leafFutures;
+    with_lock (shard.Lock) {
+        EraseNodesIf(
+            shard.Data,
+            [&](auto& nodeKv)
+            {
+                auto& [nodeId, perHandle] = nodeKv;
+                EraseNodesIf(
+                    perHandle,
+                    [&](auto& handleKv)
+                    {
+                        auto& [handle, map] = handleKv;
+                        TItem item{
+                            .Request =
+                                {.ReqId = reqId,
+                                 .NodeId = nodeId,
+                                 .Handle = handle},
+                            .Promise = NewPromise<NProto::TError>(),
+                        };
+                        leafFutures.push_back(item.Promise.GetFuture());
+                        map.emplace(reqId, std::move(item));
+                        return NotifyAndEraseLatest(map);
+                    });
+                return perHandle.empty();
+            });
     }
-    return future;
+    return WaitAll(leafFutures)
+        .Apply([](const auto&) { return NProto::TError{}; });
+}
+
+TFuture<NProto::TError> TFSyncQueue::WaitForGlobalMeta(TRequestId reqId)
+{
+    // Each shard scan is the global fsync's ordering point for that shard.
+    // Requests that enter an already-scanned shard later are concurrent from
+    // this queue's point of view even if their fuse_req_unique is lower than
+    // reqId.
+    TVector<TFuture<NProto::TError>> shardFutures;
+    shardFutures.reserve(Shards.size());
+    for (auto& shard: Shards) {
+        shardFutures.push_back(WaitForShardMeta(shard, reqId));
+    }
+    return WaitAll(shardFutures)
+        .Apply([](const auto&) { return NProto::TError{}; });
 }
 
 TFuture<NProto::TError> TFSyncQueue::WaitForGlobalData(TRequestId reqId)
 {
-    // Same contract as WaitForGlobalMeta: each shard is ordered at the moment
-    // it is scanned, not by a single global fuse_req_unique barrier.
-    auto state = std::make_shared<TGlobalFSyncState>();
-    state->Promise = NewPromise<NProto::TError>();
-    state->Remaining.store(1, std::memory_order_relaxed);
-    auto future = state->Promise.GetFuture();
-
-    TVector<TFuture<NProto::TError>> leafFutures;
-
+    TVector<TFuture<NProto::TError>> shardFutures;
+    shardFutures.reserve(Shards.size());
     for (auto& shard: Shards) {
-        with_lock (shard.Lock) {
-            EraseNodesIf(
-                shard.Data,
-                [&](auto& nodeKv)
-                {
-                    auto& [nodeId, perHandle] = nodeKv;
-                    EraseNodesIf(
-                        perHandle,
-                        [&](auto& handleKv)
-                        {
-                            auto& [handle, map] = handleKv;
-                            TItem item{
-                                .Request =
-                                    {
-                                        .ReqId = reqId,
-                                        .NodeId = nodeId,
-                                        .Handle = handle,
-                                    },
-                                .Promise = NewPromise<NProto::TError>(),
-                            };
-                            leafFutures.push_back(item.Promise.GetFuture());
-                            state->Remaining.fetch_add(
-                                1,
-                                std::memory_order_relaxed);
-                            map.emplace(reqId, std::move(item));
-                            return NotifyAndEraseLatest(map);
-                        });
-                    return perHandle.empty();
-                });
-        }
+        shardFutures.push_back(WaitForShardData(shard, reqId));
     }
-
-    for (auto& f: leafFutures) {
-        f.Subscribe(
-            [state](const auto&)
-            {
-                if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) ==
-                    1) {
-                    state->Promise.SetValue({});
-                }
-            });
-    }
-
-    if (state->Remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        state->Promise.SetValue({});
-    }
-    return future;
+    return WaitAll(shardFutures)
+        .Apply([](const auto&) { return NProto::TError{}; });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs/fsync_queue.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue.cpp
@@ -16,12 +16,12 @@ TFSyncQueue::TFSyncQueue(
         const TString& fileSystemId,
         ILoggingServicePtr logging)
     : FileSystemId(fileSystemId)
-    , LogTag("[" + fileSystemId + "][FSYNC]")
+    , LogTag("[" + fileSystemId + "][FSYNC_QUEUE]")
     , Logging(std::move(logging))
     , Log(Logging->CreateLog("NFS_FUSE"))
 {}
 
-TFSyncQueue::TShard& TFSyncQueue::GetShard(TNodeId nodeId)
+TFSyncQueue::TShard& TFSyncQueue::AccessShard(TNodeId nodeId)
 {
     return Shards[ToUnderlying(nodeId) % ShardCount];
 }
@@ -31,7 +31,7 @@ bool TFSyncQueue::IsFSync(const TItem& item)
     return item.Promise.Initialized();
 }
 
-bool TFSyncQueue::NotifyAndEraseLatest(TRequestMap& map)
+bool TFSyncQueue::NotifyAndEraseLeadingFSyncs(TRequestMap& map)
 {
     // Fires leading fsyncs in `map` (calls SetValue on their promises).
     // Returns true if the map is empty afterwards.
@@ -42,10 +42,12 @@ bool TFSyncQueue::NotifyAndEraseLatest(TRequestMap& map)
         if (!IsFSync(it->second)) {
             break;
         }
+
         auto promise = std::move(it->second.Promise);
         map.erase(it);
-        promise.SetValue({});
+        promise.SetValue(MakeError(S_OK));
     }
+
     return map.empty();
 }
 
@@ -57,11 +59,11 @@ void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
 
     STORAGE_TRACE(LogTag << " Request was started " << request);
 
-    auto& shard = GetShard(nodeId);
+    auto& shard = AccessShard(nodeId);
     with_lock (shard.Lock) {
         TItem item{.Request = request};
         auto& metaMap = shard.Meta[nodeId];
-        // There is no need to call NotifyAndEraseLatest here since the
+        // There is no need to call NotifyAndEraseLeadingFSyncs here since the
         // head of any map (lowest reqId) is always non-fsync, because
         // Dequeue and WaitFor* drain leading fsyncs under the shard lock
         // before releasing it. A non-fsync insert cannot violate this. It
@@ -73,7 +75,13 @@ void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
             FileSystemId,
             TStringBuilder() << "FSync at head of meta map for nodeId="
                              << ToUnderlying(nodeId) << " before Enqueue");
-        metaMap.emplace(reqId, item);
+        STORAGE_VERIFY_C(
+            metaMap.emplace(reqId, item).second,
+            TWellKnownEntityTypes::FILESYSTEM,
+            FileSystemId,
+            TStringBuilder() << "Duplicate requestId: " << reqId
+                             << " for nodeId: " << ToUnderlying(nodeId)
+                             << " in local meta map");
         if (handle) {
             auto& dataMap = shard.Data[nodeId][handle];
             STORAGE_VERIFY_DEBUG_C(
@@ -83,7 +91,14 @@ void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
                 TStringBuilder() << "FSync at head of data map for nodeId="
                                  << ToUnderlying(nodeId) << " handle="
                                  << ToUnderlying(handle) << " before Enqueue");
-            dataMap.emplace(reqId, item);
+            STORAGE_VERIFY_C(
+                dataMap.emplace(reqId, item).second,
+                TWellKnownEntityTypes::FILESYSTEM,
+                FileSystemId,
+                TStringBuilder() << "Duplicate requestId: " << reqId
+                                 << " for nodeId: " << ToUnderlying(nodeId)
+                                 << " and handle: " << ToUnderlying(handle)
+                                 << " in local data map");
         }
     }
 }
@@ -102,7 +117,7 @@ void TFSyncQueue::Dequeue(
 
     STORAGE_TRACE(LogTag << " Request was finished " << request);
 
-    auto& shard = GetShard(nodeId);
+    auto& shard = AccessShard(nodeId);
     with_lock (shard.Lock) {
         // Local meta map: always present.
         auto metaNodeIt = shard.Meta.find(nodeId);
@@ -117,7 +132,7 @@ void TFSyncQueue::Dequeue(
             TStringBuilder() << "Cannot find requestId: " << reqId
                              << " for nodeId: " << ToUnderlying(nodeId)
                              << " in local meta map");
-        if (NotifyAndEraseLatest(metaNodeIt->second)) {
+        if (NotifyAndEraseLeadingFSyncs(metaNodeIt->second)) {
             shard.Meta.erase(metaNodeIt);
         }
 
@@ -141,7 +156,7 @@ void TFSyncQueue::Dequeue(
                                  << " for nodeId: " << ToUnderlying(nodeId)
                                  << " and handle: " << ToUnderlying(handle)
                                  << " in local data map");
-            if (NotifyAndEraseLatest(handleIt->second)) {
+            if (NotifyAndEraseLeadingFSyncs(handleIt->second)) {
                 dataNodeIt->second.erase(handleIt);
                 if (dataNodeIt->second.empty()) {
                     shard.Data.erase(dataNodeIt);
@@ -165,19 +180,25 @@ TFuture<NProto::TError> TFSyncQueue::WaitForRequests(
     }
 
     TFuture<NProto::TError> future;
-    auto& shard = GetShard(nodeId);
+    auto& shard = AccessShard(nodeId);
     with_lock (shard.Lock) {
         auto it = shard.Meta.find(nodeId);
         if (it == shard.Meta.end()) {
-            return MakeFuture<NProto::TError>();
+            return MakeFuture(MakeError(S_OK));
         }
         TItem item{
             .Request = request,
             .Promise = NewPromise<NProto::TError>(),
         };
         future = item.Promise.GetFuture();
-        it->second.emplace(reqId, std::move(item));
-        if (NotifyAndEraseLatest(it->second)) {
+        STORAGE_VERIFY_C(
+            it->second.emplace(reqId, std::move(item)).second,
+            TWellKnownEntityTypes::FILESYSTEM,
+            FileSystemId,
+            TStringBuilder() << "Duplicate requestId: " << reqId
+                             << " for nodeId: " << ToUnderlying(nodeId)
+                             << " in local meta map");
+        if (NotifyAndEraseLeadingFSyncs(it->second)) {
             shard.Meta.erase(it);
         }
     }
@@ -204,17 +225,17 @@ TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(
     }
 
     TFuture<NProto::TError> future;
-    auto& shard = GetShard(nodeId);
+    auto& shard = AccessShard(nodeId);
     with_lock (shard.Lock) {
         auto nodeIt = shard.Data.find(nodeId);
         if (nodeIt == shard.Data.end()) {
-            return MakeFuture<NProto::TError>();
+            return MakeFuture(MakeError(S_OK));
         }
 
         auto& nodeMap = nodeIt->second;
         auto handleIt = nodeMap.find(handle);
         if (handleIt == nodeMap.end()) {
-            return MakeFuture<NProto::TError>();
+            return MakeFuture(MakeError(S_OK));
         }
 
         TItem item{
@@ -222,8 +243,15 @@ TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(
             .Promise = NewPromise<NProto::TError>(),
         };
         future = item.Promise.GetFuture();
-        handleIt->second.emplace(reqId, std::move(item));
-        if (NotifyAndEraseLatest(handleIt->second)) {
+        STORAGE_VERIFY_C(
+            handleIt->second.emplace(reqId, std::move(item)).second,
+            TWellKnownEntityTypes::FILESYSTEM,
+            FileSystemId,
+            TStringBuilder() << "Duplicate requestId: " << reqId
+                             << " for nodeId: " << ToUnderlying(nodeId)
+                             << " and handle: " << ToUnderlying(handle)
+                             << " in local data map");
+        if (NotifyAndEraseLeadingFSyncs(handleIt->second)) {
             nodeMap.erase(handleIt);
             if (nodeMap.empty()) {
                 shard.Data.erase(nodeIt);
@@ -254,12 +282,18 @@ TFuture<NProto::TError> TFSyncQueue::WaitForShardMeta(
                     .Promise = NewPromise<NProto::TError>(),
                 };
                 leafFutures.push_back(item.Promise.GetFuture());
-                map.emplace(reqId, std::move(item));
-                return NotifyAndEraseLatest(map);
+                STORAGE_VERIFY_C(
+                    map.emplace(reqId, std::move(item)).second,
+                    TWellKnownEntityTypes::FILESYSTEM,
+                    FileSystemId,
+                    TStringBuilder() << "Duplicate requestId: " << reqId
+                                     << " for nodeId: " << ToUnderlying(nodeId)
+                                     << " in shard meta map");
+                return NotifyAndEraseLeadingFSyncs(map);
             });
     }
     return WaitAll(leafFutures)
-        .Apply([](const auto&) { return NProto::TError{}; });
+        .Apply([](const auto&) { return MakeError(S_OK); });
 }
 
 TFuture<NProto::TError> TFSyncQueue::WaitForShardData(
@@ -286,14 +320,22 @@ TFuture<NProto::TError> TFSyncQueue::WaitForShardData(
                             .Promise = NewPromise<NProto::TError>(),
                         };
                         leafFutures.push_back(item.Promise.GetFuture());
-                        map.emplace(reqId, std::move(item));
-                        return NotifyAndEraseLatest(map);
+                        STORAGE_VERIFY_C(
+                            map.emplace(reqId, std::move(item)).second,
+                            TWellKnownEntityTypes::FILESYSTEM,
+                            FileSystemId,
+                            TStringBuilder()
+                                << "Duplicate requestId: " << reqId
+                                << " for nodeId: " << ToUnderlying(nodeId)
+                                << " and handle: " << ToUnderlying(handle)
+                                << " in shard data map");
+                        return NotifyAndEraseLeadingFSyncs(map);
                     });
                 return perHandle.empty();
             });
     }
     return WaitAll(leafFutures)
-        .Apply([](const auto&) { return NProto::TError{}; });
+        .Apply([](const auto&) { return MakeError(S_OK); });
 }
 
 TFuture<NProto::TError> TFSyncQueue::WaitForGlobalMeta(TRequestId reqId)
@@ -308,7 +350,7 @@ TFuture<NProto::TError> TFSyncQueue::WaitForGlobalMeta(TRequestId reqId)
         shardFutures.push_back(WaitForShardMeta(shard, reqId));
     }
     return WaitAll(shardFutures)
-        .Apply([](const auto&) { return NProto::TError{}; });
+        .Apply([](const auto&) { return MakeError(S_OK); });
 }
 
 TFuture<NProto::TError> TFSyncQueue::WaitForGlobalData(TRequestId reqId)
@@ -319,7 +361,7 @@ TFuture<NProto::TError> TFSyncQueue::WaitForGlobalData(TRequestId reqId)
         shardFutures.push_back(WaitForShardData(shard, reqId));
     }
     return WaitAll(shardFutures)
-        .Apply([](const auto&) { return NProto::TError{}; });
+        .Apply([](const auto&) { return MakeError(S_OK); });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -349,13 +391,13 @@ TFuture<NProto::TError> TFSyncQueueStub::WaitForRequests(
 {
     Y_UNUSED(reqId);
     Y_UNUSED(nodeId);
-    return MakeFuture<NProto::TError>();
+    return MakeFuture(MakeError(S_OK));
 }
 
 TFuture<NProto::TError> TFSyncQueueStub::WaitForDataRequests(TRequestId reqId)
 {
     Y_UNUSED(reqId);
-    return MakeFuture<NProto::TError>();
+    return MakeFuture(MakeError(S_OK));
 }
 
 TFuture<NProto::TError> TFSyncQueueStub::WaitForDataRequests(
@@ -366,7 +408,7 @@ TFuture<NProto::TError> TFSyncQueueStub::WaitForDataRequests(
     Y_UNUSED(reqId);
     Y_UNUSED(nodeId);
     Y_UNUSED(handle);
-    return MakeFuture<NProto::TError>();
+    return MakeFuture(MakeError(S_OK));
 }
 
 }   // namespace NCloud::NFileStore::NVFS

--- a/cloud/filestore/libs/vfs/fsync_queue.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue.cpp
@@ -75,8 +75,9 @@ void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
             FileSystemId,
             TStringBuilder() << "FSync at head of meta map for nodeId="
                              << ToUnderlying(nodeId) << " before Enqueue");
+        const bool metaEmplaced = metaMap.emplace(reqId, item).second;
         STORAGE_VERIFY_C(
-            metaMap.emplace(reqId, item).second,
+            metaEmplaced,
             TWellKnownEntityTypes::FILESYSTEM,
             FileSystemId,
             TStringBuilder() << "Duplicate requestId: " << reqId
@@ -91,8 +92,9 @@ void TFSyncQueue::Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle)
                 TStringBuilder() << "FSync at head of data map for nodeId="
                                  << ToUnderlying(nodeId) << " handle="
                                  << ToUnderlying(handle) << " before Enqueue");
+            const bool dataEmplaced = dataMap.emplace(reqId, item).second;
             STORAGE_VERIFY_C(
-                dataMap.emplace(reqId, item).second,
+                dataEmplaced,
                 TWellKnownEntityTypes::FILESYSTEM,
                 FileSystemId,
                 TStringBuilder() << "Duplicate requestId: " << reqId
@@ -125,8 +127,9 @@ void TFSyncQueue::Dequeue(
             metaNodeIt != shard.Meta.end(),
             TWellKnownEntityTypes::FILESYSTEM,
             FileSystemId);
+        const bool metaErased = metaNodeIt->second.erase(reqId);
         STORAGE_VERIFY_C(
-            metaNodeIt->second.erase(reqId),
+            metaErased,
             TWellKnownEntityTypes::FILESYSTEM,
             FileSystemId,
             TStringBuilder() << "Cannot find requestId: " << reqId
@@ -148,8 +151,9 @@ void TFSyncQueue::Dequeue(
                 handleIt != dataNodeIt->second.end(),
                 TWellKnownEntityTypes::FILESYSTEM,
                 FileSystemId);
+            const bool dataErased = handleIt->second.erase(reqId);
             STORAGE_VERIFY_C(
-                handleIt->second.erase(reqId),
+                dataErased,
                 TWellKnownEntityTypes::FILESYSTEM,
                 FileSystemId,
                 TStringBuilder() << "Cannot find requestId: " << reqId
@@ -191,8 +195,9 @@ TFuture<NProto::TError> TFSyncQueue::WaitForRequests(
             .Promise = NewPromise<NProto::TError>(),
         };
         future = item.Promise.GetFuture();
+        const bool emplaced = it->second.emplace(reqId, std::move(item)).second;
         STORAGE_VERIFY_C(
-            it->second.emplace(reqId, std::move(item)).second,
+            emplaced,
             TWellKnownEntityTypes::FILESYSTEM,
             FileSystemId,
             TStringBuilder() << "Duplicate requestId: " << reqId
@@ -243,8 +248,10 @@ TFuture<NProto::TError> TFSyncQueue::WaitForDataRequests(
             .Promise = NewPromise<NProto::TError>(),
         };
         future = item.Promise.GetFuture();
+        const bool emplaced =
+            handleIt->second.emplace(reqId, std::move(item)).second;
         STORAGE_VERIFY_C(
-            handleIt->second.emplace(reqId, std::move(item)).second,
+            emplaced,
             TWellKnownEntityTypes::FILESYSTEM,
             FileSystemId,
             TStringBuilder() << "Duplicate requestId: " << reqId
@@ -282,8 +289,9 @@ TFuture<NProto::TError> TFSyncQueue::WaitForShardMeta(
                     .Promise = NewPromise<NProto::TError>(),
                 };
                 leafFutures.push_back(item.Promise.GetFuture());
+                const bool emplaced = map.emplace(reqId, std::move(item)).second;
                 STORAGE_VERIFY_C(
-                    map.emplace(reqId, std::move(item)).second,
+                    emplaced,
                     TWellKnownEntityTypes::FILESYSTEM,
                     FileSystemId,
                     TStringBuilder() << "Duplicate requestId: " << reqId
@@ -320,8 +328,10 @@ TFuture<NProto::TError> TFSyncQueue::WaitForShardData(
                             .Promise = NewPromise<NProto::TError>(),
                         };
                         leafFutures.push_back(item.Promise.GetFuture());
+                        const bool emplaced =
+                            map.emplace(reqId, std::move(item)).second;
                         STORAGE_VERIFY_C(
-                            map.emplace(reqId, std::move(item)).second,
+                            emplaced,
                             TWellKnownEntityTypes::FILESYSTEM,
                             FileSystemId,
                             TStringBuilder()

--- a/cloud/filestore/libs/vfs/fsync_queue.h
+++ b/cloud/filestore/libs/vfs/fsync_queue.h
@@ -49,6 +49,11 @@ public:
         TNodeId nodeId,
         THandle handle = {}) = 0;
 
+    // Callbacks attached to futures returned by WaitFor* run asynchronously
+    // inside Dequeue while the implementation holds an internal lock. Callers
+    // must not invoke any IFSyncQueue method from such a callback, otherwise
+    // the non-reentrant lock will deadlock.
+
     // Meta requests.
     virtual NThreading::TFuture<NProto::TError> WaitForRequests(
         TRequestId reqId,
@@ -91,7 +96,7 @@ private:
 
     using TRequestMap = TMap<TRequestId, TItem>;
 
-    struct alignas(64) TShard
+    struct Y_CACHE_ALIGNED TShard
     {
         TAdaptiveLock Lock;
         THashMap<TNodeId, TRequestMap> Meta;
@@ -130,11 +135,11 @@ public:
         THandle handle) override;
 
 private:
-    TShard& GetShard(TNodeId nodeId);
+    TShard& AccessShard(TNodeId nodeId);
 
     static bool IsFSync(const TItem& item);
 
-    static bool NotifyAndEraseLatest(TRequestMap& map);
+    static bool NotifyAndEraseLeadingFSyncs(TRequestMap& map);
 
     NThreading::TFuture<NProto::TError>
     WaitForShardMeta(TShard& shard, TRequestId reqId);

--- a/cloud/filestore/libs/vfs/fsync_queue.h
+++ b/cloud/filestore/libs/vfs/fsync_queue.h
@@ -13,7 +13,10 @@
 
 #include <util/generic/hash.h>
 #include <util/generic/map.h>
-#include <util/system/mutex.h>
+#include <util/generic/vector.h>
+#include <util/system/spinlock.h>
+
+#include <array>
 
 namespace NCloud::NFileStore::NVFS {
 
@@ -38,10 +41,8 @@ public:
 
     virtual ~IFSyncQueue() = default;
 
-    virtual void Enqueue(
-        TRequestId reqId,
-        TNodeId nodeId,
-        THandle handle = {}) = 0;
+    virtual void
+    Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle = {}) = 0;
     virtual void Dequeue(
         TRequestId reqId,
         const NProto::TError& error,
@@ -54,20 +55,34 @@ public:
         TNodeId nodeId = {}) = 0;
 
     // Data requests.
-    virtual NThreading::TFuture<NProto::TError> WaitForDataRequests(TRequestId reqId) = 0;
     virtual NThreading::TFuture<NProto::TError> WaitForDataRequests(
-        TRequestId reqId,
-        TNodeId nodeId,
-        THandle handle) = 0;
+        TRequestId reqId) = 0;
+    virtual NThreading::TFuture<NProto::TError>
+    WaitForDataRequests(TRequestId reqId, TNodeId nodeId, THandle handle) = 0;
 };
 
-class TFSyncCache
+////////////////////////////////////////////////////////////////////////////////
+
+class TFSyncQueue final: public IFSyncQueue
 {
 public:
     using TRequestId = IFSyncQueue::TRequestId;
     using TRequest = IFSyncQueue::TRequest;
 
 private:
+    // Sharding by NodeId. Hot-path Enqueue/Dequeue and per-node WaitFor*
+    // acquire exactly one shard lock; no global lock exists. Global fsync
+    // (WaitFor*(reqId) without nodeId) fans out across all shards.
+    //
+    // Enqueue is the ordering admission point. ReqIds order requests that
+    // have already reached this queue, but multi-queue virtiofs assigns
+    // fuse_req_unique before dispatching across queues, so lower unique ids
+    // can be admitted to this code after higher ones by a different loop
+    // thread. The reqId-keyed TMap re-sorts them. Global fsync therefore
+    // waits for the per-map state visible when each shard is scanned; it
+    // is not a global fuse_req_unique resequencer.
+    static constexpr ui32 ShardCount = 16;
+
     struct TItem
     {
         TRequest Request;
@@ -76,56 +91,24 @@ private:
 
     using TRequestMap = TMap<TRequestId, TItem>;
 
-    using TMetaMap = THashMap<TNodeId, TRequestMap>;
-    using TDataMap = THashMap<TNodeId, THashMap<THandle, TRequestMap>>;
+    struct alignas(64) TShard
+    {
+        TAdaptiveLock Lock;
+        THashMap<TNodeId, TRequestMap> Meta;
+        THashMap<TNodeId, THashMap<THandle, TRequestMap>> Data;
+    };
 
-private:
     const TString LogTag;
     const ILoggingServicePtr Logging;
     TLog Log;
 
-    TMetaMap Meta;
-    TRequestMap GlobalMeta;
-
-    TDataMap Data;
-    TRequestMap GlobalData;
-
-public:
-    TFSyncCache(TString logTag, ILoggingServicePtr logging);
-
-    void AddRequest(const TRequest& request);
-    NThreading::TFuture<NProto::TError> AddFSyncRequest(const TRequest& request);
-
-    void RemoveRequest(const TRequest& request);
-
-private:
-    void CheckFSyncNotifications();
-    bool NotifyAndEraseLatest(TRequestMap& map);
-    void Notify(
-        const TRequest& request,
-        NThreading::TPromise<NProto::TError>&& promise);
-
-    bool IsFSync(const TItem& item) const;
-};
-
-class TFSyncQueue final
-    : public IFSyncQueue
-{
-private:
-    const TString LogTag;
-    const ILoggingServicePtr Logging;
-    TLog Log;
-
-    TFSyncCache CurrentState;
-    TAdaptiveLock StateLock;
+    std::array<TShard, ShardCount> Shards;
 
 public:
     TFSyncQueue(const TString& fileSystemId, ILoggingServicePtr logging);
 
-    void Enqueue(
-        TRequestId reqId,
-        TNodeId nodeId,
-        THandle handle = {}) override;
+    void
+    Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle = {}) override;
     void Dequeue(
         TRequestId reqId,
         const NProto::TError& error,
@@ -138,21 +121,31 @@ public:
         TNodeId nodeId = {}) override;
 
     // Data requests.
-    NThreading::TFuture<NProto::TError> WaitForDataRequests(TRequestId reqId) override;
+    NThreading::TFuture<NProto::TError> WaitForDataRequests(
+        TRequestId reqId) override;
     NThreading::TFuture<NProto::TError> WaitForDataRequests(
         TRequestId reqId,
         TNodeId nodeId,
         THandle handle) override;
+
+private:
+    TShard& GetShard(TNodeId nodeId);
+
+    static bool IsFSync(const TItem& item);
+
+    static bool NotifyAndEraseLatest(TRequestMap& map);
+
+    NThreading::TFuture<NProto::TError> WaitForGlobalMeta(TRequestId reqId);
+    NThreading::TFuture<NProto::TError> WaitForGlobalData(TRequestId reqId);
 };
 
-class TFSyncQueueStub final
-    : public IFSyncQueue
+////////////////////////////////////////////////////////////////////////////////
+
+class TFSyncQueueStub final: public IFSyncQueue
 {
 public:
-    void Enqueue(
-        TRequestId reqId,
-        TNodeId nodeId,
-        THandle handle = {}) override;
+    void
+    Enqueue(TRequestId reqId, TNodeId nodeId, THandle handle = {}) override;
     void Dequeue(
         TRequestId reqId,
         const NProto::TError& error,
@@ -165,7 +158,8 @@ public:
         TNodeId nodeId = {}) override;
 
     // Data requests.
-    NThreading::TFuture<NProto::TError> WaitForDataRequests(TRequestId reqId) override;
+    NThreading::TFuture<NProto::TError> WaitForDataRequests(
+        TRequestId reqId) override;
     NThreading::TFuture<NProto::TError> WaitForDataRequests(
         TRequestId reqId,
         TNodeId nodeId,

--- a/cloud/filestore/libs/vfs/fsync_queue.h
+++ b/cloud/filestore/libs/vfs/fsync_queue.h
@@ -98,6 +98,7 @@ private:
         THashMap<TNodeId, THashMap<THandle, TRequestMap>> Data;
     };
 
+    const TString FileSystemId;
     const TString LogTag;
     const ILoggingServicePtr Logging;
     TLog Log;
@@ -134,6 +135,11 @@ private:
     static bool IsFSync(const TItem& item);
 
     static bool NotifyAndEraseLatest(TRequestMap& map);
+
+    NThreading::TFuture<NProto::TError>
+    WaitForShardMeta(TShard& shard, TRequestId reqId);
+    NThreading::TFuture<NProto::TError>
+    WaitForShardData(TShard& shard, TRequestId reqId);
 
     NThreading::TFuture<NProto::TError> WaitForGlobalMeta(TRequestId reqId);
     NThreading::TFuture<NProto::TError> WaitForGlobalData(TRequestId reqId);

--- a/cloud/filestore/libs/vfs/fsync_queue_ut.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue_ut.cpp
@@ -31,7 +31,7 @@ struct TEnvironment
 
     TFSyncQueue Queue = TFSyncQueue(FileSystemId, Logging);
 
-    TFSyncCache::TRequestId CurrentRequestId = 1ul;
+    IFSyncQueue::TRequestId CurrentRequestId = 1ul;
     TNodeId::TUnderlyingType CurrentNodeId = 1ul;
 
     std::mt19937_64 eng = CreateRandomEngine();
@@ -43,7 +43,7 @@ struct TEnvironment
     void TearDown(NUnitTest::TTestContext& /*context*/) override
     {}
 
-    TFSyncCache::TRequestId GetNextRequestId()
+    IFSyncQueue::TRequestId GetNextRequestId()
     {
         return CurrentRequestId++;
     }
@@ -191,6 +191,31 @@ Y_UNIT_TEST_SUITE(TFSyncQueueTest)
         Queue.Dequeue(thirdMetaReqId, {}, thirdNodeId);
     }
 
+    Y_UNIT_TEST_F(ShouldTreatGlobalMetaShardScanAsOrderingPoint, TEnvironment)
+    {
+        const TNodeId earlyScannedNodeId {16}; // shard 0
+        const TNodeId laterScannedNodeId {1};  // shard 1
+
+        const auto blockerReqId = 100ul;
+        const auto fsyncReqId = 200ul;
+        const auto lateLowerReqId = 150ul;
+
+        Queue.Enqueue(blockerReqId, laterScannedNodeId);
+
+        const auto future = Queue.WaitForRequests(fsyncReqId);
+        UNIT_ASSERT(!future.HasValue());
+
+        // This request has a lower reqId, but it was admitted after the global
+        // fsync had already scanned its shard.
+        Queue.Enqueue(lateLowerReqId, earlyScannedNodeId);
+
+        Queue.Dequeue(blockerReqId, {}, laterScannedNodeId);
+        UNIT_ASSERT(future.HasValue());
+        UNIT_ASSERT(!HasError(future.GetValueSync()));
+
+        Queue.Dequeue(lateLowerReqId, {}, earlyScannedNodeId);
+    }
+
     Y_UNIT_TEST_F(ShouldWorkWithLocalDataRequests, TEnvironment)
     {
         const auto firstNodeId = GetNextNodeId();
@@ -260,6 +285,33 @@ Y_UNIT_TEST_SUITE(TFSyncQueueTest)
 
         Queue.Dequeue(thirdDataReqId, {}, thirdNodeId, thirdHandle);
         Queue.Dequeue(firstMetaReqId, {}, firstNodeId);
+    }
+
+    Y_UNIT_TEST_F(ShouldTreatGlobalDataShardScanAsOrderingPoint, TEnvironment)
+    {
+        const TNodeId earlyScannedNodeId {16}; // shard 0
+        const TNodeId laterScannedNodeId {1};  // shard 1
+        const THandle earlyHandle {1};
+        const THandle laterHandle {2};
+
+        const auto blockerReqId = 100ul;
+        const auto fsyncReqId = 200ul;
+        const auto lateLowerReqId = 150ul;
+
+        Queue.Enqueue(blockerReqId, laterScannedNodeId, laterHandle);
+
+        const auto future = Queue.WaitForDataRequests(fsyncReqId);
+        UNIT_ASSERT(!future.HasValue());
+
+        // This request has a lower reqId, but it was admitted after the global
+        // fsync had already scanned its shard.
+        Queue.Enqueue(lateLowerReqId, earlyScannedNodeId, earlyHandle);
+
+        Queue.Dequeue(blockerReqId, {}, laterScannedNodeId, laterHandle);
+        UNIT_ASSERT(future.HasValue());
+        UNIT_ASSERT(!HasError(future.GetValueSync()));
+
+        Queue.Dequeue(lateLowerReqId, {}, earlyScannedNodeId, earlyHandle);
     }
 
     Y_UNIT_TEST_F(ShouldWorkWithSimpleOrder, TEnvironment)

--- a/cloud/filestore/libs/vfs/fsync_queue_ut_stress.cpp
+++ b/cloud/filestore/libs/vfs/fsync_queue_ut_stress.cpp
@@ -84,7 +84,7 @@ struct TEnvironment
 
     TFSyncQueue Queue = TFSyncQueue(FileSystemId, Logging);
 
-    std::atomic<TFSyncCache::TRequestId> CurrentRequestId = 1ul;
+    std::atomic<IFSyncQueue::TRequestId> CurrentRequestId = 1ul;
     std::atomic<TNodeId::TUnderlyingType> CurrentNodeId = 1ul;
 
     TMutex HandleMutex;
@@ -97,7 +97,7 @@ struct TEnvironment
     void TearDown(NUnitTest::TTestContext& /*context*/) override
     {}
 
-    TFSyncCache::TRequestId GetNextRequestId()
+    IFSyncQueue::TRequestId GetNextRequestId()
     {
         return CurrentRequestId.fetch_add(1ul);
     }
@@ -138,23 +138,23 @@ Y_UNIT_TEST_SUITE(TFSyncQueueStressTest)
         std::atomic<ui64> fsyncStarted = 0ul;
         std::atomic<ui64> fsyncCompleted = 0ul;
 
-        std::atomic<TFSyncCache::TRequestId> metaFsyncGlobal = 0ul;
-        std::atomic<TFSyncCache::TRequestId> dataFsyncGlobal = 0ul;
+        std::atomic<IFSyncQueue::TRequestId> metaFsyncGlobal = 0ul;
+        std::atomic<IFSyncQueue::TRequestId> dataFsyncGlobal = 0ul;
 
         TMutex metaFsyncMutex;
-        TMap<TNodeId, TFSyncCache::TRequestId> metaFsyncMap;
+        TMap<TNodeId, IFSyncQueue::TRequestId> metaFsyncMap;
 
         TMutex dataFsyncMutex;
         TMap<
             std::pair<TNodeId, THandle>,
-            TFSyncCache::TRequestId> dataFsyncMap;
+            IFSyncQueue::TRequestId> dataFsyncMap;
 
         TMutex metaMutex;
-        TMap<TFSyncCache::TRequestId, TNodeId> metaMap;
+        TMap<IFSyncQueue::TRequestId, TNodeId> metaMap;
 
         TMutex dataMutex;
         TMap<
-            TFSyncCache::TRequestId,
+            IFSyncQueue::TRequestId,
             std::pair<TNodeId, THandle>> dataMap;
 
         std::atomic_flag shouldStop(false);
@@ -189,7 +189,7 @@ Y_UNIT_TEST_SUITE(TFSyncQueueStressTest)
         const auto removeRandomMetaRequest = [&] {
             static auto localEng = CreateRandomEngine();
 
-            TFSyncCache::TRequestId reqId = 0ul;
+            IFSyncQueue::TRequestId reqId = 0ul;
             TNodeId nodeId;
             with_lock (metaMutex) {
                 const auto size = metaMap.size();
@@ -239,7 +239,7 @@ Y_UNIT_TEST_SUITE(TFSyncQueueStressTest)
         const auto removeRandomDataRequest = [&] {
             static auto localEng = CreateRandomEngine();
 
-            TFSyncCache::TRequestId reqId = 0ul;
+            IFSyncQueue::TRequestId reqId = 0ul;
             TNodeId nodeId;
             THandle handle;
             with_lock (dataMutex) {

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-mq-test/test.py
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-mq-test/test.py
@@ -1,0 +1,37 @@
+import sys
+
+import pytest
+import yatest.common as common
+
+import cloud.filestore.tools.testing.profile_log.common as profile
+import cloud.storage.core.tools.testing.fio.lib as fio
+
+from cloud.filestore.tests.python.lib.common import get_filestore_mount_path
+
+
+TESTS = fio.generate_default_index_test()
+
+
+@pytest.mark.parametrize("name", TESTS.keys())
+def test_fio(name):
+    mount_dir = get_filestore_mount_path()
+    dir_name = fio.get_dir_name(mount_dir, name)
+
+    fio.run_index_test(dir_name, TESTS[name], fail_on_errors=True)
+
+    profile_tool_bin_path = common.binary_path(
+        "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool")
+    fs_name = "nfs_test"
+    events = profile.get_profile_log_events(
+        profile_tool_bin_path,
+        common.output_path("vhost-profile.log"),
+        fs_name)
+
+    thread_ids = set()
+    for event in events:
+        loop_thread_id = event[1].get("loop_thread_id")
+        if loop_thread_id is not None:
+            thread_ids.add(loop_thread_id)
+
+    print("loop_thread_count=%s" % len(thread_ids), file=sys.stderr)
+    assert len(thread_ids) > 1

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-mq-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-mq-test/ya.make
@@ -1,0 +1,39 @@
+PY3TEST()
+
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+ENDIF()
+
+DEPENDS(
+    cloud/filestore/tools/analytics/profile_tool
+    cloud/storage/core/tools/testing/fio/bin
+    cloud/storage/core/tools/testing/qemu/image-plucky
+)
+
+PEERDIR(
+    cloud/filestore/tests/python/lib
+    cloud/filestore/tools/testing/profile_log
+    cloud/storage/core/tools/testing/fio/lib
+)
+
+TEST_SRCS(
+    test.py
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/fio/qemu-kikimr-mq-test/nfs-patch.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_ROOTFS cloud/storage/core/tools/testing/qemu/image-plucky/rootfs.img)
+SET(QEMU_NUM_REQUEST_QUEUES 8)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/fio_index/ya.make
+++ b/cloud/filestore/tests/fio_index/ya.make
@@ -4,6 +4,7 @@ RECURSE_FOR_TESTS(
     qemu-kikimr-multishard-nemesis-test
     qemu-kikimr-multishard-tablets-restart-test
     qemu-kikimr-multishard-test
+    qemu-kikimr-mq-test
     qemu-kikimr-nemesis-test
     qemu-kikimr-test
     qemu-local-test


### PR DESCRIPTION
#5948

Benchmark improvementt
```
Benchmark: cloud/filestore/libs/vfs/bench --budget=300

  Throughput (Mops/s), before -> after:

    Workload                    1T          2T          4T         8T         16T
    ------------------------------------------------------------------------------
    DataEnqDeq               29.6->37.1  7.12->18.6  5.42->9.73  4.17->6.87  2.44->3.65
    MetaEnqDeq               42.0->49.8  19.5->19.2  12.0->15.9  7.47->8.43  3.72->4.47
    DataMixed (local wait)   23.1->32.0  5.14->16.4  5.04->9.69  3.48->5.68  2.02->3.16
    MetaMixed (local wait)   32.7->42.1  12.4->30.8  9.79->15.9  5.37->7.81  2.67->3.89    
    DataMixed (global wait)  8.61->25.1  2.49->14.7  1.74->7.26  1.19->4.15  0.83->2.50    
    MetaMixed (global wait)  17.6->31.6  6.44->24.5  3.34->8.86  2.16->4.92  1.47->2.86

  Parallel scaling at 16 threads (cpu_util, ideal=16):    
    DataEnqDeq               4.40 -> 5.53
    MetaEnqDeq               4.00 -> 7.30
    DataMixed (local wait)   3.85 -> 5.80
    MetaMixed (local wait)   3.70 -> 6.49
    DataMixed (global wait)  2.73 -> 7.84
    MetaMixed (global wait)  3.05 -> 7.38
```

without fix
```
$ ya make -rT cloud/filestore/libs/vfs/bench && cloud/filestore/libs/vfs/bench/bench --budget=300
Ok
----------- TFSyncQueue_DataEnqDeq_1 ---------------
 samples:       7750
 iterations:    37087578
 iterations hr:    37.1M
 run time:      10.0028386
 per iteration: 572.8787131 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_1
  iterations=37087578
  operations: enqueues=37087578 dequeues=37087578 waits=0
  enqueue_latency: p50=60ns p95=70ns p99=80ns max=46.8us
  dequeue_latency: p50=70ns p95=70ns p99=70ns max=176us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=8.54s system=817ms total=9.36s
  wall_time=9.14s cpu_util=1.02393386
----------- TFSyncQueue_DataEnqDeq_2 ---------------
 samples:       5486
 iterations:    18583656
 iterations hr:    18.6M
 run time:      10.00245135
 per iteration: 970.5212244 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_2
  iterations=18583656
  operations: enqueues=18583656 dequeues=18583656 waits=0
  enqueue_latency: p50=270ns p95=1.22us p99=2.02us max=1.4ms
  dequeue_latency: p50=331ns p95=1.04us p99=2.09us max=791us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=15.6s system=1.05s total=16.6s
  wall_time=8.7s cpu_util=1.912094781
----------- TFSyncQueue_DataEnqDeq_4 ---------------
 samples:       3969
 iterations:    9730666
 iterations hr:    9.73M
 run time:      10.0034465
 per iteration: 2223.546027 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_4
  iterations=9730666
  operations: enqueues=9730666 dequeues=9730666 waits=0
  enqueue_latency: p50=961ns p95=4.88us p99=8.92us max=849us
  dequeue_latency: p50=431ns p95=4.38us p99=8.06us max=821us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=27.9s system=1.86s total=29.8s
  wall_time=8.08s cpu_util=3.688980501
----------- TFSyncQueue_DataEnqDeq_8 ---------------
 samples:       3336
 iterations:    6872778
 iterations hr:    6.87M
 run time:      10.00312813
 per iteration: 2010.689933 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_8
  iterations=6872778
  operations: enqueues=6872778 dequeues=6872778 waits=0
  enqueue_latency: p50=1.05us p95=8.26us p99=22.3us max=3.46ms
  dequeue_latency: p50=441ns p95=5.18us p99=15.8us max=3.14ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=27.5s system=3.17s total=30.7s
  wall_time=6.39s cpu_util=4.801384186
----------- TFSyncQueue_DataEnqDeq_16 ---------------
 samples:       2432
 iterations:    3654456
 iterations hr:    3.65M
 run time:      10.00439011
 per iteration: 2066.66076 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_16
  iterations=3654456
  operations: enqueues=3654456 dequeues=3654456 waits=0
  enqueue_latency: p50=971ns p95=11.2us p99=58.9us max=3.29ms
  dequeue_latency: p50=461ns p95=5.36us p99=20.3us max=3.31ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=20.8s system=4.07s total=24.8s
  wall_time=4.49s cpu_util=5.532127067
----------- TFSyncQueue_MetaEnqDeq_1 ---------------
 samples:       8977
 iterations:    49755300
 iterations hr:    49.8M
 run time:      10.00251444
 per iteration: 420.5887705 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_1
  iterations=49755300
  operations: enqueues=49755300 dequeues=49755300 waits=0
  enqueue_latency: p50=30ns p95=40ns p99=40ns max=51.3us
  dequeue_latency: p50=40ns p95=40ns p99=40ns max=40.1us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=8.6s system=726ms total=9.32s
  wall_time=9.05s cpu_util=1.029642142
----------- TFSyncQueue_MetaEnqDeq_2 ---------------
 samples:       5570
 iterations:    19154955
 iterations hr:    19.2M
 run time:      10.00297051
 per iteration: 1568.749797 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_2
  iterations=19154955
  operations: enqueues=19154955 dequeues=19154955 waits=0
  enqueue_latency: p50=200ns p95=721ns p99=1.39us max=57.9us
  dequeue_latency: p50=200ns p95=771ns p99=1.27us max=46.9us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=16.3s system=1.22s total=17.5s
  wall_time=8.76s cpu_util=1.998818588
----------- TFSyncQueue_MetaEnqDeq_4 ---------------
 samples:       5076
 iterations:    15907620
 iterations hr:    15.9M
 run time:      10.00160872
 per iteration: 1341.158656 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_4
  iterations=15907620
  operations: enqueues=15907620 dequeues=15907620 waits=0
  enqueue_latency: p50=501ns p95=2.67us p99=5.36us max=784us
  dequeue_latency: p50=381ns p95=2.25us p99=4.9us max=790us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=26.4s system=2.1s total=28.5s
  wall_time=7.76s cpu_util=3.66951764
----------- TFSyncQueue_MetaEnqDeq_8 ---------------
 samples:       3695
 iterations:    8431671
 iterations hr:    8.43M
 run time:      10.00254484
 per iteration: 1652.325246 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_8
  iterations=8431671
  operations: enqueues=8431671 dequeues=8431671 waits=0
  enqueue_latency: p50=711ns p95=6.21us p99=21.6us max=3.07ms
  dequeue_latency: p50=511ns p95=5.52us p99=18us max=3.11ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=30.3s system=3.06s total=33.3s
  wall_time=5.95s cpu_util=5.598195206
----------- TFSyncQueue_MetaEnqDeq_16 ---------------
 samples:       2689
 iterations:    4465566
 iterations hr:    4.47M
 run time:      10.00380557
 per iteration: 1919.881907 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_16
  iterations=4465566
  operations: enqueues=4465566 dequeues=4465566 waits=0
  enqueue_latency: p50=761ns p95=9.48us p99=46.9us max=2.09ms
  dequeue_latency: p50=541ns p95=8.56us p99=36us max=3.12ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=25.7s system=4.43s total=30.1s
  wall_time=4.12s cpu_util=7.296494539
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_1 ---------------
 samples:       7197
 iterations:    31980003
 iterations hr:    32M
 run time:      10.00303925
 per iteration: 645.7833706 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_1
  iterations=31980003
  operations: enqueues=31484251 dequeues=31484251 waits=495752
  enqueue_latency: p50=60ns p95=90ns p99=120ns max=42us
  dequeue_latency: p50=90ns p95=120ns p99=150ns max=104us
  wait_latency: p50=8.49us p95=10.2us p99=14us max=115us
  cpu_time: user=8.32s system=744ms total=9.07s
  wall_time=8.88s cpu_util=1.021615802
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_2 ---------------
 samples:       5161
 iterations:    16447980
 iterations hr:    16.4M
 run time:      10.00223709
 per iteration: 901.2615937 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_2
  iterations=16447980
  operations: enqueues=16196608 dequeues=16196608 waits=251372
  enqueue_latency: p50=260ns p95=1.08us p99=3.35us max=709us
  dequeue_latency: p50=331ns p95=791ns p99=2.63us max=88.9us
  wait_latency: p50=25.1us p95=54.8us p99=71us max=186us
  cpu_time: user=15.4s system=1.17s total=16.6s
  wall_time=8.36s cpu_util=1.985855943
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_4 ---------------
 samples:       3961
 iterations:    9691003
 iterations hr:    9.69M
 run time:      10.00114614
 per iteration: 2027.327042 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_4
  iterations=9691003
  operations: enqueues=9548169 dequeues=9548169 waits=142834
  enqueue_latency: p50=681ns p95=5.11us p99=15.4us max=1.85ms
  dequeue_latency: p50=341ns p95=3us p99=10.8us max=811us
  wait_latency: p50=58.8us p95=134us p99=182us max=1.29ms
  cpu_time: user=24.9s system=1.57s total=26.4s
  wall_time=7.18s cpu_util=3.678539233
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_8 ---------------
 samples:       3033
 iterations:    5683506
 iterations hr:    5.68M
 run time:      10.00108202
 per iteration: 2320.453996 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_8
  iterations=5683506
  operations: enqueues=5607498 dequeues=5607498 waits=76008
  enqueue_latency: p50=851ns p95=12.7us p99=40us max=6.02ms
  dequeue_latency: p50=331ns p95=4.65us p99=19.8us max=1.89ms
  wait_latency: p50=74.8us p95=268us p99=878us max=2.57ms
  cpu_time: user=25.8s system=2.81s total=28.6s
  wall_time=5.63s cpu_util=5.071927445
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_16 ---------------
 samples:       2263
 iterations:    3163870
 iterations hr:    3.16M
 run time:      10.00108539
 per iteration: 2946.585746 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_16
  iterations=3163870
  operations: enqueues=3132270 dequeues=3132270 waits=31600
  enqueue_latency: p50=992ns p95=19.4us p99=88.8us max=3.3ms
  dequeue_latency: p50=351ns p95=5.67us p99=23.8us max=2.77ms
  wait_latency: p50=91.5us p95=647us p99=1.07ms max=2.94ms
  cpu_time: user=21.2s system=3.75s total=24.9s
  wall_time=4.3s cpu_util=5.796950482
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_1 ---------------
 samples:       8260
 iterations:    42122431
 iterations hr:    42.1M
 run time:      10.0023696
 per iteration: 487.1335435 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_1
  iterations=42122431
  operations: enqueues=41468778 dequeues=41468778 waits=653653
  enqueue_latency: p50=40ns p95=50ns p99=70ns max=83.3us
  dequeue_latency: p50=50ns p95=70ns p99=90ns max=42.1us
  wait_latency: p50=6.26us p95=6.97us p99=9.54us max=50.4us
  cpu_time: user=8.26s system=849ms total=9.11s
  wall_time=8.9s cpu_util=1.024423334
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_2 ---------------
 samples:       7057
 iterations:    30752403
 iterations hr:    30.8M
 run time:      10.00125314
 per iteration: 678.6989822 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_2
  iterations=30752403
  operations: enqueues=30279592 dequeues=30279592 waits=472811
  enqueue_latency: p50=110ns p95=341ns p99=831ns max=71.3us
  dequeue_latency: p50=160ns p95=391ns p99=841ns max=249us
  wait_latency: p50=14.4us p95=28.6us p99=37.5us max=265us
  cpu_time: user=14.2s system=1.56s total=15.8s
  wall_time=8.02s cpu_util=1.968400245
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_4 ---------------
 samples:       5076
 iterations:    15913261
 iterations hr:    15.9M
 run time:      10.00124845
 per iteration: 1111.861098 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_4
  iterations=15913261
  operations: enqueues=15675705 dequeues=15675705 waits=237556
  enqueue_latency: p50=341ns p95=2.52us p99=5.94us max=686us
  dequeue_latency: p50=280ns p95=2.08us p99=5.14us max=595us
  wait_latency: p50=41.5us p95=83.6us p99=119us max=617us
  cpu_time: user=23.7s system=2.06s total=25.8s
  wall_time=6.89s cpu_util=3.744019274
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_8 ---------------
 samples:       3555
 iterations:    7807176
 iterations hr:    7.81M
 run time:      10.00238887
 per iteration: 1635.779093 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_8
  iterations=7807176
  operations: enqueues=7700356 dequeues=7700356 waits=106820
  enqueue_latency: p50=561ns p95=7.98us p99=26.8us max=1.99ms
  dequeue_latency: p50=270ns p95=4us p99=16.5us max=1.92ms
  wait_latency: p50=49.6us p95=300us p99=793us max=2.04ms
  cpu_time: user=26.2s system=2.98s total=29.2s
  wall_time=5.32s cpu_util=5.489168508
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_16 ---------------
 samples:       2510
 iterations:    3890655
 iterations hr:    3.89M
 run time:      10.00026763
 per iteration: 2419.11345 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_16
  iterations=3890655
  operations: enqueues=3850287 dequeues=3850287 waits=40368
  enqueue_latency: p50=721ns p95=12.7us p99=69.1us max=2.03ms
  dequeue_latency: p50=280ns p95=5.02us p99=19.1us max=1.96ms
  wait_latency: p50=68.3us p95=453us p99=961us max=1.99ms
  cpu_time: user=20.5s system=4.08s total=24.5s
  wall_time=3.78s cpu_util=6.494009253
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_1 ---------------
 samples:       6377
 iterations:    25109241
 iterations hr:    25.1M
 run time:      10.00277433
 per iteration: 821.2315644 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_1
  iterations=25109241
  operations: enqueues=24720391 dequeues=24720391 waits=388850
  enqueue_latency: p50=60ns p95=80ns p99=140ns max=43.3us
  dequeue_latency: p50=120ns p95=150ns p99=180ns max=76.4us
  wait_latency: p50=13us p95=14.3us p99=22us max=91.9us
  cpu_time: user=8.52s system=567ms total=9.08s
  wall_time=8.91s cpu_util=1.019209984
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_2 ---------------
 samples:       4884
 iterations:    14728878
 iterations hr:    14.7M
 run time:      10.00289969
 per iteration: 1111.08195 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_2
  iterations=14728878
  operations: enqueues=14504052 dequeues=14504052 waits=224826
  enqueue_latency: p50=130ns p95=441ns p99=821ns max=545us
  dequeue_latency: p50=341ns p95=1.14us p99=1.93us max=56.2us
  wait_latency: p50=51.5us p95=125us p99=152us max=665us
  cpu_time: user=13.8s system=1.58s total=15.4s
  wall_time=8.44s cpu_util=1.822621868
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_4 ---------------
 samples:       3429
 iterations:    7263766
 iterations hr:    7.26M
 run time:      10.00111345
 per iteration: 2858.518751 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_4
  iterations=7263766
  operations: enqueues=7157730 dequeues=7157730 waits=106036
  enqueue_latency: p50=401ns p95=1.35us p99=3.65us max=617us
  dequeue_latency: p50=1.32us p95=2.88us p99=4.73us max=78.3us
  wait_latency: p50=264us p95=335us p99=361us max=1.99ms
  cpu_time: user=24.2s system=2.18s total=26.4s
  wall_time=7.76s cpu_util=3.401057101
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_8 ---------------
 samples:       2593
 iterations:    4154403
 iterations hr:    4.15M
 run time:      10.00227117
 per iteration: 4204.563761 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_8
  iterations=4154403
  operations: enqueues=4100383 dequeues=4100383 waits=54020
  enqueue_latency: p50=631ns p95=5.84us p99=15.9us max=745us
  dequeue_latency: p50=3.25us p95=7.13us p99=17.7us max=747us
  wait_latency: p50=635us p95=803us p99=922us max=1.37ms
  cpu_time: user=33.9s system=3.62s total=37.5s
  wall_time=6.28s cpu_util=5.978111793
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_16 ---------------
 samples:       2011
 iterations:    2498730
 iterations hr:    2.5M
 run time:      10.0014491
 per iteration: 7326.317514 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_16
  iterations=2498730
  operations: enqueues=2476090 dequeues=2476090 waits=22640
  enqueue_latency: p50=1.04us p95=18.3us p99=39.3us max=1.7ms
  dequeue_latency: p50=2.96us p95=15.4us p99=34.2us max=1.61ms
  wait_latency: p50=1.64ms p95=2.11ms p99=2.31ms max=2.78ms
  cpu_time: user=32.2s system=4.5s total=36.7s
  wall_time=4.68s cpu_util=7.835584808
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_1 ---------------
 samples:       7154
 iterations:    31597275
 iterations hr:    31.6M
 run time:      10.00177068
 per iteration: 638.9273829 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_1
  iterations=31597275
  operations: enqueues=31107475 dequeues=31107475 waits=489800
  enqueue_latency: p50=30ns p95=40ns p99=60ns max=58.6us
  dequeue_latency: p50=90ns p95=110ns p99=150ns max=103us
  wait_latency: p50=10.6us p95=12us p99=19.6us max=136us
  cpu_time: user=8.5s system=578ms total=9.08s
  wall_time=8.89s cpu_util=1.021477606
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_2 ---------------
 samples:       6298
 iterations:    24489501
 iterations hr:    24.5M
 run time:      10.0011474
 per iteration: 546.7937903 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_2
  iterations=24489501
  operations: enqueues=24113715 dequeues=24113715 waits=375786
  enqueue_latency: p50=50ns p95=240ns p99=421ns max=45.1us
  dequeue_latency: p50=140ns p95=831ns p99=1.41us max=425us
  wait_latency: p50=19.2us p95=71.6us p99=108us max=7.01ms
  cpu_time: user=13.6s system=1.62s total=15.3s
  wall_time=8.06s cpu_util=1.892419414
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_4 ---------------
 samples:       3787
 iterations:    8855736
 iterations hr:    8.86M
 run time:      10.00060402
 per iteration: 2381.80942 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_4
  iterations=8855736
  operations: enqueues=8725528 dequeues=8725528 waits=130208
  enqueue_latency: p50=190ns p95=1.36us p99=3.06us max=635us
  dequeue_latency: p50=1.13us p95=2.6us p99=4.58us max=74.9us
  wait_latency: p50=201us p95=256us p99=279us max=363us
  cpu_time: user=22.2s system=2.47s total=24.7s
  wall_time=7.56s cpu_util=3.266753895
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_8 ---------------
 samples:       2821
 iterations:    4915680
 iterations hr:    4.92M
 run time:      10.00250614
 per iteration: 3706.240511 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_8
  iterations=4915680
  operations: enqueues=4851000 dequeues=4851000 waits=64680
  enqueue_latency: p50=290ns p95=5.29us p99=12.4us max=730us
  dequeue_latency: p50=3.02us p95=5.39us p99=12.9us max=652us
  wait_latency: p50=552us p95=635us p99=664us max=6.34ms
  cpu_time: user=32.3s system=3.85s total=36.2s
  wall_time=6.24s cpu_util=5.793973204
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_16 ---------------
 samples:       2151
 iterations:    2859636
 iterations hr:    2.86M
 run time:      10.00437905
 per iteration: 6249.419435 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_16
  iterations=2859636
  operations: enqueues=2832004 dequeues=2832004 waits=27632
  enqueue_latency: p50=481ns p95=12.8us p99=28.3us max=778us
  dequeue_latency: p50=2.71us p95=13.1us p99=27.5us max=995us
  wait_latency: p50=1.35ms p95=1.71ms p99=1.87ms max=2.26ms
  cpu_time: user=29.1s system=4.28s total=33.4s
  wall_time=4.53s cpu_util=7.376787212
```

after fix
```
$ ya make -rT cloud/filestore/libs/vfs/bench && cloud/filestore/libs/vfs/bench/bench --budget=300
Ok
----------- TFSyncQueue_DataEnqDeq_1 ---------------
 samples:       7750
 iterations:    37087578
 iterations hr:    37.1M
 run time:      10.0028386
 per iteration: 572.8787131 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_1
  iterations=37087578
  operations: enqueues=37087578 dequeues=37087578 waits=0
  enqueue_latency: p50=60ns p95=70ns p99=80ns max=46.8us
  dequeue_latency: p50=70ns p95=70ns p99=70ns max=176us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=8.54s system=817ms total=9.36s
  wall_time=9.14s cpu_util=1.02393386
----------- TFSyncQueue_DataEnqDeq_2 ---------------
 samples:       5486
 iterations:    18583656
 iterations hr:    18.6M
 run time:      10.00245135
 per iteration: 970.5212244 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_2
  iterations=18583656
  operations: enqueues=18583656 dequeues=18583656 waits=0
  enqueue_latency: p50=270ns p95=1.22us p99=2.02us max=1.4ms
  dequeue_latency: p50=331ns p95=1.04us p99=2.09us max=791us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=15.6s system=1.05s total=16.6s
  wall_time=8.7s cpu_util=1.912094781
----------- TFSyncQueue_DataEnqDeq_4 ---------------
 samples:       3969
 iterations:    9730666
 iterations hr:    9.73M
 run time:      10.0034465
 per iteration: 2223.546027 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_4
  iterations=9730666
  operations: enqueues=9730666 dequeues=9730666 waits=0
  enqueue_latency: p50=961ns p95=4.88us p99=8.92us max=849us
  dequeue_latency: p50=431ns p95=4.38us p99=8.06us max=821us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=27.9s system=1.86s total=29.8s
  wall_time=8.08s cpu_util=3.688980501
----------- TFSyncQueue_DataEnqDeq_8 ---------------
 samples:       3336
 iterations:    6872778
 iterations hr:    6.87M
 run time:      10.00312813
 per iteration: 2010.689933 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_8
  iterations=6872778
  operations: enqueues=6872778 dequeues=6872778 waits=0
  enqueue_latency: p50=1.05us p95=8.26us p99=22.3us max=3.46ms
  dequeue_latency: p50=441ns p95=5.18us p99=15.8us max=3.14ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=27.5s system=3.17s total=30.7s
  wall_time=6.39s cpu_util=4.801384186
----------- TFSyncQueue_DataEnqDeq_16 ---------------
 samples:       2432
 iterations:    3654456
 iterations hr:    3.65M
 run time:      10.00439011
 per iteration: 2066.66076 cycles
FSyncQueueBench name=TFSyncQueue_DataEnqDeq_16
  iterations=3654456
  operations: enqueues=3654456 dequeues=3654456 waits=0
  enqueue_latency: p50=971ns p95=11.2us p99=58.9us max=3.29ms
  dequeue_latency: p50=461ns p95=5.36us p99=20.3us max=3.31ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=20.8s system=4.07s total=24.8s
  wall_time=4.49s cpu_util=5.532127067
----------- TFSyncQueue_MetaEnqDeq_1 ---------------
 samples:       8977
 iterations:    49755300
 iterations hr:    49.8M
 run time:      10.00251444
 per iteration: 420.5887705 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_1
  iterations=49755300
  operations: enqueues=49755300 dequeues=49755300 waits=0
  enqueue_latency: p50=30ns p95=40ns p99=40ns max=51.3us
  dequeue_latency: p50=40ns p95=40ns p99=40ns max=40.1us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=8.6s system=726ms total=9.32s
  wall_time=9.05s cpu_util=1.029642142
----------- TFSyncQueue_MetaEnqDeq_2 ---------------
 samples:       5570
 iterations:    19154955
 iterations hr:    19.2M
 run time:      10.00297051
 per iteration: 1568.749797 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_2
  iterations=19154955
  operations: enqueues=19154955 dequeues=19154955 waits=0
  enqueue_latency: p50=200ns p95=721ns p99=1.39us max=57.9us
  dequeue_latency: p50=200ns p95=771ns p99=1.27us max=46.9us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=16.3s system=1.22s total=17.5s
  wall_time=8.76s cpu_util=1.998818588
----------- TFSyncQueue_MetaEnqDeq_4 ---------------
 samples:       5076
 iterations:    15907620
 iterations hr:    15.9M
 run time:      10.00160872
 per iteration: 1341.158656 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_4
  iterations=15907620
  operations: enqueues=15907620 dequeues=15907620 waits=0
  enqueue_latency: p50=501ns p95=2.67us p99=5.36us max=784us
  dequeue_latency: p50=381ns p95=2.25us p99=4.9us max=790us
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=26.4s system=2.1s total=28.5s
  wall_time=7.76s cpu_util=3.66951764
----------- TFSyncQueue_MetaEnqDeq_8 ---------------
 samples:       3695
 iterations:    8431671
 iterations hr:    8.43M
 run time:      10.00254484
 per iteration: 1652.325246 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_8
  iterations=8431671
  operations: enqueues=8431671 dequeues=8431671 waits=0
  enqueue_latency: p50=711ns p95=6.21us p99=21.6us max=3.07ms
  dequeue_latency: p50=511ns p95=5.52us p99=18us max=3.11ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=30.3s system=3.06s total=33.3s
  wall_time=5.95s cpu_util=5.598195206
----------- TFSyncQueue_MetaEnqDeq_16 ---------------
 samples:       2689
 iterations:    4465566
 iterations hr:    4.47M
 run time:      10.00380557
 per iteration: 1919.881907 cycles
FSyncQueueBench name=TFSyncQueue_MetaEnqDeq_16
  iterations=4465566
  operations: enqueues=4465566 dequeues=4465566 waits=0
  enqueue_latency: p50=761ns p95=9.48us p99=46.9us max=2.09ms
  dequeue_latency: p50=541ns p95=8.56us p99=36us max=3.12ms
  wait_latency: p50=- p95=- p99=- max=-
  cpu_time: user=25.7s system=4.43s total=30.1s
  wall_time=4.12s cpu_util=7.296494539
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_1 ---------------
 samples:       7197
 iterations:    31980003
 iterations hr:    32M
 run time:      10.00303925
 per iteration: 645.7833706 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_1
  iterations=31980003
  operations: enqueues=31484251 dequeues=31484251 waits=495752
  enqueue_latency: p50=60ns p95=90ns p99=120ns max=42us
  dequeue_latency: p50=90ns p95=120ns p99=150ns max=104us
  wait_latency: p50=8.49us p95=10.2us p99=14us max=115us
  cpu_time: user=8.32s system=744ms total=9.07s
  wall_time=8.88s cpu_util=1.021615802
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_2 ---------------
 samples:       5161
 iterations:    16447980
 iterations hr:    16.4M
 run time:      10.00223709
 per iteration: 901.2615937 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_2
  iterations=16447980
  operations: enqueues=16196608 dequeues=16196608 waits=251372
  enqueue_latency: p50=260ns p95=1.08us p99=3.35us max=709us
  dequeue_latency: p50=331ns p95=791ns p99=2.63us max=88.9us
  wait_latency: p50=25.1us p95=54.8us p99=71us max=186us
  cpu_time: user=15.4s system=1.17s total=16.6s
  wall_time=8.36s cpu_util=1.985855943
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_4 ---------------
 samples:       3961
 iterations:    9691003
 iterations hr:    9.69M
 run time:      10.00114614
 per iteration: 2027.327042 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_4
  iterations=9691003
  operations: enqueues=9548169 dequeues=9548169 waits=142834
  enqueue_latency: p50=681ns p95=5.11us p99=15.4us max=1.85ms
  dequeue_latency: p50=341ns p95=3us p99=10.8us max=811us
  wait_latency: p50=58.8us p95=134us p99=182us max=1.29ms
  cpu_time: user=24.9s system=1.57s total=26.4s
  wall_time=7.18s cpu_util=3.678539233
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_8 ---------------
 samples:       3033
 iterations:    5683506
 iterations hr:    5.68M
 run time:      10.00108202
 per iteration: 2320.453996 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_8
  iterations=5683506
  operations: enqueues=5607498 dequeues=5607498 waits=76008
  enqueue_latency: p50=851ns p95=12.7us p99=40us max=6.02ms
  dequeue_latency: p50=331ns p95=4.65us p99=19.8us max=1.89ms
  wait_latency: p50=74.8us p95=268us p99=878us max=2.57ms
  cpu_time: user=25.8s system=2.81s total=28.6s
  wall_time=5.63s cpu_util=5.071927445
----------- TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_16 ---------------
 samples:       2263
 iterations:    3163870
 iterations hr:    3.16M
 run time:      10.00108539
 per iteration: 2946.585746 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_16
  iterations=3163870
  operations: enqueues=3132270 dequeues=3132270 waits=31600
  enqueue_latency: p50=992ns p95=19.4us p99=88.8us max=3.3ms
  dequeue_latency: p50=351ns p95=5.67us p99=23.8us max=2.77ms
  wait_latency: p50=91.5us p95=647us p99=1.07ms max=2.94ms
  cpu_time: user=21.2s system=3.75s total=24.9s
  wall_time=4.3s cpu_util=5.796950482
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_1 ---------------
 samples:       8260
 iterations:    42122431
 iterations hr:    42.1M
 run time:      10.0023696
 per iteration: 487.1335435 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_1
  iterations=42122431
  operations: enqueues=41468778 dequeues=41468778 waits=653653
  enqueue_latency: p50=40ns p95=50ns p99=70ns max=83.3us
  dequeue_latency: p50=50ns p95=70ns p99=90ns max=42.1us
  wait_latency: p50=6.26us p95=6.97us p99=9.54us max=50.4us
  cpu_time: user=8.26s system=849ms total=9.11s
  wall_time=8.9s cpu_util=1.024423334
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_2 ---------------
 samples:       7057
 iterations:    30752403
 iterations hr:    30.8M
 run time:      10.00125314
 per iteration: 678.6989822 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_2
  iterations=30752403
  operations: enqueues=30279592 dequeues=30279592 waits=472811
  enqueue_latency: p50=110ns p95=341ns p99=831ns max=71.3us
  dequeue_latency: p50=160ns p95=391ns p99=841ns max=249us
  wait_latency: p50=14.4us p95=28.6us p99=37.5us max=265us
  cpu_time: user=14.2s system=1.56s total=15.8s
  wall_time=8.02s cpu_util=1.968400245
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_4 ---------------
 samples:       5076
 iterations:    15913261
 iterations hr:    15.9M
 run time:      10.00124845
 per iteration: 1111.861098 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_4
  iterations=15913261
  operations: enqueues=15675705 dequeues=15675705 waits=237556
  enqueue_latency: p50=341ns p95=2.52us p99=5.94us max=686us
  dequeue_latency: p50=280ns p95=2.08us p99=5.14us max=595us
  wait_latency: p50=41.5us p95=83.6us p99=119us max=617us
  cpu_time: user=23.7s system=2.06s total=25.8s
  wall_time=6.89s cpu_util=3.744019274
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_8 ---------------
 samples:       3555
 iterations:    7807176
 iterations hr:    7.81M
 run time:      10.00238887
 per iteration: 1635.779093 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_8
  iterations=7807176
  operations: enqueues=7700356 dequeues=7700356 waits=106820
  enqueue_latency: p50=561ns p95=7.98us p99=26.8us max=1.99ms
  dequeue_latency: p50=270ns p95=4us p99=16.5us max=1.92ms
  wait_latency: p50=49.6us p95=300us p99=793us max=2.04ms
  cpu_time: user=26.2s system=2.98s total=29.2s
  wall_time=5.32s cpu_util=5.489168508
----------- TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_16 ---------------
 samples:       2510
 iterations:    3890655
 iterations hr:    3.89M
 run time:      10.00026763
 per iteration: 2419.11345 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqLocalWaitAfter64Iterations_16
  iterations=3890655
  operations: enqueues=3850287 dequeues=3850287 waits=40368
  enqueue_latency: p50=721ns p95=12.7us p99=69.1us max=2.03ms
  dequeue_latency: p50=280ns p95=5.02us p99=19.1us max=1.96ms
  wait_latency: p50=68.3us p95=453us p99=961us max=1.99ms
  cpu_time: user=20.5s system=4.08s total=24.5s
  wall_time=3.78s cpu_util=6.494009253
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_1 ---------------
 samples:       6377
 iterations:    25109241
 iterations hr:    25.1M
 run time:      10.00277433
 per iteration: 821.2315644 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_1
  iterations=25109241
  operations: enqueues=24720391 dequeues=24720391 waits=388850
  enqueue_latency: p50=60ns p95=80ns p99=140ns max=43.3us
  dequeue_latency: p50=120ns p95=150ns p99=180ns max=76.4us
  wait_latency: p50=13us p95=14.3us p99=22us max=91.9us
  cpu_time: user=8.52s system=567ms total=9.08s
  wall_time=8.91s cpu_util=1.019209984
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_2 ---------------
 samples:       4884
 iterations:    14728878
 iterations hr:    14.7M
 run time:      10.00289969
 per iteration: 1111.08195 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_2
  iterations=14728878
  operations: enqueues=14504052 dequeues=14504052 waits=224826
  enqueue_latency: p50=130ns p95=441ns p99=821ns max=545us
  dequeue_latency: p50=341ns p95=1.14us p99=1.93us max=56.2us
  wait_latency: p50=51.5us p95=125us p99=152us max=665us
  cpu_time: user=13.8s system=1.58s total=15.4s
  wall_time=8.44s cpu_util=1.822621868
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_4 ---------------
 samples:       3429
 iterations:    7263766
 iterations hr:    7.26M
 run time:      10.00111345
 per iteration: 2858.518751 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_4
  iterations=7263766
  operations: enqueues=7157730 dequeues=7157730 waits=106036
  enqueue_latency: p50=401ns p95=1.35us p99=3.65us max=617us
  dequeue_latency: p50=1.32us p95=2.88us p99=4.73us max=78.3us
  wait_latency: p50=264us p95=335us p99=361us max=1.99ms
  cpu_time: user=24.2s system=2.18s total=26.4s
  wall_time=7.76s cpu_util=3.401057101
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_8 ---------------
 samples:       2593
 iterations:    4154403
 iterations hr:    4.15M
 run time:      10.00227117
 per iteration: 4204.563761 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_8
  iterations=4154403
  operations: enqueues=4100383 dequeues=4100383 waits=54020
  enqueue_latency: p50=631ns p95=5.84us p99=15.9us max=745us
  dequeue_latency: p50=3.25us p95=7.13us p99=17.7us max=747us
  wait_latency: p50=635us p95=803us p99=922us max=1.37ms
  cpu_time: user=33.9s system=3.62s total=37.5s
  wall_time=6.28s cpu_util=5.978111793
----------- TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_16 ---------------
 samples:       2011
 iterations:    2498730
 iterations hr:    2.5M
 run time:      10.0014491
 per iteration: 7326.317514 cycles
FSyncQueueBench name=TFSyncQueue_DataMixedEnqDeqGlobalWaitAfter64Iterations_16
  iterations=2498730
  operations: enqueues=2476090 dequeues=2476090 waits=22640
  enqueue_latency: p50=1.04us p95=18.3us p99=39.3us max=1.7ms
  dequeue_latency: p50=2.96us p95=15.4us p99=34.2us max=1.61ms
  wait_latency: p50=1.64ms p95=2.11ms p99=2.31ms max=2.78ms
  cpu_time: user=32.2s system=4.5s total=36.7s
  wall_time=4.68s cpu_util=7.835584808
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_1 ---------------
 samples:       7154
 iterations:    31597275
 iterations hr:    31.6M
 run time:      10.00177068
 per iteration: 638.9273829 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_1
  iterations=31597275
  operations: enqueues=31107475 dequeues=31107475 waits=489800
  enqueue_latency: p50=30ns p95=40ns p99=60ns max=58.6us
  dequeue_latency: p50=90ns p95=110ns p99=150ns max=103us
  wait_latency: p50=10.6us p95=12us p99=19.6us max=136us
  cpu_time: user=8.5s system=578ms total=9.08s
  wall_time=8.89s cpu_util=1.021477606
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_2 ---------------
 samples:       6298
 iterations:    24489501
 iterations hr:    24.5M
 run time:      10.0011474
 per iteration: 546.7937903 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_2
  iterations=24489501
  operations: enqueues=24113715 dequeues=24113715 waits=375786
  enqueue_latency: p50=50ns p95=240ns p99=421ns max=45.1us
  dequeue_latency: p50=140ns p95=831ns p99=1.41us max=425us
  wait_latency: p50=19.2us p95=71.6us p99=108us max=7.01ms
  cpu_time: user=13.6s system=1.62s total=15.3s
  wall_time=8.06s cpu_util=1.892419414
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_4 ---------------
 samples:       3787
 iterations:    8855736
 iterations hr:    8.86M
 run time:      10.00060402
 per iteration: 2381.80942 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_4
  iterations=8855736
  operations: enqueues=8725528 dequeues=8725528 waits=130208
  enqueue_latency: p50=190ns p95=1.36us p99=3.06us max=635us
  dequeue_latency: p50=1.13us p95=2.6us p99=4.58us max=74.9us
  wait_latency: p50=201us p95=256us p99=279us max=363us
  cpu_time: user=22.2s system=2.47s total=24.7s
  wall_time=7.56s cpu_util=3.266753895
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_8 ---------------
 samples:       2821
 iterations:    4915680
 iterations hr:    4.92M
 run time:      10.00250614
 per iteration: 3706.240511 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_8
  iterations=4915680
  operations: enqueues=4851000 dequeues=4851000 waits=64680
  enqueue_latency: p50=290ns p95=5.29us p99=12.4us max=730us
  dequeue_latency: p50=3.02us p95=5.39us p99=12.9us max=652us
  wait_latency: p50=552us p95=635us p99=664us max=6.34ms
  cpu_time: user=32.3s system=3.85s total=36.2s
  wall_time=6.24s cpu_util=5.793973204
----------- TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_16 ---------------
 samples:       2151
 iterations:    2859636
 iterations hr:    2.86M
 run time:      10.00437905
 per iteration: 6249.419435 cycles
FSyncQueueBench name=TFSyncQueue_MetaMixedEnqDeqGlobalWaitAfter64Iterations_16
  iterations=2859636
  operations: enqueues=2832004 dequeues=2832004 waits=27632
  enqueue_latency: p50=481ns p95=12.8us p99=28.3us max=778us
  dequeue_latency: p50=2.71us p95=13.1us p99=27.5us max=995us
  wait_latency: p50=1.35ms p95=1.71ms p99=1.87ms max=2.26ms
  cpu_time: user=29.1s system=4.28s total=33.4s
  wall_time=4.53s cpu_util=7.376787212
```