### PR TITLE
[Filestore] don't call cache reset for handle when nothing to reset

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_directory_handle.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_directory_handle.cpp
@@ -195,6 +195,14 @@ void TDirectoryHandle::ResetContent()
     }
 }
 
+bool TDirectoryHandle::IsEmpty() const
+{
+    with_lock (Lock) {
+        return Content.empty() && Cookie.empty() && UpdateVersion == 0 &&
+               SerializedSize == BaseSerializedSize;
+    }
+}
+
 TString TDirectoryHandle::GetCookie()
 {
     with_lock (Lock) {

--- a/cloud/filestore/libs/vfs_fuse/fs_directory_handle.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_directory_handle.h
@@ -101,6 +101,7 @@ public:
 
     // Returns the handle's current serialized size and chunk count.
     TDirectoryHandleStats GetStats() const;
+    bool IsEmpty() const;
 
     // not thread safe, use only during restoration from storage
     void ConsumeChunk(TDirectoryHandleChunk& chunk, TLog& Log);

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
@@ -111,8 +111,12 @@ void TFileSystem::ReadDir(
     };
 
     if (!offset) {
-        // directory contents need to be refreshed on rewinddir()
-        DirectoryHandleCache->ResetHandle(fi->fh);
+        // Directory contents need to be refreshed on rewinddir(). Skip the
+        // cache call when the handle has nothing to drop (e.g. the first
+        // ReadDir after OpenDir).
+        if (!handle->IsEmpty()) {
+            DirectoryHandleCache->ResetHandle(fi->fh);
+        }
     } else if (auto content = handle->ReadContent(size, offset, Log)) {
         reply(*this, *content);
         return;


### PR DESCRIPTION
### Notes
Currently we always call ResetHandle if offset is equal to 0. Actually, it is always empty after we only opened the dir. With new additional functionality inside directory handles cache we do not want to call it inside cache to avoid additional sync on common handles map.
related to PR #6059

### Issue
#6087
