### PR TITLE
[Filestore] Copy data directly to iovecs only when ZeroCopyReadEnabled

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -180,9 +180,9 @@ TReadDataActor::TReadDataActor(
     , BlockSize(blockSize)
     , ReadBlobDisabled(readBlobDisabled)
     , OriginByteRange(
-          ReadRequest.GetOffset(),
-          ReadRequest.GetLength(),
-          BlockSize)
+        ReadRequest.GetOffset(),
+        ReadRequest.GetLength(),
+        BlockSize)
     , AlignedByteRange(OriginByteRange.AlignedSuperRange())
     , BlockBuffer(std::make_unique<TString>())
     , ZeroIntervals(TDefaultAllocator::Instance(), 0, OriginByteRange.Length)

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -89,6 +89,7 @@ private:
     const NCloud::NProto::EStorageMediaKind MediaKind;
     const bool UseTwoStageRead;
     const bool UseCustomReadDataResponseParser;
+    const bool ZeroCopyReadEnabled;
 
 public:
     TReadDataActor(
@@ -110,7 +111,8 @@ public:
         TShardStatePtr shardState,
         NCloud::NProto::EStorageMediaKind mediaKind,
         bool useTwoStageRead,
-        bool useCustomReadDataResponseParser);
+        bool useCustomReadDataResponseParser,
+        bool zeroCopyReadEnabled);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -171,15 +173,16 @@ TReadDataActor::TReadDataActor(
         TShardStatePtr shardState,
         NCloud::NProto::EStorageMediaKind mediaKind,
         bool useTwoStageRead,
-        bool useCustomReadDataResponseParser)
+        bool useCustomReadDataResponseParser,
+        bool zeroCopyReadEnabled)
     : ReadRequest(std::move(readRequest))
     , LogTag(std::move(logTag))
     , BlockSize(blockSize)
     , ReadBlobDisabled(readBlobDisabled)
     , OriginByteRange(
-        ReadRequest.GetOffset(),
-        ReadRequest.GetLength(),
-        BlockSize)
+          ReadRequest.GetOffset(),
+          ReadRequest.GetLength(),
+          BlockSize)
     , AlignedByteRange(OriginByteRange.AlignedSuperRange())
     , BlockBuffer(std::make_unique<TString>())
     , ZeroIntervals(TDefaultAllocator::Instance(), 0, OriginByteRange.Length)
@@ -198,13 +201,18 @@ TReadDataActor::TReadDataActor(
     , MediaKind(mediaKind)
     , UseTwoStageRead(useTwoStageRead)
     , UseCustomReadDataResponseParser(useCustomReadDataResponseParser)
+    , ZeroCopyReadEnabled(
+          zeroCopyReadEnabled &&
+          !ReadRequest.GetIovecs()
+               .empty())   // Zero-copy read optimization is only applicable
+                           // when iovecs are provided
 {
 }
 
 void TReadDataActor::Bootstrap(const TActorContext& ctx)
 {
     if (UseTwoStageRead) {
-        if (ReadRequest.GetIovecs().empty()) {
+        if (!ZeroCopyReadEnabled) {
             // BlockBuffer should not be initialized in constructor, because
             // creating a block buffer leads to memory allocation (and
             // initialization) which is heavy and we would like to execute that
@@ -859,7 +867,7 @@ void TReadDataActor::ReplyTwoStageAndDie(const TActorContext& ctx)
         BlockBuffer->clear();
     } else {
         const ui64 length = end - OriginByteRange.Offset;
-        if (ReadRequest.GetIovecs().empty()) {
+        if (!ZeroCopyReadEnabled) {
             BlockBuffer->ReserveAndResize(length);
             response->Record.set_allocated_buffer(BlockBuffer.release());
         } else {
@@ -867,6 +875,7 @@ void TReadDataActor::ReplyTwoStageAndDie(const TActorContext& ctx)
         }
     }
 
+    MoveBufferToIovecsIfNeeded(ctx, response->Record);
     SendResponseAndDie(ctx, std::move(response));
 }
 
@@ -1053,7 +1062,8 @@ void TStorageServiceActor::HandleReadData(
         std::move(shardState),
         session->MediaKind,
         useTwoStageRead,
-        filestore.GetFeatures().GetUseCustomReadDataResponseParser());
+        filestore.GetFeatures().GetUseCustomReadDataResponseParser(),
+        filestore.GetFeatures().GetZeroCopyReadEnabled());
 
     NCloud::Register(ctx, std::move(actor));
 }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4811,6 +4811,15 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         testReadDataRequestWithIovecs(std::move(config));
     }
 
+    Y_UNIT_TEST(
+        ShouldUseIovecsForReadDataRequestWithTwoStageReadAndZeroCopyRead)
+    {
+        NProto::TStorageConfig config;
+        config.SetTwoStageReadEnabled(true);
+        config.SetZeroCopyReadEnabled(true);
+        testReadDataRequestWithIovecs(std::move(config));
+    }
+
     Y_UNIT_TEST(ShouldUseIovecsForReadDataRequestWithCustomParserEnabled)
     {
         NProto::TStorageConfig config;

--- a/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/nfs-storage-config-patch.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/nfs-storage-config-patch.txt
@@ -1,3 +1,5 @@
 ParentlessFilesOnly: true
 AllowHandlelessIO: true
 AutomaticShardCreationEnabled: true
+TwoStageReadEnabled: true
+ThreeStageWriteEnabled: true


### PR DESCRIPTION
#6107

Filestore users running in the data-shard configuration observed that copying data directly into iovecs can be slower than first assembling the data in an intermediate buffer and then copying the entire buffer into the iovecs.
To evaluate this tradeoff and determine the optimal approach for different workloads, we need to add support for ZeroCopyReadEnabled in TReadDataActor. This will allow us to compare the performance of both configurations and choose the most efficient setup for specific scenarios.