### PR TITLE
[Disk Manager] Fix race in TestInvalidImageReading

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/url/tests/url_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/url/tests/url_test.go
@@ -252,13 +252,14 @@ func TestInvalidImageReading(t *testing.T) {
 	)
 
 	var chunkIndex uint32
-	more := true
+	moreChunks := true
+	moreErrors := true
 	var foundErrors []error
 
-	for more {
+	for moreChunks || moreErrors {
 		select {
-		case chunkIndex, more = <-chunkIndices:
-			if !more {
+		case chunkIndex, moreChunks = <-chunkIndices:
+			if !moreChunks {
 				break
 			}
 
@@ -271,7 +272,7 @@ func TestInvalidImageReading(t *testing.T) {
 			if err != nil {
 				foundErrors = append(foundErrors, err)
 			}
-		case err := <-chunkIndicesErrors:
+		case err, moreErrors = <-chunkIndicesErrors:
 			if err != nil {
 				foundErrors = append(foundErrors, err)
 			}


### PR DESCRIPTION
### Notes
There was a race in the TestInvalidImageReading when chunkIndices is closed so we do not fetch errors from the errors channel. 
