### PR TITLE
filestore: storage service ListNodes race check should properly handle session errors

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -468,10 +468,13 @@ void TListNodesActor::HandleGetNodeAttrResponseCheck(
                 "Node check in leader failed with error: %s, %s",
                 FormatError(msg->GetError()).Quote().c_str(),
                 name.Quote().c_str());
-            // Retriable errors from the tablet should not cause
-            // NodeNotFoundInShard critical events - the underlying client
+            // Retriable errors and session errors from the tablet should not
+            // cause NodeNotFoundInShard critical events - the underlying client
             // should retry the ListNodes request
-            if (GetErrorKind(msg->GetError()) == EErrorKind::ErrorRetriable) {
+            const auto errorKind = GetErrorKind(msg->GetError());
+            if (errorKind == EErrorKind::ErrorRetriable
+                    || errorKind == EErrorKind::ErrorSession)
+            {
                 HandleError(ctx, *msg->Record.MutableError());
                 return;
             }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -6531,6 +6531,124 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
     }
 
+    SERVICE_TEST(ShouldHandleGetNodeAttrErrorsFromShardInListNodesRaceDetection)
+    {
+        config.SetDirectoryCreationInShardsEnabled(true);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        auto dirId = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(RootNodeId, "dir")
+        )->Record.GetNode().GetId();
+
+        auto subdir1Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(dirId, "subdir1")
+        )->Record.GetNode().GetId();
+        Y_UNUSED(subdir1Id);
+
+        auto subdir2Id = service.CreateNode(
+            headers,
+            TCreateNodeArgs::Directory(dirId, "subdir2")
+        )->Record.GetNode().GetId();
+
+        IEventHandlePtr unlinkNodeResponse;
+        bool shouldIntercept = true;
+        NProto::TError getAttrError;
+        env.GetRuntime().SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+
+                if (event->GetTypeRewrite() == TEvService::EvUnlinkNodeResponse
+                        && shouldIntercept)
+                {
+                    unlinkNodeResponse.reset(event.Release());
+                    return true;
+                }
+
+                if (event->GetTypeRewrite()
+                        == TEvService::EvGetNodeAttrResponse)
+                {
+                    using TResponse = TEvService::TEvGetNodeAttrResponse;
+                    auto* msg = event->Get<TResponse>();
+                    *msg->Record.MutableError() = getAttrError;
+                }
+
+                return false;
+            });
+
+        service.SendUnlinkNodeRequest(headers, dirId, "subdir1", true);
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+        UNIT_ASSERT(unlinkNodeResponse);
+
+        const auto counters =
+            env.GetCounters()->FindSubgroup("component", "service");
+        UNIT_ASSERT(counters);
+        const auto counter = counters->GetCounter(
+            "AppCriticalEvents/NodeNotFoundInShard");
+
+        {
+            auto response =
+                service.SendAndRecvListNodes(headers, fsConfig.FsId, dirId);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+            const auto& listing = response->Record;
+            UNIT_ASSERT_VALUES_EQUAL(1, listing.NodesSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, listing.NamesSize());
+            UNIT_ASSERT_VALUES_EQUAL(subdir2Id, listing.GetNodes(0).GetId());
+            UNIT_ASSERT_VALUES_EQUAL("subdir2", listing.GetNames(0));
+            UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
+        }
+
+        getAttrError = MakeError(E_REJECTED);
+
+        {
+            auto response =
+                service.SendAndRecvListNodes(headers, fsConfig.FsId, dirId);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                getAttrError.GetCode(),
+                response->GetStatus(),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
+        }
+
+        getAttrError = MakeError(E_FS_INVALID_SESSION);
+
+        {
+            auto response =
+                service.SendAndRecvListNodes(headers, fsConfig.FsId, dirId);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                getAttrError.GetCode(),
+                response->GetStatus(),
+                response->GetErrorReason());
+            UNIT_ASSERT_VALUES_EQUAL(0, counter->GetAtomic());
+        }
+
+        getAttrError = MakeError(E_IO);
+
+        {
+            auto response =
+                service.SendAndRecvListNodes(headers, fsConfig.FsId, dirId);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+            const auto& listing = response->Record;
+            UNIT_ASSERT_VALUES_EQUAL(1, listing.NodesSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, listing.NamesSize());
+            UNIT_ASSERT_VALUES_EQUAL(subdir2Id, listing.GetNodes(0).GetId());
+            UNIT_ASSERT_VALUES_EQUAL("subdir2", listing.GetNames(0));
+            UNIT_ASSERT_VALUES_EQUAL(1, counter->GetAtomic());
+        }
+    }
+
     SERVICE_TEST(ShouldHandleRenameNodeInDestinationError)
     {
         config.SetDirectoryCreationInShardsEnabled(true);


### PR DESCRIPTION
### Notes
Otherwise we sometimes get false positive `NodeNotFoundInShard` crit events (and in very rare cases might return `EIO` to the client but that's very unlikely). Session errors should basically be treated in the same manner as retriable errors in such places.

### Issue
none
