### PR TITLE
backport 'EXT-1634: DnsResolver Add trailing dot option' from ydb main

### DIFF
--- a/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -653,6 +653,7 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
         resolverOptions.MonCounters = GetServiceCounters(counters, "utils")->GetSubgroup("subsystem", "dns_resolver");
         resolverOptions.ForceTcp = nsConfig.GetForceTcp();
         resolverOptions.KeepSocket = nsConfig.GetKeepSocket();
+        resolverOptions.AddTrailingDot = nsConfig.GetAddTrailingDot();
         IActor *resolver = NDnsResolver::CreateOnDemandDnsResolver(resolverOptions);
 
         setup->LocalServices.emplace_back(

--- a/contrib/ydb/core/protos/config.proto
+++ b/contrib/ydb/core/protos/config.proto
@@ -165,6 +165,7 @@ message TStaticNameserviceConfig {
     optional ENameserviceType Type = 5;
     optional bool KeepSocket = 6 [default = true];
     optional bool ForceTcp = 7 [default = false];
+    optional bool AddTrailingDot = 9 [default = false];
 }
 
 message TDynamicNameserviceConfig {

--- a/contrib/ydb/library/actors/dnsresolver/dnsresolver.cpp
+++ b/contrib/ydb/library/actors/dnsresolver/dnsresolver.cpp
@@ -130,6 +130,14 @@ namespace NDnsResolver {
         std::atomic<size_t> Activations{ 0 };
     };
 
+    static TString AddTrailingDot(TString&& name, bool addTrailingDot) noexcept
+    {
+        if (addTrailingDot && !name.empty() && name.back() != '.') {
+            name += ".";
+        }
+        return name;
+    }
+
     class TSimpleDnsResolver
         : public TActor<TSimpleDnsResolver>
         , private TAresLibraryInitBase
@@ -290,6 +298,7 @@ namespace NDnsResolver {
             memset(&hints, 0, sizeof(hints));
             hints.ai_flags = ARES_AI_NOSORT;
             hints.ai_family = family;
+            name = AddTrailingDot(std::move(name), reqCtx->Self->Options.AddTrailingDot);
             ares_getaddrinfo(AresChannel, name.c_str(), nullptr, &hints, &TThis::GetAddrInfoAresCallback, reqCtx.Get());
         }
 

--- a/contrib/ydb/library/actors/dnsresolver/dnsresolver.h
+++ b/contrib/ydb/library/actors/dnsresolver/dnsresolver.h
@@ -93,6 +93,8 @@ namespace NDnsResolver {
         bool KeepSocket = true;
         // Force tcp to perform dns requests
         bool ForceTcp = false;
+        // Add trailing dot to hostname
+        bool AddTrailingDot = false;
     };
 
     IActor* CreateSimpleDnsResolver(TSimpleDnsResolverOptions options = TSimpleDnsResolverOptions());

--- a/contrib/ydb/library/actors/dnsresolver/dnsresolver_ut.cpp
+++ b/contrib/ydb/library/actors/dnsresolver/dnsresolver_ut.cpp
@@ -24,42 +24,53 @@ Y_UNIT_TEST_SUITE(DnsResolver) {
     };
 
     Y_UNIT_TEST(ResolveLocalHost) {
-        TTestActorRuntimeBase runtime;
-        runtime.Initialize();
-        auto sender = runtime.AllocateEdgeActor();
-        auto resolver = runtime.Register(CreateSimpleDnsResolver());
-        runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("localhost", AF_UNSPEC)),
-                0, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-        size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
-        UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        for (auto addTrailingDot : { true, false }) {
+            TTestActorRuntimeBase runtime;
+            runtime.Initialize();
+            auto sender = runtime.AllocateEdgeActor();
+            TSimpleDnsResolverOptions options;
+            options.AddTrailingDot = addTrailingDot;
+            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("localhost", AF_UNSPEC)),
+                    0, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+            size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
+            UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        }
     }
 
     Y_UNIT_TEST(ResolveYandexRu) {
-        TTestActorRuntimeBase runtime;
-        runtime.Initialize();
-        auto sender = runtime.AllocateEdgeActor();
-        auto resolver = runtime.Register(CreateSimpleDnsResolver());
-        runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("yandex.ru", AF_UNSPEC)),
-                0, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-        size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
-        UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        for (auto addTrailingDot : { true, false }) {
+            TTestActorRuntimeBase runtime;
+            runtime.Initialize();
+            auto sender = runtime.AllocateEdgeActor();
+            TSimpleDnsResolverOptions options;
+            options.AddTrailingDot = addTrailingDot;
+            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetHostByName("yandex.ru", AF_UNSPEC)),
+                    0, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetHostByNameResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+            size_t addrs = ev->Get()->AddrsV4.size() + ev->Get()->AddrsV6.size();
+            UNIT_ASSERT_C(addrs > 0, "Got " << addrs << " addresses");
+        }
     }
 
     Y_UNIT_TEST(GetAddrYandexRu) {
-        TTestActorRuntimeBase runtime;
-        runtime.Initialize();
-        auto sender = runtime.AllocateEdgeActor();
-        auto resolver = runtime.Register(CreateSimpleDnsResolver());
-
-        runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetAddr("yandex.ru", AF_UNSPEC)),
-                0, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetAddrResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
-        UNIT_ASSERT_C(ev->Get()->IsV4() || ev->Get()->IsV6(), "Expect v4 or v6 address");
+        for (auto addTrailingDot : { true, false }) {
+            TTestActorRuntimeBase runtime;
+            runtime.Initialize();
+            auto sender = runtime.AllocateEdgeActor();
+            TSimpleDnsResolverOptions options;
+            options.AddTrailingDot = addTrailingDot;
+            auto resolver = runtime.Register(CreateSimpleDnsResolver(options));
+            runtime.Send(new IEventHandle(resolver, sender, new TEvDns::TEvGetAddr("yandex.ru", AF_UNSPEC)),
+                    0, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDns::TEvGetAddrResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Status, 0, ev->Get()->ErrorText);
+            UNIT_ASSERT_C(ev->Get()->IsV4() || ev->Get()->IsV6(), "Expect v4 or v6 address");
+        }
     }
 
     Y_UNIT_TEST(ResolveTimeout) {


### PR DESCRIPTION
See https://github.com/ydb-platform/ydb/pull/27774

>### Changelog entry
>
>Added an option to add a trailing dot to all resolving domains
> 
>nameservice_config:
>  add_trailing_dot: true
> 
>### Changelog category
>
>   New feature
>
>### Description for reviewers
>
>If an FQDN doesn’t end with a dot, multiple search queries may be sent to handle the search domain configuration. This can create additional load on DNS.