### PR TITLE
issue-5726: implemented UnlimitedBTreeNodeRefsCache and added StorageConfig flags that enable it

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -762,4 +762,8 @@ message TStorageConfig
 
     // Thresholds which enable backpressure - part 2.
     optional uint64 CollectGarbageThresholdForBackpressure = 495;
+
+    // These flags turn NodeRefs cache into a btree_map without capacity limits.
+    optional bool UseUnlimitedBTreeNodeRefsCacheInMainTablet = 496;
+    optional bool UseUnlimitedBTreeNodeRefsCacheInShards = 497;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -246,6 +246,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(InMemoryIndexCacheLoadSchedulePeriod,                                  \
         TDuration,                                                             \
         TDuration::Seconds(0)                                                 )\
+    xxx(UseUnlimitedBTreeNodeRefsCacheInMainTablet,     bool,       false     )\
+    xxx(UseUnlimitedBTreeNodeRefsCacheInShards,         bool,       false     )\
                                                                                \
     xxx(NonNetworkMetricsBalancingFactor,               ui32,      1_KB       )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -265,6 +265,8 @@ public:
     bool GetInMemoryIndexCacheLoadOnTabletStart() const;
     ui64 GetInMemoryIndexCacheLoadOnTabletStartRowsPerTx() const;
     TDuration GetInMemoryIndexCacheLoadSchedulePeriod() const;
+    bool GetUseUnlimitedBTreeNodeRefsCacheInMainTablet() const;
+    bool GetUseUnlimitedBTreeNodeRefsCacheInShards() const;
 
     bool GetAsyncDestroyHandleEnabled() const;
     TDuration GetAsyncHandleOperationPeriod() const;

--- a/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
+++ b/cloud/filestore/libs/storage/tablet/model/metadata_cache.h
@@ -7,6 +7,8 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
+#include <absl/container/btree_map.h>
+
 #include <optional>
 
 /*
@@ -57,6 +59,46 @@ struct TNodeRefsKeyHash
 
 ////////////////////////////////////////////////////////////////////////////////
 
+template <typename TContainer>
+class TMetadataCacheIterator
+{
+private:
+    using TImpl = typename TContainer::iterator;
+    TImpl Impl;
+    TImpl End;
+
+public:
+    TMetadataCacheIterator(TImpl impl, TImpl end)
+        : Impl(std::move(impl))
+        , End(std::move(end))
+    {}
+
+public:
+    bool Get(const TNodeRefsKey** key, const TNodeRefsRow** value)
+    {
+        if (Impl == End) {
+            *key = nullptr;
+            *value = nullptr;
+            return false;
+        }
+
+        *key = &Impl->first;
+        *value = &Impl->second;
+        return true;
+    }
+
+    auto& operator++()
+    {
+        if (Impl != End) {
+            ++Impl;
+        }
+
+        return *this;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TStandardNodeRefsCache
 {
 private:
@@ -69,43 +111,6 @@ private:
     TNodeRefs NodeRefs;
 
 public:
-    class TIterator
-    {
-    private:
-        TNodeRefs::iterator Impl;
-        TNodeRefs::iterator End;
-
-    public:
-        TIterator(TNodeRefs::iterator impl, TNodeRefs::iterator end)
-            : Impl(std::move(impl))
-            , End(std::move(end))
-        {}
-
-    public:
-        bool Get(const TNodeRefsKey** key, const TNodeRefsRow** value)
-        {
-            if (Impl == End) {
-                *key = nullptr;
-                *value = nullptr;
-                return false;
-            }
-
-            *key = &Impl->first;
-            *value = &Impl->second;
-            return true;
-        }
-
-        auto& operator++()
-        {
-            if (Impl != End) {
-                ++Impl;
-            }
-
-            return *this;
-        }
-    };
-
-public:
     TStandardNodeRefsCache(IAllocator *allocator, size_t maxSize)
         : NodeRefs(allocator)
     {
@@ -113,12 +118,12 @@ public:
     }
 
 public:
-    size_t Size() const
+    [[nodiscard]] size_t Size() const
     {
         return NodeRefs.size();
     }
 
-    size_t GetMaxSize() const
+    [[nodiscard]] size_t GetMaxSize() const
     {
         return NodeRefs.GetMaxSize();
     }
@@ -128,9 +133,9 @@ public:
         return NodeRefs.FindInIndex(key);
     }
 
-    bool TouchKey(const TNodeRefsKey& key)
+    void TouchKey(const TNodeRefsKey& key)
     {
-        return NodeRefs.TouchKey(key);
+        NodeRefs.TouchKey(key);
     }
 
     void Erase(const TNodeRefsKey& key)
@@ -145,11 +150,69 @@ public:
         return std::get<2>(NodeRefs.emplace(key, std::move(value)));
     }
 
-    TIterator LowerBound(const TNodeRefsKey& key)
+    TMetadataCacheIterator<TNodeRefs> LowerBound(const TNodeRefsKey& key)
     {
         return {NodeRefs.lower_bound(key), NodeRefs.end()};
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TUnlimitedBTreeNodeRefsCache
+{
+private:
+    using TNodeRefs = absl::btree_map<TNodeRefsKey, TNodeRefsRow>;
+    TNodeRefs NodeRefs;
+
+public:
+    TUnlimitedBTreeNodeRefsCache(IAllocator *allocator, size_t maxSize)
+    {
+        Y_UNUSED(allocator);
+        Y_UNUSED(maxSize);
+    }
+
+public:
+    [[nodiscard]] size_t Size() const
+    {
+        return NodeRefs.size();
+    }
+
+    [[nodiscard]] size_t GetMaxSize() const
+    {
+        return 0;
+    }
+
+    TNodeRefsRow* Find(const TNodeRefsKey& key)
+    {
+        auto it = NodeRefs.find(key);
+        return it != NodeRefs.end() ? &it->second : nullptr;
+    }
+
+    void TouchKey(const TNodeRefsKey& key)
+    {
+        Y_UNUSED(key);
+    }
+
+    void Erase(const TNodeRefsKey& key)
+    {
+        NodeRefs.erase(key);
+    }
+
+    std::optional<TNodeRefsKey> Put(
+        const TNodeRefsKey& key,
+        TNodeRefsRow value)
+    {
+        NodeRefs.emplace(key, std::move(value));
+        return {};
+    }
+
+    TMetadataCacheIterator<TNodeRefs> LowerBound(const TNodeRefsKey& key)
+    {
+        return {NodeRefs.lower_bound(key), NodeRefs.end()};
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
 
 struct TNodeAttrsKey
 {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -91,6 +91,52 @@ void TIndexTabletState::UpdateLogTag(TString tag)
     LogTag = std::move(tag);
 }
 
+void TIndexTabletState::InitInMemoryIndexState(const TStorageConfig& config)
+{
+    auto* alloc =
+        AllocatorRegistry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache);
+    const ui64 nodesCapacity = CalculateInMemoryIndexCacheCapacity(
+        config.GetInMemoryIndexCacheNodesCapacity(),
+        GetNodesCount(),
+        config.GetInMemoryIndexCacheNodesToNodesCapacityRatio());
+    const ui64 nodeAttrsCapacity = CalculateInMemoryIndexCacheCapacity(
+        config.GetInMemoryIndexCacheNodeAttrsCapacity(),
+        GetNodesCount(),
+        config.GetInMemoryIndexCacheNodesToNodeAttrsCapacityRatio());
+    const ui64 nodeRefsCapacity = CalculateInMemoryIndexCacheCapacity(
+        config.GetInMemoryIndexCacheNodeRefsCapacity(),
+        GetNodesCount(),
+        config.GetInMemoryIndexCacheNodesToNodeRefsCapacityRatio());
+    const ui64 nodeRefsExhaustivenessCapacity =
+        config.GetInMemoryIndexCacheNodeRefsExhaustivenessCapacity();
+
+    const bool useUnlimitedBTreeNodeRefsCache =
+        GetFileSystem().GetShardNo() == 0
+        && config.GetUseUnlimitedBTreeNodeRefsCacheInMainTablet()
+        || GetFileSystem().GetShardNo() != 0
+        && config.GetUseUnlimitedBTreeNodeRefsCacheInShards();
+
+    if (useUnlimitedBTreeNodeRefsCache) {
+        using TCacheImpl = TInMemoryIndexState<TUnlimitedBTreeNodeRefsCache>;
+        Impl->InMemoryIndexState = std::make_unique<TCacheImpl>(
+            alloc,
+            Impl->CacheReadBypass,
+            nodesCapacity,
+            nodeAttrsCapacity,
+            nodeRefsCapacity,
+            nodeRefsExhaustivenessCapacity);
+    } else {
+        using TCacheImpl = TStandardInMemoryIndexState;
+        Impl->InMemoryIndexState = std::make_unique<TCacheImpl>(
+            alloc,
+            Impl->CacheReadBypass,
+            nodesCapacity,
+            nodeAttrsCapacity,
+            nodeRefsCapacity,
+            nodeRefsExhaustivenessCapacity);
+    }
+}
+
 void TIndexTabletState::InitShardBalancer(const TStorageConfig& config)
 {
     const auto& shardIds = GetFileSystem().GetShardFileSystemIds();
@@ -192,22 +238,7 @@ void TIndexTabletState::LoadState(
         config.GetReadAheadMaxGapPercentage(),
         config.GetReadAheadCacheMaxHandlesPerNode());
 
-    Impl->InMemoryIndexState = std::make_unique<TStandardInMemoryIndexState>(
-        AllocatorRegistry.GetAllocator(EAllocatorTag::InMemoryNodeIndexCache),
-        Impl->CacheReadBypass,
-        CalculateInMemoryIndexCacheCapacity(
-            config.GetInMemoryIndexCacheNodesCapacity(),
-            GetNodesCount(),
-            config.GetInMemoryIndexCacheNodesToNodesCapacityRatio()),
-        CalculateInMemoryIndexCacheCapacity(
-            config.GetInMemoryIndexCacheNodeAttrsCapacity(),
-            GetNodesCount(),
-            config.GetInMemoryIndexCacheNodesToNodeAttrsCapacityRatio()),
-        CalculateInMemoryIndexCacheCapacity(
-            config.GetInMemoryIndexCacheNodeRefsCapacity(),
-            GetNodesCount(),
-            config.GetInMemoryIndexCacheNodesToNodeRefsCapacityRatio()),
-        config.GetInMemoryIndexCacheNodeRefsExhaustivenessCapacity());
+    InitInMemoryIndexState(config);
     Impl->InMemoryIndexState->UpdateLogTag(LogTag);
 
     Impl->MixedBlocks.Reset(config.GetMixedBlocksOffloadedRangesCapacity());

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -419,6 +419,8 @@ public:
 
     ui64 CalculateExpectedShardCount(ui32 maxShardCount) const;
 
+    void InitInMemoryIndexState(const TStorageConfig& config);
+
     NProto::TError SelectShard(
         NProto::ENodeType nodeType,
         ui64 fileSize,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -547,5 +547,6 @@ void TInMemoryIndexState<TNodeRefsImpl>::UpdateState(
 }
 
 template class TInMemoryIndexState<TStandardNodeRefsCache>;
+template class TInMemoryIndexState<TUnlimitedBTreeNodeRefsCache>;
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
@@ -1467,6 +1467,106 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesCache)
         });
     }
 
+    Y_UNIT_TEST(ShouldUseNodeRefsCacheIfOneIsExhaustiveWithUnlimitedBTree)
+    {
+        const ui64 nodeCount = 128;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetInMemoryIndexCacheEnabled(true);
+        storageConfig.SetInMemoryIndexCacheNodesCapacity(nodeCount + 1);
+        storageConfig.SetUseUnlimitedBTreeNodeRefsCacheInMainTablet(true);
+        storageConfig.SetInMemoryIndexCacheNodeRefsCapacity(5); // shouldn't
+                                                                // matter
+        storageConfig.SetInMemoryIndexCacheLoadOnTabletStart(true);
+        storageConfig.SetInMemoryIndexCacheLoadOnTabletStartRowsPerTx(
+            nodeCount + 1);
+        storageConfig.SetInMemoryIndexCacheLoadSchedulePeriod(1);
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        TVector<TString> names;
+        for (ui32 i = 0; i < nodeCount; ++i) {
+            auto name = TStringBuilder() << "test" << i;
+            tablet.CreateNode(TCreateNodeArgs::File(RootNodeId, name));
+            names.push_back(std::move(name));
+        }
+
+        auto statsBefore = GetTxStats(env, tablet);
+
+        // The noderefs cache is exhaustive thus list nodes should be a cache
+        // hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            names.size(),
+            tablet.ListNodes(RootNodeId)->Record.NodesSize());
+
+        auto statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, statsAfter.RWCount - statsBefore.RWCount);
+        UNIT_ASSERT(statsAfter.IsExhaustive);
+
+        const ui64 loadNodeRefsCounterPrev = env.GetRuntime().GetCounter(
+            TEvIndexTabletPrivate::EEvents::EvLoadNodeRefs);
+        const ui64 loadNodesCounterPrev = env.GetRuntime().GetCounter(
+            TEvIndexTabletPrivate::EEvents::EvLoadNodes);
+
+        tablet.RebootTablet();
+        tablet.InitSession("client", "session");
+
+        ui64 loadNodeRefsCounter = 0;
+        ui64 loadNodesCounter = 0;
+
+        for (int i = 0; i < 100; ++i) {
+            tablet.AdvanceTime(TDuration::MilliSeconds(10));
+            env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(10));
+
+            loadNodeRefsCounter = env.GetRuntime().GetCounter(
+                TEvIndexTabletPrivate::EEvents::EvLoadNodeRefs)
+                - loadNodeRefsCounterPrev;
+            loadNodesCounter = env.GetRuntime().GetCounter(
+                TEvIndexTabletPrivate::EEvents::EvLoadNodes)
+                - loadNodesCounterPrev;
+
+            // It will take 1 iteration to load all the nodeRefs
+            // It also will take 1 iteration to load all the nodes
+            if (loadNodeRefsCounter >= 1 && loadNodesCounter >= 1) {
+                break;
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(1, loadNodeRefsCounter);
+        UNIT_ASSERT_VALUES_EQUAL(1, loadNodesCounter);
+
+        statsBefore = GetTxStats(env, tablet);
+
+        // The noderefs cache is exhaustive thus list nodes should be a cache
+        // hit
+        UNIT_ASSERT_VALUES_EQUAL(
+            names.size(),
+            tablet.ListNodes(RootNodeId)->Record.NodesSize());
+
+        statsAfter = GetTxStats(env, tablet);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            statsAfter.ROCacheHitCount - statsBefore.ROCacheHitCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            statsAfter.ROCacheMissCount - statsBefore.ROCacheMissCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, statsAfter.RWCount - statsBefore.RWCount);
+        UNIT_ASSERT(statsAfter.IsExhaustive);
+    }
+
     Y_UNIT_TEST(ShouldUseInMemoryCacheAndMixedBlocksCacheForReads)
     {
         NProto::TStorageConfig storageConfig;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -5,6 +5,55 @@
 
 namespace NCloud::NFileStore::NStorage {
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto* Alloc()
+{
+    return TDefaultAllocator::Instance();
+}
+
+void CheckNodeRef(
+    const IInMemoryIndexState::TWriteNodeRefsRequest& request,
+    IIndexTabletDatabase::TNodeRef& ref)
+{
+    UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsKey.NodeId, ref.NodeId);
+    UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsKey.Name, ref.Name);
+    UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsRow.ChildId, ref.ChildNodeId);
+    UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsRow.CommitId, ref.MinCommitId);
+    UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, ref.MaxCommitId);
+    UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsRow.ShardId, ref.ShardId);
+    UNIT_ASSERT_VALUES_EQUAL(
+        request.NodeRefsRow.ShardNodeName,
+        ref.ShardNodeName);
+}
+
+void ReadAndCheckNodeRef(
+    IInMemoryIndexState& state,
+    const IInMemoryIndexState::TWriteNodeRefsRequest& request)
+{
+    TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+    UNIT_ASSERT(state.ReadNodeRef(
+        request.NodeRefsKey.NodeId,
+        request.NodeRefsRow.CommitId,
+        request.NodeRefsKey.Name,
+        ref));
+    CheckNodeRef(request, *ref);
+}
+
+void FillStateRequests(
+    TVector<IInMemoryIndexState::TIndexStateRequest>& stateRequests,
+    const TVector<IInMemoryIndexState::TWriteNodeRefsRequest>& requests)
+{
+    stateRequests.reserve(requests.size());
+    for (const auto& req: requests) {
+        stateRequests.push_back(req);
+    }
+}
+
+}   // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
@@ -17,11 +66,6 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
     const NProto::TNode nodeAttrs1 = CreateRegularAttrs(0666, 1, 2);
     const NProto::TNode nodeAttrs2 = CreateRegularAttrs(0666, 3, 4);
-
-    auto* Alloc()
-    {
-        return TDefaultAllocator::Instance();
-    }
 
     //
     // Nodes
@@ -303,55 +347,15 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
     const TVector<ui64> rootNodeIds = {1, 2, 3, 4};
     const TVector<ui64> childNodeIds = {1001, 1002, 1003, 1004};
 
-namespace {
-
-    void CheckNodeRef(
-        const IInMemoryIndexState::TWriteNodeRefsRequest& request,
-        IIndexTabletDatabase::TNodeRef& ref)
-    {
-        UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsKey.NodeId, ref.NodeId);
-        UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsKey.Name, ref.Name);
-        UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsRow.ChildId, ref.ChildNodeId);
-        UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsRow.CommitId, ref.MinCommitId);
-        UNIT_ASSERT_VALUES_EQUAL(InvalidCommitId, ref.MaxCommitId);
-        UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsRow.ShardId, ref.ShardId);
-        UNIT_ASSERT_VALUES_EQUAL(
-            request.NodeRefsRow.ShardNodeName,
-            ref.ShardNodeName);
-    }
-
-    void ReadAndCheckNodeRef(
-        IInMemoryIndexState& state,
-        const IInMemoryIndexState::TWriteNodeRefsRequest& request)
-    {
-        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
-        UNIT_ASSERT(state.ReadNodeRef(
-            request.NodeRefsKey.NodeId,
-            request.NodeRefsRow.CommitId,
-            request.NodeRefsKey.Name,
-            ref));
-        CheckNodeRef(request, *ref);
-    }
-
-    void FillStateRequests(
-        TVector<IInMemoryIndexState::TIndexStateRequest>& stateRequests,
-        const TVector<IInMemoryIndexState::TWriteNodeRefsRequest>& requests)
-    {
-        stateRequests.reserve(requests.size());
-        for (const auto& req: requests) {
-            stateRequests.push_back(req);
-        }
-    }
-
-}   // namespace
-
     //
     // NodeRefs
     //
-    Y_UNIT_TEST(ShouldPopulateNodeRefs)
+    template <typename TNodeRefsCache>
+    void DoTestShouldPopulateNodeRefs()
     {
         TCacheReadBypass cacheBypass;
-        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 0, 1, 0);
+        using TStateImpl = TInMemoryIndexState<TNodeRefsCache>;
+        TStateImpl state(Alloc(), cacheBypass, 0, 0, 1, 0);
         cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         TMaybe<IIndexTabletDatabase::TNodeRef> ref;
@@ -399,7 +403,17 @@ namespace {
         UNIT_ASSERT(ref.Empty());
     }
 
-    Y_UNIT_TEST(ShouldEvictNodeRefs)
+    Y_UNIT_TEST(ShouldPopulateNodeRefsStandard)
+    {
+        DoTestShouldPopulateNodeRefs<TStandardNodeRefsCache>();
+    }
+
+    Y_UNIT_TEST(ShouldPopulateNodeRefsUnlimitedBTree)
+    {
+        DoTestShouldPopulateNodeRefs<TUnlimitedBTreeNodeRefsCache>();
+    }
+
+    Y_UNIT_TEST(ShouldEvictNodeRefsStandard)
     {
         TCacheReadBypass cacheBypass;
         TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 0, 3, 0);
@@ -454,7 +468,7 @@ namespace {
             &nextName,
             nullptr,
             false));
-        UNIT_ASSERT(refs.size() == 2);
+        UNIT_ASSERT_VALUES_EQUAL(2, refs.size());
         UNIT_ASSERT(nextName.empty());
 
         // all three refs should be in cache
@@ -511,10 +525,122 @@ namespace {
         ReadAndCheckNodeRef(state, request4);
     }
 
-    Y_UNIT_TEST(ShouldDeleteNodeRefs)
+    Y_UNIT_TEST(ShouldNotEvictNodeRefsUnlimitedBTree)
     {
         TCacheReadBypass cacheBypass;
-        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 0, 1, 0);
+        using TStateImpl = TInMemoryIndexState<TUnlimitedBTreeNodeRefsCache>;
+        TStateImpl state(Alloc(), cacheBypass, 0, 0, 3, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
+
+        const TVector<IInMemoryIndexState::TWriteNodeRefsRequest> requests = {
+            {
+                .NodeRefsKey = {rootNodeIds[0], nodeNames[0]},
+                .NodeRefsRow = {
+                    .CommitId = commitId1,
+                    .ChildId = childNodeIds[0],
+                    .ShardId = shardIds[0],
+                    .ShardNodeName = shardNodeNames[0],
+                }
+            },
+            {
+                .NodeRefsKey = {rootNodeIds[0], nodeNames[1]},
+                .NodeRefsRow = {
+                    .CommitId = commitId1,
+                    .ChildId = childNodeIds[1],
+                    .ShardId = shardIds[1],
+                    .ShardNodeName = shardNodeNames[1],
+                }
+            },
+            {
+                .NodeRefsKey = {rootNodeIds[2], nodeNames[2]},
+                .NodeRefsRow = {
+                    .CommitId = commitId1,
+                    .ChildId = childNodeIds[2],
+                    .ShardId = shardIds[2],
+                    .ShardNodeName = shardNodeNames[2],
+                }
+            }
+        };
+
+        TVector<IInMemoryIndexState::TIndexStateRequest> stateRequests;
+        FillStateRequests(stateRequests, requests);
+
+        state.UpdateState(stateRequests);
+        state.MarkNodeRefsLoadComplete();
+
+        // read two first refs
+        TVector<IIndexTabletDatabase::TNodeRef> refs;
+        TString nextName;
+
+        UNIT_ASSERT(state.ReadNodeRefs(
+            requests[0].NodeRefsKey.NodeId,
+            commitId1,
+            requests[0].NodeRefsKey.Name,
+            refs,
+            Max<ui32>(),
+            &nextName,
+            nullptr,
+            false));
+        UNIT_ASSERT_VALUES_EQUAL(2, refs.size());
+        UNIT_ASSERT(nextName.empty());
+
+        // all three refs should be in cache
+        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        for (const auto& request: requests) {
+            ReadAndCheckNodeRef(state, request);
+        }
+
+        IInMemoryIndexState::TWriteNodeRefsRequest request3 = {
+            .NodeRefsKey = {rootNodeIds[3], nodeNames[3]},
+            .NodeRefsRow = {
+                .CommitId = commitId1,
+                .ChildId = childNodeIds[3],
+                .ShardId = shardIds[3],
+                .ShardNodeName = shardNodeNames[3],
+            }
+        };
+        state.UpdateState({request3});
+
+        ReadAndCheckNodeRef(state, requests[0]);
+        ReadAndCheckNodeRef(state, requests[1]);
+        ReadAndCheckNodeRef(state, requests[2]);
+        ReadAndCheckNodeRef(state, request3);
+
+        // ReadNodeRefs should still return true since nothing's evicted
+        refs.clear();
+        UNIT_ASSERT(state.ReadNodeRefs(
+            requests[0].NodeRefsKey.NodeId,
+            commitId1,
+            requests[0].NodeRefsKey.Name,
+            refs,
+            Max<ui32>(),
+            &nextName,
+            nullptr,
+            false));
+        UNIT_ASSERT_VALUES_EQUAL(2, refs.size());
+        UNIT_ASSERT(nextName.empty());
+
+        // write a ref with the same key but different value
+        IInMemoryIndexState::TWriteNodeRefsRequest request4 = {
+            .NodeRefsKey = {rootNodeIds[3], nodeNames[3]},
+            .NodeRefsRow = {
+                .CommitId = commitId2,
+                .ChildId = childNodeIds[0],
+                .ShardId = shardIds[1],
+                .ShardNodeName = shardNodeNames[2],
+            }
+        };
+        state.UpdateState({request4});
+
+        ReadAndCheckNodeRef(state, request4);
+    }
+
+    template <typename TNodeRefsCache>
+    void DoTestShouldDeleteNodeRefs()
+    {
+        TCacheReadBypass cacheBypass;
+        using TStateImpl = TInMemoryIndexState<TNodeRefsCache>;
+        TStateImpl state(Alloc(), cacheBypass, 0, 0, 1, 0);
         cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         IInMemoryIndexState::TWriteNodeRefsRequest request = {
@@ -556,6 +682,16 @@ namespace {
             request.NodeRefsKey.Name,
             ref));
         UNIT_ASSERT(ref.Empty());
+    }
+
+    Y_UNIT_TEST(ShouldDeleteNodeRefsStandard)
+    {
+        DoTestShouldDeleteNodeRefs<TStandardNodeRefsCache>();
+    }
+
+    Y_UNIT_TEST(ShouldDeleteNodeRefsUnlimitedBTree)
+    {
+        DoTestShouldDeleteNodeRefs<TUnlimitedBTreeNodeRefsCache>();
     }
 }
 


### PR DESCRIPTION
### Notes

Implemented a btree-based `NodeRefs` cache with no eviction. Can be enabled via storage config flags.

Planning to enable `UseUnlimitedBTreeNodeRefsCacheInMainTablet` for individual filesystems and `UseUnlimitedBTreeNodeRefsCacheInShards` - for all filesystems (eventually). Motivation - filesystem inodes and node refs are spread more or less evenly among the shards so each shard should hold only a small portion of node refs that should easily fit in memory so there's not point in paying the eviction logic overhead (LRU-based `TouchKey()` is expensive, we see it clearly on the flamegraphs). 

### Issue
https://github.com/ydb-platform/nbs/issues/5726