### PR TITLE
[NBS] reply to poison pill even if partition is in zombie state

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -410,10 +410,10 @@ void TPartitionActor::BeforeDie(const TActorContext& ctx)
     ClearWriteQueue(ctx);
     CancelPendingRequests(ctx, PendingRequests);
 
-    if (Poisoner) {
+    for (const auto& poisonPill: PendingPoisonPills) {
         NCloud::Reply(
             ctx,
-            *Poisoner,
+            *poisonPill,
             std::make_unique<TEvents::TEvPoisonTaken>());
     }
 
@@ -676,18 +676,20 @@ void TPartitionActor::HandlePoisonPill(
     const TEvents::TEvPoisonPill::TPtr& ev,
     const TActorContext& ctx)
 {
-    Poisoner = CreateRequestInfo(
+    PendingPoisonPills.push_back(CreateRequestInfo(
         ev->Sender,
         ev->Cookie,
-        MakeIntrusive<TCallContext>());
+        MakeIntrusive<TCallContext>()));
 
-    LOG_INFO(
-        ctx,
-        TBlockStoreComponents::PARTITION,
-        "%s Stop tablet because of PoisonPill request",
-        LogTitle.GetWithTime().c_str());
+    if (CurrentState != STATE_ZOMBIE) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::PARTITION,
+            "%s Stop tablet because of PoisonPill request",
+            LogTitle.GetWithTime().c_str());
 
-    Suicide(ctx);
+        Suicide(ctx);
+    }
 }
 
 void TPartitionActor::HandleUpdateCounters(
@@ -1218,7 +1220,8 @@ STFUNC(TPartitionActor::StateZombie)
         HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);
         IgnoreFunc(TEvTablet::TEvTabletStop);
 
-        IgnoreFunc(TEvents::TEvPoisonPill);
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
         IgnoreFunc(TEvTabletPipe::TEvServerConnected);
         IgnoreFunc(TEvTabletPipe::TEvServerDisconnected);
 

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -180,7 +180,7 @@ private:
 
     TPartitionThreadSafeStatePtr SharedState;
 
-    TRequestInfoPtr Poisoner;
+    TVector<TRequestInfoPtr> PendingPoisonPills;
 
 public:
     TPartitionActor(


### PR DESCRIPTION
### Notes
If fbw will send poison pill to partition and partition is in zombie state, event will be ignored and fbw will not die.

I added replying to posion pill  when partition is in zombie state.
