### PR TITLE
avoid calling IEventHandle::Get() in TIndexTabletProxyActor if we don't expect to see traces

### DIFF
--- a/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet_proxy/tablet_proxy_actor.cpp
@@ -441,13 +441,21 @@ void TIndexTabletProxyActor::HandleResponse(
             nullptr);
     }
 
-    auto* x = reinterpret_cast<TMethod::TResponse::TPtr*>(&event);
-    HandleServiceTraceInfo(
-        TMethod::Name,
-        ctx,
-        TraceSerializer,
-        it->second.CallContext,
-        x->Get()->Get()->Record);
+    //
+    // It's important NOT to call Get() if we don't need it because it triggers
+    // lazy event parsing and we want to avoid doing it in TabletProxy because
+    // we have only one TabletProxy per process (i.e. it's a bottleneck).
+    //
+
+    if (it->second.CallContext->LWOrbit.HasShuttles()) {
+        auto* x = reinterpret_cast<TMethod::TResponse::TPtr*>(&event);
+        HandleServiceTraceInfo(
+            TMethod::Name,
+            ctx,
+            TraceSerializer,
+            it->second.CallContext,
+            x->Get()->Get()->Record);
+    }
 
     FILESTORE_TRACK(
         ResponseSent_TabletProxy,


### PR DESCRIPTION
### Notes
Here https://github.com/ydb-platform/nbs/pull/6023 I implemented TabletProxy probes which required moving trace parsing to TabletProxy response handler code. But that PR contained a performance issue - it caused TabletProxy to call `IEventHandle::Get()` for each response. It doesn't do anything after that if there's no trace in the response or no shuttle on the request's orbit but this `Get()` causes response parsing and we want to avoid any expensive actions in TabletProxy code.

### Issue
https://github.com/ydb-platform/nbs/issues/5894