### PR TITLE
[NBS] Local NVMe service: Fix detection of VFIO device chardev

### DIFF
--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
@@ -60,7 +60,10 @@ auto GetVFioDeviceName(const TFsPath& pciDevicePath) -> TString
                 << vfioDevDir.GetPath().Quote() << " (already have "
                 << devName.Quote() << ", now also " << child.Quote() << ")");
 
-        devName = child;
+        const TFsPath vfioDevice = vfioDevDir / child / "dev";
+        if (vfioDevice.Exists()) {
+            devName = child;
+        }
     }
 
     return devName;

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
@@ -61,7 +61,7 @@ struct TFixture: public NUnitTest::TBaseFixture
         VFIODriverPath = PrepareDriver("vfio-pci");
 
         Devices = PrepareDevices();
-        UNIT_ASSERT_VALUES_EQUAL(3, Devices.size());
+        UNIT_ASSERT_VALUES_EQUAL(4, Devices.size());
 
         for (const auto& device: Devices) {
             const TFsPath devicePath = GetPCIDevicePath(device);
@@ -99,6 +99,21 @@ struct TFixture: public NUnitTest::TBaseFixture
         // NVME_1 bound to the vfio-pci driver
         {
             const auto& device = Devices[1];
+            const TFsPath devicePath = GetPCIDevicePath(device);
+            NFs::SymLink(VFIODriverPath, devicePath / "driver");
+
+            const TFsPath vfioDeviceDir =
+                devicePath / "vfio-dev" / device.GetVfioDevName();
+            NFs::MakeDirectoryRecursive(vfioDeviceDir);
+            TFileOutput(vfioDeviceDir / "dev").Write("501:0");
+        }
+
+        // NVME_2 not bound to any driver, nothing to setup
+
+        // NVME_3 bound to the vfio-pci driver but doesn't have VFIO device
+        // (VFIO_DEVICE_CDEV not supported by kernel or disabled)
+        {
+            const auto& device = Devices[3];
             const TFsPath devicePath = GetPCIDevicePath(device);
             NFs::SymLink(VFIODriverPath, devicePath / "driver");
 
@@ -156,6 +171,15 @@ struct TFixture: public NUnitTest::TBaseFixture
                 VendorId: 0x500
                 DeviceId: 0x600
                 Model: "Test NVMe 3"
+                NumaNode: 1
+            }
+            Devices {
+                SerialNumber: "NVME_3"
+                PCIAddress: "0000:34:00.0"
+                IOMMUGroup: 40
+                VendorId: 0x700
+                DeviceId: 0x800
+                Model: "Test NVMe 4"
                 NumaNode: 1
             }
         )",


### PR DESCRIPTION
Original IOMMUFD patch relied on wrong assumption that the directory "/sys/bus/pci/devices/<PCI_ADDR>/vfio-dev/vfio<N>" is present only when device supports IOMMUFD.
Turns out that when VFIO_DEVICE_CDEV is not supported by kernel or disabled the directory still exists but it doesn't contain "dev" entry.

Detect support for vfio device chardev by checking presence of "dev" entry.

Fixes: 0d74ea3da3a6 ("Add support of IOMMUFD for local NVMe (#5861)")

#5250
