### PR TITLE
issue-6011: [Filestore] enable lazy initialization for all non-IO requests in filestore

### DIFF
--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -41,7 +41,8 @@ bool IsReadWriteRequest(EFileStoreRequest rt)
 
 const auto REQUEST_COUNTERS_OPTIONS =
     TRequestCounters::EOption::ReportDataPlaneHistogram |
-    TRequestCounters::EOption::ReportControlPlaneHistogram;
+    TRequestCounters::EOption::ReportControlPlaneHistogram |
+    TRequestCounters::EOption::LazyRequestInitialization;
 
 TRequestCountersPtr MakeRequestCounters(
     ITimerPtr timer,
@@ -459,8 +460,7 @@ public:
         , Counters{MakeRequestCounters(
             timer,
             *counters,
-            REQUEST_COUNTERS_OPTIONS
-                | TRequestCounters::EOption::LazyRequestInitialization,
+            REQUEST_COUNTERS_OPTIONS,
             histogramCounterOptions)}
         , Predictor{std::move(predictor)}
         , PredictorStats{counters, std::move(timer)}

--- a/cloud/filestore/libs/diagnostics/request_stats_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats_ut.cpp
@@ -794,23 +794,10 @@ Y_UNIT_TEST_SUITE(TRequestStatRegistryTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldNotReportZeroCounters)
+    static void CheckRequestCountersInitialization(
+        TDynamicCountersPtr fsCounters,
+        IRequestStatsPtr stats)
     {
-
-
-        TBootstrap bootstrap;
-
-        auto counters = bootstrap.Counters
-            ->FindSubgroup("component", METRIC_FS_COMPONENT);
-        UNIT_ASSERT(counters);
-        counters = counters->FindSubgroup("host", "cluster");
-        UNIT_ASSERT(counters);
-
-        auto stats =
-            bootstrap.Registry->GetFileSystemStats(FS, CLIENT, CLOUD, FOLDER);
-        UNIT_ASSERT(stats);
-        auto fsCounters = GetFsCounters(counters, FS, CLIENT, CLOUD, FOLDER);
-
         // non lazy-init request
         auto readData = fsCounters->FindSubgroup("request", "ReadData");
         UNIT_ASSERT(readData);
@@ -822,6 +809,7 @@ Y_UNIT_TEST_SUITE(TRequestStatRegistryTest)
         // these ones should always be present
         auto readDataCount = readData->FindCounter("Count");
         auto readDataErrors = readData->FindCounter("Errors");
+        auto readDataRequestBytes = readData->FindCounter("RequestBytes");
 
         // non lazy-init counters
         auto createHandleCount = createHandle->FindCounter("Count");
@@ -834,6 +822,8 @@ Y_UNIT_TEST_SUITE(TRequestStatRegistryTest)
         UNIT_ASSERT_VALUES_EQUAL(0, readDataCount->Val());
         UNIT_ASSERT(readDataErrors);
         UNIT_ASSERT_VALUES_EQUAL(0, readDataErrors->Val());
+        UNIT_ASSERT(readDataRequestBytes);
+        UNIT_ASSERT_VALUES_EQUAL(0, readDataRequestBytes->Val());
         UNIT_ASSERT(createHandleCount);
         UNIT_ASSERT_VALUES_EQUAL(0, createHandleCount->Val());
         UNIT_ASSERT(createHandleErrorsFatal);
@@ -863,6 +853,61 @@ Y_UNIT_TEST_SUITE(TRequestStatRegistryTest)
             // and now we successfully registered an error
             UNIT_ASSERT_VALUES_EQUAL(1, createHandleErrors->Val());
             UNIT_ASSERT_VALUES_EQUAL(1, createHandleCount->Val());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldNotReportZeroCounters)
+    {
+        // service (global total)
+        {
+            TBootstrap bootstrap;
+            CheckRequestCountersInitialization(
+                bootstrap.Counters->FindSubgroup("component", METRIC_COMPONENT),
+                bootstrap.Registry->GetRequestStats());
+        }
+
+        // service/type/ssd
+        {
+            TBootstrap bootstrap;
+            bootstrap.Registry->GetFileSystemStats(FS, CLIENT, CLOUD, FOLDER);
+            bootstrap.Registry->SetFileSystemMediaKind(
+                FS,
+                CLIENT,
+                NProto::STORAGE_MEDIA_SSD);
+            CheckRequestCountersInitialization(
+                bootstrap.Counters->FindSubgroup("component", METRIC_COMPONENT)
+                    ->FindSubgroup("type", "ssd"),
+                bootstrap.Registry->GetRequestStats());
+        }
+
+        // service/type/hdd
+        {
+            TBootstrap bootstrap;
+            bootstrap.Registry->GetFileSystemStats(FS, CLIENT, CLOUD, FOLDER);
+            bootstrap.Registry->SetFileSystemMediaKind(
+                FS,
+                CLIENT,
+                NProto::STORAGE_MEDIA_HDD);
+            CheckRequestCountersInitialization(
+                bootstrap.Counters->FindSubgroup("component", METRIC_COMPONENT)
+                    ->FindSubgroup("type", "hdd"),
+                bootstrap.Registry->GetRequestStats());
+        }
+
+        // service_fs (per-filesystem)
+        {
+            TBootstrap bootstrap;
+            auto stats = bootstrap.Registry
+                             ->GetFileSystemStats(FS, CLIENT, CLOUD, FOLDER);
+            auto fsCounters = GetFsCounters(
+                bootstrap.Counters
+                    ->FindSubgroup("component", METRIC_FS_COMPONENT)
+                    ->FindSubgroup("host", "cluster"),
+                FS,
+                CLIENT,
+                CLOUD,
+                FOLDER);
+            CheckRequestCountersInitialization(fsCounters, stats);
         }
     }
 

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -510,10 +510,9 @@ struct TRequestCounters::TStatCounters
         Count = counters.GetCounter("Count", true);
         ErrorsFatal = counters.GetCounter("Errors/Fatal", true);
         Time = counters.GetCounter("Time", true);
-        if (ReportControlPlaneHistogram) {
-            TimeHist.Register(counters);
-        } else {
-            TimePercentiles.Register(counters);
+
+        if (IsReadWriteRequest) {
+            RequestBytes = counters.GetCounter("RequestBytes", true);
         }
     }
 
@@ -544,13 +543,20 @@ struct TRequestCounters::TStatCounters
         ErrorsSession = counters.GetCounter("Errors/Session", true);
         Retries = counters.GetCounter("Retries", true);
 
+        if (!IsReadWriteRequest) {
+            if (ReportControlPlaneHistogram) {
+                TimeHist.Register(counters);
+            } else {
+                TimePercentiles.Register(counters);
+            }
+        }
+
         if (IsReadWriteRequest) {
             ErrorsSilent = counters.GetCounter("Errors/Silent", true);
 
             MaxSize = counters.GetCounter("MaxSize");
             MaxCount = counters.GetCounter("MaxCount");
 
-            RequestBytes = counters.GetCounter("RequestBytes", true);
             MaxRequestBytes = counters.GetCounter("MaxRequestBytes");
 
             InProgressBytes = counters.GetCounter("InProgressBytes");

--- a/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
+++ b/cloud/storage/core/libs/user_stats/counter/user_counter.cpp
@@ -230,28 +230,24 @@ private:
 
     const TBuckets Buckets;
     const TString Units;
-    TVector<TBaseDynamicCounters> BaseCounters;
+    // Original inputs. Kept for lazy re-resolution if base subgroups are
+    // not yet registered.
+    const TVector<TBaseDynamicCounters> OriginalInputs;
+    // Empty if source histograms are lazily registered (not yet created at
+    // construction time).
+    const TVector<TBaseDynamicCounters> BaseCounters;
+    // True if some of the subgroups were not yet registered at construction.
+    // GetValue re-resolves from OriginalInputs on every call in this case.
+    const bool IsLazy;
     const size_t HistogramSize;
     TIntrusivePtr<TExplicitHistogramSnapshot> Histogram;
     const EMetricType Type = EMetricType::HIST_RATE;
     const EHistogramCounterOptions HistogramCounterOptions;
 
-public:
-    TUserSumHistogramWrapper(
-        const TBucketsWithUnits& buckets,
-        const TVector<TBaseDynamicCounters>& baseCounters,
-        EHistogramCounterOptions histogramCounterOptions)
-        : Buckets(buckets.first)
-        , Units(buckets.second)
-        , HistogramSize(Buckets.size() - MergeFirstBucketsCount)
-        , Histogram(TExplicitHistogramSnapshot::New(HistogramSize))
-        , HistogramCounterOptions(histogramCounterOptions)
+    TVector<TBaseDynamicCounters> ResolveBaseCounters() const
     {
-        for (size_t i = 0; i < HistogramSize; ++i) {
-            (*Histogram)[i].first = Buckets[i + MergeFirstBucketsCount].Bound;
-        }
-
-        for (const auto& [baseCounter, name]: baseCounters) {
+        TVector<TBaseDynamicCounters> result;
+        for (const auto& [baseCounter, name]: OriginalInputs) {
             if (!baseCounter) {
                 continue;
             }
@@ -266,8 +262,28 @@ public:
                 }
             }
             if (subgroup) {
-                BaseCounters.emplace_back(subgroup, name);
+                result.emplace_back(subgroup, name);
             }
+        }
+        return result;
+    }
+
+public:
+    TUserSumHistogramWrapper(
+        const TBucketsWithUnits& buckets,
+        const TVector<TBaseDynamicCounters>& baseCounters,
+        EHistogramCounterOptions histogramCounterOptions)
+        : Buckets(buckets.first)
+        , Units(buckets.second)
+        , OriginalInputs(baseCounters)
+        , BaseCounters(ResolveBaseCounters())
+        , IsLazy(BaseCounters.size() < OriginalInputs.size())
+        , HistogramSize(Buckets.size() - MergeFirstBucketsCount)
+        , Histogram(TExplicitHistogramSnapshot::New(HistogramSize))
+        , HistogramCounterOptions(histogramCounterOptions)
+    {
+        for (size_t i = 0; i < HistogramSize; ++i) {
+            (*Histogram)[i].first = Buckets[i + MergeFirstBucketsCount].Bound;
         }
     }
 
@@ -296,9 +312,14 @@ public:
         TInstant time,
         NMonitoring::IMetricConsumer* consumer) const override
     {
+        // Re-resolve on every call when lazy: histogram subgroups may not have
+        // existed at construction but are created once the first request fires.
+        const auto lazyCounters =
+            IsLazy ? ResolveBaseCounters() : TVector<TBaseDynamicCounters>{};
+        const auto& counters = IsLazy ? lazyCounters : BaseCounters;
         Clear();
 
-        for (const auto& [baseCounter, name]: BaseCounters) {
+        for (const auto& [baseCounter, name]: counters) {
             if (!baseCounter) {
                 continue;
             }


### PR DESCRIPTION
### Notes
First step described in the original issue: _Stop reporting root/ssd/hdd-level requests for non-essential requests (e.g., GetNodeXAttr or KickEndpoint) and make them lazy_.

+stop registering the time histogram for all 60+ requests

In the case of a stale service, the number of counters went from:

```
$ curl -s localhost:8768/counters/prometheus | wc -l
20456
```
to 
```
$  curl -s localhost:8768/counters/prometheus | wc -l                                    
8012
```

### Issue
#6011
