### PR TITLE
Remove BlockSize field from local requests

### DIFF
--- a/cloud/blockstore/apps/client/lib/backup_volume.cpp
+++ b/cloud/blockstore/apps/client/lib/backup_volume.cpp
@@ -264,7 +264,7 @@ protected:
         request->SetStartIndex(startIndex);
         request->SetBlocksCount(blocksCount);
         request->SetCheckpointId(CheckpointId);
-        request->BlockSize = BlockSize;
+        request->SetBlockSize(BlockSize);
         request->Sglist = holder.GetGuardedSgList();
 
         auto future = SrcSession->ReadBlocksLocal(
@@ -293,8 +293,8 @@ protected:
         TGuardedBuffer holder(std::move(buffer));
         auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         request->SetStartIndex(startIndex);
+        request->SetBlockSize(BlockSize);
         request->BlocksCount = blocksCount;
-        request->BlockSize = BlockSize;
         request->Sglist = holder.GetGuardedSgList();
 
         Write[bucket] = DstSession->WriteBlocksLocal(

--- a/cloud/blockstore/apps/client/lib/read_blocks.cpp
+++ b/cloud/blockstore/apps/client/lib/read_blocks.cpp
@@ -459,7 +459,7 @@ private:
             request->SetStartIndex(readRange->StartIndex);
             request->SetBlocksCount(readRange->BlocksCount);
             request->SetCheckpointId(CheckpointId);
-            request->BlockSize = Volume.GetBlockSize();
+            request->SetBlockSize(Volume.GetBlockSize());
             request->Sglist = holder.GetGuardedSgList();
             PrepareHeaders(*request->MutableHeaders());
             request->MutableHeaders()->SetReplicaIndex(ReplicaIndex);

--- a/cloud/blockstore/apps/client/lib/write_blocks.cpp
+++ b/cloud/blockstore/apps/client/lib/write_blocks.cpp
@@ -349,8 +349,8 @@ private:
             auto error = SafeExecute<NProto::TError>([&] {
                 auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
                 request->SetStartIndex(writeRange->StartIndex);
+                request->SetBlockSize(Volume.GetBlockSize());
                 request->BlocksCount = writeRange->BlocksCount;
-                request->BlockSize = Volume.GetBlockSize();
                 request->Sglist = writeRange->SgList;
                 PrepareHeaders(*request->MutableHeaders());
 

--- a/cloud/blockstore/libs/client/bench/main.cpp
+++ b/cloud/blockstore/libs/client/bench/main.cpp
@@ -159,7 +159,7 @@ Y_CPU_BENCHMARK(ClientTest, iface)
     auto context = MakeIntrusive<TCallContext>();
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->BlocksCount = 32;
-    request->BlockSize = bootstrap.BlockSize;
+    request->SetBlockSize(bootstrap.BlockSize);
 
     TVector<TString> blocks;
     request->Sglist = TGuardedSgList(ResizeBlocks(
@@ -182,7 +182,7 @@ Y_CPU_BENCHMARK(DurableClientTest, iface)
     auto context = MakeIntrusive<TCallContext>();
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->BlocksCount = 32;
-    request->BlockSize = bootstrap.BlockSize;
+    request->SetBlockSize(bootstrap.BlockSize);
 
     TVector<TString> blocks;
     request->Sglist = TGuardedSgList(ResizeBlocks(
@@ -208,7 +208,7 @@ Y_CPU_BENCHMARK(SessionDurableClientTest, iface)
     auto context = MakeIntrusive<TCallContext>();
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->BlocksCount = 32;
-    request->BlockSize = bootstrap.BlockSize;
+    request->SetBlockSize(bootstrap.BlockSize);
 
     TVector<TString> blocks;
     request->Sglist = TGuardedSgList(ResizeBlocks(
@@ -233,7 +233,7 @@ Y_CPU_BENCHMARK(SessionClientTest, iface)
     auto context = MakeIntrusive<TCallContext>();
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->BlocksCount = 32;
-    request->BlockSize = bootstrap.BlockSize;
+    request->SetBlockSize(bootstrap.BlockSize);
 
     TVector<TString> blocks;
     request->Sglist = TGuardedSgList(ResizeBlocks(
@@ -260,7 +260,7 @@ Y_CPU_BENCHMARK(EncryptionClientTest, iface)
     auto context = MakeIntrusive<TCallContext>();
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->BlocksCount = 32;
-    request->BlockSize = bootstrap.BlockSize;
+    request->SetBlockSize(bootstrap.BlockSize);
 
     TVector<TString> blocks;
     request->Sglist = TGuardedSgList(ResizeBlocks(

--- a/cloud/blockstore/libs/client/client.cpp
+++ b/cloud/blockstore/libs/client/client.cpp
@@ -74,11 +74,11 @@ NProto::TError CompleteReadBlocksLocalRequest(
     NProto::TReadBlocksLocalRequest& request,
     const NProto::TReadBlocksLocalResponse& response)
 {
-    if (request.BlockSize == 0) {
+    if (request.GetBlockSize() == 0) {
         return TErrorResponse(E_ARGUMENT, "block size is zero");
     }
 
-    auto sgListOrError = GetSgList(response, request.BlockSize);
+    auto sgListOrError = GetSgList(response, request.GetBlockSize());
     if (HasError(sgListOrError)) {
         return sgListOrError.GetError();
     }
@@ -86,7 +86,7 @@ NProto::TError CompleteReadBlocksLocalRequest(
     auto src = sgListOrError.ExtractResult();
     size_t srcSize = SgListGetSize(src);
 
-    size_t expectedSize = request.GetBlocksCount() * request.BlockSize;
+    size_t expectedSize = request.GetBlocksCount() * request.GetBlockSize();
     if (srcSize != expectedSize) {
         return TErrorResponse(E_ARGUMENT, TStringBuilder()
             << "invalid response size (expected: " << expectedSize
@@ -122,7 +122,7 @@ using TWriteBlocksRequestPtr = std::shared_ptr<NProto::TWriteBlocksRequest>;
 TResultOrError<TWriteBlocksRequestPtr> CreateWriteBlocksRequest(
     const NProto::TWriteBlocksLocalRequest& localRequest)
 {
-    if (localRequest.BlockSize == 0) {
+    if (localRequest.GetBlockSize() == 0) {
         return TErrorResponse(E_ARGUMENT, "block size is zero");
     }
 
@@ -135,7 +135,7 @@ TResultOrError<TWriteBlocksRequestPtr> CreateWriteBlocksRequest(
     const auto& src = guard.Get();
     auto srcSize = SgListGetSize(src);
 
-    size_t expectedSize = localRequest.BlocksCount * localRequest.BlockSize;
+    size_t expectedSize = localRequest.BlocksCount * localRequest.GetBlockSize();
     if (srcSize < expectedSize) {
         return TErrorResponse(E_ARGUMENT, TStringBuilder()
             << "invalid buffer size (expected: " << expectedSize
@@ -147,7 +147,7 @@ TResultOrError<TWriteBlocksRequestPtr> CreateWriteBlocksRequest(
     auto dst = ResizeIOVector(
         *request->MutableBlocks(),
         localRequest.BlocksCount,
-        localRequest.BlockSize);
+        localRequest.GetBlockSize());
 
     size_t bytesWritten = SgListCopy(src, dst);
     STORAGE_VERIFY(

--- a/cloud/blockstore/libs/client/durable_ut.cpp
+++ b/cloud/blockstore/libs/client/durable_ut.cpp
@@ -668,7 +668,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
                 request->Clear();
                 request->CommitId = 0;
-                request->BlockSize = 0;
+                request->SetBlockSize(0);
                 request->Sglist = TGuardedSgList();
 
                 NProto::TReadBlocksLocalResponse response;
@@ -693,7 +693,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
                 request->Clear();
                 request->BlocksCount = 0;
-                request->BlockSize = 0;
+                request->SetBlockSize(0);
                 request->Sglist = TGuardedSgList();
 
                 NProto::TWriteBlocksLocalResponse response;
@@ -779,7 +779,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             request->SetDiskId(diskId);
             request->SetStartIndex(startIndex);
             request->SetBlocksCount(blocksCount);
-            request->BlockSize = DefaultBlockSize;
+            request->SetBlockSize(DefaultBlockSize);
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = durable->ReadBlocksLocal(
@@ -795,7 +795,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
             request->SetDiskId(diskId);
             request->SetStartIndex(startIndex);
             request->BlocksCount = blocksCount;
-            request->BlockSize = DefaultBlockSize;
+            request->SetBlockSize(DefaultBlockSize);
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = durable->WriteBlocksLocal(

--- a/cloud/blockstore/libs/client/session_ut.cpp
+++ b/cloud/blockstore/libs/client/session_ut.cpp
@@ -347,7 +347,7 @@ Y_UNIT_TEST_SUITE(TSessionTest)
         request->SetStartIndex(startIndex);
         request->SetBlocksCount(blocksCount);
         request->SetCheckpointId(TString());
-        request->BlockSize = blockSize;
+        request->SetBlockSize(blockSize);
         request->Sglist = TGuardedSgList(std::move(sglist));
 
         return session->ReadBlocksLocal(
@@ -379,7 +379,7 @@ Y_UNIT_TEST_SUITE(TSessionTest)
         auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         request->SetStartIndex(startIndex);
         request->BlocksCount = blocksCount;
-        request->BlockSize = blockSize;
+        request->SetBlockSize(blockSize);
         request->Sglist = TGuardedSgList(std::move(sglist));
 
         return session->WriteBlocksLocal(

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -129,8 +129,8 @@ public:
 
     size_t GetResponseSize() const
     {
-        return MAX_PROTO_SIZE +
-            (static_cast<size_t>(Request->BlockSize) * Request->GetBlocksCount());
+        return MAX_PROTO_SIZE + (static_cast<size_t>(Request->GetBlockSize()) *
+                                 Request->GetBlocksCount());
     }
 
     TFuture<TResponse> GetResponse() const
@@ -273,7 +273,8 @@ public:
     {
         return NRdma::TProtoMessageSerializer::MessageByteSize(
             *Request,
-            static_cast<size_t>(Request->BlockSize) * Request->BlocksCount);
+            static_cast<size_t>(Request->GetBlockSize()) *
+                Request->BlocksCount);
     }
 
     size_t GetResponseSize() const

--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -150,8 +150,6 @@ public:
             CallContext->LWOrbit);
         StartTime = GetCycleCount();
 
-        Request->SetBlockSize(Request->BlockSize);
-
         return NRdma::TProtoMessageSerializer::Serialize(
             buffer,
             TBlockStoreProtocol::ReadBlocksRequest,
@@ -310,8 +308,6 @@ public:
 
             StartTime = GetCycleCount();
         }
-
-        Request->SetBlockSize(Request->BlockSize);
 
         return NRdma::TProtoMessageSerializer::SerializeWithData(
             buffer,

--- a/cloud/blockstore/libs/common/split_request_helpers.cpp
+++ b/cloud/blockstore/libs/common/split_request_helpers.cpp
@@ -100,13 +100,13 @@ auto SplitReadRequest(
     result.reserve(requestBlockRanges.size());
 
     auto sglistBlockRange =
-        TSgListBlockRange(originalSglist, originalRequest.BlockSize);
+        TSgListBlockRange(originalSglist, originalRequest.GetBlockSize());
     for (const auto& blockRange: requestBlockRanges) {
         auto blocksNeeded = blockRange.Size();
 
         auto newSglist = sglistBlockRange.Next(blocksNeeded);
         if (SgListGetSize(newSglist) !=
-            blocksNeeded * originalRequest.BlockSize)
+            blocksNeeded * originalRequest.GetBlockSize())
         {
             // It means that we doesn't have enough buffers in original request,
             // so it is incorrect.

--- a/cloud/blockstore/libs/common/split_request_helpers_ut.cpp
+++ b/cloud/blockstore/libs/common/split_request_helpers_ut.cpp
@@ -103,7 +103,7 @@ Y_UNIT_TEST_SUITE(TSplitRequestTest)
         request.SetFlags(1234);   // just some random number
         request.SetCheckpointId("checkpoint-1");
         request.SetSessionId("session-1");
-        request.BlockSize = blockSize;
+        request.SetBlockSize(blockSize);
         request.CommitId = 12345;
 
         // SplitRequest function doesn't access memory, so it's must be safe to
@@ -160,19 +160,23 @@ Y_UNIT_TEST_SUITE(TSplitRequestTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 blockRangeSplittedByDeviceBorders[i].Size(),
                 partSplit.GetBlocksCount());
-            UNIT_ASSERT_VALUES_EQUAL(request.BlockSize, partSplit.BlockSize);
+            UNIT_ASSERT_VALUES_EQUAL(
+                request.GetBlockSize(),
+                partSplit.GetBlockSize());
             UNIT_ASSERT_VALUES_EQUAL(request.CommitId, partSplit.CommitId);
 
             auto guard = partSplit.Sglist.Acquire();
             const auto& splitSglist = guard.Get();
             size_t overallSize = 0;
             for (auto buf: splitSglist) {
-                UNIT_ASSERT_VALUES_EQUAL(0, buf.Size() % request.BlockSize);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    0,
+                    buf.Size() % request.GetBlockSize());
                 overallSize += buf.Size();
                 overallSglist.emplace_back(buf);
             }
             UNIT_ASSERT_VALUES_EQUAL(
-                partSplit.BlockSize * partSplit.GetBlocksCount(),
+                partSplit.GetBlockSize() * partSplit.GetBlocksCount(),
                 overallSize);
         }
 
@@ -198,7 +202,7 @@ Y_UNIT_TEST_SUITE(TSplitRequestTest)
         request.SetFlags(1234);   // just some random number
         request.SetCheckpointId("checkpoint-1");
         request.SetSessionId("session-1");
-        request.BlockSize = blockSize;
+        request.SetBlockSize(blockSize);
         request.CommitId = 12345;
 
         // SplitRequest function doesn't access memory, so it's must be safe to
@@ -235,7 +239,7 @@ Y_UNIT_TEST_SUITE(TSplitRequestTest)
         request.SetFlags(1234);   // just some random number
         request.SetCheckpointId("checkpoint-1");
         request.SetSessionId("session-1");
-        request.BlockSize = blockSize;
+        request.SetBlockSize(blockSize);
         request.CommitId = 12345;
 
         // SplitRequest function doesn't access memory, so it's must be safe to

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -407,18 +407,18 @@ TFuture<NProto::TReadBlocksLocalResponse> TEncryptionClient::ReadBlocksLocal(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
 {
-    if (request->GetBlocksCount() == 0 || request->BlockSize == 0) {
+    if (request->GetBlocksCount() == 0 || request->GetBlockSize() == 0) {
         return MakeFutureErrorResponse<NProto::TReadBlocksLocalResponse>(
             E_ARGUMENT,
             "Request size should not be zero");
     }
 
     ui64 bufferSize = static_cast<ui64>(request->GetBlocksCount()) *
-        request->BlockSize;
+        request->GetBlockSize();
     auto buffer = AllocateStorageBuffer(*Client, bufferSize);
     auto sgListOrError = SgListNormalize(
         { buffer.get(), bufferSize },
-        request->BlockSize);
+        request->GetBlockSize());
 
     if (HasError(sgListOrError)) {
         return MakeFuture<NProto::TReadBlocksLocalResponse>(
@@ -478,7 +478,7 @@ NProto::TReadBlocksLocalResponse TEncryptionClient::HandleReadBlocksLocalRespons
             "failed to acquire sglist in EncryptionClient");
     }
 
-    auto sgListOrError = SgListNormalize(guard.Get(), request.BlockSize);
+    auto sgListOrError = SgListNormalize(guard.Get(), request.GetBlockSize());
     if (HasError(sgListOrError)) {
         return TErrorResponse(sgListOrError.GetError());
     }
@@ -508,7 +508,7 @@ TFuture<NProto::TWriteBlocksLocalResponse> TEncryptionClient::WriteBlocksLocal(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TWriteBlocksLocalRequest> request)
 {
-    if (request->BlocksCount == 0 || request->BlockSize == 0) {
+    if (request->BlocksCount == 0 || request->GetBlockSize() == 0) {
         return MakeFutureErrorResponse<NProto::TWriteBlocksLocalResponse>(
             E_ARGUMENT,
             "Request size should not be zero");
@@ -522,14 +522,14 @@ TFuture<NProto::TWriteBlocksLocalResponse> TEncryptionClient::WriteBlocksLocal(
     }
 
     ui64 bufferSize = static_cast<ui64>(request->BlocksCount) *
-        request->BlockSize;
+        request->GetBlockSize();
     auto buffer = AllocateStorageBuffer(*Client, bufferSize);
 
     TSgList encryptedSglist;
     {
         auto sgListOrError = SgListNormalize(
             { buffer.get(), bufferSize },
-            request->BlockSize);
+            request->GetBlockSize());
 
         if (HasError(sgListOrError)) {
             return MakeFuture<NProto::TWriteBlocksLocalResponse>(
@@ -540,7 +540,8 @@ TFuture<NProto::TWriteBlocksLocalResponse> TEncryptionClient::WriteBlocksLocal(
 
     TSgList srcSglist;
     {
-        auto sgListOrError = SgListNormalize(guard.Get(), request->BlockSize);
+        auto sgListOrError =
+            SgListNormalize(guard.Get(), request->GetBlockSize());
         if (HasError(sgListOrError)) {
             return MakeFuture<NProto::TWriteBlocksLocalResponse>(
                 TErrorResponse(sgListOrError.GetError()));
@@ -606,8 +607,8 @@ TFuture<NProto::TZeroBlocksResponse> TEncryptionClient::ZeroBlocks(
     writeRequest->SetStartIndex(request->GetStartIndex());
     writeRequest->SetFlags(request->GetFlags());
     writeRequest->SetSessionId(request->GetSessionId());
+    writeRequest->SetBlockSize(BlockSize);
     writeRequest->BlocksCount = request->GetBlocksCount();
-    writeRequest->BlockSize = BlockSize;
     writeRequest->Sglist = guardedSgList;
 
     auto future = WriteBlocksLocal(
@@ -976,7 +977,7 @@ TFuture<NProto::TReadBlocksLocalResponse> TSnapshotEncryptionClient::ReadBlocksL
     std::shared_ptr<NProto::TReadBlocksLocalRequest> request)
 {
     auto requestSglist = request->Sglist;
-    auto blockSize = request->BlockSize;
+    auto blockSize = request->GetBlockSize();
 
     auto future = Client->ReadBlocksLocal(
         std::move(callContext),

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -373,7 +373,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto sglist = ResizeBlocks(blocks, blocksCount, TString(blockSize, 0));
         auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         request->BlocksCount = blocksCount;
-        request->BlockSize = blockSize;
+        request->SetBlockSize(blockSize);
         request->Sglist = TGuardedSgList(sglist);
 
         for (size_t i = 0; i < sglist.size(); ++i) {
@@ -789,7 +789,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
         request->SetStartIndex(0);
         request->SetBlocksCount(blocksCount);
-        request->BlockSize = blockSize;
+        request->SetBlockSize(blockSize);
         request->Sglist = TGuardedSgList(sglist);
 
         auto future = encryptionClient->ReadBlocksLocal(
@@ -979,7 +979,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
         request->SetStartIndex(0);
         request->SetBlocksCount(blocksCount);
-        request->BlockSize = blockSize;
+        request->SetBlockSize(blockSize);
         request->Sglist = TGuardedSgList(sglist);
 
         auto future = encryptionClient->ReadBlocksLocal(
@@ -1100,7 +1100,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto ctx = MakeIntrusive<TCallContext>();
         auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
         request->SetBlocksCount(blocksCount);
-        request->BlockSize = DefaultBlockSize;
+        request->SetBlockSize(DefaultBlockSize);
         request->Sglist = TGuardedSgList(sglist);
 
         bitmaskStr = TString(4, 0xFF);
@@ -1223,12 +1223,12 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
         auto localReadRequest = std::make_shared<NProto::TReadBlocksLocalRequest>();
         localReadRequest->SetBlocksCount(blocksCount);
-        localReadRequest->BlockSize = DefaultBlockSize;
+        localReadRequest->SetBlockSize(DefaultBlockSize);
         localReadRequest->Sglist = TGuardedSgList(sglist);
 
         auto localWriteRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         localWriteRequest->BlocksCount = blocksCount;
-        localWriteRequest->BlockSize = DefaultBlockSize;
+        localWriteRequest->SetBlockSize(DefaultBlockSize);
         localWriteRequest->Sglist = TGuardedSgList(sglist);
 
         auto zeroRequest = std::make_shared<NProto::TZeroBlocksRequest>();
@@ -1486,7 +1486,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                     std::make_shared<NProto::TReadBlocksLocalRequest>();
                 request->SetStartIndex(0);
                 request->SetBlocksCount(blockCount);
-                request->BlockSize = BlockSize;
+                request->SetBlockSize(BlockSize);
                 request->Sglist = TGuardedSgList(sglist);
 
                 auto future = encryptionClient->ReadBlocksLocal(
@@ -1587,7 +1587,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                     std::make_shared<NProto::TReadBlocksLocalRequest>();
                 request->SetStartIndex(0);
                 request->SetBlocksCount(blockCount);
-                request->BlockSize = BlockSize;
+                request->SetBlockSize(BlockSize);
                 request->Sglist = TGuardedSgList(sglist);
 
                 auto future = encryptionClient->ReadBlocksLocal(

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -961,7 +961,7 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
             request->SetStartIndex(startIndex);
             request->BlocksCount = blocksCount;
-            request->BlockSize = DefaultBlockSize;
+            request->SetBlockSize(DefaultBlockSize);
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = session->WriteBlocksLocal(
@@ -976,7 +976,7 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
             auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
             request->SetStartIndex(startIndex);
             request->SetBlocksCount(blocksCount);
-            request->BlockSize = DefaultBlockSize;
+            request->SetBlockSize(DefaultBlockSize);
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = session->ReadBlocksLocal(

--- a/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
+++ b/cloud/blockstore/libs/endpoints_spdk/spdk_server.cpp
@@ -84,7 +84,7 @@ public:
         request->MutableHeaders()->SetTimestamp(TInstant::Now().MicroSeconds());
         request->SetStartIndex(fileOffset / BlockSize);
         request->SetBlocksCount(bytesCount / BlockSize);
-        request->BlockSize = BlockSize;
+        request->SetBlockSize(BlockSize);
 
         auto sgListOrError = SgListNormalize(
             { (char *)buf, bytesCount },
@@ -121,7 +121,7 @@ public:
         request->MutableHeaders()->SetTimestamp(TInstant::Now().MicroSeconds());
         request->SetStartIndex(fileOffset / BlockSize);
         request->SetBlocksCount(bytesCount / BlockSize);
-        request->BlockSize = BlockSize;
+        request->SetBlockSize(BlockSize);
 
         auto sgListOrError = SgListNormalize(std::move(sglist), BlockSize);
         if (HasError(sgListOrError)) {
@@ -154,8 +154,8 @@ public:
         request->MutableHeaders()->SetRequestId(callContext->RequestId);
         request->MutableHeaders()->SetTimestamp(TInstant::Now().MicroSeconds());
         request->SetStartIndex(fileOffset / BlockSize);
+        request->SetBlockSize(BlockSize);
         request->BlocksCount = bytesCount / BlockSize;
-        request->BlockSize = BlockSize;
 
         auto sgListOrError = SgListNormalize(
             { (char *)buf, bytesCount },
@@ -191,8 +191,8 @@ public:
         request->MutableHeaders()->SetRequestId(callContext->RequestId);
         request->MutableHeaders()->SetTimestamp(TInstant::Now().MicroSeconds());
         request->SetStartIndex(fileOffset / BlockSize);
+        request->SetBlockSize(BlockSize);
         request->BlocksCount = bytesCount / BlockSize;
-        request->BlockSize = BlockSize;
 
         auto sgListOrError = SgListNormalize(std::move(sglist), BlockSize);
         if (HasError(sgListOrError)) {

--- a/cloud/blockstore/libs/nbd/bench/main.cpp
+++ b/cloud/blockstore/libs/nbd/bench/main.cpp
@@ -53,7 +53,7 @@ Y_CPU_BENCHMARK(WriteBlocks, iface)
 
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->BlocksCount = blocksCount;
-    request->BlockSize = options->BlockSize;
+    request->SetBlockSize(options->BlockSize);
     request->Sglist = TGuardedSgList(std::move(sglist));
 
     for (size_t i = 0; i < iface.Iterations(); ++i) {

--- a/cloud/blockstore/libs/nbd/server_ut.cpp
+++ b/cloud/blockstore/libs/nbd/server_ut.cpp
@@ -343,7 +343,7 @@ NProto::TError ReadBlocksLocal(const IBlockStorePtr& clientEndpoint)
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(0);
     request->SetBlocksCount(blocksCount);
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
     request->Sglist = TGuardedSgList(sglist);
 
     auto future = clientEndpoint->ReadBlocksLocal(
@@ -366,8 +366,8 @@ NProto::TError WriteBlocksLocal(const IBlockStorePtr& clientEndpoint)
 
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(0);
+    request->SetBlockSize(DefaultBlockSize);
     request->BlocksCount = blocksCount;
-    request->BlockSize = DefaultBlockSize;
     request->Sglist = TGuardedSgList(sglist);
 
     auto future = clientEndpoint->WriteBlocksLocal(
@@ -473,8 +473,8 @@ Y_UNIT_TEST_SUITE(TServerTest)
         {
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
             request->SetStartIndex(startIndex);
+            request->SetBlockSize(DefaultBlockSize);
             request->BlocksCount = blocksCount;
-            request->BlockSize = DefaultBlockSize;
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = bootstrap->GetClientEndpoint()->WriteBlocksLocal(
@@ -489,7 +489,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
             auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
             request->SetStartIndex(startIndex);
             request->SetBlocksCount(blocksCount);
-            request->BlockSize = DefaultBlockSize;
+            request->SetBlockSize(DefaultBlockSize);
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = bootstrap->GetClientEndpoint()->ReadBlocksLocal(

--- a/cloud/blockstore/libs/rdma_test/memory_test_storage.cpp
+++ b/cloud/blockstore/libs/rdma_test/memory_test_storage.cpp
@@ -106,11 +106,11 @@ TFuture<NProto::TWriteBlocksLocalResponse> TMemoryTestStorage::
     const TSgList& sgList = guard.Get();
     auto range = TBlockRange32::WithLength(
         request->GetStartIndex(),
-        SgListGetSize(sgList) / request->BlockSize);
+        SgListGetSize(sgList) / request->GetBlockSize());
 
     auto lockIt = LockRange(range);
 
-    char* ptr = GetPtr(request->GetStartIndex(), request->BlockSize);
+    char* ptr = GetPtr(request->GetStartIndex(), request->GetBlockSize());
     for (auto dataRef: sgList) {
         std::memcpy(ptr, dataRef.Data(), dataRef.Size());
         ptr += dataRef.Size();
@@ -142,19 +142,19 @@ TFuture<NProto::TReadBlocksLocalResponse> TMemoryTestStorage::DoReadBlocksLocal(
     ui32 totalBlocksToRead = request->GetBlocksCount();
     ui32 totalBlocksRead = 0;
     for (auto dataRef: sgList) {
-        UNIT_ASSERT(dataRef.Size() % request->BlockSize == 0);
+        UNIT_ASSERT(dataRef.Size() % request->GetBlockSize() == 0);
 
         ui32 blocksToRead = std::min(
             totalBlocksToRead,
-            static_cast<ui32>(dataRef.Size() / request->BlockSize));
+            static_cast<ui32>(dataRef.Size() / request->GetBlockSize()));
 
         char* ptr = GetPtr(
             request->GetStartIndex() + totalBlocksRead,
-            request->BlockSize);
+            request->GetBlockSize());
         std::memcpy(
             const_cast<char*>(dataRef.Data()),
             ptr,
-            blocksToRead * request->BlockSize);
+            blocksToRead * request->GetBlockSize());
         totalBlocksToRead -= blocksToRead;
         totalBlocksRead += blocksToRead;
     }

--- a/cloud/blockstore/libs/server/server_ut.cpp
+++ b/cloud/blockstore/libs/server/server_ut.cpp
@@ -1306,7 +1306,7 @@ Y_UNIT_TEST_SUITE(TServerTest)
 
             auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
             request->SetBlocksCount(blocksCount);
-            request->BlockSize = blockSize;
+            request->SetBlockSize(blockSize);
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = endpoint->ReadBlocksLocal(
@@ -1328,8 +1328,8 @@ Y_UNIT_TEST_SUITE(TServerTest)
             memset(const_cast<char*>(buffer.data()), content, blocksCount * blockSize);
 
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
+            request->SetBlockSize(blockSize);
             request->BlocksCount = blocksCount;
-            request->BlockSize = blockSize;
             request->Sglist = TGuardedSgList({{buffer.data(), buffer.size()}});
 
             auto future = endpoint->WriteBlocksLocal(

--- a/cloud/blockstore/libs/service/aligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/aligned_device_handler.cpp
@@ -202,7 +202,6 @@ TAlignedDeviceHandler::ExecuteReadRequest(
     request->SetStartIndex(blocksInfo.Range.Start);
     request->SetBlocksCount(requestBlockCount);
     request->SetBlockSize(BlockSize);
-    request->BlockSize = BlockSize;
 
     if (requestBlockCount == blocksInfo.Range.Size()) {
         // The request size is quite small. We do all work at once.
@@ -291,7 +290,6 @@ TAlignedDeviceHandler::ExecuteWriteRequest(
     request->SetStartIndex(blocksInfo.Range.Start);
     request->SetBlockSize(BlockSize);
     request->BlocksCount = requestBlockCount;
-    request->BlockSize = BlockSize;
 
     if (requestBlockCount == blocksInfo.Range.Size()) {
         // The request size is quite small. We do all work at once.

--- a/cloud/blockstore/libs/service/request.cpp
+++ b/cloud/blockstore/libs/service/request.cpp
@@ -36,7 +36,6 @@ TWriteBlocksLocalRequest TWriteBlocksLocalRequest::CreateDependentRequest() cons
     // Copy non-protobuf fields
     copiedRecord.Sglist = Sglist;
     copiedRecord.BlocksCount = BlocksCount;
-    copiedRecord.BlockSize = BlockSize;
 
     return copiedRecord;
 }

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -35,8 +35,6 @@ struct TReadBlocksLocalRequest
 {
     TGuardedSgList Sglist;
     ui64 CommitId = 0;
-    // TODO: remove BlockSize as it is now in NProto::TReadBlocksRequest
-    ui32 BlockSize = 0;
     bool ShouldReportFailedRangesOnFailure = false;
 };
 
@@ -73,8 +71,6 @@ struct TWriteBlocksLocalRequest
 {
     TGuardedSgList Sglist;
     ui32 BlocksCount = 0;
-    // TODO: remove BlockSize as it is now in NProto::TWriteBlocksRequest
-    ui32 BlockSize = 0;
 
     std::optional<TGuardedSglistOwner> SglistOwner;
 

--- a/cloud/blockstore/libs/service/request_helpers.cpp
+++ b/cloud/blockstore/libs/service/request_helpers.cpp
@@ -101,9 +101,9 @@ ui32 CalculateWriteRequestBlockCount(
     const NProto::TWriteBlocksLocalRequest& request,
     const ui32 blockSize)
 {
-    if (blockSize != request.BlockSize) {
+    if (blockSize != request.GetBlockSize()) {
         [[maybe_unused]] ui64 sglistSize = 0;
-        [[maybe_unused]] ui64 sglistBlockSize = 0;
+        [[maybe_unused]] ui64 sglistBlockSize = blockSize;
         {
             auto guard = request.Sglist.Acquire();
             if (guard && guard.Get().size()) {
@@ -117,7 +117,7 @@ ui32 CalculateWriteRequestBlockCount(
             "blockSize %u != request.BlockSize %u, request.BlocksCount=%u"
             ", sglist size=%lu, sglist buffer size=%lu",
             blockSize,
-            request.BlockSize,
+            request.GetBlockSize(),
             request.BlocksCount,
             sglistSize,
             sglistBlockSize);

--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -66,12 +66,12 @@ TVector<std::shared_ptr<NProto::TReadBlocksLocalRequest>> CreateSubRequests(
         subRequest->CopyFrom(*request);
         subRequest->SetStartIndex(subRange.Start);
         subRequest->SetBlocksCount(subRange.Size());
-        subRequest->BlockSize = request->BlockSize;
 
         auto subSgList = CreateSgListSubRange(
             srcSgList,
-            (subRange.Start - request->GetStartIndex()) * request->BlockSize,
-            subRange.Size() * request->BlockSize);
+            (subRange.Start - request->GetStartIndex()) *
+                request->GetBlockSize(),
+            subRange.Size() * request->GetBlockSize());
         subRequest->Sglist =
             request->Sglist.CreateDepender(std::move(subSgList));
 
@@ -137,12 +137,12 @@ TVector<std::shared_ptr<NProto::TWriteBlocksLocalRequest>> CreateSubRequests(
         subRequest->CopyFrom(*request);
         subRequest->SetStartIndex(subRange.Start);
         subRequest->BlocksCount = subRange.Size();
-        subRequest->BlockSize = request->BlockSize;
+        subRequest->SetBlockSize(request->GetBlockSize());
 
         auto subSgList = CreateSgListSubRange(
             srcSgList,
-            (subRange.Start - request->GetStartIndex()) * request->BlockSize,
-            subRange.Size() * request->BlockSize);
+            (subRange.Start - request->GetStartIndex()) * request->GetBlockSize(),
+            subRange.Size() * request->GetBlockSize());
 
         if (request->ChecksumsSize() > 0) {
             subRequest->MutableChecksums()->Clear();

--- a/cloud/blockstore/libs/service/split_request_service_ut.cpp
+++ b/cloud/blockstore/libs/service/split_request_service_ut.cpp
@@ -268,7 +268,7 @@ struct TTestEnvironment
         request->SetDiskId(DefaultDiskId);
         request->SetStartIndex(range.Start);
         request->SetBlocksCount(range.Size());
-        request->BlockSize = DefaultBlockSize;
+        request->SetBlockSize(DefaultBlockSize);
         request->Sglist = TGuardedSgList(
             {TBlockDataRef(data->data(), range.Size() * DefaultBlockSize)});
         UNIT_ASSERT_VALUES_EQUAL(range.Size() * DefaultBlockSize, data->size());
@@ -295,7 +295,7 @@ struct TTestEnvironment
     {
         request->SetDiskId(DefaultDiskId);
         request->SetStartIndex(range.Start);
-        request->BlockSize = DefaultBlockSize;
+        request->SetBlockSize(DefaultBlockSize);
         request->BlocksCount = range.Size();
 
         TSgList sglist;

--- a/cloud/blockstore/libs/service/storage.cpp
+++ b/cloud/blockstore/libs/service/storage.cpp
@@ -298,7 +298,6 @@ TFuture<NProto::TReadBlocksResponse> TStorageAdapter::TImpl::ReadBlocks(
     localRequest->SetCheckpointId(request->GetCheckpointId());
     localRequest->SetSessionId(request->GetSessionId());
     localRequest->SetBlockSize(StorageBlockSize);
-    localRequest->BlockSize = StorageBlockSize;
 
     auto response = std::make_shared<NProto::TReadBlocksResponse>();
 
@@ -443,7 +442,6 @@ TFuture<NProto::TWriteBlocksResponse> TStorageAdapter::TImpl::WriteBlocks(
     localRequest->SetSessionId(request->GetSessionId());
     localRequest->SetBlockSize(StorageBlockSize);
     localRequest->BlocksCount = localBlocksCount;
-    localRequest->BlockSize = StorageBlockSize;
     if (request->ChecksumsSize() > 0) {
         localRequest->MutableChecksums()->CopyFrom(request->GetChecksums());
     }

--- a/cloud/blockstore/libs/service/storage_ut.cpp
+++ b/cloud/blockstore/libs/service/storage_ut.cpp
@@ -63,7 +63,7 @@ Y_UNIT_TEST_SUITE(TStorageTest)
             Y_UNUSED(ctx);
 
             UNIT_ASSERT_VALUES_EQUAL(1_MB / 4_KB, request->BlocksCount);
-            UNIT_ASSERT_VALUES_EQUAL(4_KB, request->BlockSize);
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, request->GetBlockSize());
 
             auto guard = request->Sglist.Acquire();
             UNIT_ASSERT(guard);
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(TStorageTest)
             Y_UNUSED(ctx);
 
             UNIT_ASSERT_VALUES_EQUAL(1_MB / 4_KB, request->BlocksCount);
-            UNIT_ASSERT_VALUES_EQUAL(4_KB, request->BlockSize);
+            UNIT_ASSERT_VALUES_EQUAL(4_KB, request->GetBlockSize());
 
             auto guard = request->Sglist.Acquire();
             UNIT_ASSERT(guard);
@@ -448,7 +448,7 @@ Y_UNIT_TEST_SUITE(TStorageTest)
 
             const ui64 requestByteCount =
                 static_cast<ui64>(request->GetBlocksCount()) *
-                request->BlockSize;
+                request->GetBlockSize();
 
             TString data;
             data.resize(requestByteCount, 0);

--- a/cloud/blockstore/libs/service_local/compound_storage.cpp
+++ b/cloud/blockstore/libs/service_local/compound_storage.cpp
@@ -436,7 +436,7 @@ TFuture<NProto::TReadBlocksLocalResponse> TCompoundStorage::ReadBlocksLocal(
         subRequest->MutableHeaders()->CopyFrom(request->GetHeaders());
         subRequest->SetStartIndex(startIndex);
         subRequest->SetBlocksCount(blockCount);
-        subRequest->BlockSize = request->BlockSize;
+        subRequest->SetBlockSize(request->GetBlockSize());
         subRequest->Sglist.SetSgList(src.Next(blockCount));
 
         Storages[storageBlockRange.Storage]->ReadBlocksLocal(
@@ -509,8 +509,8 @@ TFuture<NProto::TWriteBlocksLocalResponse> TCompoundStorage::WriteBlocksLocal(
         auto subRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         subRequest->MutableHeaders()->CopyFrom(request->GetHeaders());
         subRequest->SetStartIndex(startIndex);
+        subRequest->SetBlockSize(request->GetBlockSize());
         subRequest->BlocksCount = blockCount;
-        subRequest->BlockSize = request->BlockSize;
         subRequest->Sglist.SetSgList(dst.Next(blockCount));
 
         Storages[storageBlockRange.Storage]->WriteBlocksLocal(

--- a/cloud/blockstore/libs/service_local/compound_storage_ut.cpp
+++ b/cloud/blockstore/libs/service_local/compound_storage_ut.cpp
@@ -197,7 +197,7 @@ auto RequestReadBlocksLocal(IStoragePtr storage, ui64 startIndex, ui32 blockCoun
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
     request->SetBlocksCount(blockCount);
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
 
     const auto bytes = blockCount * DefaultBlockSize;
     auto buffer = storage->AllocateBuffer(bytes);
@@ -216,7 +216,7 @@ TString ReadBlocksLocal(IStoragePtr storage, ui64 startIndex, ui32 blockCount)
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
     request->SetBlocksCount(blockCount);
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
 
     const auto bytes = blockCount * DefaultBlockSize;
     auto buffer = storage->AllocateBuffer(bytes);
@@ -253,7 +253,7 @@ auto RequestWriteBlocksLocal(
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
     request->BlocksCount = blockCount;
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
 
     const auto bytes = blockCount * DefaultBlockSize;
 
@@ -794,7 +794,7 @@ Y_UNIT_TEST_SUITE(TCompoundStorageTest)
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
             request->SetStartIndex(0);
             request->BlocksCount = 100;
-            request->BlockSize = DefaultBlockSize;
+            request->SetBlockSize(DefaultBlockSize);
             request->Sglist.Close();
 
             auto response = storage->WriteBlocksLocal(
@@ -807,7 +807,7 @@ Y_UNIT_TEST_SUITE(TCompoundStorageTest)
         {
             auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
             request->SetBlocksCount(100);
-            request->BlockSize = DefaultBlockSize;
+            request->SetBlockSize(DefaultBlockSize);
             request->Sglist.Close();
 
             auto response = storage->ReadBlocksLocal(

--- a/cloud/blockstore/libs/service_local/storage_local_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_local_ut.cpp
@@ -51,7 +51,7 @@ TFuture<NProto::TReadBlocksLocalResponse> ReadBlocksLocal(
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
     request->SetBlocksCount(blockCount);
-    request->BlockSize = blockSize;
+    request->SetBlockSize(blockSize);
     request->Sglist = std::move(sglist);
 
     return storage.ReadBlocksLocal(
@@ -70,8 +70,8 @@ TFuture<NProto::TWriteBlocksLocalResponse> WriteBlocksLocal(
 
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
+    request->SetBlockSize(blockSize);
     request->BlocksCount = blockCount;
-    request->BlockSize = blockSize;
     request->Sglist = std::move(sglist);
 
     return storage.WriteBlocksLocal(

--- a/cloud/blockstore/libs/service_local/storage_local_ut_large.cpp
+++ b/cloud/blockstore/libs/service_local/storage_local_ut_large.cpp
@@ -83,8 +83,8 @@ Y_UNIT_TEST_SUITE(TLocalStorageTest)
         auto write = [&] (ui64 startIndex, ui64 blockCount) {
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
             request->SetStartIndex(startIndex);
+            request->SetBlockSize(blockSize);
             request->BlocksCount = blockCount;
-            request->BlockSize = blockSize;
             request->Sglist = writeSgList;
 
             auto response = storage->WriteBlocksLocal(
@@ -103,7 +103,7 @@ Y_UNIT_TEST_SUITE(TLocalStorageTest)
             auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
             request->SetStartIndex(startIndex);
             request->SetBlocksCount(blockCount);
-            request->BlockSize = blockSize;
+            request->SetBlockSize(blockSize);
             request->Sglist = readSgList;
 
             auto response = storage->ReadBlocksLocal(

--- a/cloud/blockstore/libs/service_local/storage_null_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_null_ut.cpp
@@ -37,7 +37,7 @@ auto ReadBlocksLocal(IStorage& storage, TGuardedSgList sglist)
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(0);
     request->SetBlocksCount(1);
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
     request->Sglist = std::move(sglist);
 
     return storage.ReadBlocksLocal(
@@ -52,7 +52,7 @@ auto WriteBlocksLocal(IStorage& storage, TGuardedSgList sglist)
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(0);
     request->BlocksCount = 1;
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
     request->Sglist = std::move(sglist);
 
     return storage.WriteBlocksLocal(

--- a/cloud/blockstore/libs/service_local/storage_rdma.cpp
+++ b/cloud/blockstore/libs/service_local/storage_rdma.cpp
@@ -188,7 +188,8 @@ public:
     {
         return Serializer->MessageByteSize(
             Proto,
-            Request->BlockSize * Request->BlocksCount);
+            static_cast<size_t>(Request->GetBlockSize()) *
+                Request->BlocksCount);
     }
 
     size_t GetResponseSize() const

--- a/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_spdk_ut.cpp
@@ -290,7 +290,7 @@ TFuture<NProto::TReadBlocksLocalResponse> ReadBlocksLocal(
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
     request->SetBlocksCount(blocksCount);
-    request->BlockSize = blockSize;
+    request->SetBlockSize(blockSize);
     request->Sglist = std::move(sglist);
 
     return storage.ReadBlocksLocal(
@@ -309,8 +309,8 @@ TFuture<NProto::TWriteBlocksLocalResponse> WriteBlocksLocal(
 
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(startIndex);
+    request->SetBlockSize(blockSize);
     request->BlocksCount = blocksCount;
-    request->BlockSize = blockSize;
     request->Sglist = std::move(sglist);
 
     return storage.WriteBlocksLocal(
@@ -609,7 +609,7 @@ Y_UNIT_TEST_SUITE(TSpdkStorageTest)
             auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
             request->SetStartIndex(8);
             request->BlocksCount = sglist.size();
-            request->BlockSize = blockSize;
+            request->SetBlockSize(blockSize);
             request->Sglist = TGuardedSgList(std::move(sglist));
 
             auto future = storage->WriteBlocksLocal(
@@ -627,7 +627,7 @@ Y_UNIT_TEST_SUITE(TSpdkStorageTest)
             auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
             request->SetStartIndex(8);
             request->SetBlocksCount(sglist.size());
-            request->BlockSize = blockSize;
+            request->SetBlockSize(blockSize);
             request->Sglist = TGuardedSgList(sglist);
 
             auto future = storage->ReadBlocksLocal(

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -220,7 +220,6 @@ private:
 
         auto req = std::make_shared<NProto::TReadBlocksLocalRequest>();
         req->CopyFrom(*request);
-        req->BlockSize = request->GetBlockSize();
 
         req->Sglist = guardedSgList;
 
@@ -315,8 +314,8 @@ private:
         req->CopyFrom(*request);
 
         req->Sglist = guardedSgList;
-        req->BlockSize = request->GetBlockSize();
-        req->BlocksCount = requestData.length() / req->BlockSize;
+        req->SetBlockSize(request->GetBlockSize());
+        req->BlocksCount = requestData.length() / req->GetBlockSize();
 
         auto future = Service->WriteBlocksLocal(callContext, std::move(req));
 

--- a/cloud/blockstore/libs/storage/core/block_handler_ut.cpp
+++ b/cloud/blockstore/libs/storage/core/block_handler_ut.cpp
@@ -28,8 +28,8 @@ IWriteBlocksHandlerPtr CreateTestWriteBlocksHandler(
     auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
     request->Record.Sglist = TGuardedSgList(std::move(sglist));
     request->Record.SetStartIndex(range.Start);
+    request->Record.SetBlockSize(content.size() / range.Size());
     request->Record.BlocksCount = range.Size();
-    request->Record.BlockSize = content.size() / range.Size();
 
     return CreateWriteBlocksHandler(range, std::move(request));
 }

--- a/cloud/blockstore/libs/storage/disk_agent/hash_table_storage.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/hash_table_storage.cpp
@@ -124,7 +124,7 @@ struct THashTableStorage final
 
         while (b < e) {
             auto& block = Blocks[b];
-            block.resize(request->BlockSize);
+            block.resize(request->GetBlockSize());
             dst[b - request->GetStartIndex()] = {block.data(), block.size()};
             ++b;
         }

--- a/cloud/blockstore/libs/storage/disk_agent/storage_with_stats_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_with_stats_ut.cpp
@@ -99,7 +99,7 @@ void ReadBlocksLocal(IStoragePtr storage)
 {
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetBlocksCount(DefaultBlockCount);
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
 
     TVector<TString> blocks;
     request->Sglist.SetSgList(ResizeBlocks(
@@ -117,7 +117,7 @@ void WriteBlocksLocal(IStoragePtr storage)
 {
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->BlocksCount = DefaultBlockCount;
-    request->BlockSize = DefaultBlockSize;
+    request->SetBlockSize(DefaultBlockSize);
 
     TVector<TString> blocks;
     request->Sglist.SetSgList(ResizeBlocks(

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -163,9 +163,9 @@ public:
         auto request =
             std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
         request->Record.SetStartIndex(writeRange.Start);
+        request->Record.SetBlockSize(blockSize);
         request->Record.Sglist = std::move(sglist);
         request->Record.BlocksCount = writeRange.Size();
-        request->Record.BlockSize = blockSize;
         return request;
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_view.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_view.cpp
@@ -117,9 +117,9 @@ void THttpReadBlockActor::ReadBlocks(const TActorContext& ctx)
     auto request = std::make_unique<TEvService::TEvReadBlocksLocalRequest>();
     request->Record.SetStartIndex(BlockIndex);
     request->Record.SetBlocksCount(1);
+    request->Record.SetBlockSize(BufferHolder.Get().size());
     request->Record.Sglist = BufferHolder.GetGuardedSgList();
     request->Record.CommitId = CommitId;
-    request->Record.BlockSize = BufferHolder.Get().size();
 
     NCloud::SendWithUndeliveryTracking(
         ctx,

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_view.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_view.cpp
@@ -110,9 +110,9 @@ void THttpReadBlockActor::ReadBlocks(const TActorContext& ctx)
     auto request = std::make_unique<TEvService::TEvReadBlocksLocalRequest>();
     request->Record.SetStartIndex(BlockIndex);
     request->Record.SetBlocksCount(1);
+    request->Record.SetBlockSize(BufferHolder.Get().size());
     request->Record.Sglist = BufferHolder.GetGuardedSgList();
     request->Record.CommitId = CommitId;
-    request->Record.BlockSize = BufferHolder.Get().size();
 
     NCloud::Send(
         ctx,

--- a/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_ut.cpp
@@ -545,9 +545,9 @@ public:
 
         auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
         request->Record.SetStartIndex(writeRange.Start);
+        request->Record.SetBlockSize(blockContent.size() / writeRange.Size());
         request->Record.Sglist = TGuardedSgList(std::move(sglist));
         request->Record.BlocksCount = writeRange.Size();
-        request->Record.BlockSize = blockContent.size() / writeRange.Size();
         return request;
     }
 
@@ -627,9 +627,9 @@ public:
         request->Record.SetCheckpointId(checkpointId);
         request->Record.SetStartIndex(readRange.Start);
         request->Record.SetBlocksCount(readRange.Size());
+        request->Record.SetBlockSize(SgListGetSize(sglist) / readRange.Size());
 
         request->Record.Sglist = TGuardedSgList(sglist);
-        request->Record.BlockSize = SgListGetSize(sglist) / readRange.Size();
         return request;
     }
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agents_replica_proxy_actor.cpp
@@ -510,7 +510,7 @@ TResultOrError<TVector<TSplitRequest>> TLaggingAgentsReplicaProxyActor::DoSplitR
             "Failed to acquire sglist in LaggingAgentsReplicaProxyActor");
     }
 
-    TSgListBlockRange src(guard.Get(), msg->Record.BlockSize);
+    TSgListBlockRange src(guard.Get(), msg->Record.GetBlockSize());
 
     for (const auto& deviceRequest: deviceRequests) {
         auto request =
@@ -522,7 +522,7 @@ TResultOrError<TVector<TSplitRequest>> TLaggingAgentsReplicaProxyActor::DoSplitR
 
         request->Record.SetStartIndex(deviceRequest.BlockRange.Start);
         request->Record.BlocksCount = deviceRequest.BlockRange.Size();
-        request->Record.BlockSize = msg->Record.BlockSize;
+        request->Record.SetBlockSize(msg->Record.GetBlockSize());
 
         Y_DEBUG_ABORT_UNLESS(src.HasNext());
         TSgList sglist = src.Next(deviceRequest.BlockRange.Size());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/multi_agent_write_actor.h
@@ -225,8 +225,8 @@ void TMultiAgentWriteActor<TMethod>::SendMultiagentWriteRequest(
     auto& rec = request->Record;
 
     *rec.MutableHeaders() = Request.GetHeaders();
-    rec.BlockSize =
-        ReplicasDiscovery[0].DiscoveryResult.PartConfig->GetBlockSize();
+    rec.SetBlockSize(
+        ReplicasDiscovery[0].DiscoveryResult.PartConfig->GetBlockSize());
     rec.Range = Range;
     if constexpr (IsExactlyWriteMethod<TMethod>) {
         rec.MutableChecksums()->CopyFrom(Request.GetChecksums());
@@ -246,7 +246,10 @@ void TMultiAgentWriteActor<TMethod>::SendMultiagentWriteRequest(
         }
         SgListCopy(
             guard.Get(),
-            ResizeIOVector(*rec.MutableBlocks(), Range.Size(), rec.BlockSize));
+            ResizeIOVector(
+                *rec.MutableBlocks(),
+                Range.Size(),
+                rec.GetBlockSize()));
 
     } else {
         rec.MutableBlocks()->Swap(Request.MutableBlocks());

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_fastpath_actor.cpp
@@ -69,7 +69,7 @@ void TMirrorPartitionResyncFastPathActor::ReadBlocks(const TActorContext& ctx)
     auto request = std::make_unique<TEvService::TEvReadBlocksLocalRequest>();
     request->Record.SetStartIndex(Range.Start);
     request->Record.SetBlocksCount(Range.Size());
-    request->Record.BlockSize = BlockSize;
+    request->Record.SetBlockSize(BlockSize);
     request->Record.Sglist = SgList;
 
     auto* headers = request->Record.MutableHeaders();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor_writeblocks_multi_agent.cpp
@@ -101,7 +101,7 @@ void TDiskAgentMultiWriteActor::SendRequest(const TActorContext& ctx)
         std::make_unique<TEvDiskAgent::TEvWriteDeviceBlocksRequest>();
 
     *request->Record.MutableHeaders() = Request.GetHeaders();
-    request->Record.SetBlockSize(Request.BlockSize);
+    request->Record.SetBlockSize(Request.GetBlockSize());
     request->Record.MutableBlocks()->Swap(Request.MutableBlocks());
 
     for (const auto& deviceInfo: Request.DevicesAndRanges) {
@@ -120,7 +120,8 @@ void TDiskAgentMultiWriteActor::SendRequest(const TActorContext& ctx)
     if (auto checksum = CombineChecksums(Request.GetChecksums());
         checksum.GetByteCount() > 0)
     {
-        if (checksum.GetByteCount() == Request.Range.Size() * Request.BlockSize)
+        if (checksum.GetByteCount() ==
+            Request.Range.Size() * Request.GetBlockSize())
         {
             *request->Record.MutableChecksum() = std::move(checksum);
         } else {
@@ -130,7 +131,7 @@ void TDiskAgentMultiWriteActor::SendRequest(const TActorContext& ctx)
                 {{"range", Request.Range.Print()},
                  {"request range length", Request.Range.Size()},
                  {"checksum length",
-                  checksum.GetByteCount() / Request.BlockSize},
+                  checksum.GetByteCount() / Request.GetBlockSize()},
                  {"disk id", PartConfig->GetName().Quote()}});
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_events_private.h
@@ -646,7 +646,6 @@ struct TMultiAgentWriteRequest: public NProto::TWriteBlocksRequest
     using TGetDeviceForRangeResponse = NCloud::NBlockStore::NStorage::
         TEvNonreplPartitionPrivate::TGetDeviceForRangeResponse;
 
-    ui32 BlockSize = 0;
     TBlockRange64 Range;
     TVector<TGetDeviceForRangeResponse> DevicesAndRanges;
 };

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks_multi_agent.cpp
@@ -133,7 +133,7 @@ NProto::TWriteDeviceBlocksRequest MakeWriteDeviceBlocksRequest(
 {
     NProto::TWriteDeviceBlocksRequest result;
     *result.MutableHeaders() = request.GetHeaders();
-    result.SetBlockSize(request.BlockSize);
+    result.SetBlockSize(request.GetBlockSize());
 
     for (const auto& deviceInfo: request.DevicesAndRanges) {
         auto* replicationTarget = result.AddReplicationTargets();
@@ -150,7 +150,8 @@ NProto::TWriteDeviceBlocksRequest MakeWriteDeviceBlocksRequest(
     if (auto checksum = CombineChecksums(request.GetChecksums());
         checksum.GetByteCount() > 0)
     {
-        if (checksum.GetByteCount() == request.Range.Size() * request.BlockSize)
+        if (checksum.GetByteCount() ==
+            request.Range.Size() * request.GetBlockSize())
         {
             *result.MutableChecksum() = std::move(checksum);
         } else {
@@ -160,7 +161,7 @@ NProto::TWriteDeviceBlocksRequest MakeWriteDeviceBlocksRequest(
                 {{"range", request.Range.Print()},
                  {"request range length", request.Range.Size()},
                  {"checksum length",
-                  checksum.GetByteCount() / request.BlockSize},
+                  checksum.GetByteCount() / request.GetBlockSize()},
                  {"disk id", partConfig->GetName().Quote()}});
         }
     }
@@ -275,7 +276,7 @@ void TNonreplicatedPartitionRdmaActor::HandleMultiAgentWrite(
         std::make_unique<TDeviceRequestRdmaContext>(deviceRequest.DeviceIdx),
         NCloud::NStorage::NRdma::TProtoMessageSerializer::MessageByteSize(
             writeDeviceBlocksRequest,
-            blockRange.Size() * msg->Record.BlockSize),
+            blockRange.Size() * msg->Record.GetBlockSize()),
         4_KB);
 
     if (HasError(err)) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/resync_range.cpp
@@ -188,7 +188,7 @@ void TResyncRangeActor::ReadBlocks(const TActorContext& ctx)
     auto request = std::make_unique<TEvService::TEvReadBlocksLocalRequest>();
     request->Record.SetStartIndex(Range.Start);
     request->Record.SetBlocksCount(Range.Size());
-    request->Record.BlockSize = BlockSize;
+    request->Record.SetBlockSize(BlockSize);
     request->Record.Sglist = SgList;
 
     auto* headers = request->Record.MutableHeaders();
@@ -232,7 +232,7 @@ void TResyncRangeActor::WriteReplicaBlocks(
     auto clientId =
         WriterClientId ? WriterClientId : TString(BackgroundOpsClientId);
     request->Record.BlocksCount = Range.Size();
-    request->Record.BlockSize = BlockSize;
+    request->Record.SetBlockSize(BlockSize);
     request->Record.Sglist = SgList;
     if (readResponse.HasChecksum()) {
         *request->Record.MutableChecksums()->Add() = readResponse.GetChecksum();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut_env.h
@@ -445,7 +445,7 @@ public:
                 Min<ui32>(blocksInBuffer, (blockRange.Size() - i)) * BlockSize,
                 fill);
         }
-        request->Record.BlockSize = BlockSize;
+        request->Record.SetBlockSize(BlockSize);
         request->Record.Range = blockRange;
         request->Record.DevicesAndRanges = std::move(devicesAndRanges);
 
@@ -468,8 +468,8 @@ public:
         auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
         request->Record.Sglist = TGuardedSgList(std::move(sglist));
         request->Record.SetStartIndex(range.Start);
+        request->Record.SetBlockSize(BlockSize);
         request->Record.BlocksCount = range.Size();
-        request->Record.BlockSize = BlockSize;
         Y_ABORT_UNLESS(BlockSize == content.size());
 
         return request;
@@ -481,7 +481,7 @@ public:
         request->Record.Sglist = std::move(sglist);
         request->Record.SetStartIndex(range.Start);
         request->Record.SetBlocksCount(range.Size());
-        request->Record.BlockSize = BlockSize;
+        request->Record.SetBlockSize(BlockSize);
 
         return request;
     }

--- a/cloud/blockstore/libs/storage/service/service_ut_read_write.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_read_write.cpp
@@ -374,6 +374,7 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
         writeBlocksRequest->Record.SetSessionId(sessionId);
         writeBlocksRequest->Record.SetStartIndex(0);
         writeBlocksRequest->Record.MutableHeaders()->SetClientId(service.GetClientId());
+        writeBlocksRequest->Record.SetBlockSize(DefaultBlockSize);
 
         ui32 blocksCount = 1024;
         auto writeBlockContent = GetBlockContent(char(1));
@@ -381,7 +382,6 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
         sglist.resize(blocksCount, {writeBlockContent.data(), writeBlockContent.size()});
         writeBlocksRequest->Record.Sglist = TGuardedSgList(std::move(sglist));
         writeBlocksRequest->Record.BlocksCount = blocksCount;
-        writeBlocksRequest->Record.BlockSize = DefaultBlockSize;
 
         service.SendRequest(MakeStorageServiceId(), std::move(writeBlocksRequest));
         auto response = service.RecvWriteBlocksLocalResponse();
@@ -452,11 +452,11 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
         readBlocksRequest->Record.SetStartIndex(0);
         readBlocksRequest->Record.SetBlocksCount(1);
         readBlocksRequest->Record.MutableHeaders()->SetClientId(service.GetClientId());
+        readBlocksRequest->Record.SetBlockSize(DefaultBlockSize);
 
         auto block = TString::Uninitialized(DefaultBlockSize);
         auto buffer = TGuardedBuffer(std::move(block));
         readBlocksRequest->Record.Sglist = buffer.GetGuardedSgList();
-        readBlocksRequest->Record.BlockSize = DefaultBlockSize;
 
         service.SendRequest(MakeStorageServiceId(), std::move(readBlocksRequest));
         auto response = service.RecvReadBlocksLocalResponse();
@@ -567,11 +567,11 @@ Y_UNIT_TEST_SUITE(TServiceReadWriteZeroBlocksTest)
         readBlocksRequest->Record.SetStartIndex(0);
         readBlocksRequest->Record.SetBlocksCount(1);
         readBlocksRequest->Record.MutableHeaders()->SetClientId(service.GetClientId());
+        readBlocksRequest->Record.SetBlockSize(DefaultBlockSize);
 
         auto block = TString::Uninitialized(DefaultBlockSize);
         auto buffer = TGuardedBuffer(std::move(block));
         readBlocksRequest->Record.Sglist = buffer.GetGuardedSgList();
-        readBlocksRequest->Record.BlockSize = DefaultBlockSize;
 
         service.SendRequest(MakeStorageServiceId(), std::move(readBlocksRequest));
         auto response = service.RecvReadBlocksLocalResponse();

--- a/cloud/blockstore/libs/storage/testlib/part_client.cpp
+++ b/cloud/blockstore/libs/storage/testlib/part_client.cpp
@@ -110,9 +110,9 @@ TPartitionClient::CreateWriteBlocksLocalRequest(
 
     auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
     request->Record.SetStartIndex(writeRange.Start);
+    request->Record.SetBlockSize(blockContent.size() / writeRange.Size());
     request->Record.Sglist = TGuardedSgList(std::move(sglist));
     request->Record.BlocksCount = writeRange.Size();
-    request->Record.BlockSize = blockContent.size() / writeRange.Size();
     return request;
 }
 
@@ -218,9 +218,9 @@ TPartitionClient::CreateReadBlocksLocalRequest(
     request->Record.SetCheckpointId(checkpointId);
     request->Record.SetStartIndex(readRange.Start);
     request->Record.SetBlocksCount(readRange.Size());
+    request->Record.SetBlockSize(DefaultBlockSize);
 
     request->Record.Sglist = sglist;
-    request->Record.BlockSize = DefaultBlockSize;
     return request;
 }
 

--- a/cloud/blockstore/libs/storage/testlib/service_client.cpp
+++ b/cloud/blockstore/libs/storage/testlib/service_client.cpp
@@ -289,8 +289,8 @@ std::unique_ptr<TEvService::TEvReadBlocksLocalRequest> TServiceClient::CreateRea
     request->Record.SetSessionId(sessionId);
     request->Record.SetBlocksCount(1);
     request->Record.SetCheckpointId(checkpointId);
+    request->Record.SetBlockSize(DefaultBlockSize);
     request->Record.Sglist = std::move(sglist);
-    request->Record.BlockSize = DefaultBlockSize;
     return request;
 }
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_requests.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_requests.cpp
@@ -338,7 +338,7 @@ NProto::TError ToPartitionRequests<TEvService::TWriteBlocksLocalMethod>(
         );
 
         request.Event->Record.BlocksCount = blocksCount;
-        request.Event->Record.BlockSize = blockSize;
+        request.Event->Record.SetBlockSize(blockSize);
     }
 
     return MakeError(S_OK);
@@ -383,7 +383,7 @@ NProto::TError ToPartitionRequests<TEvService::TReadBlocksLocalMethod>(
 
         request.Event->Record.SetBlocksCount(blocksCount);
         request.Event->Record.SetCheckpointId(proto.GetCheckpointId());
-        request.Event->Record.BlockSize = blockSize;
+        request.Event->Record.SetBlockSize(blockSize);
         request.Event->Record.ShouldReportFailedRangesOnFailure =
             ev->Get()->Record.ShouldReportFailedRangesOnFailure;
     }

--- a/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay.cpp
@@ -159,7 +159,7 @@ bool TReadDiskRegistryBasedOverlayActor<TMethod>::InitRequest(
         static_cast<const NProto::TReadBlocksRequest&>(OriginalRequest);
     request.SetStartIndex(blockIndices.front());
     request.SetBlocksCount(resultSgList.size());
-    request.BlockSize = BlockSize;
+    request.SetBlockSize(BlockSize);
     request.Sglist = sgList.Create(std::move(resultSgList));
 
     if constexpr (std::is_same_v<TMethod, TEvService::TReadBlocksLocalMethod>) {

--- a/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/read_disk_registry_based_overlay_ut.cpp
@@ -185,7 +185,7 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
         auto request = NProto::TReadBlocksLocalRequest();
         request.SetStartIndex(0);
         request.SetBlocksCount(10);
-        request.BlockSize = blockSize;
+        request.SetBlockSize(blockSize);
         request.Sglist = TGuardedSgList(std::move(sglist));
 
         ActorSystem.Register(new TReadDiskRegistryBasedOverlayActor<
@@ -375,7 +375,7 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
         auto request = NProto::TReadBlocksLocalRequest();
         request.SetStartIndex(0);
         request.SetBlocksCount(10);
-        request.BlockSize = blockSize;
+        request.SetBlockSize(blockSize);
         request.Sglist = TGuardedSgList(std::move(sglist));
 
         ActorSystem.Register(new TReadDiskRegistryBasedOverlayActor<
@@ -434,7 +434,7 @@ Y_UNIT_TEST_SUITE(TNonreplReadTests)
         auto request = NProto::TReadBlocksLocalRequest();
         request.SetStartIndex(0);
         request.SetBlocksCount(1);
-        request.BlockSize = blockSize;
+        request.SetBlockSize(blockSize);
         request.Sglist = TGuardedSgList(std::move(sglist));
 
         ActorSystem.Register(new TReadDiskRegistryBasedOverlayActor<

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor.cpp
@@ -405,13 +405,13 @@ void TVolumeAsPartitionActor::HandleWriteBlocksLocal(
     TSgList dst = ResizeIOVector(
         *msg->Record.MutableBlocks(),
         msg->Record.BlocksCount,
-        msg->Record.BlockSize);
+        msg->Record.GetBlockSize());
 
+    const size_t bytesToWrite = static_cast<size_t>(msg->Record.BlocksCount) *
+                                msg->Record.GetBlockSize();
     writeRequest->Record.Swap(&msg->Record);
     const size_t bytesWritten = SgListCopy(guard.Get(), dst);
-    Y_ABORT_UNLESS(
-        bytesWritten ==
-        static_cast<size_t>(msg->Record.BlocksCount) * msg->Record.BlockSize);
+    Y_ABORT_UNLESS(bytesWritten == bytesToWrite);
 
     NActors::TActorId nondeliveryActor = ev->GetForwardOnNondeliveryRecipient();
     TAutoPtr<::NActors::IEventHandle> newEv(new NActors::IEventHandle(

--- a/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/volume_as_partition_actor_ut.cpp
@@ -93,7 +93,7 @@ MakeWriteBlocksLocalRequest(
     auto result = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
     result->Record.SetDiskId(diskId);
     result->Record.SetStartIndex(startIndex);
-    result->Record.BlockSize = blockSize;
+    result->Record.SetBlockSize(blockSize);
     result->Record.BlocksCount = blocksContent.size();
     result->Record.Sglist = TGuardedSgList(std::move(sglist));
 

--- a/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/volume/testlib/test_env.cpp
@@ -430,9 +430,9 @@ TVolumeClient::CreateReadBlocksLocalRequest(
     request->Record.SetStartIndex(readRange.Start);
     request->Record.SetBlocksCount(readRange.Size());
     request->Record.MutableHeaders()->SetClientId(clientId);
+    request->Record.SetBlockSize(DefaultBlockSize);
 
     request->Record.Sglist = sglist;
-    request->Record.BlockSize = DefaultBlockSize;
     return request;
 }
 
@@ -476,9 +476,9 @@ TVolumeClient::CreateWriteBlocksLocalRequest(
     auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
     request->Record.SetStartIndex(writeRange.Start);
     request->Record.MutableHeaders()->SetClientId(clientId);
+    request->Record.SetBlockSize(DefaultBlockSize);
     request->Record.Sglist = TGuardedSgList(std::move(sglist));
     request->Record.BlocksCount = writeRange.Size();
-    request->Record.BlockSize = DefaultBlockSize;
     return request;
 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -5579,9 +5579,9 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             auto request = std::make_unique<TEvService::TEvWriteBlocksLocalRequest>();
             request->Record.SetStartIndex(range.Start);
             request->Record.MutableHeaders()->SetClientId(clientInfo.GetClientId());
+            request->Record.SetBlockSize(DefaultBlockSize);
             request->Record.Sglist = glist;
             request->Record.BlocksCount = range.Size();
-            request->Record.BlockSize = DefaultBlockSize;
 
             glist.Close();
 
@@ -7074,9 +7074,9 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             request->Record.SetStartIndex(range.Start);
             request->Record.MutableHeaders()->SetClientId(
                 clientInfo.GetClientId());
+            request->Record.SetBlockSize(DefaultBlockSize);
             request->Record.Sglist = glist;
             request->Record.BlocksCount = range.Size();
-            request->Record.BlockSize = DefaultBlockSize;
 
             volume.SendToPipe(std::move(request));
 
@@ -7299,9 +7299,9 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             request->Record.SetStartIndex(range.Start);
             request->Record.MutableHeaders()->SetClientId(
                 clientInfo.GetClientId());
+            request->Record.SetBlockSize(DefaultBlockSize);
             request->Record.Sglist = glist;
             request->Record.BlocksCount = range.Size();
-            request->Record.BlockSize = DefaultBlockSize;
 
             volume.SendToPipe(std::move(request));
 

--- a/cloud/blockstore/libs/validation/data_integrity_client_ut.cpp
+++ b/cloud/blockstore/libs/validation/data_integrity_client_ut.cpp
@@ -114,7 +114,6 @@ std::shared_ptr<NProto::TWriteBlocksLocalRequest> CreateWriteBlocksLocalRequest(
     request->SetDiskId(diskId);
     request->SetStartIndex(startIndex);
     request->SetBlockSize(blockSize);
-    request->BlockSize = blockSize;
     request->BlocksCount = blocksCount;
 
     TSgList sglist;
@@ -143,7 +142,6 @@ std::shared_ptr<NProto::TReadBlocksLocalRequest> CreateReadBlocksLocalRequest(
     request->SetStartIndex(startIndex);
     request->SetBlocksCount(blocksCount);
     request->SetBlockSize(blockSize);
-    request->BlockSize = blockSize;
     request->Sglist = TGuardedSgList(std::move(sglist));
     return request;
 }

--- a/cloud/blockstore/libs/validation/validation_client_ut.cpp
+++ b/cloud/blockstore/libs/validation/validation_client_ut.cpp
@@ -121,7 +121,7 @@ std::shared_ptr<NProto::TWriteBlocksLocalRequest> CreateWriteBlocksLocalRequest(
     request->SetDiskId(diskId);
     request->SetStartIndex(startIndex);
     request->BlocksCount = blocksCount;
-    request->BlockSize = data.size();
+    request->SetBlockSize(data.size());
 
     auto blocksHolder = std::make_shared<TVector<TString>>();
     blocksHolderList.push_back(blocksHolder);
@@ -153,7 +153,7 @@ std::shared_ptr<NProto::TReadBlocksLocalRequest> CreateReadBlocksLocalRequest(
     request->SetDiskId(diskId);
     request->SetStartIndex(startIndex);
     request->SetBlocksCount(blocksCount);
-    request->BlockSize = data.size();
+    request->SetBlockSize(data.size());
     request->Sglist = TGuardedSgList(std::move(sglist));
     return request;
 }

--- a/cloud/blockstore/libs/validation/validation_service_ut.cpp
+++ b/cloud/blockstore/libs/validation/validation_service_ut.cpp
@@ -151,7 +151,7 @@ std::shared_ptr<NProto::TWriteBlocksLocalRequest> CreateWriteBlocksLocalRequest(
     request->SetDiskId(diskId);
     request->SetStartIndex(startIndex);
     request->BlocksCount = blocksCount;
-    request->BlockSize = data.size();
+    request->SetBlockSize(data.size());
 
     auto blocksHolder = std::make_shared<TVector<TString>>();
     blocksHolderList.push_back(blocksHolder);
@@ -183,7 +183,7 @@ std::shared_ptr<NProto::TReadBlocksLocalRequest> CreateReadBlocksLocalRequest(
     request->SetDiskId(diskId);
     request->SetStartIndex(startIndex);
     request->SetBlocksCount(blocksCount);
-    request->BlockSize = data.size();
+    request->SetBlockSize(data.size());
     request->Sglist = TGuardedSgList(std::move(sglist));
     return request;
 }

--- a/cloud/blockstore/tools/testing/loadtest/lib/compare_data_action_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/compare_data_action_runner.cpp
@@ -176,7 +176,7 @@ void TCompareDataActionRunner::ReadBlocks(
     request->SetStartIndex(blockIndex);
     request->SetBlocksCount(blocksCount);
     request->SetCheckpointId(checkpointId);
-    request->BlockSize = TestContext.Volume.GetBlockSize();
+    request->SetBlockSize(TestContext.Volume.GetBlockSize());
     request->Sglist = TGuardedSgList({{buffer->data(), buffer->size()}});
     auto guardedSgList = request->Sglist;
 

--- a/cloud/blockstore/tools/testing/loadtest/lib/filesystem_client.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/filesystem_client.cpp
@@ -221,7 +221,7 @@ struct TClient: TClientBase
                 TErrorResponse(E_REJECTED));
         }
 
-        Y_ABORT_UNLESS(request->BlockSize == BlockSize);
+        Y_ABORT_UNLESS(request->GetBlockSize() == BlockSize);
         ui64 dataSize = 0;
         for (const auto& b: sglist.Get()) {
             dataSize += b.Size();
@@ -280,7 +280,7 @@ struct TClient: TClientBase
                 TErrorResponse(E_REJECTED));
         }
 
-        Y_ABORT_UNLESS(request->BlockSize == BlockSize);
+        Y_ABORT_UNLESS(request->GetBlockSize() == BlockSize);
         ui64 dataSize = 0;
         for (const auto& b: sglist.Get()) {
             dataSize += b.Size();

--- a/cloud/blockstore/tools/testing/loadtest/lib/load_test_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/load_test_runner.cpp
@@ -394,7 +394,7 @@ void TLoadTestRunner::SetupTest(
                 request->SetStartIndex(blockIndex);
                 request->SetBlocksCount(requestSize);
                 request->SetCheckpointId(test.GetCheckpointId());
-                request->BlockSize = blockSize;
+                request->SetBlockSize(blockSize);
                 request->Sglist = TGuardedSgList(std::move(sglist));
                 auto guardedSgList = request->Sglist;
 

--- a/cloud/blockstore/tools/testing/loadtest/lib/test_runner.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/test_runner.cpp
@@ -248,7 +248,7 @@ void TTestRunner::SendReadRequest(const TBlockRange64& range)
     request->SetStartIndex(range.Start);
     request->SetBlocksCount(range.Size());
     request->SetCheckpointId(CheckpointId);
-    request->BlockSize = Volume.GetBlockSize();
+    request->SetBlockSize(Volume.GetBlockSize());
     request->Sglist = guardedSgList;
 
     auto future = Session->ReadBlocksLocal(
@@ -308,8 +308,8 @@ void TTestRunner::SendWriteRequest(const TBlockRange64& range)
     auto started = TInstant::Now();
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(range.Start);
+    request->SetBlockSize(Volume.GetBlockSize());
     request->BlocksCount = range.Size();
-    request->BlockSize = Volume.GetBlockSize();
     request->Sglist = guardedSgList;
 
     auto future = Session->WriteBlocksLocal(

--- a/cloud/blockstore/tools/testing/nbd-test/initiator.cpp
+++ b/cloud/blockstore/tools/testing/nbd-test/initiator.cpp
@@ -170,8 +170,8 @@ private:
 
         auto req = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         req->SetStartIndex(request->StartOffset);
+        req->SetBlockSize(Options.BlockSize);
         req->BlocksCount = request->BlocksCount;
-        req->BlockSize = Options.BlockSize;
 
         auto sgList = TSgList {{
             request->Buffer.begin(),
@@ -200,7 +200,7 @@ private:
         auto req = std::make_shared<NProto::TReadBlocksLocalRequest>();
         req->SetStartIndex(request->StartOffset);
         req->SetBlocksCount(request->BlocksCount);
-        req->BlockSize = Options.BlockSize;
+        req->SetBlockSize(Options.BlockSize);
 
         TSgList sgList = {{
             request->Buffer.begin(),

--- a/cloud/blockstore/vhost-server/backend_rdma.cpp
+++ b/cloud/blockstore/vhost-server/backend_rdma.cpp
@@ -373,7 +373,7 @@ void TRdmaBackend::ProcessReadRequest(struct vhd_io* io, TCpuCycles startCycles)
 
     request->SetStartIndex(bio->first_sector >> SectorsToBlockShift);
     request->SetBlocksCount(bio->total_sectors >> SectorsToBlockShift);
-    request->BlockSize = BlockSize;
+    request->SetBlockSize(BlockSize);
     request->Sglist.SetSgList(std::move(ConvertVhdSgList(bio->sglist)));
 
     STORAGE_DEBUG(
@@ -381,7 +381,7 @@ void TRdmaBackend::ProcessReadRequest(struct vhd_io* io, TCpuCycles startCycles)
         reqHeaders->GetRequestId(),
         request->GetStartIndex(),
         request->GetBlocksCount(),
-        request->BlockSize);
+        request->GetBlockSize());
     auto future =
         DataClient->ReadBlocksLocal(std::move(callContext), std::move(request));
     future.Subscribe(
@@ -414,8 +414,8 @@ void TRdmaBackend::ProcessWriteRequest(
     reqHeaders->SetClientId(ClientId);
 
     request->SetStartIndex(bio->first_sector >> SectorsToBlockShift);
+    request->SetBlockSize(BlockSize);
     request->BlocksCount = bio->total_sectors >> SectorsToBlockShift;
-    request->BlockSize = BlockSize;
     request->Sglist.SetSgList(std::move(ConvertVhdSgList(bio->sglist)));
 
     STORAGE_DEBUG(
@@ -423,7 +423,7 @@ void TRdmaBackend::ProcessWriteRequest(
         reqHeaders->GetRequestId(),
         request->GetStartIndex(),
         request->BlocksCount,
-        request->BlockSize);
+        request->GetBlockSize());
     auto future =
         DataClient->WriteBlocksLocal(std::move(callContext), std::move(request));
     future.Subscribe(

--- a/cloud/vm/blockstore/lib/plugin.cpp
+++ b/cloud/vm/blockstore/lib/plugin.cpp
@@ -580,8 +580,8 @@ void TPlugin::HandleReadBlocks(
     auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
     request->SetStartIndex(r->start_index);
     request->SetBlocksCount(r->blocks_count);
+    request->SetBlockSize(volume->block_size);
     request->Sglist = guardedSgList;
-    request->BlockSize = volume->block_size;
 
     SetupHeaders(*request->MutableHeaders(), comp->id);
 
@@ -647,9 +647,9 @@ void TPlugin::HandleWriteBlocks(
 
     auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
     request->SetStartIndex(r->start_index);
+    request->SetBlockSize(volume->block_size);
     request->Sglist = guardedSgList;
     request->BlocksCount = r->blocks_count;
-    request->BlockSize = volume->block_size;
 
     SetupHeaders(*request->MutableHeaders(), comp->id);
 


### PR DESCRIPTION
### Notes
Remove BlockSize field from local requests. Use GetBlockSize()/SetBlockSize() from base class.

