### PR TITLE
Read BlockMasks and BlobMetas in separate transaction

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1609,4 +1609,9 @@ message TStorageServiceConfig
     optional uint32 SystemSSDUnitWriteIops = 508;
     optional uint32 SystemSSDMaxReadIops = 509;
     optional uint32 SystemSSDMaxWriteIops = 510;
+
+    // If true, partition compaction splits the per-blob BlockMask / BlobMeta
+    // read into a separate transaction issued by TCompactionActor instead of
+    // doing it inside the main TCompaction prepare phase.
+    optional bool SplitCompactionTxEnabled = 511;
 }

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -131,6 +131,7 @@ using TCritEventParams =
     xxx(DiskRegistryDetachPathWithDependentDisk)                               \
     xxx(DiskDevicesSizeViolation)                                              \
     xxx(RdmaMessageTypeMismatch)                                               \
+    xxx(BlockChecksumAbsent)                                                   \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -709,10 +709,10 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
         bool,                                                                  \
         false                                                                 )\
                                                                                \
+    xxx(SplitCompactionTxEnabled,                   bool,       false         )\
     xxx(VolumeBalancerGentlePreemptionEnabled,      bool,       false         )\
     xxx(VolumeBalancerGentlePreemptionTimeout,      TDuration,  Hours(72)     )\
-                                                                               \
-    xxx(SplitByCompactionRangeMaxBlobCount,   ui64,        0                  )\
+    xxx(SplitByCompactionRangeMaxBlobCount,         ui64,       0             )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on
@@ -751,6 +751,7 @@ BLOCKSTORE_STORAGE_CONFIG(BLOCKSTORE_STORAGE_DECLARE_CONFIG)
     xxx(EnableVhostDiscardOnVolumeRestart)                                     \
     xxx(FreshBlocksWriter)                                                     \
     xxx(ReadBlockMaskOnCompactionOptimization)                                 \
+    xxx(SplitCompactionTx)                                                     \
 
 // BLOCKSTORE_BINARY_FEATURES
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -422,6 +422,11 @@ public:
         const TString& folderId,
         const TString& diskId) const;
 
+    [[nodiscard]] bool IsSplitCompactionTxFeatureEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& diskId) const;
+
     TDuration GetMaxTimedOutDeviceStateDurationFeatureValue(
         const TString& cloudId,
         const TString& folderId,
@@ -826,6 +831,8 @@ public:
     [[nodiscard]] ui64 GetVolumeBalancerMaxInProgress() const;
 
     [[nodiscard]] bool GetReadBlockMaskOnCompactionOptimizationEnabled() const;
+
+    [[nodiscard]] bool GetSplitCompactionTxEnabled() const;
 
     [[nodiscard]] bool GetVolumeBalancerGentlePreemptionEnabled() const;
 

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1219,6 +1219,7 @@ STFUNC(TPartitionActor::StateWork)
         IgnoreFunc(TEvPartitionPrivate::TEvCleanupResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCollectGarbageResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCompactionResponse);
+        IgnoreFunc(TEvPartitionPrivate::TEvCompactionReadBlobInfoResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvMetadataRebuildUsedBlocksResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvMetadataRebuildBlockCountResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvFlushResponse);
@@ -1288,6 +1289,7 @@ STFUNC(TPartitionActor::StateZombie)
         IgnoreFunc(TEvPartitionPrivate::TEvCleanupResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCollectGarbageResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvCompactionResponse);
+        IgnoreFunc(TEvPartitionPrivate::TEvCompactionReadBlobInfoResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvMetadataRebuildUsedBlocksResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvMetadataRebuildBlockCountResponse);
         IgnoreFunc(TEvPartitionPrivate::TEvFlushResponse);

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -130,13 +130,6 @@ private:
     const ui64 ChannelHistorySize;
     const NBlockCodecs::ICodec* BlobCodec;
     const ui64 VolumeTabletId;
-    const bool SplitCompactionTxEnabled =
-        Config->GetSplitCompactionTxEnabled() ||
-        Config->IsSplitCompactionTxFeatureEnabled(
-            PartitionConfig.GetCloudId(),
-            PartitionConfig.GetFolderId(),
-            PartitionConfig.GetDiskId());
-
     TLogTitle LogTitle;
 
     std::unique_ptr<TPartitionState> State;

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -130,6 +130,12 @@ private:
     const ui64 ChannelHistorySize;
     const NBlockCodecs::ICodec* BlobCodec;
     const ui64 VolumeTabletId;
+    const bool SplitCompactionTxEnabled =
+        Config->GetSplitCompactionTxEnabled() ||
+        Config->IsSplitCompactionTxFeatureEnabled(
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
+            PartitionConfig.GetDiskId());
 
     TLogTitle LogTitle;
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -88,6 +88,15 @@ private:
     TVector<TRangeCompactionInfo> RangeCompactionInfos;
     TVector<TRequest> Requests;
 
+    const bool SplitTxEnabled;
+    TVector<TPartialBlobId> BlobsToReadBlockMasks;
+    TVector<TPartialBlobId> BlobsToReadBlobMetas;
+
+    THashMap<TPartialBlobId, size_t, TPartialBlobIdHash>
+        BlockMaskResponseIndex;
+    THashMap<TPartialBlobId, size_t, TPartialBlobIdHash>
+        BlobMetaResponseIndex;
+
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
 
     TVector<TBatchRequest> BatchRequests;
@@ -132,7 +141,10 @@ public:
         TVector<TRangeCompactionInfo> rangeCompactionInfos,
         TVector<TRequest> requests,
         TDuration compactionTxTime,
-        TChildLogTitle logTitle);
+        TChildLogTitle logTitle,
+        bool splitTxEnabled,
+        TVector<TPartialBlobId> blobsToReadBlockMasks,
+        TVector<TPartialBlobId> blobsToReadBlobMetas);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -143,6 +155,8 @@ private:
     void WriteBlobs(const TActorContext& ctx);
     void AddBlobs(const TActorContext& ctx);
     void MakeDiffs(TRangeCompactionInfo& rc);
+
+    void ContinueAfterBlobInfo(const TActorContext& ctx);
 
     void NotifyCompleted(const TActorContext& ctx, const NProto::TError& error);
     bool HandleError(const TActorContext& ctx, const NProto::TError& error);
@@ -175,6 +189,10 @@ private:
         const TEvPartitionPrivate::TEvAddBlobsResponse::TPtr& ev,
         const TActorContext& ctx);
 
+    void HandleCompactionReadBlobInfoResponse(
+        const TEvPartitionPrivate::TEvCompactionReadBlobInfoResponse::TPtr& ev,
+        const TActorContext& ctx);
+
     void HandlePoisonPill(
         const TEvents::TEvPoisonPill::TPtr& ev,
         const TActorContext& ctx);
@@ -198,7 +216,10 @@ TCompactionActor::TCompactionActor(
         TVector<TRangeCompactionInfo> rangeCompactionInfos,
         TVector<TRequest> requests,
         TDuration compactionTxTime,
-        TChildLogTitle logTitle)
+        TChildLogTitle logTitle,
+        bool splitTxEnabled,
+        TVector<TPartialBlobId> blobsToReadBlockMasks,
+        TVector<TPartialBlobId> blobsToReadBlobMetas)
     : RequestInfo(std::move(requestInfo))
     , TabletId(tabletId)
     , DiskId(std::move(diskId))
@@ -214,6 +235,9 @@ TCompactionActor::TCompactionActor(
     , CommitId(commitId)
     , RangeCompactionInfos(std::move(rangeCompactionInfos))
     , Requests(std::move(requests))
+    , SplitTxEnabled(splitTxEnabled)
+    , BlobsToReadBlockMasks(std::move(blobsToReadBlockMasks))
+    , BlobsToReadBlobMetas(std::move(blobsToReadBlobMetas))
     , CompactionTxTime(compactionTxTime)
 {}
 
@@ -229,6 +253,35 @@ void TCompactionActor::Bootstrap(const TActorContext& ctx)
         "Compaction",
         RequestInfo->CallContext->RequestId);
 
+    if (SplitTxEnabled &&
+        (!BlobsToReadBlockMasks.empty() || !BlobsToReadBlobMetas.empty()))
+    {
+        size_t blockMaskResponseIndex = 0;
+        for (const auto& blobId: BlobsToReadBlockMasks) {
+            BlockMaskResponseIndex[blobId] = blockMaskResponseIndex;
+            ++blockMaskResponseIndex;
+        }
+
+        size_t blobMetaResponseIndex = 0;
+        for (const auto& blobId: BlobsToReadBlobMetas) {
+            BlobMetaResponseIndex[blobId] = blobMetaResponseIndex;
+            ++blobMetaResponseIndex;
+        }
+
+        auto request = std::make_unique<
+            TEvPartitionPrivate::TEvCompactionReadBlobInfoRequest>(
+            std::move(BlobsToReadBlockMasks),
+            std::move(BlobsToReadBlobMetas));
+
+        NCloud::Send(ctx, Tablet, std::move(request));
+        return;
+    }
+
+    ContinueAfterBlobInfo(ctx);
+}
+
+void TCompactionActor::ContinueAfterBlobInfo(const TActorContext& ctx)
+{
     if (Requests) {
         ReadBlocks(ctx);
 
@@ -838,7 +891,8 @@ void TCompactionActor::HandleReadBlobResponse(
 
     Y_ABORT_UNLESS(batchIndex < BatchRequests.size());
     auto& batch = BatchRequests[batchIndex];
-    const auto& rc = *batch.RangeCompactionInfo;
+    auto& rc = *batch.RangeCompactionInfo;
+    ApplyChecksumFixups(rc);
 
     const auto n = Min(batch.Requests.size(), msg->BlockChecksums.size());
     for (ui32 i = 0; i < n; ++i) {
@@ -953,6 +1007,40 @@ void TCompactionActor::HandleAddBlobsResponse(
     );
 }
 
+void TCompactionActor::HandleCompactionReadBlobInfoResponse(
+    const TEvPartitionPrivate::TEvCompactionReadBlobInfoResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    if (HandleError(ctx, msg->GetError())) {
+        return;
+    }
+
+    Y_ABORT_UNLESS(
+        msg->BlockMasksForBlobs.size() == BlockMaskResponseIndex.size());
+    Y_ABORT_UNLESS(
+        msg->BlobMetasForBlobs.size() == BlobMetaResponseIndex.size());
+
+    for (auto& rc: RangeCompactionInfos) {
+        for (auto& [blobId, ab]: rc.AffectedBlobs) {
+            if (auto it = BlockMaskResponseIndex.find(blobId);
+                it != BlockMaskResponseIndex.end())
+            {
+                ab.BlockMask = msg->BlockMasksForBlobs[it->second];
+            }
+
+            if (auto it = BlobMetaResponseIndex.find(blobId);
+                it != BlobMetaResponseIndex.end())
+            {
+                ab.BlobMeta = msg->BlobMetasForBlobs[it->second];
+            }
+        }
+    }
+
+    ContinueAfterBlobInfo(ctx);
+}
+
 void TCompactionActor::HandlePoisonPill(
     const TEvents::TEvPoisonPill::TPtr& ev,
     const TActorContext& ctx)
@@ -977,6 +1065,9 @@ STFUNC(TCompactionActor::StateWork)
             HandleWriteBlobResponse);
         HFunc(TEvPartitionCommonPrivate::TEvPatchBlobResponse, HandlePatchBlobResponse);
         HFunc(TEvPartitionPrivate::TEvAddBlobsResponse, HandleAddBlobsResponse);
+        HFunc(
+            TEvPartitionPrivate::TEvCompactionReadBlobInfoResponse,
+            HandleCompactionReadBlobInfoResponse);
 
         default:
             HandleUnexpectedEvent(
@@ -1753,14 +1844,71 @@ bool TPartitionActor::PrepareCompaction(
             *Config,
             maxSkippedBlobs,
             args.CommitId,
-            ctx,
             TabletID(),
             IsReadBlockMaskOnCompactionOptimizationEnabled(),
             ready,
             db,
             *State,
             rangeCompaction,
-            LogTitle.GetWithTime());
+            args.BlobsToReadBlockMasks,
+            args.BlobsToReadBlobMetas);
+
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::PARTITION,
+            "%s Dropping last %u blobs, %u blocks, remaining blobs: %u",
+            LogTitle.GetWithTime().c_str(),
+            rangeCompaction.BlobsSkipped,
+            rangeCompaction.BlocksSkipped,
+            rangeCompaction.AffectedBlobs.size());
+    }
+
+    if (SplitCompactionTxEnabled) {
+        // BlockMask / BlobMeta are read in a separate TX issued by
+        // TCompactionActor.
+        return ready;
+    }
+
+    for (const auto& blobId: args.BlobsToReadBlockMasks) {
+        TMaybe<TBlockMask> blockMask;
+        if (db.ReadBlockMask(blobId, blockMask)) {
+            STORAGE_VERIFY_C(
+                blockMask.Defined(),
+                TWellKnownEntityTypes::TABLET,
+                TabletID(),
+                TStringBuilder() << "Could not read block mask for blob: "
+                                 << MakeBlobId(TabletID(), blobId));
+        } else {
+            ready = false;
+            continue;
+        }
+
+        for (auto& rangeCompaction: args.RangeCompactions) {
+            if (auto* ab = rangeCompaction.AffectedBlobs.FindPtr(blobId)) {
+                ab->BlockMask = *blockMask;
+            }
+        }
+    }
+
+    for (const auto& blobId: args.BlobsToReadBlobMetas) {
+        TMaybe<NProto::TBlobMeta> blobMeta;
+        if (db.ReadBlobMeta(blobId, blobMeta)) {
+            STORAGE_VERIFY_C(
+                blobMeta.Defined(),
+                TWellKnownEntityTypes::TABLET,
+                TabletID(),
+                TStringBuilder() << "Could not read blob meta for blob: "
+                                 << MakeBlobId(TabletID(), blobId));
+        } else {
+            ready = false;
+            continue;
+        }
+
+        for (auto& rangeCompaction: args.RangeCompactions) {
+            if (auto* ab = rangeCompaction.AffectedBlobs.FindPtr(blobId)) {
+                ab->BlobMeta = *blobMeta;
+            }
+        }
     }
 
     return ready;
@@ -1831,9 +1979,9 @@ void TPartitionActor::CompleteCompaction(
     }
 
     const auto compactionType =
-        args.CompactionOptions.test(ToBit(ECompactionOption::Forced)) ?
-            ECompactionType::Forced:
-            ECompactionType::Tablet;
+        args.CompactionOptions.test(ToBit(ECompactionOption::Forced))
+            ? ECompactionType::Forced
+            : ECompactionType::Tablet;
 
     auto actor = NCloud::Register<TCompactionActor>(
         ctx,
@@ -1852,7 +2000,14 @@ void TPartitionActor::CompleteCompaction(
         std::move(rangeCompactionInfos),
         std::move(requests),
         compactionTxTime,
-        LogTitle.GetChild(GetCycleCount()));
+        LogTitle.GetChild(GetCycleCount()),
+        SplitCompactionTxEnabled,
+        TVector<TPartialBlobId>(
+            args.BlobsToReadBlockMasks.begin(),
+            args.BlobsToReadBlockMasks.end()),
+        TVector<TPartialBlobId>(
+            args.BlobsToReadBlobMetas.begin(),
+            args.BlobsToReadBlobMetas.end()));
     LOG_DEBUG(
         ctx,
         TBlockStoreComponents::PARTITION,

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -40,7 +40,13 @@ TVector<ui32> EnsureBlockChecksums(
     TVector<ui32> result;
     result.reserve(blockChecksums.size());
     for (const auto& checksum: blockChecksums) {
-        STORAGE_VERIFY(checksum, TWellKnownEntityTypes::TABLET, tabletId);
+        if (!checksum) {
+            ReportBlockChecksumAbsent(
+                "block checksum is absent",
+                {{"tabletId", ToString(tabletId)}});
+            result.push_back(0);
+            continue;
+        }
         result.push_back(*checksum);
     }
     return result;
@@ -907,12 +913,15 @@ void TCompactionActor::HandleReadBlobResponse(
     const auto n = Min(batch.Requests.size(), msg->BlockChecksums.size());
     for (ui32 i = 0; i < n; ++i) {
         const auto* r = batch.Requests[i];
-        STORAGE_VERIFY(
-            rc.BlockChecksums[r->IndexInBlobContent],
-            TWellKnownEntityTypes::TABLET,
-            TabletId);
-        const auto expectedChecksum =
-            *rc.BlockChecksums[r->IndexInBlobContent];
+        if (!rc.BlockChecksums[r->IndexInBlobContent]) {
+            ReportBlockChecksumAbsent(
+                "block checksum is absent",
+                {{"blobId", ToString(MakeBlobId(TabletId, r->BlobId))},
+                 {"blockIndex", r->BlockIndex},
+                 {"blobOffset", r->BlobOffset}});
+            rc.BlockChecksums[r->IndexInBlobContent] = 0;
+        }
+        const auto expectedChecksum = *rc.BlockChecksums[r->IndexInBlobContent];
 
         auto error = VerifyBlockChecksum(
             msg->BlockChecksums[i],

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1905,6 +1905,9 @@ bool TPartitionActor::PrepareCompaction(
         return ready;
     }
 
+    State->IncrementBlockMaskReadDuringCompaction(
+        args.BlobsToReadBlockMasks.size());
+
     for (const auto& blobId: args.BlobsToReadBlockMasks) {
         TMaybe<TBlockMask> blockMask;
         if (db.ReadBlockMask(blobId, blockMask)) {
@@ -1965,6 +1968,11 @@ void TPartitionActor::CompleteCompaction(
     TTxPartition::TCompaction& args)
 {
     TRequestScope timer(*args.RequestInfo);
+
+    for (auto& rangeCompaction: args.RangeCompactions) {
+        State->IncrementBlobsProcessedDuringCompaction(
+            rangeCompaction.AffectedBlobs.size());
+    }
 
     const auto compactionTxTime = ctx.Now() - args.TxStarted;
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -33,6 +33,19 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TVector<ui32> EnsureBlockChecksums(
+    const TVector<std::optional<ui32>>& blockChecksums,
+    ui64 tabletId)
+{
+    TVector<ui32> result;
+    result.reserve(blockChecksums.size());
+    for (const auto& checksum: blockChecksums) {
+        STORAGE_VERIFY(checksum, TWellKnownEntityTypes::TABLET, tabletId);
+        result.push_back(*checksum);
+    }
+    return result;
+}
+
 class TCompactionActor final
     : public TActorBootstrapped<TCompactionActor>
 {
@@ -88,14 +101,13 @@ private:
     TVector<TRangeCompactionInfo> RangeCompactionInfos;
     TVector<TRequest> Requests;
 
-    const bool SplitTxEnabled;
+    // If true, partition compaction splits the per-blob BlockMask / BlobMeta
+    // read into a separate transaction issued by TCompactionActor instead of
+    // doing it inside the main TCompaction prepare phase.
+    const bool SplitCompactionTxEnabled;
+
     TVector<TPartialBlobId> BlobsToReadBlockMasks;
     TVector<TPartialBlobId> BlobsToReadBlobMetas;
-
-    THashMap<TPartialBlobId, size_t, TPartialBlobIdHash>
-        BlockMaskResponseIndex;
-    THashMap<TPartialBlobId, size_t, TPartialBlobIdHash>
-        BlobMetaResponseIndex;
 
     TVector<IProfileLog::TBlockInfo> AffectedBlockInfos;
 
@@ -156,7 +168,7 @@ private:
     void AddBlobs(const TActorContext& ctx);
     void MakeDiffs(TRangeCompactionInfo& rc);
 
-    void ContinueAfterBlobInfo(const TActorContext& ctx);
+    void CompactionReadBlobInfosFinished(const TActorContext& ctx);
 
     void NotifyCompleted(const TActorContext& ctx, const NProto::TError& error);
     bool HandleError(const TActorContext& ctx, const NProto::TError& error);
@@ -235,7 +247,7 @@ TCompactionActor::TCompactionActor(
     , CommitId(commitId)
     , RangeCompactionInfos(std::move(rangeCompactionInfos))
     , Requests(std::move(requests))
-    , SplitTxEnabled(splitTxEnabled)
+    , SplitCompactionTxEnabled(splitTxEnabled)
     , BlobsToReadBlockMasks(std::move(blobsToReadBlockMasks))
     , BlobsToReadBlobMetas(std::move(blobsToReadBlobMetas))
     , CompactionTxTime(compactionTxTime)
@@ -253,35 +265,27 @@ void TCompactionActor::Bootstrap(const TActorContext& ctx)
         "Compaction",
         RequestInfo->CallContext->RequestId);
 
-    if (SplitTxEnabled &&
+    if (SplitCompactionTxEnabled &&
         (!BlobsToReadBlockMasks.empty() || !BlobsToReadBlobMetas.empty()))
     {
-        size_t blockMaskResponseIndex = 0;
-        for (const auto& blobId: BlobsToReadBlockMasks) {
-            BlockMaskResponseIndex[blobId] = blockMaskResponseIndex;
-            ++blockMaskResponseIndex;
-        }
-
-        size_t blobMetaResponseIndex = 0;
-        for (const auto& blobId: BlobsToReadBlobMetas) {
-            BlobMetaResponseIndex[blobId] = blobMetaResponseIndex;
-            ++blobMetaResponseIndex;
-        }
-
         auto request = std::make_unique<
             TEvPartitionPrivate::TEvCompactionReadBlobInfoRequest>(
-            std::move(BlobsToReadBlockMasks),
-            std::move(BlobsToReadBlobMetas));
+            BlobsToReadBlockMasks,
+            BlobsToReadBlobMetas);
 
         NCloud::Send(ctx, Tablet, std::move(request));
         return;
     }
 
-    ContinueAfterBlobInfo(ctx);
+    CompactionReadBlobInfosFinished(ctx);
 }
 
-void TCompactionActor::ContinueAfterBlobInfo(const TActorContext& ctx)
+void TCompactionActor::CompactionReadBlobInfosFinished(const TActorContext& ctx)
 {
+    for (auto& rc: RangeCompactionInfos) {
+        ApplyChecksumFixups(rc);
+    }
+
     if (Requests) {
         ReadBlocks(ctx);
 
@@ -605,7 +609,7 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
         const TPartialBlobId& blobId,
         TBlockRange32 range,
         TBlockMask skipMask,
-        const TVector<ui32>& blockChecksums,
+        const TVector<std::optional<ui32>>& blockChecksums,
         ui32 blobsSkipped,
         ui32 blocksSkipped,
         EChannelDataKind channelDataKind)
@@ -619,8 +623,15 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
             --range.End;
         }
 
+        auto ensuredBlockChecksums =
+            EnsureBlockChecksums(blockChecksums, TabletId);
+
         if (channelDataKind == EChannelDataKind::Merged) {
-            mergedBlobs.emplace_back(blobId, range, skipMask, blockChecksums);
+            mergedBlobs.emplace_back(
+                blobId,
+                range,
+                skipMask,
+                std::move(ensuredBlockChecksums));
             mergedBlobCompactionInfos.push_back({blobsSkipped, blocksSkipped});
         } else if (channelDataKind == EChannelDataKind::Mixed) {
             TVector<ui32> blockIndices(Reserve(range.Size()));
@@ -634,7 +645,7 @@ void TCompactionActor::AddBlobs(const TActorContext& ctx)
             mixedBlobs.emplace_back(
                 blobId,
                 std::move(blockIndices),
-                blockChecksums,
+                std::move(ensuredBlockChecksums),
                 0);   // unknown blob alignment
             mixedBlobCompactionInfos.push_back({blobsSkipped, blocksSkipped});
         } else {
@@ -892,13 +903,16 @@ void TCompactionActor::HandleReadBlobResponse(
     Y_ABORT_UNLESS(batchIndex < BatchRequests.size());
     auto& batch = BatchRequests[batchIndex];
     auto& rc = *batch.RangeCompactionInfo;
-    ApplyChecksumFixups(rc);
 
     const auto n = Min(batch.Requests.size(), msg->BlockChecksums.size());
     for (ui32 i = 0; i < n; ++i) {
         const auto* r = batch.Requests[i];
+        STORAGE_VERIFY(
+            rc.BlockChecksums[r->IndexInBlobContent],
+            TWellKnownEntityTypes::TABLET,
+            TabletId);
         const auto expectedChecksum =
-            rc.BlockChecksums[r->IndexInBlobContent];
+            *rc.BlockChecksums[r->IndexInBlobContent];
 
         auto error = VerifyBlockChecksum(
             msg->BlockChecksums[i],
@@ -1017,28 +1031,33 @@ void TCompactionActor::HandleCompactionReadBlobInfoResponse(
         return;
     }
 
-    Y_ABORT_UNLESS(
-        msg->BlockMasksForBlobs.size() == BlockMaskResponseIndex.size());
-    Y_ABORT_UNLESS(
-        msg->BlobMetasForBlobs.size() == BlobMetaResponseIndex.size());
+    for (size_t i = 0; i < BlobsToReadBlobMetas.size(); ++i) {
+        const auto& blobId = BlobsToReadBlobMetas[i];
+        const auto& blobMeta = msg->BlobMetasForBlobs[i];
 
-    for (auto& rc: RangeCompactionInfos) {
-        for (auto& [blobId, ab]: rc.AffectedBlobs) {
-            if (auto it = BlockMaskResponseIndex.find(blobId);
-                it != BlockMaskResponseIndex.end())
-            {
-                ab.BlockMask = msg->BlockMasksForBlobs[it->second];
+        for (auto& rc: RangeCompactionInfos) {
+            auto* ab = rc.AffectedBlobs.FindPtr(blobId);
+            if (!ab) {
+                continue;
             }
-
-            if (auto it = BlobMetaResponseIndex.find(blobId);
-                it != BlobMetaResponseIndex.end())
-            {
-                ab.BlobMeta = msg->BlobMetasForBlobs[it->second];
-            }
+            ab->BlobMeta = blobMeta;
         }
     }
 
-    ContinueAfterBlobInfo(ctx);
+    for (size_t i = 0; i < BlobsToReadBlockMasks.size(); ++i) {
+        const auto& blobId = BlobsToReadBlockMasks[i];
+        const auto& blockMask = msg->BlockMasksForBlobs[i];
+
+        for (auto& rc: RangeCompactionInfos) {
+            auto* ab = rc.AffectedBlobs.FindPtr(blobId);
+            if (!ab) {
+                continue;
+            }
+            ab->BlockMask = blockMask;
+        }
+    }
+
+    CompactionReadBlobInfosFinished(ctx);
 }
 
 void TCompactionActor::HandlePoisonPill(
@@ -1699,10 +1718,18 @@ void TPartitionActor::HandleCompaction(
 
     AddTransaction<TEvPartitionPrivate::TCompactionMethod>(*requestInfo);
 
+    const bool splitCompactionTxEnabled =
+        Config->GetSplitCompactionTxEnabled() ||
+        Config->IsSplitCompactionTxFeatureEnabled(
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
+            PartitionConfig.GetDiskId());
+
     auto tx = CreateTx<TCompaction>(
         requestInfo,
         commitId,
         msg->CompactionOptions,
+        splitCompactionTxEnabled,
         std::move(ranges),
         ctx.Now());
 
@@ -1863,7 +1890,7 @@ bool TPartitionActor::PrepareCompaction(
             rangeCompaction.AffectedBlobs.size());
     }
 
-    if (SplitCompactionTxEnabled) {
+    if (args.SplitCompactionTxEnabled) {
         // BlockMask / BlobMeta are read in a separate TX issued by
         // TCompactionActor.
         return ready;
@@ -2001,7 +2028,7 @@ void TPartitionActor::CompleteCompaction(
         std::move(requests),
         compactionTxTime,
         LogTitle.GetChild(GetCycleCount()),
-        SplitCompactionTxEnabled,
+        args.SplitCompactionTxEnabled,
         TVector<TPartialBlobId>(
             args.BlobsToReadBlockMasks.begin(),
             args.BlobsToReadBlockMasks.end()),

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblobinfo.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblobinfo.cpp
@@ -51,9 +51,6 @@ bool TPartitionActor::PrepareCompactionReadBlobInfo(
 
     bool ready = true;
 
-    State->IncrementBlockMaskReadDuringCompaction(
-        args.BlobsToReadBlockMasks.size());
-
     for (size_t i = 0; i < args.BlobsToReadBlockMasks.size(); ++i) {
         TMaybe<TBlockMask> mask;
         if (!db.ReadBlockMask(args.BlobsToReadBlockMasks[i], mask)) {
@@ -117,6 +114,9 @@ void TPartitionActor::CompleteCompactionReadBlobInfo(
         TStringBuilder() << "Blob metas size mismatch: "
                          << args.BlobMetas.size()
                          << " != " << args.BlobsToReadBlobMetas.size());
+
+    State->IncrementBlockMaskReadDuringCompaction(
+        args.BlobsToReadBlockMasks.size());
 
     TRequestScope timer(*args.RequestInfo);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblobinfo.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblobinfo.cpp
@@ -51,6 +51,9 @@ bool TPartitionActor::PrepareCompactionReadBlobInfo(
 
     bool ready = true;
 
+    State->IncrementBlockMaskReadDuringCompaction(
+        args.BlobsToReadBlockMasks.size());
+
     for (size_t i = 0; i < args.BlobsToReadBlockMasks.size(); ++i) {
         TMaybe<TBlockMask> mask;
         if (!db.ReadBlockMask(args.BlobsToReadBlockMasks[i], mask)) {

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -14,6 +14,7 @@
 #include <cloud/storage/core/libs/common/alloc.h>
 #include <cloud/storage/core/libs/common/block_buffer.h>
 #include <cloud/storage/core/libs/common/verify.h>
+#include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/tablet/blob_id.h>
 #include <cloud/storage/core/libs/tablet/model/partial_blob_id.h>
 
@@ -48,7 +49,8 @@ TRangeCompactionInfo::TRangeCompactionInfo(
     TBlockBuffer blobContent,
     TVector<ui32> zeroBlocks,
     TAffectedBlobs affectedBlobs,
-    TAffectedBlocks affectedBlocks)
+    TAffectedBlocks affectedBlocks,
+    TVector<TChecksumFixup> checksumFixups)
     : BlockRange(blockRange)
     , OriginalBlobId(originalBlobId)
     , DataBlobId(dataBlobId)
@@ -63,6 +65,7 @@ TRangeCompactionInfo::TRangeCompactionInfo(
     , ZeroBlocks(std::move(zeroBlocks))
     , AffectedBlobs(std::move(affectedBlobs))
     , AffectedBlocks(std::move(affectedBlocks))
+    , ChecksumFixups(std::move(checksumFixups))
 {}
 
 TBlobCompactionRequest::TBlobCompactionRequest(
@@ -81,6 +84,20 @@ TBlobCompactionRequest::TBlobCompactionRequest(
     , GroupId(groupId)
     , RangeCompactionIndex(rangeCompactionIndex)
 {}
+
+void ApplyChecksumFixups(TRangeCompactionInfo& rc)
+{
+    for (const auto& fixup: rc.ChecksumFixups) {
+        const auto* ab = rc.AffectedBlobs.FindPtr(fixup.BlobId);
+        Y_ABORT_UNLESS(ab);
+        auto* meta = ab->BlobMeta.Get();
+        Y_ABORT_UNLESS(meta);
+        if (fixup.BlobOffset < meta->BlockChecksumsSize()) {
+            rc.BlockChecksums[fixup.ChecksumIndex] =
+                meta->GetBlockChecksums(fixup.BlobOffset);
+        }
+    }
+}
 
 namespace {
 
@@ -301,8 +318,6 @@ TCompactionResultBlobIds DetermineCompactionResultBlobIds(
 void ApplyIncrementalCompactionSkipping(
     const TStorageConfig& config,
     ui32 maxSkippedBlobs,
-    const TActorContext& ctx,
-    const TString& logTitle,
     TPartitionState& state,
     TTxPartition::TRangeCompaction& args)
 {
@@ -353,17 +368,6 @@ void ApplyIncrementalCompactionSkipping(
         ++it;
     }
 
-    LOG_DEBUG(
-        ctx,
-        TBlockStoreComponents::PARTITION,
-        "%s Dropping last %u blobs, %u blocks, remaining blobs: %u, "
-        "blocks: %u",
-        logTitle.c_str(),
-        args.BlobsSkipped,
-        args.BlocksSkipped,
-        liveBlocks.size(),
-        blocks);
-
     THashSet<ui32> skippedBlockIndices;
 
     for (const auto& x: liveBlocks) {
@@ -396,17 +400,21 @@ void ApplyIncrementalCompactionSkipping(
     }
 }
 
-void ReadAffectedBlobsForCompaction(
+void FillBlobsInfoToRead(
     ui64 commitId,
-    ui64 tabletId,
     bool readBlockMaskOnCompactionOptimizationEnabled,
-    bool& ready,
-    TPartitionDatabase& db,
+    TTxPartition::TRangeCompaction& args,
     TPartitionState& state,
-    TTxPartition::TRangeCompaction& args)
+    THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlockMasks,
+    THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlobMetas)
 {
     for (auto& kv: args.AffectedBlobs) {
         state.IncrementBlobsProcessedDuringCompaction();
+
+        if (state.GetCleanupQueue().HasBlob(kv.first)) {
+            kv.second.BlockMask = GetFullBlockMask(state.GetMaxBlocksInBlob());
+            continue;
+        }
 
         const bool blobOnlyInOneCompactRange =
             kv.second.CompactionRangeCount == 1;
@@ -419,33 +427,18 @@ void ReadAffectedBlobsForCompaction(
             !readBlockMaskOnCompactionOptimizationEnabled)
         {
             state.IncrementBlockMaskReadDuringCompaction();
-
-            if (db.ReadBlockMask(kv.first, kv.second.BlockMask)) {
-                STORAGE_VERIFY_C(
-                    kv.second.BlockMask.Defined(),
-                    TWellKnownEntityTypes::TABLET,
-                    tabletId,
-                    TStringBuilder() << "Could not read block mask for blob: "
-                                     << MakeBlobId(tabletId, kv.first));
-            } else {
-                ready = false;
-            }
-        } else if (state.GetCleanupQueue().HasBlob(kv.first)) {
-            // If the blob is in the cleanup queue, we should not try to add
-            // this blob to cleanup queue again.
-            kv.second.BlockMask = GetFullBlockMask(state.GetMaxBlocksInBlob());
+            blobsToReadBlockMasks.emplace(kv.first);
         }
+    }
 
-        if (args.ChecksumsEnabled) {
-            if (db.ReadBlobMeta(kv.first, kv.second.BlobMeta)) {
-                STORAGE_VERIFY_C(
-                    kv.second.BlobMeta.Defined(),
-                    TWellKnownEntityTypes::TABLET,
-                    tabletId,
-                    TStringBuilder() << "Could not read blob meta for blob: "
-                                     << MakeBlobId(tabletId, kv.first));
-            } else {
-                ready = false;
+    // blob metas are needed for checksums validation, so we will read
+    // them only for blobs with live data
+    if (args.ChecksumsEnabled) {
+        for (const auto& mark: args.BlockMarks) {
+            if (mark.CommitId && !mark.BlockContent &&
+                !IsDeletionMarker(mark.BlobId))
+            {
+                blobsToReadBlobMetas.emplace(mark.BlobId);
             }
         }
     }
@@ -458,6 +451,7 @@ struct TBuildBlobContentAndMasksResult
     TVector<ui32> ZeroBlocks;
     TBlockMask DataBlobSkipMask;
     TBlockMask ZeroBlobSkipMask;
+    TVector<TChecksumFixup> ChecksumFixups;
 };
 
 TBuildBlobContentAndMasksResult BuildBlobContentAndMasks(
@@ -518,23 +512,14 @@ TBuildBlobContentAndMasksResult BuildBlobContentAndMasks(
                 // we will read this block later
                 result.BlobContent.AddBlock(state.GetBlockSize(), char(0));
 
-                // block checksum is simply moved from the affected blob's meta
                 if (args.ChecksumsEnabled) {
-                    ui32 blockChecksum = 0;
-
-                    auto* affectedBlob =
-                        args.AffectedBlobs.FindPtr(mark.BlobId);
-                    Y_DEBUG_ABORT_UNLESS(affectedBlob);
-                    if (affectedBlob) {
-                        if (auto* meta = affectedBlob->BlobMeta.Get()) {
-                            if (mark.BlobOffset < meta->BlockChecksumsSize()) {
-                                blockChecksum =
-                                    meta->GetBlockChecksums(mark.BlobOffset);
-                            }
-                        }
-                    }
-
-                    result.BlockChecksums.push_back(blockChecksum);
+                    // checksums will be moved from the affected blob's meta
+                    // later
+                    result.ChecksumFixups.emplace_back(
+                        result.BlockChecksums.size(),   // ChecksumIndex
+                        mark.BlobId,
+                        mark.BlobOffset);
+                    result.BlockChecksums.push_back(0);
                 }
 
                 if (zeroBlobId) {
@@ -663,14 +648,14 @@ void PrepareRangeCompaction(
     const TStorageConfig& config,
     const ui32 maxSkippedBlobs,
     const ui64 commitId,
-    const TActorContext& ctx,
     const ui64 tabletId,
     const bool readBlockMaskOnCompactionOptimizationEnabled,
     bool& ready,
     TPartitionDatabase& db,
     TPartitionState& state,
     TTxPartition::TRangeCompaction& args,
-    const TString& logTitle)
+    THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlockMasks,
+    THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlobMetas)
 {
     TCompactionBlockVisitor visitor(
         args,
@@ -695,8 +680,6 @@ void PrepareRangeCompaction(
         ApplyIncrementalCompactionSkipping(
             config,
             maxSkippedBlobs,
-            ctx,
-            logTitle,
             state,
             args);
     }
@@ -706,14 +689,13 @@ void PrepareRangeCompaction(
         state.GetBlockSize();
     args.ChecksumsEnabled = args.BlockRange.Start < checksumBoundary;
 
-    ReadAffectedBlobsForCompaction(
+    FillBlobsInfoToRead(
         commitId,
-        tabletId,
         readBlockMaskOnCompactionOptimizationEnabled,
-        ready,
-        db,
+        args,
         state,
-        args);
+        blobsToReadBlockMasks,
+        blobsToReadBlobMetas);
 }
 
 void CompleteRangeCompaction(
@@ -782,7 +764,8 @@ void CompleteRangeCompaction(
         std::move(buildBlobContentResult.BlobContent),
         std::move(buildBlobContentResult.ZeroBlocks),
         std::move(args.AffectedBlobs),
-        std::move(args.AffectedBlocks));
+        std::move(args.AffectedBlocks),
+        std::move(buildBlobContentResult.ChecksumFixups));
 
     if (!patchingResult.DataBlobId && !resultBlobIds.ZeroBlobId) {
         const auto rangeDescr = DescribeRange(args.BlockRange);

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -410,8 +410,6 @@ void FillBlobsInfoToRead(
     THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlobMetas)
 {
     for (auto& kv: args.AffectedBlobs) {
-        state.IncrementBlobsProcessedDuringCompaction();
-
         if (state.GetCleanupQueue().HasBlob(kv.first)) {
             kv.second.BlockMask = GetFullBlockMask(state.GetMaxBlocksInBlob());
             continue;
@@ -427,7 +425,6 @@ void FillBlobsInfoToRead(
         if (!blobFullyAvailableForRangeCompaction ||
             !readBlockMaskOnCompactionOptimizationEnabled)
         {
-            state.IncrementBlockMaskReadDuringCompaction();
             blobsToReadBlockMasks.emplace(kv.first);
         }
     }

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -44,7 +44,7 @@ TRangeCompactionInfo::TRangeCompactionInfo(
     TBlockMask zeroBlobSkipMask,
     ui32 blobsSkippedByCompaction,
     ui32 blocksSkippedByCompaction,
-    TVector<ui32> blockChecksums,
+    TVector<std::optional<ui32>> blockChecksums,
     EChannelDataKind channelDataKind,
     TBlockBuffer blobContent,
     TVector<ui32> zeroBlocks,
@@ -447,7 +447,7 @@ void FillBlobsInfoToRead(
 struct TBuildBlobContentAndMasksResult
 {
     TBlockBuffer BlobContent;
-    TVector<ui32> BlockChecksums;
+    TVector<std::optional<ui32>> BlockChecksums;
     TVector<ui32> ZeroBlocks;
     TBlockMask DataBlobSkipMask;
     TBlockMask ZeroBlobSkipMask;
@@ -519,7 +519,7 @@ TBuildBlobContentAndMasksResult BuildBlobContentAndMasks(
                         result.BlockChecksums.size(),   // ChecksumIndex
                         mark.BlobId,
                         mark.BlobOffset);
-                    result.BlockChecksums.push_back(0);
+                    result.BlockChecksums.push_back(std::nullopt);
                 }
 
                 if (zeroBlobId) {

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -92,10 +92,11 @@ void ApplyChecksumFixups(TRangeCompactionInfo& rc)
         Y_ABORT_UNLESS(ab);
         auto* meta = ab->BlobMeta.Get();
         Y_ABORT_UNLESS(meta);
-        if (fixup.BlobOffset < meta->BlockChecksumsSize()) {
-            rc.BlockChecksums[fixup.ChecksumIndex] =
-                meta->GetBlockChecksums(fixup.BlobOffset);
-        }
+
+        ui32 checksum = fixup.BlobOffset < meta->BlockChecksumsSize()
+                            ? meta->GetBlockChecksums(fixup.BlobOffset)
+                            : 0;
+        rc.BlockChecksums[fixup.ChecksumIndex] = checksum;
     }
 }
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
@@ -52,7 +52,7 @@ struct TRangeCompactionInfo
     const TBlockMask ZeroBlobSkipMask;
     const ui32 BlobsSkippedByCompaction;
     const ui32 BlocksSkippedByCompaction;
-    TVector<ui32> BlockChecksums;
+    TVector<std::optional<ui32>> BlockChecksums;
     const EChannelDataKind ChannelDataKind;
 
     TGuardedBuffer<TBlockBuffer> BlobContent;
@@ -73,7 +73,7 @@ struct TRangeCompactionInfo
             TBlockMask zeroBlobSkipMask,
             ui32 blobsSkippedByCompaction,
             ui32 blocksSkippedByCompaction,
-            TVector<ui32> blockChecksums,
+            TVector<std::optional<ui32>> blockChecksums,
             EChannelDataKind channelDataKind,
             TBlockBuffer blobContent,
             TVector<ui32> zeroBlocks,

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
@@ -30,6 +30,18 @@ class TPartitionDatabase;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TChecksumFixup
+{
+    // Index into TRangeCompactionInfo::BlockChecksums that must be filled
+    // with the checksum from AffectedBlobs[BlobId].BlobMeta after the
+    // CompactionReadBlobInfo TX response arrives.
+    size_t ChecksumIndex = 0;
+    TPartialBlobId BlobId;
+    ui16 BlobOffset = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TRangeCompactionInfo
 {
     const TBlockRange32 BlockRange;
@@ -40,7 +52,7 @@ struct TRangeCompactionInfo
     const TBlockMask ZeroBlobSkipMask;
     const ui32 BlobsSkippedByCompaction;
     const ui32 BlocksSkippedByCompaction;
-    const TVector<ui32> BlockChecksums;
+    TVector<ui32> BlockChecksums;
     const EChannelDataKind ChannelDataKind;
 
     TGuardedBuffer<TBlockBuffer> BlobContent;
@@ -48,6 +60,7 @@ struct TRangeCompactionInfo
     TAffectedBlobs AffectedBlobs;
     TAffectedBlocks AffectedBlocks;
     TVector<ui16> UnchangedBlobOffsets;
+    TVector<TChecksumFixup> ChecksumFixups;
     TArrayHolder<NKikimr::TEvBlobStorage::TEvPatch::TDiff> Diffs;
     ui32 DiffCount = 0;
 
@@ -65,8 +78,11 @@ struct TRangeCompactionInfo
             TBlockBuffer blobContent,
             TVector<ui32> zeroBlocks,
             TAffectedBlobs affectedBlobs,
-            TAffectedBlocks affectedBlocks);
+            TAffectedBlocks affectedBlocks,
+            TVector<TChecksumFixup> checksumFixups);
 };
+
+void ApplyChecksumFixups(TRangeCompactionInfo& rc);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -96,14 +112,14 @@ void PrepareRangeCompaction(
     const TStorageConfig& config,
     const ui32 maxSkippedBlobs,
     const ui64 commitId,
-    const NActors::TActorContext& ctx,
     const ui64 tabletId,
     const bool readBlockMaskOnCompactionOptimizationEnabled,
     bool& ready,
     TPartitionDatabase& db,
     TPartitionState& state,
     TTxPartition::TRangeCompaction& args,
-    const TString& logTitle);
+    THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlockMasks,
+    THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlobMetas);
 
 void CompleteRangeCompaction(
     const bool blobPatchingEnabled,

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -1,0 +1,472 @@
+#include "part_compaction_logic.h"
+
+#include "part_database.h"
+#include "part_state.h"
+
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
+#include <cloud/blockstore/libs/storage/partition_common/part_thread_safe_state.h>
+#include <cloud/blockstore/libs/storage/testlib/test_executor.h>
+#include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+
+#include <cloud/storage/core/libs/features/features_config.h>
+#include <cloud/storage/core/libs/tablet/model/commit.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TPartitionMeta DefaultConfig(size_t channelCount, size_t blockCount)
+{
+    NProto::TPartitionMeta meta;
+
+    auto& config = *meta.MutableConfig();
+    config.SetBlockSize(DefaultBlockSize);
+    config.SetBlocksCount(blockCount);
+
+    auto cps = config.MutableExplicitChannelProfiles();
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::System));
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Log));
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Index));
+
+    for (ui32 i = 0; i < channelCount; ++i) {
+        cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Merged));
+    }
+
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Fresh));
+
+    return meta;
+}
+
+TBackpressureFeaturesConfig DefaultBPConfig()
+{
+    return {
+        {30, 10, 10},
+        {1600_KB, 400_KB, 10},
+        {8_MB, 4_MB, 10},
+    };
+}
+
+TFreeSpaceConfig DefaultFreeSpaceConfig()
+{
+    return {0.25, 0.15};
+}
+
+TPartitionState MakeState(size_t blockCount = 2048)
+{
+    auto threadSafeState = std::make_shared<TPartitionThreadSafeState>();
+    return TPartitionState(
+        DefaultConfig(1, blockCount),
+        BuildDefaultCompactionPolicy(5),
+        0,      // compactionScoreHistorySize
+        0,      // cleanupScoreHistorySize
+        DefaultBPConfig(),
+        DefaultFreeSpaceConfig(),
+        Max<ui32>(),    // maxIORequestsInFlight
+        0,      // reassignChannelsPercentageThreshold
+        100,    // reassignFreshChannelsPercentageThreshold
+        100,    // reassignMixedChannelsPercentageThreshold
+        false,  // reassignSystemChannelsImmediately
+        5,      // channelCount (System + Log + Index + 1 Merged + Fresh)
+        0,      // mixedIndexCacheSize
+        10000,  // allocationUnit
+        100,    // maxBlobsPerUnit
+        10,     // maxBlobsPerRange
+        1,      // compactionRangeCountPerRun
+        std::move(threadSafeState));
+}
+
+std::shared_ptr<TStorageConfig> MakeStorageConfig(ui64 diskPrefixLength = 0)
+{
+    NProto::TStorageServiceConfig proto;
+    proto.SetDiskPrefixLengthWithBlockChecksumsInBlobs(diskPrefixLength);
+    return std::make_shared<TStorageConfig>(
+        std::move(proto),
+        std::make_shared<NFeatures::TFeaturesConfig>());
+}
+
+NKikimr::TTabletStorageInfo MakeStorageInfo(ui32 numChannels)
+{
+    NKikimr::TTabletStorageInfo info;
+    info.TabletID = TTestExecutor::TabletId;
+    for (ui32 ch = 0; ch < numChannels; ++ch) {
+        NKikimr::TTabletChannelInfo channelInfo(
+            ch,
+            NKikimr::TBlobStorageGroupType::ErasureNone);
+        channelInfo.History.emplace_back(0, 1);
+        info.Channels.push_back(std::move(channelInfo));
+    }
+    return info;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
+{
+    // PrepareRangeCompaction: blob goes into blobsToReadBlockMasks when
+    // read-block-mask optimization is disabled, regardless of blob range count.
+    Y_UNIT_TEST(PrepareAddsToBlockMasksWhenOptimizationDisabled)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId blobId;
+        executor.WriteTx([&](TPartitionDatabase db) {
+            blobId = executor.MakeBlobId(4);
+            db.WriteMergedBlocks(
+                blobId,
+                TBlockRange32::MakeClosedInterval(0, 3),
+                TBlockMask{});
+        });
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, MaxBlocksCount - 1));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx([&](TPartitionDatabase db) {
+            PrepareRangeCompaction(
+                *MakeStorageConfig(),
+                0,
+                MakeCommitId(0, 100),
+                TTestExecutor::TabletId,
+                false,  // optimization disabled
+                ready,
+                db,
+                state,
+                args,
+                blobsToReadBlockMasks,
+                blobsToReadBlobMetas);
+        });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT_VALUES_EQUAL(1, blobsToReadBlockMasks.size());
+        UNIT_ASSERT(blobsToReadBlockMasks.contains(blobId));
+    }
+
+    // PrepareRangeCompaction: a fully-available single-range blob is NOT added
+    // to blobsToReadBlockMasks when optimization is enabled.
+    Y_UNIT_TEST(PrepareSkipsBlockMasksWhenOptimizationEnabledAndSingleRange)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId blobId;
+        executor.WriteTx([&](TPartitionDatabase db) {
+            blobId = executor.MakeBlobId(4);
+            db.WriteMergedBlocks(
+                blobId,
+                TBlockRange32::MakeClosedInterval(0, 3),
+                TBlockMask{});
+        });
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, MaxBlocksCount - 1));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx([&](TPartitionDatabase db) {
+            PrepareRangeCompaction(
+                *MakeStorageConfig(),
+                0,
+                MakeCommitId(0, 100),
+                TTestExecutor::TabletId,
+                true,   // optimization enabled
+                ready,
+                db,
+                state,
+                args,
+                blobsToReadBlockMasks,
+                blobsToReadBlobMetas);
+        });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT(blobsToReadBlockMasks.empty());
+    }
+
+    // PrepareRangeCompaction: a blob spanning two compaction ranges has
+    // CompactionRangeCount > 1 and must go into blobsToReadBlockMasks even
+    // when optimization is enabled.
+    Y_UNIT_TEST(PrepareAddsToBlockMasksForMultiRangeBlob)
+    {
+        auto state = MakeState(2048);
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        // Blob [1023..1024] crosses the boundary between range 0 and range 1.
+        TPartialBlobId blobId;
+        executor.WriteTx([&](TPartitionDatabase db) {
+            blobId = executor.MakeBlobId(2);
+            db.WriteMergedBlocks(
+                blobId,
+                TBlockRange32::MakeClosedInterval(1023, 1024),
+                TBlockMask{});
+        });
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, MaxBlocksCount - 1));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx([&](TPartitionDatabase db) {
+            PrepareRangeCompaction(
+                *MakeStorageConfig(),
+                0,
+                MakeCommitId(0, 100),
+                TTestExecutor::TabletId,
+                true,   // optimization enabled
+                ready,
+                db,
+                state,
+                args,
+                blobsToReadBlockMasks,
+                blobsToReadBlobMetas);
+        });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT_VALUES_EQUAL(1, blobsToReadBlockMasks.size());
+        UNIT_ASSERT(blobsToReadBlockMasks.contains(blobId));
+    }
+
+    // PrepareRangeCompaction: a blob already in the cleanup queue gets a full
+    // block mask assigned in-place and is NOT put into blobsToReadBlockMasks.
+    Y_UNIT_TEST(PrepareSkipsBlockMasksForCleanupQueueBlob)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId blobId;
+        executor.WriteTx([&](TPartitionDatabase db) {
+            blobId = executor.MakeBlobId(4);
+            db.WriteMergedBlocks(
+                blobId,
+                TBlockRange32::MakeClosedInterval(0, 3),
+                TBlockMask{});
+        });
+
+        state.GetCleanupQueue().Add({blobId, executor.CommitId()});
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, MaxBlocksCount - 1));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx([&](TPartitionDatabase db) {
+            PrepareRangeCompaction(
+                *MakeStorageConfig(),
+                0,
+                MakeCommitId(0, 100),
+                TTestExecutor::TabletId,
+                false,
+                ready,
+                db,
+                state,
+                args,
+                blobsToReadBlockMasks,
+                blobsToReadBlobMetas);
+        });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT(blobsToReadBlockMasks.empty());
+    }
+
+    // PrepareRangeCompaction: when checksums are enabled and the compacted range
+    // starts before the checksum boundary, every non-fresh merged block puts its
+    // blob into blobsToReadBlobMetas.
+    Y_UNIT_TEST(PrepareAddsToBlobMetasWhenChecksumsEnabled)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId blobId;
+        executor.WriteTx([&](TPartitionDatabase db) {
+            blobId = executor.MakeBlobId(4);
+            db.WriteMergedBlocks(
+                blobId,
+                TBlockRange32::MakeClosedInterval(0, 3),
+                TBlockMask{});
+        });
+
+        auto config = MakeStorageConfig(1000 * DefaultBlockSize);
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, MaxBlocksCount - 1));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx([&](TPartitionDatabase db) {
+            PrepareRangeCompaction(
+                *config,
+                0,
+                MakeCommitId(0, 100),
+                TTestExecutor::TabletId,
+                true,
+                ready,
+                db,
+                state,
+                args,
+                blobsToReadBlockMasks,
+                blobsToReadBlobMetas);
+        });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT_VALUES_EQUAL(1, blobsToReadBlobMetas.size());
+        UNIT_ASSERT(blobsToReadBlobMetas.contains(blobId));
+    }
+
+    // PrepareRangeCompaction: blobsToReadBlobMetas stays empty when checksums
+    // are disabled (DiskPrefixLengthWithBlockChecksumsInBlobs == 0).
+    Y_UNIT_TEST(PrepareEmptyBlobMetasWhenChecksumsDisabled)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId blobId;
+        executor.WriteTx([&](TPartitionDatabase db) {
+            blobId = executor.MakeBlobId(4);
+            db.WriteMergedBlocks(
+                blobId,
+                TBlockRange32::MakeClosedInterval(0, 3),
+                TBlockMask{});
+        });
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, MaxBlocksCount - 1));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx([&](TPartitionDatabase db) {
+            PrepareRangeCompaction(
+                *MakeStorageConfig(),   // DiskPrefixLength == 0 → checksums off
+                0,
+                MakeCommitId(0, 100),
+                TTestExecutor::TabletId,
+                true,
+                ready,
+                db,
+                state,
+                args,
+                blobsToReadBlockMasks,
+                blobsToReadBlobMetas);
+        });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT(blobsToReadBlobMetas.empty());
+    }
+
+    // CompleteRangeCompaction: when ChecksumsEnabled is true, every non-fresh
+    // merged block produces a TChecksumFixup entry with the correct index,
+    // source BlobId and BlobOffset.
+    Y_UNIT_TEST(CompleteCreatesChecksumFixupsWhenEnabled)
+    {
+        auto state = MakeState();
+        auto storageInfo = MakeStorageInfo(1);  // channel 0 configured
+
+        // Source blob lives on channel 0, generation 0.
+        const TPartialBlobId sourceBlobId(0, 1, 0, 4 * DefaultBlockSize, 0, 0);
+        const ui16 sourceBlobOffset = 7;
+
+        const auto compactionCommitId = MakeCommitId(0, 100);
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, 3));
+        args.ChecksumsEnabled = true;
+
+        auto& mark = args.GetBlockMark(0);
+        mark.CommitId = MakeCommitId(0, 1);
+        mark.BlobId = sourceBlobId;
+        mark.BlobOffset = sourceBlobOffset;
+
+        args.AffectedBlobs[sourceBlobId].Offsets.push_back(sourceBlobOffset);
+
+        TVector<TBlobCompactionRequest> requests;
+        TVector<TRangeCompactionInfo> rangeCompactionInfos;
+
+        CompleteRangeCompaction(
+            false,  // blobPatchingEnabled
+            0,      // mergedBlobThreshold
+            compactionCommitId,
+            storageInfo,
+            state,
+            args,
+            requests,
+            rangeCompactionInfos,
+            0);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, rangeCompactionInfos.size());
+        const auto& result = rangeCompactionInfos[0];
+        UNIT_ASSERT_VALUES_EQUAL(1, result.ChecksumFixups.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, result.ChecksumFixups[0].ChecksumIndex);
+        UNIT_ASSERT_VALUES_EQUAL(sourceBlobId, result.ChecksumFixups[0].BlobId);
+        UNIT_ASSERT_VALUES_EQUAL(
+            sourceBlobOffset,
+            result.ChecksumFixups[0].BlobOffset);
+    }
+
+    // CompleteRangeCompaction: when ChecksumsEnabled is false, no checksum
+    // fixup entries are produced regardless of the block marks present.
+    Y_UNIT_TEST(CompleteEmptyChecksumFixupsWhenDisabled)
+    {
+        auto state = MakeState();
+        auto storageInfo = MakeStorageInfo(1);
+
+        const TPartialBlobId sourceBlobId(0, 1, 0, 4 * DefaultBlockSize, 0, 0);
+
+        const auto compactionCommitId = MakeCommitId(0, 100);
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, 3));
+        args.ChecksumsEnabled = false;
+
+        auto& mark = args.GetBlockMark(0);
+        mark.CommitId = MakeCommitId(0, 1);
+        mark.BlobId = sourceBlobId;
+        mark.BlobOffset = 0;
+
+        args.AffectedBlobs[sourceBlobId].Offsets.push_back(0);
+
+        TVector<TBlobCompactionRequest> requests;
+        TVector<TRangeCompactionInfo> rangeCompactionInfos;
+
+        CompleteRangeCompaction(
+            false,
+            0,
+            compactionCommitId,
+            storageInfo,
+            state,
+            args,
+            requests,
+            rangeCompactionInfos,
+            0);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, rangeCompactionInfos.size());
+        UNIT_ASSERT(rangeCompactionInfos[0].ChecksumFixups.empty());
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -411,6 +411,7 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
             false,  // blobPatchingEnabled
             0,      // mergedBlobThreshold
             compactionCommitId,
+            TTestExecutor::TabletId,
             storageInfo,
             state,
             args,
@@ -457,6 +458,7 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
             false,
             0,
             compactionCommitId,
+            TTestExecutor::TabletId,
             storageInfo,
             state,
             args,

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -726,14 +726,14 @@ public:
     void UnsetUsedBlocks(TPartitionDatabase& db, const TBlockRange32& range);
     void UnsetUsedBlocks(TPartitionDatabase& db, const TVector<ui32>& blocks);
 
-    void IncrementBlobsProcessedDuringCompaction()
+    void IncrementBlobsProcessedDuringCompaction(ui64 value)
     {
-        ++BlobsProcessedDuringCompaction;
+        BlobsProcessedDuringCompaction += value;
     }
 
-    void IncrementBlockMaskReadDuringCompaction()
+    void IncrementBlockMaskReadDuringCompaction(ui64 value)
     {
-        ++BlockMaskReadDuringCompaction;
+        BlockMaskReadDuringCompaction += value;
     }
 
     ui64 GetBlobsProcessedDuringCompaction() const

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -439,6 +439,7 @@ struct TTxPartition
         const TRequestInfoPtr RequestInfo;
         const ui64 CommitId;
         const TCompactionOptions CompactionOptions;
+        const bool SplitCompactionTxEnabled;
 
         TVector<TRangeCompaction> RangeCompactions;
         TInstant TxStarted;
@@ -450,11 +451,13 @@ struct TTxPartition
                 TRequestInfoPtr requestInfo,
                 ui64 commitId,
                 TCompactionOptions compactionOptions,
+                bool splitCompactionTxEnabled,
                 const TVector<std::pair<ui32, TBlockRange32>>& ranges,
                 TInstant txStarted)
             : RequestInfo(std::move(requestInfo))
             , CommitId(commitId)
             , CompactionOptions(compactionOptions)
+            , SplitCompactionTxEnabled(splitCompactionTxEnabled)
             , TxStarted(txStarted)
         {
             RangeCompactions.reserve(ranges.size());

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -443,6 +443,9 @@ struct TTxPartition
         TVector<TRangeCompaction> RangeCompactions;
         TInstant TxStarted;
 
+        THashSet<TPartialBlobId, TPartialBlobIdHash> BlobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> BlobsToReadBlobMetas;
+
         TCompaction(
                 TRequestInfoPtr requestInfo,
                 ui64 commitId,
@@ -465,6 +468,8 @@ struct TTxPartition
             for (auto& range: RangeCompactions) {
                 range.Clear();
             }
+            BlobsToReadBlockMasks.clear();
+            BlobsToReadBlobMetas.clear();
         }
     };
 
@@ -511,6 +516,7 @@ struct TTxPartition
             bool Filled = false;
             ui64 MaxCommitId = 0;
         };
+
         TVector<TBlockInfo> BlockInfos;
         ui32 FilledBlockCount = 0;
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -14092,6 +14092,170 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         DoTestShouldCleanupMergedBlobsWithoutReadingBlockMasks(32_KB);
     }
 
+    Y_UNIT_TEST(ShouldCompactWithSplitCompactionTx)
+    {
+        auto config = DefaultConfig();
+        config.SetSplitCompactionTxEnabled(true);
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(0, MaxBlocksCount),
+            '1');
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(0, MaxBlocksCount),
+            '2');
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(MaxBlocksCount, MaxBlocksCount),
+            '3');
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(512, MaxBlocksCount),
+            '4');
+
+        partition.Compaction();
+
+        // The split-tx path must produce the same observable counters as the
+        // legacy path — these match ShouldCleanupMergedBlobsWithoutReadingBlockMasks.
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                3,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('2', 512) + GetBlocksContent('4', 512),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(0, MaxBlocksCount))));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('4', 512) + GetBlocksContent('3', 512),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(MaxBlocksCount, MaxBlocksCount))));
+    }
+
+    Y_UNIT_TEST(ShouldCompactWithSplitCompactionTxWithoutOptimization)
+    {
+        auto config = DefaultConfig();
+        config.SetSplitCompactionTxEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(0, MaxBlocksCount),
+            '1');
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(0, MaxBlocksCount),
+            '2');
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(MaxBlocksCount, MaxBlocksCount),
+            '3');
+
+        partition.Compaction();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('2', MaxBlocksCount),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(0, MaxBlocksCount))));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('3', MaxBlocksCount),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(MaxBlocksCount, MaxBlocksCount))));
+    }
+
+    Y_UNIT_TEST(ShouldCompactZeroedRangeWithSplitCompactionTx)
+    {
+        auto config = DefaultConfig();
+        config.SetSplitCompactionTxEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), '1');
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        partition.Compaction();
+
+        // Reads after compaction must return zeros, not '1's.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlocksContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 1024))));
+    }
+
+    Y_UNIT_TEST(ShouldCompactWithGarbageBlobsWithSplitCompactionTx)
+    {
+        auto config = DefaultConfig();
+        config.SetSplitCompactionTxEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 512), '1');
+        partition.WriteBlocks(TBlockRange32::WithLength(512, 512), '2');
+
+        partition.Compaction();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 512), '3');
+
+        bool intercept = true;
+
+        std::unique_ptr<IEventHandle> compactionReadBlobInfoRequest;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionPrivate::EvCompactionReadBlobInfoRequest &&
+                    intercept)
+                {
+                    compactionReadBlobInfoRequest.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendCompactionRequest();
+
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(compactionReadBlobInfoRequest);
+        intercept = false;
+
+        partition.Cleanup();
+
+        runtime->SendAsync(compactionReadBlobInfoRequest.release());
+
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(response->GetStatus(), S_OK);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('3', 512) + GetBlocksContent('2', 512),
+            GetBlocksContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 1024))));
+    }
+
     Y_UNIT_TEST(
         ShouldNotLoseAnyMixedMergedBlocksWhileWaitingForCheckpointCreation)
     {

--- a/cloud/blockstore/libs/storage/partition/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 SRCS(
     part_database_ut.cpp
     part_state_ut.cpp
+    part_compaction_logic_ut.cpp
     part_ut.cpp
 )
 

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -129,6 +129,7 @@ def storage_config_with_fresh_blocks_writer_enabled(enabled):
 
 def storage_config_with_read_block_mask_on_compaction_optimization_enabled(enabled):
     storage = default_storage_config()
+    storage.SplitCompactionTxEnabled = enabled
     storage.ReadBlockMaskOnCompactionOptimizationEnabled = enabled
 
     return storage


### PR DESCRIPTION
### Notes
Moved reading block masks  and blob metas into separate transactions to be able to execute them in parallel with the readblob/writeblob, which can speed up compacting in case blob splitting optimization(ReadBlockMaskOnCompactionOptimizationEnabled + SplitByCompactionRangeMaxBlobCount features) is not working.

### Issue
#5590
