### PR TITLE
Eternal-load: add LogTag to distingush log messages between instances for multi-file tests

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -49,7 +49,9 @@ private:
 
     ITestScenarioPtr CreateTestScenario(
         IConfigHolderPtr config,
+        const TString& logTag,
         const TLog& log) const;
+
     TTestExecutorSettings ConfigureTest() const;
     int RunTest();
 
@@ -124,25 +126,28 @@ void TTest::DumpConfiguration()
 
 ITestScenarioPtr TTest::CreateTestScenario(
     IConfigHolderPtr config,
+    const TString& logTag,
     const TLog& log) const
 {
     switch (Options->Scenario) {
         case EScenario::Aligned:
-            return CreateAlignedTestScenario(std::move(config), log);
+            return CreateAlignedTestScenario(std::move(config), logTag, log);
 
         case EScenario::Unaligned:
-            return CreateUnalignedTestScenario(std::move(config), log);
+            return CreateUnalignedTestScenario(std::move(config), logTag, log);
 
         case EScenario::Sequential:
             return CreateSimpleTestScenario(
                 ESimpleTestScenarioMode::Sequential,
                 std::move(config),
+                logTag,
                 log);
 
         case EScenario::Random:
             return CreateSimpleTestScenario(
                 ESimpleTestScenarioMode::Random,
                 std::move(config),
+                logTag,
                 log);
 
         default:
@@ -176,7 +181,15 @@ TTestExecutorSettings TTest::ConfigureTest() const
             Y_ABORT("Unsupported EIoEngine value %d", Options->Engine);
     }
 
-    TVector<IConfigHolderPtr> testConfigs;
+    auto addTestScenario =
+        [&](const IConfigHolderPtr& config, const TString& logTag)
+    {
+        settings.TestScenarios.push_back(
+            {.TestScenario = CreateTestScenario(config, logTag, log),
+             .FilePath = config->GetConfig().GetFilePath(),
+             .FileSize = config->GetConfig().GetFileSize()});
+    };
+
     const auto& config = ConfigHolder->GetConfig();
 
     if (config.GetTestCount()) {
@@ -197,21 +210,14 @@ TTestExecutorSettings TTest::ConfigureTest() const
             IConfigHolderPtr testConfig = ConfigHolder->Clone();
             testConfig->GetConfig().SetFilePath(
                 Sprintf("%s%u%s", str1.c_str(), i, str2.c_str()));
-            testConfigs.push_back(std::move(testConfig));
+            addTestScenario(testConfig, Sprintf("[f:%u]", i));
         }
     } else {
         STORAGE_INFO("Using test file: " << config.GetFilePath());
-        testConfigs.push_back(ConfigHolder);
+        addTestScenario(ConfigHolder, "");
     }
 
     STORAGE_INFO("Using test file size: " << config.GetFileSize());
-
-    for (const auto& testConfig: testConfigs) {
-        settings.TestScenarios.push_back(
-            {.TestScenario = CreateTestScenario(testConfig, log),
-             .FilePath = testConfig->GetConfig().GetFilePath(),
-             .FileSize = testConfig->GetConfig().GetFileSize()});
-    }
 
     settings.RunInCallbacks = Options->RunInCallbacks;
     STORAGE_INFO(

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.cpp
@@ -167,8 +167,11 @@ private:
     };
 
 public:
-    TAlignedTestScenario(IConfigHolderPtr configHolder, const TLog& log)
-        : TTestScenarioBase({}, std::move(configHolder), log)
+    TAlignedTestScenario(
+        IConfigHolderPtr configHolder,
+        const TString& logTag,
+        const TLog& log)
+        : TTestScenarioBase({}, std::move(configHolder), logTag, log)
     {
         auto& config = ConfigHolder->GetConfig();
         for (ui16 i = 0; i < config.GetIoDepth(); ++i) {
@@ -220,8 +223,8 @@ void TAlignedTestScenario::OnResponse(
     const auto d = now - startTs;
     if (d > SlowRequestThreshold) {
         STORAGE_WARN(
-            "Slow " << reqType << " request: "
-                    << "range=" << rangeIdx << ", duration=" << d);
+            LogTag << " Slow " << reqType << " request: "
+                   << "range=" << rangeIdx << ", duration=" << d);
     }
 }
 
@@ -258,8 +261,8 @@ void TAlignedTestScenario::DoReadRequest(ui16 rangeIdx, IService& service)
             {
                 service.Fail(
                     TStringBuilder()
-                    << "[" << rangeIdx << "] Wrong data in block " << blockIdx
-                    << " expected RequestNumber " << expected
+                    << LogTag << "[" << rangeIdx << "] Wrong data in block "
+                    << blockIdx << " expected RequestNumber " << expected
                     << " actual TBlockData " << blockData);
                 return;
             }
@@ -311,10 +314,11 @@ void TAlignedTestScenario::DoWriteRequest(ui16 rangeIdx, IService& service)
 
 ITestScenarioPtr CreateAlignedTestScenario(
     IConfigHolderPtr configHolder,
+    const TString& logTag,
     const TLog& log)
 {
     return ITestScenarioPtr(
-        new TAlignedTestScenario(std::move(configHolder), log));
+        new TAlignedTestScenario(std::move(configHolder), logTag, log));
 }
 
 }   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/aligned_test_scenario.h
@@ -9,6 +9,7 @@ namespace NCloud::NBlockStore::NTesting {
 
 ITestScenarioPtr CreateAlignedTestScenario(
     IConfigHolderPtr configHolder,
+    const TString& logTag,
     const TLog& log);
 
 }   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/simple_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/simple_test_scenario.cpp
@@ -43,6 +43,7 @@ public:
     TSimpleTestScenario(
         ESimpleTestScenarioMode mode,
         IConfigHolderPtr configHolder,
+        const TString& logTag,
         const TLog& log);
 };
 
@@ -155,8 +156,9 @@ private:
 TSimpleTestScenario::TSimpleTestScenario(
         ESimpleTestScenarioMode mode,
         IConfigHolderPtr configHolder,
+        const TString& logTag,
         const TLog& log)
-    : TTestScenarioBase(BaseConfig, std::move(configHolder), log)
+    : TTestScenarioBase(BaseConfig, std::move(configHolder), logTag, log)
     , Mode(mode)
 {
     auto& config = ConfigHolder->GetConfig();
@@ -172,10 +174,11 @@ TSimpleTestScenario::TSimpleTestScenario(
 ITestScenarioPtr CreateSimpleTestScenario(
     ESimpleTestScenarioMode mode,
     IConfigHolderPtr configHolder,
+    const TString& logTag,
     const TLog& log)
 {
     return ITestScenarioPtr(
-        new TSimpleTestScenario(mode, std::move(configHolder), log));
+        new TSimpleTestScenario(mode, std::move(configHolder), logTag, log));
 }
 
 }   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/simple_test_scenario.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/simple_test_scenario.h
@@ -18,6 +18,7 @@ enum class ESimpleTestScenarioMode
 ITestScenarioPtr CreateSimpleTestScenario(
     ESimpleTestScenarioMode mode,
     IConfigHolderPtr configHolder,
+    const TString& logTag,
     const TLog& log);
 
 }   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
@@ -20,8 +20,10 @@ namespace NCloud::NBlockStore::NTesting {
 TTestScenarioBase::TTestScenarioBase(
         const TTestScenarioBaseConfig& baseConfig,
         IConfigHolderPtr configHolder,
+        const TString& logTag,
         const TLog& log)
     : ConfigHolder(std::move(configHolder))
+    , LogTag(logTag)
     , Log(log)
     , TestStartTime(Now())
     , MinReadByteCount(baseConfig.DefaultMinReadByteCount)

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.h
@@ -28,6 +28,7 @@ class TTestScenarioBase: public ITestScenario
 {
 protected:
     IConfigHolderPtr ConfigHolder;
+    const TString LogTag;
     const TLog Log;
 
     ui64 FileSize = 0;
@@ -55,6 +56,7 @@ protected:
     TTestScenarioBase(
         const TTestScenarioBaseConfig& config,
         IConfigHolderPtr configHolder,
+        const TString& logTag,
         const TLog& log);
 
 public:

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
@@ -234,7 +234,10 @@ private:
     bool ShouldValidate = false;
 
 public:
-    TUnalignedTestScenario(IConfigHolderPtr configHolder, const TLog& log);
+    TUnalignedTestScenario(
+        IConfigHolderPtr configHolder,
+        const TString& logTag,
+        const TLog& log);
 
 private:
     ui64 GetNextRegionByteCount(ui64 remainingFileSize) const;
@@ -374,8 +377,9 @@ public:
 
 TUnalignedTestScenario::TUnalignedTestScenario(
         IConfigHolderPtr configHolder,
+        const TString& logTag,
         const TLog& log)
-    : TTestScenarioBase(BaseConfig, std::move(configHolder), log)
+    : TTestScenarioBase(BaseConfig, std::move(configHolder), logTag, log)
 {
     auto& config = ConfigHolder->GetConfig();
     for (ui32 i = 0; i < config.GetIoDepth(); ++i) {
@@ -417,8 +421,8 @@ bool TUnalignedTestScenario::GenerateRegionMetadata()
 
     if (size < minSize) {
         STORAGE_ERROR(
-            "File size " << size << " is less than the minimal allowed size "
-                         << minSize);
+            LogTag << " File size " << size
+                   << " is less than the minimal allowed size " << minSize);
         return false;
     }
 
@@ -455,19 +459,19 @@ bool TUnalignedTestScenario::ValidateRegionMetadata() const
         const auto& metadata = RegionMetadata[i];
         if (metadata.Offset != offset) {
             STORAGE_ERROR(
-                "File format error: region #"
-                << i << " is not contiguous (expected offset " << offset
-                << ", found " << metadata.Offset << ")");
+                LogTag << " File format error: region #" << i
+                       << " is not contiguous (expected offset " << offset
+                       << ", found " << metadata.Offset << ")");
             return false;
         }
         if (metadata.Offset > FileSize ||
             metadata.ByteCount > FileSize - metadata.Offset)
         {
             STORAGE_ERROR(
-                "File format error: region #"
-                << i << " points outside the file (offset " << metadata.Offset
-                << ", size " << metadata.ByteCount << ", file size " << FileSize
-                << ")");
+                LogTag << " File format error: region #" << i
+                       << " points outside the file (offset " << metadata.Offset
+                       << ", size " << metadata.ByteCount << ", file size "
+                       << FileSize << ")");
             return false;
         }
         offset += metadata.ByteCount;
@@ -482,14 +486,14 @@ bool TUnalignedTestScenario::Init(TFileHandle& file)
 
     TFileHeader header;
     if (file.Read(&header, sizeof(TFileHeader)) != sizeof(TFileHeader)) {
-        STORAGE_ERROR("Cannot read file header");
+        STORAGE_ERROR(LogTag << " Cannot read file header");
         return false;
     }
 
     if (header.Magic == TFileHeader::ExpectedMagic) {
         auto actualCrc32 = Crc32c(&header, offsetof(TFileHeader, Crc32));
         if (header.Crc32 != actualCrc32) {
-            STORAGE_ERROR("Header CRC mismatch");
+            STORAGE_ERROR(LogTag << " Header CRC mismatch");
             return false;
         }
 
@@ -498,7 +502,7 @@ bool TUnalignedTestScenario::Init(TFileHandle& file)
             if (file.Read(&metadata, sizeof(TRegionMetadata)) !=
                 sizeof(TRegionMetadata))
             {
-                STORAGE_ERROR("Cannot read test metadata");
+                STORAGE_ERROR(LogTag << " Cannot read test metadata");
                 return false;
             }
         }
@@ -513,7 +517,7 @@ bool TUnalignedTestScenario::Init(TFileHandle& file)
         header.RegionCount = RegionMetadata.size();
         header.Crc32 = Crc32c(&header, offsetof(TFileHeader, Crc32));
         if (file.Write(&header, sizeof(TFileHeader)) != sizeof(TFileHeader)) {
-            STORAGE_ERROR("Cannot write file header");
+            STORAGE_ERROR(LogTag << " Cannot write file header");
             return false;
         }
 
@@ -521,7 +525,7 @@ bool TUnalignedTestScenario::Init(TFileHandle& file)
             if (file.Write(&metadata, sizeof(TRegionMetadata)) !=
                 sizeof(TRegionMetadata))
             {
-                STORAGE_ERROR("Cannot write test metadata");
+                STORAGE_ERROR(LogTag << " Cannot write test metadata");
                 return false;
             }
         }
@@ -530,22 +534,22 @@ bool TUnalignedTestScenario::Init(TFileHandle& file)
 
     if (GetWorkerCount() > RegionMetadata.size()) {
         STORAGE_ERROR(
-            "The number of workers "
-            << GetWorkerCount()
-            << " is greater than the number of regions in the file "
-            << RegionMetadata.size());
+            LogTag << " The number of workers " << GetWorkerCount()
+                   << " is greater than the number of regions in the file "
+                   << RegionMetadata.size());
         return false;
     }
 
     RegionLockedForWriteFlags = TVector<bool>(RegionMetadata.size(), false);
 
-    STORAGE_INFO("File format: " << RegionMetadata.size() << " regions");
+    STORAGE_INFO(
+        LogTag << " File format: " << RegionMetadata.size() << " regions");
 
     for (const auto& metadata: RegionMetadata) {
         if (metadata.NewState.SeqNum != 0) {
             STORAGE_INFO(
-                "Test file contains written data and will be fully validated "
-                "before writing new data");
+                LogTag << " Test file contains written data and will be fully"
+                          " validated before writing new data");
             ShouldValidate = true;
             break;
         }
@@ -572,7 +576,7 @@ void TUnalignedTestScenario::Read(
         if (ShouldValidate) {
             auto offset = ValidationOffset.fetch_add(len);
             if (offset == 0) {
-                STORAGE_INFO("Starting sequential read validation");
+                STORAGE_INFO(LogTag << " Starting sequential read validation");
             }
             if (offset < FileSize) {
                 len = Min(len, FileSize - offset);
@@ -633,7 +637,7 @@ bool TUnalignedTestScenario::Read(
                 Y_ABORT_UNLESS(prev + buffer.size() <= FileSize);
                 if (prev + buffer.size() == FileSize) {
                     ShouldValidate = false;
-                    STORAGE_INFO("Finished sequential read validation");
+                    STORAGE_INFO(LogTag << " Finished sequential read validation");
                 }
             }
         });
@@ -758,7 +762,7 @@ void TUnalignedTestScenario::ValidateReadDataRegion(
             RegionMetadata[regionIndex].Offset + offsetInRegion + offset;
 
         TStringBuilder sb;
-        sb << "Read validation failed";
+        sb << LogTag << " Read validation failed";
         sb << "\nWrong data at file range [" << offsetInFile << ", "
            << offsetInFile + fragment.size() << "], Region: " << regionIndex
            << ", OffsetInRegion: " << offsetInRegion + offset;
@@ -851,8 +855,8 @@ size_t TUnalignedTestScenario::WriteBegin(IService& service)
         };
     } else {
         STORAGE_DEBUG(
-            "Writing to region #"
-            << index << " was interrupted in the previous test run, restoring");
+            LogTag << " Writing to region #" << index
+                   << " was interrupted in the previous test run, restoring");
     }
 
     guard.Release();
@@ -932,10 +936,11 @@ void TUnalignedTestScenario::WriteEnd(IService& service, size_t index)
 
 ITestScenarioPtr CreateUnalignedTestScenario(
     IConfigHolderPtr configHolder,
+    const TString& logTag,
     const TLog& log)
 {
     return ITestScenarioPtr(
-        new TUnalignedTestScenario(std::move(configHolder), log));
+        new TUnalignedTestScenario(std::move(configHolder), logTag, log));
 }
 
 }   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.h
@@ -9,6 +9,7 @@ namespace NCloud::NBlockStore::NTesting {
 
 ITestScenarioPtr CreateUnalignedTestScenario(
     IConfigHolderPtr configHolder,
+    const TString& logTag,
     const TLog& log);
 
 }   // namespace NCloud::NBlockStore::NTesting

--- a/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/range-validator/lib/validate_ut.cpp
@@ -43,7 +43,7 @@ Y_UNIT_TEST_SUITE(ValidateTest)
         auto executor = NTesting::CreateTestExecutor(
             {.TestScenarios = {{
                  .TestScenario =
-                     NTesting::CreateAlignedTestScenario(configHolder, log),
+                     NTesting::CreateAlignedTestScenario(configHolder, "", log),
                  .FilePath = filePath,
              }},
              .FileService = NTesting::ETestExecutorFileService::AsyncIo,


### PR DESCRIPTION
### Notes
Multi-file scenarios in eternal-load shares the same logger.
When a corruption event happens, it is hard to find which file is affected.

Proposal: add a log tag for each instance.