### PR TITLE
issue-5726: tablet shouldn't process private events in StateInit, counter updates should be scheduled after LoadState

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1175,48 +1175,6 @@ STFUNC(TIndexTabletActor::StateInit)
         HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
         HFunc(TEvLocal::TEvTabletMetrics, HandleTabletMetrics);
         HFunc(TEvFileStore::TEvUpdateConfig, HandleUpdateConfig);
-        HFunc(TEvIndexTabletPrivate::TEvUpdateCounters, HandleUpdateCounters);
-        HFunc(TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters, HandleUpdateLeakyBucketCounters);
-        IgnoreFunc(TEvIndexTabletPrivate::TEvRunRegularTasks);
-        HFunc(TEvIndexTabletPrivate::TEvReleaseCollectBarrier, HandleReleaseCollectBarrier);
-        IgnoreFunc(TEvIndexTabletPrivate::TEvCancelUnconfirmedData);
-        HFunc(
-            TEvIndexTabletPrivate::TEvForcedRangeOperationProgress,
-            HandleForcedRangeOperationProgress);
-        HFunc(
-            TEvIndexTabletPrivate::TEvNodeCreatedInShard,
-            HandleNodeCreatedInShard);
-        HFunc(
-            TEvIndexTabletPrivate::TEvNodeUnlinkedInShard,
-            HandleNodeUnlinkedInShard);
-        HFunc(
-            TEvIndexTabletPrivate::TEvUnlinkDirectoryNodeAbortedInShard,
-            HandleUnlinkDirectoryNodeAbortedInShard);
-        HFunc(
-            TEvIndexTabletPrivate::TEvDoRenameNodeInDestination,
-            HandleDoRenameNodeInDestination);
-        HFunc(TEvIndexTabletPrivate::TEvDoRenameNode, HandleDoRenameNode);
-        HFunc(
-            TEvIndexTabletPrivate::TEvNodeRenamedInDestination,
-            HandleNodeRenamedInDestination);
-        HFunc(
-            TEvIndexTabletPrivate::TEvResponseLogEntryDeleted,
-            HandleResponseLogEntryDeleted);
-        HFunc(
-            TEvIndexTabletPrivate::TEvAggregateStatsCompleted,
-            HandleAggregateStatsCompleted);
-        HFunc(
-            TEvIndexTabletPrivate::TEvShardRequestCompleted,
-            HandleShardRequestCompleted);
-        HFunc(
-            TEvIndexTabletPrivate::TEvLoadNodeRefsRequest,
-            HandleLoadNodeRefsRequest);
-        HFunc(
-            TEvIndexTabletPrivate::TEvLoadNodesRequest,
-            HandleLoadNodesRequest);
-        HFunc(
-            TEvIndexTabletPrivate::TEvEnqueueBlobIndexOpIfNeeded,
-            HandleEnqueueBlobIndexOpIfNeeded);
 
         FILESTORE_HANDLE_REQUEST(WaitReady, TEvIndexTablet)
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -512,8 +512,7 @@ void TIndexTabletActor::RegisterCounters(const TActorContext& ctx)
         // only aggregated statistics will be reported by default
         // (you can always turn on per-tablet statistics on monitoring page)
         // TabletCountersAddTablet(TabletID(), ctx);
-
-        ScheduleUpdateCounters(ctx);
+        Y_UNUSED(ctx);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -318,6 +318,8 @@ void TIndexTabletActor::CompleteTx_LoadState(
         return;
     }
 
+    ScheduleUpdateCounters(ctx);
+
     if (args.FileSystem.GetIsFastShard()) {
         BecomeAux(ctx, STATE_ADAPTER);
         CompleteAdapterLoadState(ctx, args);


### PR DESCRIPTION
### Notes
https://github.com/ydb-platform/nbs/pull/5973 revealed a problem - we can actually try to process counter updates in `StateInit`. This PR:
* moves counter update scheduling from `OnActivateExecutor` to `CompleteTx_LoadState`
* deletes all private event handlers from `StateInit` - those events should not arrive at this point, if something arrives - it's a bug (but I checked the code and they shouldn't arrive, apart from the counters thing that this PR fixes)

### Issue
https://github.com/ydb-platform/nbs/issues/5726