### PR TITLE
Set default std::terminate handler and print exception stack in it

### DIFF
--- a/cloud/blockstore/apps/disk_agent/ya.make
+++ b/cloud/blockstore/apps/disk_agent/ya.make
@@ -20,14 +20,12 @@ PEERDIR(
     contrib/ydb/library/keys
 
     library/cpp/getopt
+
+    util/terminate_handler
 )
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG" AND BUILD_TYPE != "RELWITHDEBINFO")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/blockstore/apps/server/ya.make
+++ b/cloud/blockstore/apps/server/ya.make
@@ -28,14 +28,12 @@ PEERDIR(
     contrib/ydb/library/keys
 
     library/cpp/getopt
+
+    util/terminate_handler
 )
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG" AND BUILD_TYPE != "RELWITHDEBINFO")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -8,10 +8,6 @@ SRCS(
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)
@@ -23,6 +19,8 @@ PEERDIR(
     cloud/blockstore/libs/service
 
     cloud/storage/core/libs/daemon
+
+    util/terminate_handler
 )
 
 CHECK_DEPENDENT_DIRS(ALLOW_ONLY PEERDIRS

--- a/cloud/filestore/apps/server/ya.make
+++ b/cloud/filestore/apps/server/ya.make
@@ -6,10 +6,6 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)
@@ -26,6 +22,8 @@ PEERDIR(
 
     contrib/ydb/core/security
     contrib/ydb/library/keys
+
+    util/terminate_handler
 )
 
 YQL_LAST_ABI_VERSION()

--- a/cloud/filestore/apps/vhost/ya.make
+++ b/cloud/filestore/apps/vhost/ya.make
@@ -10,10 +10,6 @@ ENDIF()
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)
@@ -32,6 +28,8 @@ PEERDIR(
 
     contrib/ydb/core/security
     contrib/ydb/library/keys
+
+    util/terminate_handler
 )
 
 YQL_LAST_ABI_VERSION()

--- a/util/terminate_handler/terminate_handler.cpp
+++ b/util/terminate_handler/terminate_handler.cpp
@@ -1,0 +1,36 @@
+#include <util/generic/yexception.h>
+#include <util/stream/output.h>
+#include <util/stream/str.h>
+#include <util/system/backtrace.h>
+
+#include <cstdlib>
+#include <exception>
+
+namespace {
+// Avoid infinite recursion if std::terminate is triggered anew by the
+// FancyTerminateHandler.
+thread_local int TerminateCount = 0;
+
+void TerminateHandler() noexcept
+{
+    if (++TerminateCount != 1) {
+        Cerr << "FancyTerminateHandler called recursively" << Endl;
+        std::abort();
+    }
+
+    auto report = TStringStream();
+    if (std::current_exception()) {
+        report << "\n========== Uncaught exception ===============\n";
+        FormatCurrentExceptionTo(report);
+    } else {
+        report << "Terminate for unknown reason (no current exception)\n";
+    }
+    report << "\n========== Terminate handler stack ==========\n";
+    FormatBackTrace(&report);
+
+    Cerr << report.Str() << '\n' << Flush;
+    std::abort();
+}
+
+[[maybe_unused]] const auto _ = std::set_terminate(&TerminateHandler);
+}   // namespace

--- a/util/terminate_handler/terminate_handler.cpp
+++ b/util/terminate_handler/terminate_handler.cpp
@@ -7,14 +7,13 @@
 #include <exception>
 
 namespace {
-// Avoid infinite recursion if std::terminate is triggered anew by the
-// FancyTerminateHandler.
+// Avoid recursion if std::terminate is triggered inside TerminateHandler
 thread_local int TerminateCount = 0;
 
 void TerminateHandler() noexcept
 {
     if (++TerminateCount != 1) {
-        Cerr << "FancyTerminateHandler called recursively" << Endl;
+        Cerr << "TerminateHandler is called recursively" << Endl;
         std::abort();
     }
 

--- a/util/terminate_handler/ya.make
+++ b/util/terminate_handler/ya.make
@@ -1,0 +1,7 @@
+LIBRARY()
+
+SRCS(
+    GLOBAL terminate_handler.cpp
+)
+
+END()


### PR DESCRIPTION
## Motivation

The terminate handler printed only the current stack, which often points to `std::terminate()` / exception handling machinery rather than the original throw site.

## Changes

- Print backtrace captured from the current exception in `FancyTerminateHandler`
- Keep printing the regular current backtrace as before
- Always link `library/cpp/terminate_handler` into blockstore/filestore binaries
- Use `auto report = TStringStream()` to get the message that is not interrupted by other log entries


## Issue
#5991 
