### PR TITLE
Set default std::terminate handler and print exception stack in it

### DIFF
--- a/cloud/blockstore/apps/client/ya.make
+++ b/cloud/blockstore/apps/client/ya.make
@@ -8,9 +8,9 @@ SRCS(
 
 PEERDIR(
     library/cpp/getopt
-    library/cpp/terminate_handler
     cloud/blockstore/apps/client/lib
     cloud/storage/core/libs/iam/iface
+    cloud/storage/core/libs/terminate_handler
 )
 
 END()

--- a/cloud/blockstore/apps/disk_agent/ya.make
+++ b/cloud/blockstore/apps/disk_agent/ya.make
@@ -24,10 +24,6 @@ PEERDIR(
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG" AND BUILD_TYPE != "RELWITHDEBINFO")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/blockstore/apps/server/ya.make
+++ b/cloud/blockstore/apps/server/ya.make
@@ -32,10 +32,6 @@ PEERDIR(
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG" AND BUILD_TYPE != "RELWITHDEBINFO")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/blockstore/apps/server_lightweight/ya.make
+++ b/cloud/blockstore/apps/server_lightweight/ya.make
@@ -8,10 +8,6 @@ SRCS(
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/filestore/apps/client/ya.make
+++ b/cloud/filestore/apps/client/ya.make
@@ -17,8 +17,8 @@ SRCS(
 PEERDIR(
     cloud/filestore/apps/client/lib
     cloud/storage/core/libs/iam/iface
+    cloud/storage/core/libs/terminate_handler
     library/cpp/getopt
-    library/cpp/terminate_handler
 )
 
 END()

--- a/cloud/filestore/apps/server/ya.make
+++ b/cloud/filestore/apps/server/ya.make
@@ -6,10 +6,6 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/binaries_dependency.inc)
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/filestore/apps/vhost/ya.make
+++ b/cloud/filestore/apps/vhost/ya.make
@@ -10,10 +10,6 @@ ENDIF()
 
 IF (BUILD_TYPE != "PROFILE" AND BUILD_TYPE != "DEBUG")
     SPLIT_DWARF()
-ELSE()
-    PEERDIR(
-        library/cpp/terminate_handler
-    )
 ENDIF()
 
 IF (SANITIZER_TYPE)

--- a/cloud/storage/core/libs/daemon/ya.make
+++ b/cloud/storage/core/libs/daemon/ya.make
@@ -10,6 +10,7 @@ SRCS(
 PEERDIR(
     cloud/storage/core/libs/common
     cloud/storage/core/libs/diagnostics
+    cloud/storage/core/libs/terminate_handler
 
     contrib/ydb/library/actors/util
     library/cpp/deprecated/atomic

--- a/cloud/storage/core/libs/terminate_handler/terminate_handler.cpp
+++ b/cloud/storage/core/libs/terminate_handler/terminate_handler.cpp
@@ -7,6 +7,8 @@
 #include <exception>
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
 // Avoid recursion if std::terminate is triggered inside TerminateHandler
 thread_local int TerminateCount = 0;
 

--- a/cloud/storage/core/libs/terminate_handler/terminate_handler.cpp
+++ b/cloud/storage/core/libs/terminate_handler/terminate_handler.cpp
@@ -1,0 +1,35 @@
+#include <util/generic/yexception.h>
+#include <util/stream/output.h>
+#include <util/stream/str.h>
+#include <util/system/backtrace.h>
+
+#include <cstdlib>
+#include <exception>
+
+namespace {
+// Avoid recursion if std::terminate is triggered inside TerminateHandler
+thread_local int TerminateCount = 0;
+
+void TerminateHandler()
+{
+    if (++TerminateCount != 1) {
+        Cerr << "TerminateHandler is called recursively" << Endl;
+        std::abort();
+    }
+
+    auto report = TStringStream();
+    if (std::current_exception()) {
+        report << "\n========== Uncaught exception + stack =======\n";
+        FormatCurrentExceptionTo(report);
+    } else {
+        report << "Terminate for unknown reason (no current exception)\n";
+    }
+    report << "\n========== Terminate handler stack ==========\n";
+    FormatBackTrace(&report);
+
+    Cerr << report.Str() << '\n' << Flush;
+    std::abort();
+}
+
+[[maybe_unused]] const auto _ = std::set_terminate(&TerminateHandler);
+}   // namespace

--- a/cloud/storage/core/libs/terminate_handler/ya.make
+++ b/cloud/storage/core/libs/terminate_handler/ya.make
@@ -1,0 +1,7 @@
+LIBRARY()
+
+SRCS(
+    GLOBAL terminate_handler.cpp
+)
+
+END()


### PR DESCRIPTION
Adds a new module that installs a custom std::terminate handler which prints the formatted current exception (including any stored backtrace) plus a backtrace from the terminate site, and wires it into several blockstore/filestore daemon binaries so it’s enabled by default.

Changes:
* Introduced `cloud/storage/core/libs/terminate_handler` library that installs a global std::terminate handler and reports exception + backtrace details.
* Updated `cloud/storage/core/libs/daemon/ya.make` to always link the new terminate handler module.
* Removed the previous conditional dependency on library/cpp/terminate_handler from all daemons.
