### PR TITLE
Fix tests under ubsan

### DIFF
--- a/cloud/blockstore/libs/diagnostics/volume_perf.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf.cpp
@@ -29,7 +29,7 @@ template <typename T>
     requires(std::is_integral_v<T> && std::is_unsigned_v<T>)
 [[nodiscard]] T SafeMultiply(T a, double m)
 {
-    if (m >= 1.0 && static_cast<T>(std::numeric_limits<T>::max() / m) <= a) {
+    if (m > 1.0 && static_cast<T>(std::numeric_limits<T>::max() / m) <= a) {
         return std::numeric_limits<T>::max();
     }
     return a * m;


### PR DESCRIPTION
### Notes
```
/actions-runner/_work/nbs/nbs/cloud/blockstore/libs/diagnostics/volume_perf.cpp:32:36: runtime error: 1.84467e+19 is outside the range of representable values of type 'unsigned long'
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0xf0 has a premature terminator entry at offset 0x100
warning: address range table at offset 0x120 has a premature terminator entry at offset 0x130
warning: address range table at offset 0x150 has a premature terminator entry at offset 0x160
    #0 0x4a23e05 in NCloud::NBlockStore::(anonymous namespace)::SafeMultiply<unsigned long> /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/diagnostics/volume_perf.cpp:32:36
    #1 0x4a23e05 in NCloud::NBlockStore::TVolumePerformanceCalculator::Register(NCloud::NBlockStore::NProto::TVolume const&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/diagnostics/volume_perf.cpp:102:17
    #2 0x1f4bb5c in NCloud::NBlockStore::NTestSuiteTVolumePerfTest::TTestCaseShouldApplyThrottlerOvercommitToPerformanceProfileLimits::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp:953:25
    #3 0x1f5a20e in NCloud::NBlockStore::NTestSuiteTVolumePerfTest::TCurrentTest::Execute()::'lambda'()::operator()() const /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp:584:1
    #4 0x2398459 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18
    #5 0x1f58cc0 in NCloud::NBlockStore::NTestSuiteTVolumePerfTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp:584:1
    #6 0x2399cdc in NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19
    #7 0x23bd8ac in NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44
    #8 0x7fcb9a829d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
    #9 0x7fcb9a829e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
    #10 0x1e23028 in _start (/home/github/.ya/build/build_root/rbpx/000f22/cloud/blockstore/libs/diagnostics/ut/cloud-blockstore-libs-diagnostics-ut+0x1e23028) (BuildId: 0d57ade4a1deb3044f2efe36e6ef2c5080f97ecb)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /actions-runner/_work/nbs/nbs/cloud/blockstore/libs/diagnostics/volume_perf.cpp:32:36 in 
```
