### PR TITLE
issue-5894: KikimrFileStore - SideChannel with a stub impl

### DIFF
--- a/cloud/filestore/config/vhost.proto
+++ b/cloud/filestore/config/vhost.proto
@@ -18,6 +18,14 @@ message TServiceEndpoint
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum ESideChannelType
+{
+    SCT_NONE = 0;
+    SCT_TCP = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 message TVhostServiceConfig
 {
     // Endpoints mapping.
@@ -97,6 +105,10 @@ message TVhostServiceConfig
     // cached state instead of expanding file mappings.
     // Value 0 disables the limit and uses a permissive stub limiter.
     optional uint64 FileMapMemoryLimit = 23;
+
+    // Whether to use a direct service <-> shard side-channel for
+    // latency-critical requests instead of actor system.
+    optional ESideChannelType SideChannelType = 24;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -168,7 +168,10 @@ void TBootstrapServer::InitLWTrace()
 void TBootstrapServer::InitKikimrService()
 {
     Y_ABORT_UNLESS(ActorSystem, "Actor system MUST be initialized to create kikimr filestore");
-    Service = CreateKikimrFileStore(ActorSystem, 0 /* permanentActorCount */);
+    Service = CreateKikimrFileStore(
+        ActorSystem,
+        nullptr /* sideChannel */,
+        0 /* permanentActorCount */);
 
     Service = CreateAuthService(
         std::move(Service),

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -27,6 +27,7 @@
 #include <cloud/filestore/libs/service/service_auth.h>
 #include <cloud/filestore/libs/service_kikimr/auth_provider_kikimr.h>
 #include <cloud/filestore/libs/service_kikimr/service.h>
+#include <cloud/filestore/libs/service_kikimr/side_channel.h>
 #include <cloud/filestore/libs/service_local/config.h>
 #include <cloud/filestore/libs/service_local/service.h>
 #include <cloud/filestore/libs/service_null/service.h>
@@ -152,6 +153,7 @@ public:
         const TString& name,
         const NProto::TClientConfig& config,
         NDaemon::EServiceKind kind,
+        NProto::ESideChannelType sideChannelType,
         ui32 permanentActorCount)
     {
         auto clientConfig = std::make_shared<NClient::TClientConfig>(config);
@@ -163,8 +165,10 @@ public:
             }
 
             case NDaemon::EServiceKind::Kikimr: {
-                fileStore =
-                    CreateKikimrFileStore(ActorSystem, permanentActorCount);
+                fileStore = CreateKikimrFileStore(
+                    ActorSystem,
+                    CreateSideChannel(sideChannelType),
+                    permanentActorCount);
                 break;
             }
 
@@ -211,6 +215,17 @@ private:
 
         Endpoints.emplace(name, std::move(client));
         return true;
+    }
+
+    static ISideChannelPtr CreateSideChannel(
+        NProto::ESideChannelType sideChannelType)
+    {
+        switch (sideChannelType) {
+            case NProto::SCT_NONE: return nullptr;
+            case NProto::SCT_TCP: return CreateTCPSideChannel();
+        }
+
+        Y_ABORT("sct=%d", static_cast<int>(sideChannelType));
     }
 };
 
@@ -448,6 +463,7 @@ void TBootstrapVhost::InitEndpoints()
             endpoint.GetName(),
             endpoint.GetClientConfig(),
             Configs->Options->Service,
+            serviceConfig.GetSideChannelType(),
             serviceConfig.GetPermanentActorCount());
 
         if (inserted) {

--- a/cloud/filestore/libs/endpoint_vhost/config.cpp
+++ b/cloud/filestore/libs/endpoint_vhost/config.cpp
@@ -45,6 +45,9 @@ static constexpr int MODE0660 = S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR;
     xxx(DirectoryHandlesStoragePath,                TString,    ""            )\
     xxx(DirectoryHandlesInitialDataSize,            ui64,       16_MB         )\
     xxx(PermanentActorCount,                        ui32,       0             )\
+    xxx(SideChannelType,                                                       \
+            NProto::ESideChannelType,                                          \
+            NProto::SCT_NONE                                                  )\
     xxx(DirectoryHandlesMaxDataAreaStepSize,        ui64,       1_GB          )\
     xxx(FileMapMemoryLimit,                         ui64,       0             )\
 // VHOST_SERVICE_CONFIG
@@ -100,6 +103,25 @@ void DumpImpl(const TVector<T>& t, IOutputStream& os)
 {
     for (const auto& v: t) {
         os << v;
+    }
+}
+template <>
+void DumpImpl(
+    const NProto::ESideChannelType& value,
+    IOutputStream& os)
+{
+    switch (value) {
+        case NProto::SCT_NONE:
+            os << "SCT_NONE";
+            break;
+        case NProto::SCT_TCP:
+            os << "SCT_TCP";
+            break;
+        default:
+            os << "(Unknown ESideChannelType value "
+                << static_cast<int>(value)
+                << ")";
+            break;
     }
 }
 

--- a/cloud/filestore/libs/endpoint_vhost/config.h
+++ b/cloud/filestore/libs/endpoint_vhost/config.h
@@ -47,6 +47,7 @@ public:
     ui64 GetDirectoryHandlesMaxDataAreaStepSize() const;
 
     ui32 GetPermanentActorCount() const;
+    NProto::ESideChannelType GetSideChannelType() const;
     ui64 GetFileMapMemoryLimit() const;
 
     void Dump(IOutputStream& out) const;

--- a/cloud/filestore/libs/service_kikimr/public.h
+++ b/cloud/filestore/libs/service_kikimr/public.h
@@ -1,1 +1,12 @@
 #pragma once
+
+#include <memory>
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class ISideChannel;
+using ISideChannelPtr = std::shared_ptr<ISideChannel>;
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/service.cpp
+++ b/cloud/filestore/libs/service_kikimr/service.cpp
@@ -3,6 +3,7 @@
 #include "handler_actor.h"
 #include "methods.h"
 #include "request_actor.h"
+#include "side_channel.h"
 #include "stream_request_actor.h"
 
 #include <cloud/filestore/libs/service/context.h>
@@ -29,6 +30,8 @@ private:
     const IActorSystemPtr ActorSystem;
     TLog Log;
 
+    ISideChannelPtr SideChannel;
+
     using THandlerPtr = std::shared_ptr<THandler>;
     TVector<THandlerPtr> Handlers;
     std::atomic<ui32> Selector{0};
@@ -36,9 +39,11 @@ private:
 public:
     TKikimrFileStore(
             IActorSystemPtr actorSystem,
+            ISideChannelPtr sideChannel,
             ui32 permanentActorCount)
         : ActorSystem(std::move(actorSystem))
         , Log(ActorSystem->CreateLog("KIKIMR_SERVICE"))
+        , SideChannel(std::move(sideChannel))
     {
         Handlers.resize(permanentActorCount);
     }
@@ -121,7 +126,7 @@ public:
 
 private:
     template <typename T>
-    void ExecuteRequest(
+    void ExecuteRequestImpl(
         TCallContextPtr callContext,
         std::shared_ptr<typename T::TRequest> request,
         TPromise<typename T::TResponse> response)
@@ -142,6 +147,18 @@ private:
             std::move(callContext),
             std::move(request),
             std::move(response)));
+    }
+
+    template <typename T>
+    void ExecuteRequest(
+        TCallContextPtr callContext,
+        std::shared_ptr<typename T::TRequest> request,
+        TPromise<typename T::TResponse> response)
+    {
+        ExecuteRequestImpl<T>(
+            std::move(callContext),
+            std::move(request),
+            std::move(response));
     }
 
     template<>
@@ -181,6 +198,54 @@ private:
             std::move(request),
             std::move(responseHandler)));
     }
+
+    template <typename T>
+    void ExecuteRequestWithSideChannel(
+        TCallContextPtr callContext,
+        std::shared_ptr<typename T::TRequest> request,
+        TPromise<typename T::TResponse> response)
+    {
+        if (SideChannel) {
+            if (SideChannel->ExecuteRequest(callContext, request, response)) {
+                return;
+            }
+
+            response.GetFuture().Subscribe(
+                [sc = SideChannel] (TFuture<typename T::TResponse> f) {
+                    const auto& i = f.GetValue().GetHeaders().GetBackendInfo();
+                    sc->Update(i);
+                });
+        }
+
+        ExecuteRequestImpl<T>(
+            std::move(callContext),
+            std::move(request),
+            std::move(response));
+    }
+
+    template <>
+    void ExecuteRequest<TReadDataServiceMethod>(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TReadDataRequest> request,
+        TPromise<NProto::TReadDataResponse> response)
+    {
+        ExecuteRequestWithSideChannel<TReadDataServiceMethod>(
+            std::move(callContext),
+            std::move(request),
+            std::move(response));
+    }
+
+    template <>
+    void ExecuteRequest<TWriteDataServiceMethod>(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteDataRequest> request,
+        TPromise<NProto::TWriteDataResponse> response)
+    {
+        ExecuteRequestWithSideChannel<TWriteDataServiceMethod>(
+            std::move(callContext),
+            std::move(request),
+            std::move(response));
+    }
 };
 
 }   // namespace
@@ -189,10 +254,12 @@ private:
 
 IFileStoreServicePtr CreateKikimrFileStore(
     IActorSystemPtr actorSystem,
+    ISideChannelPtr sideChannel,
     ui32 permanentActorCount)
 {
     return std::make_shared<TKikimrFileStore>(
         std::move(actorSystem),
+        std::move(sideChannel),
         permanentActorCount);
 }
 

--- a/cloud/filestore/libs/service_kikimr/service.h
+++ b/cloud/filestore/libs/service_kikimr/service.h
@@ -12,6 +12,7 @@ namespace NCloud::NFileStore {
 
 IFileStoreServicePtr CreateKikimrFileStore(
     IActorSystemPtr actorSystem,
+    ISideChannelPtr sideChannel,
     ui32 permanentActorCount);
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/service_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/service_ut.cpp
@@ -86,6 +86,7 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
 
         auto service = CreateKikimrFileStore(
             actorSystem,
+            nullptr /* sideChannel */,
             permanentActorCount);
         service->Start();
 
@@ -123,8 +124,10 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service =
-            CreateKikimrFileStore(actorSystem, 0 /* permanentActorCount */);
+        auto service = CreateKikimrFileStore(
+            actorSystem,
+            nullptr /* sideChannel */,
+            0 /* permanentActorCount */);
         service->Start();
 
         {
@@ -179,8 +182,10 @@ Y_UNIT_TEST_SUITE(TKikimrFileStore)
         auto actorSystem = MakeIntrusive<TTestActorSystem>();
         actorSystem->RegisterTestService(std::move(serviceActor));
 
-        auto service =
-            CreateKikimrFileStore(actorSystem, 0 /* permanentActorCount */);
+        auto service = CreateKikimrFileStore(
+            actorSystem,
+            nullptr /* sideChannel */,
+            0 /* permanentActorCount */);
         service->Start();
 
         auto context = MakeIntrusive<TCallContext>();

--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -1,0 +1,52 @@
+#include "side_channel.h"
+
+namespace NCloud::NFileStore {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTCPSideChannel: public ISideChannel
+{
+    bool ExecuteRequest(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TReadDataRequest> request,
+        NThreading::TPromise<NProto::TReadDataResponse> response) override
+    {
+        Y_UNUSED(callContext, request, response);
+
+        // TODO(#5894): impl
+
+        return false;
+    }
+
+    virtual bool ExecuteRequest(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteDataRequest> request,
+        NThreading::TPromise<NProto::TWriteDataResponse> response) override
+    {
+        Y_UNUSED(callContext, request, response);
+
+        // TODO(#5894): impl
+
+        return false;
+    }
+
+    void Update(const NProto::TBackendInfo& backendInfo) override
+    {
+        Y_UNUSED(backendInfo);
+
+        // TODO(#5894): impl
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ISideChannelPtr CreateTCPSideChannel()
+{
+    return std::make_shared<TTCPSideChannel>();
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/side_channel.h
+++ b/cloud/filestore/libs/service_kikimr/side_channel.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "public.h"
+
+#include <cloud/filestore/libs/service/context.h>
+
+#include <cloud/filestore/public/api/protos/headers.pb.h>
+
+namespace NCloud::NFileStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class ISideChannel
+{
+public:
+    virtual ~ISideChannel() = default;
+
+public:
+    virtual bool ExecuteRequest(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TReadDataRequest> request,
+        NThreading::TPromise<NProto::TReadDataResponse> response) = 0;
+
+    virtual bool ExecuteRequest(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteDataRequest> request,
+        NThreading::TPromise<NProto::TWriteDataResponse> response) = 0;
+
+    virtual void Update(const NProto::TBackendInfo& backendInfo) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+ISideChannelPtr CreateTCPSideChannel();
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/ya.make
+++ b/cloud/filestore/libs/service_kikimr/ya.make
@@ -6,6 +6,7 @@ SRCS(
     methods.cpp
     request_actor.cpp
     service.cpp
+    side_channel.cpp
     stream_request_actor.cpp
 )
 


### PR DESCRIPTION
### Notes
Implementing the ability to send read and write requests to the filesystem storage layer (in our case right now - to the tablets) bypassing the actorsystem in filestore-vhost. To make the review process easier, publishing this integration with stub code (hidden under a config enum) in TCPSideChannel instead of the actual implementation now.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
