### PR TITLE
[Blockstore] TDurableClient should initialize RequestId if it is missing

### DIFF
--- a/cloud/blockstore/libs/client/client.cpp
+++ b/cloud/blockstore/libs/client/client.cpp
@@ -432,11 +432,7 @@ private:
             headers.SetRequestTimeout(requestTimeout.MilliSeconds());
         }
 
-        RequestId = headers.GetRequestId();
-        if (!RequestId) {
-            RequestId = CreateRequestId();
-            headers.SetRequestId(RequestId);
-        }
+        RequestId = EnsureRequestId(*Request);
 
         DiskId = GetDiskId(*Request);
 

--- a/cloud/blockstore/libs/client/durable.cpp
+++ b/cloud/blockstore/libs/client/durable.cpp
@@ -188,6 +188,8 @@ private:
             return;
         }
 
+        EnsureRequestId(*request);
+
         TMethod::Execute(Client.get(), state->CallContext, std::move(request))
             .Subscribe(
                 [state = std::move(state), weakSelf = this->weak_from_this()](

--- a/cloud/blockstore/libs/client/durable_ut.cpp
+++ b/cloud/blockstore/libs/client/durable_ut.cpp
@@ -7,7 +7,9 @@
 #include <cloud/blockstore/libs/diagnostics/request_stats.h>
 #include <cloud/blockstore/libs/diagnostics/volume_stats.h>
 #include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/service/service_test.h>
+
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
@@ -73,7 +75,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
-                Y_UNUSED(request);
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
                 NProto::TPingResponse response;
 
@@ -130,7 +132,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler = [&](std::shared_ptr<NProto::TPingRequest> request)
         {
-            Y_UNUSED(request);
+            UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
             NProto::TPingResponse response;
 
@@ -195,7 +197,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler = [&](std::shared_ptr<NProto::TPingRequest> request)
         {
-            Y_UNUSED(request);
+            UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
             NProto::TPingResponse response;
 
@@ -269,7 +271,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler = [&](std::shared_ptr<NProto::TPingRequest> request)
         {
-            Y_UNUSED(request);
+            UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
             NProto::TPingResponse response;
 
@@ -331,7 +333,8 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
-                Y_UNUSED(request);
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
+
                 ++requestsCount;
 
                 NProto::TPingResponse response;
@@ -502,7 +505,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
         auto client = std::make_shared<TTestService>();
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
-                Y_UNUSED(request);
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
                 return promise.GetFuture();
             };
 
@@ -559,7 +562,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
         auto client = std::make_shared<TTestService>();
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
-                Y_UNUSED(request);
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
                 NProto::TPingResponse response;
                 auto& error = *response.MutableError();
@@ -1245,7 +1248,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
-                Y_UNUSED(request);
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
                 return MakeFuture<NProto::TPingResponse>(
                     TErrorResponse(E_REJECTED));
@@ -1355,7 +1358,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
-                Y_UNUSED(request);
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
                 NProto::TPingResponse response;
                 if (!requestCount++) {
@@ -1432,7 +1435,7 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
-                Y_UNUSED(request);
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
 
                 NProto::TPingResponse response;
                 if (!requestCount++) {
@@ -1493,6 +1496,8 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
 
         client->PingHandler =
             [&] (std::shared_ptr<NProto::TPingRequest> request) {
+                UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
+
                 const auto& headers = request->GetHeaders();
                 const auto requestTimeoutMsec = headers.GetRequestTimeout();
                 UNIT_ASSERT_EQUAL(

--- a/cloud/blockstore/libs/service/request_helpers.h
+++ b/cloud/blockstore/libs/service/request_helpers.h
@@ -66,6 +66,18 @@ ui64 GetRequestId(const T& request)
     return request.GetHeaders().GetRequestId();
 }
 
+template <typename T>
+ui64 EnsureRequestId(T& request)
+{
+    auto& headers = *request.MutableHeaders();
+
+    if (!headers.GetRequestId()) {
+        headers.SetRequestId(CreateRequestId());
+    }
+
+    return headers.GetRequestId();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // NBS-2966. We can't get BlocksCount for TWriteBlocksRequest.
@@ -375,6 +387,5 @@ consteval bool ShouldBeThrottled()
 {
     return IsReadWriteRequest(GetBlockStoreRequest<T>());
 }
-
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/filestore/libs/client/bench/ya.make
+++ b/cloud/filestore/libs/client/bench/ya.make
@@ -1,5 +1,7 @@
 Y_BENCHMARK()
 
+SIZE(medium)
+
 IF (SANITIZER_TYPE)
     TAG(ya:manual)
 ENDIF()


### PR DESCRIPTION
### Notes
Noticed that RequestId is sometimes missing in logs:
```
2026/05/29 12:05:32.461657 ReleaseNVMeDevice retry request (retries: 2, timeout: 5m0s, error: E_GRPC_DEADLINE_EXCEEDED Deadline Exceeded)
```

RequestId initialization is currently present only in TClient code: https://github.com/ydb-platform/nbs/blob/d1c9ed4b9680da97f760dc4fe12a3d7cf44cde63/cloud/blockstore/libs/client/client.cpp#L435

This change makes the logic more robust by ensuring that RequestId is set before TDurableClient starts request execution.


### Issue
Put links to the related issues here
