### PR TITLE
issue-4649: Add E_TRANSPORT_ERROR to the aborted error kinds (part 2)

### DIFF
--- a/cloud/filestore/libs/diagnostics/request_stats_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/request_stats_ut.cpp
@@ -1033,6 +1033,44 @@ Y_UNIT_TEST_SUITE(TRequestStatRegistryTest)
         bootstrap.Registry->GetRequestStats()->Reset();
         bootstrap.Registry->GetRequestStats()->UpdateStats(false);
     }
+
+    Y_UNIT_TEST(ShouldProperlyRegisterErrorKinds)
+    {
+        TBootstrap bootstrap;
+
+        auto stats =
+            bootstrap.Registry->GetFileSystemStats(FS, CLIENT, CLOUD, FOLDER);
+        UNIT_ASSERT(stats);
+
+        auto fsCounters = GetFsCounters(
+            bootstrap.Counters
+                ->FindSubgroup("component", METRIC_FS_COMPONENT)
+                ->FindSubgroup("host", "cluster"),
+            FS,
+            CLIENT,
+            CLOUD,
+            FOLDER);
+        UNIT_ASSERT(fsCounters);
+
+        auto requestCounters =
+            fsCounters->FindSubgroup("request", "CreateHandle");
+        UNIT_ASSERT(requestCounters);
+
+        {
+            auto context = MakeIntrusive<TCallContext>(FS, ui64(1));
+            context->RequestType = EFileStoreRequest::CreateHandle;
+            stats->RequestStarted(*context);
+            stats->RequestCompleted(*context, MakeError(E_TRANSPORT_ERROR));
+        }
+
+        // E_TRANSPORT_ERROR must be counted as Aborted, not Fatal
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            requestCounters->GetCounter("Errors/Aborted")->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            requestCounters->GetCounter("Errors/Fatal")->Val());
+    }
 }
 
 } // namespace NCloud::NFileStore::NStorage

--- a/cloud/storage/core/libs/common/error.cpp
+++ b/cloud/storage/core/libs/common/error.cpp
@@ -168,6 +168,7 @@ EDiagnosticsErrorKind GetDiagnosticsErrorKind(const NProto::TError& e)
         case E_BS_INVALID_SESSION:
             return EDiagnosticsErrorKind::ErrorSession;
         case E_ABORTED:
+        case E_TRANSPORT_ERROR:
             return EDiagnosticsErrorKind::ErrorAborted;
     }
 


### PR DESCRIPTION
### Notes
Forgot to do it here (see more details in this PR): https://github.com/ydb-platform/nbs/pull/6038

### Issue
#4649
