### PR TITLE
Fix smooth and critical suffers calculation

### DIFF
--- a/cloud/blockstore/libs/diagnostics/volume_perf.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf.cpp
@@ -169,11 +169,12 @@ void TVolumePerformanceCalculator::OnRequestCompleted(
 }
 
 bool TVolumePerformanceCalculator::DidSuffer(
-    long expectedScore,
-    long actualScore) const
+    ui64 expectedScore,
+    ui64 actualScore,
+    TDuration window) const
 {
-    return (expectedScore < ExpectedIoParallelism * 1e6)
-        && (actualScore > expectedScore);
+    const ui64 windowCapacity = window.MicroSeconds() * ExpectedIoParallelism;
+    return (expectedScore < windowCapacity) && (actualScore > expectedScore);
 }
 
 bool TVolumePerformanceCalculator::UpdateStats()
@@ -182,9 +183,10 @@ bool TVolumePerformanceCalculator::UpdateStats()
         return false;
     }
 
-    auto expectedScore = AtomicGet(ExpectedScore);
-    auto actualScore = AtomicGet(CurrentScore);
-    bool suffered = DidSuffer(expectedScore, actualScore);
+    const auto expectedScore = AtomicGet(ExpectedScore);
+    const auto actualScore = AtomicGet(CurrentScore);
+    const bool suffered =
+        DidSuffer(expectedScore, actualScore, UpdateStatsInterval);
 
     AtomicAdd(SufferCount, suffered - Samples[UpdateCounter].Suffered);
     Samples[UpdateCounter] = {suffered, expectedScore, actualScore};
@@ -199,12 +201,18 @@ bool TVolumePerformanceCalculator::UpdateStats()
 
     AtomicSet(
         SmoothSufferCount,
-        DidSuffer(windowExpectedScore, windowActualScore));
+        DidSuffer(
+            windowExpectedScore,
+            windowActualScore,
+            UpdateCountersInterval));
 
     ui32 criticalFactor = Max(2u, ConfigSettings.CriticalFactor);
     AtomicSet(
         CriticalSufferCount,
-        DidSuffer(windowExpectedScore * criticalFactor, windowActualScore));
+        DidSuffer(
+            windowExpectedScore * criticalFactor,
+            windowActualScore,
+            UpdateCountersInterval));
 
     if (!UpdateCounter && Counter) {
         *Counter = SufferCount;

--- a/cloud/blockstore/libs/diagnostics/volume_perf.h
+++ b/cloud/blockstore/libs/diagnostics/volume_perf.h
@@ -52,7 +52,8 @@ private:
 private:
     TVolumePerfSettings GetConfigSettings(
         TDiagnosticsConfigPtr diagnosticsConfig) const;
-    bool DidSuffer(long expectedScore, long actualScore) const;
+    bool
+    DidSuffer(ui64 expectedScore, ui64 actualScore, TDuration window) const;
 
 public:
     TVolumePerformanceCalculator(

--- a/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp
@@ -696,6 +696,105 @@ Y_UNIT_TEST_SUITE(TVolumePerfTest)
         UNIT_ASSERT_VALUES_EQUAL(0, sufferCounter->Val());
     }
 
+    Y_UNIT_TEST(ShouldUse15SecondWindowForSmoothSuffer)
+    {
+        constexpr ui32 RequestBytes = 1024 * 1024;
+
+        auto monitoring = CreateMonitoringServiceStub();
+        auto counters = monitoring->GetCounters();
+
+        auto config = CreatePerformanceSettings(
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            1,          // readIops
+            128_KB,     // readBandwidth
+            1,          // writeIops
+            128_KB,     // writeBandwidth
+            0,          // minReadIops
+            0,          // minReadBandwidth
+            0,          // minWriteIops
+            0           // minWriteBandwidth
+        );
+        config.SetExpectedIoParallelism(1);
+        config.MutableSsdPerfSettings()->SetCriticalFactor(100);
+
+        auto volume = CreateVolumeWithDiagnosticsProfile(
+            "test_window_critical",
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            config
+        );
+
+        auto volumeCounters = CreateVolumeCounters(counters, volume.GetDiskId());
+        TVolumePerformanceCalculator calc(
+            volume,
+            std::make_shared<TDiagnosticsConfig>(std::move(config)));
+        calc.Register(*volumeCounters, volume);
+
+        const auto expectedCost = calc.GetExpectedWriteCost(RequestBytes);
+        UNIT_ASSERT(expectedCost > TDuration::Seconds(8));
+        UNIT_ASSERT(expectedCost < TDuration::Seconds(15));
+
+        const auto requestTime = expectedCost + TDuration::Seconds(1);
+
+        // expectedCost > 1s => per-second Suffer must stay off,
+        // but for the 15s window SmoothSuffer should still be set.
+        TestSufferCount(
+            calc,
+            requestTime,
+            TDuration::Seconds(15),
+            0,      // expected Suffer
+            1,      // expected SmoothSuffer
+            0);     // expected CriticalSuffer
+    }
+
+    Y_UNIT_TEST(ShouldUse15SecondWindowForCriticalSuffer)
+    {
+        constexpr ui32 RequestBytes = 1024 * 1024;
+
+        auto monitoring = CreateMonitoringServiceStub();
+        auto counters = monitoring->GetCounters();
+
+        auto config = CreatePerformanceSettings(
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            1,          // readIops
+            512_KB,     // readBandwidth
+            1,          // writeIops
+            512_KB,     // writeBandwidth
+            0,          // minReadIops
+            0,          // minReadBandwidth
+            0,          // minWriteIops
+            0           // minWriteBandwidth
+        );
+        config.SetExpectedIoParallelism(1);
+        config.MutableSsdPerfSettings()->SetCriticalFactor(2);
+
+        auto volume = CreateVolumeWithDiagnosticsProfile(
+            "test_window_critical",
+            NCloud::NProto::STORAGE_MEDIA_SSD,
+            config
+        );
+
+        auto volumeCounters = CreateVolumeCounters(counters, volume.GetDiskId());
+        TVolumePerformanceCalculator calc(
+            volume,
+            std::make_shared<TDiagnosticsConfig>(std::move(config)));
+        calc.Register(*volumeCounters, volume);
+
+        const auto expectedCost = calc.GetExpectedWriteCost(RequestBytes);
+        UNIT_ASSERT(expectedCost > TDuration::Seconds(1));
+        UNIT_ASSERT(expectedCost < TDuration::Seconds(7));
+
+        const auto requestTime =
+            expectedCost + expectedCost + TDuration::Seconds(1);
+
+        TestSufferCount(
+            calc,
+            requestTime,
+            TDuration::Seconds(15),
+            0,  // expected Suffer
+            1,  // expected SmoothSuffer
+            1); // expected CriticalSuffer
+    }
+
     Y_UNIT_TEST(ShouldSetUnsetSufferForSsd)
     {
         TestSufferWithMetrics(NCloud::NProto::STORAGE_MEDIA_SSD);


### PR DESCRIPTION
### Notes
Smooth and Critical suffers are calculated over 15 seconds window. But the `DidSuffer()` method had a hardcoded 1 second window. This PR adds window size parameter to the `DidSuffer()` to properly calculate regular `Suffer` count and the `SmoothSuffer`/`CriticalSuffer` flags