### PR TITLE
[Filestore] remove dynamic persistent table migration from v1 to v2

### DIFF
--- a/cloud/storage/core/libs/file_backed_containers/dynamic_persistent_table.h
+++ b/cloud/storage/core/libs/file_backed_containers/dynamic_persistent_table.h
@@ -332,7 +332,8 @@ public:
             TryCompactDataArea(dataSize);
             const ui64 requiredSize = NextDataOffset + dataSize;
             if (requiredSize > DataAreaSize) {
-                if (auto error = ExpandDataArea(requiredSize); HasError(error)) {
+                if (auto error = ExpandDataArea(requiredSize); HasError(error))
+                {
                     FreeRecordIndexes.push_back(index);
                     return error;
                 }
@@ -455,23 +456,6 @@ public:
     }
 
 private:
-    // TODO remove after migration is done
-    void MigrateDataOffsetsToAbsolute()
-    {
-        if (HeaderPtr->Version != 1) {
-            return;
-        }
-
-        for (ui64 index = 0; index < NextFreeRecordIndex; ++index) {
-            if (DescriptorsPtr[index].State == ERecordState::Free) {
-                continue;
-            }
-            DescriptorsPtr[index].DataOffset += DataAreaOffset;
-        }
-
-        HeaderPtr->Version = Version;
-    }
-
     ui64 CalcDataAreaOffset(ui64 maxRecords) const
     {
         return sizeof(THeader) + maxRecords * sizeof(TRecordDescriptor);
@@ -768,9 +752,8 @@ private:
             HeaderPtr->MaxRecords = MaxRecords;
         }
 
-        // TODO remove Version==1 after migration is done
         Y_ABORT_UNLESS(
-            HeaderPtr->Version == Version || HeaderPtr->Version == 1,
+            HeaderPtr->Version == Version,
             "Invalid header version %d",
             HeaderPtr->Version);
         Y_ABORT_UNLESS(
@@ -790,8 +773,6 @@ private:
         DataAreaSize = HeaderPtr->DataAreaSize;
 
         ResizeAndRemap();
-
-        MigrateDataOffsetsToAbsolute();
 
         ResetShrinkState();
 

--- a/cloud/storage/core/libs/file_backed_containers/dynamic_persistent_table_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/dynamic_persistent_table_ut.cpp
@@ -672,56 +672,6 @@ Y_UNIT_TEST_SUITE(TDynamicPersistentTableTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldMigrateLegacyRelativeDataOffsetsOnStartup)
-    {
-        TTempDir tempDir;
-        TString tablePath = tempDir.Path() / "test.table";
-
-        TVector<TString> payloads = {
-            TString("first_payload"),
-            TString("second_payload"),
-            TString("third_payload")};
-        TVector<ui64> indices;
-
-        {
-            auto table = CreateTable(tablePath, 32, 1024);
-
-            for (const auto& payload: payloads) {
-                indices.push_back(AllocAndCommitRecord(table, payload));
-            }
-
-            auto [tableHeader, descriptorsPtr, _] = GetTableInternals(table);
-
-            for (ui64 index: indices) {
-                UNIT_ASSERT_C(
-                    descriptorsPtr[index].DataOffset >=
-                        CalcDataAreaOffset(tableHeader),
-                    "Expected absolute data offset");
-                descriptorsPtr[index].DataOffset -=
-                    CalcDataAreaOffset(tableHeader);
-            }
-
-            tableHeader->Version = 1;
-        }
-
-        {
-            auto table = CreateTable(tablePath, 32, 1024);
-            auto [tableHeader, descriptorsPtr, _] = GetTableInternals(table);
-
-            UNIT_ASSERT_VALUES_EQUAL(TTable::Version, tableHeader->Version);
-            UNIT_ASSERT_VALUES_EQUAL(payloads.size(), table.CountRecords());
-
-            for (size_t i = 0; i < indices.size(); ++i) {
-                TStringBuf record = table.GetRecordWithValidation(indices[i]);
-                UNIT_ASSERT_VALUES_EQUAL(payloads[i], TString(record));
-                UNIT_ASSERT_C(
-                    descriptorsPtr[indices[i]].DataOffset >=
-                        CalcDataAreaOffset(tableHeader),
-                    "Expected migrated absolute data offset");
-            }
-        }
-    }
-
     Y_UNIT_TEST(ShouldCompactCorrectly)
     {
         TTempDir tempDir;


### PR DESCRIPTION
### Notes
Removed migration as migration is done in all envs.
Also removed corresponding ut
