### PR TITLE
issue-5643: support for metrics and traces in tablet adapter

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -544,6 +544,12 @@ private:
     void CompleteResponse(
         typename TMethod::TResponse::ProtoRecordType& response,
         const TCallContextPtr& callContext,
+        bool* builtTraceInfo);
+
+    template <typename TMethod>
+    void CompleteResponse(
+        typename TMethod::TResponse::ProtoRecordType& response,
+        const TCallContextPtr& callContext,
         const NActors::TActorContext& ctx);
 
     template <typename TMethod>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
@@ -10,32 +10,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename TRequestProto>
-ui64 GetRequestBytes(const TRequestProto& r)
-{
-    Y_UNUSED(r);
-    return 0;
-}
-
-ui64 GetRequestBytes(const NProto::TWriteDataRequest& r)
-{
-    if (r.GetIovecs().empty()) {
-        return r.GetBuffer().size() - r.GetBufferOffset();
-    }
-
-    ui64 bytes = 0;
-    for (const auto& iovec: r.GetIovecs()) {
-        bytes += iovec.GetLength();
-    }
-
-    return bytes;
-}
-
-ui64 GetRequestBytes(const NProto::TReadDataRequest& r)
-{
-    return r.GetLength();
-}
-
 template <typename TMethod>
 void UpdateAdapterMetrics(TTabletMetrics& m, ui64 requestBytes, TDuration d)
 {
@@ -94,7 +68,7 @@ void TIndexTabletActor::HandleAdapter##name(                                   \
     }                                                                          \
                                                                                \
     TInstant startedTs = ctx.Now();                                            \
-    const ui64 requestBytes = GetRequestBytes(msg->Record);                    \
+    const ui64 requestBytes = CalculateByteCount(msg->Record);                 \
     auto sender = ev->Sender;                                                  \
     ui64 cookie = ev->Cookie;                                                  \
     auto* ass = ctx.ActorSystem();                                             \

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adapter.cpp
@@ -6,6 +6,70 @@ namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TRequestProto>
+ui64 GetRequestBytes(const TRequestProto& r)
+{
+    Y_UNUSED(r);
+    return 0;
+}
+
+ui64 GetRequestBytes(const NProto::TWriteDataRequest& r)
+{
+    if (r.GetIovecs().empty()) {
+        return r.GetBuffer().size() - r.GetBufferOffset();
+    }
+
+    ui64 bytes = 0;
+    for (const auto& iovec: r.GetIovecs()) {
+        bytes += iovec.GetLength();
+    }
+
+    return bytes;
+}
+
+ui64 GetRequestBytes(const NProto::TReadDataRequest& r)
+{
+    return r.GetLength();
+}
+
+template <typename TMethod>
+void UpdateAdapterMetrics(TTabletMetrics& m, ui64 requestBytes, TDuration d)
+{
+    Y_UNUSED(m, requestBytes, d);
+}
+
+#define ADAPTER_METRICS_REQUESTS_PUBLIC(xxx, ...)                              \
+    xxx(ReadData,                                       __VA_ARGS__)           \
+    xxx(WriteData,                                      __VA_ARGS__)           \
+    xxx(GetNodeAttr,                                    __VA_ARGS__)           \
+    xxx(CreateHandle,                                   __VA_ARGS__)           \
+    xxx(DestroyHandle,                                  __VA_ARGS__)           \
+    xxx(CreateNode,                                     __VA_ARGS__)           \
+    xxx(UnlinkNode,                                     __VA_ARGS__)           \
+    xxx(GetNodeXAttr,                                   __VA_ARGS__)           \
+// ADAPTER_METRICS_REQUESTS_PUBLIC
+
+#define DECLARE_UPDATE_ADAPTER_METRICS(name, ns)                               \
+template <>                                                                    \
+void UpdateAdapterMetrics<ns::T##name##Method>(                                \
+    TTabletMetrics& m,                                                         \
+    ui64 requestBytes,                                                         \
+    TDuration d)                                                               \
+{                                                                              \
+    m.name.Update(1, requestBytes, d);                                         \
+}                                                                              \
+// DECLARE_UPDATE_ADAPTER_METRICS
+
+ADAPTER_METRICS_REQUESTS_PUBLIC(DECLARE_UPDATE_ADAPTER_METRICS, TEvService)
+
+#undef DECLARE_UPDATE_ADAPTER_METRICS
+
+}   // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #define FILESTORE_IMPLEMENT_ADAPTER_REQUEST_IN_ACTOR(name, ns)                 \
@@ -18,19 +82,53 @@ void TIndexTabletActor::HandleAdapter##name(                                   \
         "%s " Y_STRINGIZE(name) " request %s",                                 \
         LogTag.c_str(),                                                        \
         msg->Record.ShortUtf8DebugString().Quote().c_str());                   \
+    using TMethod = ns::T##name##Method;                                       \
+    const bool accepted = AcceptRequestNoSession<TMethod>(                     \
+        ev,                                                                    \
+        ctx,                                                                   \
+        [] (const TMethod::TRequest::ProtoRecordType&) {                       \
+            return MakeError(S_OK);                                            \
+        });                                                                    \
+    if (!accepted) {                                                           \
+        return;                                                                \
+    }                                                                          \
                                                                                \
+    TInstant startedTs = ctx.Now();                                            \
+    const ui64 requestBytes = GetRequestBytes(msg->Record);                    \
     auto sender = ev->Sender;                                                  \
     ui64 cookie = ev->Cookie;                                                  \
     auto* ass = ctx.ActorSystem();                                             \
+    auto callContext = msg->CallContext;                                       \
     FastShard->name(std::move(msg->Record)).Subscribe(                         \
         [=] (const auto& f) {                                                  \
+            /* TODO(#5894): ensure that tablet actor is still alive */         \
             auto response = std::make_unique<ns::TEv##name##Response>(         \
                 UnsafeExtractValue(f));                                        \
-            LOG_TRACE(ctx, TFileStoreComponents::TABLET,                       \
+                                                                               \
+            bool builtTraceInfo = false;                                       \
+            CompleteResponse<TMethod>(                                         \
+                response->Record,                                              \
+                callContext,                                                   \
+                &builtTraceInfo);                                              \
+                                                                               \
+            LOG_DEBUG(*ass, TFileStoreComponents::TABLET,                      \
+                "%s %s: #%lu completed (%s), trace-info: %d",                  \
+                LogTag.c_str(),                                                \
+                TMethod::Name,                                                 \
+                callContext->RequestId,                                        \
+                FormatError(response->Record.GetError()).c_str(),              \
+                builtTraceInfo);                                               \
+            LOG_TRACE(*ass, TFileStoreComponents::TABLET,                      \
                 "%s " Y_STRINGIZE(name) " response %s",                        \
                 LogTag.c_str(),                                                \
                 response->Record.ShortUtf8DebugString().Quote().c_str());      \
+                                                                               \
             ass->Send(sender, response.release(), 0 /* flags */, cookie);      \
+                                                                               \
+            UpdateAdapterMetrics<TMethod>(                                     \
+                Metrics,                                                       \
+                requestBytes,                                                  \
+                ass->Timestamp() - startedTs);                                 \
         });                                                                    \
 }                                                                              \
 // FILESTORE_IMPLEMENT_ADAPTER_REQUEST_IN_ACTOR

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -96,7 +96,7 @@ template <typename TMethod>
 void TIndexTabletActor::CompleteResponse(
     typename TMethod::TResponse::ProtoRecordType& response,
     const TCallContextPtr& callContext,
-    const NActors::TActorContext& ctx)
+    bool* builtTraceInfo)
 {
     if (HasError(response.GetError())) {
         auto* e = response.MutableError();
@@ -109,17 +109,10 @@ void TIndexTabletActor::CompleteResponse(
         callContext,
         TMethod::Name);
 
-    const bool builtTraceInfo = BuildTraceInfo(
+    *builtTraceInfo = BuildTraceInfo(
         TraceSerializer,
         callContext,
         response);
-    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
-        "%s %s: #%lu completed (%s), trace-info: %d",
-        LogTag.c_str(),
-        TMethod::Name,
-        callContext->RequestId,
-        FormatError(response.GetError()).c_str(),
-        builtTraceInfo);
     BuildThrottlerInfo(*callContext, response);
     BuildBackendInfo(
         *Config,
@@ -134,6 +127,23 @@ void TIndexTabletActor::CompleteResponse(
     }
 
     Metrics.BusyIdleCalc.OnRequestCompleted();
+}
+
+template <typename TMethod>
+void TIndexTabletActor::CompleteResponse(
+    typename TMethod::TResponse::ProtoRecordType& response,
+    const TCallContextPtr& callContext,
+    const NActors::TActorContext& ctx)
+{
+    bool builtTraceInfo = false;
+    CompleteResponse<TMethod>(response, callContext, &builtTraceInfo);
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s %s: #%lu completed (%s), trace-info: %d",
+        LogTag.c_str(),
+        TMethod::Name,
+        callContext->RequestId,
+        FormatError(response.GetError()).c_str(),
+        builtTraceInfo);
 }
 
 #define FILESTORE_GENERATE_IMPL(name, ns)                                             \

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -435,11 +435,10 @@ void TIndexTabletActor::CompleteTx_WriteData(
         EnqueueFlushIfNeeded(ctx);
         EnqueueBlobIndexOpIfNeeded(ctx);
 
-        Metrics.WriteData.Count.fetch_add(1, std::memory_order_relaxed);
-        Metrics.WriteData.RequestBytes.fetch_add(
+        Metrics.WriteData.Update(
+            1,
             args.ByteRange.Length,
-            std::memory_order_relaxed);
-        Metrics.WriteData.Time.Record(ctx.Now() - args.RequestInfo->StartedTs);
+            ctx.Now() - args.RequestInfo->StartedTs);
 
         return;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
@@ -256,6 +256,44 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
             UNIT_ASSERT_VALUES_EQUAL(7_KB, node.GetSize());
         }
 
+        auto registry = env.GetRegistry();
+        tablet.AdvanceTime(TDuration::Seconds(15));
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+        TTestRegistryVisitor visitor;
+        registry->Visit(TInstant::Zero(), visitor);
+        visitor.ValidateExpectedCounters({
+            {{
+                {"sensor", "ReadData.RequestBytes"},
+                {"filesystem", "test"}}, 13_KB},
+            {{
+                {"sensor", "ReadData.Count"},
+                {"filesystem", "test"}}, 2},
+            {{
+                {"sensor", "WriteData.RequestBytes"},
+                {"filesystem", "test"}}, 3_KB},
+            {{
+                {"sensor", "WriteData.Count"},
+                {"filesystem", "test"}}, 2},
+            {{
+                {"sensor", "GetNodeAttr.Count"},
+                {"filesystem", "test"}}, 5},
+            {{
+                {"sensor", "CreateHandle.Count"},
+                {"filesystem", "test"}}, 3},
+            {{
+                {"sensor", "DestroyHandle.Count"},
+                {"filesystem", "test"}}, 1},
+            {{
+                {"sensor", "CreateNode.Count"},
+                {"filesystem", "test"}}, 2},
+            {{
+                {"sensor", "UnlinkNode.Count"},
+                {"filesystem", "test"}}, 2},
+            {{
+                {"sensor", "GetNodeXAttr.Count"},
+                {"filesystem", "test"}}, 0},
+        });
+
         tablet.DestroySession();
     }
 }


### PR DESCRIPTION
### Notes
* support for tablet-level metrics and traces for the requests going through tablet adapter
* fixed WriteData metrics tracking in one of the branches (the code in that branch, unlike the other branches and other request handlers, accidentally updated `Time` instead of `TimeSumUs`)

### Issue
https://github.com/ydb-platform/nbs/issues/5643
