### PR TITLE
issue-5726: support for ListNodesInternal in private API and support for ListNodes+ListNodesInternal in loadtest

### DIFF
--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -151,6 +151,12 @@ ELogPriority GetRequestLogPriority()
         : ELogPriority::TLOG_RESOURCES;
 }
 
+template <>
+ELogPriority GetRequestLogPriority<NProto::TExecuteActionRequest>()
+{
+    return ELogPriority::TLOG_RESOURCES;
+}
+
 #undef FILESTORE_REQUEST_CHECK
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -375,6 +375,10 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    NActors::IActorPtr CreateListNodesInternalActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
     void PerformToggleServiceStateAction(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo,

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -156,6 +156,10 @@ void TStorageServiceActor::HandleExecuteAction(
             "getresponselogentry",
             &TStorageServiceActor::CreateGetResponseLogEntryActor
         },
+        {
+            "listnodesinternal",
+            &TStorageServiceActor::CreateListNodesInternalActor
+        },
     };
 
     using TInstantAction = void (TStorageServiceActor::*)(

--- a/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
@@ -293,4 +293,19 @@ IActorPtr TStorageServiceActor::CreateGetResponseLogEntryActor(
         std::move(input));
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// ListNodes[Internal]
+
+IActorPtr TStorageServiceActor::CreateListNodesInternalActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TListNodesInternalActor = TTabletActionActor<
+        TEvIndexTablet::TEvListNodesInternalRequest,
+        TEvIndexTablet::TEvListNodesInternalResponse>;
+    return std::make_unique<TListNodesInternalActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -643,6 +643,56 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
                 r.GetNodes(0).GetShardNodeName());
         }
 
+        {
+            auto r = service.ListNodes(headers, fsId, parentId)->Record;
+            UNIT_ASSERT_VALUES_EQUAL(1, r.NodesSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, r.NamesSize());
+            UNIT_ASSERT_VALUES_EQUAL(name2, r.GetNames(0));
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardId2,
+                r.GetNodes(0).GetShardFileSystemId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardNodeName2,
+                r.GetNodes(0).GetShardNodeName());
+
+            NProtoPrivate::TListNodesInternalRequest request;
+            request.SetFileSystemId(fsId);
+            auto& originalRequest = *request.MutableOriginalRequest();
+            originalRequest.SetNodeId(parentId);
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("ListNodesInternal", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+
+            NProtoPrivate::TListNodesInternalResponse lniResponse;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                response->Record.GetOutput(),
+                &lniResponse).ok());
+
+            UNIT_ASSERT_VALUES_EQUAL(1, lniResponse.NameSizesSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, lniResponse.ShardIdSizesSize());
+            UNIT_ASSERT_VALUES_EQUAL(1, lniResponse.ShardNodeNameSizesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                name2,
+                lniResponse.GetNameBuffer().substr(
+                    0,
+                    lniResponse.GetNameSizes(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardId2,
+                lniResponse.GetExternalRefBuffer().substr(
+                    0,
+                    lniResponse.GetShardIdSizes(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                shardNodeName2,
+                lniResponse.GetExternalRefBuffer().substr(
+                    lniResponse.GetShardIdSizes(0),
+                    lniResponse.GetShardNodeNameSizes(0)));
+        }
+
         service.DestroySession(headers);
     }
 

--- a/cloud/filestore/tools/testing/loadtest/lib/request.h
+++ b/cloud/filestore/tools/testing/loadtest/lib/request.h
@@ -62,6 +62,7 @@ struct IRequestGenerator
 IRequestGeneratorPtr CreateIndexRequestGenerator(
     NProto::TIndexLoadSpec spec,
     ILoggingServicePtr logging,
+    IFileStoreServicePtr client,
     NClient::ISessionPtr session,
     TString filesystemId,
     NProto::THeaders headers);

--- a/cloud/filestore/tools/testing/loadtest/lib/request_index.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_index.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/client/session.h>
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/service/filestore.h>
+#include <cloud/filestore/private/api/protos/tablet.pb.h>
 #include <cloud/filestore/public/api/protos/data.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
@@ -51,6 +52,7 @@ private:
 
     TLog Log;
 
+    IFileStoreServicePtr Client;
     ISessionPtr Session;
 
     TVector<std::pair<ui64, NProto::EAction>> Actions;
@@ -71,12 +73,14 @@ public:
     TIndexRequestGenerator(
             NProto::TIndexLoadSpec spec,
             ILoggingServicePtr logging,
+            IFileStoreServicePtr client,
             ISessionPtr session,
             TString filesystemId,
             NProto::THeaders headers)
         : Spec(std::move(spec))
         , FileSystemId(std::move(filesystemId))
         , Headers(std::move(headers))
+        , Client(std::move(client))
         , Session(std::move(session))
     {
         Log = logging->CreateLog(Headers.GetClientId());
@@ -116,6 +120,10 @@ public:
             return DoAcquireLock();
         case NProto::ACTION_RELEASE_LOCK:
             return DoReleaseLock();
+        case NProto::ACTION_LIST_NODES:
+            return DoListNodes();
+        case NProto::ACTION_LIST_NODES_INTERNAL:
+            return DoListNodesInternal();
         default:
             Y_ABORT("unexpected action: %u", (ui32)action);
         }
@@ -138,6 +146,14 @@ private:
     TFuture<TCompletedRequest> DoCreateNode()
     {
         TGuard<TMutex> guard(StateLock);
+        auto started = TInstant::Now();
+
+        if (Spec.GetMaxNodes() && Nodes.size() >= Spec.GetMaxNodes()) {
+            return MakeFuture<TCompletedRequest>({
+                NProto::ACTION_CREATE_NODE,
+                started,
+                MakeError(S_FALSE)});
+        }
 
         auto name = GenerateNodeName();
         StagedNodes[name] = {};
@@ -147,7 +163,6 @@ private:
         request->SetName(name);
         request->MutableFile()->SetMode(0777);
 
-        auto started = TInstant::Now();
         auto self = weak_from_this();
         return Session->CreateNode(CreateCallContext(), std::move(request)).Apply(
             [=] (const TFuture<NProto::TCreateNodeResponse>& future) {
@@ -628,6 +643,101 @@ private:
         }
     }
 
+    TFuture<TCompletedRequest> DoListNodes()
+    {
+        TGuard<TMutex> guard(StateLock);
+
+        auto request = CreateRequest<NProto::TListNodesRequest>();
+        request->SetNodeId(RootNodeId);
+
+        auto started = TInstant::Now();
+        auto self = weak_from_this();
+        return Session->ListNodes(CreateCallContext(), std::move(request))
+            .Apply([=] (const TFuture<NProto::TListNodesResponse>& future) {
+                if (auto ptr = self.lock()) {
+                    return ptr->HandleListNodes(future, started);
+                }
+
+                return TCompletedRequest{
+                    NProto::ACTION_LIST_NODES,
+                    started,
+                    MakeError(E_CANCELLED, "cancelled")};
+            });
+    }
+
+    TCompletedRequest HandleListNodes(
+        const TFuture<NProto::TListNodesResponse>& future,
+        TInstant started)
+    {
+        TGuard<TMutex> guard(StateLock);
+
+        try {
+            CheckResponse(future.GetValue());
+            return {NProto::ACTION_LIST_NODES, started, {}};
+        } catch (const TServiceError& e)  {
+            auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
+            STORAGE_ERROR("list nodes has failed: %s",
+                FormatError(error).c_str());
+
+            return {NProto::ACTION_LIST_NODES, started, error};
+        }
+    }
+
+    TFuture<TCompletedRequest> DoListNodesInternal()
+    {
+        TGuard<TMutex> guard(StateLock);
+
+        auto request = std::make_shared<NProto::TExecuteActionRequest>();
+        request->MutableHeaders()->CopyFrom(Headers);
+        request->SetAction("ListNodesInternal");
+
+        NProtoPrivate::TListNodesInternalRequest lniRequest;
+        lniRequest.SetFileSystemId(FileSystemId);
+        auto& lnRequest = *lniRequest.MutableOriginalRequest();
+        lnRequest.SetNodeId(RootNodeId);
+
+        TStringStream ss;
+        lniRequest.PrintJSON(ss);
+        request->SetInput(std::move(ss.Str()));
+
+        auto started = TInstant::Now();
+        auto self = weak_from_this();
+        return Client->ExecuteAction(CreateCallContext(), std::move(request))
+            .Apply([=] (const TFuture<NProto::TExecuteActionResponse>& future) {
+                if (auto ptr = self.lock()) {
+                    return ptr->HandleExecuteAction(
+                        future,
+                        NProto::ACTION_LIST_NODES_INTERNAL,
+                        started);
+                }
+
+                return TCompletedRequest{
+                    NProto::ACTION_LIST_NODES_INTERNAL,
+                    started,
+                    MakeError(E_CANCELLED, "cancelled")};
+            });
+    }
+
+    TCompletedRequest HandleExecuteAction(
+        const TFuture<NProto::TExecuteActionResponse>& future,
+        NProto::EAction action,
+        TInstant started)
+    {
+        TGuard<TMutex> guard(StateLock);
+
+        try {
+            CheckResponse(future.GetValue());
+            return {action, started, {}};
+        } catch (const TServiceError& e)  {
+            auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
+            STORAGE_ERROR("action %s has failed: %s",
+                NProto::EAction_Name(action).c_str(),
+                FormatError(error).c_str());
+
+            return {action, started, error};
+        }
+    }
+
     template <typename T>
     std::shared_ptr<T> CreateRequest()
     {
@@ -664,6 +774,7 @@ private:
 IRequestGeneratorPtr CreateIndexRequestGenerator(
     NProto::TIndexLoadSpec spec,
     ILoggingServicePtr logging,
+    IFileStoreServicePtr client,
     ISessionPtr session,
     TString filesystemId,
     NProto::THeaders headers)
@@ -671,6 +782,7 @@ IRequestGeneratorPtr CreateIndexRequestGenerator(
     return std::make_shared<TIndexRequestGenerator>(
         std::move(spec),
         std::move(logging),
+        std::move(client),
         std::move(session),
         std::move(filesystemId),
         std::move(headers));

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -530,6 +530,7 @@ private:
                 RequestGenerator = CreateIndexRequestGenerator(
                     Config.GetIndexLoadSpec(),
                     Logging,
+                    Client,
                     Session,
                     FileSystemId,
                     headers);

--- a/cloud/filestore/tools/testing/loadtest/lib/ya.make
+++ b/cloud/filestore/tools/testing/loadtest/lib/ya.make
@@ -20,6 +20,7 @@ PEERDIR(
     cloud/filestore/libs/diagnostics/events
     cloud/filestore/libs/service
     cloud/filestore/libs/service_local
+    cloud/filestore/private/api/protos
     cloud/filestore/public/api/protos
     cloud/filestore/tools/analytics/libs/event-log
     cloud/filestore/tools/testing/loadtest/protos

--- a/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
+++ b/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
@@ -21,6 +21,7 @@ enum EAction
     ACTION_ACCESS_NODE = 8;
     ACTION_LIST_NODES = 9;
     ACTION_FLUSH = 10;
+    ACTION_LIST_NODES_INTERNAL = 11;
 
     // DATA
     ACTION_WRITE = 101;
@@ -36,6 +37,7 @@ message TIndexLoadSpec
     }
 
     repeated TAction Actions = 1;
+    uint64 MaxNodes = 2;
 }
 
 message TDataLoadSpec


### PR DESCRIPTION
### Notes
Implemented the ability to test `ListNodes` / `ListNodesInternal` performance via filestore-loadtest. Separate `ListNodesInternal` testing is needed because in single-node tests (where everything's deployed on one node - e.g. on a dev machine) the performance is mostly limited by `GetNodeAttrBatch` performance and it's harder to test the performance of the `ListNodes` tx in `IndexTablet` (which is important because on multinode clusters `GetNodeAttrBatch` for single-dir listings is spread across multiple nodes whereas `ListNodes` tx cannot scale).

Implemented a limit for the number of created nodes in filestore-loadtest as well.

Also changed loglevel for `ExecuteAction` logging in `filestore/libs/server` to `DEBUG` - we already log the things that we really need to log in `libs/storage/{service,tablet}` so logging the whole requests (including headers) with `INFO` loglevel at the server level is excessive. I included this change in this PR because I use `ExecuteAction` to send `ListNodesInternal` requests via filestore-loadtest and the logs get flooded.

### Testing

To test this, I launched filestore locally, created a filesystem and enabled index cache by adding the following settings to nfs-storage.txt:
```
InMemoryIndexCacheEnabled: true
InMemoryIndexCacheLoadOnTabletStart: true
InMemoryIndexCacheLoadOnTabletStartRowsPerTx: 100000
InMemoryIndexCacheNodesCapacity: 1000000
InMemoryIndexCacheNodeAttrsCapacity: 1000000
InMemoryIndexCacheNodeRefsCapacity: 1000000
InMemoryIndexCacheNodeRefsExhaustivenessCapacity: 1000000
```

I ran the following loadtest script to initialize the root dir of the filesystem in my local filestore setup:
```
Tests {
    LoadTest {
        Name: "smoke"
        FileSystemId: "nfs"
        IndexLoadSpec {
            Actions {
                Action: ACTION_CREATE_NODE
                Rate: 50
            }
            Actions {
                Action: ACTION_LIST_NODES
                Rate: 50
            }
            MaxNodes: 10000
        }
        IODepth: 16
        TestDuration: 60
    }
}
``` 

Then I mounted the filesystem via FUSE and ran dirtree with the following params to generate some more directories and files:
```
~/git/nbs/cloud/filestore/bin/mounts/1$ ../../../tools/testing/dirtree/bin/dirtree --test-dir dirtree_wd --children-count 1000 --subdir-probability 0.005
...
2026-05-21T12:55:25.723975Z :BENCH INFO: cloud/filestore/tools/testing/dirtree/bin/app.cpp:219: Producer dirtree_wd/producer_0 at depth 3, created 8992 files, 18 symlinks, 8 dirs
2026-05-21T12:55:25.723991Z :BENCH INFO: cloud/filestore/tools/testing/dirtree/bin/app.cpp:219: Producer dirtree_wd/producer_1 at depth 3, created 5995 files, 12 symlinks, 5 dirs
2026-05-21T12:55:25.723995Z :BENCH INFO: cloud/filestore/tools/testing/dirtree/bin/app.cpp:219: Producer dirtree_wd/producer_2 at depth 3, created 5995 files, 12 symlinks, 5 dirs
2026-05-21T12:55:25.723996Z :BENCH INFO: cloud/filestore/tools/testing/dirtree/bin/app.cpp:219: Producer dirtree_wd/producer_3 at depth 2, created 20976 files, 40 symlinks, 20 dirs
```

Then ran the following loadtest script to test directory listing performance:
```
Tests {
    LoadTest {
        Name: "smoke"
        FileSystemId: "nfs"
        IndexLoadSpec {
            Actions {
                Action: ACTION_LIST_NODES_INTERNAL
                Rate: 100
            }
            MaxNodes: 10000
        }
        IODepth: 16
        TestDuration: 60
    }
}
```

Got 47474 completed listing requests with `UseUnlimitedBTreeNodeRefsCacheInMainTablet: true` vs 36973 with `UseUnlimitedBTreeNodeRefsCacheInMainTablet: false`

So even in this small test we get 30% higher listing RPS. According to the flamegraph, ListNodes tx performance is 50% better now. It's expected to be even better for large filesystems (where the cache can contain millions of node refs in the corresponding data structure, which is `TMap` + `TLRUCache` on top of it by default)

### Issue
https://github.com/ydb-platform/nbs/issues/5726
