### PR TITLE
fix: fail fast on checkout instead of waiting

### DIFF
--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -109,6 +109,7 @@ jobs:
     steps:
     - name: Checkout PR
       uses: actions/checkout@v6
+      timeout-minutes: 10
       if: github.event.pull_request.head.sha != ''
       with:
         submodules: true
@@ -130,6 +131,7 @@ jobs:
         git submodule update --init --recursive
     - name: Checkout
       uses: actions/checkout@v6
+      timeout-minutes: 10
       if: github.event.pull_request.head.sha == ''
       with:
         submodules: true

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -109,6 +109,7 @@ jobs:
     steps:
     - name: Checkout PR
       uses: actions/checkout@v6
+      timeout-minutes: 10
       if: github.event.pull_request.head.sha != ''
       with:
         submodules: true
@@ -130,6 +131,7 @@ jobs:
         git submodule update --init --recursive
     - name: Checkout
       uses: actions/checkout@v6
+      timeout-minutes: 10
       if: github.event.pull_request.head.sha == ''
       with:
         submodules: true

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -119,6 +119,7 @@ jobs:
         chown -R root:root $GITHUB_WORKSPACE
     - name: Checkout PR
       uses: actions/checkout@v6
+      timeout-minutes: 10
       if: github.event.pull_request.head.sha != ''
       with:
         submodules: true
@@ -140,6 +141,7 @@ jobs:
         git submodule update --init --recursive
     - name: Checkout
       uses: actions/checkout@v6
+      timeout-minutes: 10
       if: github.event.pull_request.head.sha == ''
       with:
         submodules: true
@@ -331,6 +333,7 @@ jobs:
           chown -R root:root $GITHUB_WORKSPACE
       - name: Checkout PR
         uses: actions/checkout@v6
+        timeout-minutes: 10
         if: github.event.pull_request.head.sha != ''
         with:
           submodules: true
@@ -352,6 +355,7 @@ jobs:
           git submodule update --init --recursive
       - name: Checkout
         uses: actions/checkout@v6
+        timeout-minutes: 10
         if: github.event.pull_request.head.sha == ''
         with:
           submodules: true


### PR DESCRIPTION
While https://github.com/actions/checkout/pull/2392 is in the works we sometimes experience issue when repo checks out really slowly and it is better to fail fast and restart check than to wait for repo download for 6 hours

https://www.reddit.com/r/github/comments/1tkgoiw/git_checkouts_extremely_slow_or_timing_out_from_eu/