### PR TITLE
[Filestore] fix data race in TFileSystemTest.(ShouldDrainRequestsWhileStopping|ShouldHandleDoubleInit)

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -3346,12 +3346,6 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     Y_UNIT_TEST(ShouldDrainRequestsWhileStopping)
     {
         TBootstrap bootstrap;
-        bootstrap.Start();
-
-        bootstrap.Service->ReadDataHandler = [&](auto, auto)
-        {
-            return MakeFuture(NProto::TReadDataResponse());
-        };
 
         auto writeDataPromise = NewPromise<NProto::TWriteDataResponse>();
         std::atomic<int> writeDataCalled = 0;
@@ -3360,6 +3354,13 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             writeDataCalled++;
             return writeDataPromise.GetFuture();
         };
+
+        bootstrap.Service->ReadDataHandler = [&](auto, auto)
+        {
+            return MakeFuture(NProto::TReadDataResponse());
+        };
+
+        bootstrap.Start();
 
         const ui64 nodeId = 123;
         const ui64 handleId = 456;
@@ -3389,6 +3390,12 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
     {
         TBootstrap bootstrap;
 
+        auto writeDataPromise = NewPromise<NProto::TWriteDataResponse>();
+
+        bootstrap.Service->WriteDataHandler = [&](auto, auto) {
+            return writeDataPromise.GetFuture();
+        };
+
         bootstrap.Start(/* sendInitRequest = */ false);
 
         auto init = bootstrap.Fuse->SendRequest<TInitRequest>();
@@ -3396,12 +3403,6 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
         const ui64 nodeId = 123;
         const ui64 handleId = 456;
-
-        auto writeDataPromise = NewPromise<NProto::TWriteDataResponse>();
-
-        bootstrap.Service->WriteDataHandler = [&](auto, auto) {
-            return writeDataPromise.GetFuture();
-        };
 
         auto write = bootstrap.Fuse->SendRequest<TWriteRequest>(
             nodeId, handleId, 0, CreateBuffer(4096, 'a'));


### PR DESCRIPTION
### Notes
Tests added in https://github.com/ydb-platform/nbs/pull/6029

Start should not be called before TSession handler initialization
```
==================
WARNING: ThreadSanitizer: data race (pid=72258)
  Read of size 8 at 0x7b7400001ca0 by thread T76 (mutexes: read M0, write M1):
    #0 std::__y1::__function::__value_func<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse> (TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:517:13 (cloud-filestore-libs-vfs_fuse-ut+0x1853f50) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #1 std::__y1::function<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse> (TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>)>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12 (cloud-filestore-libs-vfs_fuse-ut+0x1853f50)
    #2 NCloud::NFileStore::TFileStoreTest::WriteData(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/service/filestore_test.h:59:5 (cloud-filestore-libs-vfs_fuse-ut+0x1853f50)
    #3 NCloud::NFileStore::NClient::(anonymous namespace)::TWriteDataMethod::Execute<NCloud::NFileStore::IFileStoreService, TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> > &, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest> &> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:44:1 (cloud-filestore-libs-vfs_fuse-ut+0x422947f) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #4 void NCloud::NFileStore::NClient::(anonymous namespace)::TSession::ExecuteRequestWithSession<NCloud::NFileStore::NClient::(anonymous namespace)::TWriteDataMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TWriteDataMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TWriteDataMethod>>>) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:750:9 (cloud-filestore-libs-vfs_fuse-ut+0x422947f)
    #5 void NCloud::NFileStore::NClient::(anonymous namespace)::TSession::ExecuteRequest<NCloud::NFileStore::NClient::(anonymous namespace)::TWriteDataMethod>(TIntrusivePtr<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TWriteDataMethod>, TDefaultIntrusivePtrOps<NCloud::NFileStore::NClient::(anonymous namespace)::TRequestState<NCloud::NFileStore::NClient::(anonymous namespace)::TWriteDataMethod>>>) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:705:17 (cloud-filestore-libs-vfs_fuse-ut+0x422858e) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #6 NCloud::NFileStore::NClient::(anonymous namespace)::TSession::WriteData(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/client/session.cpp:327:1 (cloud-filestore-libs-vfs_fuse-ut+0x41bb31d) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #7 NCloud::NFileStore::NFuse::TFileSystem::DoWrite(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, fuse_req*, unsigned long, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>, unsigned long, fuse_file_info*) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:592:22 (cloud-filestore-libs-vfs_fuse-ut+0x4358f70) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #8 NCloud::NFileStore::NFuse::TFileSystem::WriteBuf(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, fuse_req*, unsigned long, fuse_bufvec*, long, fuse_file_info*) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp:738:5 (cloud-filestore-libs-vfs_fuse-ut+0x435b569) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #9 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::Call<void (NCloud::NFileStore::NFuse::IFileSystem::*)(TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, fuse_req *, unsigned long, fuse_bufvec *, long, fuse_file_info *), unsigned long &, fuse_bufvec *&, long &, fuse_file_info *&> /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1540:13 (cloud-filestore-libs-vfs_fuse-ut+0x42a12e8) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #10 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::InitOps(fuse_lowlevel_ops &)::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1706:13 (cloud-filestore-libs-vfs_fuse-ut+0x42a12e8)
    #11 NCloud::NFileStore::NFuse::(anonymous namespace)::TFileSystemLoop::InitOps(fuse_lowlevel_ops&)::'lambda'(fuse_req*, unsigned long, fuse_bufvec*, long, fuse_file_info*)::__invoke(fuse_req*, unsigned long, fuse_bufvec*, long, fuse_file_info*) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:1705:25 (cloud-filestore-libs-vfs_fuse-ut+0x42a12e8)
    #12 do_write_buf /actions-runner/_work/nbs/nbs/cloud/contrib/virtiofsd/fuse_lowlevel.c:1276:5 (libvirtiofsd.so+0xb0d9) (BuildId: f79bf78724d7a5729a67147f56987e9d5ef5d7df)
    #13 fuse_session_process_buf_int /actions-runner/_work/nbs/nbs/cloud/contrib/virtiofsd/fuse_lowlevel.c:2635:9 (libvirtiofsd.so+0xb0d9)
    #14 process_request /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:317:5 (cloud-filestore-libs-vfs_fuse-ut+0x447a88a) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #15 virtio_session_loop /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:544:19 (cloud-filestore-libs-vfs_fuse-ut+0x447a88a)
    #16 fuse_session_loop /actions-runner/_work/nbs/nbs/cloud/contrib/virtiofsd/fuse_lowlevel.c:2859:12 (libvirtiofsd.so+0xbafe) (BuildId: f79bf78724d7a5729a67147f56987e9d5ef5d7df)
    #17 NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/loop.cpp:603:9 (cloud-filestore-libs-vfs_fuse-ut+0x42a784b) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #18 void* (anonymous namespace)::ThreadProcWrapper<ISimpleThread>(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:383:45 (cloud-filestore-libs-vfs_fuse-ut+0x1b8bc12) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #19 (anonymous namespace)::TPosixThread::ThreadProxy(void*) /actions-runner/_work/nbs/nbs/util/system/thread.cpp:244:20 (cloud-filestore-libs-vfs_fuse-ut+0x1b8c11c) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
  Previous write of size 8 at 0x7b7400001ca0 by main thread:
    #0 std::__y1::__function::__value_func<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse> (TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>)>::swap[abi:v180000](std::__y1::__function::__value_func<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse> (TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext>>, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>)>&) /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h (cloud-filestore-libs-vfs_fuse-ut+0x1887665) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #1 std::__y1::function<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse> (TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>)>::swap /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1163:10 (cloud-filestore-libs-vfs_fuse-ut+0x17d47fc) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #2 std::__y1::function<NThreading::TFuture<NCloud::NFileStore::NProto::TWriteDataResponse> (TIntrusivePtr<NCloud::NFileStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NFileStore::TCallContext> >, std::__y1::shared_ptr<NCloud::NFileStore::NProto::TWriteDataRequest>)>::operator=<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:3359:47), void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1152:40 (cloud-filestore-libs-vfs_fuse-ut+0x17d47fc)
    #3 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TTestCaseShouldDrainRequestsWhileStopping::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:3359:45 (cloud-filestore-libs-vfs_fuse-ut+0x17d47fc)
    #4 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1 (cloud-filestore-libs-vfs_fuse-ut+0x184e904) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #5 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #6 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:419:5 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #7 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:195:16 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #8 std::__y1::__function::__func<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:366:12 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #9 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16 (cloud-filestore-libs-vfs_fuse-ut+0x1bce9af) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #10 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12 (cloud-filestore-libs-vfs_fuse-ut+0x1bce9af)
    #11 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-filestore-libs-vfs_fuse-ut+0x1bce9af)
    #12 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-filestore-libs-vfs_fuse-ut+0x1bb284a) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #13 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1 (cloud-filestore-libs-vfs_fuse-ut+0x184dfc6) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #14 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-filestore-libs-vfs_fuse-ut+0x1bb3653) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #15 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-filestore-libs-vfs_fuse-ut+0x1bcadfc) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #16 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-filestore-libs-vfs_fuse-ut+0x1bc9d70) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
  Location is heap block of size 2512 at 0x7b7400001400 allocated by main thread:
    #0 operator new(unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/tsan/rtl/tsan_new_delete.cpp:64:3 (cloud-filestore-libs-vfs_fuse-ut+0x19c8e37) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #1 std::__y1::__libcpp_operator_new<unsigned long> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/new:272:10 (cloud-filestore-libs-vfs_fuse-ut+0x1724155) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #2 std::__y1::__libcpp_allocate /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/new:298:10 (cloud-filestore-libs-vfs_fuse-ut+0x1724155)
    #3 std::__y1::allocator<std::__y1::__shared_ptr_emplace<NCloud::NFileStore::TFileStoreTest, std::__y1::allocator<NCloud::NFileStore::TFileStoreTest> > >::allocate /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:114:38 (cloud-filestore-libs-vfs_fuse-ut+0x1724155)
    #4 std::__y1::allocator_traits<std::__y1::allocator<std::__y1::__shared_ptr_emplace<NCloud::NFileStore::TFileStoreTest, std::__y1::allocator<NCloud::NFileStore::TFileStoreTest> > > >::allocate /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:268:20 (cloud-filestore-libs-vfs_fuse-ut+0x1724155)
    #5 std::__y1::__allocation_guard<std::__y1::allocator<std::__y1::__shared_ptr_emplace<NCloud::NFileStore::TFileStoreTest, std::__y1::allocator<NCloud::NFileStore::TFileStoreTest> > > >::__allocation_guard<std::__y1::allocator<NCloud::NFileStore::TFileStoreTest> > /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/allocation_guard.h:57:18 (cloud-filestore-libs-vfs_fuse-ut+0x1724155)
    #6 std::__y1::allocate_shared<NCloud::NFileStore::TFileStoreTest, std::__y1::allocator<NCloud::NFileStore::TFileStoreTest>, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:1050:48 (cloud-filestore-libs-vfs_fuse-ut+0x1724155)
    #7 std::__y1::make_shared<NCloud::NFileStore::TFileStoreTest, void> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:1060:12 (cloud-filestore-libs-vfs_fuse-ut+0x1724155)
    #8 NCloud::NFileStore::NFuse::(anonymous namespace)::TBootstrap::TBootstrap(std::__y1::shared_ptr<NCloud::ITimer>, std::__y1::shared_ptr<NCloud::IScheduler>, NCloud::NFileStore::NProto::TFileStoreFeatures const&, unsigned int, unsigned int, unsigned long, unsigned long, unsigned long, std::__y1::shared_ptr<NCloud::IFileMapMemoryLimiter>) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:213:19 (cloud-filestore-libs-vfs_fuse-ut+0x1724155)
    #9 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TTestCaseShouldDrainRequestsWhileStopping::Execute_(NUnitTest::TTestContext&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:3348:20 (cloud-filestore-libs-vfs_fuse-ut+0x17d4595) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #10 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::(anonymous class)::operator() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1 (cloud-filestore-libs-vfs_fuse-ut+0x184e904) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #11 std::__y1::__invoke<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #12 std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1) &> /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:419:5 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #13 std::__y1::__function::__alloc_func<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1), std::__y1::allocator<(lambda at /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1)>, void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:195:16 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #14 std::__y1::__function::__func<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:366:12 (cloud-filestore-libs-vfs_fuse-ut+0x184e904)
    #15 std::__y1::__function::__value_func<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16 (cloud-filestore-libs-vfs_fuse-ut+0x1bce9af) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #16 std::__y1::function<void ()>::operator() /actions-runner/_work/nbs/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12 (cloud-filestore-libs-vfs_fuse-ut+0x1bce9af)
    #17 TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:525:20 (cloud-filestore-libs-vfs_fuse-ut+0x1bce9af)
    #18 NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:374:18 (cloud-filestore-libs-vfs_fuse-ut+0x1bb284a) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #19 NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:407:1 (cloud-filestore-libs-vfs_fuse-ut+0x184dfc6) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #20 NUnitTest::TTestFactory::Execute() /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/registar.cpp:495:19 (cloud-filestore-libs-vfs_fuse-ut+0x1bb3653) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #21 NUnitTest::RunMain(int, char**) /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest/utmain.cpp:872:44 (cloud-filestore-libs-vfs_fuse-ut+0x1bcadfc) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
    #22 main /actions-runner/_work/nbs/nbs/library/cpp/testing/unittest_main/main.cpp:4:12 (cloud-filestore-libs-vfs_fuse-ut+0x1bc9d70) (BuildId: 346113261baa5bd033042dd6125a71270988620f)
```
