### PR TITLE
issue-5643, issue-5894: implemented TabletProxy LW probes and moved trace info handling from service to tablet proxy

### DIFF
--- a/cloud/filestore/libs/storage/core/probes.h
+++ b/cloud/filestore/libs/storage/core/probes.h
@@ -55,6 +55,20 @@
             NCloud::NProbeParam::RequestType,                                  \
             NCloud::NProbeParam::RequestId)                                    \
     )                                                                          \
+    PROBE(RequestReceived_TabletProxy,                                         \
+        GROUPS("NFSRequest"),                                                  \
+        TYPES(TString, ui64),                                                  \
+        NAMES(                                                                 \
+            NCloud::NProbeParam::RequestType,                                  \
+            NCloud::NProbeParam::RequestId)                                    \
+    )                                                                          \
+    PROBE(ResponseSent_TabletProxy,                                            \
+        GROUPS("NFSRequest"),                                                  \
+        TYPES(TString, ui64),                                                  \
+        NAMES(                                                                 \
+            NCloud::NProbeParam::RequestType,                                  \
+            NCloud::NProbeParam::RequestId)                                    \
+    )                                                                          \
     PROBE(RequestPostponed_Tablet,                                             \
         GROUPS("NFSRequest"),                                                  \
         TYPES(TString, ui64),                                                  \

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -104,7 +104,9 @@ public:
         // IndexTabletProxy
         //
 
-        auto tabletProxy = CreateIndexTabletProxy(Args.StorageConfig);
+        auto tabletProxy = CreateIndexTabletProxy(
+            Args.StorageConfig,
+            Args.TraceSerializer);
 
         setup->LocalServices.emplace_back(
             MakeIndexTabletProxyServiceId(),

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -32,45 +32,9 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename T>
-void HandleServiceTraceInfo(
-    const char* methodName,
-    const NActors::TActorContext& ctx,
-    const ITraceSerializerPtr& traceSerializer,
-    const TCallContextBasePtr& callContext,
-    T& record)
-{
-    const bool handled =
-        HandleTraceInfo(traceSerializer, callContext, record);
-    if (handled) {
-        LOG_DEBUG(
-            ctx,
-            TFileStoreComponents::SERVICE,
-            "%s: trace handled",
-            methodName);
-        return;
-    }
-
-    if constexpr (HasResponseHeaders<T>()) {
-        if (record.GetHeaders().HasTrace()) {
-            const auto& trace = record.GetHeaders().GetTrace();
-            LOG_DEBUG(
-                ctx,
-                TFileStoreComponents::SERVICE,
-                "%s: trace not handled: %s",
-                methodName,
-                trace.Utf8DebugString().Quote().c_str(),
-                handled);
-        }
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 template <typename TMethod>
 void CompleteRequestImpl(
     const NActors::TActorContext& ctx,
-    const ITraceSerializerPtr& traceSerializer,
     typename TMethod::TResponse::ProtoRecordType& record,
     TInFlightRequest *request,
     TInFlightRequestStorage& requestStorage,

--- a/cloud/filestore/libs/storage/service/service_actor_complete.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_complete.cpp
@@ -54,7 +54,6 @@ void CalculateResponseChecksums(
 template<typename TMethod>
 void CompleteRequestImpl(
     const TActorContext& ctx,
-    const ITraceSerializerPtr& traceSerializer,
     typename TMethod::TResponse::ProtoRecordType& record,
     TInFlightRequest *request,
     TInFlightRequestStorage& requestStorage,
@@ -76,12 +75,6 @@ void CompleteRequestImpl(
     }
 
     FinalizeProfileLogRequestInfo(request->AccessProfileLogRequest(), record);
-    HandleServiceTraceInfo(
-        TMethod::Name,
-        ctx,
-        traceSerializer,
-        request->CallContext,
-        record);
     HandleThrottlerInfo(*request->CallContext, record);
 
     FILESTORE_TRACK(
@@ -126,7 +119,6 @@ void TStorageServiceActor::CompleteRequest(
 
     CompleteRequestImpl<TMethod>(
         ctx,
-        TraceSerializer,
         msg->Record,
         request,
         *InFlightRequests,

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -268,6 +268,14 @@ void TReadDataActor::DescribeData(const TActorContext& ctx)
         MainInFlightRequest->CallContext->RequestId);
     describeCallContext->SetRequestStartedCycles(GetCycleCount());
     describeCallContext->RequestType = EFileStoreRequest::DescribeData;
+    if (!MainInFlightRequest->CallContext->LWOrbit.Fork(
+            describeCallContext->LWOrbit))
+    {
+        FILESTORE_TRACK(
+            ForkFailed,
+            MainInFlightRequest->CallContext,
+            GetFileStoreRequestName(EFileStoreRequest::DescribeData));
+    }
     InFlightRequest.emplace(
         Sender,
         Cookie,
@@ -275,6 +283,7 @@ void TReadDataActor::DescribeData(const TActorContext& ctx)
         ProfileLog,
         MediaKind,
         RequestStats);
+    request->CallContext = InFlightRequest->CallContext;
 
     InFlightRequest->Start(ctx.Now());
     InitProfileLogRequestInfo(
@@ -366,16 +375,12 @@ void TReadDataActor::HandleDescribeDataResponse(
 
     SERVICE_VERIFY(InFlightRequest);
 
+    MainInFlightRequest->CallContext->LWOrbit.Join(
+        InFlightRequest->CallContext->LWOrbit);
     FinalizeProfileLogRequestInfo(
         InFlightRequest->AccessProfileLogRequest(),
         msg->Record);
     InFlightRequest->Complete(ctx.Now(), error);
-    HandleServiceTraceInfo(
-        "DescribeData",
-        ctx,
-        TraceSerializer,
-        MainInFlightRequest->CallContext,
-        msg->Record);
 
     if (FAILED(msg->GetStatus())) {
         if (error.GetCode() != E_FS_THROTTLED) {
@@ -690,6 +695,7 @@ void TReadDataActor::ReadData(
     auto request = std::make_unique<TEvService::TEvReadDataRequest>();
     request->Record = std::move(ReadRequest);
     request->Record.MutableHeaders()->SetThrottlingDisabled(true);
+    request->CallContext = MainInFlightRequest->CallContext;
     TraceSerializer->BuildTraceRequest(
         *request->Record.MutableHeaders()->MutableInternal()->MutableTrace(),
         MainInFlightRequest->CallContext->LWOrbit);
@@ -707,12 +713,6 @@ void TReadDataActor::HandleReadDataResponse(
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
-    HandleServiceTraceInfo(
-        "ReadData",
-        ctx,
-        TraceSerializer,
-        MainInFlightRequest->CallContext,
-        msg->Record);
 
     if (FAILED(msg->GetStatus())) {
         HandleError(ctx, msg->GetError());
@@ -851,7 +851,6 @@ void TReadDataActor::SendResponseAndDie(
 
     CompleteRequestImpl<TEvService::TReadDataMethod>(
         ctx,
-        TraceSerializer,
         response->Record,
         MainInFlightRequest,
         *InFlightRequests,

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -206,6 +206,7 @@ public:
             EFileStoreRequest::GenerateBlobIds,
             request->Record,
             false /* addWriteRangeInfo */);
+        request->CallContext = InFlightRequest->CallContext;
 
         LOG_DEBUG(
             ctx,
@@ -265,16 +266,12 @@ private:
 
         SERVICE_VERIFY(InFlightRequest);
 
+        RequestInfo->CallContext->LWOrbit.Join(
+            InFlightRequest->CallContext->LWOrbit);
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
         InFlightRequest->Complete(ctx.Now(), error);
-        HandleServiceTraceInfo(
-            "GenerateBlobIds",
-            ctx,
-            TraceSerializer,
-            RequestInfo->CallContext,
-            msg->Record);
 
         if (HasError(error)) {
             if (error.GetCode() != E_FS_THROTTLED) {
@@ -514,6 +511,12 @@ private:
             RequestInfo->CallContext->RequestId);
         callContext->SetRequestStartedCycles(GetCycleCount());
         callContext->RequestType = requestType;
+        if (!RequestInfo->CallContext->LWOrbit.Fork(callContext->LWOrbit)) {
+            FILESTORE_TRACK(
+                ForkFailed,
+                RequestInfo->CallContext,
+                GetFileStoreRequestName(requestType));
+        }
         InFlightRequest.ConstructInPlace(
             TRequestInfo(
                 RequestInfo->Sender,
@@ -572,6 +575,7 @@ private:
             EFileStoreRequest::AddData,
             request->Record,
             false /* addWriteRangeInfo */);
+        request->CallContext = InFlightRequest->CallContext;
 
         LOG_DEBUG(
             ctx,
@@ -590,16 +594,12 @@ private:
         auto* msg = ev->Get();
 
         SERVICE_VERIFY(InFlightRequest);
+        RequestInfo->CallContext->LWOrbit.Join(
+            InFlightRequest->CallContext->LWOrbit);
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
         InFlightRequest->Complete(ctx.Now(), msg->GetError());
-        HandleServiceTraceInfo(
-            "AddData",
-            ctx,
-            TraceSerializer,
-            RequestInfo->CallContext,
-            msg->Record);
 
         if (HasError(msg->GetError())) {
             WriteData(ctx, msg->GetError());
@@ -631,6 +631,7 @@ private:
             EFileStoreRequest::ConfirmAddData,
             request->Record,
             true);
+        request->CallContext = InFlightRequest->CallContext;
 
         LOG_DEBUG(
             ctx,
@@ -661,6 +662,7 @@ private:
             EFileStoreRequest::CancelAddData,
             request->Record,
             true);
+        request->CallContext = InFlightRequest->CallContext;
 
         LOG_DEBUG(
             ctx,
@@ -679,16 +681,12 @@ private:
         auto* msg = ev->Get();
 
         SERVICE_VERIFY(InFlightRequest);
+        RequestInfo->CallContext->LWOrbit.Join(
+            InFlightRequest->CallContext->LWOrbit);
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
         InFlightRequest->Complete(ctx.Now(), msg->GetError());
-        HandleServiceTraceInfo(
-            "ConfirmAddData",
-            ctx,
-            TraceSerializer,
-            RequestInfo->CallContext,
-            msg->Record);
 
         if (HasError(msg->GetError())) {
             if (ev->Sender == MakeIndexTabletProxyServiceId()) {
@@ -714,16 +712,12 @@ private:
         auto* msg = ev->Get();
 
         SERVICE_VERIFY(InFlightRequest);
+        RequestInfo->CallContext->LWOrbit.Join(
+            InFlightRequest->CallContext->LWOrbit);
         FinalizeProfileLogRequestInfo(
             InFlightRequest->AccessProfileLogRequest(),
             msg->Record);
         InFlightRequest->Complete(ctx.Now(), msg->GetError());
-        HandleServiceTraceInfo(
-            "CancelAddData",
-            ctx,
-            TraceSerializer,
-            RequestInfo->CallContext,
-            msg->Record);
 
         if (HasError(msg->GetError())) {
             if (ev->Sender == MakeIndexTabletProxyServiceId()) {
@@ -826,6 +820,7 @@ private:
         auto request = std::make_unique<TEvService::TEvWriteDataRequest>();
         request->Record = std::move(WriteRequest);
         request->Record.MutableHeaders()->SetThrottlingDisabled(true);
+        request->CallContext = RequestInfo->CallContext;
         auto* trace =
             request->Record.MutableHeaders()->MutableInternal()->MutableTrace();
         TraceSerializer->BuildTraceRequest(
@@ -841,12 +836,6 @@ private:
         const TActorContext& ctx)
     {
         auto* msg = ev->Get();
-        HandleServiceTraceInfo(
-            "WriteData",
-            ctx,
-            TraceSerializer,
-            RequestInfo->CallContext,
-            msg->Record);
 
         if (HasError(msg->GetError())) {
             HandleError(ctx, msg->GetError());

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy.cpp
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy.cpp
@@ -10,9 +10,13 @@ using namespace NKikimr;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IActorPtr CreateIndexTabletProxy(TStorageConfigPtr config)
+IActorPtr CreateIndexTabletProxy(
+    TStorageConfigPtr config,
+    ITraceSerializerPtr traceSerializer)
 {
-    return std::make_unique<TIndexTabletProxyActor>(std::move(config));
+    return std::make_unique<TIndexTabletProxyActor>(
+        std::move(config),
+        std::move(traceSerializer));
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy.h
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy.h
@@ -4,12 +4,15 @@
 
 #include <cloud/filestore/libs/storage/core/public.h>
 
+#include <cloud/storage/core/libs/diagnostics/public.h>
 #include <cloud/storage/core/libs/kikimr/public.h>
 
 namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NActors::IActorPtr CreateIndexTabletProxy(TStorageConfigPtr config);
+NActors::IActorPtr CreateIndexTabletProxy(
+    TStorageConfigPtr config,
+    ITraceSerializerPtr traceSerializer);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
@@ -1,7 +1,9 @@
 #include "tablet_proxy_actor.h"
 
+#include <cloud/filestore/libs/diagnostics/trace_serializer.h>
 #include <cloud/filestore/libs/storage/api/service.h>
 #include <cloud/filestore/libs/storage/api/tablet.h>
+#include <cloud/filestore/libs/storage/core/probes.h>
 
 #include <util/datetime/base.h>
 
@@ -10,6 +12,8 @@ namespace NCloud::NFileStore::NStorage {
 using namespace NActors;
 
 using namespace NKikimr;
+
+LWTRACE_USING(FILESTORE_STORAGE_PROVIDER);
 
 namespace {
 
@@ -41,13 +45,51 @@ TString GetFileSystemId(const TProtoRequestEvent<TArgs, EventId>& request)
     return request.Record.GetFileSystemId();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+void HandleServiceTraceInfo(
+    const char* methodName,
+    const NActors::TActorContext& ctx,
+    const ITraceSerializerPtr& traceSerializer,
+    const TCallContextBasePtr& callContext,
+    T& record)
+{
+    const bool handled =
+        HandleTraceInfo(traceSerializer, callContext, record);
+    if (handled) {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET_PROXY,
+            "%s: trace handled",
+            methodName);
+        return;
+    }
+
+    if constexpr (HasResponseHeaders<T>()) {
+        if (record.GetHeaders().HasTrace()) {
+            const auto& trace = record.GetHeaders().GetTrace();
+            LOG_DEBUG(
+                ctx,
+                TFileStoreComponents::TABLET_PROXY,
+                "%s: trace not handled: %s",
+                methodName,
+                trace.Utf8DebugString().Quote().c_str(),
+                handled);
+        }
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TIndexTabletProxyActor::TIndexTabletProxyActor(TStorageConfigPtr config)
+TIndexTabletProxyActor::TIndexTabletProxyActor(
+        TStorageConfigPtr config,
+        ITraceSerializerPtr traceSerializer)
     : TActor(&TThis::StateWork)
     , Config(std::move(config))
+    , TraceSerializer(std::move(traceSerializer))
     , ClientCache(CreateTabletPipeClientCache(*Config))
 {}
 
@@ -166,10 +208,11 @@ void TIndexTabletProxyActor::ForwardRequest(
 {
     auto clientId = ClientCache->Prepare(ctx, conn.TabletId);
     ui64 requestId = ++RequestId;
+    auto callContext = ev->Get()->CallContext;
 
     LOG_TRACE(ctx, TFileStoreComponents::TABLET_PROXY,
         "Forward request %lu as %lu to file store: %lu (remote: %s)",
-        ev->Get()->CallContext->RequestId,
+        callContext->RequestId,
         requestId,
         conn.TabletId,
         ToString(clientId).c_str());
@@ -189,7 +232,10 @@ void TIndexTabletProxyActor::ForwardRequest(
 
     ActiveRequests.emplace(
         requestId,
-        TActiveRequest(conn.Id, IEventHandlePtr(ev.Release())));
+        TActiveRequest(
+            conn.Id,
+            IEventHandlePtr(ev.Release()),
+            std::move(callContext)));
 }
 
 void TIndexTabletProxyActor::DescribeFileStore(
@@ -317,6 +363,10 @@ void TIndexTabletProxyActor::HandleRequest(
     }
 
     const auto* msg = ev->Get();
+    FILESTORE_TRACK(
+        RequestReceived_TabletProxy,
+        msg->CallContext,
+        TMethod::Name);
 
     TString fileSystemId = GetFileSystemId(*msg);
     // Some filestore names can point to another filestore, set by storage config
@@ -351,6 +401,7 @@ void TIndexTabletProxyActor::HandleRequest(
     }
 }
 
+template <typename TMethod>
 void TIndexTabletProxyActor::HandleResponse(
     const TActorContext& ctx,
     TAutoPtr<IEventHandle>& ev)
@@ -390,6 +441,19 @@ void TIndexTabletProxyActor::HandleResponse(
             nullptr);
     }
 
+    auto* x = reinterpret_cast<TMethod::TResponse::TPtr*>(&event);
+    HandleServiceTraceInfo(
+        TMethod::Name,
+        ctx,
+        TraceSerializer,
+        it->second.CallContext,
+        x->Get()->Get()->Record);
+
+    FILESTORE_TRACK(
+        ResponseSent_TabletProxy,
+        it->second.CallContext,
+        TMethod::Name);
+
     auto* conn = ConnectionById[it->second.ConnectionId];
     Y_ABORT_UNLESS(conn);
 
@@ -420,7 +484,7 @@ bool TIndexTabletProxyActor::HandleRequests(STFUNC_SIG)
         break;                                                                 \
     }                                                                          \
     case ns::TEv##name##Response::EventType: {                                 \
-        HandleResponse(ctx, ev);                                               \
+        HandleResponse<ns::T##name##Method>(ctx, ev);                          \
         break;                                                                 \
     }                                                                          \
 // FILESTORE_HANDLE_METHOD

--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.h
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.h
@@ -63,10 +63,15 @@ class TIndexTabletProxyActor final
     {
         const ui64 ConnectionId;
         NActors::IEventHandlePtr Request;
+        TCallContextPtr CallContext;
 
-        TActiveRequest(ui64 connectionId, NActors::IEventHandlePtr request)
+        TActiveRequest(
+                ui64 connectionId,
+                NActors::IEventHandlePtr request,
+                TCallContextPtr callContext)
             : ConnectionId(connectionId)
             , Request(std::move(request))
+            , CallContext(std::move(callContext))
         {}
     };
 
@@ -74,6 +79,7 @@ class TIndexTabletProxyActor final
 
 private:
     const TStorageConfigPtr Config;
+    const ITraceSerializerPtr TraceSerializer;
 
     ui64 ConnectionId = 0;
     THashMap<TString, TConnection> Connections;
@@ -86,7 +92,9 @@ private:
     std::unique_ptr<NKikimr::NTabletPipe::IClientCache> ClientCache;
 
 public:
-    TIndexTabletProxyActor(TStorageConfigPtr config);
+    TIndexTabletProxyActor(
+        TStorageConfigPtr config,
+        ITraceSerializerPtr traceSerializer);
 
 private:
     TConnection& CreateConnection(const TString& fileSystemId);
@@ -150,6 +158,7 @@ private:
         const NActors::TActorContext& ctx,
         const typename TMethod::TRequest::TPtr& ev);
 
+    template <typename TMethod>
     void HandleResponse(
         const NActors::TActorContext& ctx,
         TAutoPtr<NActors::IEventHandle>& ev);

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -228,7 +228,9 @@ ui32 TTestEnv::AddDynamicNode()
 
     CreateAndRegisterStorageService(nodeIdx);
 
-    auto tabletProxy = CreateIndexTabletProxy(StorageConfig);
+    auto tabletProxy = CreateIndexTabletProxy(
+        StorageConfig,
+        TraceSerializer);
     auto tabletProxyId = Runtime.Register(
         tabletProxy.release(),
         nodeIdx,


### PR DESCRIPTION
### Notes
Tablet proxy is not free so we would like to actually see how much time we lose on the way between service and tablet proxy. This PR implements tablet proxy probes. Since we need to process trace info from responses before adding ResponseSent_TabletProxy probes, trace info processing was also moved from the service layer to the tablet proxy layer.

Example tracks after this PR:
[0001.html](https://github.com/user-attachments/files/28182147/0001.html)

After looking at these traces I also realized that some RequestReceived_Service probes are missing - will fix it separately.

### Issue
https://github.com/ydb-platform/nbs/issues/5643
https://github.com/ydb-platform/nbs/issues/5894