### PR TITLE
support zero blocks in snapshot encryption client

### DIFF
--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -884,6 +884,9 @@ class TSnapshotEncryptionClient final
 private:
     const NProto::TEncryptionDesc EncryptionDesc;
 
+    ui32 BlockSize = 0;
+    TString ZeroBlock;
+
     TLog Log;
 
 public:
@@ -908,11 +911,18 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadBlocksLocalRequest> request) override;
 
+    TFuture<NProto::TWriteBlocksLocalResponse> WriteBlocksLocal(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteBlocksLocalRequest> request) override;
+
     TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TZeroBlocksRequest> request) override;
 
 private:
+    void HandleMountVolumeResponse(
+        const NProto::TMountVolumeResponse& response);
+
     static NProto::TReadBlocksResponse HandleReadBlocksResponse(
         NProto::TReadBlocksResponse response);
 
@@ -942,9 +952,26 @@ TFuture<NProto::TMountVolumeResponse> TSnapshotEncryptionClient::MountVolume(
     encryption.SetMode(EncryptionDesc.GetMode());
     encryption.SetKeyHash(EncryptionDesc.GetKeyHash());
 
-    return Client->MountVolume(
+    auto future = Client->MountVolume(
         std::move(callContext),
         std::move(request));
+
+    return future.Apply([this] (const auto& f) {
+        const auto& response = f.GetValue();
+        if (!HasError(response)) {
+            HandleMountVolumeResponse(response);
+        }
+        return response;
+    });
+}
+
+void TSnapshotEncryptionClient::HandleMountVolumeResponse(
+    const NProto::TMountVolumeResponse& response)
+{
+    if (BlockSize == 0) {
+        BlockSize = response.GetVolume().GetBlockSize();
+        ZeroBlock = TString(BlockSize, 0);
+    }
 }
 
 TFuture<NProto::TReadBlocksResponse> TSnapshotEncryptionClient::ReadBlocks(
@@ -1021,16 +1048,70 @@ NProto::TReadBlocksLocalResponse TSnapshotEncryptionClient::HandleReadBlocksLoca
     return response;
 }
 
+TFuture<NProto::TWriteBlocksLocalResponse> TSnapshotEncryptionClient::WriteBlocksLocal(
+    TCallContextPtr callContext,
+    std::shared_ptr<NProto::TWriteBlocksLocalRequest> request)
+{
+    return Client->WriteBlocksLocal(
+        std::move(callContext),
+        std::move(request));
+}
+
 TFuture<NProto::TZeroBlocksResponse> TSnapshotEncryptionClient::ZeroBlocks(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TZeroBlocksRequest> request)
 {
-    Y_UNUSED(callContext);
-    Y_UNUSED(request);
+    if (request->GetBlocksCount() == 0 || BlockSize == 0) {
+        return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
+            E_ARGUMENT,
+            "Request size should not be zero");
+    }
 
-    return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
-        E_NOT_IMPLEMENTED,
-        "ZeroBlocks requests not supported by snapshot encryption client");
+    STORAGE_VERIFY(
+        BlockSize <= ZeroBlock.size(),
+        TWellKnownEntityTypes::DISK,
+        request->GetDiskId());
+
+    TBlockDataRef zeroDataRef(ZeroBlock.data(), BlockSize);
+    TSgList zeroSgList(request->GetBlocksCount(), zeroDataRef);
+    TGuardedSgList guardedSgList(std::move(zeroSgList));
+
+    auto writeRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
+    writeRequest->MutableHeaders()->CopyFrom(request->GetHeaders());
+    writeRequest->SetDiskId(request->GetDiskId());
+    writeRequest->SetStartIndex(request->GetStartIndex());
+    writeRequest->SetFlags(request->GetFlags());
+    writeRequest->SetSessionId(request->GetSessionId());
+    writeRequest->SetBlockSize(BlockSize);
+    writeRequest->BlocksCount = request->GetBlocksCount();
+    writeRequest->Sglist = guardedSgList;
+
+    auto future = WriteBlocksLocal(
+        std::move(callContext),
+        std::move(writeRequest));
+
+    return future.Apply(
+        [sgList = std::move(guardedSgList)](const auto& f) mutable
+        {
+            sgList.Close();
+
+            const auto& response = f.GetValue();
+
+            NProto::TZeroBlocksResponse zeroResponse;
+            const auto& trace = response.GetHeaders().HasTrace()
+                                    ? response.GetHeaders().GetTrace()
+                                    : response.GetDeprecatedTrace();
+            const ui64 throttlerDelay =
+                Max(response.GetDeprecatedThrottlerDelay(),
+                    response.GetHeaders().GetThrottler().GetDelay());
+            zeroResponse.MutableError()->CopyFrom(response.GetError());
+            zeroResponse.MutableDeprecatedTrace()->CopyFrom(trace);
+            zeroResponse.MutableHeaders()->MutableTrace()->CopyFrom(trace);
+            zeroResponse.SetDeprecatedThrottlerDelay(throttlerDelay);
+            zeroResponse.MutableHeaders()->MutableThrottler()->SetDelay(
+                throttlerDelay);
+            return zeroResponse;
+        });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -880,9 +880,14 @@ private:
 
 class TSnapshotEncryptionClient final
     : public TClientWrapper
+    , public std::enable_shared_from_this<TSnapshotEncryptionClient>
 {
 private:
     const NProto::TEncryptionDesc EncryptionDesc;
+    const NProto::EEncryptZeroPolicy EncryptZeroPolicy;
+
+    ui32 BlockSize = 0;
+    TString ZeroBlock;
 
     TLog Log;
 
@@ -890,9 +895,11 @@ public:
     TSnapshotEncryptionClient(
             IBlockStorePtr client,
             ILoggingServicePtr logging,
-            NProto::TEncryptionDesc encryptionDesc)
+            NProto::TEncryptionDesc encryptionDesc,
+            NProto::EEncryptZeroPolicy encryptZeroPolicy)
         : TClientWrapper(std::move(client))
         , EncryptionDesc(std::move(encryptionDesc))
+        , EncryptZeroPolicy(encryptZeroPolicy)
         , Log(logging->CreateLog("BLOCKSTORE_CLIENT"))
     {}
 
@@ -913,6 +920,9 @@ public:
         std::shared_ptr<NProto::TZeroBlocksRequest> request) override;
 
 private:
+    void HandleMountVolumeResponse(
+        const NProto::TMountVolumeResponse& response);
+
     static NProto::TReadBlocksResponse HandleReadBlocksResponse(
         NProto::TReadBlocksResponse response);
 
@@ -942,9 +952,30 @@ TFuture<NProto::TMountVolumeResponse> TSnapshotEncryptionClient::MountVolume(
     encryption.SetMode(EncryptionDesc.GetMode());
     encryption.SetKeyHash(EncryptionDesc.GetKeyHash());
 
-    return Client->MountVolume(
+    auto future = Client->MountVolume(
         std::move(callContext),
         std::move(request));
+
+    if (EncryptZeroPolicy == NProto::EZP_WRITE_ZERO_BLOCKS) {
+        return future;
+    }
+
+    return future.Apply([self = shared_from_this()] (const auto& f) {
+        const auto& response = f.GetValue();
+        if (!HasError(response)) {
+            self->HandleMountVolumeResponse(response);
+        }
+        return response;
+    });
+}
+
+void TSnapshotEncryptionClient::HandleMountVolumeResponse(
+    const NProto::TMountVolumeResponse& response)
+{
+    if (BlockSize == 0) {
+        BlockSize = response.GetVolume().GetBlockSize();
+        ZeroBlock = TString(BlockSize, 0);
+    }
 }
 
 TFuture<NProto::TReadBlocksResponse> TSnapshotEncryptionClient::ReadBlocks(
@@ -1025,9 +1056,69 @@ TFuture<NProto::TZeroBlocksResponse> TSnapshotEncryptionClient::ZeroBlocks(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TZeroBlocksRequest> request)
 {
-    return Client->ZeroBlocks(
+    if (EncryptZeroPolicy == NProto::EZP_WRITE_ZERO_BLOCKS) {
+        return Client->ZeroBlocks(
+            std::move(callContext),
+            std::move(request));
+    }
+
+    if (request->GetBlocksCount() == 0) {
+        return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
+            E_ARGUMENT,
+            "Request size should not be zero");
+    }
+
+    if (BlockSize == 0) {
+        return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
+            E_INVALID_STATE,
+            "Volume is not mounted");
+    }
+
+    STORAGE_VERIFY(
+        BlockSize <= ZeroBlock.size(),
+        TWellKnownEntityTypes::DISK,
+        request->GetDiskId());
+
+    TBlockDataRef zeroDataRef(ZeroBlock.data(), BlockSize);
+    TSgList zeroSgList(request->GetBlocksCount(), zeroDataRef);
+    TGuardedSgList guardedSgList(std::move(zeroSgList));
+
+    auto writeRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
+    writeRequest->MutableHeaders()->CopyFrom(request->GetHeaders());
+    writeRequest->SetDiskId(request->GetDiskId());
+    writeRequest->SetStartIndex(request->GetStartIndex());
+    writeRequest->SetFlags(request->GetFlags());
+    writeRequest->SetSessionId(request->GetSessionId());
+    writeRequest->SetBlockSize(BlockSize);
+    writeRequest->BlocksCount = request->GetBlocksCount();
+    writeRequest->Sglist = guardedSgList;
+
+    auto future = Client->WriteBlocksLocal(
         std::move(callContext),
-        std::move(request));
+        std::move(writeRequest));
+
+    return future.Apply(
+        [sgList = std::move(guardedSgList)](const auto& f) mutable
+        {
+            sgList.Close();
+
+            const auto& response = f.GetValue();
+
+            NProto::TZeroBlocksResponse zeroResponse;
+            const auto& trace = response.GetHeaders().HasTrace()
+                                    ? response.GetHeaders().GetTrace()
+                                    : response.GetDeprecatedTrace();
+            const ui64 throttlerDelay =
+                Max(response.GetDeprecatedThrottlerDelay(),
+                    response.GetHeaders().GetThrottler().GetDelay());
+            zeroResponse.MutableError()->CopyFrom(response.GetError());
+            zeroResponse.MutableDeprecatedTrace()->CopyFrom(trace);
+            zeroResponse.MutableHeaders()->MutableTrace()->CopyFrom(trace);
+            zeroResponse.SetDeprecatedThrottlerDelay(throttlerDelay);
+            zeroResponse.MutableHeaders()->MutableThrottler()->SetDelay(
+                throttlerDelay);
+            return zeroResponse;
+        });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1071,7 +1162,8 @@ public:
                 CreateSnapshotEncryptionClient(
                     std::move(client),
                     Logging,
-                    encryptionDesc));
+                    encryptionDesc,
+                    EncryptZeroPolicy));
         }
 
         auto future = EncryptionKeyProvider->GetKey(encryptionSpec, diskId);
@@ -1152,12 +1244,14 @@ IBlockStorePtr CreateEncryptionClient(
 IBlockStorePtr CreateSnapshotEncryptionClient(
     IBlockStorePtr client,
     ILoggingServicePtr logging,
-    NProto::TEncryptionDesc encryptionDesc)
+    NProto::TEncryptionDesc encryptionDesc,
+    NProto::EEncryptZeroPolicy encryptZeroPolicy)
 {
     return std::make_shared<TSnapshotEncryptionClient>(
         std::move(client),
         std::move(logging),
-        std::move(encryptionDesc));
+        std::move(encryptionDesc),
+        encryptZeroPolicy);
 }
 
 IEncryptionClientFactoryPtr CreateEncryptionClientFactory(

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -880,14 +880,9 @@ private:
 
 class TSnapshotEncryptionClient final
     : public TClientWrapper
-    , public std::enable_shared_from_this<TSnapshotEncryptionClient>
 {
 private:
     const NProto::TEncryptionDesc EncryptionDesc;
-    const NProto::EEncryptZeroPolicy EncryptZeroPolicy;
-
-    ui32 BlockSize = 0;
-    TString ZeroBlock;
 
     TLog Log;
 
@@ -895,11 +890,9 @@ public:
     TSnapshotEncryptionClient(
             IBlockStorePtr client,
             ILoggingServicePtr logging,
-            NProto::TEncryptionDesc encryptionDesc,
-            NProto::EEncryptZeroPolicy encryptZeroPolicy)
+            NProto::TEncryptionDesc encryptionDesc)
         : TClientWrapper(std::move(client))
         , EncryptionDesc(std::move(encryptionDesc))
-        , EncryptZeroPolicy(encryptZeroPolicy)
         , Log(logging->CreateLog("BLOCKSTORE_CLIENT"))
     {}
 
@@ -915,13 +908,7 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadBlocksLocalRequest> request) override;
 
-    TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
-        TCallContextPtr callContext,
-        std::shared_ptr<NProto::TZeroBlocksRequest> request) override;
-
 private:
-    void HandleMountVolumeResponse(
-        const NProto::TMountVolumeResponse& response);
 
     static NProto::TReadBlocksResponse HandleReadBlocksResponse(
         NProto::TReadBlocksResponse response);
@@ -952,30 +939,9 @@ TFuture<NProto::TMountVolumeResponse> TSnapshotEncryptionClient::MountVolume(
     encryption.SetMode(EncryptionDesc.GetMode());
     encryption.SetKeyHash(EncryptionDesc.GetKeyHash());
 
-    auto future = Client->MountVolume(
+    return Client->MountVolume(
         std::move(callContext),
         std::move(request));
-
-    if (EncryptZeroPolicy == NProto::EZP_WRITE_ZERO_BLOCKS) {
-        return future;
-    }
-
-    return future.Apply([self = shared_from_this()] (const auto& f) {
-        const auto& response = f.GetValue();
-        if (!HasError(response)) {
-            self->HandleMountVolumeResponse(response);
-        }
-        return response;
-    });
-}
-
-void TSnapshotEncryptionClient::HandleMountVolumeResponse(
-    const NProto::TMountVolumeResponse& response)
-{
-    if (BlockSize == 0) {
-        BlockSize = response.GetVolume().GetBlockSize();
-        ZeroBlock = TString(BlockSize, 0);
-    }
 }
 
 TFuture<NProto::TReadBlocksResponse> TSnapshotEncryptionClient::ReadBlocks(
@@ -1052,75 +1018,6 @@ NProto::TReadBlocksLocalResponse TSnapshotEncryptionClient::HandleReadBlocksLoca
     return response;
 }
 
-TFuture<NProto::TZeroBlocksResponse> TSnapshotEncryptionClient::ZeroBlocks(
-    TCallContextPtr callContext,
-    std::shared_ptr<NProto::TZeroBlocksRequest> request)
-{
-    if (EncryptZeroPolicy == NProto::EZP_WRITE_ZERO_BLOCKS) {
-        return Client->ZeroBlocks(
-            std::move(callContext),
-            std::move(request));
-    }
-
-    if (request->GetBlocksCount() == 0) {
-        return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
-            E_ARGUMENT,
-            "Request size should not be zero");
-    }
-
-    if (BlockSize == 0) {
-        return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
-            E_INVALID_STATE,
-            "Volume is not mounted");
-    }
-
-    STORAGE_VERIFY(
-        BlockSize <= ZeroBlock.size(),
-        TWellKnownEntityTypes::DISK,
-        request->GetDiskId());
-
-    TBlockDataRef zeroDataRef(ZeroBlock.data(), BlockSize);
-    TSgList zeroSgList(request->GetBlocksCount(), zeroDataRef);
-    TGuardedSgList guardedSgList(std::move(zeroSgList));
-
-    auto writeRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
-    writeRequest->MutableHeaders()->CopyFrom(request->GetHeaders());
-    writeRequest->SetDiskId(request->GetDiskId());
-    writeRequest->SetStartIndex(request->GetStartIndex());
-    writeRequest->SetFlags(request->GetFlags());
-    writeRequest->SetSessionId(request->GetSessionId());
-    writeRequest->SetBlockSize(BlockSize);
-    writeRequest->BlocksCount = request->GetBlocksCount();
-    writeRequest->Sglist = guardedSgList;
-
-    auto future = Client->WriteBlocksLocal(
-        std::move(callContext),
-        std::move(writeRequest));
-
-    return future.Apply(
-        [sgList = std::move(guardedSgList)](const auto& f) mutable
-        {
-            sgList.Close();
-
-            const auto& response = f.GetValue();
-
-            NProto::TZeroBlocksResponse zeroResponse;
-            const auto& trace = response.GetHeaders().HasTrace()
-                                    ? response.GetHeaders().GetTrace()
-                                    : response.GetDeprecatedTrace();
-            const ui64 throttlerDelay =
-                Max(response.GetDeprecatedThrottlerDelay(),
-                    response.GetHeaders().GetThrottler().GetDelay());
-            zeroResponse.MutableError()->CopyFrom(response.GetError());
-            zeroResponse.MutableDeprecatedTrace()->CopyFrom(trace);
-            zeroResponse.MutableHeaders()->MutableTrace()->CopyFrom(trace);
-            zeroResponse.SetDeprecatedThrottlerDelay(throttlerDelay);
-            zeroResponse.MutableHeaders()->MutableThrottler()->SetDelay(
-                throttlerDelay);
-            return zeroResponse;
-        });
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 class TEncryptionClientFactory
@@ -1162,8 +1059,7 @@ public:
                 CreateSnapshotEncryptionClient(
                     std::move(client),
                     Logging,
-                    encryptionDesc,
-                    EncryptZeroPolicy));
+                    encryptionDesc));
         }
 
         auto future = EncryptionKeyProvider->GetKey(encryptionSpec, diskId);
@@ -1244,14 +1140,12 @@ IBlockStorePtr CreateEncryptionClient(
 IBlockStorePtr CreateSnapshotEncryptionClient(
     IBlockStorePtr client,
     ILoggingServicePtr logging,
-    NProto::TEncryptionDesc encryptionDesc,
-    NProto::EEncryptZeroPolicy encryptZeroPolicy)
+    NProto::TEncryptionDesc encryptionDesc)
 {
     return std::make_shared<TSnapshotEncryptionClient>(
         std::move(client),
         std::move(logging),
-        std::move(encryptionDesc),
-        encryptZeroPolicy);
+        std::move(encryptionDesc));
 }
 
 IEncryptionClientFactoryPtr CreateEncryptionClientFactory(

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -884,9 +884,6 @@ class TSnapshotEncryptionClient final
 private:
     const NProto::TEncryptionDesc EncryptionDesc;
 
-    ui32 BlockSize = 0;
-    TString ZeroBlock;
-
     TLog Log;
 
 public:
@@ -911,18 +908,11 @@ public:
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadBlocksLocalRequest> request) override;
 
-    TFuture<NProto::TWriteBlocksLocalResponse> WriteBlocksLocal(
-        TCallContextPtr callContext,
-        std::shared_ptr<NProto::TWriteBlocksLocalRequest> request) override;
-
     TFuture<NProto::TZeroBlocksResponse> ZeroBlocks(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TZeroBlocksRequest> request) override;
 
 private:
-    void HandleMountVolumeResponse(
-        const NProto::TMountVolumeResponse& response);
-
     static NProto::TReadBlocksResponse HandleReadBlocksResponse(
         NProto::TReadBlocksResponse response);
 
@@ -952,26 +942,9 @@ TFuture<NProto::TMountVolumeResponse> TSnapshotEncryptionClient::MountVolume(
     encryption.SetMode(EncryptionDesc.GetMode());
     encryption.SetKeyHash(EncryptionDesc.GetKeyHash());
 
-    auto future = Client->MountVolume(
+    return Client->MountVolume(
         std::move(callContext),
         std::move(request));
-
-    return future.Apply([this] (const auto& f) {
-        const auto& response = f.GetValue();
-        if (!HasError(response)) {
-            HandleMountVolumeResponse(response);
-        }
-        return response;
-    });
-}
-
-void TSnapshotEncryptionClient::HandleMountVolumeResponse(
-    const NProto::TMountVolumeResponse& response)
-{
-    if (BlockSize == 0) {
-        BlockSize = response.GetVolume().GetBlockSize();
-        ZeroBlock = TString(BlockSize, 0);
-    }
 }
 
 TFuture<NProto::TReadBlocksResponse> TSnapshotEncryptionClient::ReadBlocks(
@@ -1048,70 +1021,13 @@ NProto::TReadBlocksLocalResponse TSnapshotEncryptionClient::HandleReadBlocksLoca
     return response;
 }
 
-TFuture<NProto::TWriteBlocksLocalResponse> TSnapshotEncryptionClient::WriteBlocksLocal(
-    TCallContextPtr callContext,
-    std::shared_ptr<NProto::TWriteBlocksLocalRequest> request)
-{
-    return Client->WriteBlocksLocal(
-        std::move(callContext),
-        std::move(request));
-}
-
 TFuture<NProto::TZeroBlocksResponse> TSnapshotEncryptionClient::ZeroBlocks(
     TCallContextPtr callContext,
     std::shared_ptr<NProto::TZeroBlocksRequest> request)
 {
-    if (request->GetBlocksCount() == 0 || BlockSize == 0) {
-        return MakeFutureErrorResponse<NProto::TZeroBlocksResponse>(
-            E_ARGUMENT,
-            "Request size should not be zero");
-    }
-
-    STORAGE_VERIFY(
-        BlockSize <= ZeroBlock.size(),
-        TWellKnownEntityTypes::DISK,
-        request->GetDiskId());
-
-    TBlockDataRef zeroDataRef(ZeroBlock.data(), BlockSize);
-    TSgList zeroSgList(request->GetBlocksCount(), zeroDataRef);
-    TGuardedSgList guardedSgList(std::move(zeroSgList));
-
-    auto writeRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
-    writeRequest->MutableHeaders()->CopyFrom(request->GetHeaders());
-    writeRequest->SetDiskId(request->GetDiskId());
-    writeRequest->SetStartIndex(request->GetStartIndex());
-    writeRequest->SetFlags(request->GetFlags());
-    writeRequest->SetSessionId(request->GetSessionId());
-    writeRequest->SetBlockSize(BlockSize);
-    writeRequest->BlocksCount = request->GetBlocksCount();
-    writeRequest->Sglist = guardedSgList;
-
-    auto future = WriteBlocksLocal(
+    return Client->ZeroBlocks(
         std::move(callContext),
-        std::move(writeRequest));
-
-    return future.Apply(
-        [sgList = std::move(guardedSgList)](const auto& f) mutable
-        {
-            sgList.Close();
-
-            const auto& response = f.GetValue();
-
-            NProto::TZeroBlocksResponse zeroResponse;
-            const auto& trace = response.GetHeaders().HasTrace()
-                                    ? response.GetHeaders().GetTrace()
-                                    : response.GetDeprecatedTrace();
-            const ui64 throttlerDelay =
-                Max(response.GetDeprecatedThrottlerDelay(),
-                    response.GetHeaders().GetThrottler().GetDelay());
-            zeroResponse.MutableError()->CopyFrom(response.GetError());
-            zeroResponse.MutableDeprecatedTrace()->CopyFrom(trace);
-            zeroResponse.MutableHeaders()->MutableTrace()->CopyFrom(trace);
-            zeroResponse.SetDeprecatedThrottlerDelay(throttlerDelay);
-            zeroResponse.MutableHeaders()->MutableThrottler()->SetDelay(
-                throttlerDelay);
-            return zeroResponse;
-        });
+        std::move(request));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/encryption/encryption_client.h
+++ b/cloud/blockstore/libs/encryption/encryption_client.h
@@ -31,8 +31,7 @@ IBlockStorePtr CreateEncryptionClient(
 IBlockStorePtr CreateSnapshotEncryptionClient(
     IBlockStorePtr client,
     ILoggingServicePtr logging,
-    NProto::TEncryptionDesc encryptionDesc,
-    NProto::EEncryptZeroPolicy encryptZeroPolicy);
+    NProto::TEncryptionDesc encryptionDesc);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/encryption/encryption_client.h
+++ b/cloud/blockstore/libs/encryption/encryption_client.h
@@ -31,7 +31,8 @@ IBlockStorePtr CreateEncryptionClient(
 IBlockStorePtr CreateSnapshotEncryptionClient(
     IBlockStorePtr client,
     ILoggingServicePtr logging,
-    NProto::TEncryptionDesc encryptionDesc);
+    NProto::TEncryptionDesc encryptionDesc,
+    NProto::EEncryptZeroPolicy encryptZeroPolicy);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -534,123 +534,111 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldWriteZeroBlocksInSnapshotEncryptionClient)
+    Y_UNIT_TEST(ShouldForwardZeroBlocksInSnapshotEncryptionClient)
     {
         auto logging = CreateLoggingService("console");
-        size_t blockSize = 8;
-        size_t storageBlocksCount = 16;
-
-        TVector<TString> storageBlocks(Reserve(storageBlocksCount));
-        for (size_t i = 0; i < storageBlocksCount; ++i) {
-            storageBlocks.emplace_back(blockSize, '1');
-        }
-
         auto testClient = std::make_shared<TTestService>();
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
             GetDefaultEncryption());
 
-        auto zRequest = std::make_shared<NProto::TZeroBlocksRequest>();
-        zRequest->MutableHeaders()->SetClientId("testClientId");
-        zRequest->SetDiskId("testDiskId");
-        zRequest->SetStartIndex(1);
-        zRequest->SetBlocksCount(6);
-        zRequest->SetFlags(42);
-        zRequest->SetSessionId("testSessionId");
+        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
+        request->MutableHeaders()->SetClientId("testClientId");
+        request->SetDiskId("testDiskId");
+        request->SetStartIndex(1);
+        request->SetBlocksCount(6);
+        request->SetFlags(42);
+        request->SetSessionId("testSessionId");
         UNIT_ASSERT_VALUES_EQUAL(
             6,
             GetFieldCount<NProto::TZeroBlocksRequest>());
 
-        NProto::TWriteBlocksLocalResponse wResponse;
-        wResponse.MutableError()->SetMessage("testMessage");
-        wResponse.MutableDeprecatedTrace()->SetRequestStartTime(42);
-        wResponse.MutableHeaders()->MutableTrace()->SetRequestStartTime(42);
-        wResponse.SetDeprecatedThrottlerDelay(13);
-        wResponse.MutableHeaders()->MutableThrottler()->SetDelay(13);
+        NProto::TZeroBlocksResponse zResponse;
+        zResponse.MutableError()->SetMessage("testMessage");
+        zResponse.MutableDeprecatedTrace()->SetRequestStartTime(42);
+        zResponse.MutableHeaders()->MutableTrace()->SetRequestStartTime(42);
+        zResponse.SetDeprecatedThrottlerDelay(13);
+        zResponse.MutableHeaders()->MutableThrottler()->SetDelay(13);
 
-        testClient->MountVolumeHandler =
-            [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
-                const auto& spec = request->GetEncryptionSpec();
-                UNIT_ASSERT(GetDefaultEncryption().GetMode() == spec.GetMode());
+        size_t requestsCount = 0;
+        testClient->ZeroBlocksHandler =
+            [&] (std::shared_ptr<NProto::TZeroBlocksRequest> zRequest) {
+                ++requestsCount;
                 UNIT_ASSERT_VALUES_EQUAL(
-                    GetDefaultEncryption().GetKeyHash(),
-                    spec.GetKeyHash());
+                    request->MutableHeaders()->GetClientId(),
+                    zRequest->MutableHeaders()->GetClientId());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    request->GetDiskId(),
+                    zRequest->GetDiskId());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    request->GetStartIndex(),
+                    zRequest->GetStartIndex());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    request->GetBlocksCount(),
+                    zRequest->GetBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    request->GetFlags(),
+                    zRequest->GetFlags());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    request->GetSessionId(),
+                    zRequest->GetSessionId());
 
-                NProto::TMountVolumeResponse response;
-                response.MutableVolume()->SetBlockSize(blockSize);
-                return MakeFuture(std::move(response));
+                return MakeFuture(zResponse);
             };
-
-        testClient->WriteBlocksLocalHandler =
-            [&] (std::shared_ptr<NProto::TWriteBlocksLocalRequest> wRequest) {
-                auto guard = wRequest->Sglist.Acquire();
-                UNIT_ASSERT(guard);
-                const auto& sglist = guard.Get();
-
-                for (size_t i = 0; i < sglist.size(); ++i) {
-                    size_t n = i + wRequest->GetStartIndex();
-                    UNIT_ASSERT_VALUES_EQUAL(storageBlocks[n].size(), sglist[i].Size());
-                    auto* dst = const_cast<char*>(storageBlocks[n].data());
-                    auto* src = sglist[i].Data();
-                    memcpy(dst, src, sglist[i].Size());
-                }
-
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->MutableHeaders()->GetClientId(),
-                    wRequest->MutableHeaders()->GetClientId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetDiskId(),
-                    wRequest->GetDiskId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetStartIndex(),
-                    wRequest->GetStartIndex());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetFlags(),
-                    wRequest->GetFlags());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetSessionId(),
-                    wRequest->GetSessionId());
-
-                return MakeFuture(wResponse);
-            };
-
-        auto mountResponse = MountVolume(*encryptionClient);
-        UNIT_ASSERT(!HasError(mountResponse));
 
         auto future = encryptionClient->ZeroBlocks(
             MakeIntrusive<TCallContext>(),
-            zRequest);
-        auto zResponse = future.GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT(!HasError(zResponse));
+            request);
+        auto response = future.GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT(!HasError(response));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetError().GetMessage(),
-            zResponse.GetError().GetMessage());
+            zResponse.GetError().GetMessage(),
+            response.GetError().GetMessage());
         UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetDeprecatedTrace().GetRequestStartTime(),
-            zResponse.GetDeprecatedTrace().GetRequestStartTime());
+            zResponse.GetDeprecatedTrace().GetRequestStartTime(),
+            response.GetDeprecatedTrace().GetRequestStartTime());
         UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetHeaders().GetTrace().GetRequestStartTime(),
-            zResponse.GetHeaders().GetTrace().GetRequestStartTime());
+            zResponse.GetHeaders().GetTrace().GetRequestStartTime(),
+            response.GetHeaders().GetTrace().GetRequestStartTime());
         UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetDeprecatedThrottlerDelay(),
-            zResponse.GetDeprecatedThrottlerDelay());
+            zResponse.GetDeprecatedThrottlerDelay(),
+            response.GetDeprecatedThrottlerDelay());
         UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetHeaders().GetThrottler().GetDelay(),
-            zResponse.GetHeaders().GetThrottler().GetDelay());
+            zResponse.GetHeaders().GetThrottler().GetDelay(),
+            response.GetHeaders().GetThrottler().GetDelay());
+        UNIT_ASSERT_VALUES_EQUAL(1, requestsCount);
+    }
 
-        for (size_t i = 0; i < storageBlocksCount; ++i) {
-            TBlockDataRef block(storageBlocks[i].data(), storageBlocks[i].size());
+    Y_UNIT_TEST(ShouldPropagateZeroBlocksErrorInSnapshotEncryptionClient)
+    {
+        auto logging = CreateLoggingService("console");
+        auto testClient = std::make_shared<TTestService>();
+        auto encryptionClient = CreateSnapshotEncryptionClient(
+            testClient,
+            logging,
+            GetDefaultEncryption());
 
-            if (zRequest->GetStartIndex() <= i &&
-                i < zRequest->GetStartIndex() + zRequest->GetBlocksCount())
-            {
-                UNIT_ASSERT(BlockFilledByValue(block, 0));
-            } else {
-                UNIT_ASSERT(BlockFilledByValue(block, '1'));
-            }
-        }
+        testClient->ZeroBlocksHandler =
+            [] (std::shared_ptr<NProto::TZeroBlocksRequest>) {
+                NProto::TZeroBlocksResponse response;
+                response.MutableError()->SetCode(E_REJECTED);
+                response.MutableError()->SetMessage("testError");
+                return MakeFuture(response);
+            };
+
+        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
+        request->SetBlocksCount(1);
+
+        auto future = encryptionClient->ZeroBlocks(
+            MakeIntrusive<TCallContext>(),
+            request);
+        auto response = future.GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response.GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "testError",
+            response.GetError().GetMessage());
     }
 
     Y_UNIT_TEST(ShouldNotEncryptInZeroBlock)
@@ -1243,23 +1231,42 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         }
     }
 
-    Y_UNIT_TEST(SnapshotEncryptionClientShouldRejectZeroBlocksBeforeMount)
+    Y_UNIT_TEST(SnapshotEncryptionClientShouldForwardZeroBlocksBeforeMount)
     {
         auto logging = CreateLoggingService("console");
+        auto testClient = std::make_shared<TTestService>();
         auto encryptionClient = CreateSnapshotEncryptionClient(
-            std::make_shared<TTestService>(),
+            testClient,
             logging,
             GetDefaultEncryption());
 
         auto request = std::make_shared<NProto::TZeroBlocksRequest>();
         request->SetBlocksCount(1);
 
+        size_t requestsCount = 0;
+        testClient->ZeroBlocksHandler =
+            [&] (std::shared_ptr<NProto::TZeroBlocksRequest> zRequest) {
+                ++requestsCount;
+                UNIT_ASSERT_VALUES_EQUAL(
+                    request->GetBlocksCount(),
+                    zRequest->GetBlocksCount());
+
+                NProto::TZeroBlocksResponse response;
+                response.MutableError()->SetCode(E_REJECTED);
+                response.MutableError()->SetMessage("not mounted");
+                return MakeFuture(response);
+            };
+
         auto future = encryptionClient->ZeroBlocks(
             MakeIntrusive<TCallContext>(),
             request);
 
         auto response = future.GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, response.GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response.GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "not mounted",
+            response.GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(1, requestsCount);
     }
 
     Y_UNIT_TEST(ShouldHandleRequestsAfterDestroyClient)
@@ -1444,8 +1451,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             auto zeroFuture = encryptionClient->ZeroBlocks(
                 MakeIntrusive<TCallContext>(),
                 zeroRequest);
-            auto zeroResponse = zeroFuture.GetValue(TDuration::Seconds(5));
-            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, zeroResponse.GetError().GetCode());
+            UNIT_ASSERT(!zeroFuture.HasValue());
 
             encryptionClient.reset();
             trigger.SetValue();
@@ -1464,6 +1470,9 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
 
             auto localWriteResponse = localWriteFuture.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT_C(!HasError(localWriteResponse), localWriteResponse);
+
+            auto zeroResponse = zeroFuture.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_C(!HasError(zeroResponse), zeroResponse);
         }
     }
 

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -181,8 +181,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             auto encryptionClient = CreateSnapshotEncryptionClient(
                 testClient,
                 logging,
-                encryptionDesc,
-                NProto::EZP_WRITE_ZERO_BLOCKS);
+                encryptionDesc);
 
             auto mountResponse = MountVolume(*encryptionClient);
             UNIT_ASSERT(!HasError(mountResponse));
@@ -230,8 +229,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             auto encryptionClient1 = CreateSnapshotEncryptionClient(
                 testClient,
                 logging,
-                encryptionDesc,
-                NProto::EZP_WRITE_ZERO_BLOCKS);
+                encryptionDesc);
 
             auto mountResponse1 = MountVolume(*encryptionClient1);
             UNIT_ASSERT(!HasError(mountResponse1));
@@ -239,8 +237,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             auto encryptionClient2 = CreateSnapshotEncryptionClient(
                 encryptionClient1,
                 logging,
-                encryptionDesc,
-                NProto::EZP_WRITE_ZERO_BLOCKS);
+                encryptionDesc);
 
             auto mountResponse2 = MountVolume(*encryptionClient2);
             UNIT_ASSERT(!HasError(mountResponse2));
@@ -537,128 +534,6 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldWriteZeroBlocksInSnapshotEncryptionClient)
-    {
-        auto logging = CreateLoggingService("console");
-        size_t blockSize = 8;
-        size_t storageBlocksCount = 16;
-
-        TVector<TString> storageBlocks(Reserve(storageBlocksCount));
-        for (size_t i = 0; i < storageBlocksCount; ++i) {
-            storageBlocks.emplace_back(blockSize, '1');
-        }
-
-        auto testClient = std::make_shared<TTestService>();
-        auto encryptionClient = CreateSnapshotEncryptionClient(
-            testClient,
-            logging,
-            GetDefaultEncryption(),
-            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
-
-        auto zRequest = std::make_shared<NProto::TZeroBlocksRequest>();
-        zRequest->MutableHeaders()->SetClientId("testClientId");
-        zRequest->SetDiskId("testDiskId");
-        zRequest->SetStartIndex(1);
-        zRequest->SetBlocksCount(6);
-        zRequest->SetFlags(42);
-        zRequest->SetSessionId("testSessionId");
-        UNIT_ASSERT_VALUES_EQUAL(
-            6,
-            GetFieldCount<NProto::TZeroBlocksRequest>());
-
-        NProto::TWriteBlocksLocalResponse wResponse;
-        wResponse.MutableError()->SetMessage("testMessage");
-        wResponse.MutableDeprecatedTrace()->SetRequestStartTime(42);
-        wResponse.MutableHeaders()->MutableTrace()->SetRequestStartTime(42);
-        wResponse.SetDeprecatedThrottlerDelay(13);
-        wResponse.MutableHeaders()->MutableThrottler()->SetDelay(13);
-
-        testClient->MountVolumeHandler =
-            [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
-                const auto& spec = request->GetEncryptionSpec();
-                UNIT_ASSERT(GetDefaultEncryption().GetMode() == spec.GetMode());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    GetDefaultEncryption().GetKeyHash(),
-                    spec.GetKeyHash());
-
-                NProto::TMountVolumeResponse response;
-                response.MutableVolume()->SetBlockSize(blockSize);
-                return MakeFuture(std::move(response));
-            };
-
-        testClient->WriteBlocksLocalHandler =
-            [&] (std::shared_ptr<NProto::TWriteBlocksLocalRequest> wRequest) {
-                auto guard = wRequest->Sglist.Acquire();
-                UNIT_ASSERT(guard);
-                const auto& sglist = guard.Get();
-
-                for (size_t i = 0; i < sglist.size(); ++i) {
-                    size_t n = i + wRequest->GetStartIndex();
-                    UNIT_ASSERT_VALUES_EQUAL(
-                        storageBlocks[n].size(),
-                        sglist[i].Size());
-                    auto* dst = const_cast<char*>(storageBlocks[n].data());
-                    auto* src = sglist[i].Data();
-                    memcpy(dst, src, sglist[i].Size());
-                }
-
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->MutableHeaders()->GetClientId(),
-                    wRequest->MutableHeaders()->GetClientId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetDiskId(),
-                    wRequest->GetDiskId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetStartIndex(),
-                    wRequest->GetStartIndex());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetFlags(),
-                    wRequest->GetFlags());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    zRequest->GetSessionId(),
-                    wRequest->GetSessionId());
-
-                return MakeFuture(wResponse);
-            };
-
-        auto mountResponse = MountVolume(*encryptionClient);
-        UNIT_ASSERT(!HasError(mountResponse));
-
-        auto future = encryptionClient->ZeroBlocks(
-            MakeIntrusive<TCallContext>(),
-            zRequest);
-        auto zResponse = future.GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT(!HasError(zResponse));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetError().GetMessage(),
-            zResponse.GetError().GetMessage());
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetDeprecatedTrace().GetRequestStartTime(),
-            zResponse.GetDeprecatedTrace().GetRequestStartTime());
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetHeaders().GetTrace().GetRequestStartTime(),
-            zResponse.GetHeaders().GetTrace().GetRequestStartTime());
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetDeprecatedThrottlerDelay(),
-            zResponse.GetDeprecatedThrottlerDelay());
-        UNIT_ASSERT_VALUES_EQUAL(
-            wResponse.GetHeaders().GetThrottler().GetDelay(),
-            zResponse.GetHeaders().GetThrottler().GetDelay());
-
-        for (size_t i = 0; i < storageBlocksCount; ++i) {
-            TBlockDataRef block(storageBlocks[i].data(), storageBlocks[i].size());
-
-            if (zRequest->GetStartIndex() <= i &&
-                i < zRequest->GetStartIndex() + zRequest->GetBlocksCount())
-            {
-                UNIT_ASSERT(BlockFilledByValue(block, 0));
-            } else {
-                UNIT_ASSERT(BlockFilledByValue(block, '1'));
-            }
-        }
-    }
-
     Y_UNIT_TEST(ShouldPropagateZeroBlocksErrorInSnapshotEncryptionClient)
     {
         auto logging = CreateLoggingService("console");
@@ -666,8 +541,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption(),
-            NProto::EZP_WRITE_ZERO_BLOCKS);
+            GetDefaultEncryption());
 
         testClient->ZeroBlocksHandler =
             [] (std::shared_ptr<NProto::TZeroBlocksRequest>) {
@@ -1192,8 +1066,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption(),
-            NProto::EZP_WRITE_ZERO_BLOCKS);
+            GetDefaultEncryption());
 
         auto ctx = MakeIntrusive<TCallContext>();
         auto request = std::make_shared<NProto::TReadBlocksRequest>();
@@ -1244,8 +1117,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption(),
-            NProto::EZP_WRITE_ZERO_BLOCKS);
+            GetDefaultEncryption());
 
         auto blocksCount = 4 * 8;
 
@@ -1289,8 +1161,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption(),
-            NProto::EZP_WRITE_ZERO_BLOCKS);
+            GetDefaultEncryption());
 
         auto request = std::make_shared<NProto::TZeroBlocksRequest>();
         request->SetBlocksCount(1);
@@ -1319,27 +1190,6 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             "not mounted",
             response.GetError().GetMessage());
         UNIT_ASSERT_VALUES_EQUAL(1, requestsCount);
-    }
-
-    Y_UNIT_TEST(SnapshotEncryptionClientShouldRejectZeroBlocksBeforeMount)
-    {
-        auto logging = CreateLoggingService("console");
-        auto testClient = std::make_shared<TTestService>();
-        auto encryptionClient = CreateSnapshotEncryptionClient(
-            testClient,
-            logging,
-            GetDefaultEncryption(),
-            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
-
-        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
-        request->SetBlocksCount(1);
-
-        auto future = encryptionClient->ZeroBlocks(
-            MakeIntrusive<TCallContext>(),
-            request);
-
-        auto response = future.GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, response.GetError().GetCode());
     }
 
     Y_UNIT_TEST(ShouldHandleRequestsAfterDestroyClient)
@@ -1491,8 +1341,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption(),
-            NProto::EZP_WRITE_ZERO_BLOCKS);
+            GetDefaultEncryption());
 
         trigger = NewPromise<void>();
 

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -181,7 +181,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             auto encryptionClient = CreateSnapshotEncryptionClient(
                 testClient,
                 logging,
-                encryptionDesc);
+                encryptionDesc,
+                NProto::EZP_WRITE_ZERO_BLOCKS);
 
             auto mountResponse = MountVolume(*encryptionClient);
             UNIT_ASSERT(!HasError(mountResponse));
@@ -229,7 +230,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             auto encryptionClient1 = CreateSnapshotEncryptionClient(
                 testClient,
                 logging,
-                encryptionDesc);
+                encryptionDesc,
+                NProto::EZP_WRITE_ZERO_BLOCKS);
 
             auto mountResponse1 = MountVolume(*encryptionClient1);
             UNIT_ASSERT(!HasError(mountResponse1));
@@ -237,7 +239,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             auto encryptionClient2 = CreateSnapshotEncryptionClient(
                 encryptionClient1,
                 logging,
-                encryptionDesc);
+                encryptionDesc,
+                NProto::EZP_WRITE_ZERO_BLOCKS);
 
             auto mountResponse2 = MountVolume(*encryptionClient2);
             UNIT_ASSERT(!HasError(mountResponse2));
@@ -534,81 +537,126 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         }
     }
 
-    Y_UNIT_TEST(ShouldForwardZeroBlocksInSnapshotEncryptionClient)
+    Y_UNIT_TEST(ShouldWriteZeroBlocksInSnapshotEncryptionClient)
     {
         auto logging = CreateLoggingService("console");
+        size_t blockSize = 8;
+        size_t storageBlocksCount = 16;
+
+        TVector<TString> storageBlocks(Reserve(storageBlocksCount));
+        for (size_t i = 0; i < storageBlocksCount; ++i) {
+            storageBlocks.emplace_back(blockSize, '1');
+        }
+
         auto testClient = std::make_shared<TTestService>();
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption());
+            GetDefaultEncryption(),
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
 
-        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
-        request->MutableHeaders()->SetClientId("testClientId");
-        request->SetDiskId("testDiskId");
-        request->SetStartIndex(1);
-        request->SetBlocksCount(6);
-        request->SetFlags(42);
-        request->SetSessionId("testSessionId");
+        auto zRequest = std::make_shared<NProto::TZeroBlocksRequest>();
+        zRequest->MutableHeaders()->SetClientId("testClientId");
+        zRequest->SetDiskId("testDiskId");
+        zRequest->SetStartIndex(1);
+        zRequest->SetBlocksCount(6);
+        zRequest->SetFlags(42);
+        zRequest->SetSessionId("testSessionId");
         UNIT_ASSERT_VALUES_EQUAL(
             6,
             GetFieldCount<NProto::TZeroBlocksRequest>());
 
-        NProto::TZeroBlocksResponse zResponse;
-        zResponse.MutableError()->SetMessage("testMessage");
-        zResponse.MutableDeprecatedTrace()->SetRequestStartTime(42);
-        zResponse.MutableHeaders()->MutableTrace()->SetRequestStartTime(42);
-        zResponse.SetDeprecatedThrottlerDelay(13);
-        zResponse.MutableHeaders()->MutableThrottler()->SetDelay(13);
+        NProto::TWriteBlocksLocalResponse wResponse;
+        wResponse.MutableError()->SetMessage("testMessage");
+        wResponse.MutableDeprecatedTrace()->SetRequestStartTime(42);
+        wResponse.MutableHeaders()->MutableTrace()->SetRequestStartTime(42);
+        wResponse.SetDeprecatedThrottlerDelay(13);
+        wResponse.MutableHeaders()->MutableThrottler()->SetDelay(13);
 
-        size_t requestsCount = 0;
-        testClient->ZeroBlocksHandler =
-            [&] (std::shared_ptr<NProto::TZeroBlocksRequest> zRequest) {
-                ++requestsCount;
+        testClient->MountVolumeHandler =
+            [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
+                const auto& spec = request->GetEncryptionSpec();
+                UNIT_ASSERT(GetDefaultEncryption().GetMode() == spec.GetMode());
                 UNIT_ASSERT_VALUES_EQUAL(
-                    request->MutableHeaders()->GetClientId(),
-                    zRequest->MutableHeaders()->GetClientId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    request->GetDiskId(),
-                    zRequest->GetDiskId());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    request->GetStartIndex(),
-                    zRequest->GetStartIndex());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    request->GetBlocksCount(),
-                    zRequest->GetBlocksCount());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    request->GetFlags(),
-                    zRequest->GetFlags());
-                UNIT_ASSERT_VALUES_EQUAL(
-                    request->GetSessionId(),
-                    zRequest->GetSessionId());
+                    GetDefaultEncryption().GetKeyHash(),
+                    spec.GetKeyHash());
 
-                return MakeFuture(zResponse);
+                NProto::TMountVolumeResponse response;
+                response.MutableVolume()->SetBlockSize(blockSize);
+                return MakeFuture(std::move(response));
             };
+
+        testClient->WriteBlocksLocalHandler =
+            [&] (std::shared_ptr<NProto::TWriteBlocksLocalRequest> wRequest) {
+                auto guard = wRequest->Sglist.Acquire();
+                UNIT_ASSERT(guard);
+                const auto& sglist = guard.Get();
+
+                for (size_t i = 0; i < sglist.size(); ++i) {
+                    size_t n = i + wRequest->GetStartIndex();
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        storageBlocks[n].size(),
+                        sglist[i].Size());
+                    auto* dst = const_cast<char*>(storageBlocks[n].data());
+                    auto* src = sglist[i].Data();
+                    memcpy(dst, src, sglist[i].Size());
+                }
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->MutableHeaders()->GetClientId(),
+                    wRequest->MutableHeaders()->GetClientId());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetDiskId(),
+                    wRequest->GetDiskId());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetStartIndex(),
+                    wRequest->GetStartIndex());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetFlags(),
+                    wRequest->GetFlags());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetSessionId(),
+                    wRequest->GetSessionId());
+
+                return MakeFuture(wResponse);
+            };
+
+        auto mountResponse = MountVolume(*encryptionClient);
+        UNIT_ASSERT(!HasError(mountResponse));
 
         auto future = encryptionClient->ZeroBlocks(
             MakeIntrusive<TCallContext>(),
-            request);
-        auto response = future.GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT(!HasError(response));
+            zRequest);
+        auto zResponse = future.GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT(!HasError(zResponse));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            zResponse.GetError().GetMessage(),
-            response.GetError().GetMessage());
+            wResponse.GetError().GetMessage(),
+            zResponse.GetError().GetMessage());
         UNIT_ASSERT_VALUES_EQUAL(
-            zResponse.GetDeprecatedTrace().GetRequestStartTime(),
-            response.GetDeprecatedTrace().GetRequestStartTime());
+            wResponse.GetDeprecatedTrace().GetRequestStartTime(),
+            zResponse.GetDeprecatedTrace().GetRequestStartTime());
         UNIT_ASSERT_VALUES_EQUAL(
-            zResponse.GetHeaders().GetTrace().GetRequestStartTime(),
-            response.GetHeaders().GetTrace().GetRequestStartTime());
+            wResponse.GetHeaders().GetTrace().GetRequestStartTime(),
+            zResponse.GetHeaders().GetTrace().GetRequestStartTime());
         UNIT_ASSERT_VALUES_EQUAL(
-            zResponse.GetDeprecatedThrottlerDelay(),
-            response.GetDeprecatedThrottlerDelay());
+            wResponse.GetDeprecatedThrottlerDelay(),
+            zResponse.GetDeprecatedThrottlerDelay());
         UNIT_ASSERT_VALUES_EQUAL(
-            zResponse.GetHeaders().GetThrottler().GetDelay(),
-            response.GetHeaders().GetThrottler().GetDelay());
-        UNIT_ASSERT_VALUES_EQUAL(1, requestsCount);
+            wResponse.GetHeaders().GetThrottler().GetDelay(),
+            zResponse.GetHeaders().GetThrottler().GetDelay());
+
+        for (size_t i = 0; i < storageBlocksCount; ++i) {
+            TBlockDataRef block(storageBlocks[i].data(), storageBlocks[i].size());
+
+            if (zRequest->GetStartIndex() <= i &&
+                i < zRequest->GetStartIndex() + zRequest->GetBlocksCount())
+            {
+                UNIT_ASSERT(BlockFilledByValue(block, 0));
+            } else {
+                UNIT_ASSERT(BlockFilledByValue(block, '1'));
+            }
+        }
     }
 
     Y_UNIT_TEST(ShouldPropagateZeroBlocksErrorInSnapshotEncryptionClient)
@@ -618,7 +666,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption());
+            GetDefaultEncryption(),
+            NProto::EZP_WRITE_ZERO_BLOCKS);
 
         testClient->ZeroBlocksHandler =
             [] (std::shared_ptr<NProto::TZeroBlocksRequest>) {
@@ -1143,7 +1192,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption());
+            GetDefaultEncryption(),
+            NProto::EZP_WRITE_ZERO_BLOCKS);
 
         auto ctx = MakeIntrusive<TCallContext>();
         auto request = std::make_shared<NProto::TReadBlocksRequest>();
@@ -1194,7 +1244,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption());
+            GetDefaultEncryption(),
+            NProto::EZP_WRITE_ZERO_BLOCKS);
 
         auto blocksCount = 4 * 8;
 
@@ -1238,7 +1289,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         auto encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption());
+            GetDefaultEncryption(),
+            NProto::EZP_WRITE_ZERO_BLOCKS);
 
         auto request = std::make_shared<NProto::TZeroBlocksRequest>();
         request->SetBlocksCount(1);
@@ -1267,6 +1319,27 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             "not mounted",
             response.GetError().GetMessage());
         UNIT_ASSERT_VALUES_EQUAL(1, requestsCount);
+    }
+
+    Y_UNIT_TEST(SnapshotEncryptionClientShouldRejectZeroBlocksBeforeMount)
+    {
+        auto logging = CreateLoggingService("console");
+        auto testClient = std::make_shared<TTestService>();
+        auto encryptionClient = CreateSnapshotEncryptionClient(
+            testClient,
+            logging,
+            GetDefaultEncryption(),
+            NProto::EZP_WRITE_ENCRYPTED_ZEROS);
+
+        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
+        request->SetBlocksCount(1);
+
+        auto future = encryptionClient->ZeroBlocks(
+            MakeIntrusive<TCallContext>(),
+            request);
+
+        auto response = future.GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL(E_INVALID_STATE, response.GetError().GetCode());
     }
 
     Y_UNIT_TEST(ShouldHandleRequestsAfterDestroyClient)
@@ -1418,7 +1491,8 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         encryptionClient = CreateSnapshotEncryptionClient(
             testClient,
             logging,
-            GetDefaultEncryption());
+            GetDefaultEncryption(),
+            NProto::EZP_WRITE_ZERO_BLOCKS);
 
         trigger = NewPromise<void>();
 

--- a/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client_ut.cpp
@@ -534,6 +534,125 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldWriteZeroBlocksInSnapshotEncryptionClient)
+    {
+        auto logging = CreateLoggingService("console");
+        size_t blockSize = 8;
+        size_t storageBlocksCount = 16;
+
+        TVector<TString> storageBlocks(Reserve(storageBlocksCount));
+        for (size_t i = 0; i < storageBlocksCount; ++i) {
+            storageBlocks.emplace_back(blockSize, '1');
+        }
+
+        auto testClient = std::make_shared<TTestService>();
+        auto encryptionClient = CreateSnapshotEncryptionClient(
+            testClient,
+            logging,
+            GetDefaultEncryption());
+
+        auto zRequest = std::make_shared<NProto::TZeroBlocksRequest>();
+        zRequest->MutableHeaders()->SetClientId("testClientId");
+        zRequest->SetDiskId("testDiskId");
+        zRequest->SetStartIndex(1);
+        zRequest->SetBlocksCount(6);
+        zRequest->SetFlags(42);
+        zRequest->SetSessionId("testSessionId");
+        UNIT_ASSERT_VALUES_EQUAL(
+            6,
+            GetFieldCount<NProto::TZeroBlocksRequest>());
+
+        NProto::TWriteBlocksLocalResponse wResponse;
+        wResponse.MutableError()->SetMessage("testMessage");
+        wResponse.MutableDeprecatedTrace()->SetRequestStartTime(42);
+        wResponse.MutableHeaders()->MutableTrace()->SetRequestStartTime(42);
+        wResponse.SetDeprecatedThrottlerDelay(13);
+        wResponse.MutableHeaders()->MutableThrottler()->SetDelay(13);
+
+        testClient->MountVolumeHandler =
+            [&] (std::shared_ptr<NProto::TMountVolumeRequest> request) {
+                const auto& spec = request->GetEncryptionSpec();
+                UNIT_ASSERT(GetDefaultEncryption().GetMode() == spec.GetMode());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    GetDefaultEncryption().GetKeyHash(),
+                    spec.GetKeyHash());
+
+                NProto::TMountVolumeResponse response;
+                response.MutableVolume()->SetBlockSize(blockSize);
+                return MakeFuture(std::move(response));
+            };
+
+        testClient->WriteBlocksLocalHandler =
+            [&] (std::shared_ptr<NProto::TWriteBlocksLocalRequest> wRequest) {
+                auto guard = wRequest->Sglist.Acquire();
+                UNIT_ASSERT(guard);
+                const auto& sglist = guard.Get();
+
+                for (size_t i = 0; i < sglist.size(); ++i) {
+                    size_t n = i + wRequest->GetStartIndex();
+                    UNIT_ASSERT_VALUES_EQUAL(storageBlocks[n].size(), sglist[i].Size());
+                    auto* dst = const_cast<char*>(storageBlocks[n].data());
+                    auto* src = sglist[i].Data();
+                    memcpy(dst, src, sglist[i].Size());
+                }
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->MutableHeaders()->GetClientId(),
+                    wRequest->MutableHeaders()->GetClientId());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetDiskId(),
+                    wRequest->GetDiskId());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetStartIndex(),
+                    wRequest->GetStartIndex());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetFlags(),
+                    wRequest->GetFlags());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    zRequest->GetSessionId(),
+                    wRequest->GetSessionId());
+
+                return MakeFuture(wResponse);
+            };
+
+        auto mountResponse = MountVolume(*encryptionClient);
+        UNIT_ASSERT(!HasError(mountResponse));
+
+        auto future = encryptionClient->ZeroBlocks(
+            MakeIntrusive<TCallContext>(),
+            zRequest);
+        auto zResponse = future.GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT(!HasError(zResponse));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            wResponse.GetError().GetMessage(),
+            zResponse.GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(
+            wResponse.GetDeprecatedTrace().GetRequestStartTime(),
+            zResponse.GetDeprecatedTrace().GetRequestStartTime());
+        UNIT_ASSERT_VALUES_EQUAL(
+            wResponse.GetHeaders().GetTrace().GetRequestStartTime(),
+            zResponse.GetHeaders().GetTrace().GetRequestStartTime());
+        UNIT_ASSERT_VALUES_EQUAL(
+            wResponse.GetDeprecatedThrottlerDelay(),
+            zResponse.GetDeprecatedThrottlerDelay());
+        UNIT_ASSERT_VALUES_EQUAL(
+            wResponse.GetHeaders().GetThrottler().GetDelay(),
+            zResponse.GetHeaders().GetThrottler().GetDelay());
+
+        for (size_t i = 0; i < storageBlocksCount; ++i) {
+            TBlockDataRef block(storageBlocks[i].data(), storageBlocks[i].size());
+
+            if (zRequest->GetStartIndex() <= i &&
+                i < zRequest->GetStartIndex() + zRequest->GetBlocksCount())
+            {
+                UNIT_ASSERT(BlockFilledByValue(block, 0));
+            } else {
+                UNIT_ASSERT(BlockFilledByValue(block, '1'));
+            }
+        }
+    }
+
     Y_UNIT_TEST(ShouldNotEncryptInZeroBlock)
     {
         auto logging = CreateLoggingService("console");
@@ -1124,7 +1243,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
         }
     }
 
-    Y_UNIT_TEST(SnapshotEncryptionClientShouldDenyZeroBlocksRequests)
+    Y_UNIT_TEST(SnapshotEncryptionClientShouldRejectZeroBlocksBeforeMount)
     {
         auto logging = CreateLoggingService("console");
         auto encryptionClient = CreateSnapshotEncryptionClient(
@@ -1132,13 +1251,15 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
             logging,
             GetDefaultEncryption());
 
+        auto request = std::make_shared<NProto::TZeroBlocksRequest>();
+        request->SetBlocksCount(1);
+
         auto future = encryptionClient->ZeroBlocks(
             MakeIntrusive<TCallContext>(),
-            std::make_shared<NProto::TZeroBlocksRequest>());
+            request);
 
         auto response = future.GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT(HasError(response)
-            && response.GetError().GetCode() == E_NOT_IMPLEMENTED);
+        UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, response.GetError().GetCode());
     }
 
     Y_UNIT_TEST(ShouldHandleRequestsAfterDestroyClient)
@@ -1324,7 +1445,7 @@ Y_UNIT_TEST_SUITE(TEncryptionClientTest)
                 MakeIntrusive<TCallContext>(),
                 zeroRequest);
             auto zeroResponse = zeroFuture.GetValue(TDuration::Seconds(5));
-            UNIT_ASSERT_VALUES_EQUAL(E_NOT_IMPLEMENTED, zeroResponse.GetError().GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, zeroResponse.GetError().GetCode());
 
             encryptionClient.reset();
             trigger.SetValue();


### PR DESCRIPTION
### Problem

Creating a disk from an encrypted snapshot could fail when the restore flow issued `ZeroBlocks` through `TSnapshotEncryptionClient`.

Example error:

```text
commited fatal error for disks.CreateDiskFromSnapshot with task id 8de84cb7-bdda-48b5-a240-08d6b1accd88: Detailed error, Details=<nil>, Silent=false: rpc error: code = Unknown desc = E_NOT_IMPLEMENTED ZeroBlocks requests not supported by snapshot encryption client
```

There is no linked issue/ticket for this fix.

### Solution

Support `ZeroBlocks` in `TSnapshotEncryptionClient` by forwarding the request to the underlying blockstore client.

The snapshot encryption client does not encrypt writes or decrypt reads. Its read path only masks blocks marked by `UnencryptedBlockMask`. Because of that, forwarding native `ZeroBlocks` is preferable to materializing zero-filled `WriteBlocksLocal` requests: it preserves snapshot sparseness and keeps the underlying storage semantics for zeroed/unwritten blocks.

### Tests

```bash
./ya make -tt cloud/blockstore/libs/encryption/ut
```