### PR TITLE
Fix data-race in TOverlappingRequestsGuard

### DIFF
--- a/cloud/blockstore/libs/service/overlapping_requests_guard.cpp
+++ b/cloud/blockstore/libs/service/overlapping_requests_guard.cpp
@@ -41,8 +41,7 @@ class TOverlappingRequestsGuard final
 private:
     const IBlockStorePtr Service;
 
-    // Set before receiving requests, so used without lock.
-    ui32 BlockSize = 0;
+    std::atomic<ui32> BlockSize = 0;
 
     TAdaptiveLock Lock;
     ui64 RequestIdGenerator = 0;
@@ -301,7 +300,8 @@ TFuture<NProto::TWriteBlocksResponse> TOverlappingRequestsGuard::WriteBlocks(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TWriteBlocksRequest> request)
 {
-    if (!BlockSize) {
+    const ui32 blockSize = BlockSize.load(std::memory_order_relaxed);
+    if (!blockSize) {
         NProto::TWriteBlocksResponse error;
         *error.MutableError() = MakeError(
             E_BS_INVALID_SESSION,
@@ -311,7 +311,7 @@ TFuture<NProto::TWriteBlocksResponse> TOverlappingRequestsGuard::WriteBlocks(
 
     const auto range = TBlockRange64::WithLength(
         request->GetStartIndex(),
-        CalculateWriteRequestBlockCount(*request, BlockSize));
+        CalculateWriteRequestBlockCount(*request, blockSize));
 
     return DoExecuteRequest<NProto::TWriteBlocksLocalResponse>(
         range,
@@ -363,7 +363,9 @@ TFuture<NProto::TMountVolumeResponse> TOverlappingRequestsGuard::MountVolume(
                 return;
             }
             if (auto self = weakSelf.lock()) {
-                self->BlockSize = response.GetVolume().GetBlockSize();
+                self->BlockSize.store(
+                    response.GetVolume().GetBlockSize(),
+                    std::memory_order_relaxed);
             }
         });
     return result;


### PR DESCRIPTION
### Notes
Fixed data-race in TOverlappingRequestsGuard. Atomic used for BlockSize.

