### PR TITLE
Eternal-load: make test pattern for unaligned scenario more deterministic

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
@@ -83,7 +83,7 @@ struct Y_PACKED TFileHeader
     ui32 Crc32 = 0;
 
     // This is used as a marker that the header is properly initialized
-    static constexpr ui64 ExpectedMagic = 0x733c1dfaa5d2a452;
+    static constexpr ui64 ExpectedMagic = 0x6fb8e89a3a3ebfdd;
 };
 
 // Defines the expected content in the region
@@ -119,18 +119,27 @@ struct Y_PACKED TRegionMetadata
     }
 };
 
-// A region is split in blocks of size |RegionBlockByteCount|, each filled with
-// a generated pattern
-struct Y_PACKED TRegionDataBlock
+struct Y_PACKED TRegionDataBlockPart
 {
     ui64 SeqNum = 0;
     ui64 Offset = 0;
     ui64 TestStartTime = 0;
     ui64 WriteTime = 0;
-    // Data is filled with pseudo-random values generated from the above fields
-    // The array size is chosen to make the struct size = |RegionBlockByteCount|
-    // (there are 5 ui64 fields besides Data - need to subtract them)
-    std::array<ui64, (RegionBlockByteCount / sizeof(ui64)) - 5> Data = {};
+    // The four above fields are xor-ed with this value
+    ui64 Mask = 0;
+};
+
+// A region is split in blocks of size |RegionBlockByteCount|, each filled with
+// a generated pattern
+struct Y_PACKED TRegionDataBlock
+{
+    std::array<
+        TRegionDataBlockPart,
+        RegionBlockByteCount / sizeof(TRegionDataBlockPart)>
+        Parts = {};
+
+    ui64 Zero1 = 0;
+    ui64 Zero2 = 0;
     ui64 Crc32 = 0;
 
     TStringBuf AsStringBuf(size_t len) const
@@ -169,30 +178,28 @@ ui64 UpdateSeed(ui64 seed, ui64 nonce)
     return (seed * 397) + (nonce * 31) + 13;
 }
 
-ui64 NextValue(ui64* seed)
-{
-    *seed = UpdateSeed(*seed, 0);
-    return *seed;
-}
-
 void GenerateRegionData(
     const TRegionState& state,
     ui64 offset,
     TRegionDataBlock* regionData)
 {
-    regionData->SeqNum = state.SeqNum;
-    regionData->Offset = offset;
-    regionData->TestStartTime = state.TestStartTime;
-    regionData->WriteTime = state.LastWriteTime;
+    ui64 mask = 0;
 
-    ui64 seed = UpdateSeed(0, regionData->SeqNum);
-    seed = UpdateSeed(seed, regionData->Offset);
-    seed = UpdateSeed(seed, regionData->TestStartTime);
-    seed = UpdateSeed(seed, regionData->WriteTime);
+    for (auto& part: regionData->Parts) {
+        part.SeqNum = state.SeqNum ^ mask;
+        part.Offset = offset ^ mask;
+        part.TestStartTime = state.TestStartTime ^ mask;
+        part.WriteTime = state.LastWriteTime ^ mask;
+        part.Mask = mask;
 
-    for (auto& v: regionData->Data) {
-        v = NextValue(&seed);
+        mask = UpdateSeed(mask, part.SeqNum);
+        mask = UpdateSeed(mask, part.Offset);
+        mask = UpdateSeed(mask, part.TestStartTime);
+        mask = UpdateSeed(mask, part.WriteTime);
     }
+
+    regionData->Zero1 = 0;
+    regionData->Zero2 = 0;
 
     regionData->Crc32 = Crc32c(regionData, offsetof(TRegionDataBlock, Crc32));
 }
@@ -742,16 +749,16 @@ void TUnalignedTestScenario::ValidateReadDataRegion(
         }
 
         sb << "\nActual read data:";
-        if (fragment.size() >= offsetof(TRegionDataBlock, Data)) {
+        if (fragment.size() >= sizeof(TRegionDataBlockPart)) {
             TRegionDataBlock regionData;
             MemCopy(
                 reinterpret_cast<char*>(&regionData),
                 fragment.data(),
                 fragment.size());
             sb << " ("
-               << regionData.SeqNum << ", "
-               << regionData.TestStartTime << ", "
-               << regionData.WriteTime << ")";
+               << regionData.Parts[0].SeqNum << ", "
+               << regionData.Parts[0].TestStartTime << ", "
+               << regionData.Parts[0].WriteTime << ")";
         }
         sb << "\n  " << HexText(fragment);
 

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
@@ -138,8 +138,9 @@ struct Y_PACKED TRegionDataBlock
         RegionBlockByteCount / sizeof(TRegionDataBlockPart)>
         Parts = {};
 
-    ui64 Zero1 = 0;
-    ui64 Zero2 = 0;
+    // Padding to ensure the block size is 1024 bytes
+    ui64 Padding1 = 0;
+    ui64 Padding2 = 0;
     ui64 Crc32 = 0;
 
     TStringBuf AsStringBuf(size_t len) const
@@ -198,8 +199,8 @@ void GenerateRegionData(
         mask = UpdateSeed(mask, part.WriteTime);
     }
 
-    regionData->Zero1 = 0;
-    regionData->Zero2 = 0;
+    regionData->Padding1 = 0;
+    regionData->Padding2 = 0;
 
     regionData->Crc32 = Crc32c(regionData, offsetof(TRegionDataBlock, Crc32));
 }


### PR DESCRIPTION
### Notes

Currently, only the first 4 bytes of each 1K block are informative.
It complicates the analysis of corruption incidents when corruption occurs in the middle of the block.
In this PR, the test pattern is changed in a way that metadata is repeated for the entire block.

```
May 20 13:51:52 node-0005 eternal.docker_qemu_22009[2988773]: [618675.662143] eternal.nfs_eternal_different_size_unaligned_restarts[205877]: Wrong data at file range [3886226537, 3886227561], Region: 577, OffsetInRegion: 7087104
May 20 13:51:52 node-0005 eternal.docker_qemu_22009[2988773]: [618675.662447] eternal.nfs_eternal_different_size_unaligned_restarts[205877]: Expected pattern #1: (999263, 1779099484519231, 1779285095884287)
May 20 13:51:52 node-0005 eternal.docker_qemu_22009[2988773]: [618675.662853] eternal.nfs_eternal_different_size_unaligned_restarts[205877]:   5F 3F 0F 00 00 00 00 00 00 24 6C 00 00 00 00 00 3F 7B CB E0 14 52 06 00 FF 25 18 18 40 52 06 00 80 83 D7 0B 85 60 F1 72 8D ED 36 5D 53 AE 52 40 B6 63 2E 8E 47 57 38 C0 4B A1 F0 7D F7 59 5F 17 5C 21 2A 4E CE 84 DE 3E B9 BB 55 37 EF F3 13 7F F2 1D F4 CF F8 49 F1 11 57 70 92 7D DA B6 2F D3 F8 36 18 BC D4 90 FE 80 A5 3E 8D B1 E7 99 C6 0A EE 25 0A 58 4E AC FC B5 23 D2 BC 87 7E 35 D7 38 54 E0 D1 7F 38 F5 BD 25 51 E2 78 38 9E 48 95 87 AA F7 76 93 5D 9D 81 42 AF 12 7E AF 1D 0A 01 23 70 F9 82 26 09 B0 9C 48 BD D2 1C B9 30 FE FC 9A 26 CF B2 11 8F 31 56 5A FB 3D 4B 72 DE DA AA 17 4C 1E AF 3E F7 6A F5 B3 E9 FB 91 35 6C E1 96 13 62 A8 63 13 CF 94 FB 60 07 20 8C 11 21 C5 25 66 E8 AA 4D 36 48 B4 92 68 D5 09 72 36 FC 93 81 2B 5E 3F D9 6E 20 7E F2 77 D3 44 E7 E6 4B 98 0D 03 44 BB A5 14 B5 2D 15 BC 81 68 03 05 D1 E1 D7 AC 1A 10 49 C6 24 31 C9 0A 5F F8 4D 7F 07 36 01 BA 60 2B EA 6B A0 C9 E0 73 ED 43 25 5A C7 AD 98 B3 96 56 CA CB 26 7E C5 83 AB 46 C8 08 2A A2 44 59 3C 97 95 9E 2F 7B 6F 6F 19 88 FB ED D8 08 E2 CF D2 0E 12 0F 69 B8 87 61 B7 FB 00 5F EC FA 78 3F D8 5A 86 54 8F 20 9D 6E 05 E1 5A 14 46 7E AB 89 CE F4 EE 90 AD D2 F2 7E 83 A3 91 C2 29 B7 90 DE 34 92 DA BB C2 0B 6C 26 B1 BA F4 51 FD 3C 8E 95 8A 84 85 18 D8 94 94 ED 0F 8A 0E 07 1E D3 6A 6F 50 19 8C F1 90 65 A9 C8 1D 41 43 96 C6 81 B2 2E 06 FA 4B 06 F7 40 D3 6A 5B BB D2 C3 14 BF 9B A9 2C 8C CC AD 33 53 87 06 49 60 35 86 24 07 DC 1F 42 51 C6 20 A4 13 37 68 67 03 8C D3 86 75 69 9D C8 46 21 10 16 42 8B 1C 35 C4 9A 03 37 7C F5 43 3E 46 02 97 50 A1 B1 63 33 EE 86 2E FA 29 77 9A 24 65 3F 27 FA 18 CC 8A E1 D8 4F DD EE BB 82 3E FA 54 D3 34 6D 71 BD F0 BF C7 BA EB 5A E6 C8 55 40 C3 A7 90 FF 3A 8D 08 4D CA 29 54 53 7E 04 43 76 B9 CE 84 39 E7 F7 ED 0B 9C 95 F4 32 94 71 09 1C FD 02 4C 05 D3 22 A5 79 84 A2 E0 36 3F 01 17 B2 6F 07 5C 1A 08 EF AC 17 37 88 B7 E0 90 AF 2E B8 6E 3D 9E 7C AC 43 66 65 B3 44 65 41 7D F2 96 AE 33 8A 0B 6A 3E 0C 16 E3 24 52 E5 73 CA FC 30 14 34 63 A0 BA F5 05 F8 11 C3 D7 B9 6A 12 3E A1 6A 81 99 33 82 8F 42 0D 6F B1 0D 05 EA 8C 38 90 30 29 3C D6 E9 86 B2 A7 7D DF 4B 3B A1 38 DB 0F E6 94 A9 F4 08 D2 F6 96 BB E8 FB 6A E3 B7 C3 1C 0C EA A7 E8 AC 2B 84 9B A9 F4 65 CC 24 BB F7 2B 22 6A 1C FA 10 38 2D 2F C7 96 10 DE 53 F2 1F 29 A8 D2 B9 5F 0F CC 8A C6 95 AE 2B 73 D7 73 3E E5 1E BD BD 9A 1D A5 D9 81 93 47 3E F8 E8 0E 85 5E 04 FF 94 F8 48 1F 58 94 41 79 0F 7F 29 84 A8 0C DA 09 FF 0A 5A F4 54 A1 1F 47 82 0D A3 EF BE 30 20 4B 08 F3 DB 9F 19 98 AD 80 DC E3 17 E8 BC DF 56 8C F3 5C 0C ED F3 F7 6B A1 B0 25 2C 9C 46 85 FC 52 EA 72 76 30 80 AE D9 B0 62 35 B0 27 CB 9C 92 40 0C CA 42 8C 0C 27 77 22 00 55 93 83 75 8E 98 72 35 D1 7A 0B 3D EC C5 B5 E2 6F 76 CD AA 5A 8E E2 93 82 AB A0 E0 9A 43 56 56 7F F9 29 59 2E F4 C5 E3 78 EA 17 46 E0 71 FB 39 79 9D 16 B3 CC 4A EE EA FE 34 12 BA 71 CF 88 53 52 2F 3C 8E 5D 10 29 8B AB 62 55 93 15 DD AD CE 06 04 6A 7B 75 C6 9F 83 8E 3E 68 63 30 1B C6 1E 02 03 A9 28 0A EC 37 B9 49 AA 19 0E C1 09 B9 3B 54 14 CD DD 62 02 F3 9D A0 86 08 F7 51 27 DA F1 14 C7 38 18 1C 88 4E 0F 7B BB 0C 90 91 F5 C8 BC D6 BD BE 63 BC FE A3 C3 02 66 CC AE 26 5C B8 0D F5 00 00 00 00
May 20 13:51:52 node-0005 eternal.docker_qemu_22009[2988773]: [618675.663691] eternal.nfs_eternal_different_size_unaligned_restarts[205877]: Actual read data: (999263, 1779099484519231, 1779285095884287)
May 20 13:51:52 node-0005 eternal.docker_qemu_22009[2988773]: [618675.664804] eternal.nfs_eternal_different_size_unaligned_restarts[205877]:   5F 3F 0F 00 00 00 00 00 00 24 6C 00 00 00 00 00 3F 7B CB E0 14 52 06 00 FF 25 18 18 40 52 06 00 80 83 D7 0B 85 60 F1 72 8D ED 36 5D 53 AE 52 40 B6 63 2E 8E 47 57 38 C0 4B A1 F0 7D F7 59 5F 17 5C 21 2A 4E CE 84 DE 3E B9 BB 55 37 EF F3 13 7F F2 1D F4 CF F8 49 F1 11 57 70 92 7D DA B6 2F D3 F8 36 18 BC D4 90 FE 80 A5 3E 8D B1 E7 99 C6 0A EE 25 0A 58 4E AC FC B5 23 D2 BC 87 7E 35 D7 38 54 E0 D1 7F 38 F5 BD 25 51 E2 78 38 9E 48 95 87 AA F7 76 93 5D 9D 81 42 AF 12 7E AF 1D 0A 01 23 70 F9 82 26 09 B0 9C 48 BD D2 1C B9 30 FE FC 9A 26 CF B2 11 8F 31 56 5A FB 3D 4B 72 DE DA AA 17 4C 1E AF 3E F7 6A F5 B3 E9 FB 91 35 6C E1 96 13 62 A8 63 13 CF 94 FB 60 07 20 8C 11 21 C5 25 66 E8 AA 4D 36 48 B4 92 68 D5 09 72 36 FC 93 81 2B 5E 3F D9 6E 20 7E F2 77 D3 44 E7 E6 4B 98 0D 03 44 BB A5 14 B5 2D 15 BC 81 68 03 05 D1 E1 D7 AC 1A 10 49 C6 24 31 C9 0A 5F F8 4D 7F 07 36 01 BA 60 2B EA 6B A0 C9 E0 73 ED 43 25 5A C7 AD 98 B3 96 56 CA CB 26 7E C5 83 AB 46 C8 08 2A A2 44 59 3C 97 95 9E 2F 7B 6F 6F 19 88 FB ED D8 08 E2 CF D2 0E 12 0F 69 B8 87 61 B7 FB 00 5F EC FA 78 3F D8 5A 86 54 8F 20 9D 6E 05 E1 5A 14 46 7E AB 89 CE F4 EE 90 AD D2 F2 7E 83 A3 91 C2 29 B7 90 DE 34 92 DA BB C2 0B 6C 26 B1 BA F4 51 FD 3C 8E 95 8A 84 85 18 D8 94 94 ED 0F 8A 0E 07 1E D3 6A 6F 50 19 8C F1 90 65 A9 C8 1D 41 43 96 C6 81 B2 2E 06 FA 4B 06 F7 40 D3 6A 5B BB D2 C3 14 BF 9B A9 2C 8C CC AD 33 53 87 06 49 60 35 86 24 07 DC 1F 42 51 C6 20 A4 13 37 68 67 03 8C D3 86 75 69 9D C8 46 21 10 16 42 8B 1C 35 C4 9A 03 37 7C F5 43 3E 46 02 97 50 A1 B1 63 33 EE 86 2E FA 29 77 9A 24 65 3F 27 FA 18 CC 8A E1 D8 4F DD EE BB 82 3E FA 54 D3 34 6D 71 BD F0 BF C7 BA EB 5A E6 C8 55 40 C3 A7 90 FF 3A 8D 08 4D CA 29 54 53 7E 04 43 76 B9 CE 84 39 E7 F7 ED 0B 9C 95 F4 32 94 71 09 1C FD 02 4C 05 D3 22 A5 79 84 A2 E0 36 3F 01 17 B2 6F 07 5C 1A 08 EF AC 17 37 88 B7 E0 90 AF 2E B8 6E 3D 9E 7C AC 43 66 65 B3 44 65 41 7D F2 96 AE 33 8A 0B 6A 3E 0C 16 E3 24 52 E5 73 CA FC 30 14 34 63 A0 BA F5 05 F8 11 C3 D7 B9 6A 12 3E A1 6A 81 99 33 82 8F 42 0D 6F B1 0D 05 EA 8C 38 90 30 29 3C D6 E9 86 B2 A7 7D DF 4B 3B A1 38 DB 0F E6 94 A9 F4 08 D2 F6 96 BB E8 FB 6A E3 B7 C3 1C 0C EA A7 E8 AC 2B 84 9B A9 F4 65 CC 24 BB F7 2B 22 6A 1C FA 10 38 2D 2F C7 96 10 DE 53 F2 1F 29 A8 D2 B9 5F 0F CC 8A C6 95 AE 2B 73 D7 73 3E E5 1E BD BD 9A 1D A5 D9 81 93 47 3E F8 E8 0E 85 5E 04 FF 94 F8 48 1F 58 94 41 79 0F 7F 29 84 A8 0C DA 09 FF 0A 5A F4 54 A1 1F 47 82 0D A3 EF BE 30 20 4B 08 F3 DB 9F 19 98 AD 80 DC E3 17 E8 BC DF 56 8C F3 5C 0C ED F3 F7 6B A1 B0 25 2C 9C 46 85 FC 52 EA 72 76 30 80 AE D9 B0 62 35 B0 27 CB 9C 92 40 0C CA 42 8C 0C 27 77 22 00 55 93 83 75 8E 98 72 35 D1 7A 0B 3D EC C5 B5 E2 6F 76 CD AA 5A 8E E2 93 82 AB A0 E0 9A 43 56 56 7F F9 29 59 2E F4 C5 E3 78 EA 17 46 E0 71 FB 39 79 9D 16 B3 CC 4A EE EA FE 34 12 BA F3 E7 89 C8 F3 86 F6 12 63 48 DB FD 0D 48 4F 68 A4 B5 0E AD B2 BD F2 C2 F5 BE CE 5F 16 2E 70 52 1F B3 9C 93 B2 78 F7 D7 92 A4 01 EA EE 2C C6 EA B8 61 8B E4 80 AE 53 15 C4 7A 25 6C E2 9D C5 12 15 3F 1E B6 21 D8 75 1C AE C0 E7 6C 47 2C C0 22 02 CD 64 E3 C3 AA 04 E4 4F F6 51 A3 C7 D1 3C 9B E4 E3 19 A0 79 00 00 00 00
```

