### PR TITLE
[Filestore] Add hard size limit for directory handle to prevent memory backpressure

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -107,4 +107,7 @@ message TFileSystemConfig
 
     // Enable FUSE_POSIX_ACL on guest (FUSE client)
     optional bool GuestPosixAclEnabled = 32;
+
+    // Maximum serialized size of one persistent handle.
+    optional uint64 DirectoryHandlesPersistentHandleMaxSize = 33;
 }

--- a/cloud/filestore/config/server.proto
+++ b/cloud/filestore/config/server.proto
@@ -221,6 +221,9 @@ message TLocalServiceConfig
 
     // Enable FUSE_POSIX_ACL on guest (FUSE client)
     optional bool GuestPosixAclEnabled = 40;
+
+    // Maximum serialized size of one persistent handle.
+    optional uint64 DirectoryHandlesPersistentHandleMaxSize = 41;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -782,4 +782,7 @@ message TStorageConfig
     // Restart index tablet on destroy with active sessions only if tablet
     // uptime is greater than this threshold. Zero disables restarts.
     optional uint32 RestartTabletUptimeThresholdDuringDestroy = 501;
+
+    // Maximum serialized size of one persistent handle.
+    optional uint64 DirectoryHandlesPersistentHandleMaxSize = 502;
 }

--- a/cloud/filestore/libs/service_local/config.cpp
+++ b/cloud/filestore/libs/service_local/config.cpp
@@ -47,6 +47,7 @@ namespace {
     xxx(XAttrCacheTimeout,           TDuration,     TDuration::Seconds(15)    )\
     xxx(DirectoryHandlesStorageEnabled, bool,       false                     )\
     xxx(DirectoryHandlesTableSize,      ui64,       100'000                   )\
+    xxx(DirectoryHandlesPersistentHandleMaxSize, ui64, 2_GB                   )\
     xxx(GuestHandleKillPrivV2Enabled,   bool,       false                     )\
     xxx(GuestPosixAclEnabled,           bool,       false                     )\
     xxx(SnapshotsDirEnabled,            bool,       false                     )\

--- a/cloud/filestore/libs/service_local/config.h
+++ b/cloud/filestore/libs/service_local/config.h
@@ -156,6 +156,7 @@ public:
         const TString& fsId) const;
 
     ui64 GetDirectoryHandlesTableSize() const;
+    ui64 GetDirectoryHandlesPersistentHandleMaxSize() const;
 
     bool GetGuestHandleKillPrivV2Enabled() const;
     bool GetGuestHandleKillPrivV2Enabled(

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -70,6 +70,8 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         if (directoryHandleStorageEnabled) {
             features->SetDirectoryHandlesTableSize(
                 Config->GetDirectoryHandlesTableSize());
+            features->SetDirectoryHandlesPersistentHandleMaxSize(
+                Config->GetDirectoryHandlesPersistentHandleMaxSize());
         }
         features->SetGuestHandleKillPrivV2Enabled(
             Config->GetGuestHandleKillPrivV2Enabled(cloudId, folderId, fsId));

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -304,6 +304,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
                                                                                \
     xxx(DirectoryHandlesStorageEnabled,    bool,      false                   )\
     xxx(DirectoryHandlesTableSize,         ui64,      100'000                 )\
+    xxx(DirectoryHandlesPersistentHandleMaxSize, ui64, 2_GB                   )\
     xxx(GuestHandleKillPrivV2Enabled,      bool,      false                   )\
     xxx(GuestPosixAclEnabled,              bool,      false                   )\
     xxx(AllowAdditionalSystemTablets,      bool,      false                   )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -365,6 +365,7 @@ public:
 
     bool GetDirectoryHandlesStorageEnabled() const;
     ui64 GetDirectoryHandlesTableSize() const;
+    ui64 GetDirectoryHandlesPersistentHandleMaxSize() const;
 
     bool GetGuestHandleKillPrivV2Enabled() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -70,6 +70,8 @@ void FillFeatures(
     if (config.GetDirectoryHandlesStorageEnabled()) {
         features->SetDirectoryHandlesTableSize(
             config.GetDirectoryHandlesTableSize());
+        features->SetDirectoryHandlesPersistentHandleMaxSize(
+            config.GetDirectoryHandlesPersistentHandleMaxSize());
     }
 
     features->SetDirectoryCreationInShardsEnabled(

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -827,6 +827,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetServerWriteBackCacheEnabled(true);
         config.SetParentlessFilesOnly(true);
         config.SetAllowHandlelessIO(true);
+        config.SetDirectoryHandlesStorageEnabled(true);
+        config.SetDirectoryHandlesTableSize(1000);
+        config.SetDirectoryHandlesPersistentHandleMaxSize(4_GB);
         config.SetZeroCopyWriteEnabled(true);
         config.SetGuestHandleKillPrivV2Enabled(true);
         config.SetGuestPosixAclEnabled(true);
@@ -852,6 +855,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetServerWriteBackCacheEnabled(true);
         features.SetParentlessFilesOnly(true);
         features.SetAllowHandlelessIO(true);
+        features.SetDirectoryHandlesStorageEnabled(true);
+        features.SetDirectoryHandlesTableSize(1000);
+        features.SetDirectoryHandlesPersistentHandleMaxSize(4_GB);
         features.SetZeroCopyWriteEnabled(true);
         features.SetGuestHandleKillPrivV2Enabled(true);
         features.SetGuestPosixAclEnabled(false);

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -45,6 +45,7 @@ namespace {
     xxx(DirectoryHandlesStorageEnabled, bool,   false                         )\
                                                                                \
     xxx(DirectoryHandlesTableSize,      ui64,   100'000                       )\
+    xxx(DirectoryHandlesPersistentHandleMaxSize, ui64, 2_GB                   )\
                                                                                \
     xxx(GuestKeepCacheAllowed,        bool,     false                         )\
     xxx(MaxBackground,                ui32,     0                             )\

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -55,6 +55,7 @@ public:
     bool GetDirectoryHandlesStorageEnabled() const;
 
     ui64 GetDirectoryHandlesTableSize() const;
+    ui64 GetDirectoryHandlesPersistentHandleMaxSize() const;
 
     bool GetGuestKeepCacheAllowed() const;
 

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_cache.cpp
@@ -23,8 +23,9 @@ TDirectoryHandleMetrics GetDirectoryHandleMetrics(
 
     for (const auto& [_, handle]: handles) {
         if (handle) {
-            metrics.SerializedSize += handle->GetSerializedSize();
-            metrics.ChunkCount += handle->GetChunkCount();
+            const auto [serializedSize, chunkCount] = handle->GetMetrics();
+            metrics.SerializedSize += serializedSize;
+            metrics.ChunkCount += chunkCount;
         }
     }
 
@@ -63,7 +64,10 @@ ui64 TDirectoryHandleCache::CreateHandle(fuse_ino_t ino)
         IncreaseStatsForHandle(handle);
 
         if (Storage) {
-            Storage->StoreHandle(handleId, TDirectoryHandleChunk{.Index = ino});
+            Storage->StoreHandle(
+                handleId,
+                *handle,
+                TDirectoryHandleChunk{.Index = ino});
         }
     }
 
@@ -136,13 +140,14 @@ void TDirectoryHandleCache::ResetHandle(
 
 void TDirectoryHandleCache::AppendChunk(
     ui64 handleId,
+    const std::shared_ptr<TDirectoryHandle>& handle,
     const TDirectoryHandleChunk& handleChunk)
 {
     Stats->IncreaseCacheSize(handleChunk.GetSerializedSize());
     Stats->IncreaseChunkCount(1);
 
-    if (Storage) {
-        Storage->UpdateHandle(handleId, handleChunk);
+    if (Storage && handle) {
+        Storage->UpdateHandle(handleId, *handle, handleChunk);
     }
 }
 
@@ -172,8 +177,9 @@ void TDirectoryHandleCache::IncreaseStatsForHandle(
     const std::shared_ptr<TDirectoryHandle>& handle)
 {
     if (handle) {
-        Stats->IncreaseCacheSize(handle->GetSerializedSize());
-        Stats->IncreaseChunkCount(handle->GetChunkCount());
+        const auto [serializedSize, chunkCount] = handle->GetMetrics();
+        Stats->IncreaseCacheSize(serializedSize);
+        Stats->IncreaseChunkCount(chunkCount);
     }
 }
 
@@ -189,8 +195,9 @@ void TDirectoryHandleCache::DecreaseStatsForHandle(
     const std::shared_ptr<TDirectoryHandle>& handle)
 {
     if (handle) {
-        Stats->DecreaseCacheSize(handle->GetSerializedSize());
-        Stats->DecreaseChunkCount(handle->GetChunkCount());
+        const auto [serializedSize, chunkCount] = handle->GetMetrics();
+        Stats->DecreaseCacheSize(serializedSize);
+        Stats->DecreaseChunkCount(chunkCount);
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_cache.h
@@ -45,7 +45,10 @@ public:
     void ResetHandle(
         ui64 handleId,
         const std::shared_ptr<TDirectoryHandle>& handle);
-    void AppendChunk(ui64 handleId, const TDirectoryHandleChunk& handleChunk);
+    void AppendChunk(
+        ui64 handleId,
+        const std::shared_ptr<TDirectoryHandle>& handle,
+        const TDirectoryHandleChunk& handleChunk);
 
     void Clear();
     void Reset();

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_cache_ut.cpp
@@ -7,6 +7,7 @@
 
 #include <util/folder/tempdir.h>
 #include <util/generic/buffer.h>
+#include <util/generic/size_literals.h>
 
 #include <algorithm>
 
@@ -57,16 +58,18 @@ struct TDirectoryHandleCacheTestFixture: public NUnitTest::TBaseFixture
     TTempDir TempDir;
     TString StoragePath = TempDir.Path() / "directory_handles";
 
-    TDirectoryHandleStoragePtr CreateStorage()
+    TDirectoryHandleStoragePtr CreateStorage(
+        ui64 persistentHandleMaxSize = 2_GB)
     {
         return CreateDirectoryHandleStorage(
-            Log,
-            StoragePath,
-            32,
-            128,
-            128,
-            64,
-            Limiter);
+            {.Log = Log,
+             .FileMapMemoryLimiter = Limiter,
+             .FilePath = StoragePath,
+             .MaxRecords = 32,
+             .InitialDataAreaSize = 128,
+             .MaxDataAreaStepSize = 128,
+             .InitialDataMoveBufferSize = 64,
+             .PersistentHandleMaxSize = persistentHandleMaxSize});
     }
 
     TDirectoryHandleCache CreateCache(
@@ -107,7 +110,7 @@ Y_UNIT_TEST_SUITE_F(TDirectoryHandleCacheTest, TDirectoryHandleCacheTestFixture)
                 CreateContent(1024, 'x'),
                 1,
                 "next");
-            cache.AppendChunk(id, chunk);
+            cache.AppendChunk(id, handle, chunk);
 
             Limiter->CanIncreaseResult = true;
             chunk = handle->UpdateContent(
@@ -116,7 +119,7 @@ Y_UNIT_TEST_SUITE_F(TDirectoryHandleCacheTest, TDirectoryHandleCacheTestFixture)
                 CreateContent(1024, 'y'),
                 2,
                 {});
-            cache.AppendChunk(id, chunk);
+            cache.AppendChunk(id, handle, chunk);
 
             return id;
         }();
@@ -138,8 +141,7 @@ Y_UNIT_TEST_SUITE_F(TDirectoryHandleCacheTest, TDirectoryHandleCacheTestFixture)
         auto handle = cache.FindHandle(id);
         UNIT_ASSERT(handle);
 
-        const auto serializedSize = handle->GetSerializedSize();
-        const auto chunkCount = handle->GetChunkCount();
+        const auto [serializedSize, chunkCount] = handle->GetMetrics();
 
         cache.RemoveHandle(id);
 
@@ -147,8 +149,10 @@ Y_UNIT_TEST_SUITE_F(TDirectoryHandleCacheTest, TDirectoryHandleCacheTestFixture)
             handle->UpdateContent(1024, 0, CreateContent(1024, 'x'), 1, {});
 
         UNIT_ASSERT_VALUES_EQUAL(1024, chunk.DirectoryContent.GetSize());
-        UNIT_ASSERT_GT(handle->GetSerializedSize(), serializedSize);
-        UNIT_ASSERT_VALUES_EQUAL(chunkCount + 1, handle->GetChunkCount());
+        const auto [updatedSerializedSize, updatedChunkCount] =
+            handle->GetMetrics();
+        UNIT_ASSERT_GT(updatedSerializedSize, serializedSize);
+        UNIT_ASSERT_VALUES_EQUAL(chunkCount + 1, updatedChunkCount);
     }
 
     Y_UNIT_TEST(ShouldNotStoreClosedHandleContentUpdate)
@@ -165,7 +169,7 @@ Y_UNIT_TEST_SUITE_F(TDirectoryHandleCacheTest, TDirectoryHandleCacheTestFixture)
 
             auto chunk =
                 handle->UpdateContent(1024, 0, CreateContent(1024, 'x'), 1, {});
-            cache.AppendChunk(id, chunk);
+            cache.AppendChunk(id, handle, chunk);
 
             UNIT_ASSERT_VALUES_EQUAL(1024, chunk.DirectoryContent.GetSize());
         }
@@ -179,27 +183,90 @@ Y_UNIT_TEST_SUITE_F(TDirectoryHandleCacheTest, TDirectoryHandleCacheTestFixture)
         UNIT_ASSERT_VALUES_EQUAL(0, handles.size());
     }
 
+    Y_UNIT_TEST(ShouldBypassStorageAfterPersistentHandleSizeLimitExceeded)
+    {
+        const ui64 handleId = [&]
+        {
+            auto cache = CreateCache(CreateStorage(512));
+
+            const ui64 id = cache.CreateHandle(42);
+            auto handle = cache.FindHandle(id);
+            UNIT_ASSERT(handle);
+
+            auto chunk =
+                handle->UpdateContent(1024, 0, CreateContent(1024, 'x'), 1, {});
+            cache.AppendChunk(id, handle, chunk);
+
+            chunk = handle->UpdateContent(
+                1024,
+                1024,
+                CreateContent(1024, 'y'),
+                2,
+                {});
+            cache.AppendChunk(id, handle, chunk);
+
+            return id;
+        }();
+
+        auto storage = CreateStorage();
+
+        TDirectoryHandleMap handles;
+        storage->LoadHandles(handles);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, handles.size());
+        UNIT_ASSERT(!handles.contains(handleId));
+    }
+
+    Y_UNIT_TEST(ShouldDropLoadedHandleAbovePersistentHandleSizeLimit)
+    {
+        const ui64 handleId = 42;
+        {
+            auto storage = CreateStorage();
+            TDirectoryHandle handle(100);
+            storage->StoreHandle(
+                handleId,
+                handle,
+                TDirectoryHandleChunk{.Index = 100});
+
+            auto chunk =
+                handle.UpdateContent(1024, 0, CreateContent(1024, 'x'), 1, {});
+            storage->UpdateHandle(handleId, handle, chunk);
+        }
+
+        auto storage = CreateStorage(512);
+
+        TDirectoryHandleMap handles;
+        storage->LoadHandles(handles);
+
+        UNIT_ASSERT_VALUES_EQUAL(0, handles.size());
+        UNIT_ASSERT(!handles.contains(handleId));
+    }
+
     Y_UNIT_TEST(ShouldDropStoredHandleWithMissingOrDuplicatedUpdateVersion)
     {
         const ui64 handleId = 42;
         {
             auto storage = CreateStorage();
+            TDirectoryHandle handle(100);
 
-            storage->StoreHandle(handleId, TDirectoryHandleChunk{.Index = 100});
+            storage->StoreHandle(
+                handleId,
+                handle,
+                TDirectoryHandleChunk{.Index = 100});
 
             TDirectoryHandleChunk chunk1{
                 .Key = 1024,
                 .UpdateVersion = 2,
                 .Index = 100,
                 .DirectoryContent = {CreateContent(1024, 'x'), 0, 1024}};
-            storage->UpdateHandle(handleId, chunk1);
+            storage->UpdateHandle(handleId, handle, chunk1);
 
             TDirectoryHandleChunk chunk2{
                 .Key = 2048,
                 .UpdateVersion = 2,
                 .Index = 100,
                 .DirectoryContent = {CreateContent(1024, 'y'), 0, 1024}};
-            storage->UpdateHandle(handleId, chunk2);
+            storage->UpdateHandle(handleId, handle, chunk2);
         }
 
         auto storage = CreateStorage();

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_storage.cpp
@@ -11,28 +11,24 @@ namespace NCloud::NFileStore::NFuse {
 ////////////////////////////////////////////////////////////////////////////////
 
 TDirectoryHandleStorage::TDirectoryHandleStorage(
-    TLog& log,
-    const TString& filePath,
-    ui64 recordsCount,
-    ui64 initialDataAreaSize,
-    ui64 maxDataAreaStepSize,
-    ui64 initialDataMoveBufferSize,
-    IFileMapMemoryLimiterPtr fileMapMemoryLimiter)
-    : Log(log)
+    TDirectoryHandleStorageArgs args)
+    : Log(std::move(args.Log))
+    , PersistentHandleMaxSize(args.PersistentHandleMaxSize)
 {
     Table = std::make_unique<TDirectoryHandleTable>(
-        filePath,
+        args.FilePath,
         TDynamicPersistentTableConfig{
-            .MaxRecords = recordsCount,
-            .InitialDataAreaSize = initialDataAreaSize,
-            .MaxDataAreaStepSize = maxDataAreaStepSize,
-            .InitialDataMoveBufferSize = initialDataMoveBufferSize,
+            .MaxRecords = args.MaxRecords,
+            .InitialDataAreaSize = args.InitialDataAreaSize,
+            .MaxDataAreaStepSize = args.MaxDataAreaStepSize,
+            .InitialDataMoveBufferSize = args.InitialDataMoveBufferSize,
         },
-        std::move(fileMapMemoryLimiter));
+        std::move(args.FileMapMemoryLimiter));
 }
 
 void TDirectoryHandleStorage::StoreHandle(
     ui64 handleId,
+    const TDirectoryHandle& handle,
     const TDirectoryHandleChunk& initialHandleChunk)
 {
     TBuffer record = SerializeHandle(handleId, initialHandleChunk);
@@ -47,11 +43,12 @@ void TDirectoryHandleStorage::StoreHandle(
         return;
     }
 
-    CreateRecord(handleId, record);
+    CreateRecord(handleId, record, handle.GetMetrics().first);
 }
 
 void TDirectoryHandleStorage::UpdateHandle(
     ui64 handleId,
+    const TDirectoryHandle& handle,
     const TDirectoryHandleChunk& handleChunk)
 {
     TBuffer record = SerializeHandle(handleId, handleChunk);
@@ -71,11 +68,30 @@ void TDirectoryHandleStorage::UpdateHandle(
         return;
     }
 
-    CreateRecord(handleId, record);
+    CreateRecord(handleId, record, handle.GetMetrics().first);
 }
 
-void TDirectoryHandleStorage::CreateRecord(ui64 handleId, const TBuffer& record)
+void TDirectoryHandleStorage::CreateRecord(
+    ui64 handleId,
+    const TBuffer& record,
+    ui64 handleSerializedSize)
 {
+    const auto dropRecordsForHandle = [&]
+    {
+        RemoveRecords(handleId);
+        HandlesExcludedFromStorage.insert(handleId);
+    };
+
+    if (!CanStoreHandle(handleSerializedSize)) {
+        STORAGE_WARN(
+            "Dropping directory handle "
+            << handleId << " from persistent storage: size "
+            << handleSerializedSize << " exceeds limit "
+            << PersistentHandleMaxSize);
+        dropRecordsForHandle();
+        return;
+    }
+
     auto result = CreateRecord(record);
     if (HasError(result)) {
         const auto it = HandleIdToIndices.find(handleId);
@@ -85,8 +101,7 @@ void TDirectoryHandleStorage::CreateRecord(ui64 handleId, const TBuffer& record)
             "Failed to create directory handle record for handle "
             << handleId << ", indices count: " << indexCount << ": "
             << FormatError(result.GetError()));
-        RemoveRecords(handleId);
-        HandlesExcludedFromStorage.insert(handleId);
+        dropRecordsForHandle();
         return;
     }
 
@@ -210,6 +225,28 @@ void TDirectoryHandleStorage::LoadHandles(TDirectoryHandleMap& handles)
             }
         }
     }
+
+    TVector<ui64> oversizedHandleIds;
+    if (PersistentHandleMaxSize) {
+        for (const auto& [handleId, handle]: handles) {
+            const ui64 handleSerializedSize = handle->GetMetrics().first;
+            if (handleSerializedSize <= PersistentHandleMaxSize) {
+                continue;
+            }
+
+            STORAGE_WARN(
+                "Dropping directory handle "
+                << handleId << " from persistent storage: "
+                << "loaded size " << handleSerializedSize << " exceeds limit "
+                << PersistentHandleMaxSize);
+            oversizedHandleIds.push_back(handleId);
+        }
+    }
+
+    for (const auto handleId: oversizedHandleIds) {
+        RemoveHandle(handleId);
+        handles.erase(handleId);
+    }
 }
 
 void TDirectoryHandleStorage::Clear()
@@ -270,6 +307,15 @@ TResultOrError<ui64> TDirectoryHandleStorage::CreateRecord(
     return index;
 }
 
+bool TDirectoryHandleStorage::CanStoreHandle(ui64 handleSerializedSize) const
+{
+    if (!PersistentHandleMaxSize) {
+        return true;
+    }
+
+    return handleSerializedSize <= PersistentHandleMaxSize;
+}
+
 void TDirectoryHandleStorage::RemoveRecords(ui64 handleId)
 {
     auto it = HandleIdToIndices.find(handleId);
@@ -293,22 +339,9 @@ void TDirectoryHandleStorage::RemoveRecords(ui64 handleId)
 ////////////////////////////////////////////////////////////////////////////////
 
 TDirectoryHandleStoragePtr CreateDirectoryHandleStorage(
-    TLog& log,
-    const TString& filePath,
-    ui64 recordsCount,
-    ui64 initialDataAreaSize,
-    ui64 maxDataAreaStepSize,
-    ui64 initialDataMoveBufferSize,
-    IFileMapMemoryLimiterPtr fileMapMemoryLimiter)
+    TDirectoryHandleStorageArgs args)
 {
-    return std::make_unique<TDirectoryHandleStorage>(
-        log,
-        filePath,
-        recordsCount,
-        initialDataAreaSize,
-        maxDataAreaStepSize,
-        initialDataMoveBufferSize,
-        std::move(fileMapMemoryLimiter));
+    return std::make_unique<TDirectoryHandleStorage>(std::move(args));
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/directory_handle_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/directory_handle_storage.h
@@ -4,9 +4,9 @@
 
 #include "fs_directory_handle.h"
 
-#include <cloud/storage/core/libs/file_backed_containers/dynamic_persistent_table.h>
 #include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/file_backed_containers/dynamic_persistent_table.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
@@ -24,11 +24,23 @@ using TDirectoryHandleMap = THashMap<ui64, std::shared_ptr<TDirectoryHandle>>;
 using TDirectoryHandleChunkPair =
     std::pair<ui64, std::optional<TDirectoryHandleChunk>>;
 
+struct TDirectoryHandleStorageArgs
+{
+    TLog Log;
+    IFileMapMemoryLimiterPtr FileMapMemoryLimiter;
+    TString FilePath;
+    ui64 MaxRecords = 0;
+    ui64 InitialDataAreaSize = 0;
+    ui64 MaxDataAreaStepSize = 0;
+    ui64 InitialDataMoveBufferSize = 0;
+    ui64 PersistentHandleMaxSize = 0;
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
-// Storage with the provided file map memory limiter may drop records when the
-// memory limit is reached. Drops happen at handle granularity: for each
-// handle we either keep all of its data or none of it.
+// Storage may drop records when the file map memory limit or persistent handle
+// size limit is reached. Drops happen at handle granularity: for each handle
+// we either keep all of its data or none of it.
 class TDirectoryHandleStorage
 {
 private:
@@ -46,21 +58,19 @@ private:
     std::unique_ptr<TDirectoryHandleTable> Table;
     THashMap<ui64, std::vector<ui64>> HandleIdToIndices;
     THashSet<ui64> HandlesExcludedFromStorage;
+    const ui64 PersistentHandleMaxSize;
 
 public:
-    explicit TDirectoryHandleStorage(
-        TLog& log,
-        const TString& filePath,
-        ui64 recordsCount,
-        ui64 initialDataAreaSize,
-        ui64 maxDataAreaStepSize,
-        ui64 initialDataMoveBufferSize,
-        IFileMapMemoryLimiterPtr fileMapMemoryLimiter);
+    explicit TDirectoryHandleStorage(TDirectoryHandleStorageArgs args);
 
     void StoreHandle(
         ui64 handleId,
+        const TDirectoryHandle& handle,
         const TDirectoryHandleChunk& initialHandleChunk);
-    void UpdateHandle(ui64 handleId, const TDirectoryHandleChunk& handleChunk);
+    void UpdateHandle(
+        ui64 handleId,
+        const TDirectoryHandle& handle,
+        const TDirectoryHandleChunk& handleChunk);
     void RemoveHandle(ui64 handleId);
     void ResetHandle(ui64 handleId);
     void LoadHandles(TDirectoryHandleMap& handles);
@@ -73,19 +83,17 @@ private:
     TDirectoryHandleChunkPair DeserializeHandleChunk(const TStringBuf& buffer);
 
     TResultOrError<ui64> CreateRecord(const TBuffer& record);
-    void CreateRecord(ui64 handleId, const TBuffer& record);
+    void CreateRecord(
+        ui64 handleId,
+        const TBuffer& record,
+        ui64 handleSerializedSize);
+    bool CanStoreHandle(ui64 handleSerializedSize) const;
     void RemoveRecords(ui64 handleId);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TDirectoryHandleStoragePtr CreateDirectoryHandleStorage(
-    TLog& log,
-    const TString& filePath,
-    ui64 recordsCount,
-    ui64 initialDataAreaSize,
-    ui64 maxDataAreaStepSize,
-    ui64 initialDataMoveBufferSize,
-    IFileMapMemoryLimiterPtr fileMapMemoryLimiter);
+    TDirectoryHandleStorageArgs args);
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/fs_directory_handle.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_directory_handle.cpp
@@ -202,14 +202,11 @@ TString TDirectoryHandle::GetCookie()
     }
 }
 
-size_t TDirectoryHandle::GetSerializedSize() const
+std::pair<size_t, size_t> TDirectoryHandle::GetMetrics() const
 {
-    return SerializedSize;
-}
-
-size_t TDirectoryHandle::GetChunkCount() const
-{
-    return UpdateVersion + 1;
+    with_lock (Lock) {
+        return {SerializedSize, UpdateVersion + 1};
+    }
 }
 
 void TDirectoryHandle::ConsumeChunk(TDirectoryHandleChunk& chunk, TLog& Log)

--- a/cloud/filestore/libs/vfs_fuse/fs_directory_handle.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_directory_handle.h
@@ -12,6 +12,8 @@
 #include <util/stream/mem.h>
 #include <util/system/mutex.h>
 
+#include <utility>
+
 namespace NCloud::NFileStore::NFuse {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -71,7 +73,7 @@ private:
     ui64 UpdateVersion = 0;
     ui64 SerializedSize = 0;
 
-    TMutex Lock;
+    mutable TMutex Lock;
 
 public:
     const fuse_ino_t Index;
@@ -91,11 +93,8 @@ public:
     void ResetContent();
     TString GetCookie();
 
-    // Get total size of serialized content in bytes
-    size_t GetSerializedSize() const;
-
-    // Get number of chunks (UpdateVersion + 1)
-    size_t GetChunkCount() const;
+    // Get serialized size and chunk count
+    std::pair<size_t, size_t> GetMetrics() const;
 
     // not thread safe, use only during restoration from storage
     void ConsumeChunk(TDirectoryHandleChunk& chunk, TLog& Log);

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
@@ -234,7 +234,10 @@ void TFileSystem::ReadDir(
                          << " limit: " << size << " actual size "
                          << handleChunk.DirectoryContent.GetSize());
 
-                self->DirectoryHandleCache->AppendChunk(fh, handleChunk);
+                self->DirectoryHandleCache->AppendChunk(
+                    fh,
+                    handle,
+                    handleChunk);
 
                 reply(*self, handleChunk.DirectoryContent);
             });

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -1107,13 +1107,14 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             auto logging = CreateLoggingService("console");
             auto log = logging->CreateLog("DIR_HANDLE_RELOAD_TEST");
             auto storage = CreateDirectoryHandleStorage(
-                log,
-                storagePath,
-                100000,
-                128,
-                128,
-                1024 * 1024,
-                CreateFileMapMemoryLimiterStub());
+                {.Log = log,
+                 .FileMapMemoryLimiter = CreateFileMapMemoryLimiterStub(),
+                 .FilePath = storagePath,
+                 .MaxRecords = 100000,
+                 .InitialDataAreaSize = 128,
+                 .MaxDataAreaStepSize = 128,
+                 .InitialDataMoveBufferSize = 1024 * 1024,
+                 .PersistentHandleMaxSize = 2ull * 1024 * 1024 * 1024});
 
             TDirectoryHandleMap handles;
             storage->LoadHandles(handles);

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1105,13 +1105,20 @@ private:
                     }
 
                     directoryHandleStorage = CreateDirectoryHandleStorage(
-                        Log,
-                        path / DirectoryHandleStorageFileName,
-                        FileSystemConfig->GetDirectoryHandlesTableSize(),
-                        Config->GetDirectoryHandlesInitialDataSize(),
-                        Config->GetDirectoryHandlesMaxDataAreaStepSize(),
-                        FileSystemConfig->GetMaxBufferSize(),
-                        FileMapMemoryLimiter);
+                        {.Log = Log,
+                         .FileMapMemoryLimiter = FileMapMemoryLimiter,
+                         .FilePath = path / DirectoryHandleStorageFileName,
+                         .MaxRecords =
+                             FileSystemConfig->GetDirectoryHandlesTableSize(),
+                         .InitialDataAreaSize =
+                             Config->GetDirectoryHandlesInitialDataSize(),
+                         .MaxDataAreaStepSize =
+                             Config->GetDirectoryHandlesMaxDataAreaStepSize(),
+                         .InitialDataMoveBufferSize =
+                             FileSystemConfig->GetMaxBufferSize(),
+                         .PersistentHandleMaxSize =
+                             FileSystemConfig
+                                 ->GetDirectoryHandlesPersistentHandleMaxSize()});
 
                     DirectoryHandleStorageInitialized = true;
                 } else {
@@ -1255,6 +1262,11 @@ private:
             features.GetDirectoryHandlesTableSize();
         if (directoryHandlesTableSize != 0) {
             config.SetDirectoryHandlesTableSize(directoryHandlesTableSize);
+        }
+
+        if (features.HasDirectoryHandlesPersistentHandleMaxSize()) {
+            config.SetDirectoryHandlesPersistentHandleMaxSize(
+                features.GetDirectoryHandlesPersistentHandleMaxSize());
         }
 
         config.SetZeroCopyEnabled(features.GetZeroCopyEnabled());

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -55,6 +55,7 @@ message TFileStoreFeatures
     bool GuestPosixAclEnabled = 40;
     bool UseListNodesInternal = 41;
     bool UseCustomReadDataResponseParser = 42;
+    optional uint64 DirectoryHandlesPersistentHandleMaxSize = 43;
 }
 
 message TFileStore


### PR DESCRIPTION
### Notes
Added handle size limit for persistent directory handles cache
Changed params of directory handles cache to more readable form
Added uts

### Issue
#5763
