### PR TITLE
[NBS] dedup concurrent TEvBootExternalRequest per tabletId

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1588,4 +1588,11 @@ message TStorageServiceConfig
     // VolumeProxyPipeInactivityTimeout (half of it), so it is always strictly
     // smaller than the timeout and needs no separate tuning.
     optional bool BaseDiskPipeKeepAliveEnabled = 500;
+
+    // How long a deduplicated external-boot actor is kept alive after its
+    // last waiter has expired (in milliseconds). Within this window a new
+    // TEvBootExternalRequest for the same tabletId reuses the still-pending
+    // HIVE call instead of issuing a new one.
+    // 0 - the worker is kept until HIVE replies.
+    optional uint32 ExternalBootRequestIdleTimeout = 501;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -242,6 +242,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MinExternalBootRequestTimeout, TDuration, Seconds(1)                  )\
     xxx(MaxExternalBootRequestTimeout, TDuration, Seconds(30)                 )\
     xxx(ExternalBootRequestTimeoutIncrement, TDuration, MSeconds(500)         )\
+    xxx(ExternalBootRequestIdleTimeout,      TDuration, Seconds(30)           )\
     xxx(PipeClientRetryCount,          ui32,      4                           )\
     xxx(PipeClientMinRetryTime,        TDuration, Seconds(1)                  )\
     xxx(PipeClientMaxRetryTime,        TDuration, Seconds(4)                  )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -133,6 +133,7 @@ public:
     TDuration GetMinExternalBootRequestTimeout() const;
     TDuration GetExternalBootRequestTimeoutIncrement() const;
     TDuration GetMaxExternalBootRequestTimeout() const;
+    [[nodiscard]] TDuration GetExternalBootRequestIdleTimeout() const;
     bool GetDisableLocalService() const;
     ui32 GetPipeClientRetryCount() const;
     TDuration GetPipeClientMinRetryTime() const;

--- a/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/disk_agent/actorsystem.cpp
@@ -56,18 +56,22 @@ public:
 
         auto hiveProxy = CreateHiveProxy(
             {
-                .PipeClientRetryCount = Args.StorageConfig->GetPipeClientRetryCount(),
-                .PipeClientMinRetryTime = Args.StorageConfig->GetPipeClientMinRetryTime(),
-                .HiveLockExpireTimeout = Args.StorageConfig->GetHiveLockExpireTimeout(),
+                .PipeClientRetryCount =
+                    Args.StorageConfig->GetPipeClientRetryCount(),
+                .PipeClientMinRetryTime =
+                    Args.StorageConfig->GetPipeClientMinRetryTime(),
+                .HiveLockExpireTimeout =
+                    Args.StorageConfig->GetHiveLockExpireTimeout(),
+                .ExternalBootRequestIdleTimeout =
+                    Args.StorageConfig->GetExternalBootRequestIdleTimeout(),
                 .LogComponent = TBlockStoreComponents::HIVE_PROXY,
                 .TabletBootInfoBackupFilePath = {},
                 .UseBinaryFormatForTabletBootInfoBackup = false,
                 .FallbackMode = false,
-                .TenantHiveTabletId = Args.StorageConfig->GetTenantHiveTabletId(),
+                .TenantHiveTabletId =
+                    Args.StorageConfig->GetTenantHiveTabletId(),
             },
-            appData
-                ->Counters
-                ->GetSubgroup("counters", "blockstore")
+            appData->Counters->GetSubgroup("counters", "blockstore")
                 ->GetSubgroup("component", "service"));
 
         setup->LocalServices.emplace_back(

--- a/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
+++ b/cloud/blockstore/libs/storage/init/server/actorsystem.cpp
@@ -148,6 +148,8 @@ public:
                     Args.StorageConfig->GetPipeClientMinRetryTime(),
                 .HiveLockExpireTimeout =
                     Args.StorageConfig->GetHiveLockExpireTimeout(),
+                .ExternalBootRequestIdleTimeout =
+                    Args.StorageConfig->GetExternalBootRequestIdleTimeout(),
                 .LogComponent = TBlockStoreComponents::HIVE_PROXY,
                 .TabletBootInfoBackupFilePath =
                     Args.TemporaryServer

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -299,13 +299,15 @@ ui32 TTestEnv::CreateBlockStoreNode(
         nodeIdx);
 
     auto hiveProxy = CreateHiveProxy({
-        storageConfig->GetPipeClientRetryCount(),
-        storageConfig->GetPipeClientMinRetryTime(),
-        storageConfig->GetHiveLockExpireTimeout(),
-        TBlockStoreComponents::HIVE_PROXY,
-        /*TabletBootInfoBackupFilePath=*/"",
-        /*UseBinaryFormatForTabletBootInfoBackup=*/false,
-        /*FallbackMode=*/false,
+        .PipeClientRetryCount = storageConfig->GetPipeClientRetryCount(),
+        .PipeClientMinRetryTime = storageConfig->GetPipeClientMinRetryTime(),
+        .HiveLockExpireTimeout = storageConfig->GetHiveLockExpireTimeout(),
+        .ExternalBootRequestIdleTimeout =
+            storageConfig->GetExternalBootRequestIdleTimeout(),
+        .LogComponent = TBlockStoreComponents::HIVE_PROXY,
+        .TabletBootInfoBackupFilePath = "",
+        .UseBinaryFormatForTabletBootInfoBackup = false,
+        .FallbackMode = false,
     });
     auto hiveProxyId = Runtime.Register(
         hiveProxy.release(),

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -790,4 +790,11 @@ message TStorageConfig
     // mode tablets register their IFileSystemShard with this server,
     // allowing direct TCP access to shard operations.
     optional uint32 FastShardServerPort = 503;
+
+    // How long a deduplicated external-boot actor is kept alive after its
+    // last waiter has expired (in milliseconds). Within this window a new
+    // TEvBootExternalRequest for the same tabletId reuses the still-pending
+    // HIVE call instead of issuing a new one.
+    // 0 - the worker is kept until HIVE replies.
+    optional uint32 ExternalBootRequestIdleTimeout = 504;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -353,6 +353,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(UseSchemeCache,                         bool,   false                 )\
                                                                                \
     xxx(FastShardServerPort,                    ui32,   0                     )\
+                                                                               \
+    xxx(ExternalBootRequestIdleTimeout,     TDuration, TDuration::Seconds(30) )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -410,6 +410,8 @@ public:
     [[nodiscard]] bool GetUseSchemeCache() const;
 
     [[nodiscard]] ui32 GetFastShardServerPort() const;
+
+    [[nodiscard]] TDuration GetExternalBootRequestIdleTimeout() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -140,6 +140,8 @@ public:
                     Args.StorageConfig->GetPipeClientMinRetryTime(),
                 // HiveLockExpireTimeout, used by NBS, doesn't matter
                 .HiveLockExpireTimeout = TDuration::Seconds(1),
+                .ExternalBootRequestIdleTimeout =
+                    Args.StorageConfig->GetExternalBootRequestIdleTimeout(),
                 .LogComponent = TFileStoreComponents::HIVE_PROXY,
                 .TabletBootInfoBackupFilePath =
                     Args.StorageConfig->GetTabletBootInfoBackupFilePath(),

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -257,13 +257,16 @@ ui32 TTestEnv::AddDynamicNode()
         nodeIdx);
 
     auto hiveProxy = CreateHiveProxy({
-        StorageConfig->GetPipeClientRetryCount(),
-        StorageConfig->GetPipeClientMinRetryTime(),
-        TDuration::Seconds(1),  // HiveLockExpireTimeout - does not matter
-        TFileStoreComponents::HIVE_PROXY,
-        /*TabletBootInfoBackupFilePath=*/"",
-        /*UseBinaryFormatForTabletBootInfoBackup=*/false,
-        /*FallbackMode=*/false,
+        .PipeClientRetryCount = StorageConfig->GetPipeClientRetryCount(),
+        .PipeClientMinRetryTime = StorageConfig->GetPipeClientMinRetryTime(),
+        .HiveLockExpireTimeout = TDuration::Seconds(1),   // does not matter
+        .ExternalBootRequestIdleTimeout =
+            StorageConfig->GetExternalBootRequestIdleTimeout(),
+        .LogComponent = TFileStoreComponents::HIVE_PROXY,
+        .TabletBootInfoBackupFilePath = {},
+        .UseBinaryFormatForTabletBootInfoBackup = false,
+        .FallbackMode = false,
+        .TenantHiveTabletId = 0,
     });
     auto hiveProxyId = Runtime.Register(
         hiveProxy.release(),

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
@@ -39,6 +39,7 @@ THiveProxyActor::THiveProxyActor(
         NMonitoring::TDynamicCounterPtr counters)
     : ClientCache(CreateTabletPipeClientCache(config))
     , LockExpireTimeout(config.HiveLockExpireTimeout)
+    , ExternalBootRequestIdleTimeout(config.ExternalBootRequestIdleTimeout)
     , LogComponent(config.LogComponent)
     , TabletBootInfoBackupFilePath(config.TabletBootInfoBackupFilePath)
     , UseBinaryFormatForTabletBootInfoBackup(config.UseBinaryFormatForTabletBootInfoBackup)
@@ -551,6 +552,12 @@ STFUNC(THiveProxyActor::StateWork)
         HFunc(TEvHiveProxyPrivate::TEvSendTabletMetrics, HandleSendTabletMetrics);
 
         HFunc(TEvHiveProxyPrivate::TEvRequestFinished, HandleRequestFinished);
+        HFunc(
+            TEvHiveProxyPrivate::TEvBootExternalCompleted,
+            HandleBootExternalCompleted);
+        HFunc(
+            TEvHiveProxyPrivate::TEvBootExternalTimeout,
+            HandleBootExternalTimeout);
 
         default:
             if (!HandleRequests(ev)) {

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
@@ -153,6 +153,71 @@ private:
 
     using TCreateOrLookupRequestQueue = TDeque<TCreateOrLookupRequest>;
 
+    struct TBootExternalWaiterInfo
+    {
+        TRequestInfo Request;
+        TInstant Deadline;
+
+        TBootExternalWaiterInfo(TRequestInfo request, TInstant deadline)
+            : Request(std::move(request))
+            , Deadline(deadline)
+        {}
+
+        bool IsExpired(const TInstant& now) const
+        {
+            return Deadline != TInstant::Zero() && Deadline <= now;
+        }
+    };
+
+    // TInflightBootRequest contains several waiting clients.
+    // The associated TBootRequestActor sends a single
+    // TEvInitiateTabletExternalBoot to HIVE and reports the result back to
+    // THiveProxyActor, which fans the response out to every waiter.
+    struct TInflightBootRequest
+    {
+        NActors::TActorId BootRequestActor;
+        TVector<TBootExternalWaiterInfo> Waiters;
+        // Time of the currently scheduled TEvBootExternalTimeout, if any.
+        // Used to ignore stale wakeups when the schedule changes.
+        TInstant NextWakeupAt;
+        TInstant NearestDeadline;
+        // When the entry has no waiters, the moment after which the idle actor
+        // is torn down. TInstant::Zero() means "wait for a hive answer".
+        TInstant NoWaitersDeadline;
+        // Generation of the current boot episode. Assigned from
+        // THiveProxyActor::NextBootGeneration when a actor is spawned and
+        // return back via TEvBootExternalCompleted so completions belonging to
+        // an already-finished/torn-down episode can be detected and dropped.
+        ui32 Generation = 0;
+
+        void AddWaiter(TRequestInfo r, TInstant deadline)
+        {
+            Waiters.emplace_back(std::move(r), deadline);
+
+            if (deadline != TInstant::Zero() &&
+                (NearestDeadline == TInstant::Zero() ||
+                 deadline < NearestDeadline))
+            {
+                NearestDeadline = deadline;
+            }
+        }
+
+        void RecomputeNearestDeadline()
+        {
+            NearestDeadline = TInstant::Zero();
+            for (const auto& w: Waiters) {
+                if (w.Deadline == TInstant::Zero()) {
+                    continue;
+                }
+                if (NearestDeadline == TInstant::Zero() ||
+                    w.Deadline < NearestDeadline)
+                {
+                    NearestDeadline = w.Deadline;
+                }
+            }
+        }
+    };
+
     struct THiveState
     {
         THashMap<ui64, TLockState> LockStates;
@@ -161,6 +226,9 @@ private:
         THashSet<NActors::TActorId> Actors;
         THashMap<ui64, TTabletStats> UpdatedTabletMetrics;
         bool ScheduledSendTabletMetrics = false;
+
+        // tabletId -> in-flight TEvBootExternalRequest dedup entry
+        THashMap<ui64, TInflightBootRequest> InflightBootRequests;
     };
 
 private:
@@ -168,8 +236,12 @@ private:
 
     std::unique_ptr<NKikimr::NTabletPipe::IClientCache> ClientCache;
     THashMap<ui64, THiveState> HiveStates;
+    // Monotonic source of boot-episode generations. Never reused, so a stale
+    // TEvBootExternalCompleted is always distinguishable from a fresh episode.
+    ui32 NextBootGeneration = 0;
 
     const TDuration LockExpireTimeout;
+    const TDuration ExternalBootRequestIdleTimeout;
     const int LogComponent;
 
     TString TabletBootInfoBackupFilePath;
@@ -289,6 +361,23 @@ private:
     void HandleRequestFinished(
         const TEvHiveProxyPrivate::TEvRequestFinished::TPtr& ev,
         const NActors::TActorContext& ctx);
+
+    void HandleBootExternalCompleted(
+        const TEvHiveProxyPrivate::TEvBootExternalCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleBootExternalTimeout(
+        const TEvHiveProxyPrivate::TEvBootExternalTimeout::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    // Schedule TEvBootExternalTimeout for the smallest waiter deadline (if any)
+    // in the given inflight entry. Idempotent: writes NextWakeupAt and skips
+    // scheduling when nothing changed.
+    void ScheduleBootExternalTimeoutIfNeeded(
+        const NActors::TActorContext& ctx,
+        TInflightBootRequest& inflight,
+        ui64 hive,
+        ui64 tabletId);
 
     void HandleTabletMetrics(
         const NKikimr::TEvLocal::TEvTabletMetrics::TPtr& ev,

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_bootext.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_bootext.cpp
@@ -2,6 +2,8 @@
 
 #include <contrib/ydb/core/mind/local.h>
 
+#include <algorithm>
+
 namespace NCloud::NStorage {
 
 using namespace NActors;
@@ -26,44 +28,69 @@ TString PrintChannels(const TVector<TTabletChannelInfo>& channels)
     return res;
 }
 
+std::unique_ptr<TEvHiveProxy::TEvBootExternalResponse> MakeBootExternalResponse(
+    const NProto::TError& error)
+{
+    return std::make_unique<TEvHiveProxy::TEvBootExternalResponse>(error);
+}
+
+std::unique_ptr<TEvHiveProxy::TEvBootExternalResponse> MakeBootExternalResponse(
+    const TEvHiveProxyPrivate::TBootExternalCompleted& msg)
+{
+    if (HasError(msg.Error)) {
+        return MakeBootExternalResponse(msg.Error);
+    }
+    return std::make_unique<TEvHiveProxy::TEvBootExternalResponse>(
+        msg.StorageInfo,
+        msg.SuggestedGeneration,
+        msg.BootMode,
+        msg.SlaveId);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
+// Actor that works to a single HIVE and Tablet on behalf of THiveProxyActor.
+//
+// Lifetime is owned by THiveProxyActor — the actor dies after sending the
+// result. The set of waiters lives in
+// THiveProxyActor::HiveStates[..].InflightBootRequests, so a late
+// TEvBootExternalRequest is attached to the still-alive actor without a race
+// against the actor's death.
 class TBootRequestActor final
     : public TActorBootstrapped<TBootRequestActor>
 {
 private:
     const TActorId Owner;
     const int LogComponent;
-    const THiveProxyActor::TRequestInfo Request;
+    const ui64 Hive;
     const ui64 TabletId;
+    const ui32 BootGeneration;
     TActorId ClientId;
     TActorId TabletBootInfoBackup;
-    TDuration RequestTimeout;
-    ui64 TimerGeneration = 0;
 
 public:
     TBootRequestActor(
             const TActorId& owner,
             int logComponent,
-            THiveProxyActor::TRequestInfo request,
+            ui64 hive,
             ui64 tabletId,
+            ui32 bootGeneration,
             TActorId clientId,
-            TActorId tabletBootInfoBackup,
-            TDuration externalBootRequestTimeout)
+            TActorId tabletBootInfoBackup)
         : Owner(owner)
         , LogComponent(logComponent)
-        , Request(request)
+        , Hive(hive)
         , TabletId(tabletId)
+        , BootGeneration(bootGeneration)
         , ClientId(clientId)
         , TabletBootInfoBackup(std::move(tabletBootInfoBackup))
-        , RequestTimeout(externalBootRequestTimeout)
     {}
 
     void Bootstrap(const TActorContext& ctx);
 
 private:
     template<class... TArgs>
-    void ReplyAndDie(const TActorContext& ctx, TArgs&&... args);
+    void NotifyAndDie(const TActorContext& ctx, TArgs&&... args);
 
     void HandleChangeTabletClient(
         const TEvHiveProxyPrivate::TEvChangeTabletClient::TPtr& ev,
@@ -77,8 +104,8 @@ private:
         const NKikimr::TEvHive::TEvBootTabletReply::TPtr& ev,
         const TActorContext& ctx);
 
-    void HandleWakeup(
-        const TEvents::TEvWakeup::TPtr& ev,
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
         const TActorContext& ctx);
 
     STFUNC(StateWork);
@@ -93,21 +120,17 @@ void TBootRequestActor::Bootstrap(const TActorContext& ctx)
         ClientId,
         new NKikimr::TEvHive::TEvInitiateTabletExternalBoot(TabletId));
 
-    if (RequestTimeout) {
-        ctx.Schedule(RequestTimeout, new TEvents::TEvWakeup(++TimerGeneration));
-    }
-
     Become(&TThis::StateWork);
 }
 
 template<class... TArgs>
-void TBootRequestActor::ReplyAndDie(const TActorContext& ctx, TArgs&&... args)
+void TBootRequestActor::NotifyAndDie(const TActorContext& ctx, TArgs&&... args)
 {
-    auto response = std::make_unique<TEvHiveProxy::TEvBootExternalResponse>(
+    NCloud::Send<TEvHiveProxyPrivate::TEvBootExternalCompleted>(
+        ctx,
+        Owner,
+        0,   // cookie
         std::forward<TArgs>(args)...);
-    NCloud::Reply(ctx, Request, std::move(response));
-    NCloud::Send<TEvHiveProxyPrivate::TEvRequestFinished>(
-        ctx, Owner, TabletId, TabletId);
     Die(ctx);
 }
 
@@ -171,8 +194,11 @@ void TBootRequestActor::HandleBoot(
             break;
     }
 
-    ReplyAndDie(
+    NotifyAndDie(
         ctx,
+        Hive,
+        TabletId,
+        BootGeneration,
         std::move(storageInfo),
         suggestedGeneration,
         bootMode,
@@ -185,29 +211,24 @@ void TBootRequestActor::HandleError(
 {
     const auto* msg = ev->Get();
 
-    ReplyAndDie(
+    NotifyAndDie(
         ctx,
+        Hive,
+        TabletId,
+        BootGeneration,
         MakeKikimrError(msg->Record.GetStatus(), "External boot failed"));
 }
 
-void TBootRequestActor::HandleWakeup(
-    const TEvents::TEvWakeup::TPtr& ev,
+void TBootRequestActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
     const TActorContext& ctx)
 {
-    const auto* msg = ev->Get();
+    Y_UNUSED(ev);
 
-    if (msg->Tag != TimerGeneration) {
-        return;
-    }
+    LOG_DEBUG(ctx, LogComponent, "[%lu] poisoned by hive proxy", TabletId);
 
-    LOG_ERROR(ctx, LogComponent,
-        "External boot request has timed out");
-
-    ReplyAndDie(
-        ctx,
-        MakeKikimrError(
-            NKikimrProto::EReplyStatus::TRYLATER,
-            "External boot timed out"));
+    // No report — the hive proxy is the sender and already knows about.
+    Die(ctx);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -220,7 +241,7 @@ STFUNC(TBootRequestActor::StateWork)
         HFunc(NKikimr::TEvLocal::TEvBootTablet, HandleBoot);
         HFunc(NKikimr::TEvHive::TEvBootTabletReply, HandleError);
 
-        HFunc(TEvents::TEvWakeup, HandleWakeup);
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
 
         default:
             HandleUnexpectedEvent(ev, LogComponent, __PRETTY_FUNCTION__);
@@ -238,21 +259,252 @@ void THiveProxyActor::HandleBootExternal(
 {
     const auto* msg = ev->Get();
 
-    ui64 tabletId = msg->TabletId;
-    ui64 hive = GetHive(ctx, tabletId);
+    const ui64 tabletId = msg->TabletId;
+    const ui64 hive = GetHive(ctx, tabletId);
 
-    auto clientId = ClientCache->Prepare(ctx, hive);
-    auto requestId = NCloud::Register<TBootRequestActor>(
-        ctx,
-        SelfId(),
-        LogComponent,
-        TRequestInfo(ev->Sender, ev->Cookie),
-        tabletId,
-        clientId,
-        TabletBootInfoBackup,
-        msg->RequestTimeout
-    );
-    HiveStates[hive].Actors.insert(requestId);
+    auto& states = HiveStates[hive];
+    auto& inflight = states.InflightBootRequests[tabletId];
+
+    const auto now = ctx.Now();
+    const TInstant deadline =
+        msg->RequestTimeout ? now + msg->RequestTimeout : TInstant::Zero();
+
+    inflight.AddWaiter(TRequestInfo(ev->Sender, ev->Cookie), deadline);
+
+    if (!inflight.BootRequestActor) {
+        inflight.Generation = ++NextBootGeneration;
+        auto clientId = ClientCache->Prepare(ctx, hive);
+        inflight.BootRequestActor = NCloud::Register<TBootRequestActor>(
+            ctx,
+            SelfId(),
+            LogComponent,
+            hive,
+            tabletId,
+            inflight.Generation,
+            clientId,
+            TabletBootInfoBackup);
+        states.Actors.insert(inflight.BootRequestActor);
+
+        LOG_INFO(
+            ctx,
+            LogComponent,
+            "[%lu] Started new TEvBootExternalRequest actor (hive=%lu, "
+            "generation=%lu)",
+            tabletId,
+            hive,
+            inflight.Generation);
+    } else {
+        inflight.NoWaitersDeadline = TInstant::Zero();
+
+        LOG_INFO(
+            ctx,
+            LogComponent,
+            "[%lu] Attached new TEvBootExternalRequest waiter to in-flight "
+            "request (total waiters: %lu)",
+            tabletId,
+            inflight.Waiters.size());
+    }
+
+    ScheduleBootExternalTimeoutIfNeeded(ctx, inflight, hive, tabletId);
+}
+
+void THiveProxyActor::ScheduleBootExternalTimeoutIfNeeded(
+    const TActorContext& ctx,
+    TInflightBootRequest& inflight,
+    ui64 hive,
+    ui64 tabletId)
+{
+    // The next wake up moment for this entry: while clients are
+    // waiting it is the nearest waiter deadline; once the last waiter is gone
+    // it is the no-waiters deadline.
+    const TInstant target = inflight.Waiters.empty()
+                                ? inflight.NoWaitersDeadline
+                                : inflight.NearestDeadline;
+
+    if (target == TInstant::Zero()) {
+        return;
+    }
+
+    if (inflight.NextWakeupAt != TInstant::Zero() &&
+        inflight.NextWakeupAt <= target)
+    {
+        // Already have an equal or earlier wakeup scheduled — it will fire and
+        // we'll re-evaluate then.
+        return;
+    }
+
+    const auto now = ctx.Now();
+    const auto delay = target > now ? target - now : TDuration::Zero();
+
+    inflight.NextWakeupAt = target;
+    ctx.Schedule(
+        delay,
+        new TEvHiveProxyPrivate::TEvBootExternalTimeout(hive, tabletId));
+}
+
+void THiveProxyActor::HandleBootExternalCompleted(
+    const TEvHiveProxyPrivate::TEvBootExternalCompleted::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    const ui64 tabletId = msg->TabletId;
+    const ui64 hive = msg->Hive;
+
+    auto* states = HiveStates.FindPtr(hive);
+    if (!states) {
+        LOG_WARN(
+            ctx,
+            LogComponent,
+            "[%lu] can't find HiveStates with hive=%lu",
+            tabletId,
+            hive);
+        Y_DEBUG_ABORT_UNLESS(false);
+        return;
+    }
+
+    auto it = states->InflightBootRequests.find(tabletId);
+    if (it == states->InflightBootRequests.end()) {
+        // Expected under the idle-timeout race: the request was already
+        // completed or torn down and its entry erased while this completion
+        // was still queued. Drop it — neither abort nor mis-deliver.
+        LOG_DEBUG(
+            ctx,
+            LogComponent,
+            "[%lu] stale boot completed, no inflight entry, hive=%lu, "
+            "generation=%lu",
+            tabletId,
+            hive,
+            msg->InflightGeneration);
+        return;
+    }
+
+    // Reply to all waiters of the inflight boot request,
+    // drop the inflight entry from HiveStates[hive] and stop
+    // tracking the actor.
+    auto& inflight = it->second;
+
+    if (inflight.Generation != msg->InflightGeneration) {
+        // A completion from a previous request's actor raced with a new
+        // one for the same tabletId (e.g. idle teardown + fresh request).
+        // Ignore it: the new waiters keep waiting for their own answer.
+        LOG_DEBUG(
+            ctx,
+            LogComponent,
+            "[%lu] stale boot completed, generation %lu != %lu, hive=%lu",
+            tabletId,
+            msg->InflightGeneration,
+            inflight.Generation,
+            hive);
+        return;
+    }
+
+    for (const auto& waiter: inflight.Waiters) {
+        auto response = MakeBootExternalResponse(*msg);
+        NCloud::Reply(ctx, waiter.Request, std::move(response));
+    }
+
+    if (inflight.BootRequestActor) {
+        states->Actors.erase(inflight.BootRequestActor);
+    }
+
+    states->InflightBootRequests.erase(it);
+}
+
+void THiveProxyActor::HandleBootExternalTimeout(
+    const TEvHiveProxyPrivate::TEvBootExternalTimeout::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    const ui64 tabletId = msg->TabletId;
+    const ui64 hive = msg->Hive;
+
+    auto* states = HiveStates.FindPtr(hive);
+    if (!states) {
+        LOG_WARN(
+            ctx,
+            LogComponent,
+            "[%lu] can't find HiveStates with hive=%lu",
+            tabletId,
+            hive);
+        Y_DEBUG_ABORT_UNLESS(false);
+        return;
+    }
+
+    auto it = states->InflightBootRequests.find(tabletId);
+    if (it == states->InflightBootRequests.end()) {
+        // Expected: the boot already completed (HIVE replied) and the entry was
+        // erased, but the scheduled TEvBootExternalTimeout cannot be cancelled
+        // and fires afterwards. Ignore the stale timer.
+        LOG_DEBUG(
+            ctx,
+            LogComponent,
+            "[%lu] stale boot timeout, no inflight entry, hive=%lu",
+            tabletId,
+            hive);
+        return;
+    }
+
+    auto& inflight = it->second;
+
+    const auto now = ctx.Now();
+
+    if (inflight.NextWakeupAt && now < inflight.NextWakeupAt) {
+        // Stale wakeup (a smaller deadline was added after this timer was
+        // armed, or the entry has been refreshed since).
+        return;
+    }
+    inflight.NextWakeupAt = TInstant::Zero();
+
+    auto expired = std::stable_partition(
+        inflight.Waiters.begin(),
+        inflight.Waiters.end(),
+        [now](const TBootExternalWaiterInfo& w) { return !w.IsExpired(now); });
+
+    for (auto it2 = expired; it2 != inflight.Waiters.end(); ++it2) {
+        auto response = MakeBootExternalResponse(
+            MakeError(E_REJECTED, "External boot timed out"));
+        NCloud::Reply(ctx, it2->Request, std::move(response));
+    }
+    inflight.Waiters.erase(expired, inflight.Waiters.end());
+
+    inflight.RecomputeNearestDeadline();
+
+    if (inflight.Waiters.empty()) {
+        // No clients are waiting anymore. Keep the actor (and its
+        // still-pending TEvInitiateTabletExternalBoot) alive for a
+        // ExternalBootRequestIdleTimeout so a fresh retry storm for the same
+        // tabletId still collapses onto the in-flight HIVE call instead of
+        // issuing a new one — this is the whole point of the dedup.
+        // If the window elapses with no new waiter, stop the idle actor so
+        // the entry doesn't live forever and a pipe reset doesn't re-boot
+        // the tablet with nobody waiting.
+        if (ExternalBootRequestIdleTimeout == TDuration::Zero()) {
+            // keep the actor until HIVE replies (success or error)
+            // via HandleBootExternalCompleted.
+        } else if (inflight.NoWaitersDeadline == TInstant::Zero()) {
+            inflight.NoWaitersDeadline = now + ExternalBootRequestIdleTimeout;
+        } else if (now >= inflight.NoWaitersDeadline) {
+            LOG_INFO(
+                ctx,
+                LogComponent,
+                "[%lu] timeout of the idle TEvBootExternalRequest actor is "
+                "finished, stopping it (hive=%lu)",
+                tabletId,
+                hive);
+            if (inflight.BootRequestActor) {
+                NCloud::Send<TEvents::TEvPoisonPill>(
+                    ctx,
+                    inflight.BootRequestActor);
+                states->Actors.erase(inflight.BootRequestActor);
+            }
+            states->InflightBootRequests.erase(it);
+            return;
+        }
+    } else {
+        inflight.NoWaitersDeadline = TInstant::Zero();
+    }
+
+    ScheduleBootExternalTimeoutIfNeeded(ctx, inflight, hive, tabletId);
 }
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_events_private.h
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_events_private.h
@@ -4,8 +4,11 @@
 
 #include "tablet_boot_info.h"
 
+#include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/libs/kikimr/components.h>
 #include <cloud/storage/core/libs/kikimr/events.h>
+
+#include <contrib/ydb/core/base/blobstorage.h>
 
 namespace NCloud::NStorage {
 
@@ -116,6 +119,75 @@ struct TEvHiveProxyPrivate
     };
 
     //
+    // BootExternalCompleted
+    //
+    // Internal event: TBootRequestActor -> THiveProxyActor.
+    // Carries the response received from HIVE (or an error) for a single
+    // in-flight boot request. The proxy sends this information to every
+    // waiter registered with the tablet ID.
+
+    struct TBootExternalCompleted
+    {
+        const ui64 Hive;
+        const ui64 TabletId;
+        // helps to drop a completion that raced with idle teardown / a newer
+        // episode for the same tabletId.
+        const ui32 InflightGeneration = 0;
+        const NProto::TError Error;
+        const NKikimr::TTabletStorageInfoPtr StorageInfo;
+        const ui32 SuggestedGeneration = 0;
+        const TEvHiveProxy::TBootExternalResponse::EBootMode BootMode =
+            TEvHiveProxy::TBootExternalResponse::EBootMode::MASTER;
+        const ui32 SlaveId = 0;
+
+        TBootExternalCompleted(
+            ui64 hive,
+            ui64 tabletId,
+            ui32 inflightGeneration,
+            NProto::TError error)
+            : Hive(hive)
+            , TabletId(tabletId)
+            , InflightGeneration(inflightGeneration)
+            , Error(std::move(error))
+        {}
+
+        TBootExternalCompleted(
+            ui64 hive,
+            ui64 tabletId,
+            ui32 inflightGeneration,
+            NKikimr::TTabletStorageInfoPtr storageInfo,
+            ui32 suggestedGeneration,
+            TEvHiveProxy::TBootExternalResponse::EBootMode bootMode,
+            ui32 slaveId)
+            : Hive(hive)
+            , TabletId(tabletId)
+            , InflightGeneration(inflightGeneration)
+            , StorageInfo(std::move(storageInfo))
+            , SuggestedGeneration(suggestedGeneration)
+            , BootMode(bootMode)
+            , SlaveId(slaveId)
+        {}
+    };
+
+    //
+    // BootExternalTimeout
+    //
+    // Self-scheduled wakeup used by THiveProxyActor to expire waiters of an
+    // in-flight boot request. Carries tabletId to look up the inflight entry.
+    //
+
+    struct TBootExternalTimeout
+    {
+        const ui64 Hive;
+        const ui64 TabletId;
+
+        TBootExternalTimeout(ui64 hive, ui64 tabletId)
+            : Hive(hive)
+            , TabletId(tabletId)
+        {}
+    };
+
+    //
     // Events declaration
     //
 
@@ -130,6 +202,9 @@ struct TEvHiveProxyPrivate
         EvReadTabletBootInfoBackupRequest,
         EvReadTabletBootInfoBackupResponse,
         EvUpdateTabletBootInfoBackupRequest,
+
+        EvBootExternalCompleted,
+        EvBootExternalTimeout,
 
         EvEnd
     };
@@ -148,6 +223,11 @@ struct TEvHiveProxyPrivate
         TReadTabletBootInfoBackupResponse, EvReadTabletBootInfoBackupResponse>;
     using TEvUpdateTabletBootInfoBackupRequest = TRequestEvent<
         TUpdateTabletBootInfoBackupRequest, EvUpdateTabletBootInfoBackupRequest>;
+
+    using TEvBootExternalCompleted =
+        TRequestEvent<TBootExternalCompleted, EvBootExternalCompleted>;
+    using TEvBootExternalTimeout =
+        TRequestEvent<TBootExternalTimeout, EvBootExternalTimeout>;
 };
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp
@@ -472,7 +472,8 @@ struct TTestEnv
 
     TTestEnv(
             TTestActorRuntime& runtime,
-            EExternalBootOptions externalBootOptions)
+            EExternalBootOptions externalBootOptions,
+            TDuration externalBootRequestIdleTimeout = TDuration::Zero())
         : Runtime(runtime)
         , HiveState(MakeIntrusive<THiveMockState>())
     {
@@ -486,7 +487,7 @@ struct TTestEnv
 
         BootHiveMock(Runtime, FakeHiveTablet, HiveState, externalBootOptions);
 
-        SetupHiveProxy("", false, 0);
+        SetupHiveProxy("", false, 0, externalBootRequestIdleTimeout);
     }
 
     ~TTestEnv()
@@ -521,12 +522,14 @@ struct TTestEnv
     void SetupHiveProxy(
         TString tabletBootInfoBackupFilePath,
         bool fallbackMode,
-        ui64 tenantHive)
+        ui64 tenantHive,
+        TDuration externalBootRequestIdleTimeout = TDuration::Zero())
     {
         THiveProxyConfig config{
             .PipeClientRetryCount = 4,
             .PipeClientMinRetryTime = TDuration::Seconds(1),
             .HiveLockExpireTimeout = TDuration::Seconds(30),
+            .ExternalBootRequestIdleTimeout = externalBootRequestIdleTimeout,
             .LogComponent = 0,
             .TabletBootInfoBackupFilePath = tabletBootInfoBackupFilePath,
             .FallbackMode = fallbackMode,
@@ -636,21 +639,57 @@ struct TTestEnv
         return *msg;
     }
 
+    void SendBootExternalRequestAsync(const TActorId& sender, ui64 tabletId)
+    {
+        Runtime.Send(new IEventHandle(
+            MakeHiveProxyServiceId(),
+            sender,
+            new TEvHiveProxy::TEvBootExternalRequest(tabletId)));
+    }
+
+    void SendBootExternalRequestAsync(
+        const TActorId& sender,
+        ui64 tabletId,
+        TDuration requestTimeout)
+    {
+        Runtime.Send(new IEventHandle(
+            MakeHiveProxyServiceId(),
+            sender,
+            new TEvHiveProxy::TEvBootExternalRequest(
+                tabletId,
+                requestTimeout)));
+    }
+
+    struct TBootExternalResult
+    {
+        NProto::TError Error;
+        TEvHiveProxy::TBootExternalResponse Response;
+
+        ui32 GetStatus() const
+        {
+            return Error.GetCode();
+        }
+    };
+
+    TBootExternalResult GrabBootExternalResponse(const TActorId& sender)
+    {
+        auto ev = Runtime.GrabEdgeEvent<TEvHiveProxy::TEvBootExternalResponse>(
+            sender);
+        UNIT_ASSERT(ev);
+        const auto* msg = ev->Get();
+        return {msg->GetError(), *msg};
+    }
+
     TEvHiveProxy::TBootExternalResponse SendBootExternalRequest(
         const TActorId& sender,
         ui64 tabletId,
         ui32 errorCode,
         TDuration requestTimeout)
     {
-        Runtime.Send(new IEventHandle(
-            MakeHiveProxyServiceId(),
-            sender,
-            new TEvHiveProxy::TEvBootExternalRequest(tabletId, requestTimeout)));
-        auto ev = Runtime.GrabEdgeEvent<TEvHiveProxy::TEvBootExternalResponse>(sender);
-        UNIT_ASSERT(ev);
-        const auto* msg = ev->Get();
-        UNIT_ASSERT_VALUES_EQUAL(msg->GetStatus(), errorCode);
-        return *msg;
+        SendBootExternalRequestAsync(sender, tabletId, requestTimeout);
+        const auto result = GrabBootExternalResponse(sender);
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), errorCode);
+        return result.Response;
     }
 
     TEvHiveProxy::TReassignTabletResponse SendReassignTabletRequest(
@@ -1343,7 +1382,7 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
         auto result = env.SendBootExternalRequest(
             sender,
             FakeTablet2,
-            MAKE_KIKIMR_ERROR(NKikimrProto::TRYLATER),
+            E_REJECTED,
             TDuration::Seconds(1));
         UNIT_ASSERT(!result.StorageInfo);
     }
@@ -1878,6 +1917,768 @@ Y_UNIT_TEST_SUITE(THiveProxyTest)
 
             env.SendListTabletBootInfoBackups(sender, S_OK);
         }
+    }
+
+    Y_UNIT_TEST(ShouldDedupConcurrentBootRequests)
+    {
+        // While a single TEvBootExternalRequest is in flight for tabletId X,
+        // any new TEvBootExternalRequest for the same tabletId must attach
+        // to the existing in-flight call rather than spawn a duplicate
+        // TEvInitiateTabletExternalBoot to HIVE.
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, EExternalBootOptions::IGNORE);
+
+        int hiveBootRequests = 0;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() ==
+                    TEvHive::EvInitiateTabletExternalBoot) {
+                    ++hiveBootRequests;
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        auto sender2 = runtime.AllocateEdgeActor();
+        auto sender3 = runtime.AllocateEdgeActor();
+
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender2,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender3,
+            FakeTablet2,
+            TDuration::Minutes(10));
+
+        // Let proxy/actor dispatch all queued events.
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+    }
+
+    Y_UNIT_TEST(ShouldSendSuccessToAllWaiters)
+    {
+        // Several callers wait on the same tabletId. When HIVE replies once
+        // (PROCESS mode), every waiter receives the same successful response.
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TTabletStorageInfoPtr expected = CreateTestTabletInfo(
+            FakeTablet2,
+            TTabletTypes::BlockStorePartition);
+        env.HiveState->StorageInfos[FakeTablet2] = expected;
+
+        // Hold TEvInitiateTabletExternalBoot in flight until we've queued
+        // all three TEvBootExternalRequest events so dedup actually kicks in
+        // (otherwise HIVE may reply to request #1 before #2/#3 reach proxy).
+        int bootCompleted = 0;
+        int hiveBootRequests = 0;
+        TVector<TAutoPtr<IEventHandle>> heldHiveRequests;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvHive::EvInitiateTabletExternalBoot: {
+                        ++hiveBootRequests;
+                        heldHiveRequests.emplace_back(ev.Release());
+                        return true;
+                    }
+                    case TEvHiveProxyPrivate::EvBootExternalCompleted: {
+                        ++bootCompleted;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        auto sender2 = runtime.AllocateEdgeActor();
+        auto sender3 = runtime.AllocateEdgeActor();
+
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender2,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender3,
+            FakeTablet2,
+            TDuration::Minutes(10));
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        // Only one HIVE boot was dispatched.
+        UNIT_ASSERT_VALUES_EQUAL(0, bootCompleted);
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+        UNIT_ASSERT_VALUES_EQUAL(1u, heldHiveRequests.size());
+
+        // Release the held HIVE request — HIVE will now reply once.
+        runtime.Send(heldHiveRequests.front().Release());
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, bootCompleted);
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        // All three waiters receive the same successful response.
+        auto r1 = env.GrabBootExternalResponse(sender1);
+        auto r2 = env.GrabBootExternalResponse(sender2);
+        auto r3 = env.GrabBootExternalResponse(sender3);
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, r1.GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, r2.GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, r3.GetStatus());
+
+        UNIT_ASSERT(r1.Response.StorageInfo);
+        UNIT_ASSERT(r2.Response.StorageInfo);
+        UNIT_ASSERT(r3.Response.StorageInfo);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            expected->TabletID,
+            r1.Response.StorageInfo->TabletID);
+        UNIT_ASSERT_VALUES_EQUAL(
+            r1.Response.StorageInfo->TabletID,
+            r2.Response.StorageInfo->TabletID);
+        UNIT_ASSERT_VALUES_EQUAL(
+            r1.Response.StorageInfo->TabletID,
+            r3.Response.StorageInfo->TabletID);
+
+        // Only one HIVE generation bump — the request was not duplicated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            1u,
+            env.HiveState->KnownGenerations[FakeTablet2]);
+    }
+
+    Y_UNIT_TEST(ShouldSendErrorToAllWaiters)
+    {
+        // When HIVE replies with an error, every deduped waiter for that
+        // tabletId receives the same error.
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        int bootCompleted = 0;
+        int hiveBootRequests = 0;
+        TVector<TAutoPtr<IEventHandle>> heldHiveRequests;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvHive::EvInitiateTabletExternalBoot: {
+                        ++hiveBootRequests;
+                        heldHiveRequests.emplace_back(ev.Release());
+                        return true;
+                    }
+                    case TEvHiveProxyPrivate::EvBootExternalCompleted: {
+                        ++bootCompleted;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        auto sender2 = runtime.AllocateEdgeActor();
+
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender2,
+            FakeTablet2,
+            TDuration::Minutes(10));
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(0, bootCompleted);
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        runtime.Send(heldHiveRequests.front().Release());
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(1, bootCompleted);
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        auto r1 = env.GrabBootExternalResponse(sender1);
+        auto r2 = env.GrabBootExternalResponse(sender2);
+
+        UNIT_ASSERT(FAILED(r1.GetStatus()));
+        UNIT_ASSERT(FAILED(r2.GetStatus()));
+        UNIT_ASSERT(!r1.Response.StorageInfo);
+        UNIT_ASSERT(!r2.Response.StorageInfo);
+    }
+
+    Y_UNIT_TEST(ShouldKeepActorAliveAfterWaiterTimeout)
+    {
+        // After a waiter's deadline elapses we reply E_REJECTED, but the
+        // underlying TBootRequestActor must stay alive so that a subsequent
+        // TEvBootExternalRequest reuses the in-flight HIVE call instead of
+        // creating a new one. This is what actually defuses the retry storm.
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, EExternalBootOptions::IGNORE);
+
+        int hiveBootRequests = 0;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() ==
+                    TEvHive::EvInitiateTabletExternalBoot) {
+                    ++hiveBootRequests;
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Seconds(1));
+
+        // Sender1 must time out (REJECTED).
+        auto r1 = env.GrabBootExternalResponse(sender1);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, r1.GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        // Right after the timeout the actor is still alive. A second caller
+        // attaches as a waiter and the HIVE request is NOT re-sent.
+        auto sender2 = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            sender2,
+            FakeTablet2,
+            TDuration::Seconds(1));
+        auto r2 = env.GrabBootExternalResponse(sender2);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, r2.GetStatus());
+
+        // No additional TEvInitiateTabletExternalBoot was sent to HIVE.
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+    }
+
+    Y_UNIT_TEST(ShouldNotDedupAcrossTablets)
+    {
+        // Sanity check: dedup is per-tabletId. Two different tabletIds
+        // produce two separate TEvInitiateTabletExternalBoot calls.
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, EExternalBootOptions::IGNORE);
+
+        int hiveBootRequests = 0;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() ==
+                    TEvHive::EvInitiateTabletExternalBoot) {
+                    ++hiveBootRequests;
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        auto sender2 = runtime.AllocateEdgeActor();
+
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender2,
+            FakeTablet3,
+            TDuration::Minutes(10));
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        UNIT_ASSERT_VALUES_EQUAL(2, hiveBootRequests);
+    }
+
+    Y_UNIT_TEST(ShouldStartFreshActorAfterHiveResponse)
+    {
+        // After HIVE replies, the inflight entry is cleared and the actor
+        // dies. A new TEvBootExternalRequest must spawn a fresh actor (and
+        // a fresh TEvInitiateTabletExternalBoot to HIVE).
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TTabletStorageInfoPtr expected = CreateTestTabletInfo(
+            FakeTablet2,
+            TTabletTypes::BlockStorePartition);
+        env.HiveState->StorageInfos[FakeTablet2] = expected;
+
+        int hiveBootRequests = 0;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() ==
+                    TEvHive::EvInitiateTabletExternalBoot) {
+                    ++hiveBootRequests;
+                }
+                return false;
+            });
+
+        auto sender = runtime.AllocateEdgeActor();
+
+        auto r1 = env.SendBootExternalRequest(sender, FakeTablet2, S_OK);
+        UNIT_ASSERT_VALUES_EQUAL(1u, r1.SuggestedGeneration);
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        auto r2 = env.SendBootExternalRequest(sender, FakeTablet2, S_OK);
+        UNIT_ASSERT_VALUES_EQUAL(2u, r2.SuggestedGeneration);
+        UNIT_ASSERT_VALUES_EQUAL(2, hiveBootRequests);
+    }
+
+    Y_UNIT_TEST(ShouldExpireOnlyTimedOutWaiters)
+    {
+        // Three waiters share the same in-flight HIVE call. The waiter with the
+        // shorter deadline must receive E_REJECTED, then the waiter with the
+        // longer deadline must receive E_REJECTED and once HIVE finally replies
+        // the remaining waiter must receive the successful response.
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TTabletStorageInfoPtr expected = CreateTestTabletInfo(
+            FakeTablet2,
+            TTabletTypes::BlockStorePartition);
+        env.HiveState->StorageInfos[FakeTablet2] = expected;
+
+        int hiveBootRequests = 0;
+        TVector<TAutoPtr<IEventHandle>> heldHiveRequests;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() ==
+                    TEvHive::EvInitiateTabletExternalBoot) {
+                    ++hiveBootRequests;
+                    heldHiveRequests.emplace_back(ev.Release());
+                    return true;
+                }
+                return false;
+            });
+
+        auto shortSender = runtime.AllocateEdgeActor();
+        auto longSender = runtime.AllocateEdgeActor();
+        auto infinitySender = runtime.AllocateEdgeActor();
+
+        env.SendBootExternalRequestAsync(infinitySender, FakeTablet2);
+        env.SendBootExternalRequestAsync(
+            shortSender,
+            FakeTablet2,
+            TDuration::Seconds(1));
+        env.SendBootExternalRequestAsync(
+            longSender,
+            FakeTablet2,
+            TDuration::Minutes(10));
+
+        // Both requests must attach to the same in-flight HIVE call.
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+        UNIT_ASSERT_VALUES_EQUAL(1u, heldHiveRequests.size());
+
+        // Short waiter must time out with E_REJECTED while HIVE is still silent.
+        auto shortResult = env.GrabBootExternalResponse(shortSender);
+        UNIT_ASSERT(
+            !runtime.GrabEdgeEvent<TEvHiveProxy::TEvBootExternalResponse>(
+                longSender,
+                TDuration::MilliSeconds(50)));
+        UNIT_ASSERT(
+            !runtime.GrabEdgeEvent<TEvHiveProxy::TEvBootExternalResponse>(
+                infinitySender,
+                TDuration::MilliSeconds(50)));
+
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, shortResult.GetStatus());
+        UNIT_ASSERT(!shortResult.Response.StorageInfo);
+
+        // No extra HIVE request was issued — the long waiter still rides on the
+        // original in-flight call.
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        runtime.UpdateCurrentTime(runtime.GetCurrentTime() + TDuration::Minutes(10));
+        auto longResult = env.GrabBootExternalResponse(longSender);
+        UNIT_ASSERT(
+            !runtime.GrabEdgeEvent<TEvHiveProxy::TEvBootExternalResponse>(
+                infinitySender,
+                TDuration::MilliSeconds(50)));
+
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, longResult.GetStatus());
+        UNIT_ASSERT(!longResult.Response.StorageInfo);
+
+        // Release the held HIVE request — HIVE will now reply success.
+        runtime.Send(heldHiveRequests.front().Release());
+
+        auto infResult = env.GrabBootExternalResponse(infinitySender);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, infResult.GetStatus());
+        UNIT_ASSERT(infResult.Response.StorageInfo);
+        UNIT_ASSERT_VALUES_EQUAL(
+            expected->TabletID,
+            infResult.Response.StorageInfo->TabletID);
+        UNIT_ASSERT_VALUES_EQUAL(1u, infResult.Response.SuggestedGeneration);
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+    }
+
+    Y_UNIT_TEST(ShouldNotResendHiveRequestOnPipeReset)
+    {
+        // Pipe reset between HIVE and the proxy must not cause the in-flight
+        // boot request to be split into per-waiter HIVE calls: the single
+        // shared actor re-issues exactly one TEvInitiateTabletExternalBoot.
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, EExternalBootOptions::IGNORE);
+
+        int hiveBootRequests = 0;
+        int bootCompleted = 0;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvHive::EvInitiateTabletExternalBoot:
+                        ++hiveBootRequests;
+                        break;
+                    case TEvHiveProxyPrivate::EvBootExternalCompleted:
+                        ++bootCompleted;
+                        break;
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        auto sender2 = runtime.AllocateEdgeActor();
+        auto sender3 = runtime.AllocateEdgeActor();
+
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender2,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        env.SendBootExternalRequestAsync(
+            sender3,
+            FakeTablet2,
+            TDuration::Minutes(10));
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        // Pre-reset state: one HIVE request shared by three waiters,
+        // no completions yet.
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+        UNIT_ASSERT_VALUES_EQUAL(0, bootCompleted);
+
+        // Force pipe reset between proxy and HIVE. The proxy must send
+        // TEvChangeTabletClient to its actor, which re-bootstraps and re-sends
+        // a single TEvInitiateTabletExternalBoot.
+        env.EnableTabletResolverScheduling();
+        env.RebootHive();
+
+        const int hiveBootRequestsBefore = hiveBootRequests;
+        for (int retries = 0;
+             retries < 5 && hiveBootRequests == hiveBootRequestsBefore;
+             ++retries)
+        {
+            // Pipe to hive may take a long time to reconnect.
+            runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        }
+
+        // Exactly one extra TEvInitiateTabletExternalBoot per pipe reset.
+        UNIT_ASSERT_VALUES_EQUAL(2, hiveBootRequests);
+
+        // No completion has been delivered to the proxy: so all three waiters
+        // keep riding the in-flight request.
+        UNIT_ASSERT_VALUES_EQUAL(0, bootCompleted);
+    }
+
+    Y_UNIT_TEST(ShouldStopNoWaitersActorAfterIdleTimeout)
+    {
+        const auto idleTimeout = TDuration::Seconds(30);
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, EExternalBootOptions::IGNORE, idleTimeout);
+
+        int hiveBootRequests = 0;
+        TVector<TAutoPtr<IEventHandle>> heldHiveRequests;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() ==
+                    TEvHive::EvInitiateTabletExternalBoot) {
+                    ++hiveBootRequests;
+                    heldHiveRequests.emplace_back(ev.Release());
+                    return true;
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Seconds(1));
+
+        // Sender1 must time out (REJECTED).
+        auto r1 = env.GrabBootExternalResponse(sender1);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, r1.GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        runtime.UpdateCurrentTime(
+            runtime.GetCurrentTime() + idleTimeout - TDuration::Seconds(5));
+
+        auto sender2 = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            sender2,
+            FakeTablet2,
+            TDuration::Seconds(1));
+        auto r2 = env.GrabBootExternalResponse(sender2);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, r2.GetStatus());
+        // No additional TEvInitiateTabletExternalBoot was sent to HIVE.
+        UNIT_ASSERT_VALUES_EQUAL(1, hiveBootRequests);
+
+        runtime.UpdateCurrentTime(
+            runtime.GetCurrentTime() + TDuration::Seconds(5));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        runtime.UpdateCurrentTime(
+            runtime.GetCurrentTime() + idleTimeout + TDuration::Seconds(1));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        // After the idle timeout the actor must be stopped. A second caller
+        // creates new HIVE request.
+        auto sender3 = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            sender3,
+            FakeTablet2,
+            TDuration::Seconds(1));
+        auto r3 = env.GrabBootExternalResponse(sender3);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, r3.GetStatus());
+
+        // No additional TEvInitiateTabletExternalBoot was sent to HIVE.
+        UNIT_ASSERT_VALUES_EQUAL(2, hiveBootRequests);
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreStaleBootTimeoutAfterCompletion)
+    {
+        // A waiter supplies a finite RequestTimeout, but HIVE replies before
+        // it. The scheduled TEvBootExternalTimeout cannot be cancelled and
+        // fires after HandleBootExternalCompleted has already erased the entry.
+        // The proxy must ignore it (no ABORT / crash).
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);   // PROCESS: HIVE replies normally
+
+        TTabletStorageInfoPtr expected = CreateTestTabletInfo(
+            FakeTablet2,
+            TTabletTypes::BlockStorePartition);
+        env.HiveState->StorageInfos[FakeTablet2] = expected;
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        // Finite timeout => a TEvBootExternalTimeout gets scheduled at +5s.
+        auto r1 = env.SendBootExternalRequest(
+            sender1,
+            FakeTablet2,
+            S_OK,
+            TDuration::Seconds(5));
+        UNIT_ASSERT(r1.StorageInfo);   // HIVE replied, inflight entry erased
+
+        // Fire the now-orphan timeout. Must not crash.
+        runtime.UpdateCurrentTime(
+            runtime.GetCurrentTime() + TDuration::Seconds(10));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        // The proxy is still functional: a fresh boot still succeeds.
+        auto sender2 = runtime.AllocateEdgeActor();
+        auto r2 = env.SendBootExternalRequest(
+            sender2,
+            FakeTablet2,
+            S_OK,
+            TDuration::Seconds(5));
+        UNIT_ASSERT(r2.StorageInfo);
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreStaleBootCompletedAfterIdleTeardown)
+    {
+        // Waiter times out -> actor becomes idle -> idle teardown erases the
+        // entry and poisons the actor. But the actor had already produced a
+        // TEvBootExternalCompleted (HIVE replied) that is still queued. When it
+        // reaches the proxy the entry is gone -> must be ignored, not abort.
+
+        TTestBasicRuntime runtime;
+        const auto idleTimeout = TDuration::Seconds(5);
+        TTestEnv env(runtime, EExternalBootOptions::PROCESS, idleTimeout);
+
+        TTabletStorageInfoPtr expected = CreateTestTabletInfo(
+            FakeTablet2,
+            TTabletTypes::BlockStorePartition);
+        env.HiveState->StorageInfos[FakeTablet2] = expected;
+
+        TVector<TAutoPtr<IEventHandle>> heldHiveBoots;
+        TVector<TAutoPtr<IEventHandle>> heldCompleted;
+        bool holdHiveBoots = true;
+        bool holdCompleted = true;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvHive::EvInitiateTabletExternalBoot:
+                        if (holdHiveBoots) {
+                            heldHiveBoots.emplace_back(ev.Release());
+                            return true;
+                        }
+                        break;
+                    case TEvHiveProxyPrivate::EvBootExternalCompleted:
+                        if (holdCompleted) {
+                            heldCompleted.emplace_back(ev.Release());
+                            return true;
+                        }
+                        break;
+                }
+                return false;
+            });
+
+        auto sender1 = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Seconds(1));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(1u, heldHiveBoots.size());
+
+        // Waiter times out -> E_REJECTED, entry idle, NoWaitersDeadline=+idle.
+        auto r1 = env.GrabBootExternalResponse(sender1);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, r1.GetStatus());
+
+        // Let HIVE process the boot now: actor emits a (held) completion,
+        // then dies.
+        holdHiveBoots = false;
+        runtime.Send(heldHiveBoots.front().Release());
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(1u, heldCompleted.size());
+
+        // Idle teardown fires first and erases the entry.
+        runtime.UpdateCurrentTime(
+            runtime.GetCurrentTime() + idleTimeout + TDuration::Seconds(1));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        // Deliver the stale completion to an entry that no longer exists.
+        holdCompleted = false;
+        runtime.Send(heldCompleted.front().Release());
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        // No crash; proxy still works.
+        auto sender2 = runtime.AllocateEdgeActor();
+        auto r2 = env.SendBootExternalRequest(
+            sender2,
+            FakeTablet2,
+            S_OK,
+            TDuration::Seconds(5));
+        UNIT_ASSERT(r2.StorageInfo);
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreStaleBootCompletedFromPreviousEpoch)
+    {
+        // After idle teardown erases episode N, a new request creates episode
+        // N+1 (new actor, new generation). The OLD actor's completion (generation N)
+        // then arrives. With generations the proxy ignores it, so episode N+1's
+        // waiter is NOT served the stale result and keeps waiting for its own.
+
+        TTestBasicRuntime runtime;
+        const auto idleTimeout = TDuration::Seconds(5);
+        TTestEnv env(runtime, EExternalBootOptions::PROCESS, idleTimeout);
+
+        TTabletStorageInfoPtr expected = CreateTestTabletInfo(
+            FakeTablet2,
+            TTabletTypes::BlockStorePartition);
+        env.HiveState->StorageInfos[FakeTablet2] = expected;
+
+        TVector<TAutoPtr<IEventHandle>> heldHiveBoots;
+        TVector<TAutoPtr<IEventHandle>> heldCompleted;
+        bool holdHiveBoots = true;
+        bool holdCompleted = true;
+        int responsesToNew = 0;
+        TActorId newSender;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvHive::EvInitiateTabletExternalBoot:
+                        if (holdHiveBoots) {
+                            heldHiveBoots.emplace_back(ev.Release());
+                            return true;
+                        }
+                        break;
+                    case TEvHiveProxyPrivate::EvBootExternalCompleted:
+                        if (holdCompleted) {
+                            heldCompleted.emplace_back(ev.Release());
+                            return true;
+                        }
+                        break;
+                    case TEvHiveProxy::EvBootExternalResponse:
+                        if (newSender &&
+                            ev->GetRecipientRewrite() == newSender) {
+                            ++responsesToNew;
+                        }
+                        break;
+                }
+                return false;
+            });
+
+        // Episode N: a waiter that times out; actor becomes idle.
+        auto sender1 = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            sender1,
+            FakeTablet2,
+            TDuration::Seconds(1));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(1u, heldHiveBoots.size());
+
+        auto r1 = env.GrabBootExternalResponse(sender1);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, r1.GetStatus());
+
+        // Episode N actor replies (HIVE); its completion is held.
+        runtime.Send(
+            heldHiveBoots.front().Release());   // holdHiveBoots still true
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(1u, heldCompleted.size());
+
+        // Idle teardown erases episode N entry (actor already dead).
+        runtime.UpdateCurrentTime(
+            runtime.GetCurrentTime() + idleTimeout + TDuration::Seconds(1));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+
+        // Episode N+1: a fresh waiter for the same tabletId.
+        newSender = runtime.AllocateEdgeActor();
+        env.SendBootExternalRequestAsync(
+            newSender,
+            FakeTablet2,
+            TDuration::Minutes(10));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(
+            2u,
+            heldHiveBoots.size());   // new actor boot held
+
+        // Deliver the STALE completion from episode N. Generation mismatch =>
+        // ignored; the new waiter must NOT receive any response yet.
+        holdCompleted = false;
+        runtime.Send(heldCompleted.front().Release());
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(0, responsesToNew);
+
+        // Let episode N+1's HIVE boot through -> the new waiter gets its own
+        // (correct) response.
+        holdHiveBoots = false;
+        runtime.Send(heldHiveBoots.back().Release());
+        auto rNew = env.GrabBootExternalResponse(newSender);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, rNew.GetStatus());
+        UNIT_ASSERT(rNew.Response.StorageInfo);
+        UNIT_ASSERT_VALUES_EQUAL(1, responsesToNew);
     }
 }
 

--- a/cloud/storage/core/libs/hive_proxy/public.h
+++ b/cloud/storage/core/libs/hive_proxy/public.h
@@ -14,6 +14,9 @@ struct THiveProxyConfig
     ui32 PipeClientRetryCount = 0;
     TDuration PipeClientMinRetryTime;
     TDuration HiveLockExpireTimeout;
+    // Timeout for an external-boot actor that has no waiters left.
+    // 0 keeps the worker until HIVE replies.
+    TDuration ExternalBootRequestIdleTimeout;
     int LogComponent = 0;
     TString TabletBootInfoBackupFilePath;
     bool UseBinaryFormatForTabletBootInfoBackup = false;


### PR DESCRIPTION
### Notes
* `THiveProxyActor` now collapses concurrent `TEvBootExternalRequest`s for
the same `tabletId` into a single in-flight call to HIVE. Previously every
request created its own `TBootRequestActor` and sent a separate
`TEvInitiateTabletExternalBoot`, which under client-side retry storms
produced an N-fold amplification on HIVE.
* Per-(hive, tabletId) inflight entry is kept in
`THiveState::InflightBootRequests` and stores the worker actor id plus the
list of waiters (each with its own `RequestTimeout` deadline). The worker
reports the HIVE response back via a new internal
`TEvBootExternalCompleted`, and the proxy fans the result out to every
waiter.
* Waiter expiration moved from the worker to the proxy
(`TEvBootExternalTimeout` + cached `NearestDeadline`). When a waiter's
deadline elapses it gets `TRYLATER`, but the worker is intentionally kept
alive so that subsequent retries for the same `tabletId` attach to the
still-pending HIVE call instead of issuing a new one — this is what
actually defuses the retry storm.

### Issue
Improves performance when the HIVE is operating slowly and requests start to accumulate.
