### PR TITLE
Fix exception when request splitted and synchronous response received.

### DIFF
--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -195,6 +195,11 @@ public:
             return MakeFuture(std::move(response));
         }
 
+        // Acquire the future before subscribing to sub-request callbacks.
+        // A sub-request can be completed synchronously and swapped with another
+        // Promise inside the OnSubResponse() function.
+        auto future = Promise.GetFuture();
+
         for (size_t i = 0; i < SubRequests.size(); ++i) {
             auto subFuture = TBlockStoreAdapter::Execute(
                 service,
@@ -209,7 +214,7 @@ public:
                 });
         }
 
-        return Promise.GetFuture();
+        return future;
     }
 
 private:
@@ -244,7 +249,6 @@ private:
             promise.SetValue(
                 hasError ? std::move(response)
                          : MergeReadResponses(SubResponses));
-
         } else {
             promise.SetValue(std::move(response));
         }

--- a/cloud/blockstore/libs/service/split_request_service_ut.cpp
+++ b/cloud/blockstore/libs/service/split_request_service_ut.cpp
@@ -107,6 +107,8 @@ struct TTestBlockStore: public TBlockStoreImpl<TTestBlockStore, IBlockStore>
         TBlockRangeComparator>
         ZeroBlocksPromises;
 
+    std::optional<NProto::TError> SyncZeroBlocksError;
+
     TStorageBuffer AllocateBuffer(size_t bytesCount) override
     {
         Y_UNUSED(bytesCount);
@@ -172,6 +174,12 @@ struct TTestBlockStore: public TBlockStoreImpl<TTestBlockStore, IBlockStore>
         std::shared_ptr<NProto::TZeroBlocksRequest> request) override
     {
         Y_UNUSED(callContext);
+
+        if (SyncZeroBlocksError) {
+            NProto::TZeroBlocksResponse response;
+            *response.MutableError() = *SyncZeroBlocksError;
+            return MakeFuture(std::move(response));
+        }
 
         auto range = TBlockRangeHelper::GetRange(*request, DefaultBlockSize);
         auto& info =
@@ -794,6 +802,37 @@ Y_UNIT_TEST_SUITE(TSplitRequestServiceTest)
         const auto& result = future.GetValue(TDuration::MilliSeconds(1));
         UNIT_ASSERT_VALUES_EQUAL_C(
             S_OK,
+            result.GetError().GetCode(),
+            FormatError(result.GetError()));
+    }
+
+    Y_UNIT_TEST(ShouldNotFailWhenSubRequestCompletesSynchronously)
+    {
+        TTestEnvironment env;
+        env.MountVolume();
+        TTestBlockStore& testBlockStore = *env.Storage;
+
+        // Make every ZeroBlocks sub-request complete synchronously with an
+        // error.
+        testBlockStore.SyncZeroBlocksError = MakeError(E_REJECTED, "sync fail");
+
+        // Request that crosses a stripe boundary -> will be split.
+        auto range = TBlockRange64::WithLength(1, 10);
+        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
+        env.SetupRequest(request, range);
+
+        TFuture<NProto::TZeroBlocksResponse> future;
+        UNIT_ASSERT_NO_EXCEPTION(
+            future = env.SplitRequestService->ZeroBlocks(
+                MakeIntrusive<TCallContext>(),
+                std::move(request)));
+
+        // Future must be valid and already carry the propagated error.
+        UNIT_ASSERT(future.Initialized());
+        UNIT_ASSERT(future.HasValue());
+        const auto& result = future.GetValue();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
             result.GetError().GetCode(),
             FormatError(result.GetError()));
     }


### PR DESCRIPTION
### Notes
When the TSplitRequestService gets a synchronous response (or very fast from another thread) after splitting the request, this leads to an error that we send to the user.
`CRITICAL_EVENT:AppCriticalEvents/ErrorWasSentToTheGuestForReliableDisk:disk: "xxxx", op: Write, range: [1416278015..1416278018], error: E_FAIL (NThreading::TFutureException) library/cpp/threading/future/core/future-inl.h:884: state not initialized"`

