### PR TITLE
[Filestore] Enable unconfirmed data flow only if service explicitly requested it

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -195,6 +195,7 @@ public:
         request->Record.SetHandle(WriteRequest.GetHandle());
         request->Record.SetOffset(BlobRange.Offset);
         request->Record.SetLength(BlobRange.Length);
+        request->Record.SetUnconfirmedFlowRequested(UseUnconfirmedFlow);
 
         if (UseUnconfirmedFlow) {
             FillUnalignedDataRanges(

--- a/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_writedata_unconfirmed.cpp
@@ -25,6 +25,7 @@
 
 #include <util/digest/city.h>
 #include <util/generic/map.h>
+#include <util/generic/maybe.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -1359,6 +1360,137 @@ Y_UNIT_TEST_SUITE(TWriteDataUnconfirmedTest)
     // =========================================================================
     // Sharding tests
     // =========================================================================
+
+    Y_UNIT_TEST(ShouldNotEnableShardUnconfirmedFlowUnlessServiceRequested)
+    {
+        TShardedFileSystemConfig fsConfig;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetAutomaticShardCreationEnabled(true);
+        storageConfig.SetAutomaticallyCreatedShardSize(1_GB);
+        storageConfig.SetShardAllocationUnit(1_GB);
+        storageConfig.SetShardBalancerPolicy(NProto::SBP_ROUND_ROBIN);
+        storageConfig.SetAddingUnconfirmedDataEnabled(false);
+        storageConfig.SetUnconfirmedDataCountHardLimit(100);
+        storageConfig.SetWriteBlobThreshold(128_KB);
+        storageConfig.SetThreeStageWriteEnabled(true);
+        storageConfig.SetUnalignedThreeStageWriteEnabled(true);
+
+        TTestEnvConfig envConfig;
+        envConfig.DynamicNodes = 2;
+        TTestEnv env(envConfig, storageConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateFileStore(fsConfig.FsId, fsConfig.MainFsBlockCount);
+        service.ResizeFileStore(
+            fsConfig.FsId,
+            fsConfig.MainFsBlockCount,
+            false /* force */,
+            1 /* shardCount */);
+        WaitForTabletStart(service);
+
+        const auto shardTabletId = service.GetFileStoreInfo(fsConfig.Shard1Id)
+                                       ->Record.GetFileStore()
+                                       .GetMainTabletId();
+        UNIT_ASSERT(shardTabletId);
+
+        TIndexTabletClient shardTablet(
+            env.GetRuntime(),
+            nodeIdx,
+            shardTabletId,
+            {},
+            false /* updateConfig */);
+        NProto::TStorageConfig shardStorageConfig;
+        shardStorageConfig.SetAddingUnconfirmedDataEnabled(true);
+        shardStorageConfig.SetUnconfirmedDataCountHardLimit(100);
+        shardTablet.ChangeStorageConfig(std::move(shardStorageConfig));
+        shardTablet.RebootTablet();
+
+        THeaders headers;
+        auto session = service.InitSession(headers, fsConfig.FsId, "client");
+        UNIT_ASSERT(!session->Record.GetFileStore()
+                         .GetFeatures()
+                         .GetUnconfirmedFlowEnabled());
+
+        const auto nodeId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_EQUAL(1, ExtractShardNo(nodeId));
+
+        const auto handle = service
+                                .CreateHandle(
+                                    headers,
+                                    fsConfig.FsId,
+                                    nodeId,
+                                    "",
+                                    TCreateHandleArgs::RDWR)
+                                ->Record.GetHandle();
+
+        auto& runtime = env.GetRuntime();
+        TMaybe<bool> unconfirmedFlowRequested;
+        TMaybe<bool> unconfirmedFlowEnabled;
+        runtime.SetEventFilter(
+            [&](auto& runtime, auto& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvIndexTablet::EvGenerateBlobIdsRequest: {
+                        const auto* msg = event->template Get<
+                            TEvIndexTablet::TEvGenerateBlobIdsRequest>();
+                        if (msg->Record.GetFileSystemId() ==
+                            fsConfig.Shard1Id) {
+                            unconfirmedFlowRequested =
+                                msg->Record.GetUnconfirmedFlowRequested();
+                        }
+                        break;
+                    }
+                    case TEvIndexTablet::EvGenerateBlobIdsResponse: {
+                        const auto* msg = event->template Get<
+                            TEvIndexTablet::TEvGenerateBlobIdsResponse>();
+                        unconfirmedFlowEnabled =
+                            msg->Record.GetUnconfirmedFlowEnabled();
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        const ui64 confirmRequestCount =
+            runtime.GetCounter(TEvIndexTablet::EvConfirmAddDataRequest);
+        const ui64 cancelRequestCount =
+            runtime.GetCounter(TEvIndexTablet::EvCancelAddDataRequest);
+
+        const TString data = GenerateValidateData(256_KB);
+        service.WriteData(headers, fsConfig.FsId, nodeId, handle, 0, data);
+
+        UNIT_ASSERT(unconfirmedFlowRequested.Defined());
+        UNIT_ASSERT(!*unconfirmedFlowRequested);
+        UNIT_ASSERT(unconfirmedFlowEnabled.Defined());
+        UNIT_ASSERT(!*unconfirmedFlowEnabled);
+        UNIT_ASSERT_VALUES_EQUAL(
+            confirmRequestCount,
+            runtime.GetCounter(TEvIndexTablet::EvConfirmAddDataRequest));
+        UNIT_ASSERT_VALUES_EQUAL(
+            cancelRequestCount,
+            runtime.GetCounter(TEvIndexTablet::EvCancelAddDataRequest));
+
+        const auto actualResponse = service.ReadData(
+            headers,
+            fsConfig.FsId,
+            nodeId,
+            handle,
+            0,
+            data.size());
+        const auto actualData = actualResponse->Record.GetBuffer();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            CityHash64(data),
+            CityHash64(actualData),
+            "Data mismatch");
+    }
 
     Y_UNIT_TEST(ShouldDeleteShardUnconfirmedDataOnServiceDataPipeDisconnect)
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -337,7 +337,8 @@ void TIndexTabletActor::HandleGenerateBlobIds(
     }
 
     // TODO (#5468) consider take into account isOverloaded
-    const bool canUseUnconfirmed = CanUseUnconfirmedData();
+    const bool canUseUnconfirmed =
+        msg->Record.GetUnconfirmedFlowRequested() && CanUseUnconfirmedData();
 
     auto validator = [&](const NProtoPrivate::TGenerateBlobIdsRequest& request)
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -253,6 +253,36 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             ReadData(tablet, handle, expected.size(), 0));
     }
 
+    Y_UNIT_TEST(ShouldNotEnableUnconfirmedFlowUnlessRequested)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto gbi = tablet.GenerateBlobIds(
+            id,
+            handle,
+            0,
+            block,
+            false /* unconfirmedFlowRequested */);
+
+        UNIT_ASSERT(!gbi->Record.GetUnconfirmedFlowEnabled());
+        AssertStorageStats(tablet, 0, 0);
+    }
+
     Y_UNIT_TEST(ShouldConfirmUnalignedHeadAndTailData)
     {
         constexpr ui32 block = 4_KB;

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -929,7 +929,8 @@ public:
         ui64 nodeId,
         ui64 handle,
         ui64 offset,
-        ui64 length)
+        ui64 length,
+        bool unconfirmedFlowRequested = true)
     {
         auto request =
             CreateSessionRequest<TEvIndexTablet::TEvGenerateBlobIdsRequest>();
@@ -937,6 +938,7 @@ public:
         request->Record.SetHandle(handle);
         request->Record.SetOffset(offset);
         request->Record.SetLength(length);
+        request->Record.SetUnconfirmedFlowRequested(unconfirmedFlowRequested);
         return request;
     }
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -455,6 +455,9 @@ message TGenerateBlobIdsRequest
     // Unaligned head/tail data for internal AddData (used when tablet does
     // AddData internally in the unconfirmed flow).
     repeated TFreshDataRange UnalignedDataRanges = 7;
+
+    // If true, the service is ready to use the unconfirmed data flow.
+    bool UnconfirmedFlowRequested = 8;
 }
 
 message TGeneratedBlob


### PR DESCRIPTION
### Notes
We have simple logic for filesystem shards, where they control available features independently from main shard.
In this situation we can't enable communication related feature for shard if service still works with old config from main tablet. As a solution, service should explicitly negotiate feature enablement with every shard.

Added UnconfirmedFlowRequested param to GenerateBlobID which communicates to shard that service can use unconfirmed flow
Added tablet and service uts

### Issue
#2293
