### PR TITLE
fix small logging error in migration_test

### DIFF
--- a/cloud/blockstore/tools/ci/migration_test/lib/main.py
+++ b/cloud/blockstore/tools/ci/migration_test/lib/main.py
@@ -216,7 +216,7 @@ class TestRunner:
                 config_version=None,
                 performance_profile=protos.TVolumePerformanceProfile(MaxPostponedWeight=weight))
         except ClientError as e:
-            self.logger(e)
+            self.logger.error(e)
             raise Error(f'Failed to change postponed weight to <weight={weight}>:\n{e}')
 
     def check_timeout(self, start) -> bool:


### PR DESCRIPTION
### Notes
Describe your PR - what it does and why this needs to be done.

### Issue
```
Jun  1 01:20:00 node-3038 eternal.nbs-migration[1239589]:   File "cloud/blockstore/tools/ci/migration_test/lib/main.py", line 219, in change_postponed_weight
Jun  1 01:20:00 node-3038 eternal.nbs-migration[1239589]:     self.logger(e)
Jun  1 01:20:00 node-3038 eternal.nbs-migration[1239589]: TypeError: 'Logger' object is not callable
```