### PR TITLE
fix: trying to ignore possible problems when github API is unreliable

### DIFF
--- a/.github/actions/workload_comment/action.yaml
+++ b/.github/actions/workload_comment/action.yaml
@@ -49,7 +49,7 @@ runs:
       shell: bash
       run: |
         if ! pip install -r .github/scripts/requirements.txt; then
-          echo "::warning::Failed to install workload comment dependencies; continuing because PR comments are non-critical"
+            echo "::warning::Failed to install workload comment dependencies; continuing because PR comments are non-critical"
         fi
 
     - name: resolve build preset
@@ -72,18 +72,18 @@ runs:
         set -euo pipefail
         export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
         for attempt in 1 2 3; do
-          if python3 -m scripts.tests.workload_comment init \
-            --matrix-include "${MATRIX_INCLUDE}" \
-            --build-preset "${FULL_BUILD_PRESET}" \
-            --workload-status "${WORKLOAD_STATUS}"; then
-            exit 0
-          fi
+            if python3 -m scripts.tests.workload_comment init \
+                --matrix-include "${MATRIX_INCLUDE}" \
+                --build-preset "${FULL_BUILD_PRESET}" \
+                --workload-status "${WORKLOAD_STATUS}"; then
+                exit 0
+            fi
 
-          if [ "$attempt" -lt 3 ]; then
-            delay=$((attempt * 5))
-            echo "::warning::Failed to initialize workload PR comment on attempt ${attempt}; retrying in ${delay}s"
-            sleep "$delay"
-          fi
+            if [ "$attempt" -lt 3 ]; then
+                delay=$((attempt * 5))
+                echo "::warning::Failed to initialize workload PR comment on attempt ${attempt}; retrying in ${delay}s"
+                sleep "$delay"
+            fi
         done
         echo "::warning::Failed to initialize workload PR comment after 3 attempts; continuing because PR comments are non-critical"
 
@@ -103,13 +103,13 @@ runs:
         export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
         JOB_URL_OUT=$(mktemp)
         if ! python3 -m scripts.tests.workload_comment update \
-          --build-preset "${FULL_BUILD_PRESET}" \
-          --component "${COMPONENT}" \
-          --workload-check-status "${WORKLOAD_CHECK_STATUS}" \
-          --current-job-name "${CURRENT_JOB_NAME}" \
-          --runner-name "${RUNNER_NAME}" \
-          --job-url-out "$JOB_URL_OUT"; then
-          echo "::warning::Failed to update workload PR comment; continuing because PR comments are non-critical"
+            --build-preset "${FULL_BUILD_PRESET}" \
+            --component "${COMPONENT}" \
+            --workload-check-status "${WORKLOAD_CHECK_STATUS}" \
+            --current-job-name "${CURRENT_JOB_NAME}" \
+            --runner-name "${RUNNER_NAME}" \
+            --job-url-out "$JOB_URL_OUT"; then
+            echo "::warning::Failed to update workload PR comment; continuing because PR comments are non-critical"
         fi
         echo "job_url=$(cat "$JOB_URL_OUT")" >> "$GITHUB_OUTPUT"
         rm -f "$JOB_URL_OUT"

--- a/.github/actions/workload_comment/action.yaml
+++ b/.github/actions/workload_comment/action.yaml
@@ -71,12 +71,21 @@ runs:
       run: |
         set -euo pipefail
         export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
-        if ! python3 -m scripts.tests.workload_comment init \
-          --matrix-include "${MATRIX_INCLUDE}" \
-          --build-preset "${FULL_BUILD_PRESET}" \
-          --workload-status "${WORKLOAD_STATUS}"; then
-          echo "::warning::Failed to initialize workload PR comment; continuing because PR comments are non-critical"
-        fi
+        for attempt in 1 2 3; do
+          if python3 -m scripts.tests.workload_comment init \
+            --matrix-include "${MATRIX_INCLUDE}" \
+            --build-preset "${FULL_BUILD_PRESET}" \
+            --workload-status "${WORKLOAD_STATUS}"; then
+            exit 0
+          fi
+
+          if [ "$attempt" -lt 3 ]; then
+            delay=$((attempt * 5))
+            echo "::warning::Failed to initialize workload PR comment on attempt ${attempt}; retrying in ${delay}s"
+            sleep "$delay"
+          fi
+        done
+        echo "::warning::Failed to initialize workload PR comment after 3 attempts; continuing because PR comments are non-critical"
 
     - name: update workload comment
       if: ${{ inputs.command == 'update' }}

--- a/.github/actions/workload_comment/action.yaml
+++ b/.github/actions/workload_comment/action.yaml
@@ -47,7 +47,10 @@ runs:
   steps:
     - name: install dependencies
       shell: bash
-      run: pip install -r .github/scripts/requirements.txt
+      run: |
+        if ! pip install -r .github/scripts/requirements.txt; then
+          echo "::warning::Failed to install workload comment dependencies; continuing because PR comments are non-critical"
+        fi
 
     - name: resolve build preset
       id: build-preset
@@ -68,10 +71,13 @@ runs:
       run: |
         set -euo pipefail
         export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
-        python3 -m scripts.tests.workload_comment init \
-            --matrix-include "${MATRIX_INCLUDE}" \
-            --build-preset "${FULL_BUILD_PRESET}" \
-            --workload-status "${WORKLOAD_STATUS}"
+        if ! python3 -m scripts.tests.workload_comment init \
+          --matrix-include "${MATRIX_INCLUDE}" \
+          --build-preset "${FULL_BUILD_PRESET}" \
+          --workload-status "${WORKLOAD_STATUS}"; then
+          echo "::warning::Failed to initialize workload PR comment; continuing because PR comments are non-critical"
+        fi
+
     - name: update workload comment
       if: ${{ inputs.command == 'update' }}
       id: update
@@ -87,14 +93,18 @@ runs:
         set -euo pipefail
         export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
         JOB_URL_OUT=$(mktemp)
-        python3 -m scripts.tests.workload_comment update \
-            --build-preset "${FULL_BUILD_PRESET}" \
-            --component "${COMPONENT}" \
-            --workload-check-status "${WORKLOAD_CHECK_STATUS}" \
-            --current-job-name "${CURRENT_JOB_NAME}" \
-            --runner-name "${RUNNER_NAME}" \
-            --job-url-out "$JOB_URL_OUT"
+        if ! python3 -m scripts.tests.workload_comment update \
+          --build-preset "${FULL_BUILD_PRESET}" \
+          --component "${COMPONENT}" \
+          --workload-check-status "${WORKLOAD_CHECK_STATUS}" \
+          --current-job-name "${CURRENT_JOB_NAME}" \
+          --runner-name "${RUNNER_NAME}" \
+          --job-url-out "$JOB_URL_OUT"; then
+          echo "::warning::Failed to update workload PR comment; continuing because PR comments are non-critical"
+        fi
         echo "job_url=$(cat "$JOB_URL_OUT")" >> "$GITHUB_OUTPUT"
+        rm -f "$JOB_URL_OUT"
+
     - name: add job link to summary
       if: ${{ inputs.command == 'update' && inputs.add_summary_link == 'yes' && steps.update.outputs.job_url != '' }}
       shell: bash

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -693,6 +693,8 @@ def replace_workload_status_block(
     lines = body.splitlines()
     insert_at = len(lines)
     for idx, line in enumerate(lines):
+        if idx == 0 and line.startswith("<!-- status "):
+            continue
         if line.startswith("> [!NOTE]") or line.startswith("> [!IMPORTANT]"):
             continue
         if line.startswith("> This is "):
@@ -704,6 +706,17 @@ def replace_workload_status_block(
 
     updated_lines = lines[:insert_at] + [status_block, ""] + lines[insert_at:]
     return "\n".join(updated_lines)
+
+
+def ensure_workload_status_block(
+    body: str,
+    build_preset: str,
+    workload_status: str,
+) -> str:
+    if WORKLOAD_STATUS_START in body and WORKLOAD_STATUS_END in body:
+        return body
+
+    return replace_workload_status_block(body, build_preset, workload_status)
 
 
 def replace_workload_checks_block(
@@ -723,6 +736,24 @@ def replace_workload_checks_block(
         body,
         checks_block,
         after_marker=WORKLOAD_STATUS_END,
+    )
+
+
+def ensure_workload_check_row(
+    body: str,
+    build_preset: str,
+    component: str,
+) -> str:
+    if get_workload_check_line_match(body, component) is not None:
+        return body
+
+    if WORKLOAD_CHECKS_START not in body or WORKLOAD_CHECKS_END not in body:
+        return replace_workload_checks_block(body, build_preset, [component])
+
+    return body.replace(
+        WORKLOAD_CHECKS_END,
+        f"{get_workload_check_line(component, 'pending')}\n{WORKLOAD_CHECKS_END}",
+        1,
     )
 
 
@@ -1070,15 +1101,31 @@ def update_pr_comment_workload_check(
     comment = find_pr_comment(pr, header_prefix)
 
     if comment is None:
-        LOGGER.info("No existing comment found for workload check update")
-        return
+        LOGGER.info("Creating minimal comment for workload check update")
+        header = get_comment_header(pr.number, run_number, build_preset, is_dry_run)
+        pr.create_issue_comment(
+            "\n".join(
+                get_base_comment_body(
+                    header,
+                    build_preset,
+                    is_dry_run,
+                    "in_progress",
+                    [component],
+                )
+            )
+        )
+    else:
+        LOGGER.info("Updating workload check for comment id=%s", comment.id)
 
-    LOGGER.info("Updating workload check for comment id=%s", comment.id)
     edit_pr_comment(
         pr=pr,
         header_prefix=header_prefix,
         update_body=lambda body: update_workload_check_block(
-            body,
+            ensure_workload_check_row(
+                ensure_workload_status_block(body, build_preset, "in_progress"),
+                build_preset,
+                component,
+            ),
             component,
             workload_check_status,
             job_url,

--- a/.github/scripts/tests/generate_summary_test.py
+++ b/.github/scripts/tests/generate_summary_test.py
@@ -458,6 +458,186 @@ def test_initialize_pr_comment_creates_workload_checks_block() -> None:
     assert "tasks + storage" in body
 
 
+def test_update_pr_comment_workload_check_creates_minimal_comment_when_missing(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gs, "WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS", 0)
+
+    class FakeHead:
+        sha = "abc123"
+
+    class FakeComment:
+        def __init__(self, comment_id: int, body: str) -> None:
+            self.id = comment_id
+            self.body = body
+            self.edits = []
+
+        def edit(self, body: str) -> None:
+            self.body = body
+            self.edits.append(body)
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self) -> None:
+            self.comments = []
+
+        def get_issue_comments(self) -> list[FakeComment]:
+            return self.comments
+
+        def create_issue_comment(self, body: str) -> None:
+            self.comments.append(FakeComment(len(self.comments) + 1, body))
+
+    pr = FakePR()
+
+    gs.update_pr_comment_workload_check(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        component="blockstore",
+        is_dry_run=False,
+        workload_check_status="completed",
+        job_url="https://github.example/job/123",
+    )
+
+    assert len(pr.comments) == 1
+    body = pr.comments[0].body
+    assert gs.WORKLOAD_CHECKS_START in body
+    assert "Planned checks for **linux**." in body
+    assert gs.get_workload_check_status(body, "blockstore") == "completed"
+    assert "https://github.example/job/123" in body
+    assert gs.get_comment_revision(body) == 1
+
+
+def test_update_pr_comment_workload_check_adds_missing_component_row(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gs, "WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS", 0)
+
+    class FakeHead:
+        sha = "abc123"
+
+    class FakeComment:
+        id = 1001
+
+        def __init__(self, body: str) -> None:
+            self.body = body
+            self.edits = []
+
+        def edit(self, body: str) -> None:
+            self.body = body
+            self.edits.append(body)
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self, comment: FakeComment) -> None:
+            self._comment = comment
+            self.created = []
+
+        def get_issue_comments(self) -> list[FakeComment]:
+            return [self._comment]
+
+        def create_issue_comment(self, body: str) -> None:
+            self.created.append(body)
+
+    existing = FakeComment(
+        "\n".join(
+            [
+                (
+                    "<!-- status pr=77, run=12, build_preset=linux, "
+                    "dry_run=False, revision=0 -->"
+                ),
+                *gs.get_workload_status_text("linux", "in_progress"),
+                "",
+                gs.WORKLOAD_CHECKS_START,
+                gs.get_workload_check_line("blockstore", "completed"),
+                gs.WORKLOAD_CHECKS_END,
+            ]
+        )
+    )
+    pr = FakePR(existing)
+
+    gs.update_pr_comment_workload_check(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        component="filestore",
+        is_dry_run=False,
+        workload_check_status="running",
+        job_url="https://github.example/job/456",
+    )
+
+    assert pr.created == []
+    assert len(existing.edits) == 1
+    assert gs.get_workload_check_status(existing.body, "blockstore") == "completed"
+    assert gs.get_workload_check_status(existing.body, "filestore") == "running"
+    assert "https://github.example/job/456" in existing.body
+    assert gs.get_comment_revision(existing.body) == 1
+
+
+def test_update_pr_comment_workload_check_does_not_downgrade_workload_status(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gs, "WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS", 0)
+
+    class FakeHead:
+        sha = "abc123"
+
+    class FakeComment:
+        id = 1001
+
+        def __init__(self, body: str) -> None:
+            self.body = body
+
+        def edit(self, body: str) -> None:
+            self.body = body
+
+    class FakePR:
+        number = 77
+        head = FakeHead()
+
+        def __init__(self, comment: FakeComment) -> None:
+            self._comment = comment
+
+        def get_issue_comments(self) -> list[FakeComment]:
+            return [self._comment]
+
+        def create_issue_comment(self, body: str) -> None:  # noqa: U100
+            raise AssertionError("should not create a new comment")
+
+    existing = FakeComment(
+        "\n".join(
+            [
+                (
+                    "<!-- status pr=77, run=12, build_preset=linux, "
+                    "dry_run=False, revision=0 -->"
+                ),
+                *gs.get_workload_status_text("linux", "completed"),
+                "",
+                gs.WORKLOAD_CHECKS_START,
+                gs.WORKLOAD_CHECKS_END,
+            ]
+        )
+    )
+    pr = FakePR(existing)
+
+    gs.update_pr_comment_workload_check(
+        run_number=12,
+        pr=pr,
+        build_preset="linux",
+        component="blockstore",
+        is_dry_run=False,
+        workload_check_status="completed",
+    )
+
+    assert "All workloads for **linux** have completed." in existing.body
+    assert "is not finished yet" not in existing.body
+    assert gs.get_workload_check_status(existing.body, "blockstore") == "completed"
+
+
 def test_update_pr_comment_workload_check_preserves_existing_job_url() -> None:
     class FakeHead:
         sha = "abc123"

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -594,6 +594,7 @@ jobs:
         continue-on-error: true
       - name: set up dependencies
         run: pip install -r .github/scripts/requirements.txt
+        continue-on-error: true
       - name: finalize workload comments
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -603,6 +604,7 @@ jobs:
           export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
           platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
           python3 -m scripts.tests.finalize_workload_comments \
-              --matrix-include "$MATRIX_INCLUDE" \
-              --platform-name "$platform_name" \
-              --workload-status completed
+            --matrix-include "$MATRIX_INCLUDE" \
+            --platform-name "$platform_name" \
+            --workload-status completed
+        continue-on-error: true

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -604,7 +604,7 @@ jobs:
           export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
           platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
           python3 -m scripts.tests.finalize_workload_comments \
-            --matrix-include "$MATRIX_INCLUDE" \
-            --platform-name "$platform_name" \
-            --workload-status completed
+              --matrix-include "$MATRIX_INCLUDE" \
+              --platform-name "$platform_name" \
+              --workload-status completed
         continue-on-error: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -207,7 +207,7 @@ jobs:
           export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
           platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
           python3 -m scripts.tests.finalize_workload_comments \
-            --matrix-include "$MATRIX_INCLUDE" \
-            --platform-name "$platform_name" \
-            --workload-status completed
+              --matrix-include "$MATRIX_INCLUDE" \
+              --platform-name "$platform_name" \
+              --workload-status completed
         continue-on-error: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -197,6 +197,7 @@ jobs:
         continue-on-error: true
       - name: set up dependencies
         run: pip install -r .github/scripts/requirements.txt
+        continue-on-error: true
       - name: finalize workload comments
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -206,6 +207,7 @@ jobs:
           export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
           platform_name=$(uname | tr '[:upper:]' '[:lower:]')-$(arch)
           python3 -m scripts.tests.finalize_workload_comments \
-              --matrix-include "$MATRIX_INCLUDE" \
-              --platform-name "$platform_name" \
-              --workload-status completed
+            --matrix-include "$MATRIX_INCLUDE" \
+            --platform-name "$platform_name" \
+            --workload-status completed
+        continue-on-error: true


### PR DESCRIPTION
Trying to not necessarily hide errors, when Github API is throwing errors, but to make them non-critical for overall workflow
e.g. if here initalize will fail - we won't even attempt to run build/tests

https://github.com/ydb-platform/nbs/actions/runs/26571044293/job/78279590675?pr=6049
