### PR TITLE
Several minor fixes

### DIFF
--- a/cloud/blockstore/libs/storage/partition_common/part_fresh_blocks_state.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/part_fresh_blocks_state.cpp
@@ -26,7 +26,7 @@ namespace {
 template <typename T>
 T SafeIncrement(T counter, size_t value)
 {
-    Y_ABORT_UNLESS(counter < Max<T>() - value);
+    Y_ABORT_UNLESS(value <= Max<T>() - counter);
     return counter + value;
 }
 

--- a/cloud/blockstore/libs/storage/partition_common/part_fresh_blocks_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/part_fresh_blocks_state_ut.cpp
@@ -39,6 +39,16 @@ Y_UNIT_TEST_SUITE(TPartitionFreshBlocksStateTest)
 
         UNIT_ASSERT_VALUES_EQUAL(0, state.GetUntrimmedFreshBlobByteCount());
     }
+
+    Y_UNIT_TEST(ShouldAllowIncrementingFlushCountersToMaxValue)
+    {
+        TPartitionFlushState state;
+
+        state.IncrementUnflushedFreshBlobCount(Max<ui32>());
+        UNIT_ASSERT_VALUES_EQUAL(
+            Max<ui32>(),
+            state.GetUnflushedFreshBlobCount());
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/tools/analytics/dump-event-log/ut/ya.make
+++ b/cloud/blockstore/tools/analytics/dump-event-log/ut/ya.make
@@ -1,0 +1,17 @@
+UNITTEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    ../zero_ranges_stat.cpp
+    zero_ranges_stat_ut.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/diagnostics
+    cloud/blockstore/tools/analytics/libs/event-log
+
+    library/cpp/eventlog/dumper
+)
+
+END()

--- a/cloud/blockstore/tools/analytics/dump-event-log/ut/zero_ranges_stat_ut.cpp
+++ b/cloud/blockstore/tools/analytics/dump-event-log/ut/zero_ranges_stat_ut.cpp
@@ -1,0 +1,39 @@
+#include <cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TZeroRangesStatTest)
+{
+    Y_UNIT_TEST(ShouldDumpEmptyRangesWithoutNan)
+    {
+        TZeroRangesStat::TZeroRanges ranges;
+
+        auto dump = ranges.Dump();
+
+        UNIT_ASSERT_VALUES_EQUAL(0, dump["Known"].GetUIntegerSafe());
+        UNIT_ASSERT_VALUES_EQUAL(0, dump["Zero"].GetUIntegerSafe());
+        UNIT_ASSERT_VALUES_EQUAL(0, dump["Fraction"].GetDoubleSafe());
+    }
+
+    Y_UNIT_TEST(ShouldDumpZeroRangesCountAndFraction)
+    {
+        TZeroRangesStat::TZeroRanges ranges;
+
+        ranges.Set(0, true);
+        ranges.Set(1, false);
+        ranges.Set(2, true);
+        ranges.Set(3, false);
+
+        auto dump = ranges.Dump();
+
+        UNIT_ASSERT_VALUES_EQUAL(4, dump["Known"].GetUIntegerSafe());
+        UNIT_ASSERT_VALUES_EQUAL(2, dump["Zero"].GetUIntegerSafe());
+        UNIT_ASSERT_VALUES_EQUAL(50, dump["Fraction"].GetDoubleSafe());
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/tools/analytics/dump-event-log/ya.make
+++ b/cloud/blockstore/tools/analytics/dump-event-log/ya.make
@@ -19,3 +19,5 @@ SRCS(
 )
 
 END()
+
+RECURSE_FOR_TESTS(ut)

--- a/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.cpp
+++ b/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.cpp
@@ -51,8 +51,8 @@ NJson::TJsonValue TZeroRangesStat::TZeroRanges::Dump() const
 
     NJson::TJsonValue result;
     result["Known"] = known;
-    result["Zero"] = nonZero;
-    result["Fraction"] = 100.0 * zero / known;
+    result["Zero"] = zero;
+    result["Fraction"] = known ? 100.0 * zero / known : 0.0;
     return result;
 }
 

--- a/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.h
+++ b/cloud/blockstore/tools/analytics/dump-event-log/zero_ranges_stat.h
@@ -18,6 +18,7 @@ namespace NCloud::NBlockStore {
 // of disk occupancy with data.
 class TZeroRangesStat: public IProfileLogEventHandler
 {
+public:
     class TZeroRanges
     {
         TDynBitMap KnownRanges;
@@ -28,6 +29,7 @@ class TZeroRangesStat: public IProfileLogEventHandler
         [[nodiscard]] NJson::TJsonValue Dump() const;
     };
 
+private:
     class TZeroRangesBySegmentSize
     {
         TMap<ui64, TZeroRanges> BySegmentSize;

--- a/cloud/storage/core/libs/endpoints/keyring/keyring.cpp
+++ b/cloud/storage/core/libs/endpoints/keyring/keyring.cpp
@@ -149,35 +149,6 @@ bool SysKeyCtlUnlink(ui32 key, ui32 keyring)
     return res == 0;
 }
 
-ui32 SearchProcKeys(const TString& desc)
-{
-    static const TString KeysFilePath = "/proc/keys";
-    static const ui32 KeySerialColumn = 0;
-    static const ui32 KeyDescColumn = 8;
-
-    TIFStream file(KeysFilePath);
-
-    TString str;
-    while (file.ReadLine(str)) {
-        str = StripString(str);
-        if (str.empty())
-            continue;
-
-        TVector<TStringBuf> splitted;
-        StringSplitter(str).Split(' ').SkipEmpty().AddTo(&splitted);
-        const auto& keyStr = splitted.at(KeySerialColumn);
-        const auto& keyDesc = splitted.at(KeyDescColumn);
-
-        if (keyDesc.size() == desc.size() + 1 &&
-            keyDesc.back() == ':' &&
-            keyDesc.StartsWith(desc))
-        {
-            return std::strtoul(keyStr.data(), nullptr, 16);
-        }
-    }
-    return InvalidCode;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 ui32 GetRootKeySerial(TKeyring::ERootKeyring keyring)
@@ -219,6 +190,54 @@ bool TKeyring::operator==(const TKeyring& other) const
 TKeyring::operator bool() const
 {
     return KeySerial != InvalidCode;
+}
+
+ui32 TKeyring::SearchProcKeys(const TString& desc)
+{
+    static const TString KeysFilePath = "/proc/keys";
+
+    TIFStream file(KeysFilePath);
+
+    TString str;
+    while (file.ReadLine(str)) {
+        ui32 key = InvalidCode;
+        if (ParseProcKeysLine(str, desc, key)) {
+            return key;
+        }
+    }
+    return InvalidCode;
+}
+
+bool TKeyring::ParseProcKeysLine(
+    const TString& line,
+    const TString& desc,
+    ui32& key)
+{
+    constexpr ui32 KeySerialColumn = 0;
+    constexpr ui32 KeyDescColumn = 8;
+
+    auto str = StripString(line);
+    if (str.empty()) {
+        return false;
+    }
+
+    TVector<TStringBuf> splitted;
+    StringSplitter(str).Split(' ').SkipEmpty().AddTo(&splitted);
+    if (splitted.size() <= KeyDescColumn) {
+        return false;
+    }
+
+    const auto& keySerial = splitted[KeySerialColumn];
+    const auto& keyDesc = splitted[KeyDescColumn];
+
+    if (keyDesc.size() == desc.size() + 1 && keyDesc.back() == ':' &&
+        keyDesc.StartsWith(desc))
+    {
+        key = std::strtoul(keySerial.data(), nullptr, 16);
+        return true;
+    }
+
+    return false;
 }
 
 TKeyring TKeyring::Create(ui32 keySerial)

--- a/cloud/storage/core/libs/endpoints/keyring/keyring.h
+++ b/cloud/storage/core/libs/endpoints/keyring/keyring.h
@@ -34,6 +34,10 @@ public:
         UserSession,    // UID-session keyring
     };
 
+    static ui32 SearchProcKeys(const TString& desc);
+    static bool
+    ParseProcKeysLine(const TString& line, const TString& desc, ui32& key);
+
     static TKeyring Create(ui32 keySerial);
     static TKeyring GetRoot(ERootKeyring keyring);
     static TKeyring GetProcKey(const TString& desc);

--- a/cloud/storage/core/libs/endpoints/keyring/keyring_ut.cpp
+++ b/cloud/storage/core/libs/endpoints/keyring/keyring_ut.cpp
@@ -7,6 +7,8 @@
 
 namespace NCloud {
 
+bool TryParseProcKeysLine(const TString& line, const TString& desc, ui32& key);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TKeyringTest)
@@ -92,6 +94,22 @@ Y_UNIT_TEST_SUITE(TKeyringTest)
             auto root = user.SearchKeyring(rootDesc);
             RootChecker(root);
         }
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreMalformedProcKeysLines)
+    {
+        ui32 key = 0;
+        UNIT_ASSERT(!TKeyring::ParseProcKeysLine("", "desc", key));
+        UNIT_ASSERT(
+            !TKeyring::ParseProcKeysLine("12345678 short line", "desc", key));
+
+        UNIT_ASSERT(
+            TKeyring::ParseProcKeysLine(
+                "12345678 I--Q---     1 perm 3f3f0000  1000  1000 keyring   "
+                "desc: 1",
+                "desc",
+                key));
+        UNIT_ASSERT_VALUES_EQUAL(0x12345678, key);
     }
 }
 

--- a/cloud/storage/core/libs/version/version.cpp
+++ b/cloud/storage/core/libs/version/version.cpp
@@ -106,6 +106,18 @@ int GetSvnRevision()
     return GetProgramBuildTimestamp();
 }
 
+/**
+ * Expected 'branch' format ([] - optional part):
+ *
+ *      "<prefix>-<major>-<minor>-<tag>[-<hotfix>]"
+ *
+ * where:
+ *
+ *      <prefix> - string (without '-' symbol),
+ *                 must be == StablePrefix ('-' included)
+ *
+ *      <major>, <minor>, <tag>, <hotfix> - version parts, unsigned decimal
+ */
 int GetRevisionFromBranch(const TString& branch)
 {
     if (!branch.StartsWith(StablePrefix)) {
@@ -119,15 +131,16 @@ int GetRevisionFromBranch(const TString& branch)
         return -1;
     }
 
-    size_t n = 1;
-    auto major = FromString<ui32>(splitted[n++]);
-    auto minor = FromString<ui32>(splitted[n++]);
-    auto tag = FromString<ui32>(splitted[n++]);
-    auto hotfix = n < splitted.size() ? FromString<ui32>(splitted[n++]) : 0;
+    try {
+        size_t n = 1;
+        auto major = FromString<ui32>(splitted[n++]);
+        auto minor = FromString<ui32>(splitted[n++]);
+        auto tag = FromString<ui32>(splitted[n++]);
+        auto hotfix = n < splitted.size() ? FromString<ui32>(splitted[n++]) : 0;
 
-    if (splitted.size() != n) {
-        return -1;
-    }
+        if (splitted.size() != n) {
+            return -1;
+        }
 
 #define ADD_VERSION_COMPONENT(component, symbolCount)                          \
     if (component > pow(10, symbolCount)) {                                    \
@@ -135,13 +148,18 @@ int GetRevisionFromBranch(const TString& branch)
     }                                                                          \
     version = version * pow(10, symbolCount) + component;
 
-    int version = major;
-    ADD_VERSION_COMPONENT(minor, 2);
-    ADD_VERSION_COMPONENT(tag, 3);
-    ADD_VERSION_COMPONENT(hotfix, 1);
+        int version = major;
+        ADD_VERSION_COMPONENT(minor, 2);
+        ADD_VERSION_COMPONENT(tag, 3);
+        ADD_VERSION_COMPONENT(hotfix, 1);
 
 #undef ADD_VERSION_COMPONENT
-    return version;
+
+        return version;
+
+    } catch (...) {
+        return -1;
+    }
 }
 
 const TString& GetFullVersionString()

--- a/cloud/storage/core/libs/version/version_ut.cpp
+++ b/cloud/storage/core/libs/version/version_ut.cpp
@@ -216,6 +216,18 @@ Y_UNIT_TEST_SUITE(TVersionTest)
             auto revision = GetRevisionFromBranch(branch);
             UNIT_ASSERT_VALUES_EQUAL(-1, revision);
         }
+
+        {
+            TString branch = "stable-20-invalid-5-6";
+            auto revision = GetRevisionFromBranch(branch);
+            UNIT_ASSERT_VALUES_EQUAL(-1, revision);
+        }
+
+        {
+            TString branch = "stable-20-4-5-invalid";
+            auto revision = GetRevisionFromBranch(branch);
+            UNIT_ASSERT_VALUES_EQUAL(-1, revision);
+        }
     }
 
     Y_UNIT_TEST(ShouldGetFullVersionString)


### PR DESCRIPTION
### Notes

**version.cpp**: Implemented exception handling for FromString when the version string format is invalid (e.g., "stable-20-invalid-..."). Added tests.

**keyring.cpp**: Fixed a bug where `splitted.at(8)` could throw an exception on malformed `/proc/keys` lines. Extracted parsers into public static methods to facilitate testing. Added tests.

**zero_ranges_stat.cpp:** Fixed a division by zero error occurring with empty data. Corrected a logic error where the "Zero" field was incorrectly populated with the nonZero value instead of zero. Added tests.

**part_fresh_blocks_state.cpp**: Fixed an incorrect overflow guard: `Max<T>()` - value is unsafe for large `size_t` values, and the previous condition prevented reaching exactly `Max<T>()`. Added test.