### PR TITLE
[Filestore] Add scheduled cancel for unconfirmed data

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
@@ -173,8 +173,12 @@ ReadData(TTestSetup& setup, ui64 offset, ui64 bytes)
 
 enum class EShardPipeToDisconnect
 {
-    Session,
-    Write,
+    // Pipe between the main filesystem tablet and the shard tablet, used for
+    // shard control requests such as CreateSession.
+    Control,
+    // Pipe between the service write actor and the shard tablet, used by the
+    // data write path such as GenerateBlobIds.
+    Data,
 };
 
 void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
@@ -207,16 +211,16 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
     const TString targetClientId = "client";
 
     TMap<TActorId, TActorId> shardPipeClientsByServer;
-    TActorId shardSessionPipeServer;
-    TActorId shardSessionClient;
-    TActorId shardWritePipeServer;
-    TActorId shardWriteClient;
+    TActorId shardControlPipeServer;
+    TActorId shardControlClient;
+    TActorId shardDataPipeServer;
+    TActorId shardDataClient;
     TActorId writeActor;
-    TString shardSessionId;
-    TString shardWriteSessionId;
+    TString shardControlSessionId;
+    TString shardDataSessionId;
     TAutoPtr<IEventHandle> blockedPutResult;
 
-    // Capture the shard session pipe and the independent shard write pipe.
+    // Capture the shard control pipe and the independent shard data pipe.
     // The blob put result is held to keep the write actor alive while the test
     // disconnects one of those pipes.
     auto prevFilter = runtime.SetEventFilter(
@@ -251,11 +255,11 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
                     if (msg->Record.GetFileSystemId() == fsConfig.Shard1Id &&
                         msg->Record.GetHeaders().GetClientId() ==
                             targetClientId &&
-                        !shardSessionPipeServer)
+                        !shardControlPipeServer)
                     {
-                        shardSessionPipeServer = event->Recipient;
-                        shardSessionClient = event->Sender;
-                        shardSessionId =
+                        shardControlPipeServer = event->Recipient;
+                        shardControlClient = event->Sender;
+                        shardControlSessionId =
                             msg->Record.GetHeaders().GetSessionId();
                     }
 
@@ -277,9 +281,9 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
                         break;
                     }
 
-                    shardWritePipeServer = event->Recipient;
-                    shardWriteClient = event->Sender;
-                    shardWriteSessionId =
+                    shardDataPipeServer = event->Recipient;
+                    shardDataClient = event->Sender;
+                    shardDataSessionId =
                         msg->Record.GetHeaders().GetSessionId();
                     break;
                 }
@@ -317,7 +321,7 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
 
     // Create a file on the shard and write through the service. The write
     // service is placed on a node different from the main tablet node, so the
-    // write uses a different tablet pipe than the shard session creation path.
+    // data path uses a different tablet pipe than the shard control path.
     const ui32 serviceNodeIdx = env.AddDynamicNode();
     UNIT_ASSERT_VALUES_UNEQUAL(
         mainTabletActorId.NodeId(),
@@ -354,8 +358,8 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
                 .CustomFinalCondition =
                     [&]()
                 {
-                    return !!blockedPutResult && !!shardSessionPipeServer &&
-                           !!shardWritePipeServer;
+                    return !!blockedPutResult && !!shardControlPipeServer &&
+                           !!shardDataPipeServer;
                 }},
             TDuration::Seconds(5)),
         "Timed out waiting for blocked write and shard pipe capture");
@@ -364,40 +368,40 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
     // use: same logical session, different tablet pipe servers.
     UNIT_ASSERT_C(blockedPutResult, "Write blob result was not blocked");
     UNIT_ASSERT_C(
-        shardSessionPipeServer,
-        "Shard session creation request to tablet pipe was not observed");
+        shardControlPipeServer,
+        "Shard control pipe CreateSession request was not observed");
     UNIT_ASSERT_C(
-        shardWritePipeServer,
-        "Shard WriteData GenerateBlobIds request was not observed");
-    UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, shardSessionId);
-    UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, shardWriteSessionId);
+        shardDataPipeServer,
+        "Shard data pipe GenerateBlobIds request was not observed");
+    UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, shardControlSessionId);
+    UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, shardDataSessionId);
     UNIT_ASSERT_C(
-        shardSessionPipeServer != shardWritePipeServer,
+        shardControlPipeServer != shardDataPipeServer,
         TStringBuilder()
-            << "Shard session creation and WriteData used the same pipe "
-            << "server: " << shardSessionPipeServer);
+            << "Shard control path and data path used the same pipe server: "
+            << shardControlPipeServer);
     UNIT_ASSERT_VALUES_EQUAL(
         mainTabletActorId.NodeId(),
-        shardSessionClient.NodeId());
+        shardControlClient.NodeId());
     UNIT_ASSERT_VALUES_EQUAL(
         runtime.GetNodeId(serviceNodeIdx),
-        shardWriteClient.NodeId());
+        shardDataClient.NodeId());
 
-    const auto sessionPipeClientIt =
-        shardPipeClientsByServer.find(shardSessionPipeServer);
+    const auto controlPipeClientIt =
+        shardPipeClientsByServer.find(shardControlPipeServer);
     UNIT_ASSERT_C(
-        sessionPipeClientIt != shardPipeClientsByServer.end(),
+        controlPipeClientIt != shardPipeClientsByServer.end(),
         TStringBuilder()
-            << "Pipe client for shard session pipe server was not observed: "
-            << shardSessionPipeServer);
+            << "Pipe client for shard control pipe server was not observed: "
+            << shardControlPipeServer);
 
-    const auto writePipeClientIt =
-        shardPipeClientsByServer.find(shardWritePipeServer);
+    const auto dataPipeClientIt =
+        shardPipeClientsByServer.find(shardDataPipeServer);
     UNIT_ASSERT_C(
-        writePipeClientIt != shardPipeClientsByServer.end(),
+        dataPipeClientIt != shardPipeClientsByServer.end(),
         TStringBuilder()
-            << "Pipe client for shard write pipe server was not observed: "
-            << shardWritePipeServer);
+            << "Pipe client for shard data pipe server was not observed: "
+            << shardDataPipeServer);
 
     TIndexTabletClient shardTablet(
         runtime,
@@ -407,13 +411,13 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
         false /* updateConfig */);
 
     // At this point the write actor is blocked on blob storage, so the
-    // unconfirmed entry must stay visible until either the write pipe or the
-    // session pipe is disconnected.
+    // unconfirmed entry must stay visible until either the data pipe or the
+    // control pipe is disconnected.
     UNIT_ASSERT_VALUES_EQUAL(
         1,
         GetStorageStats(shardTablet).GetUnconfirmedDataCount());
 
-    // Select either the shard session pipe or the active write pipe.
+    // Select either the shard control pipe or the active data pipe.
     struct TPipeToDisconnect
     {
         TActorId Server;
@@ -421,19 +425,19 @@ void DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
         ui32 NodeIdx = 0;
     };
 
-    const TPipeToDisconnect sessionPipeToDisconnect{
-        shardSessionPipeServer,
-        sessionPipeClientIt->second,
+    const TPipeToDisconnect controlPipeToDisconnect{
+        shardControlPipeServer,
+        controlPipeClientIt->second,
         fsNodeIdx};
-    const TPipeToDisconnect writePipeToDisconnect{
-        shardWritePipeServer,
-        writePipeClientIt->second,
+    const TPipeToDisconnect dataPipeToDisconnect{
+        shardDataPipeServer,
+        dataPipeClientIt->second,
         serviceNodeIdx};
 
     const TPipeToDisconnect pipeToDisconnectInfo =
-        pipeToDisconnect == EShardPipeToDisconnect::Session
-            ? sessionPipeToDisconnect
-            : writePipeToDisconnect;
+        pipeToDisconnect == EShardPipeToDisconnect::Control
+            ? controlPipeToDisconnect
+            : dataPipeToDisconnect;
 
     runtime.ClosePipe(
         pipeToDisconnectInfo.Client,
@@ -1356,16 +1360,16 @@ Y_UNIT_TEST_SUITE(TWriteDataUnconfirmedTest)
     // Sharding tests
     // =========================================================================
 
-    Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceWritePipeDisconnect)
+    Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceDataPipeDisconnect)
     {
         DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
-            EShardPipeToDisconnect::Write);
+            EShardPipeToDisconnect::Data);
     }
 
-    Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceSessionPipeDisconnect)
+    Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceControlPipeDisconnect)
     {
         DoShouldDeleteShardUnconfirmedDataOnServicePipeDisconnect(
-            EShardPipeToDisconnect::Session);
+            EShardPipeToDisconnect::Control);
     }
 
     // =========================================================================

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -1151,6 +1151,19 @@ struct TEvIndexTabletPrivate
     };
 
     //
+    // Cancel unconfirmed data
+    //
+
+    struct TCancelUnconfirmedData
+    {
+        ui64 CommitId;
+
+        explicit TCancelUnconfirmedData(ui64 commitId)
+            : CommitId(commitId)
+        {}
+    };
+
+    //
     // Generate commit id
     //
 
@@ -1211,6 +1224,7 @@ struct TEvIndexTabletPrivate
         EvAddDataCompleted,
 
         EvReleaseCollectBarrier,
+        EvCancelUnconfirmedData,
 
         EvForcedRangeOperationProgress,
 
@@ -1250,6 +1264,9 @@ struct TEvIndexTabletPrivate
 
     using TEvReleaseCollectBarrier =
         TRequestEvent<TReleaseCollectBarrier, EvReleaseCollectBarrier>;
+    using TEvCancelUnconfirmedData = TRequestEvent<
+        TCancelUnconfirmedData,
+        EvCancelUnconfirmedData>;
 
     using TEvReadDataCompleted =
         TResponseEvent<TReadWriteCompleted, EvReadDataCompleted>;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -763,7 +763,8 @@ void TIndexTabletActor::HandleSessionDisconnectedInWork(
 {
     const auto& msg = *ev->Get();
 
-    // TODO (#4962) use proper session id
+    // TODO (#4962): once owner-to-session relation is tracked properly, use
+    // the session id directly and simplify this split session/pipe cleanup.
     const auto& sessionIds = FindSessionIdsByPipeServer(msg.ServerId);
 
     LOG_INFO(
@@ -777,9 +778,16 @@ void TIndexTabletActor::HandleSessionDisconnectedInWork(
         msg.ServerId.ToString().c_str(),
         sessionIds.size());
 
+    // The disconnected pipe may be the control pipe, while unconfirmed writes
+    // for the same logical session can be tracked with a separate data pipe
+    // server id. Delete by session too.
     for (const auto& sessionId: sessionIds) {
         DeleteUnconfirmedDataForSession(sessionId, ctx);
     }
+
+    // msg.ServerId is the tablet-pipe server actor that received requests
+    // from this client connection. Unconfirmed data keeps this actor id from
+    // GenerateBlobIds, so clean it up when the pipe disconnects.
     DeleteUnconfirmedDataForPipeServer(msg.ServerId, ctx);
     RemoveSessionByPipeServer(msg.ServerId);
 }
@@ -1134,6 +1142,7 @@ STFUNC(TIndexTabletActor::StateBoot)
         IgnoreFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters);
         IgnoreFunc(TEvIndexTabletPrivate::TEvRunRegularTasks);
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvCancelUnconfirmedData);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodesRequest);
@@ -1163,6 +1172,7 @@ STFUNC(TIndexTabletActor::StateInit)
         HFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters, HandleUpdateLeakyBucketCounters);
         IgnoreFunc(TEvIndexTabletPrivate::TEvRunRegularTasks);
         HFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier, HandleReleaseCollectBarrier);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvCancelUnconfirmedData);
         HFunc(
             TEvIndexTabletPrivate::TEvForcedRangeOperationProgress,
             HandleForcedRangeOperationProgress);
@@ -1249,6 +1259,9 @@ STFUNC(TIndexTabletActor::StateWork)
         HFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters, HandleUpdateLeakyBucketCounters);
 
         HFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier, HandleReleaseCollectBarrier);
+        HFunc(
+            TEvIndexTabletPrivate::TEvCancelUnconfirmedData,
+            HandleCancelUnconfirmedData);
         HFunc(
             TEvIndexTabletPrivate::TEvForcedRangeOperationProgress,
             HandleForcedRangeOperationProgress);
@@ -1428,6 +1441,7 @@ STFUNC(TIndexTabletActor::StateZombie)
         IgnoreFunc(TEvIndexTabletPrivate::TEvRunRegularTasks);
 
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvCancelUnconfirmedData);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadCompactionMapChunkResponse);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
@@ -1494,6 +1508,7 @@ STFUNC(TIndexTabletActor::StateBroken)
         IgnoreFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters);
         IgnoreFunc(TEvIndexTabletPrivate::TEvRunRegularTasks);
         IgnoreFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier);
+        IgnoreFunc(TEvIndexTabletPrivate::TEvCancelUnconfirmedData);
         IgnoreFunc(TEvIndexTabletPrivate::TEvForcedRangeOperationProgress);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodeRefsRequest);
         IgnoreFunc(TEvIndexTabletPrivate::TEvLoadNodesRequest);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -782,6 +782,13 @@ void TIndexTabletActor::HandleSessionDisconnectedInWork(
     // for the same logical session can be tracked with a separate data pipe
     // server id. Delete by session too.
     for (const auto& sessionId: sessionIds) {
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s Deleting unconfirmed data for session: sessionId=%s",
+            LogTag.c_str(),
+            sessionId.Quote().c_str());
+
         DeleteUnconfirmedDataForSession(sessionId, ctx);
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -660,6 +660,9 @@ private:
     void HandleReleaseCollectBarrier(
         const TEvIndexTabletPrivate::TEvReleaseCollectBarrier::TPtr& ev,
         const NActors::TActorContext& ctx);
+    void HandleCancelUnconfirmedData(
+        const TEvIndexTabletPrivate::TEvCancelUnconfirmedData::TPtr& ev,
+        const NActors::TActorContext& ctx);
 
     void HandleReadDataCompleted(
         const TEvIndexTabletPrivate::TEvReadDataCompleted::TPtr& ev,
@@ -768,9 +771,9 @@ private:
 
     void DeleteUnconfirmedData(
         const NActors::TActorContext& ctx,
-        const char* deletionEntity,
-        const TString& entityId,
-        const std::function<bool(const TTrackedUnconfirmedData&)>&
+        const char* entityLogTag,
+        const TString& entityLogValue,
+        const std::function<bool(ui64, const TTrackedUnconfirmedData&)>&
             shouldDelete);
 
     void DeleteUnconfirmedDataForSession(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -413,7 +413,13 @@ void TIndexTabletActor::HandleGenerateBlobIds(
         offset += length;
     }
 
-    if (!canUseUnconfirmed) {
+    if (canUseUnconfirmed) {
+        // If the client never confirms or cancels the operation, delete
+        // unconfirmed data and release the collect barrier eventually.
+        ctx.Schedule(
+            Config->GetGenerateBlobIdsReleaseCollectBarrierTimeout(),
+            new TEvIndexTabletPrivate::TEvCancelUnconfirmedData(commitId));
+    } else {
         // We schedule this event for the case if the client does not call
         // AddData. Thus we ensure that the collect barrier will be released
         // eventually.
@@ -465,12 +471,6 @@ void TIndexTabletActor::HandleGenerateBlobIds(
                 .SessionId = GetSessionId(msg->Record),
                 .PipeServerId = ev->Recipient});
         TABLET_VERIFY(inserted);
-
-        // If the client never confirms or cancels the operation, delete
-        // unconfirmed data and release the collect barrier eventually.
-        ctx.Schedule(
-            Config->GetGenerateBlobIdsReleaseCollectBarrierTimeout(),
-            new TEvIndexTabletPrivate::TEvCancelUnconfirmedData(commitId));
 
         NProto::TProfileLogRequestInfo profileLogRequest;
         InitTabletProfileLogRequestInfo(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -466,6 +466,12 @@ void TIndexTabletActor::HandleGenerateBlobIds(
                 .PipeServerId = ev->Recipient});
         TABLET_VERIFY(inserted);
 
+        // If the client never confirms or cancels the operation, delete
+        // unconfirmed data and release the collect barrier eventually.
+        ctx.Schedule(
+            Config->GetGenerateBlobIdsReleaseCollectBarrierTimeout(),
+            new TEvIndexTabletPrivate::TEvCancelUnconfirmedData(commitId));
+
         NProto::TProfileLogRequestInfo profileLogRequest;
         InitTabletProfileLogRequestInfo(
             profileLogRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -126,9 +126,10 @@ void TIndexTabletActor::CompleteTx_AddDataUnconfirmed(
             args.CommitId,
             args.NodeId);
 
-        // If deletion in progress, do nothing. Deferred reply will be triggered
-        // in DeleteUnconfirmedData completion. At this point we could already
-        // pass ExecuteTx for DeleteUnconfirmed.
+        // If deletion is in progress, do nothing. DeleteUnconfirmedData owns
+        // cleanup from this point and is kept page-fault-free so it cannot be
+        // overtaken by later AddBlob TXs. The deferred reply will be triggered
+        // in DeleteUnconfirmedData completion.
         if (!deletionInProgress) {
             UnconfirmedData.emplace(
                 args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -434,6 +434,10 @@ void TIndexTabletActor::DeleteUnconfirmedData(
     enqueueCommitIdsToDelete(UnconfirmedData);
     enqueueCommitIdsToDelete(UnconfirmedDataInProgress);
 
+    if (commitIdsToDelete.empty()) {
+        return;
+    }
+
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET,
@@ -442,10 +446,6 @@ void TIndexTabletActor::DeleteUnconfirmedData(
         entityLogTag,
         entityLogValue.c_str(),
         commitIdsToDelete.size());
-
-    if (commitIdsToDelete.empty()) {
-        return;
-    }
 
     // Cleanup has the same ordering requirement as CancelAddData: once
     // commitIds are placed into DeletionQueue, DeleteUnconfirmedData must be

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -10,6 +10,7 @@
 #include <util/generic/cast.h>
 #include <util/generic/vector.h>
 #include <util/string/builder.h>
+#include <util/string/cast.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -162,10 +163,8 @@ void TIndexTabletActor::HandleConfirmAddData(
             unconfirmedIt->second.Data.GetBlobIds(),
             msg->Record);
 
-        if (DeletionQueue.contains(commitId)) {
-            reply(ErrorUnconfirmedDataDeleted());
-        } else {
-            deferReply();
+        deferReply();
+        if (!DeletionQueue.contains(commitId)) {
             ConfirmData(commitId, ctx);
         }
         return;
@@ -253,7 +252,7 @@ void TIndexTabletActor::HandleCancelAddData(
     if (!DeletionQueue.contains(commitId)) {
         DeletionQueue.emplace(commitId);
         // We reply to CancelAddData immediately, so from this point forward we
-        // rely on DeleteUnconfirmedData  being executed ahead of any later
+        // rely on DeleteUnconfirmedData being executed ahead of any later
         // AddBlob TX. Keep this execute before the reply path,
         // and keep TDeleteUnconfirmedData page-fault-free, or a later execute
         // may reorder and revive data that was already cancelled.
@@ -390,16 +389,17 @@ void TIndexTabletActor::ConfirmData(ui64 commitId, const TActorContext& ctx)
 
 void TIndexTabletActor::DeleteUnconfirmedData(
     const TActorContext& ctx,
-    const char* deletionEntity,
-    const TString& entityId,
-    const std::function<bool(const TTrackedUnconfirmedData&)>& shouldDelete)
+    const char* entityLogTag,
+    const TString& entityLogValue,
+    const std::function<bool(ui64, const TTrackedUnconfirmedData&)>&
+        shouldDelete)
 {
     TVector<ui64> commitIdsToDelete;
 
     auto enqueueCommitIdsToDelete = [&](const auto& data)
     {
         for (const auto& [commitId, trackedData]: data) {
-            if (!shouldDelete(trackedData)) {
+            if (!shouldDelete(commitId, trackedData)) {
                 continue;
             }
 
@@ -419,8 +419,8 @@ void TIndexTabletActor::DeleteUnconfirmedData(
         TFileStoreComponents::TABLET,
         "%s Deleting unconfirmed data: %s=%s, deleteNow=%zu",
         LogTag.c_str(),
-        deletionEntity,
-        entityId.c_str(),
+        entityLogTag,
+        entityLogValue.c_str(),
         commitIdsToDelete.size());
 
     if (commitIdsToDelete.empty()) {
@@ -448,7 +448,7 @@ void TIndexTabletActor::DeleteUnconfirmedDataForSession(
         ctx,
         "sessionId",
         sessionId.Quote(),
-        [&sessionId](const TTrackedUnconfirmedData& trackedData)
+        [&sessionId](ui64, const TTrackedUnconfirmedData& trackedData)
         { return trackedData.SessionId == sessionId; });
 }
 
@@ -458,10 +458,24 @@ void TIndexTabletActor::DeleteUnconfirmedDataForPipeServer(
 {
     DeleteUnconfirmedData(
         ctx,
-        "pipeServer",
+        "pipeServerId",
         pipeServerId.ToString(),
-        [&pipeServerId](const TTrackedUnconfirmedData& trackedData)
+        [&pipeServerId](ui64, const TTrackedUnconfirmedData& trackedData)
         { return trackedData.PipeServerId == pipeServerId; });
+}
+
+void TIndexTabletActor::HandleCancelUnconfirmedData(
+    const TEvIndexTabletPrivate::TEvCancelUnconfirmedData::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const ui64 commitId = ev->Get()->CommitId;
+
+    DeleteUnconfirmedData(
+        ctx,
+        "commitId",
+        ToString(commitId),
+        [commitId](ui64 trackedCommitId, const TTrackedUnconfirmedData&)
+        { return trackedCommitId == commitId; });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -475,7 +489,8 @@ bool TIndexTabletActor::PrepareTx_DeleteUnconfirmedData(
     Y_UNUSED(tx);
     Y_UNUSED(args);
 
-    // Nothing to prepare
+    // This TX must stay page-fault-free: after DeletionQueue is updated,
+    // AddBlob TXs must not overtake this cleanup.
     return true;
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -58,14 +58,16 @@ void TIndexTabletActor::SendPendingConfirmAddDataResponse(
         return;
     }
 
-    auto pending = std::move(pendingIt->second);
+    auto pendingRequests = std::move(pendingIt->second);
     PendingConfirmation.erase(pendingIt);
 
-    if (!HasError(error)) {
-        Metrics.ConfirmAddData.Update(1, 0, ctx.Now() - pending.DeferredTs);
-    }
+    for (auto& pending: pendingRequests) {
+        if (!HasError(error)) {
+            Metrics.ConfirmAddData.Update(1, 0, ctx.Now() - pending.DeferredTs);
+        }
 
-    SendDeferredConfirmAddDataResponse(ctx, std::move(pending), error);
+        SendDeferredConfirmAddDataResponse(ctx, std::move(pending), error);
+    }
 }
 
 void TIndexTabletActor::UnconfirmedAddBlobSafePointReached(
@@ -152,8 +154,26 @@ void TIndexTabletActor::HandleConfirmAddData(
         pending.DeferredTs = startedTs;
         pending.CallContext = msg->CallContext;
         pending.ProfileLogRequest = std::move(profileLogRequest);
-        PendingConfirmation[commitId] = std::move(pending);
+        PendingConfirmation[commitId].push_back(std::move(pending));
     };
+
+    // The client may retry ConfirmAddData with the same commit id after losing
+    // the previous response on a pipe disconnect. From the tablet's point of
+    // view, the first request can still be waiting while AddDataUnconfirmed is
+    // in progress, or while AddBlob is in flight but has not reached the safe
+    // point that sends the reply. Keep all waiters and complete them together
+    // when the commit reaches a terminal state.
+    if (PendingConfirmation.contains(commitId)) {
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s Deferring duplicate ConfirmAddData: commitId=%lu",
+            LogTag.c_str(),
+            commitId);
+
+        deferReply();
+        return;
+    }
 
     if (auto unconfirmedIt = UnconfirmedData.find(commitId);
         unconfirmedIt != UnconfirmedData.end())

--- a/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
@@ -67,8 +67,17 @@ bool TCacheReadBypass::ShouldBypassRead(ui64 nodeId, ui64 commitId) const
         return false;
     }
 
-    // Otherwise, ensure that all writes with commit ids up to the current
-    // commit are already in the cache.
+    // Commit ids are generated monotonically when unconfirmed data is
+    // materialized by AddBlob, and this queue is activated/deactivated in the
+    // same order. Thus the front item is the oldest write that may still be
+    // missing from in-memory caches.
+    //
+    // A read at "commitId" can observe only writes with commit ids <=
+    // "commitId". If the oldest active write is newer than the read snapshot,
+    // all other active writes are newer as well and the cache cannot miss any
+    // data visible to this read. Otherwise at least one visible write is still
+    // active, so the read must bypass the cache and go through the database
+    // path to keep the snapshot consistent.
     const ui64 frontCommitId = it->second.front();
     // The InvalidCommitId comparison handles the CommitIdOverflow case.
     return frontCommitId == InvalidCommitId || frontCommitId <= commitId;

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -208,6 +208,7 @@ struct TTrackedUnconfirmedData
 {
     NProto::TUnconfirmedData Data;
     TString SessionId;
+    // Tablet-pipe server actor that accepted GenerateBlobIds for this data.
     NActors::TActorId PipeServerId;
 };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -262,7 +262,7 @@ protected:
     THashSet<ui64> DeletionQueue;
     // ConfirmAddData requests that arrived before internal AddData completed.
     // Used for all requests until (#5353)
-    THashMap<ui64, TPendingConfirmAddData> PendingConfirmation;
+    THashMap<ui64, TVector<TPendingConfirmAddData>> PendingConfirmation;
 
     // Recovery gate for data operations: true when startup unconfirmed flow
     // has completed recovery confirmation.

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -509,50 +509,83 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         AssertStorageStats(tablet, 0, 0);
     }
 
-    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataAfterTimeout)
+    Y_UNIT_TEST(ShouldDeferDuplicatePendingConfirmAddData)
     {
+        // Writing-data scenario: duplicate ConfirmAddData requests wait for
+        // the same commit and are completed together after data is indexed.
         constexpr ui32 block = 4_KB;
-        const auto unconfirmedDataTimeout = TDuration::Seconds(1);
 
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(1);
         storageConfig.SetAddingUnconfirmedDataEnabled(true);
         storageConfig.SetUnconfirmedDataCountHardLimit(10);
-        storageConfig.SetGenerateBlobIdsReleaseCollectBarrierTimeout(
-            unconfirmedDataTimeout.MilliSeconds());
 
         TTestEnv env({}, std::move(storageConfig));
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
-        auto& runtime = env.GetRuntime();
-
-        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
         tablet.InitSession("client", "session");
 
         auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
         ui64 handle = CreateHandle(tablet, id);
 
+        auto& runtime = env.GetRuntime();
+        TVector<TAutoPtr<IEventHandle>> heldCommitResults;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvTablet::EvCommitResult) {
+                    heldCommitResults.push_back(event.Release());
+                    return true;
+                }
+                return false;
+            });
+
         auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
         const ui64 commitId = gbi->Record.GetCommitId();
-        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
 
-        AssertStorageStats(tablet, 1, 0);
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]()
+                { return !heldCommitResults.empty(); }},
+            TDuration::Seconds(1));
 
-        runtime.AdvanceCurrentTime(
-            unconfirmedDataTimeout + TDuration::MilliSeconds(100));
-        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
-
-        AssertStorageStats(tablet, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            1,
+            heldCommitResults.size(),
+            "Expected AddDataUnconfirmed commit result to be held");
 
         tablet.SendConfirmAddDataRequest(commitId);
-        auto response = tablet.AssertConfirmAddDataResponse(E_REJECTED);
+        tablet.AssertConfirmAddDataNoResponse();
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        tablet.AssertConfirmAddDataNoResponse();
+
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        for (auto it = heldCommitResults.rbegin();
+             it != heldCommitResults.rend();
+             ++it)
+        {
+            runtime.PushFront(*it);
+        }
+        heldCommitResults.clear();
+        runtime.DispatchEvents({}, TDuration::Seconds(1));
+
+        tablet.AssertConfirmAddDataResponse(S_OK);
+        tablet.AssertConfirmAddDataResponse(S_OK);
+
+        AssertStorageStats(tablet, 0, 0);
     }
 
-    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataInProgressAfterTimeout)
+    Y_UNIT_TEST(ShouldDeferDuplicatePendingConfirmAddDataDuringDeletion)
     {
+        // Deleting-data scenario: duplicate ConfirmAddData requests wait for
+        // the same commit and are completed together after deletion finishes.
         constexpr ui32 block = 4_KB;
-        const auto unconfirmedDataTimeout = TDuration::Seconds(1);
+        const auto unconfirmedDataTimeout = TDuration::Seconds(50);
 
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(1);
@@ -601,8 +634,131 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             heldCommitResults.size(),
             "Expected AddDataUnconfirmed commit result to be held");
 
-        runtime.AdvanceCurrentTime(
-            unconfirmedDataTimeout + TDuration::MilliSeconds(100));
+        runtime.AdvanceCurrentTime(unconfirmedDataTimeout);
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]()
+                { return heldCommitResults.size() >= 2; }},
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(
+            heldCommitResults.size() >= 2,
+            "Expected DeleteUnconfirmedData commit result to be held");
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        tablet.AssertConfirmAddDataNoResponse();
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        tablet.AssertConfirmAddDataNoResponse();
+
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        for (auto it = heldCommitResults.rbegin();
+             it != heldCommitResults.rend();
+             ++it)
+        {
+            runtime.PushFront(*it);
+        }
+        heldCommitResults.clear();
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        tablet.AssertConfirmAddDataResponse(E_REJECTED);
+        tablet.AssertConfirmAddDataResponse(E_REJECTED);
+
+        AssertStorageStats(tablet, 0, 0);
+    }
+
+    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataAfterTimeout)
+    {
+        constexpr ui32 block = 4_KB;
+        const auto unconfirmedDataTimeout = TDuration::Seconds(50);
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetGenerateBlobIdsReleaseCollectBarrierTimeout(
+            unconfirmedDataTimeout.MilliSeconds());
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        const ui64 commitId = gbi->Record.GetCommitId();
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        AssertStorageStats(tablet, 1, 0);
+
+        runtime.AdvanceCurrentTime(unconfirmedDataTimeout);
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        AssertStorageStats(tablet, 0, 0);
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        tablet.AssertConfirmAddDataResponse(E_REJECTED);
+    }
+
+    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataInProgressAfterTimeout)
+    {
+        constexpr ui32 block = 4_KB;
+        const auto unconfirmedDataTimeout = TDuration::Seconds(50);
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetGenerateBlobIdsReleaseCollectBarrierTimeout(
+            unconfirmedDataTimeout.MilliSeconds());
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        runtime.CaptureScheduledEvents();
+
+        TVector<TAutoPtr<IEventHandle>> heldCommitResults;
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvTablet::EvCommitResult) {
+                    heldCommitResults.push_back(event.Release());
+                    return true;
+                }
+                return false;
+            });
+
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        const ui64 commitId = gbi->Record.GetCommitId();
+
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]()
+                { return !heldCommitResults.empty(); }},
+            TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            1,
+            heldCommitResults.size(),
+            "Expected AddDataUnconfirmed commit result to be held");
+
+        runtime.AdvanceCurrentTime(unconfirmedDataTimeout);
         runtime.DispatchEvents(
             TDispatchOptions{
                 .CustomFinalCondition = [&]()
@@ -626,14 +782,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         heldCommitResults.clear();
         runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
 
-        auto response = tablet.AssertConfirmAddDataResponse(E_REJECTED);
+        tablet.AssertConfirmAddDataResponse(E_REJECTED);
+
         AssertStorageStats(tablet, 0, 0);
     }
 
     Y_UNIT_TEST(ShouldIgnoreUnconfirmedDataTimeoutAfterConfirm)
     {
         constexpr ui32 block = 4_KB;
-        const auto unconfirmedDataTimeout = TDuration::Seconds(1);
+        const auto unconfirmedDataTimeout = TDuration::Seconds(50);
 
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(1);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -495,9 +495,6 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         tablet.AssertConfirmAddDataNoResponse();
         AssertStorageStats(tablet, 1, 0);
 
-        runtime.AdvanceCurrentTime(TDuration::Seconds(15));
-        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
-
         // Pending confirmation is not cleaned up by timeout.
         tablet.AssertConfirmAddDataNoResponse();
 
@@ -510,6 +507,164 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         tablet.AssertConfirmAddDataResponse(S_OK);
 
         AssertStorageStats(tablet, 0, 0);
+    }
+
+    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataAfterTimeout)
+    {
+        constexpr ui32 block = 4_KB;
+        const auto unconfirmedDataTimeout = TDuration::Seconds(1);
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetGenerateBlobIdsReleaseCollectBarrierTimeout(
+            unconfirmedDataTimeout.MilliSeconds());
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        const ui64 commitId = gbi->Record.GetCommitId();
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        AssertStorageStats(tablet, 1, 0);
+
+        runtime.AdvanceCurrentTime(
+            unconfirmedDataTimeout + TDuration::MilliSeconds(100));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        AssertStorageStats(tablet, 0, 0);
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        auto response = tablet.AssertConfirmAddDataResponse(E_REJECTED);
+    }
+
+    Y_UNIT_TEST(ShouldDeleteUnconfirmedDataInProgressAfterTimeout)
+    {
+        constexpr ui32 block = 4_KB;
+        const auto unconfirmedDataTimeout = TDuration::Seconds(1);
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetGenerateBlobIdsReleaseCollectBarrierTimeout(
+            unconfirmedDataTimeout.MilliSeconds());
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        runtime.CaptureScheduledEvents();
+
+        TVector<TAutoPtr<IEventHandle>> heldCommitResults;
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() == TEvTablet::EvCommitResult) {
+                    heldCommitResults.push_back(event.Release());
+                    return true;
+                }
+                return false;
+            });
+
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        const ui64 commitId = gbi->Record.GetCommitId();
+
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]()
+                { return !heldCommitResults.empty(); }},
+            TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            1,
+            heldCommitResults.size(),
+            "Expected AddDataUnconfirmed commit result to be held");
+
+        runtime.AdvanceCurrentTime(
+            unconfirmedDataTimeout + TDuration::MilliSeconds(100));
+        runtime.DispatchEvents(
+            TDispatchOptions{
+                .CustomFinalCondition = [&]()
+                { return heldCommitResults.size() >= 2; }},
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_C(
+            heldCommitResults.size() >= 2,
+            "Expected DeleteUnconfirmedData commit result to be held");
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        tablet.AssertConfirmAddDataNoResponse();
+
+        runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);
+        for (auto it = heldCommitResults.rbegin();
+             it != heldCommitResults.rend();
+             ++it)
+        {
+            runtime.PushFront(*it);
+        }
+        heldCommitResults.clear();
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        auto response = tablet.AssertConfirmAddDataResponse(E_REJECTED);
+        AssertStorageStats(tablet, 0, 0);
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreUnconfirmedDataTimeoutAfterConfirm)
+    {
+        constexpr ui32 block = 4_KB;
+        const auto unconfirmedDataTimeout = TDuration::Seconds(1);
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetGenerateBlobIdsReleaseCollectBarrierTimeout(
+            unconfirmedDataTimeout.MilliSeconds());
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        auto& runtime = env.GetRuntime();
+
+        TIndexTabletClient tablet(runtime, nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        const TString expected(block, 'a');
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        GenerateBlobIdsPutBlobAndConfirm(env, tablet, *gbi, expected);
+        AssertStorageStats(tablet, 0, 0);
+
+        runtime.AdvanceCurrentTime(
+            unconfirmedDataTimeout + TDuration::MilliSeconds(1));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        AssertStorageStats(tablet, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(expected, ReadData(tablet, handle, block, 0));
     }
 
     // We emulate situation, where under high load, we received confirmation
@@ -1669,8 +1824,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
 
         tablet.SendGetNodeAttrRequest(id);
 
-        // With cache bypass we will not receive response until release of Commit
-        // event
+        // With cache bypass we will not receive response until release of
+        // Commit event
         tablet.AssertGetNodeAttrNoResponse();
 
         runtime.SetEventFilter(TTestActorRuntimeBase::DefaultFilterFunc);


### PR DESCRIPTION
### Notes
Schedule a private cancel event for each unconfirmed GenerateBlobIds result. This cleans up unconfirmed data and releases the collect barrier when a client never sends ConfirmAddData or CancelAddData.

Add CancelUnconfirmedData which will invalidate unconfirmed data after timeout interval
Add processing for cases when we can receive duplicate requests in case of pipe disconnection. Now we will delay all such request up to a point where we can send reply to all of them 
Add uts
Add more comments to some places and increased redability

### Issue
#2293
