### PR TITLE
Eternal-load: Add option DisableParallelReadWrite for unaligned test scenario

### DIFF
--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.cpp
@@ -290,6 +290,11 @@ void TOptions::Parse(int argc, char** argv)
         .StoreResult(&MaxRegionSize);
 
     opts.AddLongOption(
+        "disable-parallel-read-write",
+        "disable reading regions that are being written")
+        .StoreTrue(&DisableParallelReadWrite);
+
+    opts.AddLongOption(
         "debug",
         "print debug statistics")
         .StoreTrue(&PrintDebugStats);

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/options.h
@@ -68,6 +68,7 @@ struct TOptions
     ui64 MaxWriteSize = 0;
     ui64 MinRegionSize = 0;
     ui64 MaxRegionSize = 0;
+    bool DisableParallelReadWrite = false;
 
     bool PrintDebugStats = false;
 

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/bin/test.cpp
@@ -79,23 +79,27 @@ int TTest::Run()
             Y_ENSURE(Options->FileSize.Defined(), "You need to specify the file size");
             Y_ENSURE(Options->WriteRate <= 100, "Write rate should be in range [0, 100]");
 
-            ConfigHolder = CreateTestConfig(TCreateTestConfigArguments
-                {.FilePath = *Options->FilePath,
-                 .FileSize = *Options->FileSize,
-                 .TestCount = Options->TestCount,
-                 .IoDepth = Options->IoDepth,
-                 .BlockSize = Options->BlockSize,
-                 .WriteRate = Options->WriteRate,
-                 .RequestBlockCount = Options->RequestBlockCount,
-                 .WriteParts = Options->WriteParts,
-                 .AlternatingPhase = Options->AlternatingPhase,
-                 .MaxWriteRequestCount = 0,
-                 .MinReadByteCount = Options->MinReadSize,
-                 .MaxReadByteCount = Options->MaxReadSize,
-                 .MinWriteByteCount = Options->MinWriteSize,
-                 .MaxWriteByteCount = Options->MaxWriteSize,
-                 .MinRegionByteCount = Options->MinRegionSize,
-                 .MaxRegionByteCount = Options->MaxRegionSize});
+            ConfigHolder = CreateTestConfig(
+                TCreateTestConfigArguments{
+                    .FilePath = *Options->FilePath,
+                    .FileSize = *Options->FileSize,
+                    .TestCount = Options->TestCount,
+                    .IoDepth = Options->IoDepth,
+                    .BlockSize = Options->BlockSize,
+                    .WriteRate = Options->WriteRate,
+                    .RequestBlockCount = Options->RequestBlockCount,
+                    .WriteParts = Options->WriteParts,
+                    .AlternatingPhase = Options->AlternatingPhase,
+                    .MaxWriteRequestCount = 0,
+                    .MinReadByteCount = Options->MinReadSize,
+                    .MaxReadByteCount = Options->MaxReadSize,
+                    .MinWriteByteCount = Options->MinWriteSize,
+                    .MaxWriteByteCount = Options->MaxWriteSize,
+                    .MinRegionByteCount = Options->MinRegionSize,
+                    .MaxRegionByteCount = Options->MaxRegionSize,
+                    .DisableParallelReadWrite =
+                        Options->DisableParallelReadWrite,
+                });
 
             DumpConfiguration();
             break;

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.cpp
@@ -94,6 +94,7 @@ TConfigHolder::TConfigHolder(const TCreateTestConfigArguments& args)
     fileTestConfig.SetMaxWriteByteCount(args.MaxWriteByteCount);
     fileTestConfig.SetMinRegionByteCount(args.MinRegionByteCount);
     fileTestConfig.SetMaxRegionByteCount(args.MaxRegionByteCount);
+    fileTestConfig.SetDisableParallelReadWrite(args.DisableParallelReadWrite);
 }
 
 TConfigHolder::TConfigHolder(const TTestConfig& config)

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config.h
@@ -44,6 +44,7 @@ struct TCreateTestConfigArguments
     ui64 MaxWriteByteCount = 0;
     ui64 MinRegionByteCount = 0;
     ui64 MaxRegionByteCount = 0;
+    bool DisableParallelReadWrite = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config/config.proto
@@ -23,6 +23,7 @@ message TUnalignedTestConfig {
   optional uint64 MaxWriteByteCount = 4;
   optional uint64 MinRegionByteCount = 5;
   optional uint64 MaxRegionByteCount = 6;
+  optional bool DisableParallelReadWrite = 7;
 }
 
 message TTestConfig {

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config_ut.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/config_ut.cpp
@@ -149,7 +149,8 @@ Y_UNIT_TEST_SUITE(ConfigTest)
                 "MinWriteByteCount":3,
                 "MaxWriteByteCount":4,
                 "MinRegionByteCount":5,
-                "MaxRegionByteCount":6
+                "MaxRegionByteCount":6,
+                "DisableParallelReadWrite":true
             },
         "BlockSize":4096,
         "FilePath":"/dev/vdb",
@@ -213,7 +214,8 @@ Y_UNIT_TEST_SUITE(ConfigTest)
              .MinWriteByteCount = 3,
              .MaxWriteByteCount = 4,
              .MinRegionByteCount = 5,
-             .MaxRegionByteCount = 6});
+             .MaxRegionByteCount = 6,
+             .DisableParallelReadWrite = true});
 
         auto filename = MakeTempName();
         configHolder->DumpConfig(filename);

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.cpp
@@ -44,6 +44,8 @@ TTestScenarioBase::TTestScenarioBase(
     INIT_CONFIG_PARAMS_HELPER(fileTestConfig, ReadByteCount);
     INIT_CONFIG_PARAMS_HELPER(fileTestConfig, WriteByteCount);
     INIT_CONFIG_PARAMS_HELPER(fileTestConfig, RegionByteCount);
+
+    DisableParallelReadWrite = fileTestConfig.GetDisableParallelReadWrite();
 }
 
 ui32 TTestScenarioBase::GetWorkerCount() const

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.h
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/test_scenario_base.h
@@ -39,6 +39,7 @@ protected:
     ui64 MaxWriteByteCount = 0;
     ui64 MinRegionByteCount = 0;
     ui64 MaxRegionByteCount = 0;
+    bool DisableParallelReadWrite = false;
 
 private:
     TVector<std::unique_ptr<ITestScenarioWorker>> Workers;

--- a/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
+++ b/cloud/blockstore/tools/testing/eternal_tests/eternal-load/lib/test_scenarios/unaligned_test_scenario.cpp
@@ -244,7 +244,7 @@ private:
     bool InitialValidationInProgress() const;
 
     void Read(IService& service, TVector<char>& readBuffer);
-    void Read(
+    bool Read(
         IService& service,
         ui64 offset,
         ui64 length,
@@ -563,29 +563,38 @@ void TUnalignedTestScenario::Read(
     ITestExecutorIOService& service,
     TVector<char>& readBuffer)
 {
-    auto len =
-        Min(RandomNumberFromRange(MinReadByteCount, MaxReadByteCount),
-            readBuffer.size(),
-            FileSize);
+    while (true) {
+        auto len =
+            Min(RandomNumberFromRange(MinReadByteCount, MaxReadByteCount),
+                readBuffer.size(),
+                FileSize);
 
-    if (ShouldValidate) {
-        auto offset = ValidationOffset.fetch_add(len);
-        if (offset == 0) {
-            STORAGE_INFO("Starting sequential read validation");
+        if (ShouldValidate) {
+            auto offset = ValidationOffset.fetch_add(len);
+            if (offset == 0) {
+                STORAGE_INFO("Starting sequential read validation");
+            }
+            if (offset < FileSize) {
+                len = Min(len, FileSize - offset);
+                Read(service, offset, len, true, readBuffer);
+                return;
+            }
         }
-        if (offset < FileSize) {
-            len = Min(len, FileSize - offset);
-            Read(service, offset, len, true, readBuffer);
-            return;
+
+        auto randomOffset = RandomNumber(FileSize - len + 1);
+
+        if (Read(service, randomOffset, len, false, readBuffer)) {
+            break;
         }
+
+        // If we reach here, it means the generated read request intersects with
+        // in-flight write requests - we need to retry
+        // It is guaranteed that at least one region is not being written so
+        // eventually we will succeed
     }
-
-    auto randomOffset = RandomNumber(FileSize - len + 1);
-
-    Read(service, randomOffset, len, false, readBuffer);
 }
 
-void TUnalignedTestScenario::Read(
+bool TUnalignedTestScenario::Read(
     IService& service,
     ui64 offset,
     ui64 length,
@@ -593,6 +602,17 @@ void TUnalignedTestScenario::Read(
     TVector<char>& readBuffer)
 {
     auto regions = GetReadRegions(offset, length);
+
+    if (DisableParallelReadWrite) {
+        for (const auto& region: regions) {
+            if (RegionLockedForWriteFlags[region.Index]) {
+                // Skip read if it overlaps with a region that is being written
+                return false;
+            }
+        }
+    }
+
+
     auto buffer = TStringBuf(readBuffer.data(), length);
 
     service.Read(
@@ -617,6 +637,8 @@ void TUnalignedTestScenario::Read(
                 }
             }
         });
+
+    return true;
 }
 
 TVector<TReadRegionInfo> TUnalignedTestScenario::GetReadRegions(


### PR DESCRIPTION
### Notes
We have found that unaligned scenario in eternal-load fails in the following scenario:
1. Initiate write.
2. Initiate overlapping read.
3. Read completes.
4. Write completes after read.
5. Read the region - the stale (pre-write) data is read.

Therefore, we want to add an option `--disable-parallel-read-write` than will prevent this scenario from happening