### PR TITLE
[Filestore] Fix stale read-ahead cache hits during unconfirmed AddBlob confirmation

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -200,7 +200,7 @@ private:
             !HasError(args.Error) || args.CommitIdOverflow,
             "Error: " << FormatError(args.Error));
 
-        Tablet.ActivateInMemoryIndexStateBypass(
+        Tablet.ActivateCacheReadBypass(
             args.WriteRanges.front().NodeId,
             args.CommitId);
 
@@ -585,7 +585,7 @@ void TIndexTabletActor::CompleteTx_AddBlob(
     // For unconfirmed data we already released the barrier and answered to
     // the client, nothing left to do and we can skip event.
     if (args.Mode == EAddBlobMode::WriteUnconfirmed) {
-        DeactivateInMemoryIndexStateBypass(
+        DeactivateCacheReadBypass(
             args.WriteRanges.front().NodeId,
             args.CommitId);
         EnqueueCollectGarbageIfNeeded(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -758,10 +758,15 @@ void TIndexTabletActor::HandleDescribeData(
 
     auto* handle = FindHandle(msg->Record.GetHandle());
     const ui64 nodeId = handle ? handle->GetNodeId() : InvalidNodeId;
+    const ui64 commitId = handle
+        ? handle->GetCommitId()
+        : GetCurrentCommitId();
+
     NProtoPrivate::TDescribeDataResponse result;
     const bool filled = TryFillDescribeResult(
         nodeId,
         msg->Record.GetHandle(),
+        commitId,
         byteRange,
         &result);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
@@ -1,0 +1,77 @@
+#include "tablet_cache_read_bypass.h"
+
+#include <cloud/filestore/libs/storage/tablet/model/verify.h>
+
+#include <cloud/storage/core/libs/tablet/model/commit.h>
+
+#include <utility>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TCacheReadBypass::UpdateLogTag(TString logTag)
+{
+    LogTag = std::move(logTag);
+}
+
+void TCacheReadBypass::Activate(ui64 nodeId, ui64 commitId)
+{
+    CommitIdsByNodeId[nodeId].push_back(commitId);
+}
+
+void TCacheReadBypass::Deactivate(ui64 nodeId, ui64 commitId)
+{
+    auto nodeIt = CommitIdsByNodeId.find(nodeId);
+    TABLET_VERIFY_C(
+        nodeIt != CommitIdsByNodeId.end(),
+        "nodeId: " << nodeId << ", commitId: " << commitId);
+    TABLET_VERIFY_C(
+        !nodeIt->second.empty(),
+        "nodeId: " << nodeId << ", commitId: " << commitId);
+    TABLET_VERIFY_C(
+        nodeIt->second.front() == commitId,
+        "nodeId: " << nodeId << ", expected commitId: " << commitId
+                   << ", actual commitId: " << nodeIt->second.front()
+                   << ", queue size: " << nodeIt->second.size());
+
+    nodeIt->second.pop_front();
+    if (nodeIt->second.empty()) {
+        CommitIdsByNodeId.erase(nodeIt);
+    }
+}
+
+void TCacheReadBypass::SetUnconfirmedRecoveryReady(
+    bool unconfirmedRecoveryReady)
+{
+    UnconfirmedRecoveryReady = unconfirmedRecoveryReady;
+}
+
+bool TCacheReadBypass::ShouldBypassRead(ui64 nodeId, ui64 commitId) const
+{
+    // If recovery is in progress, reading from the cache is not possible.
+    if (!UnconfirmedRecoveryReady) {
+        return true;
+    }
+
+    // No records at all. The map is always empty after the recovery phase if
+    // unconfirmed data is disabled, as it is the only client of this API for
+    // now.
+    if (CommitIdsByNodeId.empty()) {
+        return false;
+    }
+
+    // If there are no records for the given node, we can read from the cache.
+    const auto it = CommitIdsByNodeId.find(nodeId);
+    if (it == CommitIdsByNodeId.end() || it->second.empty()) {
+        return false;
+    }
+
+    // Otherwise, ensure that all writes with commit ids up to the current
+    // commit are already in the cache.
+    const ui64 frontCommitId = it->second.front();
+    // The InvalidCommitId comparison handles the CommitIdOverflow case.
+    return frontCommitId == InvalidCommitId || frontCommitId <= commitId;
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <util/generic/deque.h>
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/system/types.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Tracks cache reads that must go to the database while unconfirmed data
+ * is not fully reflected in in-memory caches.
+ */
+class TCacheReadBypass
+{
+public:
+    void UpdateLogTag(TString logTag);
+
+    void Activate(ui64 nodeId, ui64 commitId);
+
+    void Deactivate(ui64 nodeId, ui64 commitId);
+
+    void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady);
+
+    bool ShouldBypassRead(ui64 nodeId, ui64 commitId) const;
+
+private:
+    TString LogTag;
+    bool UnconfirmedRecoveryReady = false;
+    THashMap<ui64, TDeque<ui64>> CommitIdsByNodeId;
+};
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -83,6 +83,7 @@ TIndexTabletState::~TIndexTabletState() = default;
 
 void TIndexTabletState::UpdateLogTag(TString tag)
 {
+    Impl->CacheReadBypass.UpdateLogTag(tag);
     Impl->FreshBytes.UpdateLogTag(tag);
     if (Impl->InMemoryIndexState) {
         Impl->InMemoryIndexState->UpdateLogTag(tag);
@@ -193,6 +194,7 @@ void TIndexTabletState::LoadState(
 
     Impl->InMemoryIndexState = std::make_unique<TStandardInMemoryIndexState>(
         AllocatorRegistry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache),
+        Impl->CacheReadBypass,
         CalculateInMemoryIndexCacheCapacity(
             config.GetInMemoryIndexCacheNodesCapacity(),
             GetNodesCount(),

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -993,8 +993,8 @@ public:
         ui64 nodeId,
         const TByteRange& requestRange) const;
 
-    void ActivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
-    void DeactivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId);
+    void ActivateCacheReadBypass(ui64 nodeId, ui64 commitId);
+    void DeactivateCacheReadBypass(ui64 nodeId, ui64 commitId);
 
     //
     // FreshBytes
@@ -1533,6 +1533,7 @@ public:
     bool TryFillDescribeResult(
         ui64 nodeId,
         ui64 handle,
+        ui64 commitId,
         const TByteRange& range,
         NProtoPrivate::TDescribeDataResponse* response);
     TMaybe<TByteRange> RegisterDescribe(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -1,7 +1,5 @@
 #include "tablet_state_cache.h"
 
-#include <cloud/filestore/libs/storage/tablet/model/verify.h>
-
 #include <cloud/storage/core/libs/tablet/model/commit.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -10,12 +8,14 @@ namespace NCloud::NFileStore::NStorage {
 
 template <typename TNodeRefsImpl>
 TInMemoryIndexState<TNodeRefsImpl>::TInMemoryIndexState(
-        IAllocator* allocator,
-        ui64 nodesCapacity,
-        ui64 nodeAttrsCapacity,
-        ui64 nodeRefsCapacity,
-        ui64 nodeRefsExhaustivenessCapacity)
-    : Nodes(nodesCapacity)
+    IAllocator* allocator,
+    const TCacheReadBypass& cacheReadBypass,
+    ui64 nodesCapacity,
+    ui64 nodeAttrsCapacity,
+    ui64 nodeRefsCapacity,
+    ui64 nodeRefsExhaustivenessCapacity)
+    : CacheReadBypass(cacheReadBypass)
+    , Nodes(nodesCapacity)
     , NodeAttrs(nodeAttrsCapacity)
     , NodeRefs(allocator, nodeRefsCapacity)
     , NodeRefsExhaustivenessInfo(nodeRefsExhaustivenessCapacity)
@@ -70,75 +70,6 @@ TInMemoryIndexStateStats TInMemoryIndexState<TNodeRefsImpl>::GetStats() const
         .IsNodeRefsExhaustive = NodeRefsExhaustivenessInfo.IsExhaustive()};
 }
 
-template <typename TNodeRefsImpl>
-void TInMemoryIndexState<TNodeRefsImpl>::ActivateInMemoryIndexStateBypass(
-    ui64 nodeId,
-    ui64 commitId)
-{
-    CacheBypassCommitIdsByNodeId[nodeId].push_back(commitId);
-}
-
-template <typename TNodeRefsImpl>
-void TInMemoryIndexState<TNodeRefsImpl>::DeactivateInMemoryIndexStateBypass(
-    ui64 nodeId,
-    ui64 commitId)
-{
-    auto nodeIt = CacheBypassCommitIdsByNodeId.find(nodeId);
-    TABLET_VERIFY_C(
-        nodeIt != CacheBypassCommitIdsByNodeId.end(),
-        "nodeId: " << nodeId << ", commitId: " << commitId);
-    TABLET_VERIFY_C(
-        !nodeIt->second.empty(),
-        "nodeId: " << nodeId << ", commitId: " << commitId);
-    TABLET_VERIFY_C(
-        nodeIt->second.front() == commitId,
-        "nodeId: " << nodeId << ", expected commitId: " << commitId
-                   << ", actual commitId: " << nodeIt->second.front()
-                   << ", queue size: " << nodeIt->second.size());
-
-    nodeIt->second.pop_front();
-    if (nodeIt->second.empty()) {
-        CacheBypassCommitIdsByNodeId.erase(nodeIt);
-    }
-}
-
-template <typename TNodeRefsImpl>
-void TInMemoryIndexState<TNodeRefsImpl>::SetUnconfirmedRecoveryReady(
-    bool unconfirmedRecoveryReady)
-{
-    UnconfirmedRecoveryReady = unconfirmedRecoveryReady;
-}
-
-template <typename TNodeRefsImpl>
-bool TInMemoryIndexState<TNodeRefsImpl>::ShouldBypassCacheRead(
-    ui64 nodeId,
-    ui64 commitId) const
-{
-    // If recovery is in progress, reading from the cache is not possible.
-    if (!UnconfirmedRecoveryReady) {
-        return true;
-    }
-
-    // No records at all. The map is always empty after the recovery phase if
-    // unconfirmed data is disabled, as it is the only client of this API for
-    // now.
-    if (CacheBypassCommitIdsByNodeId.empty()) {
-        return false;
-    }
-
-    // If there are no records for the given node, we can read from the cache.
-    const auto it = CacheBypassCommitIdsByNodeId.find(nodeId);
-    if (it == CacheBypassCommitIdsByNodeId.end() || it->second.empty()) {
-        return false;
-    }
-
-    // Otherwise, ensure that all writes with commit ids up to the current
-    // commit are already in the cache.
-    const ui64 frontCommitId = it->second.front();
-    // The InvalidCommitId comparison handles the CommitIdOverflow case.
-    return frontCommitId == InvalidCommitId || frontCommitId <= commitId;
-}
-
 //
 // Nodes
 //
@@ -150,7 +81,7 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadNode(
     TMaybe<TNode>& node)
 {
     // TODO (#5912) use waiting queue instead of going full TX flow
-    if (ShouldBypassCacheRead(nodeId, commitId)) {
+    if (CacheReadBypass.ShouldBypassRead(nodeId, commitId)) {
         return false;
     }
 
@@ -230,7 +161,7 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeAttr(
     TMaybe<TNodeAttr>& attr)
 {
     // TODO (#5912) use waiting queue instead of going full TX flow
-    if (ShouldBypassCacheRead(nodeId, commitId)) {
+    if (CacheReadBypass.ShouldBypassRead(nodeId, commitId)) {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tablet_cache_read_bypass.h"
 #include "tablet_state_iface.h"
 
 #include <cloud/filestore/libs/storage/tablet/model/metadata_cache.h>
@@ -9,7 +10,6 @@
 
 #include <library/cpp/cache/cache.h>
 
-#include <util/generic/deque.h>
 #include <util/generic/hash.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -43,20 +43,6 @@ public:
     [[nodiscard]] virtual TInMemoryIndexStateStats GetStats() const = 0;
 
     virtual void UpdateLogTag(TString logTag) = 0;
-
-    //
-    // Cache bypass
-    //
-
-    virtual void ActivateInMemoryIndexStateBypass(
-        ui64 nodeId,
-        ui64 commitId) = 0;
-
-    virtual void DeactivateInMemoryIndexStateBypass(
-        ui64 nodeId,
-        ui64 commitId) = 0;
-
-    virtual void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady) = 0;
 
     //
     // Nodes
@@ -130,6 +116,7 @@ class TInMemoryIndexState : public IInMemoryIndexState
 public:
     TInMemoryIndexState(
         IAllocator* allocator,
+        const TCacheReadBypass& cacheReadBypass,
         ui64 nodesCapacity,
         ui64 nodeAttrsCapacity,
         ui64 nodeRefsCapacity,
@@ -147,25 +134,7 @@ public:
 
 private:
     TString LogTag;
-
-    //
-    // Cache bypass
-    //
-
-public:
-    void ActivateInMemoryIndexStateBypass(ui64 nodeId, ui64 commitId) override;
-
-    void DeactivateInMemoryIndexStateBypass(
-        ui64 nodeId,
-        ui64 commitId) override;
-
-    void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady) override;
-
-private:
-    bool ShouldBypassCacheRead(ui64 nodeId, ui64 commitId) const;
-
-    bool UnconfirmedRecoveryReady = false;
-    THashMap<ui64, TDeque<ui64>> CacheBypassCommitIdsByNodeId;
+    const TCacheReadBypass& CacheReadBypass;
 
     //
     // Nodes

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -421,28 +421,20 @@ bool TIndexTabletState::HasDataOverlapWithUnconfirmed(
     return hasDataOverlap(UnconfirmedData) || hasDataOverlap(ConfirmedData);
 }
 
-void TIndexTabletState::ActivateInMemoryIndexStateBypass(
-    ui64 nodeId,
-    ui64 commitId)
+void TIndexTabletState::ActivateCacheReadBypass(ui64 nodeId, ui64 commitId)
 {
-    Impl->InMemoryIndexState->ActivateInMemoryIndexStateBypass(
-        nodeId,
-        commitId);
+    Impl->CacheReadBypass.Activate(nodeId, commitId);
 }
 
-void TIndexTabletState::DeactivateInMemoryIndexStateBypass(
-    ui64 nodeId,
-    ui64 commitId)
+void TIndexTabletState::DeactivateCacheReadBypass(ui64 nodeId, ui64 commitId)
 {
-    Impl->InMemoryIndexState->DeactivateInMemoryIndexStateBypass(
-        nodeId,
-        commitId);
+    Impl->CacheReadBypass.Deactivate(nodeId, commitId);
 }
 
 void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
 {
     UnconfirmedRecoveryReady = value;
-    Impl->InMemoryIndexState->SetUnconfirmedRecoveryReady(value);
+    Impl->CacheReadBypass.SetUnconfirmedRecoveryReady(value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1529,9 +1521,14 @@ auto TIndexTabletState::FindForcedRangeOperation(
 bool TIndexTabletState::TryFillDescribeResult(
     ui64 nodeId,
     ui64 handle,
+    ui64 commitId,
     const TByteRange& range,
     NProtoPrivate::TDescribeDataResponse* response)
 {
+    if (Impl->CacheReadBypass.ShouldBypassRead(nodeId, commitId)) {
+        return false;
+    }
+
     return Impl->ReadAheadCache.TryFillResult(nodeId, handle, range, response);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_impl.h
@@ -68,6 +68,7 @@ struct TIndexTabletState::TImpl
     TCompactionMap CompactionMap;
     TGarbageQueue GarbageQueue;
     TTruncateQueue TruncateQueue;
+    TCacheReadBypass CacheReadBypass;
     TReadAheadCache ReadAheadCache;
     std::unique_ptr<IInMemoryIndexState> InMemoryIndexState;
     TSet<ui64> OrphanNodeIds;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -28,8 +28,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     //
     Y_UNIT_TEST(ShouldPopulateNodes)
     {
-        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 1, 0, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
@@ -61,8 +62,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldEvictNodes)
     {
-        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 1, 0, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
             {IInMemoryIndexState::TWriteNodeRequest{
@@ -86,8 +88,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldDeleteNodes)
     {
-        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 1, 0, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
@@ -110,8 +113,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldBypassCacheReads)
     {
-        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 1, 0, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
@@ -124,7 +128,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
         UNIT_ASSERT(node.Defined());
 
-        state.ActivateInMemoryIndexStateBypass(nodeId1, commitId2);
+        cacheBypass.Activate(nodeId1, commitId2);
 
         node.Clear();
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
@@ -134,13 +138,13 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
         UNIT_ASSERT(node.Empty());
 
-        state.DeactivateInMemoryIndexStateBypass(nodeId1, commitId2);
+        cacheBypass.Deactivate(nodeId1, commitId2);
 
         node.Clear();
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId2, node));
         UNIT_ASSERT(node.Defined());
 
-        state.ActivateInMemoryIndexStateBypass(
+        cacheBypass.Activate(
             nodeId1,
             InvalidCommitId);
 
@@ -152,7 +156,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
         UNIT_ASSERT(node.Empty());
 
-        state.DeactivateInMemoryIndexStateBypass(
+        cacheBypass.Deactivate(
             nodeId1,
             InvalidCommitId);
 
@@ -163,7 +167,8 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldBypassCacheReadsUntilUnconfirmedWritesComplete)
     {
-        TStandardInMemoryIndexState state(Alloc(), 1, 0, 0, 0);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 1, 0, 0, 0);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeRequest{
             .NodeId = nodeId1,
@@ -172,19 +177,19 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                 .Node = nodeAttrs1,
             }}});
 
-        state.ActivateInMemoryIndexStateBypass(nodeId1, commitId2);
+        cacheBypass.Activate(nodeId1, commitId2);
 
         TMaybe<IIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
         UNIT_ASSERT(node.Empty());
 
-        state.SetUnconfirmedRecoveryReady(true);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         node.Clear();
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
         UNIT_ASSERT(node.Empty());
 
-        state.DeactivateInMemoryIndexStateBypass(nodeId1, commitId2);
+        cacheBypass.Deactivate(nodeId1, commitId2);
 
         node.Clear();
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId2, node));
@@ -205,8 +210,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     //
     Y_UNIT_TEST(ShouldPopulateNodeAttrs)
     {
-        TStandardInMemoryIndexState state(Alloc(), 0, 1, 0, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 1, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId2, attrName1, attr));
@@ -241,8 +247,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldEvictNodeAttrs)
     {
-        TStandardInMemoryIndexState state(Alloc(), 0, 1, 0, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 1, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState(
             {IInMemoryIndexState::TWriteNodeAttrsRequest{
@@ -261,8 +268,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     Y_UNIT_TEST(ShouldDeleteNodeAttrs)
     {
-        TStandardInMemoryIndexState state(Alloc(), 0, 1, 0, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 1, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeAttrsRequest{
             .NodeAttrsKey = {nodeId1, attrName1},
@@ -342,8 +350,9 @@ namespace {
     //
     Y_UNIT_TEST(ShouldPopulateNodeRefs)
     {
-        TStandardInMemoryIndexState state(Alloc(), 0, 0, 1, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 0, 1, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
         UNIT_ASSERT(
@@ -392,8 +401,9 @@ namespace {
 
     Y_UNIT_TEST(ShouldEvictNodeRefs)
     {
-        TStandardInMemoryIndexState state(Alloc(), 0, 0, 3, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 0, 3, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         const TVector<IInMemoryIndexState::TWriteNodeRefsRequest> requests = {
             {
@@ -503,8 +513,9 @@ namespace {
 
     Y_UNIT_TEST(ShouldDeleteNodeRefs)
     {
-        TStandardInMemoryIndexState state(Alloc(), 0, 0, 1, 0);
-        state.SetUnconfirmedRecoveryReady(true);
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 0, 1, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         IInMemoryIndexState::TWriteNodeRefsRequest request = {
             .NodeRefsKey = {rootNodeIds[0], nodeNames[0]},

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1682,6 +1682,141 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             tablet.GetNodeAttr(id)->Record.GetNode().GetSize());
         AssertStorageStats(tablet, 0, 0);
     }
+
+    Y_UNIT_TEST(ShouldNotUseReadAheadCacheUntilAddBlobUnconfirmedCommits)
+    {
+        constexpr ui32 block = 4_KB;
+        constexpr ui64 readAheadStep = 128_KB;
+        constexpr ui64 writeOffset = 1_MB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetReadAheadCacheRangeSize(1_MB);
+        storageConfig.SetReadAheadCacheMaxResultsPerNode(32);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        tablet.WriteData(handle, 0, 2_MB, 'a');
+
+        for (ui32 i = 0; i < 7; ++i) {
+            tablet.DescribeData(handle, i * readAheadStep, readAheadStep);
+        }
+
+        const ui64 commitId = GenerateBlobIdsAndPutBlob(
+            env,
+            tablet,
+            id,
+            handle,
+            writeOffset,
+            block,
+            'b');
+        WaitForTabletCommit(env);
+        AssertStorageStats(tablet, 1, 0);
+
+        TAutoPtr<IEventHandle> blockedRwPut;
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvBlobStorage::EvPut &&
+                    !blockedRwPut)
+                {
+                    blockedRwPut = event.Release();
+                    return true;
+                }
+                return false;
+            });
+
+        tablet.SendSetNodeAttrRequest(TSetNodeAttrArgs(RootNodeId).SetUid(2));
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]() { return !!blockedRwPut; }},
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(blockedRwPut, "Expected blocked RW tx put");
+        tablet.AssertSetNodeAttrNoResponse();
+
+        TAutoPtr<IEventHandle> addBlobCommitResult;
+        bool confirmResponseSeen = false;
+        ui32 commitResultsAfterConfirm = 0;
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() ==
+                    TEvIndexTablet::EvConfirmAddDataResponse)
+                {
+                    confirmResponseSeen = true;
+                    return false;
+                }
+
+                if (confirmResponseSeen &&
+                    event->GetTypeRewrite() == TEvTablet::EvCommitResult)
+                {
+                    ++commitResultsAfterConfirm;
+                    if (commitResultsAfterConfirm == 2 &&
+                        !addBlobCommitResult) {
+                        addBlobCommitResult = event.Release();
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+
+        // This request is prepared before AddBlob is executed and can
+        // repopulate read-ahead with the old blob mapping after AddBlob has
+        // already invalidated it in ExecuteTx.
+        tablet.SendDescribeDataRequest(
+            handle,
+            writeOffset - readAheadStep,
+            readAheadStep);
+
+        tablet.SendConfirmAddDataRequest(commitId);
+
+        runtime.Send(blockedRwPut.Release(), nodeIdx);
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]()
+                { return !!addBlobCommitResult; }},
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(
+            addBlobCommitResult,
+            "Expected AddBlob commit result to be held by the test");
+
+        tablet.AssertSetNodeAttrResponse(S_OK);
+        tablet.AssertConfirmAddDataResponse(S_OK);
+        tablet.AssertDescribeDataResponse(S_OK);
+
+        tablet.SendDescribeDataRequest(handle, writeOffset, block);
+
+        // A stale read-ahead hit would answer immediately here, before
+        // CompleteTx_AddBlob gets a chance to invalidate the cache again.
+        tablet.AssertDescribeDataNoResponse();
+
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        runtime.Send(addBlobCommitResult.Release(), nodeIdx);
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        tablet.AssertDescribeDataResponse(S_OK);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(block, 'b'),
+            ReadData(tablet, handle, block, writeOffset));
+        AssertStorageStats(tablet, 0, 0);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -88,6 +88,7 @@ SRCS(
     tablet_actor_writedata.cpp
     tablet_actor_write_compactionmap.cpp
     tablet_actor_zerorange.cpp
+    tablet_cache_read_bypass.cpp
     tablet_counters.cpp
     tablet_database.cpp
     tablet_schema.cpp


### PR DESCRIPTION
### Notes
This change prevents DescribeData from serving stale read-ahead cache entries while an unconfirmed AddBlob write is being committed.

Previously, the cache bypass state lived inside TInMemoryIndexState, so it only naturally covered index-state cache reads. DescribeData could still hit the read-ahead cache in the window where AddBlob had invalidated cache during ExecuteTx, but CompleteTx_AddBlob had not yet run. A concurrent older DescribeData could repopulate read-ahead with old blob mappings in that window.

Changes

Extract cache bypass tracking into shared TCacheReadBypass.
Both IndexStateCache and ReadAheadCache now use the same CacheReadByPass
Add regression coverage for stale read-ahead hits before AddBlob CompleteTx.

### Issue
#2293
