### PR TITLE
[Disk Agent] Fix msan failure in null backend read path

### DIFF
--- a/cloud/blockstore/libs/service_local/storage_null.cpp
+++ b/cloud/blockstore/libs/service_local/storage_null.cpp
@@ -4,6 +4,9 @@
 #include <cloud/blockstore/libs/service/storage.h>
 #include <cloud/blockstore/libs/service/storage_provider.h>
 
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/sglist.h>
+
 namespace NCloud::NBlockStore::NServer {
 
 using namespace NThreading;
@@ -31,7 +34,31 @@ public:
         std::shared_ptr<NProto::TReadBlocksLocalRequest> request) override
     {
         Y_UNUSED(callContext);
-        Y_UNUSED(request);
+
+        const auto blockSize = request->GetBlockSize();
+        const auto blocksCount = request->GetBlocksCount();
+        size_t responseSize = blockSize * blocksCount;
+
+        auto guard = request->Sglist.Acquire();
+        if (!guard) {
+            NProto::TReadBlocksLocalResponse response = TErrorResponse(
+                E_CANCELLED,
+                "failed to acquire sglist in NullStorage");
+            return MakeFuture(std::move(response));
+        }
+
+        // simulate zero response
+        for (const auto& buf : guard.Get()) {
+            if (responseSize == 0) {
+                break;
+            }
+
+            const auto size = std::min(buf.Size(), responseSize);
+            if (buf.Data()) {
+                memset(const_cast<char*>(buf.Data()), 0, size);
+            }
+            responseSize -= size;
+        }
 
         return MakeFuture(NProto::TReadBlocksLocalResponse());
     }

--- a/cloud/blockstore/libs/service_local/storage_null_ut.cpp
+++ b/cloud/blockstore/libs/service_local/storage_null_ut.cpp
@@ -104,6 +104,9 @@ Y_UNIT_TEST_SUITE(TNullStorageTest)
 
         auto readResponse = ReadBlocksLocal(*storage, std::move(readSglist));
         UNIT_ASSERT_SUCCEEDED(readResponse.GetError());
+        UNIT_ASSERT(IsAllZeroes(
+            readBuffer.Get().data(),
+            readBuffer.Get().size()));
 
         auto zeroResponse = ZeroBlocks(*storage);
         UNIT_ASSERT_SUCCEEDED(writeResponse.GetError());


### PR DESCRIPTION
### Notes

Initialize read buffers in TNullStorage::ReadBlocksLocal before returning a successful response
Mirror the logic from `service_null.cpp` with acquire the request sglist, zero out read buffers, return `E_CANCELLED` on sglist acquire failure

### Issue
`test_null_backend` in `cloud/blockstore/tests/disk_agent_config` fails under MSAN with `use-of-uninitialized-value` during serialization of `TReadDeviceBlocksResponse`

When `DISK_AGENT_BACKEND_NULL` is used, `TStorageAdapter::ReadBlocks` allocates response buffers via `ResizeIOVector` → `ReserveAndResize` without initializing memory. `TNullStorage::ReadBlocksLocal` returned success without touching those buffers, so the protobuf response contained uninitialized bytes. The actor system runs `CheckEventMemory` before Send and MSAN correctly flags this during `TIOVector::_InternalSerialize`.


```
2026-06-10T12:57:33.423275Z :BLOCKSTORE_DISK_AGENT INFO: disk_agent_actor_secure_erase.cpp:141: Secure erase for "c89c2b4b9c27092fe71114c8e0e8edb5" succeeded
2026-06-10T12:57:33.638197Z :BLOCKSTORE_DISK_AGENT ERROR: disk_agent_actor_io.cpp:120: WriteDeviceBlocks [3401196593fbcd829bdc8bb06f56d812 / 5fdb8b80-8374-4ab0-a213-44beccfc8f62] Service state error: E_BS_INVALID_SESSION (/storage/d/arcc/mount/1/d4f5fe07-9dd9261-eebc7471-5b07c544/cloud/storage/core/libs/common/error.h:299: E_BS_INVALID_SESSION | Device "3401196593fbcd829bdc8bb06f56d812" not acquired by client "5fdb8b80-8374-4ab0-a213-44beccfc8f62", current active writer: "", current readers: [])
2026-06-10T12:57:33.639277Z :BLOCKSTORE_DISK_AGENT INFO: cloud/blockstore/libs/storage/disk_agent/model/device_client.cpp:214: Device "3401196593fbcd829bdc8bb06f56d812" was acquired by client 5fdb8b80-8374-4ab0-a213-44beccfc8f62 for writing.
2026-06-10T12:57:33.639254Z :BLOCKSTORE_DISK_AGENT DEBUG: disk_agent_actor_acquire.cpp:59: AcquireDevices: clientId=5fdb8b80-8374-4ab0-a213-44beccfc8f62, uuids=3401196593fbcd829bdc8bb06f56d812
Uninitialized bytes in __msan_check_mem_is_initialized at offset 8 inside [0x7f9a8b8dab08, 4096)
==817154==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x000017e32118 in CheckMemIsInitialized /-S/util/system/sanitizers.h:150:9
    #1 0x000017e32118 in NActors::CheckEventMemory(NActors::IEventBase*)::TSerializerChecker::Next(void**, int*) /-S/contrib/ydb/library/actors/core/actorsystem.cpp:121:21
    #2 0x000016f38450 in Next /-S/contrib/libs/protobuf/src/google/protobuf/io/coded_stream.cc:853:11
    #3 0x000016f38450 in EnsureSpaceFallback /-S/contrib/libs/protobuf/src/google/protobuf/io/coded_stream.cc:887:11
    #4 0x000016f38450 in google::protobuf::io::EpsCopyOutputStream::WriteRawFallback(void const*, int, unsigned char*) /-S/contrib/libs/protobuf/src/google/protobuf/io/coded_stream.cc:900:11
    #5 0x00004af1aa54 in WriteString<TBasicString<char, std::__y1::char_traits<char> > > /-S/contrib/libs/protobuf/src/google/protobuf/io/coded_stream.h:734:14
    #6 0x00004af1aa54 in WriteBytes<TBasicString<char, std::__y1::char_traits<char> > > /-S/contrib/libs/protobuf/src/google/protobuf/io/coded_stream.h:753:12
    #7 0x00004af1aa54 in NCloud::NBlockStore::NProto::TIOVector::_InternalSerialize(unsigned char*, google::protobuf::io::EpsCopyOutputStream*) const /-B/cloud/blockstore/public/api/protos/io.pb.cc:544:22
    #8 0x00004ae0fd9e in NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse::_InternalSerialize(unsigned char*, google::protobuf::io::EpsCopyOutputStream*) const /-B/cloud/blockstore/libs/storage/protos/disk.pb.cc:22611:14
    #9 0x000016f80e3b in google::protobuf::MessageLite::SerializePartialToZeroCopyStream(google::protobuf::io::ZeroCopyOutputStream*) const /-S/contrib/libs/protobuf/src/google/protobuf/message_lite.cc:485:12
    #10 0x000017e2676f in CheckEventMemory /-S/contrib/ydb/library/actors/core/actorsystem.cpp:179:34
    #11 0x000017e2676f in bool NActors::TActorSystem::GenericSend<&NActors::IExecutorPool::Send(TAutoPtr<NActors::IEventHandle, TDelete>&)>(TAutoPtr<NActors::IEventHandle, TDelete>) const /-S/contrib/ydb/library/actors/core/actorsystem.cpp:206:17
    #12 0x000017e196a4 in bool NActors::TActorSystem::Send<(NActors::ESendingType)0>(TAutoPtr<NActors::IEventHandle, TDelete>) const /-S/contrib/ydb/library/actors/core/actor.cpp:680:26
    #13 0x00004b3693c9 in Reply<NCloud::NBlockStore::NStorage::TEvDiskAgent::TReadDeviceBlocksMethod, NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse> /-S/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp:89:17
    #14 0x00004b3693c9 in auto void NCloud::NBlockStore::NStorage::TDiskAgentActor::PerformIO<NCloud::NBlockStore::NStorage::TEvDiskAgent::TReadDeviceBlocksMethod, TAutoPtr<NActors::TEventHandle<NCloud::NBlockStore::TProtoRequestEvent<NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest, 272762153u>>, TDelete>, NThreading::TFuture<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse> (NCloud::NBlockStore::NStorage::TDiskAgentState::*)(TInstant, NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest)>(NActors::TActorContext const&, TAutoPtr<NActors::TEventHandle<NCloud::NBlockStore::TProtoRequestEvent<NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest, 272762153u>>, TDelete> const&, NThreading::TFuture<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse> (NCloud::NBlockStore::NStorage::TDiskAgentState::*)(TInstant, NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest))::'lambda'(auto)::operator()<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse>(auto) const /-S/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp:190:9
    #15 0x00004b366e45 in auto void NCloud::NBlockStore::NStorage::TDiskAgentActor::PerformIO<NCloud::NBlockStore::NStorage::TEvDiskAgent::TReadDeviceBlocksMethod, TAutoPtr<NActors::TEventHandle<NCloud::NBlockStore::TProtoRequestEvent<NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest, 272762153u>>, TDelete>, NThreading::TFuture<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse> (NCloud::NBlockStore::NStorage::TDiskAgentState::*)(TInstant, NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest)>(NActors::TActorContext const&, TAutoPtr<NActors::TEventHandle<NCloud::NBlockStore::TProtoRequestEvent<NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest, 272762153u>>, TDelete> const&, NThreading::TFuture<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse> (NCloud::NBlockStore::NStorage::TDiskAgentState::*)(TInstant, NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest))::'lambda'(auto const&)::operator()<NThreading::TFuture<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse>>(auto const&) const /-S/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp:236:21
    #16 0x00004b33fca7 in Subscribe<(lambda at /-S/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp:232:13)> /-S/library/cpp/threading/future/core/future-inl.h:623:13
    #17 0x00004b33fca7 in void NCloud::NBlockStore::NStorage::TDiskAgentActor::PerformIO<NCloud::NBlockStore::NStorage::TEvDiskAgent::TReadDeviceBlocksMethod, TAutoPtr<NActors::TEventHandle<NCloud::NBlockStore::TProtoRequestEvent<NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest, 272762153u>>, TDelete>, NThreading::TFuture<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse> (NCloud::NBlockStore::NStorage::TDiskAgentState::*)(TInstant, NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest)>(NActors::TActorContext const&, TAutoPtr<NActors::TEventHandle<NCloud::NBlockStore::TProtoRequestEvent<NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest, 272762153u>>, TDelete> const&, NThreading::TFuture<NCloud::NBlockStore::NProto::TReadDeviceBlocksResponse> (NCloud::NBlockStore::NStorage::TDiskAgentState::*)(TInstant, NCloud::NBlockStore::NProto::TReadDeviceBlocksRequest)) /-S/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_io.cpp:231:16
    #18 0x00004b157433 in NCloud::NBlockStore::NStorage::TDiskAgentActor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor.cpp:405:13
    #19 0x000017e18c9b in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/contrib/ydb/library/actors/core/actor.cpp:406:17
    #20 0x000017ec6c7b in NActors::TExecutorThread::Execute(NActors::TMailbox*, bool) /-S/contrib/ydb/library/actors/core/executor_thread.cpp:268:28
    #21 0x000017ed1511 in NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const /-S/contrib/ydb/library/actors/core/executor_thread.cpp:458:39
    #22 0x000017ed0b5c in NActors::TExecutorThread::ProcessExecutorPool() /-S/contrib/ydb/library/actors/core/executor_thread.cpp:510:13
    #23 0x000017ed2a92 in NActors::TExecutorThread::ThreadProc() /-S/contrib/ydb/library/actors/core/executor_thread.cpp:536:9
    #24 0x000016b7bfb3 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /-S/util/system/thread.cpp:245:20
    #25 0x7f9a97187608 in start_thread /build/glibc-LcI20x/glibc-2.31/nptl/pthread_create.c:477:8
    #26 0x7f9a970ac352 in __clone /build/glibc-LcI20x/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

SUMMARY: MemorySanitizer: use-of-uninitialized-value /-S/util/system/sanitizers.h:150:9 in CheckMemIsInitialized
Exiting
```
