### PR TITLE
issue-1751: [Filestore] TWriteBackCache: pending requests should fail when flush has failed due to E_FS_NOSPC

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -376,6 +376,11 @@ EFlushRetryStatus TWriteBackCacheState::FlushFailed(
         nodeState.Barriers.erase(it);
     }
 
+    // Fail all pending requests in the case of E_FS_NOSPC
+    if (error.GetCode() == E_FS_NOSPC) {
+        FailPendingRequests(error);
+    }
+
     if (nodeState.Handles.size() == nodeState.HandleToReleaseCount) {
         // All handles with active WriteData requests are to be released
         // Drop node data on flush failure
@@ -799,6 +804,38 @@ void TWriteBackCacheState::DropCachedData(
     nodeState.HandleToReleaseCount = 0;
 
     EvictUnpinnedFlushedEntries(nodeId, nodeState);
+}
+
+void TWriteBackCacheState::FailPendingRequests(
+    const NCloud::NProto::TError& error)
+{
+    while (auto* request = RequestManager.TryRemovePendingRequest()) {
+        const ui64 nodeId = request->GetRequest().GetNodeId();
+        auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
+        auto pendingRequest = nodeState.Cache.DequeuePendingRequest();
+
+        Y_ABORT_UNLESS(
+            pendingRequest->GetSequenceId() == request->GetSequenceId());
+
+        QueuedOperations.FailWriteDataPromise(
+            std::move(request->AccessPromise()),
+            error);
+
+        // Since no data loss has taken place and errors have been already
+        // reported by failing WriteData requests, we respond to Flush and
+        // ReleaseHandle with success
+        RemoveActiveRequestFromHandleState(
+            nodeState,
+            request->GetRequest().GetHandle());
+
+        TriggerFlushCompletions(nodeState);
+
+        if (nodeState.CanBeDeleted()) {
+            Nodes.DeleteNodeState(nodeId);
+        } else {
+            CheckAndAcquireBarriers(nodeState);
+        }
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -809,13 +809,16 @@ void TWriteBackCacheState::DropCachedData(
 void TWriteBackCacheState::FailPendingRequests(
     const NCloud::NProto::TError& error)
 {
-    while (auto* request = RequestManager.TryRemovePendingRequest()) {
+    while (auto* request = RequestManager.TryPopFrontPendingRequest()) {
         const ui64 nodeId = request->GetRequest().GetNodeId();
         auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
         auto pendingRequest = nodeState.Cache.DequeuePendingRequest();
 
-        Y_ABORT_UNLESS(
-            pendingRequest->GetSequenceId() == request->GetSequenceId());
+        // The same request lives in two queues:
+        // - all pending requests
+        // - pending requests associated with the node
+        // Both queues are ordered with respect to their SequenceId
+        Y_ABORT_UNLESS(pendingRequest.get() == request);
 
         QueuedOperations.FailWriteDataPromise(
             std::move(request->AccessPromise()),

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -142,7 +142,8 @@ public:
     void FlushSucceeded(ui64 nodeId, size_t requestCount);
 
     // Inform that the flush has failed - the error should be propagated to
-    // Flush, FlushAll and ReleaseHandle requests
+    // Flush, FlushAll and ReleaseHandle requests.
+    // In the case of E_FS_NOSPC, pending requests will be also failed.
     EFlushRetryStatus FlushFailed(
         ui64 nodeId,
         const NCloud::NProto::TError& error);
@@ -193,6 +194,8 @@ private:
         ui64 nodeId,
         TNodeState& nodeState,
         const NCloud::NProto::TError& error);
+
+    void FailPendingRequests(const NCloud::NProto::TError& error);
 };
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -143,7 +143,7 @@ public:
 
     // Inform that the flush has failed - the error should be propagated to
     // Flush, FlushAll and ReleaseHandle requests.
-    // In the case of E_FS_NOSPC, pending requests will be also failed.
+    // In the case of E_FS_NOSPC, pending requests will also be failed.
     EFlushRetryStatus FlushFailed(
         ui64 nodeId,
         const NCloud::NProto::TError& error);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -6,6 +6,7 @@
 #include "write_data_request.h"
 
 #include <cloud/filestore/libs/diagnostics/metrics/metric.h>
+#include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h>
 #include <cloud/filestore/public/api/protos/data.pb.h>
 
@@ -61,7 +62,7 @@ struct TBootstrap
     std::shared_ptr<TTestStorage> Storage;
     TProcessor Processor;
     std::unique_ptr<TWriteBackCacheState> State;
-    TWriteBackCacheStateMetrics Metrics;
+    TWriteBackCacheMetrics Metrics;
 
     TBootstrap()
         : Timer(std::make_shared<TTestTimer>())
@@ -85,6 +86,21 @@ struct TBootstrap
 
         return future.Apply([](const auto& result)
                             { return !HasError(result.GetValue()); });
+    }
+
+    auto Add2(ui64 nodeId, ui64 handle, ui64 offset, TString data)
+        -> NThreading::TFuture<NProto::TError>
+    {
+        auto request = std::make_shared<NProto::TWriteDataRequest>();
+        request->SetNodeId(nodeId);
+        request->SetHandle(handle);
+        request->SetOffset(offset);
+        *request->MutableBuffer() = std::move(data);
+
+        auto future = State->AddWriteDataRequest(std::move(request));
+
+        return future.Apply([](const auto& result)
+                            { return result.GetValue().GetError(); });
     }
 
     bool Recreate()
@@ -1165,6 +1181,78 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         UNIT_ASSERT_VALUES_EQUAL(0, stats.MaxTime->Get());
         UNIT_ASSERT_VALUES_EQUAL(1, stats.CompletedImmediately->Get());
         UNIT_ASSERT_VALUES_EQUAL(1, stats.FailedCount->Get());
+    }
+
+    Y_UNIT_TEST(ShouldHandleNoSpaceError)
+    {
+        TBootstrap b;
+
+        b.Storage->SetCapacity(3);
+
+        // Will trigger E_FS_NOSPC on this request
+        b.Add(1000, 1000, 0, "xyz");
+
+        b.Add(1, 101, 0, "abc");
+        b.Add(2, 201, 0, "def");
+
+        // Existing node - different handle
+        auto w1 = b.Add2(1, 102, 0, "ghi");
+
+        // Existing node - same handle
+        auto w2 = b.Add2(2, 201, 0, "jkl");
+
+        // New node
+        auto w3 = b.Add2(3, 301, 0, "mno");
+
+        auto f1 = b.State->AddFlushRequest(1);
+        auto f2 = b.State->AddFlushRequest(2);
+        auto f3 = b.State->AddFlushRequest(3);
+
+        auto r1 = b.State->AddReleaseHandleRequest(1, 101);
+        auto r2 = b.State->AddReleaseHandleRequest(2, 201);
+        auto r3 = b.State->AddReleaseHandleRequest(3, 301);
+
+        auto b1 = b.State->AcquireBarrier(1);
+        auto b2 = b.State->AcquireBarrier(2);
+        auto b3 = b.State->AcquireBarrier(3);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, b.Metrics.PendingQueue.Count->Get());
+
+        // Only E_FS_NOSPC should trigger pending requests failure
+        b.State->FlushFailed(1000, MakeError(E_FAIL));
+
+        UNIT_ASSERT_VALUES_EQUAL(3, b.Metrics.PendingQueue.Count->Get());
+
+        auto error = ErrorNoSpaceLeft();
+        b.State->FlushFailed(1000, error);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, b.Metrics.PendingQueue.Count->Get());
+
+        // All pending requests should be failed
+        UNIT_ASSERT(w1.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(error, w1.GetValue());
+
+        UNIT_ASSERT(w2.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(error, w2.GetValue());
+
+        UNIT_ASSERT(w3.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(error, w3.GetValue());
+
+        // Flush, ReleaseHandle and AcquireBarrier should be completed normally
+        UNIT_ASSERT(!f1.HasValue());
+        UNIT_ASSERT(!f2.HasValue());
+        UNIT_ASSERT(f3.HasValue());
+        UNIT_ASSERT(!HasError(f3.GetValue()));
+
+        UNIT_ASSERT(!r1.HasValue());
+        UNIT_ASSERT(!r2.HasValue());
+        UNIT_ASSERT(r3.HasValue());
+        UNIT_ASSERT(!HasError(r3.GetValue()));
+
+        UNIT_ASSERT(!b1.HasValue());
+        UNIT_ASSERT(!b2.HasValue());
+        UNIT_ASSERT(b3.HasValue());
+        UNIT_ASSERT(!HasError(b3.GetValue().GetError()));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -88,7 +88,7 @@ struct TBootstrap
                             { return !HasError(result.GetValue()); });
     }
 
-    auto Add2(ui64 nodeId, ui64 handle, ui64 offset, TString data)
+    auto AddAndGetError(ui64 nodeId, ui64 handle, ui64 offset, TString data)
         -> NThreading::TFuture<NProto::TError>
     {
         auto request = std::make_shared<NProto::TWriteDataRequest>();
@@ -1189,20 +1189,19 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
 
         b.Storage->SetCapacity(3);
 
-        // Will trigger E_FS_NOSPC on this request
         b.Add(1000, 1000, 0, "xyz");
 
         b.Add(1, 101, 0, "abc");
         b.Add(2, 201, 0, "def");
 
         // Existing node - different handle
-        auto w1 = b.Add2(1, 102, 0, "ghi");
+        auto w1 = b.AddAndGetError(1, 102, 0, "ghi");
 
         // Existing node - same handle
-        auto w2 = b.Add2(2, 201, 0, "jkl");
+        auto w2 = b.AddAndGetError(2, 201, 0, "jkl");
 
         // New node
-        auto w3 = b.Add2(3, 301, 0, "mno");
+        auto w3 = b.AddAndGetError(3, 301, 0, "mno");
 
         auto f1 = b.State->AddFlushRequest(1);
         auto f2 = b.State->AddFlushRequest(2);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -239,7 +239,7 @@ auto TWriteDataRequestManager::TryProcessPendingRequest()
     return cachedRequest;
 }
 
-TPendingWriteDataRequest* TWriteDataRequestManager::TryRemovePendingRequest()
+TPendingWriteDataRequest* TWriteDataRequestManager::TryPopFrontPendingRequest()
 {
     if (PendingRequests.Empty()) {
         return nullptr;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -239,6 +239,17 @@ auto TWriteDataRequestManager::TryProcessPendingRequest()
     return cachedRequest;
 }
 
+TPendingWriteDataRequest* TWriteDataRequestManager::TryRemovePendingRequest()
+{
+    if (PendingRequests.Empty()) {
+        return nullptr;
+    }
+
+    auto* pendingRequest = PendingRequests.Front();
+    PendingRequestsPopFront();
+    return pendingRequest;
+}
+
 void TWriteDataRequestManager::Remove(
     std::unique_ptr<TPendingWriteDataRequest> request)
 {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
@@ -86,6 +86,10 @@ public:
      */
     std::unique_ptr<TCachedWriteDataRequest> TryProcessPendingRequest();
 
+    // Takes and removes front request from the pending queue.
+    // Returns the removed request or nullptr if there are no pending requests.
+    TPendingWriteDataRequest* TryRemovePendingRequest();
+
     // Removes the request from the pending queue
     void Remove(std::unique_ptr<TPendingWriteDataRequest> request);
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
@@ -88,7 +88,7 @@ public:
 
     // Takes and removes front request from the pending queue.
     // Returns the removed request or nullptr if there are no pending requests.
-    TPendingWriteDataRequest* TryRemovePendingRequest();
+    TPendingWriteDataRequest* TryPopFrontPendingRequest();
 
     // Removes the request from the pending queue
     void Remove(std::unique_ptr<TPendingWriteDataRequest> request);


### PR DESCRIPTION
### Notes
Turning on WriteBackCache changes behavior when there is no space left in FS.
Current behavior: pending requests wait indefinitely when cache is full and flush cannot progress due to `E_FS_NOSPC`.
Expected behavior: pending requests should fail with no space error.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
