### PR TITLE
[Disk Manager] fix govet disk_service_test

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -1019,12 +1019,13 @@ func testDiskServiceCreateEncryptedDiskFromSnapshot(
 		lastSnapshotID = snapshotID2
 
 		// Fill diskID1 with random data once again.
-		_, err := nbsClient.FillEncryptedDisk(
+		_, err = nbsClient.FillEncryptedDisk(
 			ctx,
 			diskID1,
 			diskSize,
 			encryptionDesc,
 		)
+		require.NoError(t, err)
 		// Since the source disk contains data from the old and new filling,
 		// re-calculate crc32 from the disk.
 		srcDiskContentInfo, err := nbsClient.CalculateCrc32WithEncryption(


### PR DESCRIPTION
### Notes

Summary
Fixes lint failure in `testDiskServiceCreateEncryptedDiskFromSnapshot` (`disk_service_test.go`).

In the incremental snapshot path, FillEncryptedDisk assigned err but never checked it before CalculateCrc32WithEncryption overwrote the variable. The fix reuses the existing `err` with `=` instead of `:=` and adds `require.NoError(t, err)` after the call, matching the pattern used for the first disk fill earlier in the same test.

### Issue
Put links to the related issues here
