### PR TITLE
[NBS] Log gRPC peer address for control-plane requests

### DIFF
--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -567,6 +567,7 @@ void TServerStats::RequestCompleted(
         << ", unaligned: " << req.Unaligned
         << maxTimeSuppressedMessage
         << ", error: " << FormatError(error)
+        << ", peer: " << req.Peer
         << ")");
 }
 

--- a/cloud/blockstore/libs/diagnostics/server_stats.h
+++ b/cloud/blockstore/libs/diagnostics/server_stats.h
@@ -25,6 +25,7 @@ struct TMetricRequest
     const EBlockStoreRequest RequestType;
     TString ClientId;
     TString DiskId;
+    TString Peer;
     IVolumeInfoPtr VolumeInfo;
     ui64 StartIndex = 0;
     NCloud::NProto::EStorageMediaKind MediaKind

--- a/cloud/blockstore/libs/server/server.cpp
+++ b/cloud/blockstore/libs/server/server.cpp
@@ -707,6 +707,7 @@ private:
         auto& internal = *Request->MutableHeaders()->MutableInternal();
         internal.Clear();
         internal.SetRequestSource(*source);
+        internal.SetPeer(TString(Context->peer()));
 
         // we will only get token from secure control channel
         if (source == NProto::SOURCE_SECURE_CONTROL_CHANNEL) {
@@ -743,6 +744,8 @@ private:
         if (IsControlRequest(MetricRequest.RequestType)) {
             message = TStringBuilder() << *Request;
         }
+
+        MetricRequest.Peer = TString(Context->peer());
 
         AppCtx.ServerStats->RequestStarted(
             AppCtx.Log,

--- a/cloud/blockstore/libs/server/server_ut.cpp
+++ b/cloud/blockstore/libs/server/server_ut.cpp
@@ -954,6 +954,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
                     int(NProto::SOURCE_FD_CONTROL_CHANNEL),
                     int(request->GetHeaders().GetInternal().GetRequestSource())
                 );
+                UNIT_ASSERT(!request->GetHeaders().GetInternal().GetPeer().empty());
                 return MakeFuture<NProto::TListEndpointsResponse>();
             };
 

--- a/cloud/blockstore/libs/service/auth_provider.h
+++ b/cloud/blockstore/libs/service/auth_provider.h
@@ -29,7 +29,8 @@ struct IAuthProvider
         TString authToken,
         EBlockStoreRequest requestType,
         TDuration requestTimeout,
-        TString diskId) = 0;
+        TString diskId,
+        TString peer) = 0;
 };
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/service/service_auth.cpp
+++ b/cloud/blockstore/libs/service/service_auth.cpp
@@ -73,7 +73,8 @@ public:
             internal.GetAuthToken(),
             TMethod::BlockStoreRequest,
             TDuration::MilliSeconds(headers.GetRequestTimeout()),
-            GetDiskId(*request));
+            GetDiskId(*request),
+            internal.GetPeer());
 
         return HandleAuthResponse<TMethod>(
             std::move(authResponse),

--- a/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
@@ -43,6 +43,7 @@ private:
     const EBlockStoreRequest RequestType;
     const TDuration RequestTimeout;
     const TString DiskId;
+    const TString Peer;
 
     bool RequestCompleted = false;
 
@@ -54,7 +55,8 @@ public:
             TCallContextPtr callContext,
             EBlockStoreRequest requestType,
             TDuration requestTimeout,
-            TString diskId)
+            TString diskId,
+            TString peer)
         : Permissions(permissions)
         , AuthToken(std::move(authToken))
         , Response(std::move(response))
@@ -62,6 +64,7 @@ public:
         , RequestType(requestType)
         , RequestTimeout(requestTimeout)
         , DiskId(std::move(diskId))
+        , Peer(std::move(peer))
     {}
 
     ~TRequestActor() override
@@ -159,7 +162,7 @@ private:
         if (FAILED(msg->GetStatus())) {
             LOG_WARN_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
                 TRequestInfo(RequestType, CallContext->RequestId, DiskId)
-                << " unauthorized request");
+                << " unauthorized request, peer: " << Peer);
         }
 
         CompleteRequest(ctx, msg->Error);
@@ -173,7 +176,7 @@ private:
 
         LOG_WARN_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
             TRequestInfo(RequestType, CallContext->RequestId, DiskId)
-            << " request timed out");
+            << " request timed out, peer: " << Peer);
 
         NProto::TError error;
         error.SetCode(E_REJECTED);  // TODO: E_TIMEOUT
@@ -211,7 +214,8 @@ public:
         TString authToken,
         EBlockStoreRequest requestType,
         TDuration requestTimeout,
-        TString diskId) override
+        TString diskId,
+        TString peer) override
     {
         auto response = NewPromise<NProto::TError>();
 
@@ -222,7 +226,8 @@ public:
             std::move(callContext),
             requestType,
             requestTimeout,
-            std::move(diskId)));
+            std::move(diskId),
+            std::move(peer)));
 
         return response.GetFuture();
     }

--- a/cloud/blockstore/public/api/protos/headers.proto
+++ b/cloud/blockstore/public/api/protos/headers.proto
@@ -68,6 +68,9 @@ message THeaders
 
         // Source of control plane request.
         EControlRequestSource ControlSource = 5;
+
+        // Peer address of the request sender.
+        string Peer = 6;
     }
 
     // These headers must not be set by end clients. They will be overwritten


### PR DESCRIPTION
### Notes
Capture the gRPC peer address at request ingress and propagate it through the control-plane pipeline so it can be attached to error/diagnostic logs.

### Issue
This enhancement is required to quickly identify the request sender from the logs (particularly in cases of unauthorized access attempts).