### PR TITLE
[Filestore] Fix description of build commands

### DIFF
--- a/cloud/filestore/README.md
+++ b/cloud/filestore/README.md
@@ -10,15 +10,21 @@ apt-get install qemu-kvm
 usermod -a -G kvm $USER
 ```
 
+### 3. clone nbs repository and submodules
+```
+git clone --recurse-submodules git@github.com:ydb-platform/nbs.git
+```
+
+If you already cloned the repository without submodules, run the following command from the repository root folder:
+```
+git submodule update --init
+```
+
 # How to build and run
 
 ### 1. Building
 To build run the following command from the repository root folder:
 
-```bash
-./ya make -r -- cloud/filestore/buildall -D CFLAGS="-fno-omit-frame-pointer"
-```
-or
 ```bash
 ./ya make --build=profile -- cloud/filestore/buildall
 ```


### PR DESCRIPTION
### Notes

ya failed to pass `-D` flags to build system, error example
```
./ya make -r -- cloud/filestore/buildall -D CFLAGS="-fno-omit-frame-pointer"
Error[-WUserErr]: in At top level: Target '-D' not found
Error[-WUserErr]: in At top level: Target 'CFLAGS=-fno-omit-frame-pointer' not found
Configure error (use -k to proceed)
```

The command `./ya make --build=profile` already adds the flag no-omit-frame-pointer automatically
