### PR TITLE
cell manager should use own certificate provider

### DIFF
--- a/cloud/blockstore/libs/cells/impl/bootstrap.h
+++ b/cloud/blockstore/libs/cells/impl/bootstrap.h
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/libs/service/public.h>
 
 #include <cloud/storage/core/libs/common/public.h>
+#include <cloud/storage/core/libs/grpc/public.h>
 #include <cloud/storage/core/libs/rdma/iface/client.h>
 
 namespace NCloud::NBlockStore::NCells {
@@ -23,6 +24,7 @@ struct TBootstrap
     IMonitoringServicePtr Monitoring;
     ITraceSerializerPtr TraceSerializer;
 
+    NCloud::ICertificateProviderPtr CertProvider;
     NClient::IMultiHostClientPtr GrpcClient;
     NCloud::NStorage::NRdma::IClientPtr RdmaClient;
 

--- a/cloud/blockstore/libs/cells/impl/cell_manager_impl.cpp
+++ b/cloud/blockstore/libs/cells/impl/cell_manager_impl.cpp
@@ -15,6 +15,7 @@
 #include <cloud/storage/core/libs/common/task_queue.h>
 #include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
+#include <cloud/storage/core/libs/grpc/tls_certificate_provider.h>
 #include <cloud/storage/core/libs/rdma/impl/client.h>
 #include <cloud/storage/core/libs/rdma/impl/verbs.h>
 
@@ -69,6 +70,7 @@ TCellManager::TCellManager(TCellsConfigPtr config, TBootstrap bootstrap)
 
 void TCellManager::Start()
 {
+    Bootstrap.CertProvider->Start();
     Bootstrap.GrpcClient->Start();
 
     for (auto& cell: Cells) {
@@ -83,6 +85,7 @@ void TCellManager::Stop()
     }
 
     Bootstrap.GrpcClient->Stop();
+    Bootstrap.CertProvider->Stop();
 }
 
 TResultOrError<TCellHostEndpoint> TCellManager::GetCellEndpoint(
@@ -178,7 +181,7 @@ ICellManagerPtr CreateCellManager(
         logging,
         monitoring,
         std::move(serverStats),
-        std::move(certificateProvider));
+        certificateProvider);
 
     if (HasError(result)) {
         STORAGE_THROW_SERVICE_ERROR(E_FAIL) << "unable to create gRPC client";
@@ -197,6 +200,7 @@ ICellManagerPtr CreateCellManager(
         .Logging = std::move(logging),
         .Monitoring = std::move(monitoring),
         .TraceSerializer = std::move(traceSerializer),
+        .CertProvider = std::move(certificateProvider),
         .GrpcClient = std::move(result.ExtractResult()),
         .RdmaClient = std::move(rdmaClient),
         .RdmaTaskQueue = std::move(rdmaTaskQueue),

--- a/cloud/blockstore/libs/cells/impl/ya.make
+++ b/cloud/blockstore/libs/cells/impl/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     cloud/blockstore/libs/kikimr
     cloud/blockstore/libs/service
 
+    cloud/storage/core/libs/grpc
     cloud/storage/core/libs/rdma/impl
 )
 

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -5,6 +5,7 @@
 
 #include <cloud/blockstore/libs/cells/iface/config.h>
 #include <cloud/blockstore/libs/cells/impl/cell_manager.h>
+#include <cloud/storage/core/libs/grpc/tls_certificate_provider.h>
 #include <cloud/blockstore/libs/common/caching_allocator.h>
 #include <cloud/blockstore/libs/diagnostics/block_digest.h>
 #include <cloud/blockstore/libs/diagnostics/config.h>
@@ -974,6 +975,15 @@ void TBootstrapYdb::InitRdmaRequestServer()
 void TBootstrapYdb::SetupCellManager()
 {
     if (Configs->CellsConfig->GetCellsEnabled()) {
+        const auto& grpcConfig = Configs->CellsConfig->GetGrpcClientConfig();
+        TVector<NCloud::TCertificateFiles> certList {{
+            .PrivateKeyPath = grpcConfig.GetCertPrivateKeyFile(),
+            .CertChainPath  = grpcConfig.GetCertFile(),
+        }};
+        auto cellCertProvider = NCloud::CreateStaticCertificateProvider(
+            grpcConfig.GetRootCertsFile(),
+            std::move(certList));
+
         CellManager = CreateCellManager(
             Configs->CellsConfig,
             Timer,
@@ -982,7 +992,7 @@ void TBootstrapYdb::SetupCellManager()
             Monitoring,
             GetTraceSerializer(),
             ServerStats,
-            CertificateProvider,
+            std::move(cellCertProvider),
             RdmaClient);
     } else {
         CellManager = NCells::CreateCellManagerStub();


### PR DESCRIPTION
### Notes
It turned out that using server certificates as client is a bad idea since peer denies to authorize it. So we need another pair of certificates for using as client. The only place in the code where we create grpc client is a cell manager.

### Issue
Put links to the related issues here
