### PR TITLE
[Filestore] cleanup directory handles filemap if feature is disabled, but file exists

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -256,9 +256,10 @@ struct TBootstrap
             proto.SetHandleOpsQueueSize(handleOpsQueueSize);
         }
 
+        proto.SetDirectoryHandlesStoragePath(
+            TempDir.Path() / "DirectoryHandles");
+        DirectoryHandleStoragePath = proto.GetDirectoryHandlesStoragePath();
         if (featuresConfig.GetDirectoryHandlesStorageEnabled()) {
-            proto.SetDirectoryHandlesStoragePath(TempDir.Path() / "DirectoryHandles");
-            DirectoryHandleStoragePath = proto.GetDirectoryHandlesStoragePath();
             if (directoryHandlesInitialDataSize) {
                 proto.SetDirectoryHandlesInitialDataSize(
                     directoryHandlesInitialDataSize);
@@ -1134,6 +1135,101 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             storage->LoadHandles(handles);
 
             UNIT_ASSERT(!handles.contains(handleId));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRemoveOrphanDirectoryHandleStorageFileWhenFeatureDisabled)
+    {
+        const TString sessionId = CreateGuidAsString();
+
+        TString storageFilePath;
+
+        // Phase 1: feature ENABLED — open a directory handle so the
+        // persistent storage file is created on disk, then simulate a crash by
+        // suspending the loop without the normal cleanup.
+        {
+            auto bootstrap = TBootstrap::CreateWithHandleStorage();
+
+            bootstrap.Service->CreateSessionHandler =
+                [&sessionId](auto callContext, auto request)
+            {
+                Y_UNUSED(callContext);
+                UNIT_ASSERT(request->GetRestoreClientSession());
+
+                NProto::TCreateSessionResponse result;
+                result.MutableSession()->SetSessionId(sessionId);
+                result.MutableFileStore()->SetBlockSize(4096);
+                NProto::TFileStoreFeatures features;
+                features.SetDirectoryHandlesStorageEnabled(true);
+                result.MutableFileStore()->MutableFeatures()->CopyFrom(
+                    features);
+                result.MutableFileStore()->SetFileSystemId(FileSystemId);
+                return MakeFuture(result);
+            };
+
+            bootstrap.Service->ListNodesHandler = [](auto, auto)
+            {
+                NProto::TListNodesResponse result;
+                return MakeFuture(result);
+            };
+
+            bootstrap.Start();
+
+            const ui64 nodeId = 123;
+            auto open = bootstrap.Fuse->SendRequest<TOpenDirRequest>(nodeId);
+            UNIT_ASSERT(open.Wait(WaitTimeout));
+            const auto handleId = open.GetValue();
+
+            auto read =
+                bootstrap.Fuse->SendRequest<TReadDirRequest>(nodeId, handleId);
+            UNIT_ASSERT(read.Wait(WaitTimeout));
+
+            storageFilePath =
+                (TFsPath(bootstrap.DirectoryHandleStoragePath) / FileSystemId /
+                 sessionId / "directory_handles_storage")
+                    .GetPath();
+            UNIT_ASSERT(TFsPath(storageFilePath).Exists());
+
+            auto suspend = bootstrap.Loop->SuspendAsync();
+            UNIT_ASSERT(suspend.Wait(WaitTimeout));
+        }
+
+        // File from the previous session is still on disk.
+        UNIT_ASSERT(TFsPath(storageFilePath).Exists());
+
+        // Phase 2: feature DISABLED — startup must clean up the orphaned
+        // storage file.
+        {
+            NProto::TFileStoreFeatures features;
+            TBootstrap bootstrap(
+                CreateWallClockTimer(),
+                CreateScheduler(),
+                features);
+
+            bootstrap.Service->CreateSessionHandler =
+                [&sessionId](auto callContext, auto request)
+            {
+                Y_UNUSED(callContext);
+                UNIT_ASSERT(request->GetRestoreClientSession());
+
+                NProto::TCreateSessionResponse result;
+                result.MutableSession()->SetSessionId(sessionId);
+                result.MutableFileStore()->SetBlockSize(4096);
+                // storage disabled in the response features
+                NProto::TFileStoreFeatures disabled;
+                result.MutableFileStore()->MutableFeatures()->CopyFrom(
+                    disabled);
+                result.MutableFileStore()->SetFileSystemId(FileSystemId);
+                return MakeFuture(result);
+            };
+
+            bootstrap.Start();
+            Y_DEFER
+            {
+                bootstrap.Stop();
+            };
+
+            UNIT_ASSERT(!TFsPath(storageFilePath).Exists());
         }
     }
 

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1089,12 +1089,12 @@ private:
 
             IDirectoryHandleStorageStatsPtr directoryHandleStorageStats;
             TDirectoryHandleStoragePtr directoryHandleStorage;
-            if (FileSystemConfig->GetDirectoryHandlesStorageEnabled()) {
-                if (Config->GetDirectoryHandlesStoragePath()) {
-                    auto path =
-                        TFsPath(Config->GetDirectoryHandlesStoragePath()) /
-                        FileSystemConfig->GetFileSystemId() / SessionId;
+            if (Config->GetDirectoryHandlesStoragePath()) {
+                auto path = TFsPath(Config->GetDirectoryHandlesStoragePath()) /
+                            FileSystemConfig->GetFileSystemId() / SessionId;
+                auto filePath = path / DirectoryHandleStorageFileName;
 
+                if (FileSystemConfig->GetDirectoryHandlesStorageEnabled()) {
                     auto error = CreateAndLockFile(
                         path,
                         DirectoryHandleStorageFileName,
@@ -1112,7 +1112,7 @@ private:
                         {.Log = Log,
                          .FileMapMemoryLimiter = FileMapMemoryLimiter,
                          .Stats = directoryHandleStorageStats,
-                         .FilePath = path / DirectoryHandleStorageFileName,
+                         .FilePath = filePath,
                          .MaxRecords =
                              FileSystemConfig->GetDirectoryHandlesTableSize(),
                          .InitialDataAreaSize =
@@ -1126,14 +1126,27 @@ private:
                                  ->GetDirectoryHandlesPersistentHandleMaxSize()});
 
                     DirectoryHandleStorageInitialized = true;
-                } else {
-                    STORAGE_ERROR(
-                        "[f:%s][c:%s] Error initializing "
-                        "DirectoryHandleStorage: DirectoryHandlesStoragePath "
-                        "is not set",
-                        Config->GetFileSystemId().Quote().c_str(),
-                        Config->GetClientId().Quote().c_str());
+                } else if (filePath.Exists()) {
+                    // The feature is disabled but a file from a previous
+                    // session with it enabled is still on disk. The file
+                    // holds only a derived view of the directory listing,
+                    // so it can be removed without any drain.
+                    try {
+                        NFs::Remove(filePath);
+                    } catch (const TSystemError& err) {
+                        ReportDirectoryHandlesStorageError(
+                            TStringBuilder()
+                            << "Failed to remove orphan directory handles "
+                            << filePath << ": " << err.AsStrBuf());
+                    }
                 }
+            } else if (FileSystemConfig->GetDirectoryHandlesStorageEnabled()) {
+                STORAGE_ERROR(
+                    "[f:%s][c:%s] Error initializing "
+                    "DirectoryHandleStorage: DirectoryHandlesStoragePath "
+                    "is not set",
+                    Config->GetFileSystemId().Quote().c_str(),
+                    Config->GetClientId().Quote().c_str());
             }
 
             DirectoryHandleStats = CreateDirectoryHandleStats(


### PR DESCRIPTION
### Notes
It is possible that the feature can be disabled right after startup or after a crash. In this case, we do not want to keep stale filemaps, so we clean up the directory handles filemap because it is no longer needed.

### Issue
Put links to the related issues here
