### PR TITLE
fix error code when disk is not mounted

### DIFF
--- a/cloud/blockstore/libs/service/overlapping_requests_guard.cpp
+++ b/cloud/blockstore/libs/service/overlapping_requests_guard.cpp
@@ -43,7 +43,6 @@ private:
 
     // Set before receiving requests, so used without lock.
     ui32 BlockSize = 0;
-    TString DiskId;
 
     TAdaptiveLock Lock;
     ui64 RequestIdGenerator = 0;
@@ -305,7 +304,7 @@ TFuture<NProto::TWriteBlocksResponse> TOverlappingRequestsGuard::WriteBlocks(
     if (!BlockSize) {
         NProto::TWriteBlocksResponse error;
         *error.MutableError() = MakeError(
-            E_REJECTED,
+            E_BS_INVALID_SESSION,
             "Need to mount volume before execute WriteBlocks");
         return MakeFuture<NProto::TWriteBlocksResponse>(std::move(error));
     }
@@ -365,7 +364,6 @@ TFuture<NProto::TMountVolumeResponse> TOverlappingRequestsGuard::MountVolume(
             }
             if (auto self = weakSelf.lock()) {
                 self->BlockSize = response.GetVolume().GetBlockSize();
-                self->DiskId = response.GetVolume().GetDiskId();
             }
         });
     return result;
@@ -378,8 +376,6 @@ TFuture<TResponse> TOverlappingRequestsGuard::DoExecuteRequest(
     std::shared_ptr<TRequest> request)
 {
     auto guard = Guard(Lock);
-
-    Y_ABORT_UNLESS(DiskId == request->GetDiskId());
 
     auto overlapping = InflightRequests.FindFirstOverlapping(range);
 

--- a/cloud/blockstore/libs/service/overlapping_requests_guard_service_ut.cpp
+++ b/cloud/blockstore/libs/service/overlapping_requests_guard_service_ut.cpp
@@ -699,7 +699,7 @@ Y_UNIT_TEST_SUITE(TOverlappingRequestsGuardStorageWrapperTest)
         const auto& result1 = future1.GetValue(TDuration::MilliSeconds(1));
 
         UNIT_ASSERT_VALUES_EQUAL_C(
-            E_REJECTED,
+            E_BS_INVALID_SESSION,
             result1.GetError().code(),
             FormatError(result1.GetError()));
     }

--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -488,7 +488,9 @@ TFuture<TResponse> TSplitRequestService::ExecuteRequestWithSplit(
 
     if (!config) {
         TResponse response;
-        *response.MutableError() = MakeError(E_BS_INVALID_SESSION, "Volume not mounted");
+        *response.MutableError() = MakeError(
+            E_BS_INVALID_SESSION,
+            "Volume not mounted");
         return MakeFuture<TResponse>(std::move(response));
     }
 

--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -488,7 +488,7 @@ TFuture<TResponse> TSplitRequestService::ExecuteRequestWithSplit(
 
     if (!config) {
         TResponse response;
-        *response.MutableError() = MakeError(E_REJECTED, "Volume not mounted");
+        *response.MutableError() = MakeError(E_BS_INVALID_SESSION, "Volume not mounted");
         return MakeFuture<TResponse>(std::move(response));
     }
 

--- a/cloud/blockstore/libs/service/split_request_service_ut.cpp
+++ b/cloud/blockstore/libs/service/split_request_service_ut.cpp
@@ -832,6 +832,64 @@ Y_UNIT_TEST_SUITE(TSplitRequestServiceTest)
             result.GetError().GetCode(),
             FormatError(result.GetError()));
     }
+
+    Y_UNIT_TEST(ShouldReplyErrorWithoutMount)
+    {
+        TTestEnvironment env;
+
+        auto range = TBlockRange64::WithLength(1, 10);
+
+        {
+            // Run ZeroBlocks request
+            auto request = std::make_shared<NProto::TZeroBlocksRequest>();
+            env.SetupRequest(request, range);
+            auto future = env.SplitRequestService->ZeroBlocks(
+                MakeIntrusive<TCallContext>(),
+                std::move(request));
+
+            const auto& result = future.GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_BS_INVALID_SESSION,
+                result.GetError().GetCode(),
+                FormatError(result.GetError()));
+        }
+
+        {
+            // Run ReadBlocks request
+
+            auto request = std::make_shared<NProto::TReadBlocksRequest>();
+            env.SetupRequest(request, range);
+            auto future = env.SplitRequestService->ReadBlocks(
+                MakeIntrusive<TCallContext>(),
+                std::move(request));
+
+            const auto& result = future.GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_BS_INVALID_SESSION,
+                result.GetError().GetCode(),
+                FormatError(result.GetError()));
+
+        }
+
+        {
+            // Run WriteBlocks request
+            const TString data = "abcdefghij";
+            auto range =
+                TBlockRange64::WithLength(1, data.size() / DefaultBlockSize);
+            auto request = std::make_shared<NProto::TWriteBlocksRequest>();
+            env.SetupRequest(request, range, data);
+            auto future = env.SplitRequestService->WriteBlocks(
+                MakeIntrusive<TCallContext>(),
+                std::move(request));
+
+            const auto& result = future.GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_BS_INVALID_SESSION,
+                result.GetError().GetCode(),
+                FormatError(result.GetError()));
+
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore


### PR DESCRIPTION
### Notes
1. Both TSplitRequestService and TOverlappingRequestsGuard should reply with E_BS_INVALID_SESSION rather than E_REJECTED when disk is not mounted (since both of them rely on information returned in Mount Response). E_REJECTED is useless because it does not trigger remount.
2. DiskId in TOverlappingRequestsGuard seems to be useless because it is used only in Y_ABORT_UNLESS which is also removed. The only information we acutally need is a BlockSize.

### Issue
Put links to the related issues here
