### PR TITLE
Proper usage of ICertificateProvider interface

### DIFF
--- a/cloud/blockstore/apps/client/lib/command.cpp
+++ b/cloud/blockstore/apps/client/lib/command.cpp
@@ -438,6 +438,8 @@ void TCommand::Init()
             VolumeStats,
             ClientConfig->GetInstanceId());
 
+        CertificateProvider = CreateClientCertificateProvider(ClientConfig);
+
         auto [client, error] = CreateClient(
             ClientConfig,
             Timer,
@@ -445,7 +447,7 @@ void TCommand::Init()
             Logging,
             Monitoring,
             ClientStats,
-            CreateClientCertificateProvider(ClientConfig));
+            CertificateProvider);
 
         Y_ABORT_UNLESS(!HasError(error));
         Client = std::move(client);
@@ -654,6 +656,10 @@ void TCommand::Start()
         Monitoring->Start();
     }
 
+    if (CertificateProvider) {
+        CertificateProvider->Start();
+    }
+
     if (Client) {
         Client->Start();
     }
@@ -691,6 +697,10 @@ void TCommand::Stop()
 
     if (Client) {
         Client->Stop();
+    }
+
+    if (CertificateProvider) {
+        CertificateProvider->Stop();
     }
 
     if (Monitoring) {

--- a/cloud/blockstore/apps/client/lib/command.h
+++ b/cloud/blockstore/apps/client/lib/command.h
@@ -13,6 +13,7 @@
 #include <cloud/blockstore/libs/throttling/throttler.h>
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/iam/iface/client.h>
+#include <cloud/storage/core/libs/grpc/public.h>
 
 #include <contrib/ydb/library/actors/util/should_continue.h>
 #include <library/cpp/getopt/small/last_getopt.h>
@@ -70,6 +71,7 @@ protected:
     TClientAppConfigPtr ClientConfig;
     IClientPtr Client;
     IBlockStorePtr ClientEndpoint;
+    ICertificateProviderPtr CertificateProvider;
 
     IThrottlerPtr Throttler;
 

--- a/cloud/blockstore/tools/nbd/bootstrap.cpp
+++ b/cloud/blockstore/tools/nbd/bootstrap.cpp
@@ -238,6 +238,10 @@ void TBootstrap::Start()
         Monitoring->Start();
     }
 
+    if (CertificateProvider) {
+        CertificateProvider->Start();
+    }
+
     if (Client) {
         Client->Start();
     }
@@ -347,6 +351,10 @@ void TBootstrap::Stop()
         Client->Stop();
     }
 
+    if (CertificateProvider) {
+        CertificateProvider->Stop();
+    }
+
     if (Monitoring) {
         Monitoring->Stop();
     }
@@ -390,6 +398,8 @@ void TBootstrap::InitControlClient()
         VolumeStats,
         ClientConfig->GetInstanceId());
 
+    CertificateProvider = CreateClientCertificateProvider(ClientConfig);
+
     auto [client, error] = CreateClient(
         ClientConfig,
         Timer,
@@ -397,7 +407,7 @@ void TBootstrap::InitControlClient()
         Logging,
         Monitoring,
         ClientStats,
-        CreateClientCertificateProvider(ClientConfig));
+        CertificateProvider);
 
     Y_ABORT_UNLESS(!HasError(error));
     Client = std::move(client);

--- a/cloud/blockstore/tools/nbd/bootstrap.h
+++ b/cloud/blockstore/tools/nbd/bootstrap.h
@@ -8,6 +8,8 @@
 #include <cloud/blockstore/libs/nbd/public.h>
 #include <cloud/blockstore/libs/service/public.h>
 
+#include <cloud/storage/core/libs/grpc/public.h>
+
 #include <library/cpp/logger/log.h>
 
 #include <util/network/socket.h>
@@ -33,6 +35,7 @@ private:
     IVolumeStatsPtr VolumeStats;
     IServerStatsPtr ClientStats;
     IStatsUpdaterPtr StatsUpdater;
+    ICertificateProviderPtr CertificateProvider;
 
     NClient::IClientPtr Client;
     IBlockStorePtr ClientEndpoint;

--- a/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.cpp
@@ -141,6 +141,21 @@ TRdmaEndpointConfig CreateRdmaEndpointConfig(const TClientAppConfig& config)
     };
 }
 
+ICertificateProviderPtr CreateCertificateProvider(
+    const TClientAppConfigPtr& config)
+{
+    TVector<NCloud::TCertificateFiles> certPathList {
+        {
+            .PrivateKeyPath = config->GetCertPrivateKeyFile(),
+            .CertChainPath = config->GetCertFile()
+        }
+    };
+
+    return CreateStaticCertificateProvider(
+        config->GetRootCertsFile(),
+        std::move(certPathList));
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -232,6 +247,8 @@ void TBootstrap::Init()
         SpdkLog = Logging->CreateLog("BLOCKSTORE_SPDK");
         spdkParts.LogInitializer(SpdkLog);
     }
+
+    CertificateProvider = CreateCertificateProvider(ClientConfig);
 }
 
 IBlockStoreValidationClientPtr TBootstrap::CreateValidationClient(
@@ -274,21 +291,6 @@ TClientAppConfigPtr CreateClientConfig(
     return std::make_shared<TClientAppConfig>(appConfig);
 }
 
-ICertificateProviderPtr CreateCertificateProvider(
-    const TClientAppConfigPtr& config)
-{
-    TVector<NCloud::TCertificateFiles> certPathList {
-        {
-            .PrivateKeyPath = config->GetCertPrivateKeyFile(),
-            .CertChainPath = config->GetCertFile()
-        }
-    };
-
-    return CreateStaticCertificateProvider(
-        config->GetRootCertsFile(),
-        std::move(certPathList));
-}
-
 IClientPtr TBootstrap::CreateAndStartGrpcClient(TString clientId)
 {
     auto config = CreateClientConfig(ClientConfig, std::move(clientId));
@@ -300,7 +302,6 @@ IClientPtr TBootstrap::CreateAndStartGrpcClient(TString clientId)
         VolumeStats,
         TestInstanceId);
 
-    auto certificateProvider = CreateCertificateProvider(config);
     auto [client, error] = NClient::CreateClient(
         std::move(config),
         Timer,
@@ -308,7 +309,7 @@ IClientPtr TBootstrap::CreateAndStartGrpcClient(TString clientId)
         Logging,
         Monitoring,
         std::move(clientStats),
-        certificateProvider);
+        CertificateProvider);
 
     Y_ABORT_UNLESS(!HasError(error));
 
@@ -608,6 +609,10 @@ void TBootstrap::Start()
         Scheduler->Start();
     }
 
+    if (CertificateProvider) {
+        CertificateProvider->Start();
+    }
+
     if (Spdk) {
         Spdk->Start();
     }
@@ -622,6 +627,10 @@ void TBootstrap::Stop()
 
     if (Spdk) {
         Spdk->Stop();
+    }
+
+    if (CertificateProvider) {
+        CertificateProvider->Stop();
     }
 
     if (Scheduler) {

--- a/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.h
+++ b/cloud/blockstore/tools/testing/loadtest/lib/bootstrap.h
@@ -12,6 +12,7 @@
 
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
+#include <cloud/storage/core/libs/grpc/public.h>
 #include <cloud/storage/core/libs/rdma/iface/public.h>
 
 #include <util/thread/lfstack.h>
@@ -51,6 +52,7 @@ private:
     IRequestStatsPtr RequestStats;
     IVolumeStatsPtr VolumeStats;
     IServerStatsPtr ClientStats;
+    ICertificateProviderPtr CertificateProvider;
     NSpdk::ISpdkEnvPtr Spdk;
     std::function<void(TLog& log)> SpdkLogInitializer;
 

--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -337,6 +337,8 @@ void TFileStoreServiceCommand::Init()
 {
     TCommand::Init();
 
+    CertificateProvider = CreateClientCertificateProvider(ClientConfig);
+
     Client = CreateDurableClient(
         Logging,
         Timer,
@@ -345,12 +347,16 @@ void TFileStoreServiceCommand::Init()
         CreateFileStoreClient(
             ClientConfig,
             Logging,
-            CreateClientCertificateProvider(ClientConfig)));
+            CertificateProvider));
 }
 
 void TFileStoreServiceCommand::Start()
 {
     TCommand::Start();
+
+    if (CertificateProvider) {
+        CertificateProvider->Start();
+    }
 
     if (Client) {
         Client->Start();
@@ -361,6 +367,10 @@ void TFileStoreServiceCommand::Stop()
 {
     if (Client) {
         Client->Stop();
+    }
+
+    if (CertificateProvider) {
+        CertificateProvider->Stop();
     }
 
     TCommand::Stop();

--- a/cloud/filestore/apps/client/lib/command.cpp
+++ b/cloud/filestore/apps/client/lib/command.cpp
@@ -244,6 +244,8 @@ void TCommand::Init()
     }
 
     ClientConfig = std::make_shared<TClientConfig>(config);
+
+    CertificateProvider = CreateClientCertificateProvider(ClientConfig);
 }
 
 void TCommand::Start()
@@ -259,12 +261,20 @@ void TCommand::Start()
     if (Monitoring) {
         Monitoring->Start();
     }
+
+    if (CertificateProvider) {
+        CertificateProvider->Start();
+    }
 }
 
 void TCommand::Stop()
 {
     if (IamClient) {
         IamClient->Stop();
+    }
+
+    if (CertificateProvider) {
+        CertificateProvider->Stop();
     }
 
     if (Monitoring) {
@@ -337,8 +347,6 @@ void TFileStoreServiceCommand::Init()
 {
     TCommand::Init();
 
-    CertificateProvider = CreateClientCertificateProvider(ClientConfig);
-
     Client = CreateDurableClient(
         Logging,
         Timer,
@@ -354,10 +362,6 @@ void TFileStoreServiceCommand::Start()
 {
     TCommand::Start();
 
-    if (CertificateProvider) {
-        CertificateProvider->Start();
-    }
-
     if (Client) {
         Client->Start();
     }
@@ -367,10 +371,6 @@ void TFileStoreServiceCommand::Stop()
 {
     if (Client) {
         Client->Stop();
-    }
-
-    if (CertificateProvider) {
-        CertificateProvider->Stop();
     }
 
     TCommand::Stop();

--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -18,6 +18,7 @@
 #include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
+#include <cloud/storage/core/libs/grpc/public.h>
 #include <cloud/storage/core/libs/iam/iface/client.h>
 
 #include <contrib/ydb/library/actors/util/should_continue.h>
@@ -48,6 +49,7 @@ protected:
     ui32 MonitoringPort = 0;
     ui32 MonitoringThreads = 0;
     IMonitoringServicePtr Monitoring;
+    ICertificateProviderPtr CertificateProvider;
 
     ITimerPtr Timer;
     ISchedulerPtr Scheduler;

--- a/cloud/filestore/apps/client/lib/ping.cpp
+++ b/cloud/filestore/apps/client/lib/ping.cpp
@@ -9,21 +9,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ICertificateProviderPtr CreateClientCertificateProvider(
-    const TClientConfigPtr& config)
-{
-    TVector<NCloud::TCertificateFiles> certPathList {
-        {
-            .PrivateKeyPath = config->GetCertPrivateKeyFile(),
-            .CertChainPath = config->GetCertFile()
-        }
-    };
-
-    return CreateStaticCertificateProvider(
-        config->GetRootCertsFile(),
-        std::move(certPathList));
-}
-
 class TPingCommand final:
     public TCommand
 {
@@ -54,7 +39,7 @@ public:
                 CreateFileStoreClient(
                     ClientConfig,
                     Logging,
-                    CreateClientCertificateProvider(ClientConfig)));
+                    CertificateProvider));
         } else {
             EndpointClient = CreateDurableClient(
                 Logging,
@@ -64,7 +49,7 @@ public:
                 CreateEndpointManagerClient(
                     ClientConfig,
                     Logging,
-                    CreateClientCertificateProvider(ClientConfig)));
+                    CertificateProvider));
         }
     }
 

--- a/cloud/filestore/tools/testing/loadtest/bin/bootstrap.cpp
+++ b/cloud/filestore/tools/testing/loadtest/bin/bootstrap.cpp
@@ -57,6 +57,7 @@ private:
     const ILoggingServicePtr Logging;
     const ITimerPtr Timer;
     const ISchedulerPtr Scheduler;
+    const ICertificateProviderPtr CertificateProvider;
     const NClient::TClientConfigPtr ClientConfig;
 
     TVector<IFileStoreServicePtr> Clients;
@@ -66,10 +67,12 @@ public:
             ILoggingServicePtr logging,
             ITimerPtr timer,
             ISchedulerPtr scheduler,
+            ICertificateProviderPtr certificateProvider,
             NClient::TClientConfigPtr clientConfig)
         : Logging(std::move(logging))
         , Timer(std::move(timer))
         , Scheduler(std::move(scheduler))
+        , CertificateProvider(std::move(certificateProvider))
         , ClientConfig(std::move(clientConfig))
     {}
 
@@ -92,7 +95,7 @@ public:
         auto client = NClient::CreateFileStoreClient(
             ClientConfig,
             Logging,
-            CreateClientCertificateProvider(ClientConfig));
+            CertificateProvider);
 
         client = NClient::CreateDurableClient(
             Logging,
@@ -133,10 +136,13 @@ void TBootstrap::Init()
     Timer = CreateWallClockTimer();
     Scheduler = CreateScheduler();
 
+    CertificateProvider = CreateClientCertificateProvider(ClientConfig);
+
     ClientFactory = std::make_shared<TClientFactory>(
         Logging,
         Timer,
         Scheduler,
+        CertificateProvider,
         ClientConfig);
 }
 
@@ -154,6 +160,10 @@ void TBootstrap::Start()
         Scheduler->Start();
     }
 
+    if (CertificateProvider) {
+        CertificateProvider->Start();
+    }
+
     if (ClientFactory) {
         ClientFactory->Start();
     }
@@ -163,6 +173,10 @@ void TBootstrap::Stop()
 {
     if (ClientFactory) {
         ClientFactory->Stop();
+    }
+
+    if (CertificateProvider) {
+        CertificateProvider->Stop();
     }
 
     if (Scheduler) {

--- a/cloud/filestore/tools/testing/loadtest/bin/bootstrap.h
+++ b/cloud/filestore/tools/testing/loadtest/bin/bootstrap.h
@@ -9,6 +9,7 @@
 
 #include <cloud/storage/core/libs/common/public.h>
 #include <cloud/storage/core/libs/diagnostics/public.h>
+#include <cloud/storage/core/libs/grpc/public.h>
 
 #include <library/cpp/logger/log.h>
 
@@ -28,6 +29,7 @@ private:
     IMonitoringServicePtr Monitoring;
     ITimerPtr Timer;
     ISchedulerPtr Scheduler;
+    ICertificateProviderPtr CertificateProvider;
 
     NClient::TClientConfigPtr ClientConfig;
     IClientFactoryPtr ClientFactory;

--- a/cloud/vm/blockstore/bootstrap.cpp
+++ b/cloud/vm/blockstore/bootstrap.cpp
@@ -194,6 +194,8 @@ void TBootstrap::Init()
         VolumeStats,
         ClientConfig->GetInstanceId());
 
+    CertificateProvider = CreateCertificateProvider(ClientConfig);
+
     auto [client, error] = CreateClient(
         ClientConfig,
         Timer,
@@ -201,7 +203,7 @@ void TBootstrap::Init()
         Logging,
         Monitoring,
         ClientStats,
-        CreateCertificateProvider(ClientConfig));
+        CertificateProvider);
 
     Y_ABORT_UNLESS(!HasError(error));
     Client = std::move(client);
@@ -409,6 +411,10 @@ void TBootstrap::Start()
         TraceProcessor->Start();
     }
 
+    if (CertificateProvider) {
+        CertificateProvider->Start();
+    }
+
     if (Client) {
         Client->Start();
     }
@@ -454,6 +460,10 @@ void TBootstrap::Stop()
 
     if (Client) {
         Client->Stop();
+    }
+
+    if (CertificateProvider) {
+        CertificateProvider->Stop();
     }
 
     if (TraceProcessor) {

--- a/cloud/vm/blockstore/bootstrap.h
+++ b/cloud/vm/blockstore/bootstrap.h
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/nbd/public.h>
 #include <cloud/blockstore/libs/throttling/public.h>
 #include <cloud/storage/core/libs/grpc/init.h>
+#include <cloud/storage/core/libs/grpc/public.h>
 
 #include <cloud/blockstore/config/plugin.pb.h>
 
@@ -47,6 +48,7 @@ private:
     IStatsUpdaterPtr StatsUpdater;
     TVector<ITraceReaderPtr> TraceReaders;
     ITraceProcessorPtr TraceProcessor;
+    ICertificateProviderPtr CertificateProvider;
 
     IThrottlerPtr Throttler;
     NClient::IClientPtr Client;


### PR DESCRIPTION
### Notes
Proper usage of ICertificateProvider interface. It should be started befor using and stopped before destruction. It is not nessesary for static provider but future implementations will require this

### Issue
https://github.com/ydb-platform/nbs/issues/5722
