### PR TITLE
issue-6011: [Filestore] Add option to disable throttling histograms registration

### DIFF
--- a/cloud/filestore/config/diagnostics.proto
+++ b/cloud/filestore/config/diagnostics.proto
@@ -156,5 +156,5 @@ message TDiagnosticsConfig
     optional uint32 DumpTracksInterval = 32;
 
     // Disable registration of throttling metrics in the metrics registry.
-    optional bool ThrottlingMetricsDisabled = 33;
+    optional bool ThrottlingHistogramsDisabled = 33;
 }

--- a/cloud/filestore/config/diagnostics.proto
+++ b/cloud/filestore/config/diagnostics.proto
@@ -154,4 +154,7 @@ message TDiagnosticsConfig
 
     // Dump lwtrace tracks every DumpTracksInterval ms.
     optional uint32 DumpTracksInterval = 32;
+
+    // Disable registration of throttling metrics in the metrics registry.
+    optional bool ThrottlingMetricsDisabled = 33;
 }

--- a/cloud/filestore/libs/diagnostics/config.cpp
+++ b/cloud/filestore/libs/diagnostics/config.cpp
@@ -49,7 +49,7 @@ namespace {
                                                                                \
     xxx(ProfileLogMaxFlushRecords,      ui64, 0                               )\
     xxx(ProfileLogMaxFrameFlushRecords, ui64, 0                               )\
-    xxx(ThrottlingMetricsDisabled,      bool, false                           )\
+    xxx(ThrottlingHistogramsDisabled,       bool,            false            )\
 
 // FILESTORE_DIAGNOSTICS_CONFIG
 

--- a/cloud/filestore/libs/diagnostics/config.cpp
+++ b/cloud/filestore/libs/diagnostics/config.cpp
@@ -49,6 +49,7 @@ namespace {
                                                                                \
     xxx(ProfileLogMaxFlushRecords,      ui64, 0                               )\
     xxx(ProfileLogMaxFrameFlushRecords, ui64, 0                               )\
+    xxx(ThrottlingMetricsDisabled,      bool, false                           )\
 
 // FILESTORE_DIAGNOSTICS_CONFIG
 

--- a/cloud/filestore/libs/diagnostics/config.h
+++ b/cloud/filestore/libs/diagnostics/config.h
@@ -144,6 +144,8 @@ public:
     ui64 GetProfileLogMaxFlushRecords() const;
     ui64 GetProfileLogMaxFrameFlushRecords() const;
 
+    bool GetThrottlingMetricsDisabled() const;
+
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;
 };

--- a/cloud/filestore/libs/diagnostics/config.h
+++ b/cloud/filestore/libs/diagnostics/config.h
@@ -144,7 +144,7 @@ public:
     ui64 GetProfileLogMaxFlushRecords() const;
     ui64 GetProfileLogMaxFrameFlushRecords() const;
 
-    bool GetThrottlingMetricsDisabled() const;
+    bool GetThrottlingHistogramsDisabled() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -39,11 +39,6 @@ bool IsReadWriteRequest(EFileStoreRequest rt)
         || rt == EFileStoreRequest::ReadData;
 }
 
-const auto REQUEST_COUNTERS_OPTIONS =
-    TRequestCounters::EOption::ReportDataPlaneHistogram |
-    TRequestCounters::EOption::ReportControlPlaneHistogram |
-    TRequestCounters::EOption::LazyRequestInitialization;
-
 TRequestCountersPtr MakeRequestCounters(
     ITimerPtr timer,
     TDynamicCounters& counters,
@@ -165,27 +160,28 @@ class TRequestStats final
 
 public:
     TRequestStats(
-            TDynamicCountersPtr counters,
-            ITimerPtr timer,
-            TDuration executionTimeThreshold,
-            TDuration totalTimeThreshold,
-            EHistogramCounterOptions histogramCounterOptions)
+        TDynamicCountersPtr counters,
+        ITimerPtr timer,
+        TDuration executionTimeThreshold,
+        TDuration totalTimeThreshold,
+        EHistogramCounterOptions histogramCounterOptions,
+        TRequestCounters::EOptions counterOptions)
         : TRequestLogger(executionTimeThreshold, totalTimeThreshold)
         , RootCounters(std::move(counters))
         , TotalCounters(MakeRequestCounters(
             timer,
             *RootCounters,
-            REQUEST_COUNTERS_OPTIONS,
+            counterOptions,
             histogramCounterOptions))
         , SsdCounters(MakeRequestCounters(
             timer,
             *RootCounters->GetSubgroup("type", "ssd"),
-            REQUEST_COUNTERS_OPTIONS,
+            counterOptions,
             histogramCounterOptions))
         , HddCounters(MakeRequestCounters(
             timer,
             *RootCounters->GetSubgroup("type", "hdd"),
-            REQUEST_COUNTERS_OPTIONS,
+            counterOptions,
             histogramCounterOptions))
     {
         auto revisionGroup =
@@ -451,7 +447,8 @@ public:
             IPostponeTimePredictorPtr predictor,
             TDuration executionTimeThreshold,
             TDuration totalTimeThreshold,
-            EHistogramCounterOptions histogramCounterOptions)
+            EHistogramCounterOptions histogramCounterOptions,
+            TRequestCounters::EOptions counterOptions)
         : TRequestLogger{executionTimeThreshold, totalTimeThreshold}
         , FileSystemId{std::move(fileSystemId)}
         , ClientId{std::move(clientId)}
@@ -460,7 +457,7 @@ public:
         , Counters{MakeRequestCounters(
             timer,
             *counters,
-            REQUEST_COUNTERS_OPTIONS,
+            counterOptions,
             histogramCounterOptions)}
         , Predictor{std::move(predictor)}
         , PredictorStats{counters, std::move(timer)}
@@ -715,6 +712,7 @@ private:
     NMonitoring::TDynamicCountersPtr RootCounters;
     ITimerPtr Timer;
 
+    TRequestCounters::EOptions CounterOptions;
     std::shared_ptr<TRequestStats> RequestStats;
 
     IFsCountersProviderPtr FsCountersProvider;
@@ -733,6 +731,13 @@ public:
         : DiagnosticsConfig(std::move(diagnosticsConfig))
         , RootCounters(std::move(rootCounters))
         , Timer(std::move(timer))
+        , CounterOptions(
+              TRequestCounters::EOption::ReportDataPlaneHistogram |
+              TRequestCounters::EOption::ReportControlPlaneHistogram |
+              TRequestCounters::EOption::LazyRequestInitialization |
+              (DiagnosticsConfig->GetThrottlingMetricsDisabled()
+                   ? TRequestCounters::EOption::ThrottlingMetricsDisabled
+                   : TRequestCounters::EOptions{}))
         , FsCountersProvider(std::move(fsCountersProvider))
         , UserCounters(std::move(userCounters))
     {
@@ -744,7 +749,8 @@ public:
             Timer,
             DiagnosticsConfig->GetSlowExecutionTimeRequestThreshold(),
             DiagnosticsConfig->GetSlowTotalTimeRequestThreshold(),
-            DiagnosticsConfig->GetHistogramCounterOptions());
+            DiagnosticsConfig->GetHistogramCounterOptions(),
+            CounterOptions);
     }
 
     IRequestStatsPtr GetFileSystemStats(
@@ -778,7 +784,8 @@ public:
                 DiagnosticsConfig->GetPostponeTimePredictorMaxTime(),
                 DiagnosticsConfig->GetSlowExecutionTimeRequestThreshold(),
                 DiagnosticsConfig->GetSlowTotalTimeRequestThreshold(),
-                DiagnosticsConfig->GetHistogramCounterOptions());
+                DiagnosticsConfig->GetHistogramCounterOptions(),
+                CounterOptions);
             it = StatsMap.emplace(
                 key,
                 TFileSystemStatsHolder{std::move(counters), stats}).first;
@@ -887,7 +894,8 @@ private:
         TMaybe<TDuration> delayMaxTime,
         TDuration executionTimeThreshold,
         TDuration totalTimeThreshold,
-        EHistogramCounterOptions histogramCounterOptions) const
+        EHistogramCounterOptions histogramCounterOptions,
+        TRequestCounters::EOptions counterOptions) const
     {
         Y_UNUSED(delayWindowInterval);
         Y_UNUSED(delayWindowPercentage);
@@ -910,7 +918,8 @@ private:
             std::move(predictor),
             executionTimeThreshold,
             totalTimeThreshold,
-            histogramCounterOptions);
+            histogramCounterOptions,
+            counterOptions);
     }
 };
 

--- a/cloud/filestore/libs/diagnostics/request_stats.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats.cpp
@@ -160,12 +160,12 @@ class TRequestStats final
 
 public:
     TRequestStats(
-        TDynamicCountersPtr counters,
-        ITimerPtr timer,
-        TDuration executionTimeThreshold,
-        TDuration totalTimeThreshold,
-        EHistogramCounterOptions histogramCounterOptions,
-        TRequestCounters::EOptions counterOptions)
+            TDynamicCountersPtr counters,
+            ITimerPtr timer,
+            TDuration executionTimeThreshold,
+            TDuration totalTimeThreshold,
+            EHistogramCounterOptions histogramCounterOptions,
+            TRequestCounters::EOptions counterOptions)
         : TRequestLogger(executionTimeThreshold, totalTimeThreshold)
         , RootCounters(std::move(counters))
         , TotalCounters(MakeRequestCounters(
@@ -735,8 +735,8 @@ public:
               TRequestCounters::EOption::ReportDataPlaneHistogram |
               TRequestCounters::EOption::ReportControlPlaneHistogram |
               TRequestCounters::EOption::LazyRequestInitialization |
-              (DiagnosticsConfig->GetThrottlingMetricsDisabled()
-                   ? TRequestCounters::EOption::ThrottlingMetricsDisabled
+              (DiagnosticsConfig->GetThrottlingHistogramsDisabled()
+                   ? TRequestCounters::EOption::ThrottlingHistogramsDisabled
                    : TRequestCounters::EOptions{}))
         , FsCountersProvider(std::move(fsCountersProvider))
         , UserCounters(std::move(userCounters))

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -731,7 +731,9 @@ struct TRequestCounters::TStatCounters
             if (unaligned) {
                 UnalignedCount->Inc();
                 TimeHistUnaligned.Increment(time);
-                ExecutionTimeHistUnaligned.Increment(execTime);
+                if (!ThrottlingHistogramsDisabled) {
+                    ExecutionTimeHistUnaligned.Increment(execTime);
+                }
             }
 
             if (!ThrottlingHistogramsDisabled) {

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -372,6 +372,7 @@ struct TRequestCounters::TStatCounters
     bool IsReadWriteRequest = false;
     bool ReportDataPlaneHistogram = false;
     bool ReportControlPlaneHistogram = false;
+    bool ThrottlingMetricsDisabled = false;
 
     TIntrusivePtr<TDynamicCounters> CountersGroup;
 
@@ -496,7 +497,8 @@ struct TRequestCounters::TStatCounters
         TDynamicCountersPtr countersGroup,
         bool isReadWriteRequest,
         bool reportDataPlaneHistogram,
-        bool reportControlPlaneHistogram)
+        bool reportControlPlaneHistogram,
+        bool throttlingMetricsDisabled)
     {
         CountersGroup = std::move(countersGroup);
         auto& counters = *CountersGroup;
@@ -504,6 +506,7 @@ struct TRequestCounters::TStatCounters
         IsReadWriteRequest = isReadWriteRequest;
         ReportDataPlaneHistogram = reportDataPlaneHistogram;
         ReportControlPlaneHistogram = reportControlPlaneHistogram;
+        ThrottlingMetricsDisabled = throttlingMetricsDisabled;
 
         // always reporting the most important counters even when lazy
         // initialization is enabled and the values are zeroes
@@ -569,27 +572,33 @@ struct TRequestCounters::TStatCounters
 
                 SizeHist.Register(counters);
                 TimeHistUnaligned.Register(*unalignedClassGroup);
-                ExecutionTimeHist.Register(counters);
-                ExecutionTimeHistUnaligned.Register(*unalignedClassGroup);
+                if (!ThrottlingMetricsDisabled) {
+                    ExecutionTimeHist.Register(counters);
+                    ExecutionTimeHistUnaligned.Register(*unalignedClassGroup);
+                }
             } else {
                 SizePercentiles.Register(counters);
-                ExecutionTimePercentiles.Register(counters);
-                PostponedTimePercentiles.Register(counters);
-                BackoffTimePercentiles.Register(counters);
-                ShapingTimePercentiles.Register(counters);
+                if (!ThrottlingMetricsDisabled) {
+                    ExecutionTimePercentiles.Register(counters);
+                    PostponedTimePercentiles.Register(counters);
+                    BackoffTimePercentiles.Register(counters);
+                    ShapingTimePercentiles.Register(counters);
+                }
                 TimePercentiles.Register(counters);
             }
 
-            for (auto& [_, sizeClass]: ExecutionTimeSizeClasses) {
-                auto sizeClassCounters = counters.GetSubgroup(
-                    "sizeclass",
-                    ToString(TSizeInterval{sizeClass.Begin, sizeClass.End}));
-                if (ReportDataPlaneHistogram) {
-                    sizeClass.Value->ExecutionTimeHist.Register(
-                        *sizeClassCounters);
-                } else {
-                    sizeClass.Value->ExecutionTimePercentiles.Register(
-                        *sizeClassCounters);
+            if (!ThrottlingMetricsDisabled) {
+                for (auto& [_, sizeClass]: ExecutionTimeSizeClasses) {
+                    auto sizeClassCounters = counters.GetSubgroup(
+                        "sizeclass",
+                        ToString(TSizeInterval{sizeClass.Begin, sizeClass.End}));
+                    if (ReportDataPlaneHistogram) {
+                        sizeClass.Value->ExecutionTimeHist.Register(
+                            *sizeClassCounters);
+                    } else {
+                        sizeClass.Value->ExecutionTimePercentiles.Register(
+                            *sizeClassCounters);
+                    }
                 }
             }
 
@@ -597,9 +606,11 @@ struct TRequestCounters::TStatCounters
                 ? TCountableBase::EVisibility::Public
                 : TCountableBase::EVisibility::Private;
 
-            PostponedTimeHist.Register(counters, visibleHistogram);
-            BackoffTimeHist.Register(counters, visibleHistogram);
-            ShapingTimeHist.Register(counters, visibleHistogram);
+            if (!ThrottlingMetricsDisabled) {
+                PostponedTimeHist.Register(counters, visibleHistogram);
+                BackoffTimeHist.Register(counters, visibleHistogram);
+                ShapingTimeHist.Register(counters, visibleHistogram);
+            }
             TimeHist.Register(counters, visibleHistogram);
 
             // Always enough only percentiles.
@@ -723,19 +734,21 @@ struct TRequestCounters::TStatCounters
                 ExecutionTimeHistUnaligned.Increment(execTime);
             }
 
-            ExecutionTimeHist.Increment(execTime);
+            if (!ThrottlingMetricsDisabled) {
+                ExecutionTimeHist.Increment(execTime);
 
-            ExecutionTimeSizeClasses.VisitOverlapping(
-                requestBytes,
-                requestBytes + 1,
-                [&](TDisjointIntervalMap<
-                    ui64,
-                    std::unique_ptr<TSizeClassCounters>>::TIterator it)
-                { it->second.Value->ExecutionTimeHist.Increment(execTime); });
+                ExecutionTimeSizeClasses.VisitOverlapping(
+                    requestBytes,
+                    requestBytes + 1,
+                    [&](TDisjointIntervalMap<
+                        ui64,
+                        std::unique_ptr<TSizeClassCounters>>::TIterator it)
+                    { it->second.Value->ExecutionTimeHist.Increment(execTime); });
 
-            PostponedTimeHist.Increment(postponedTime);
-            BackoffTimeHist.Increment(backoffTime);
-            ShapingTimeHist.Increment(shapingTime);
+                PostponedTimeHist.Increment(postponedTime);
+                BackoffTimeHist.Increment(backoffTime);
+                ShapingTimeHist.Increment(shapingTime);
+            }
         }
     }
 
@@ -877,14 +890,16 @@ struct TRequestCounters::TStatCounters
             if (updatePercentiles && !ReportDataPlaneHistogram) {
                 SizePercentiles.Update();
                 TimePercentiles.Update();
-                ExecutionTimePercentiles.Update();
                 RequestCompletionTimePercentiles.Update();
-                PostponedTimePercentiles.Update();
-                BackoffTimePercentiles.Update();
-                ShapingTimePercentiles.Update();
+                if (!ThrottlingMetricsDisabled) {
+                    ExecutionTimePercentiles.Update();
+                    PostponedTimePercentiles.Update();
+                    BackoffTimePercentiles.Update();
+                    ShapingTimePercentiles.Update();
 
-                for (auto& [_, sizeClass]: ExecutionTimeSizeClasses) {
-                    sizeClass.Value->ExecutionTimePercentiles.Update();
+                    for (auto& [_, sizeClass]: ExecutionTimeSizeClasses) {
+                        sizeClass.Value->ExecutionTimePercentiles.Update();
+                    }
                 }
             }
         } else if (updatePercentiles && !ReportControlPlaneHistogram) {
@@ -951,7 +966,8 @@ void TRequestCounters::Register(TDynamicCounters& counters)
                 std::move(requestGroup),
                 IsReadWriteRequestType(t),
                 Options & EOption::ReportDataPlaneHistogram,
-                Options & EOption::ReportControlPlaneHistogram);
+                Options & EOption::ReportControlPlaneHistogram,
+                Options & EOption::ThrottlingMetricsDisabled);
 
             // ReadWrite counters are usually the most important ones so let's
             // report zeroes for them instead of not reporting anything at all

--- a/cloud/storage/core/libs/diagnostics/request_counters.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters.cpp
@@ -372,7 +372,7 @@ struct TRequestCounters::TStatCounters
     bool IsReadWriteRequest = false;
     bool ReportDataPlaneHistogram = false;
     bool ReportControlPlaneHistogram = false;
-    bool ThrottlingMetricsDisabled = false;
+    bool ThrottlingHistogramsDisabled = false;
 
     TIntrusivePtr<TDynamicCounters> CountersGroup;
 
@@ -498,7 +498,7 @@ struct TRequestCounters::TStatCounters
         bool isReadWriteRequest,
         bool reportDataPlaneHistogram,
         bool reportControlPlaneHistogram,
-        bool throttlingMetricsDisabled)
+        bool throttlingHistogramsDisabled)
     {
         CountersGroup = std::move(countersGroup);
         auto& counters = *CountersGroup;
@@ -506,7 +506,7 @@ struct TRequestCounters::TStatCounters
         IsReadWriteRequest = isReadWriteRequest;
         ReportDataPlaneHistogram = reportDataPlaneHistogram;
         ReportControlPlaneHistogram = reportControlPlaneHistogram;
-        ThrottlingMetricsDisabled = throttlingMetricsDisabled;
+        ThrottlingHistogramsDisabled = throttlingHistogramsDisabled;
 
         // always reporting the most important counters even when lazy
         // initialization is enabled and the values are zeroes
@@ -572,13 +572,13 @@ struct TRequestCounters::TStatCounters
 
                 SizeHist.Register(counters);
                 TimeHistUnaligned.Register(*unalignedClassGroup);
-                if (!ThrottlingMetricsDisabled) {
+                if (!ThrottlingHistogramsDisabled) {
                     ExecutionTimeHist.Register(counters);
                     ExecutionTimeHistUnaligned.Register(*unalignedClassGroup);
                 }
             } else {
                 SizePercentiles.Register(counters);
-                if (!ThrottlingMetricsDisabled) {
+                if (!ThrottlingHistogramsDisabled) {
                     ExecutionTimePercentiles.Register(counters);
                     PostponedTimePercentiles.Register(counters);
                     BackoffTimePercentiles.Register(counters);
@@ -587,7 +587,7 @@ struct TRequestCounters::TStatCounters
                 TimePercentiles.Register(counters);
             }
 
-            if (!ThrottlingMetricsDisabled) {
+            if (!ThrottlingHistogramsDisabled) {
                 for (auto& [_, sizeClass]: ExecutionTimeSizeClasses) {
                     auto sizeClassCounters = counters.GetSubgroup(
                         "sizeclass",
@@ -606,7 +606,7 @@ struct TRequestCounters::TStatCounters
                 ? TCountableBase::EVisibility::Public
                 : TCountableBase::EVisibility::Private;
 
-            if (!ThrottlingMetricsDisabled) {
+            if (!ThrottlingHistogramsDisabled) {
                 PostponedTimeHist.Register(counters, visibleHistogram);
                 BackoffTimeHist.Register(counters, visibleHistogram);
                 ShapingTimeHist.Register(counters, visibleHistogram);
@@ -734,7 +734,7 @@ struct TRequestCounters::TStatCounters
                 ExecutionTimeHistUnaligned.Increment(execTime);
             }
 
-            if (!ThrottlingMetricsDisabled) {
+            if (!ThrottlingHistogramsDisabled) {
                 ExecutionTimeHist.Increment(execTime);
 
                 ExecutionTimeSizeClasses.VisitOverlapping(
@@ -891,7 +891,7 @@ struct TRequestCounters::TStatCounters
                 SizePercentiles.Update();
                 TimePercentiles.Update();
                 RequestCompletionTimePercentiles.Update();
-                if (!ThrottlingMetricsDisabled) {
+                if (!ThrottlingHistogramsDisabled) {
                     ExecutionTimePercentiles.Update();
                     PostponedTimePercentiles.Update();
                     BackoffTimePercentiles.Update();
@@ -967,7 +967,7 @@ void TRequestCounters::Register(TDynamicCounters& counters)
                 IsReadWriteRequestType(t),
                 Options & EOption::ReportDataPlaneHistogram,
                 Options & EOption::ReportControlPlaneHistogram,
-                Options & EOption::ThrottlingMetricsDisabled);
+                Options & EOption::ThrottlingHistogramsDisabled);
 
             // ReadWrite counters are usually the most important ones so let's
             // report zeroes for them instead of not reporting anything at all

--- a/cloud/storage/core/libs/diagnostics/request_counters.h
+++ b/cloud/storage/core/libs/diagnostics/request_counters.h
@@ -37,6 +37,7 @@ public:
         AddSpecialCounters          = (1 << 3),
         LazyRequestInitialization   = (1 << 4),
         OnlyStartEndpointRequests   = (1 << 5),
+        ThrottlingMetricsDisabled   = (1 << 6),
     };
 
     using TRequestType = TDiagnosticsRequestType;

--- a/cloud/storage/core/libs/diagnostics/request_counters.h
+++ b/cloud/storage/core/libs/diagnostics/request_counters.h
@@ -37,7 +37,7 @@ public:
         AddSpecialCounters          = (1 << 3),
         LazyRequestInitialization   = (1 << 4),
         OnlyStartEndpointRequests   = (1 << 5),
-        ThrottlingMetricsDisabled   = (1 << 6),
+        ThrottlingHistogramsDisabled= (1 << 6),
     };
 
     using TRequestType = TDiagnosticsRequestType;

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -1280,7 +1280,8 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         auto monitoring = CreateMonitoringServiceStub();
 
         auto requestCounters = MakeRequestCounters(
-            {.Options = TRequestCounters::EOption::ThrottlingMetricsDisabled});
+            {.Options =
+                 TRequestCounters::EOption::ThrottlingHistogramsDisabled});
         requestCounters.Register(*monitoring->GetCounters());
 
         auto writeBlocks =

--- a/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/request_counters_ut.cpp
@@ -1275,6 +1275,49 @@ Y_UNIT_TEST_SUITE(TRequestCountersTest)
         UNIT_ASSERT_EQUAL_C(8_GB, requestBytes->Val(), requestBytes->Val());
     }
 
+    Y_UNIT_TEST(ShouldNotRegisterOrAccountThrottlingMetrics)
+    {
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto requestCounters = MakeRequestCounters(
+            {.Options = TRequestCounters::EOption::ThrottlingMetricsDisabled});
+        requestCounters.Register(*monitoring->GetCounters());
+
+        auto writeBlocks =
+            monitoring->GetCounters()->GetSubgroup("request", "WriteBlocks");
+
+        AddRequestStats(
+            requestCounters,
+            WriteRequestType,
+            {
+                {.RequestBytes = 1_MB,
+                 .RequestTime = TDuration::MilliSeconds(200),
+                 .PostponedTime = TDuration::MilliSeconds(50),
+                 .BackoffTime = TDuration::MilliSeconds(30),
+                 .ShapingTime = TDuration::MilliSeconds(40)},
+            });
+
+        requestCounters.UpdateStats(true);
+
+        // Time percentile must still be reported
+        {
+            auto p100 = writeBlocks->GetSubgroup("percentiles", "Time")
+                            ->GetSubgroup("units", "usec")
+                            ->GetCounter("100");
+            UNIT_ASSERT_VALUES_UNEQUAL(0, p100->Val());
+        }
+
+        for (const TString histogram:
+             {"ExecutionTime", "ThrottlerDelay", "BackoffTime", "ShapingTime"})
+        {
+            auto percentilesGroup =
+                writeBlocks->FindSubgroup("percentiles", histogram);
+            UNIT_ASSERT_C(
+                !percentilesGroup,
+                "Percentiles for " << histogram << " should not be registered");
+        }
+    }
+
     Y_UNIT_TEST(ShouldFillTimePercentilesForDifferentSizeClassesSeparately)
     {
         auto monitoring = CreateMonitoringServiceStub();


### PR DESCRIPTION
### Notes
Second part of the linked  issue: _For non-throttlable requests, do not report throttling-related params_

### Issue
#6011
