### PR TITLE
issue-5643: MemFileSystemShard - support for node creation upon access

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/mem/memshard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/mem/memshard.cpp
@@ -5,9 +5,13 @@
 #include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/service/filestore.h>
 
+#include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/string/builder.h>
+
+#include <sys/stat.h>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
@@ -22,7 +26,7 @@ auto CreateAttrs(ui64 id, ui32 mode, ui64 size, ui64 uid, ui64 gid)
     NProto::TNodeAttr attrs;
     attrs.SetId(id);
     attrs.SetType(NProto::E_REGULAR_NODE);
-    attrs.SetMode(mode);
+    attrs.SetMode(S_IFREG | mode);
     attrs.SetATime(now);
     attrs.SetMTime(now);
     attrs.SetCTime(now);
@@ -66,6 +70,7 @@ class TMemFileSystemShard: public IFileSystemShard
 {
 private:
     const ui32 ShardNo;
+    const NProtoPrivate::TMemFastShardConfig Config;
 
     TDirectoryNode Root;
     THashMap<ui64, NProto::TNodeAttr> Attrs;
@@ -75,8 +80,11 @@ private:
     ui64 LastHandleId = 0;
 
 public:
-    explicit TMemFileSystemShard(ui32 shardNo)
+    TMemFileSystemShard(
+            ui32 shardNo,
+            const NProtoPrivate::TMemFastShardConfig& config)
         : ShardNo(shardNo)
+        , Config(config)
     {}
 
 public:
@@ -89,18 +97,18 @@ public:
             return MakeFuture(std::move(response));
         }
         for (const auto& name: request.GetNames()) {
-            const auto* p = Root.Name2Id.FindPtr(name);
-            if (!p) {
+            ui64 nodeId;
+            if (!FindNodeId(name, &nodeId)) {
                 *response.MutableError() =
                     ErrorInvalidTarget(request.GetNodeId(), name);
                 return MakeFuture(std::move(response));
             }
 
-            const auto* a = Attrs.FindPtr(*p);
+            const auto* a = Attrs.FindPtr(nodeId);
             if (!a) {
                 *response.MutableError() = MakeError(
                     E_INVALID_STATE,
-                    TStringBuilder() << "can't find attrs for " << *p);
+                    TStringBuilder() << "can't find attrs for " << nodeId);
                 return MakeFuture(std::move(response));
             }
 
@@ -121,19 +129,14 @@ public:
         }
 
         ui64 nodeId = request.GetNodeId();
-        if (!request.GetName().empty()) {
-            const auto* p = Root.Name2Id.FindPtr(request.GetName());
-            if (!p) {
-                *response.MutableError() =
-                    ErrorInvalidTarget(request.GetNodeId(), request.GetName());
-                return MakeFuture(std::move(response));
-            }
-
-            nodeId = *p;
+        if (request.GetName() && !FindNodeId(request.GetName(), &nodeId)) {
+            *response.MutableError() =
+                ErrorInvalidTarget(request.GetNodeId(), request.GetName());
+            return MakeFuture(std::move(response));
         }
 
-        const auto* a = Attrs.FindPtr(nodeId);
-        if (!a) {
+        NProto::TNodeAttr* a = nullptr;
+        if (!FindAttrs(nodeId, &a)) {
             NProto::TError e;
             if (!request.GetName().empty()) {
                 e = MakeError(
@@ -154,8 +157,8 @@ public:
     SetNodeAttr(NProto::TSetNodeAttrRequest request) override
     {
         NProto::TSetNodeAttrResponse response;
-        auto* a = Attrs.FindPtr(request.GetNodeId());
-        if (!a) {
+        NProto::TNodeAttr* a = nullptr;
+        if (!FindAttrs(request.GetNodeId(), &a)) {
             *response.MutableError() = ErrorInvalidTarget(request.GetNodeId());
             return MakeFuture(std::move(response));
         }
@@ -215,16 +218,11 @@ public:
             return MakeFuture(std::move(response));
         }
 
-        const ui64 nodeId = ShardedId(++LastNodeId, ShardNo);
-        auto& a = Attrs[nodeId];
-        a = CreateAttrs(
-            nodeId,
+        const auto& a = CreateNodeImpl(
             request.GetFile().GetMode(),
-            0 /* size */,
             request.GetUid(),
             request.GetGid());
-        Files[nodeId];
-        nodeRef = nodeId;
+        nodeRef = a.GetId();
 
         *response.MutableNode() = a;
         return MakeFuture(std::move(response));
@@ -241,7 +239,10 @@ public:
 
         auto it = Root.Name2Id.find(request.GetName());
         if (it == Root.Name2Id.end()) {
-            *response.MutableError() = ErrorInvalidTarget(request.GetNodeId());
+            if (!Config.GetCreateNodeUponAccess()) {
+                *response.MutableError() =
+                    ErrorInvalidTarget(request.GetNodeId());
+            }
             return MakeFuture(std::move(response));
         }
 
@@ -274,8 +275,7 @@ public:
 
         NProto::TNodeAttr* a = nullptr;
         if (request.GetName().empty()) {
-            a = Attrs.FindPtr(request.GetNodeId());
-            if (!a) {
+            if (!FindAttrs(request.GetNodeId(), &a)) {
                 *response.MutableError() =
                     ErrorInvalidTarget(request.GetNodeId());
                 return MakeFuture(std::move(response));
@@ -284,16 +284,16 @@ public:
             auto it = Root.Name2Id.find(request.GetName());
             if (it == Root.Name2Id.end()) {
                 if (HasFlag(flags, createFlag)) {
-                    const ui64 nodeId = ShardedId(++LastNodeId, ShardNo);
-                    it = Root.Name2Id.insert({request.GetName(), nodeId}).first;
-                    a = &Attrs[nodeId];
-                    *a = CreateAttrs(
-                        nodeId,
+                    a = &CreateNodeImpl(
                         request.GetMode(),
-                        0 /* size */,
                         request.GetUid(),
                         request.GetGid());
-                    Files[nodeId];
+                    const bool inserted = Root.Name2Id.insert({
+                        request.GetName(),
+                        a->GetId()}).second;
+                    Y_ABORT_UNLESS(inserted);
+                } else if (Config.GetCreateNodeUponAccess()) {
+                    a = &CreateDefaultNode(request.GetName());
                 } else {
                     *response.MutableError() = ErrorInvalidTarget(
                         request.GetNodeId(),
@@ -516,13 +516,73 @@ private:
         *response.MutableError() = MakeError(E_NOT_IMPLEMENTED);
         return MakeFuture(std::move(response));
     }
+
+    NProto::TNodeAttr& CreateNodeImpl(ui32 mode, ui64 uid, ui64 gid)
+    {
+        const ui64 nodeId = ShardedId(++LastNodeId, ShardNo);
+        auto& a = Attrs[nodeId];
+        a = CreateAttrs(
+            nodeId,
+            mode,
+            0 /* size */,
+            uid,
+            gid);
+        Files[nodeId];
+        return a;
+    }
+
+    NProto::TNodeAttr& CreateDefaultNode(const TString& name)
+    {
+        constexpr ui32 DefaultMode = 0664;
+        constexpr ui64 DefaultUid = 1000;
+        constexpr ui64 DefaultGid = 1000;
+        auto& a = CreateNodeImpl(DefaultMode, DefaultUid, DefaultGid);
+        if (name) {
+            const bool inserted = Root.Name2Id.insert({name, a.GetId()}).second;
+            Y_ABORT_UNLESS(inserted);
+        }
+        return a;
+    }
+
+    bool FindAttrs(ui64 nodeId, NProto::TNodeAttr** a)
+    {
+        *a = Attrs.FindPtr(nodeId);
+        if (*a) {
+            return true;
+        }
+
+        if (Config.GetCreateNodeUponAccess()) {
+            *a = &CreateDefaultNode({} /* name */);
+            return true;
+        }
+
+        return false;
+    }
+
+    bool FindNodeId(const TString& name, ui64* nodeId)
+    {
+        auto* p = Root.Name2Id.FindPtr(name);
+        if (p) {
+            *nodeId = *p;
+            return true;
+        }
+
+        if (Config.GetCreateNodeUponAccess()) {
+            *nodeId = CreateDefaultNode(name).GetId();
+            return true;
+        }
+
+        return false;
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IFileSystemShardPtr CreateMemFileSystemShard(ui32 shardNo)
+IFileSystemShardPtr CreateMemFileSystemShard(
+    ui32 shardNo,
+    const NProtoPrivate::TMemFastShardConfig& config)
 {
-    return std::make_shared<TMemFileSystemShard>(shardNo);
+    return std::make_shared<TMemFileSystemShard>(shardNo, config);
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/mem/memshard.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/mem/memshard.h
@@ -2,10 +2,20 @@
 
 #include <cloud/filestore/libs/storage/fastshard/iface/public.h>
 
+namespace NCloud::NFileStore::NProtoPrivate {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TMemFastShardConfig;
+
+}   // namespace NCloud::NFileStore::NProtoPrivate
+
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IFileSystemShardPtr CreateMemFileSystemShard(ui32 shardNo);
+IFileSystemShardPtr CreateMemFileSystemShard(
+    ui32 shardNo,
+    const NProtoPrivate::TMemFastShardConfig& config);
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/mem/memshard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/mem/memshard_ut.cpp
@@ -1,6 +1,9 @@
 #include "memshard.h"
 
+#include <cloud/filestore/libs/service/filestore.h>
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+
+#include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 
@@ -8,26 +11,197 @@
 
 #include <util/generic/size_literals.h>
 
+#include <sys/stat.h>
+
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TMemShardTest)
 {
-    Y_UNIT_TEST(ShouldCreateUnlinkFiles)
+    //
+    // Tablet ut test suite contains tests with memshard w/o
+    // CreateNodeUponAccess flag.
+    //
+
+    Y_UNIT_TEST(ShouldCreateNodeUponAccess)
     {
         constexpr ui32 ShardNo = 77;
 
-        auto s = CreateMemFileSystemShard(ShardNo);
-        UNIT_ASSERT_VALUES_EQUAL(
-            E_NOT_IMPLEMENTED,
-            s->CreateNode({}).GetValueSync().GetError().GetCode());
+        NProtoPrivate::TMemFastShardConfig config;
+        config.SetCreateNodeUponAccess(true);
+        auto s = CreateMemFileSystemShard(ShardNo, config);
 
-        // TODO(#5643): write uts.
-        //
-        // We have some uts in the tablet ut test suite - not sure whether we
-        // really need the same coverage here. But covering some basic stuff
-        // would be nice.
+        ui64 lastNodeId = 0;
+        {
+            //
+            // Create upon access
+            //
+
+            NProto::TGetNodeAttrRequest request;
+            request.SetNodeId(RootNodeId);
+            request.SetName("f0");
+            auto response = s->GetNodeAttr(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+            const ui64 nodeId = response.GetNode().GetId();
+            lastNodeId = nodeId;
+            UNIT_ASSERT(nodeId);
+            UNIT_ASSERT_C(
+                S_IFREG & response.GetNode().GetMode(),
+                response.GetNode().GetMode());
+            UNIT_ASSERT(response.GetNode().GetUid());
+            UNIT_ASSERT(response.GetNode().GetGid());
+
+            //
+            // Next accesses should return the same node.
+            //
+
+            response = s->GetNodeAttr(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL(nodeId, response.GetNode().GetId());
+
+            request.SetNodeId(nodeId);
+            request.ClearName();
+            response = s->GetNodeAttr(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL(nodeId, response.GetNode().GetId());
+        }
+
+        {
+            //
+            // Create upon access
+            //
+
+            NProtoPrivate::TGetNodeAttrBatchRequest request;
+            request.SetNodeId(RootNodeId);
+            request.AddNames("f1");
+            auto response = s->GetNodeAttrBatch(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+            UNIT_ASSERT_VALUES_EQUAL(1, response.ResponsesSize());
+            const ui64 nodeId = response.GetResponses(0).GetNode().GetId();
+            lastNodeId = nodeId;
+            UNIT_ASSERT(nodeId);
+            UNIT_ASSERT_C(
+                S_IFREG & response.GetResponses(0).GetNode().GetMode(),
+                response.GetResponses(0).GetNode().GetMode());
+            UNIT_ASSERT(response.GetResponses(0).GetNode().GetUid());
+            UNIT_ASSERT(response.GetResponses(0).GetNode().GetGid());
+
+            //
+            // Next accesses should return the same node.
+            //
+
+            response = s->GetNodeAttrBatch(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL(1, response.ResponsesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                nodeId,
+                response.GetResponses(0).GetNode().GetId());
+        }
+
+        {
+            //
+            // Create upon access
+            //
+
+            NProto::TCreateHandleRequest request;
+            request.SetNodeId(RootNodeId);
+            request.SetName("f2");
+            auto response = s->CreateHandle(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+            const ui64 nodeId = response.GetNodeAttr().GetId();
+            UNIT_ASSERT(nodeId);
+            UNIT_ASSERT_C(
+                nodeId > lastNodeId,
+                TStringBuilder() << nodeId << ", " << lastNodeId);
+            lastNodeId = nodeId;
+            UNIT_ASSERT_C(
+                S_IFREG & response.GetNodeAttr().GetMode(),
+                response.GetNodeAttr().GetMode());
+            UNIT_ASSERT(response.GetNodeAttr().GetUid());
+            UNIT_ASSERT(response.GetNodeAttr().GetGid());
+
+            //
+            // Next accesses should return the same node.
+            //
+
+            response = s->CreateHandle(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL(nodeId, response.GetNodeAttr().GetId());
+
+            request.SetNodeId(nodeId);
+            request.ClearName();
+            response = s->CreateHandle(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL(nodeId, response.GetNodeAttr().GetId());
+        }
+
+        {
+            //
+            // Just testing that basic create still works.
+            //
+
+            constexpr ui32 Mode = 0444;
+            constexpr ui64 Uid = 1111;
+            constexpr ui64 Gid = 2222;
+            NProto::TCreateNodeRequest request;
+            request.SetNodeId(RootNodeId);
+            request.SetName("f3");
+            request.MutableFile()->SetMode(Mode);
+            request.SetUid(Uid);
+            request.SetGid(Gid);
+            auto response = s->CreateNode(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+            const ui64 nodeId = response.GetNode().GetId();
+            UNIT_ASSERT(nodeId);
+            UNIT_ASSERT_C(
+                nodeId > lastNodeId,
+                TStringBuilder() << nodeId << ", " << lastNodeId);
+            lastNodeId = nodeId;
+            UNIT_ASSERT_VALUES_EQUAL(
+                S_IFREG | Mode,
+                response.GetNode().GetMode());
+            UNIT_ASSERT_VALUES_EQUAL(Uid, response.GetNode().GetUid());
+            UNIT_ASSERT_VALUES_EQUAL(Gid, response.GetNode().GetGid());
+
+            //
+            // Next accesses should return E_FS_EXIST.
+            //
+
+            response = s->CreateNode(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_FS_EXIST,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+        }
+
+        {
+            //
+            // Nonexistent file - no op.
+            //
+
+            NProto::TUnlinkNodeRequest request;
+            request.SetNodeId(RootNodeId);
+            request.SetName("f4");
+            auto response = s->UnlinkNode(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+
+            response = s->UnlinkNode(request).GetValue();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+        }
     }
 }
 

--- a/cloud/filestore/libs/storage/fastshard/impl/mem/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/mem/ya.make
@@ -9,6 +9,8 @@ SRCS(
 PEERDIR(
     cloud/filestore/libs/service
     cloud/filestore/libs/storage/fastshard/iface
+
+    cloud/filestore/private/api/unsafe_protos
 )
 
 END()

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -233,12 +233,14 @@ void TIndexTabletActor::CompleteAdapterLoadState(
         config);
     UpdateLogTag();
 
-    if (GetFileSystem().GetFastShardConfig().StorageGroupsSize() == 0) {
-        FastShard =
-            NFastShard::CreateMemFileSystemShard(GetFileSystem().GetShardNo());
-    } else {
+    const auto& fastShardConfig = GetFileSystem().GetFastShardConfig();
+    if (fastShardConfig.HasPersistentConfig()) {
         // not supported yet
         FastShard = NFastShard::CreateFileSystemShardStub();
+    } else {
+        FastShard = NFastShard::CreateMemFileSystemShard(
+            GetFileSystem().GetShardNo(),
+            fastShardConfig.GetMemConfig());
     }
 
     NMetrics::Store(Metrics.OpLogEntryCount, GetOpLogEntryCount());

--- a/cloud/filestore/private/api/unsafe_protos/unsafe.proto
+++ b/cloud/filestore/private/api/unsafe_protos/unsafe.proto
@@ -97,9 +97,23 @@ message TStorageGroup
     EStorageGroupType Type = 2;
 }
 
-message TFastShardConfig
+message TPersistentFastShardConfig
 {
     repeated TStorageGroup StorageGroups = 1;
+}
+
+message TMemFastShardConfig
+{
+    bool CreateNodeUponAccess = 1;
+}
+
+message TFastShardConfig
+{
+    oneof Config
+    {
+        TPersistentFastShardConfig PersistentConfig = 1;
+        TMemFastShardConfig MemConfig = 2;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
Introducing `CreateNodeUponAccess` flag for mem file system shards. Needed to avoid crit events and dangling node refs that happen upon tablet restart.

### Issue
https://github.com/ydb-platform/nbs/issues/5643
