### PR TITLE
[disk-manager] fix for DOSing discovery loop

### DIFF
--- a/cloud/blockstore/public/sdk/go/client/discovery.go
+++ b/cloud/blockstore/public/sdk/go/client/discovery.go
@@ -15,6 +15,7 @@ import (
 const (
 	defaultHardTimeout = 8 * time.Minute
 	defaultSoftTimeout = 15 * time.Second
+	defaultRetryDelay  = 200 * time.Millisecond
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,6 +50,7 @@ type DiscoveryClientOpts struct {
 	Limit       uint32
 	HardTimeout time.Duration
 	SoftTimeout time.Duration
+	RetryDelay  time.Duration
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,6 +67,7 @@ type discoveryClient struct {
 	secure        bool
 	cachedImpl    ClientIface
 	mtx           sync.Mutex
+	retryDelay    time.Duration
 }
 
 type shootResult struct {
@@ -300,6 +303,12 @@ func (client *discoveryClient) mainShoot(
 		}
 
 		instances = nil
+
+		select {
+		case <-ctx.Done():
+			return &shootResult{nil, nil, ctx.Err()}
+		case <-time.After(client.retryDelay):
+		}
 	}
 }
 
@@ -1062,6 +1071,12 @@ func newDiscoveryClient(
 		softTimeout = discoveryOpts.SoftTimeout
 	}
 
+	retryDelay := defaultRetryDelay
+
+	if discoveryOpts.RetryDelay != 0 {
+		retryDelay = discoveryOpts.RetryDelay
+	}
+
 	return &discoveryClient{
 		endpoints:     endpoints,
 		clientFactory: factory,
@@ -1070,6 +1085,7 @@ func newDiscoveryClient(
 		hardTimeout:   hardTimeout,
 		softTimeout:   softTimeout,
 		secure:        secure,
+		retryDelay:    retryDelay,
 	}
 }
 

--- a/cloud/disk_manager/internal/pkg/clients/nbs/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/config/config.proto
@@ -33,4 +33,5 @@ message ClientConfig {
     optional string SessionRediscoverPeriodMax = 12 [default = "6m"];
     // ServerRequestTimeout is passed to server in headers and handled on the server side.
     optional string ServerRequestTimeout = 13 [default = "20s"];
+    optional string DiscoveryClientRetryDelay = 14 [default = "200ms"];
 }

--- a/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
@@ -148,7 +148,7 @@ func (f *factory) initClients(
 			&nbs_client.DiscoveryClientOpts{
 				HardTimeout: discoveryClientHardTimeout,
 				SoftTimeout: discoveryClientSoftTimeout,
-				RetryDelay: discoveryClientRetryDelay,
+				RetryDelay:  discoveryClientRetryDelay,
 			},
 			logging.GetLogger(ctx),
 		)

--- a/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
+++ b/cloud/disk_manager/internal/pkg/clients/nbs/factory.go
@@ -88,6 +88,13 @@ func (f *factory) initClients(
 		return err
 	}
 
+	discoveryClientRetryDelay, err := time.ParseDuration(
+		f.config.GetDiscoveryClientRetryDelay(),
+	)
+	if err != nil {
+		return err
+	}
+
 	sessionRediscoverPeriodMin, err := time.ParseDuration(
 		f.config.GetSessionRediscoverPeriodMin(),
 	)
@@ -141,6 +148,7 @@ func (f *factory) initClients(
 			&nbs_client.DiscoveryClientOpts{
 				HardTimeout: discoveryClientHardTimeout,
 				SoftTimeout: discoveryClientSoftTimeout,
+				RetryDelay: discoveryClientRetryDelay,
 			},
 			logging.GetLogger(ctx),
 		)


### PR DESCRIPTION
### Notes
Fix for DOSing discovery loop in disk-manager.
If nbs_control returns empty Discovery response, disk-manager doesn't wait and immediately sends new request.

### Issue
In case of problems with access to hosts in nbs-discovery.txt config file or gradual decommissioning, nbs_control can return empty response - it is valid situation. But disk-manager in loop sends new requests without pause.
Logs from nbs_control server:
```
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.247558Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:561: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #13087443118984340247 RESPONSE request completed (execution: 65us, postponed: 0, predicted: 0, backoff: 0, size: 0 B, unaligned: 0, error: S_OK)
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.247485Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:317: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #13087443118984340247 REQUEST { Headers { ClientId: "691f1349-5cc2-9796-7e9f-5e29-d93f4a6d" Timestamp: 1765464428244626 RequestId: 13087443118984340247 RequestTimeout: 20000 } Limit: 3 InstanceFilter: DISCOVERY_SECURE_PORT }
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.241328Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:561: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #11044860395333073586 RESPONSE request completed (execution: 65us, postponed: 0, predicted: 0, backoff: 0, size: 0 B, unaligned: 0, error: S_OK)
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.241256Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:317: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #11044860395333073586 REQUEST { Headers { ClientId: "691f1349-5cc2-9796-7e9f-5e29-d93f4a6d" Timestamp: 1765464428238417 RequestId: 11044860395333073586 RequestTimeout: 20000 } Limit: 3 InstanceFilter: DISCOVERY_SECURE_PORT }
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.235101Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:561: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #9776180973520366886 RESPONSE request completed (execution: 64us, postponed: 0, predicted: 0, backoff: 0, size: 0 B, unaligned: 0, error: S_OK)
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.235028Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:317: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #9776180973520366886 REQUEST { Headers { ClientId: "691f1349-5cc2-9796-7e9f-5e29-d93f4a6d" Timestamp: 1765464428232178 RequestId: 9776180973520366886 RequestTimeout: 20000 } Limit: 3 InstanceFilter: DISCOVERY_SECURE_PORT }
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.228851Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:561: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #4993717764273214388 RESPONSE request completed (execution: 78us, postponed: 0, predicted: 0, backoff: 0, size: 0 B, unaligned: 0, error: S_OK)
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.228762Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:317: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #4993717764273214388 REQUEST { Headers { ClientId: "691f1349-5cc2-9796-7e9f-5e29-d93f4a6d" Timestamp: 1765464428225891 RequestId: 4993717764273214388 RequestTimeout: 20000 } Limit: 3 InstanceFilter: DISCOVERY_SECURE_PORT }
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.222586Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:561: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #11155294375939822770 RESPONSE request completed (execution: 71us, postponed: 0, predicted: 0, backoff: 0, size: 0 B, unaligned: 0, error: S_OK)
Dec 11 14:47:08 nbs-control-nub1.svc.cloud.yandex.net NBS_SERVER[2902723]: 2025-12-11T14:47:08.222507Z :BLOCKSTORE_SERVER INFO: cloud/blockstore/libs/diagnostics/server_stats.cpp:317: [c:691f1349-5cc2-9796-7e9f-5e29-d93f4a6d] DiscoverInstances #11155294375939822770 REQUEST { Headers { ClientId: "691f1349-5cc2-9796-7e9f-5e29-d93f4a6d" Timestamp: 1765464428219670 RequestId: 11155294375939822770 RequestTimeout: 20000 } Limit: 3 InstanceFilter: DISCOVERY_SECURE_PORT }
...
```
