### PR TITLE
issue-5894: direct tcp interface for fastshard

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client.cpp
@@ -1,0 +1,102 @@
+#include "client.h"
+
+#include <silk/fibers/fiber.h>
+
+#include <util/generic/string.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+using silk::FiberScheduler;
+using namespace NProtoSrv;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TClient::TClient(ui16 port)
+    : Port(port)
+{}
+
+TResponse TClient::Send(const TRequest& req)
+{
+    // Use ThreadModeScope so blocking socket calls don't block
+    // the silk scheduler thread.
+    FiberScheduler::ThreadModeScope threadMode;
+
+    int fd = Connect();
+    Y_ABORT_UNLESS(fd >= 0, "connect failed");
+
+    TString reqBuf;
+    Y_PROTOBUF_SUPPRESS_NODISCARD req.SerializeToString(&reqBuf);
+
+    ui32 lenBe = htonl(static_cast<ui32>(reqBuf.size()));
+    SendAll(fd, &lenBe, sizeof(lenBe));
+    SendAll(fd, reqBuf.data(), reqBuf.size());
+
+    ui32 respLenBe = 0;
+    RecvAll(fd, &respLenBe, sizeof(respLenBe));
+    ui32 respLen = ntohl(respLenBe);
+
+    TString respBuf;
+    respBuf.ReserveAndResize(respLen);
+    RecvAll(fd, respBuf.begin(), respLen);
+
+    TResponse resp;
+    Y_PROTOBUF_SUPPRESS_NODISCARD resp.ParseFromString(respBuf);
+    ::close(fd);
+    return resp;
+}
+
+int TClient::Connect()
+{
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(Port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (::connect(
+            fd,
+            reinterpret_cast<sockaddr*>(&addr),
+            sizeof(addr)) < 0)
+    {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+void TClient::RecvAll(int fd, void* buf, size_t len)
+{
+    auto* p = static_cast<ui8*>(buf);
+    size_t done = 0;
+    while (done < len) {
+        ssize_t n = ::recv(fd, p + done, len - done, 0);
+        if (n <= 0) {
+            break;
+        }
+        done += static_cast<size_t>(n);
+    }
+}
+
+void TClient::SendAll(int fd, const void* buf, size_t len)
+{
+    const auto* p = static_cast<const ui8*>(buf);
+    size_t done = 0;
+    while (done < len) {
+        ssize_t n = ::send(fd, p + done, len - done, MSG_NOSIGNAL);
+        if (n <= 0) {
+            break;
+        }
+        done += static_cast<size_t>(n);
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client.cpp
@@ -1,11 +1,16 @@
 #include "client.h"
 
+#include <cloud/filestore/libs/storage/fastshard/ipc/ipc.h>
+
 #include <silk/fibers/fiber.h>
 
 #include <util/generic/string.h>
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -22,10 +27,6 @@ TClient::TClient(ui16 port)
 
 TResponse TClient::Send(const TRequest& req)
 {
-    // Use ThreadModeScope so blocking socket calls don't block
-    // the silk scheduler thread.
-    FiberScheduler::ThreadModeScope threadMode;
-
     int fd = Connect();
     Y_ABORT_UNLESS(fd >= 0, "connect failed");
 
@@ -33,16 +34,20 @@ TResponse TClient::Send(const TRequest& req)
     Y_PROTOBUF_SUPPRESS_NODISCARD req.SerializeToString(&reqBuf);
 
     ui32 lenBe = htonl(static_cast<ui32>(reqBuf.size()));
-    SendAll(fd, &lenBe, sizeof(lenBe));
-    SendAll(fd, reqBuf.data(), reqBuf.size());
+    int r = SendAll(fd, &lenBe, sizeof(lenBe));
+    Y_ABORT_UNLESS(r == 0, "send length failed");
+    r = SendAll(fd, reqBuf.data(), reqBuf.size());
+    Y_ABORT_UNLESS(r == 0, "send body failed");
 
     ui32 respLenBe = 0;
-    RecvAll(fd, &respLenBe, sizeof(respLenBe));
+    r = RecvAll(fd, &respLenBe, sizeof(respLenBe));
+    Y_ABORT_UNLESS(r == 0, "recv length failed");
     ui32 respLen = ntohl(respLenBe);
 
     TString respBuf;
     respBuf.ReserveAndResize(respLen);
-    RecvAll(fd, respBuf.begin(), respLen);
+    r = RecvAll(fd, respBuf.begin(), respLen);
+    Y_ABORT_UNLESS(r == 0, "recv body failed");
 
     TResponse resp;
     Y_PROTOBUF_SUPPRESS_NODISCARD resp.ParseFromString(respBuf);
@@ -52,7 +57,10 @@ TResponse TClient::Send(const TRequest& req)
 
 int TClient::Connect()
 {
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int fd = ::socket(
+        AF_INET,
+        SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC,
+        0);
     if (fd < 0) {
         return -1;
     }
@@ -62,41 +70,38 @@ int TClient::Connect()
     addr.sin_port = htons(Port);
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
-    if (::connect(
-            fd,
-            reinterpret_cast<sockaddr*>(&addr),
-            sizeof(addr)) < 0)
-    {
+    int ret = ::connect(
+        fd,
+        reinterpret_cast<sockaddr*>(&addr),
+        sizeof(addr));
+    if (ret < 0 && errno != EINPROGRESS) {
         ::close(fd);
         return -1;
     }
+
+    if (ret < 0) {
+        // EINPROGRESS — wait for connection to complete.
+        int r = FiberScheduler::poll(fd, POLLOUT);
+        if (r) {
+            ::close(fd);
+            return -1;
+        }
+
+        // Check for connect error.
+        int err = 0;
+        socklen_t errLen = sizeof(err);
+        ::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errLen);
+        if (err) {
+            ::close(fd);
+            return -1;
+        }
+    }
+
+    int one = 1;
+    ::setsockopt(
+        fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
     return fd;
-}
-
-void TClient::RecvAll(int fd, void* buf, size_t len)
-{
-    auto* p = static_cast<ui8*>(buf);
-    size_t done = 0;
-    while (done < len) {
-        ssize_t n = ::recv(fd, p + done, len - done, 0);
-        if (n <= 0) {
-            break;
-        }
-        done += static_cast<size_t>(n);
-    }
-}
-
-void TClient::SendAll(int fd, const void* buf, size_t len)
-{
-    const auto* p = static_cast<const ui8*>(buf);
-    size_t done = 0;
-    while (done < len) {
-        ssize_t n = ::send(fd, p + done, len - done, MSG_NOSIGNAL);
-        if (n <= 0) {
-            break;
-        }
-        done += static_cast<size_t>(n);
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/client.h
+++ b/cloud/filestore/libs/storage/fastshard/client/client.h
@@ -8,9 +8,9 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Simple blocking TCP client for the fastshard server.
-// Must be called from a silk fiber context — uses ThreadModeScope internally
-// so blocking socket calls don't stall the scheduler.
+// Async TCP client for the fastshard server.
+// Uses silk's non-blocking poll + io_uring under the hood.
+// Must be called from a silk fiber context.
 class TClient
 {
 public:
@@ -20,8 +20,6 @@ public:
 
 private:
     int Connect();
-    static void RecvAll(int fd, void* buf, size_t len);
-    static void SendAll(int fd, const void* buf, size_t len);
 
     ui16 Port;
 };

--- a/cloud/filestore/libs/storage/fastshard/client/client.h
+++ b/cloud/filestore/libs/storage/fastshard/client/client.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
+
+#include <util/system/types.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Simple blocking TCP client for the fastshard server.
+// Must be called from a silk fiber context — uses ThreadModeScope internally
+// so blocking socket calls don't stall the scheduler.
+class TClient
+{
+public:
+    explicit TClient(ui16 port);
+
+    NProtoSrv::TResponse Send(const NProtoSrv::TRequest& req);
+
+private:
+    int Connect();
+    static void RecvAll(int fd, void* buf, size_t len);
+    static void SendAll(int fd, const void* buf, size_t len);
+
+    ui16 Port;
+};
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/client_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client_stub.cpp
@@ -1,0 +1,31 @@
+#include "client.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+using namespace NProtoSrv;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TClient::TClient(ui16 port)
+    : Port(port)
+{
+    Y_UNUSED(Port);
+}
+
+TResponse TClient::Send(const TRequest& req)
+{
+    Y_UNUSED(req);
+
+    TResponse resp;
+    *resp.MutableError() = MakeError(E_NOT_IMPLEMENTED);
+    return resp;
+}
+
+int TClient::Connect()
+{
+    return -1;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/client/ya.make
@@ -6,6 +6,8 @@ IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     )
 
     PEERDIR(
+        cloud/filestore/libs/storage/fastshard/ipc
+
         contrib/libs/silk/src/fibers
     )
 ELSE()
@@ -15,8 +17,9 @@ ELSE()
 ENDIF()
 
 PEERDIR(
-    cloud/filestore/libs/storage/fastshard/ipc
     cloud/filestore/libs/storage/fastshard/server/protos
+
+    cloud/storage/core/libs/common
 )
 
 END()

--- a/cloud/filestore/libs/storage/fastshard/client/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/client/ya.make
@@ -1,11 +1,11 @@
 LIBRARY()
 
-
 SRCS(
     client.cpp
 )
 
 PEERDIR(
+    cloud/filestore/libs/storage/fastshard/ipc
     cloud/filestore/libs/storage/fastshard/server/protos
 
     contrib/libs/silk/src/fibers

--- a/cloud/filestore/libs/storage/fastshard/client/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/client/ya.make
@@ -1,14 +1,22 @@
 LIBRARY()
 
-SRCS(
-    client.cpp
-)
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    SRCS(
+        client.cpp
+    )
+
+    PEERDIR(
+        contrib/libs/silk/src/fibers
+    )
+ELSE()
+    SRCS(
+        client_stub.cpp
+    )
+ENDIF()
 
 PEERDIR(
     cloud/filestore/libs/storage/fastshard/ipc
     cloud/filestore/libs/storage/fastshard/server/protos
-
-    contrib/libs/silk/src/fibers
 )
 
 END()

--- a/cloud/filestore/libs/storage/fastshard/client/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/client/ya.make
@@ -1,0 +1,14 @@
+LIBRARY()
+
+
+SRCS(
+    client.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/server/protos
+
+    contrib/libs/silk/src/fibers
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/ipc/ipc.cpp
+++ b/cloud/filestore/libs/storage/fastshard/ipc/ipc.cpp
@@ -1,0 +1,67 @@
+#include "ipc.h"
+
+#include <silk/fibers/fiber.h>
+
+#include <cerrno>
+
+#include <poll.h>
+#include <sys/socket.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+using silk::FiberScheduler;
+
+////////////////////////////////////////////////////////////////////////////////
+
+int RecvAll(int fd, void* buf, size_t len)
+{
+    auto* p = static_cast<ui8*>(buf);
+    size_t done = 0;
+    while (done < len) {
+        ssize_t n = ::recv(fd, p + done, len - done, 0);
+        if (n > 0) {
+            done += static_cast<size_t>(n);
+            continue;
+        }
+        if (n == 0) {
+            return EIO;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            if (int r = FiberScheduler::poll(fd, POLLIN); r) {
+                return r;
+            }
+            continue;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        return errno;
+    }
+    return 0;
+}
+
+int SendAll(int fd, const void* buf, size_t len)
+{
+    const auto* p = static_cast<const ui8*>(buf);
+    size_t done = 0;
+    while (done < len) {
+        ssize_t n = ::send(fd, p + done, len - done, MSG_NOSIGNAL);
+        if (n > 0) {
+            done += static_cast<size_t>(n);
+            continue;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            if (int r = FiberScheduler::poll(fd, POLLOUT); r) {
+                return r;
+            }
+            continue;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        return errno;
+    }
+    return 0;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/ipc/ipc.h
+++ b/cloud/filestore/libs/storage/fastshard/ipc/ipc.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <util/system/types.h>
+
+#include <cstddef>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Async TCP helpers using silk's non-blocking poll.
+// Must be called from a silk fiber context.
+// Return 0 on success, errno on failure, EIO on unexpected EOF.
+
+int RecvAll(int fd, void* buf, size_t len);
+int SendAll(int fd, const void* buf, size_t len);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/ipc/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/ipc/ya.make
@@ -1,0 +1,11 @@
+LIBRARY()
+
+SRCS(
+    ipc.cpp
+)
+
+PEERDIR(
+    contrib/libs/silk/src/fibers
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/server/protos/fastshard.proto
+++ b/cloud/filestore/libs/storage/fastshard/server/protos/fastshard.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+package NCloud.NFileStore.NStorage.NFastShard.NProtoSrv;
+
+import "cloud/filestore/private/api/protos/tablet.proto";
+import "cloud/filestore/public/api/protos/data.proto";
+import "cloud/filestore/public/api/protos/locks.proto";
+import "cloud/filestore/public/api/protos/node.proto";
+import "cloud/storage/core/protos/error.proto";
+
+////////////////////////////////////////////////////////////////////////////////
+// Wire format:
+//   [4-byte big-endian length][TRequest or TResponse bytes]
+//
+// Each connection carries a single request/response exchange, then closes.
+
+message TRequest
+{
+    // Identifies which shard to route the request to.
+    string FileSystemId = 100;
+
+    oneof Body {
+        NCloud.NFileStore.NProto.TGetNodeAttrRequest GetNodeAttr = 1;
+        NCloud.NFileStore.NProto.TSetNodeAttrRequest SetNodeAttr = 2;
+        NCloud.NFileStore.NProto.TAccessNodeRequest AccessNode = 3;
+        NCloud.NFileStore.NProto.TCreateNodeRequest CreateNode = 4;
+        NCloud.NFileStore.NProto.TUnlinkNodeRequest UnlinkNode = 5;
+        NCloud.NFileStore.NProto.TCreateHandleRequest CreateHandle = 6;
+        NCloud.NFileStore.NProto.TDestroyHandleRequest DestroyHandle = 7;
+        NCloud.NFileStore.NProto.TAllocateDataRequest AllocateData = 8;
+        NCloud.NFileStore.NProto.TAcquireLockRequest AcquireLock = 9;
+        NCloud.NFileStore.NProto.TReleaseLockRequest ReleaseLock = 10;
+        NCloud.NFileStore.NProto.TTestLockRequest TestLock = 11;
+        NCloud.NFileStore.NProto.TWriteDataRequest WriteData = 12;
+        NCloud.NFileStore.NProto.TReadDataRequest ReadData = 13;
+        NCloud.NFileStore.NProto.TRemoveNodeXAttrRequest RemoveNodeXAttr = 14;
+        NCloud.NFileStore.NProto.TGetNodeXAttrRequest GetNodeXAttr = 15;
+        NCloud.NFileStore.NProto.TSetNodeXAttrRequest SetNodeXAttr = 16;
+        NCloud.NFileStore.NProto.TListNodeXAttrRequest ListNodeXAttr = 17;
+        NCloud.NFileStore.NProtoPrivate.TGetNodeAttrBatchRequest
+            GetNodeAttrBatch = 18;
+    }
+}
+
+message TResponse
+{
+    // Non-empty when the request could not be processed (e.g. unknown
+    // FileSystemId or dispatch failure).
+    NCloud.NProto.TError Error = 100;
+
+    oneof Body {
+        NCloud.NFileStore.NProto.TGetNodeAttrResponse GetNodeAttr = 1;
+        NCloud.NFileStore.NProto.TSetNodeAttrResponse SetNodeAttr = 2;
+        NCloud.NFileStore.NProto.TAccessNodeResponse AccessNode = 3;
+        NCloud.NFileStore.NProto.TCreateNodeResponse CreateNode = 4;
+        NCloud.NFileStore.NProto.TUnlinkNodeResponse UnlinkNode = 5;
+        NCloud.NFileStore.NProto.TCreateHandleResponse CreateHandle = 6;
+        NCloud.NFileStore.NProto.TDestroyHandleResponse DestroyHandle = 7;
+        NCloud.NFileStore.NProto.TAllocateDataResponse AllocateData = 8;
+        NCloud.NFileStore.NProto.TAcquireLockResponse AcquireLock = 9;
+        NCloud.NFileStore.NProto.TReleaseLockResponse ReleaseLock = 10;
+        NCloud.NFileStore.NProto.TTestLockResponse TestLock = 11;
+        NCloud.NFileStore.NProto.TWriteDataResponse WriteData = 12;
+        NCloud.NFileStore.NProto.TReadDataResponse ReadData = 13;
+        NCloud.NFileStore.NProto.TRemoveNodeXAttrResponse RemoveNodeXAttr = 14;
+        NCloud.NFileStore.NProto.TGetNodeXAttrResponse GetNodeXAttr = 15;
+        NCloud.NFileStore.NProto.TSetNodeXAttrResponse SetNodeXAttr = 16;
+        NCloud.NFileStore.NProto.TListNodeXAttrResponse ListNodeXAttr = 17;
+        NCloud.NFileStore.NProtoPrivate.TGetNodeAttrBatchResponse
+            GetNodeAttrBatch = 18;
+    }
+}

--- a/cloud/filestore/libs/storage/fastshard/server/protos/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/protos/ya.make
@@ -1,0 +1,15 @@
+PROTO_LIBRARY()
+
+ONLY_TAGS(CPP_PROTO)
+
+SRCS(
+    fastshard.proto
+)
+
+PEERDIR(
+    cloud/filestore/private/api/protos
+    cloud/filestore/public/api/protos
+    cloud/storage/core/protos
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server.cpp
@@ -1,0 +1,432 @@
+#include "server.h"
+
+#include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+#include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/logger.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/size_literals.h>
+#include <util/generic/string.h>
+#include <util/string/builder.h>
+#include <util/system/spinlock.h>
+
+#include <cerrno>
+#include <cstring>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+using silk::FiberFuture;
+using silk::FiberScheduler;
+using namespace NProtoSrv;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// Constants.
+
+constexpr ui64 MaxMessageSize = 64_MB;
+constexpr int SocketBacklog = 128;
+
+////////////////////////////////////////////////////////////////////////////////
+// Async TCP helpers.
+
+int RecvAll(int fd, void* buf, size_t len)
+{
+    auto* p = static_cast<ui8*>(buf);
+    size_t done = 0;
+    while (done < len) {
+        ssize_t n = ::recv(fd, p + done, len - done, 0);
+        if (n > 0) {
+            done += static_cast<size_t>(n);
+            continue;
+        }
+        if (n == 0) {
+            return EIO;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            if (int r = FiberScheduler::poll(fd, POLLIN); r) {
+                return r;
+            }
+            continue;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        return errno;
+    }
+    return 0;
+}
+
+int SendAll(int fd, const void* buf, size_t len)
+{
+    const auto* p = static_cast<const ui8*>(buf);
+    size_t done = 0;
+    while (done < len) {
+        ssize_t n = ::send(fd, p + done, len - done, MSG_NOSIGNAL);
+        if (n > 0) {
+            done += static_cast<size_t>(n);
+            continue;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            if (int r = FiberScheduler::poll(fd, POLLOUT); r) {
+                return r;
+            }
+            continue;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        return errno;
+    }
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Bridge NThreading::TFuture to silk FiberFuture.
+
+template <typename T>
+T WaitFiber(const NThreading::TFuture<T>& future)
+{
+    FiberFuture fiberFuture;
+    future.Subscribe([&fiberFuture](const auto&) {
+        fiberFuture.set(0);
+    });
+    fiberFuture.wait();
+    return future.GetValue();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Request dispatch.
+
+TResponse Dispatch(IFileSystemShard& shard, const TRequest& req)
+{
+    TResponse resp;
+
+    switch (req.GetBodyCase()) {
+#define DISPATCH_REQUEST(name, ...)                                            \
+    case TRequest::k##name: {                                                  \
+        auto result = WaitFiber(                                               \
+            shard.name(req.Get##name()));                                      \
+        *resp.Mutable##name() = std::move(result);                             \
+        break;                                                                 \
+    }                                                                          \
+// DISPATCH_REQUEST
+
+    FAST_SHARD_PRIVATE_METHODS(DISPATCH_REQUEST)
+    FAST_SHARD_PUBLIC_METHODS(DISPATCH_REQUEST)
+
+#undef DISPATCH_REQUEST
+
+    case TRequest::BODY_NOT_SET:
+        break;
+    }
+
+    return resp;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Shard registry — thread-safe map of FileSystemId -> IFileSystemShard.
+
+class TShardRegistry
+{
+public:
+    void Register(const TString& id, IFileSystemShardPtr shard)
+    {
+        auto guard = Guard(Lock);
+        Shards[id] = std::move(shard);
+    }
+
+    void Unregister(const TString& id)
+    {
+        auto guard = Guard(Lock);
+        Shards.erase(id);
+    }
+
+    IFileSystemShardPtr Find(const TString& id)
+    {
+        auto guard = Guard(Lock);
+        auto it = Shards.find(id);
+        return it != Shards.end() ? it->second : nullptr;
+    }
+
+private:
+    TAdaptiveLock Lock;
+    THashMap<TString, IFileSystemShardPtr> Shards;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Per-connection handler fiber.
+
+struct TConnParams
+{
+    int Fd;
+    TShardRegistry* Registry;
+};
+static_assert(sizeof(TConnParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int ConnFiberMain(TConnParams* params) noexcept
+{
+    int fd = params->Fd;
+    auto* registry = params->Registry;
+
+    // Read length prefix.
+    ui32 lenBe = 0;
+    if (int r = RecvAll(fd, &lenBe, sizeof(lenBe)); r) {
+        ::close(fd);
+        return r;
+    }
+    ui32 len = ntohl(lenBe);
+    if (len > MaxMessageSize) {
+        ::close(fd);
+        return EMSGSIZE;
+    }
+
+    // Read request body.
+    TString reqBuf;
+    reqBuf.ReserveAndResize(len);
+    if (int r = RecvAll(fd, reqBuf.begin(), len); r) {
+        ::close(fd);
+        return r;
+    }
+
+    TRequest req;
+    if (!req.ParseFromString(reqBuf)) {
+        ::close(fd);
+        return EBADMSG;
+    }
+
+    // Route to the right shard.
+    TResponse resp;
+    auto shard = registry->Find(req.GetFileSystemId());
+    if (!shard) {
+        auto* err = resp.MutableError();
+        err->SetCode(ENOENT);
+        err->SetMessage(
+            TStringBuilder() << "no shard registered for "
+                << req.GetFileSystemId());
+    } else {
+        resp = Dispatch(*shard, req);
+    }
+
+    // Send response.
+    TString respBuf;
+    const bool serialized = resp.SerializeToString(&respBuf);
+    if (!serialized) {
+        SILK_ERROR("failed to serialize response");
+    }
+
+    ui32 respLenBe = htonl(static_cast<ui32>(respBuf.size()));
+    if (int r = SendAll(fd, &respLenBe, sizeof(respLenBe)); r) {
+        SILK_WARN("send resp length: %s", ::strerror(r));
+        ::close(fd);
+        return r;
+    }
+    if (int r = SendAll(fd, respBuf.data(), respBuf.size()); r) {
+        SILK_WARN("send resp body: %s", ::strerror(r));
+        ::close(fd);
+        return r;
+    }
+
+    ::close(fd);
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Accept loop fiber.
+
+struct TAcceptParams
+{
+    int ListenFd;
+    int ShutdownFd;
+    TShardRegistry* Registry;
+};
+static_assert(sizeof(TAcceptParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int AcceptFiberMain(TAcceptParams* params) noexcept
+{
+    int lfd = params->ListenFd;
+    int sfd = params->ShutdownFd;
+    auto* registry = params->Registry;
+
+    for (;;) {
+        sockaddr_in addr{};
+        socklen_t addrLen = sizeof(addr);
+        int cfd = ::accept4(
+            lfd,
+            reinterpret_cast<sockaddr*>(&addr),
+            &addrLen,
+            SOCK_NONBLOCK | SOCK_CLOEXEC);
+        if (cfd >= 0) {
+            int one = 1;
+            ::setsockopt(
+                cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+            int r = FiberScheduler::run(
+                ConnFiberMain,
+                TConnParams{.Fd = cfd, .Registry = registry},
+                nullptr);
+            if (r) {
+                SILK_ERROR(
+                    "spawn handler fiber: %s",
+                    ::strerror(r));
+                ::close(cfd);
+            }
+            continue;
+        }
+
+        if (errno == EINTR || errno == ECONNABORTED) {
+            continue;
+        }
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            return errno;
+        }
+
+        // Wait for connection or shutdown.
+        FiberScheduler::IoFuture acceptFuture;
+        FiberScheduler::IoFuture shutdownFuture;
+        FiberScheduler::poll(lfd, POLLIN, nullptr, &acceptFuture);
+        FiberScheduler::poll(sfd, POLLIN, nullptr, &shutdownFuture);
+
+        FiberFuture* futures[] = {&acceptFuture, &shutdownFuture};
+        uint64_t which =
+            FiberFuture::waitForMultiple(futures, std::size(futures));
+
+        if (which == 1) {
+            acceptFuture.cancel();
+            acceptFuture.wait();
+            return 0;
+        }
+
+        shutdownFuture.cancel();
+        shutdownFuture.wait();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TServer: public IServer
+{
+public:
+    explicit TServer(ui16 port)
+        : Port(port)
+    {}
+
+    ~TServer() override
+    {
+        if (ShutdownFd >= 0) {
+            ::close(ShutdownFd);
+        }
+        if (ListenFd >= 0) {
+            ::close(ListenFd);
+        }
+    }
+
+    void Start() override
+    {
+        ShutdownFd = ::eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+        if (ShutdownFd < 0) {
+            SILK_ERROR("eventfd: %s", ::strerror(errno));
+            return;
+        }
+
+        ListenFd = MakeListenSocket();
+        if (ListenFd < 0) {
+            return;
+        }
+
+        SILK_INFO("fastshard server listening on port %u", Port);
+
+        FiberScheduler::run(
+            AcceptFiberMain,
+            TAcceptParams{
+                .ListenFd = ListenFd,
+                .ShutdownFd = ShutdownFd,
+                .Registry = &Registry,
+            });
+    }
+
+    void Stop() override
+    {
+        if (ShutdownFd >= 0) {
+            uint64_t one = 1;
+            if (::write(ShutdownFd, &one, sizeof(one)) < 0) {
+                SILK_ERROR("shutdown write: %s", ::strerror(errno));
+            }
+        }
+    }
+
+    void RegisterShard(
+        const TString& fileSystemId,
+        IFileSystemShardPtr shard) override
+    {
+        Registry.Register(fileSystemId, std::move(shard));
+    }
+
+    void UnregisterShard(const TString& fileSystemId) override
+    {
+        Registry.Unregister(fileSystemId);
+    }
+
+private:
+    int MakeListenSocket()
+    {
+        int fd = ::socket(
+            AF_INET,
+            SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC,
+            0);
+        if (fd < 0) {
+            SILK_ERROR("socket: %s", ::strerror(errno));
+            return -1;
+        }
+
+        int one = 1;
+        ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(Port);
+        addr.sin_addr.s_addr = INADDR_ANY;
+
+        if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr))
+            < 0)
+        {
+            SILK_ERROR("bind: %s", ::strerror(errno));
+            ::close(fd);
+            return -1;
+        }
+
+        if (::listen(fd, SocketBacklog) < 0) {
+            SILK_ERROR("listen: %s", ::strerror(errno));
+            ::close(fd);
+            return -1;
+        }
+        return fd;
+    }
+
+    ui16 Port;
+    int ListenFd = -1;
+    int ShutdownFd = -1;
+    TShardRegistry Registry;
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IServerPtr CreateServer(ui16 port)
+{
+    return std::make_unique<TServer>(port);
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server.cpp
@@ -1,6 +1,7 @@
 #include "server.h"
 
 #include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+#include <cloud/filestore/libs/storage/fastshard/ipc/ipc.h>
 #include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
 
 #include <silk/fibers/fiber.h>
@@ -37,60 +38,6 @@ namespace {
 
 constexpr ui64 MaxMessageSize = 64_MB;
 constexpr int SocketBacklog = 128;
-
-////////////////////////////////////////////////////////////////////////////////
-// Async TCP helpers.
-
-int RecvAll(int fd, void* buf, size_t len)
-{
-    auto* p = static_cast<ui8*>(buf);
-    size_t done = 0;
-    while (done < len) {
-        ssize_t n = ::recv(fd, p + done, len - done, 0);
-        if (n > 0) {
-            done += static_cast<size_t>(n);
-            continue;
-        }
-        if (n == 0) {
-            return EIO;
-        }
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            if (int r = FiberScheduler::poll(fd, POLLIN); r) {
-                return r;
-            }
-            continue;
-        }
-        if (errno == EINTR) {
-            continue;
-        }
-        return errno;
-    }
-    return 0;
-}
-
-int SendAll(int fd, const void* buf, size_t len)
-{
-    const auto* p = static_cast<const ui8*>(buf);
-    size_t done = 0;
-    while (done < len) {
-        ssize_t n = ::send(fd, p + done, len - done, MSG_NOSIGNAL);
-        if (n > 0) {
-            done += static_cast<size_t>(n);
-            continue;
-        }
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            if (int r = FiberScheduler::poll(fd, POLLOUT); r) {
-                return r;
-            }
-            continue;
-        }
-        if (errno == EINTR) {
-            continue;
-        }
-        return errno;
-    }
-    return 0;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Bridge NThreading::TFuture to silk FiberFuture.

--- a/cloud/filestore/libs/storage/fastshard/server/server.h
+++ b/cloud/filestore/libs/storage/fastshard/server/server.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/iface/public.h>
+
+#include <util/generic/string.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IServer
+{
+    virtual ~IServer() = default;
+
+    // Start the server. Blocks until Stop() is called from another
+    // thread/fiber. Must be called from a silk fiber context.
+    virtual void Start() = 0;
+
+    // Signal the server to stop accepting new connections and return
+    // from Start(). Safe to call from any thread.
+    virtual void Stop() = 0;
+
+    // Register a shard under the given filesystem id. Requests with
+    // matching FileSystemId will be routed to this shard.
+    // Thread-safe; may be called while the server is running.
+    virtual void RegisterShard(
+        const TString& fileSystemId,
+        IFileSystemShardPtr shard) = 0;
+
+    // Unregister a previously registered shard. Subsequent requests
+    // for this filesystem id will fail.
+    virtual void UnregisterShard(const TString& fileSystemId) = 0;
+};
+
+using IServerPtr = std::unique_ptr<IServer>;
+
+IServerPtr CreateServer(ui16 port);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/server/server_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server_stub.cpp
@@ -1,0 +1,48 @@
+#include "server.h"
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TServer: public IServer
+{
+public:
+    explicit TServer(ui16 port)
+    {
+        Y_UNUSED(port);
+    }
+
+    void Start() override
+    {
+    }
+
+    void Stop() override
+    {
+    }
+
+    void RegisterShard(
+        const TString& fileSystemId,
+        IFileSystemShardPtr shard) override
+    {
+        Y_UNUSED(fileSystemId);
+        Y_UNUSED(shard);
+    }
+
+    void UnregisterShard(const TString& fileSystemId) override
+    {
+        Y_UNUSED(fileSystemId);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IServerPtr CreateServer(ui16 port)
+{
+    return std::make_unique<TServer>(port);
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
@@ -27,7 +27,7 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 // Silk test environment.
 
-class SilkEnv : public ::testing::Environment
+class TSilkEnv : public ::testing::Environment
 {
 public:
     void SetUp() override
@@ -43,7 +43,7 @@ public:
 };
 
 [[maybe_unused]] auto* const gEnv =
-    ::testing::AddGlobalTestEnvironment(new SilkEnv);
+    ::testing::AddGlobalTestEnvironment(new TSilkEnv);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Pick a free port.

--- a/cloud/filestore/libs/storage/fastshard/server/ut/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/ut/server_ut.cpp
@@ -1,0 +1,188 @@
+#include <cloud/filestore/libs/storage/fastshard/client/client.h>
+#include <cloud/filestore/libs/storage/fastshard/server/server.h>
+#include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/mem/memshard.h>
+
+#include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
+#include <cloud/filestore/public/api/protos/node.pb.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/init.h>
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace NCloud::NFileStore::NStorage::NFastShard;
+using namespace NCloud::NFileStore::NStorage::NFastShard::NProtoSrv;
+using silk::FiberFuture;
+using silk::FiberScheduler;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// Silk test environment.
+
+class SilkEnv : public ::testing::Environment
+{
+public:
+    void SetUp() override
+    {
+        silk::initialize();
+        FiberScheduler::initialize();
+    }
+    void TearDown() override
+    {
+        FiberScheduler::destroy();
+        silk::destroy();
+    }
+};
+
+[[maybe_unused]] auto* const gEnv =
+    ::testing::AddGlobalTestEnvironment(new SilkEnv);
+
+////////////////////////////////////////////////////////////////////////////////
+// Pick a free port.
+
+ui16 GetFreePort()
+{
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    ::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+    socklen_t len = sizeof(addr);
+    ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len);
+    ui16 port = ntohs(addr.sin_port);
+    ::close(fd);
+    return port;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Test fixture that runs the server in a fiber.
+
+struct TServerFixture
+{
+    ui16 Port;
+    IServerPtr Server;
+    FiberFuture ServerFuture;
+
+    TServerFixture()
+        : Port(GetFreePort())
+        , Server(CreateServer(Port))
+    {}
+
+    void StartServer(IFileSystemShardPtr shard)
+    {
+        Server->RegisterShard("test-fs", std::move(shard));
+
+        struct Params
+        {
+            IServer* Srv;
+        };
+        static_assert(sizeof(Params) <= silk::FIBER_PARAMETERS_SIZE);
+
+        (void)FiberScheduler::run(
+            +[](Params* p) noexcept -> int {
+                p->Srv->Start();
+                return 0;
+            },
+            Params{Server.get()},
+            &ServerFuture);
+
+        // Give the server a moment to bind.
+        FiberScheduler::SleepFuture sf;
+        FiberScheduler::sleep(50'000'000, &sf);  // 50ms
+        sf.wait();
+    }
+
+    void StopServer()
+    {
+        Server->Stop();
+        ServerFuture.wait();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(ServerTest, CreateNodeAndGetAttr)
+{
+    int result = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            NCloud::NFileStore::NProtoPrivate::TMemFastShardConfig cfg;
+            cfg.SetCreateNodeUponAccess(true);
+            auto shard = CreateMemFileSystemShard(1, cfg);
+
+            TServerFixture fixture;
+            fixture.StartServer(shard);
+
+            TClient client(fixture.Port);
+
+            // CreateNode
+            {
+                TRequest req;
+                req.SetFileSystemId("test-fs");
+                auto* body = req.MutableCreateNode();
+                body->SetNodeId(1);
+                body->MutableFile()->SetMode(0644);
+                body->SetName("hello.txt");
+                auto resp = client.Send(req);
+                EXPECT_TRUE(resp.HasCreateNode());
+            }
+
+            // GetNodeAttr
+            {
+                TRequest req;
+                req.SetFileSystemId("test-fs");
+                auto* body = req.MutableGetNodeAttr();
+                body->SetNodeId(1);
+                body->SetName("hello.txt");
+                auto resp = client.Send(req);
+                EXPECT_TRUE(resp.HasGetNodeAttr());
+            }
+
+            fixture.StopServer();
+            return 0;
+        },
+        0);
+
+    EXPECT_EQ(result, 0);
+}
+
+TEST(ServerTest, UnknownShardReturnsEmptyResponse)
+{
+    int result = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            NCloud::NFileStore::NProtoPrivate::TMemFastShardConfig cfg;
+            auto shard = CreateMemFileSystemShard(1, cfg);
+
+            TServerFixture fixture;
+            fixture.StartServer(shard);
+
+            TClient client(fixture.Port);
+
+            TRequest req;
+            req.SetFileSystemId("nonexistent-fs");
+            auto* body = req.MutableGetNodeAttr();
+            body->SetNodeId(1);
+            body->SetName("x");
+            auto resp = client.Send(req);
+            EXPECT_TRUE(resp.HasError());
+            EXPECT_EQ(
+                resp.GetError().GetCode(),
+                static_cast<ui32>(ENOENT));
+
+            fixture.StopServer();
+            return 0;
+        },
+        0);
+
+    EXPECT_EQ(result, 0);
+}

--- a/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
@@ -1,6 +1,5 @@
 GTEST()
 
-
 SRCS(
     ../server_ut.cpp
 )

--- a/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
@@ -1,0 +1,21 @@
+GTEST()
+
+
+SRCS(
+    server_ut.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/client
+    cloud/filestore/libs/storage/fastshard/server
+    cloud/filestore/libs/storage/fastshard/server/protos
+    cloud/filestore/libs/storage/fastshard/impl/mem
+
+    cloud/filestore/private/api/unsafe_protos
+
+    contrib/libs/silk/src/fibers
+
+    contrib/restricted/googletest/googletest
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
@@ -2,7 +2,7 @@ GTEST()
 
 
 SRCS(
-    server_ut.cpp
+    ../server_ut.cpp
 )
 
 PEERDIR(

--- a/cloud/filestore/libs/storage/fastshard/server/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ya.make
@@ -1,0 +1,21 @@
+LIBRARY()
+
+
+SRCS(
+    server.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/iface
+    cloud/filestore/libs/storage/fastshard/server/protos
+
+    contrib/libs/silk/src/fibers
+
+    library/cpp/threading/future
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/cloud/filestore/libs/storage/fastshard/server/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ya.make
@@ -1,22 +1,31 @@
 LIBRARY()
 
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    SRCS(
+        server.cpp
+    )
 
-SRCS(
-    server.cpp
-)
+    PEERDIR(
+        contrib/libs/silk/src/fibers
+    )
+ELSE()
+    SRCS(
+        server_stub.cpp
+    )
+ENDIF()
 
 PEERDIR(
     cloud/filestore/libs/storage/fastshard/iface
     cloud/filestore/libs/storage/fastshard/ipc
     cloud/filestore/libs/storage/fastshard/server/protos
 
-    contrib/libs/silk/src/fibers
-
     library/cpp/threading/future
 )
 
 END()
 
-RECURSE_FOR_TESTS(
-    ut
-)
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    RECURSE_FOR_TESTS(
+        ut
+    )
+ENDIF()

--- a/cloud/filestore/libs/storage/fastshard/server/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ya.make
@@ -6,6 +6,8 @@ IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     )
 
     PEERDIR(
+        cloud/filestore/libs/storage/fastshard/ipc
+
         contrib/libs/silk/src/fibers
     )
 ELSE()
@@ -16,8 +18,9 @@ ENDIF()
 
 PEERDIR(
     cloud/filestore/libs/storage/fastshard/iface
-    cloud/filestore/libs/storage/fastshard/ipc
     cloud/filestore/libs/storage/fastshard/server/protos
+
+    cloud/storage/core/libs/common
 
     library/cpp/threading/future
 )

--- a/cloud/filestore/libs/storage/fastshard/server/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ya.make
@@ -7,6 +7,7 @@ SRCS(
 
 PEERDIR(
     cloud/filestore/libs/storage/fastshard/iface
+    cloud/filestore/libs/storage/fastshard/ipc
     cloud/filestore/libs/storage/fastshard/server/protos
 
     contrib/libs/silk/src/fibers

--- a/cloud/filestore/libs/storage/fastshard/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/ya.make
@@ -2,5 +2,6 @@ RECURSE(
     client
     iface
     impl
+    ipc
     server
 )

--- a/cloud/filestore/libs/storage/fastshard/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/ya.make
@@ -1,4 +1,6 @@
 RECURSE(
+    client
     iface
     impl
+    server
 )


### PR DESCRIPTION
### Notes
Added a tcp server that can register `IFileSystemShard`s and forward requests to them. Needed to be able to:
* test different `IFileSystemShard` implementations directly without the need to launch filestore-server
* implement a filestore-vhost <-> shard side-channel for some of the requests - initially for reads and writes (see https://github.com/ydb-platform/nbs/pull/6072)

Added a simple client - currently it's not very efficient, I'll optimize it later (to reuse tcp connections, etc)

Client and server are replaced with stubs in non-oss builds

The next PRs will include:
1. `NFastShard::TServer` integration into `filestore-server`
2. `NFastShard::TClient` integration into `filestore-loadtest` + a loadtest test suite that works with memshards via these client+server
3. `NFastShard::TClient` optimization to reuse tcp connections
4. `NFastShard::TClient` integration into `filestore-vhost` + `TTCPSideChannel` implementation
5. a standalone daemon that can host `IFileSystemShard` instances and expose them via `NFastShard::TServer`

### Issue
https://github.com/ydb-platform/nbs/issues/5894