### PR TITLE
Fix flaky test ShouldDestroyFileStoreAfterTabletRestartAndOrphanSessionsCleanup

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -3686,6 +3686,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         ui32 restartTabletRequests = 0;
         ui32 getStorageStatsResponses = 0;
         bool patchedStorageStatsResponse = false;
+        bool blockCreateSession = false;
         runtime.SetEventFilter(
             [&](auto&, TAutoPtr<IEventHandle>& event)
             {
@@ -3720,10 +3721,18 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
                         }
                         break;
                     }
+                    case TEvIndexTablet::EvCreateSessionRequest: {
+                        if (blockCreateSession) {
+                            return true;
+                        }
+                        break;
+                    }
                 }
 
                 return false;
             });
+
+        blockCreateSession = true;
 
         auto destroyFileStoreResponse =
             service.AssertDestroyFileStoreFailed(fsId);


### PR DESCRIPTION
### Notes

Fix flaky test ShouldDestroyFileStoreAfterTabletRestartAndOrphanSessionsCleanup

### Problem

The test was failing with assertion `sessions[0].GetIsOrphan()`

```
assertion failed at cloud/filestore/libs/storage/service/service_ut.cpp:3749, virtual void NCloud::NFileStore::NStorage::NTestSuiteTStorageServiceTest::TTestCaseShouldDestroyFileStoreAfterTabletRestartAndOrphanSessionsCleanup::Execute_(NUnitTest::TTestContext &): (sessions[0].GetIsOrphan()) 
TBackTrace::Capture() at /-S/util/system/backtrace.cpp:284:9
GetCurrentTest at /-S/library/cpp/testing/unittest/registar.cpp:70:12
UnRef at /-S/util/generic/ptr.h:637:13
~TScopeGuard at /-S/util/generic/scope.h:26:13
TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) at /-S/library/cpp/testing/unittest/utmain.cpp:527:13
~__value_func at /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:266:16
UnRef at /-S/util/generic/ptr.h:637:13
NUnitTest::TTestFactory::Execute() at /-S/library/cpp/testing/unittest/registar.cpp:0:19
NUnitTest::RunMain(int, char**) at /-S/library/cpp/testing/unittest/utmain.cpp:0:44
?? at ??:0:0
_start at ??:0:0
```

https://gist.github.com/kobzonega/0586283774449d26bc1dfd751171491b

After `DestroyFileStore` triggers a tablet restart, the session is restored from the database as orphan (no active pipe owner). However, the service worker automatically reconnects and recovers the session before the test checks the orphan status — turning it back into an active (non-orphan) session. This is a race condition in the test

### Root cause

The sequence of events:
1. `DestroyFileStore` detects an active session and restarts the tablet
2. The tablet restarts, restoring the session as orphan (no owner)
3. The service worker detects the pipe disconnect and reconnects
4. The service worker sends `CreateSession`, which adds a new owner to the session — it is no longer orphan
5. The test calls `DescribeSessions` and sees a non-orphan session → assertion fails

Steps 3–4 happen during `DispatchEvents` before the test gets to check the session state.

### Fix

Block `EvCreateSessionRequest` in the event filter after the tablet restart. This prevents the service worker from recovering the session, so the test can reliably observe the orphan state. The blocked requests are simply dropped (not buffered), since the test proceeds to clean up the session via `TIndexTabletClient` and then successfully destroys the filestore.

### Issue
Put links to the related issues here
