### PR TITLE
[Disk Agent, Disk Registry] Show device model in monitoring pages

### DIFF
--- a/cloud/blockstore/config/disk.proto
+++ b/cloud/blockstore/config/disk.proto
@@ -76,6 +76,9 @@ message TFileDeviceArgs
     optional uint64 Offset = 6;
     // File size override.
     optional uint64 FileSize = 7;
+
+    // Device model.
+    optional string DeviceModel = 8;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -136,6 +136,13 @@ public:
         return TString();
     }
 
+    auto GetDeviceModel(const TString& path) -> TResultOrError<TString> final
+    {
+        Y_UNUSED(path);
+
+        return TString();
+    }
+
     NProto::TError ResetToSingleNamespace(const TString& ctrlPath) final
     {
         Y_UNUSED(ctrlPath);

--- a/cloud/blockstore/libs/nvme/nvme.h
+++ b/cloud/blockstore/libs/nvme/nvme.h
@@ -40,6 +40,8 @@ struct INvmeManager
     virtual TResultOrError<TString> GetSerialNumber(const TString& path) = 0;
 
     virtual NProto::TError ResetToSingleNamespace(const TString& ctrlPath) = 0;
+
+    virtual TResultOrError<TString> GetDeviceModel(const TString& path) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/nvme/nvme_linux.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_linux.cpp
@@ -434,6 +434,34 @@ public:
         });
     }
 
+    TResultOrError<TString> GetDeviceModel(const TString& path) override
+    {
+        return SafeExecute<TResultOrError<TString>>(
+            [&]
+            {
+                TFileHandle device(path, OpenExisting | RdOnly);
+
+                auto str = [](auto& arr)
+                {
+                    auto* model = std::bit_cast<const char*>(&arr[0]);
+                    auto end = std::find(model, model + sizeof(arr), '\0');
+
+                    return TString(model, end);
+                };
+
+                auto [isRot, error] = IsRotational(device);
+
+                if (!HasError(error) && isRot) {
+                    auto hd = HDIdentity(device);
+                    return str(hd.model);
+                }
+
+                auto ctrl = NVMeIdentifyCtrl(device, AdminCmdTimeout);
+
+                return str(ctrl.mn);
+            });
+    }
+
     TResultOrError<bool> IsSsd(const TString& path) override
     {
         return SafeExecute<TResultOrError<bool>>([&] {

--- a/cloud/blockstore/libs/nvme/nvme_stub.cpp
+++ b/cloud/blockstore/libs/nvme/nvme_stub.cpp
@@ -60,6 +60,13 @@ public:
         return TString {};
     }
 
+    TResultOrError<TString> GetDeviceModel(const TString& path) override
+    {
+        Y_UNUSED(path);
+
+        return TString{};
+    }
+
     TResultOrError<bool> IsSsd(const TString& path) override
     {
         Y_UNUSED(path);

--- a/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
+++ b/cloud/blockstore/libs/service_local/safe_deallocator_ut.cpp
@@ -78,6 +78,12 @@ struct TTestNvmeManager final: NNvme::INvmeManager
         return TString("serial");
     }
 
+    TResultOrError<TString> GetDeviceModel(const TString& path) final
+    {
+        Y_UNUSED(path);
+        return TString("model");
+    }
+
     NProto::TError Sanitize(const TString& ctrlPath) override
     {
         Y_UNUSED(ctrlPath);

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_monitoring.cpp
@@ -157,6 +157,7 @@ void TDiskAgentActor::RenderDevices(IOutputStream& out) const
                 TABLER() {
                     TABLEH() { out << "UUID"; }
                     TABLEH() { out << "S/N"; }
+                    TABLEH() { out << "Model"; }
                     TABLEH() { out << "Name"; }
                     TABLEH() { out << "State"; }
                     TABLEH() { out << "State Timestamp"; }
@@ -177,6 +178,7 @@ void TDiskAgentActor::RenderDevices(IOutputStream& out) const
                 TABLER() {
                     TABLED() { out << uuid; }
                     TABLED() { out << config.GetSerialNumber(); }
+                    TABLED() { out << config.GetDeviceModel(); }
                     TABLED() { out << config.GetDeviceName(); }
                     TABLED() {
                         DumpDeviceState(

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_register.cpp
@@ -101,7 +101,8 @@ void TRegisterActor::Bootstrap(const TActorContext& ctx)
                     << config.GetBlocksCount() << " x "
                     << config.GetBlockSize() << ", Rack="
                     << config.GetRack() << ", SN="
-                    << config.GetSerialNumber()
+                    << config.GetSerialNumber() << ", Model="
+                    << config.GetDeviceModel()
                     << "); ";
             }
             return out.Str();

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -98,10 +98,13 @@ TVector<ui64> FindProcessesWithOpenFile(const TString& targetPath)
 struct TTestNvmeManager: NNvme::INvmeManager
 {
     THashMap<TString, TString> PathToSerial;
+    THashMap<TString, TString> PathToModel;
 
-    explicit TTestNvmeManager(
-            const TVector<std::pair<TString, TString>>& pathToSerial)
+    TTestNvmeManager(
+            const TVector<std::pair<TString, TString>>& pathToSerial,
+            const TVector<std::pair<TString, TString>>& pathToModel)
         : PathToSerial{pathToSerial.cbegin(), pathToSerial.cend()}
+        , PathToModel{pathToModel.cbegin(), pathToModel.cend()}
     {}
 
     void Start() final
@@ -143,6 +146,23 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         auto it = PathToSerial.find(device);
         if (it == PathToSerial.end()) {
+            return MakeError(MAKE_SYSTEM_ERROR(42), path);
+        }
+
+        return it->second;
+    }
+
+    TResultOrError<TString> GetDeviceModel(const TString& path) override
+    {
+        TString device;
+        try {
+            device = NFs::ReadLink(path);
+        } catch (...) {
+            return MakeError(E_FAIL, CurrentExceptionMessage());
+        }
+
+        auto it = PathToModel.find(path);
+        if (it == PathToModel.end()) {
             return MakeError(MAKE_SYSTEM_ERROR(42), path);
         }
 
@@ -5502,6 +5522,13 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             {Devices[3], "Z"},   // nvme3n1
         };
 
+        TVector<std::pair<TString, TString>> pathToModel{
+            {Devices[0], "A"},   // nvme0n1
+            {Devices[1], "B"},   // nvme1n1
+            {Devices[2], "C"},   // nvme2n1
+            {Devices[3], "D"},   // nvme3n1
+        };
+
         // build the config cache
         {
             NProto::TDiskAgentConfig config;
@@ -5550,10 +5577,13 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             });
 
         auto env = TTestEnvBuilder(*Runtime)
-            .With(CreateDiskAgentConfig())
-            .With(std::make_shared<TTestNvmeManager>(pathToSerial))
-            .With(diskregistryState)
-            .Build();
+                       .With(CreateDiskAgentConfig())
+                       .With(
+                           std::make_shared<TTestNvmeManager>(
+                               pathToSerial,
+                               pathToModel))
+                       .With(diskregistryState)
+                       .Build();
 
         Runtime->UpdateCurrentTime(Now());
 
@@ -6924,10 +6954,18 @@ Y_UNIT_TEST_SUITE(TDiskAgentTest)
             {Devices[3], "Z"},   // nvme3n1
         };
 
+        TVector<std::pair<TString, TString>> pathToModel{
+            {Devices[0], "A"},   // nvme0n1
+            {Devices[1], "B"},   // nvme1n1
+            {Devices[2], "C"},   // nvme2n1
+            {Devices[3], "D"},   // nvme3n1
+        };
+
         auto storageConfig = NProto::TStorageServiceConfig();
         storageConfig.SetAttachDetachPathsEnabled(true);
 
-        auto nvmeManager = std::make_shared<TTestNvmeManager>(pathToSerial);
+        auto nvmeManager =
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel);
 
         auto env = TTestEnvBuilder(*Runtime)
                        .With(CreateDiskAgentConfig())

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -146,7 +146,7 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         auto it = PathToSerial.find(device);
         if (it == PathToSerial.end()) {
-            return MakeError(MAKE_SYSTEM_ERROR(ENOENT), path);
+            return MakeError(MAKE_SYSTEM_ERROR(EIO), path);
         }
 
         return it->second;
@@ -163,7 +163,7 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         auto it = PathToModel.find(path);
         if (it == PathToModel.end()) {
-            return MakeError(MAKE_SYSTEM_ERROR(ENOENT), path);
+            return MakeError(MAKE_SYSTEM_ERROR(EIO), path);
         }
 
         return it->second;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_ut.cpp
@@ -146,7 +146,7 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         auto it = PathToSerial.find(device);
         if (it == PathToSerial.end()) {
-            return MakeError(MAKE_SYSTEM_ERROR(42), path);
+            return MakeError(MAKE_SYSTEM_ERROR(ENOENT), path);
         }
 
         return it->second;
@@ -163,7 +163,7 @@ struct TTestNvmeManager: NNvme::INvmeManager
 
         auto it = PathToModel.find(path);
         if (it == PathToModel.end()) {
-            return MakeError(MAKE_SYSTEM_ERROR(42), path);
+            return MakeError(MAKE_SYSTEM_ERROR(ENOENT), path);
         }
 
         return it->second;

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_state_ut.cpp
@@ -94,6 +94,11 @@ struct TTestNvmeManager
         return "SN-" + path;
     }
 
+    TResultOrError<TString> GetDeviceModel(const TString& path) override
+    {
+        return "MODEL-" + path;
+    }
+
     TResultOrError<bool> IsSsd(const TString& path) override
     {
         Y_UNUSED(path);

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -137,6 +137,7 @@ private:
     TMutex Lock;
 
     THashMap<TString, TString> PathToSerial;
+    THashMap<TString, TString> PathToModel;
 
 public:
     TInitializer(
@@ -183,6 +184,9 @@ private:
 
     TString GetSerialNumber(const TString& path);
     void SetupSerialNumbers(TVector<NProto::TFileDeviceArgs>& fileDevices);
+
+    TString GetDeviceModel(const TString& path);
+    void SetupDeviceModels(TVector<NProto::TFileDeviceArgs>& fileDevices);
 
     auto ProcessConfigCache(const THashSet<TString>& allowedPaths = {})
         -> TResultOrError<TVector<NProto::TFileDeviceArgs>>;
@@ -365,6 +369,33 @@ void TInitializer::SetupSerialNumbers(
     }
 }
 
+TString TInitializer::GetDeviceModel(const TString& path)
+{
+    auto it = PathToModel.find(path);
+    if (it == PathToModel.end()) {
+        auto [model, error] = NvmeManager->GetDeviceModel(path);
+        it = PathToModel.emplace(path, model).first;
+        if (HasError(error)) {
+            with_lock (Lock) {
+                Errors.push_back(
+                    TStringBuilder()
+                    << "Can't get model for " << path.Quote() << ": "
+                    << FormatError(error));
+            }
+        }
+    }
+
+    return it->second;
+}
+
+void TInitializer::SetupDeviceModels(
+    TVector<NProto::TFileDeviceArgs>& fileDevices)
+{
+    for (auto& file: fileDevices) {
+        file.SetDeviceModel(GetDeviceModel(file.GetPath()));
+    }
+}
+
 void TInitializer::ScanFileDevices(const THashSet<TString>& allowedPaths)
 {
     if (!ValidateStorageDiscoveryConfig()) {
@@ -399,6 +430,7 @@ void TInitializer::ScanFileDevices(const THashSet<TString>& allowedPaths)
 
     SortBy(files, GetDeviceId);
     SetupSerialNumbers(files);
+    SetupDeviceModels(files);
 
     if (!ValidateGeneratedConfigs(files)) {
         ReportDiskAgentConfigMismatchEvent("Bad generated config");
@@ -715,6 +747,7 @@ NProto::TDeviceConfig TInitializer::CreateConfig(
     config.SetPoolName(device.GetPoolName());
     config.SetSerialNumber(device.GetSerialNumber());
     config.SetPhysicalOffset(device.GetOffset());
+    config.SetDeviceModel(device.GetDeviceModel());
 
     return config;
 }

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -347,7 +347,6 @@ TString TInitializer::GetSerialNumber(const TString& path)
     auto it = PathToSerial.find(path);
     if (it == PathToSerial.end()) {
         auto [sn, error] = NvmeManager->GetSerialNumber(path);
-        it = PathToSerial.emplace(path, sn).first;
         if (HasError(error)) {
             with_lock (Lock) {
                 Errors.push_back(
@@ -355,7 +354,9 @@ TString TInitializer::GetSerialNumber(const TString& path)
                     << "Can't get serial number for " << path.Quote() << ": "
                     << FormatError(error));
             }
+            return sn;
         }
+        it = PathToSerial.emplace(path, sn).first;
     }
 
     return it->second;

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -374,7 +374,6 @@ TString TInitializer::GetDeviceModel(const TString& path)
     auto it = PathToModel.find(path);
     if (it == PathToModel.end()) {
         auto [model, error] = NvmeManager->GetDeviceModel(path);
-        it = PathToModel.emplace(path, model).first;
         if (HasError(error)) {
             with_lock (Lock) {
                 Errors.push_back(
@@ -382,7 +381,9 @@ TString TInitializer::GetDeviceModel(const TString& path)
                     << "Can't get model for " << path.Quote() << ": "
                     << FormatError(error));
             }
+            return model;
         }
+        it = PathToModel.emplace(path, model).first;
     }
 
     return it->second;
@@ -407,6 +408,9 @@ void TInitializer::ScanFileDevices(const THashSet<TString>& allowedPaths)
     for (auto& file: FileDevices) {
         if (file.GetSerialNumber().empty()) {
             file.SetSerialNumber(GetSerialNumber(file.GetPath()));
+        }
+        if (file.GetDeviceModel().empty()) {
+            file.SetDeviceModel(GetDeviceModel(file.GetPath()));
         }
     }
 

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer.cpp
@@ -545,6 +545,7 @@ bool TInitializer::TryToAcceptCurrentConfigs(
     STORAGE_WARN("Current config is broken, fallback to the cached one.");
     FileDevices = cachedDevices;
     SetupSerialNumbers(FileDevices);
+    SetupDeviceModels(FileDevices);
 
     Errors.push_back(TStringBuilder()
         << "broken config: " << FormatError(error));

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -30,10 +30,13 @@ struct TTestNvmeManager
     : NNvme::INvmeManager
 {
     THashMap<TString, TString> PathToSerial;
+    THashMap<TString, TString> PathToModel;
 
-    explicit TTestNvmeManager(
-            const TVector<std::pair<TString, TString>> pathToSerial)
+    TTestNvmeManager(
+            const TVector<std::pair<TString, TString>> pathToSerial,
+            const TVector<std::pair<TString, TString>> pathToModel)
         : PathToSerial{pathToSerial.cbegin(), pathToSerial.cend()}
+        , PathToModel{pathToModel.cbegin(), pathToModel.cend()}
     {}
 
     void Start() final
@@ -68,6 +71,16 @@ struct TTestNvmeManager
     {
         auto it = PathToSerial.find(TFsPath{path}.Basename());
         if (it == PathToSerial.end()) {
+            return MakeError(MAKE_SYSTEM_ERROR(42));
+        }
+
+        return it->second;
+    }
+
+    TResultOrError<TString> GetDeviceModel(const TString& path) override
+    {
+        auto it = PathToModel.find(TFsPath{path}.Basename());
+        if (it == PathToModel.end()) {
             return MakeError(MAKE_SYSTEM_ERROR(42));
         }
 
@@ -189,6 +202,13 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS04", "Z"},
         };
 
+        const TVector<std::pair<TString, TString>> pathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+        };
+
         UNIT_ASSERT(!NFs::Exists(DefaultConfig.GetCachedConfigPath()));
 
         auto future = InitializeStorage(
@@ -196,7 +216,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial));
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel));
 
         const auto& r = future.GetValueSync();
 
@@ -233,12 +253,19 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS04", "Z"},
         };
 
+        const TVector<std::pair<TString, TString>> pathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+        };
+
         auto future1 = InitializeStorage(
             Logging->CreateLog("Test"),
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial));
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel));
 
         const auto& r1 = future1.GetValueSync();
 
@@ -252,6 +279,14 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS05", "A"},
         };
 
+        const TVector<std::pair<TString, TString>> newPathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "new-B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+            {"NVMENBS05", "A"},
+        };
+
         PrepareFile("NVMENBS05");
 
         auto future2 = InitializeStorage(
@@ -259,7 +294,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(newPathToSerial));
+            std::make_shared<TTestNvmeManager>(newPathToSerial, newPathToModel));
 
         const auto& r2 = future2.GetValueSync();
 
@@ -290,7 +325,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(newPathToSerial));
+            std::make_shared<TTestNvmeManager>(newPathToSerial, newPathToModel));
 
         const auto& r3 = future3.GetValueSync();
 
@@ -328,6 +363,13 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS04", "Z"},
         };
 
+        const TVector<std::pair<TString, TString>> pathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+        };
+
         UNIT_ASSERT(!NFs::Exists(DefaultConfig.GetCachedConfigPath()));
 
         auto future1 = InitializeStorage(
@@ -335,7 +377,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial));
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel));
 
         const auto& r1 = future1.GetValueSync();
 
@@ -346,6 +388,13 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS02", "A"},
             {"NVMENBS03", "Z"},
             {"NVMENBS04", "Y"},
+        };
+
+        const TVector<std::pair<TString, TString>> newPathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "BB"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
         };
 
         auto newConfig = DefaultConfig;
@@ -360,7 +409,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(newConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(newPathToSerial));
+            std::make_shared<TTestNvmeManager>(newPathToSerial, newPathToModel));
 
         const auto& r2 = future2.GetValueSync();
 
@@ -406,12 +455,19 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS04", "Z"},
         };
 
+        const TVector<std::pair<TString, TString>> pathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+        };
+
         auto future1 = InitializeStorage(
             Logging->CreateLog("Test"),
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial));
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel));
 
         const auto& r1 = future1.GetValueSync();
 
@@ -420,6 +476,13 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS02", "A"},
             {"NVMENBS03", "Z"},
             {"NVMENBS04", "Y"},
+        };
+
+        const TVector<std::pair<TString, TString>> newPathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "BB"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
         };
 
         auto newConfig = DefaultConfig;
@@ -432,7 +495,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(newConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(newPathToSerial));
+            std::make_shared<TTestNvmeManager>(newPathToSerial, newPathToModel));
 
         const auto& r2 = future2.GetValueSync();
 
@@ -478,6 +541,13 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS04", "Z"},
         };
 
+        const TVector<std::pair<TString, TString>> pathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+        };
+
         auto staticConfig = DefaultConfig;
         staticConfig.ClearStorageDiscoveryConfig();
 
@@ -498,7 +568,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(staticConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial));
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel));
 
         const auto& r = future.GetValueSync();
 
@@ -526,6 +596,13 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS04", "Z"},
         };
 
+        const TVector<std::pair<TString, TString>> pathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+        };
+
         UNIT_ASSERT(!NFs::Exists(DefaultConfig.GetCachedConfigPath()));
 
         auto future = InitializePaths(
@@ -533,7 +610,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial),
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel),
             {DevicesPath / "NVMENBS01", DevicesPath / "NVMENBS03"});
 
         const auto& r = future.GetValueSync();
@@ -567,12 +644,19 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             {"NVMENBS04", "Z"},
         };
 
+        const TVector<std::pair<TString, TString>> pathToModel{
+            {"NVMENBS01", "A"},
+            {"NVMENBS02", "B"},
+            {"NVMENBS03", "C"},
+            {"NVMENBS04", "D"},
+        };
+
         auto future1 = InitializeStorage(
             Logging->CreateLog("Test"),
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(DefaultConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial));
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel));
 
         future1.GetValueSync();
 
@@ -588,7 +672,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(newConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial),
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel),
             {DevicesPath / "NVMENBS01"});
 
         const auto& r2 = future2.GetValueSync();
@@ -608,7 +692,7 @@ Y_UNIT_TEST_SUITE(TInitializerTest)
             StorageConfig,
             std::make_shared<TDiskAgentConfig>(newConfig, "rack", 1000),
             StorageProvider,
-            std::make_shared<TTestNvmeManager>(pathToSerial),
+            std::make_shared<TTestNvmeManager>(pathToSerial, pathToModel),
             {DevicesPath / "NVMENBS02"});
 
         const auto& r3 = future3.GetValueSync();

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -81,7 +81,7 @@ struct TTestNvmeManager
     {
         auto it = PathToModel.find(TFsPath{path}.Basename());
         if (it == PathToModel.end()) {
-            return MakeError(MAKE_SYSTEM_ERROR(42));
+            return MakeError(MAKE_SYSTEM_ERROR(ENOENT));
         }
 
         return it->second;

--- a/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/storage_initializer_ut.cpp
@@ -81,7 +81,7 @@ struct TTestNvmeManager
     {
         auto it = PathToModel.find(TFsPath{path}.Basename());
         if (it == PathToModel.end()) {
-            return MakeError(MAKE_SYSTEM_ERROR(ENOENT));
+            return MakeError(MAKE_SYSTEM_ERROR(EIO));
         }
 
         return it->second;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -317,6 +317,7 @@ void TDiskRegistryActor::RenderDevicesWithDetails(
                     TABLEH() { out << "UUID"; }
                     TABLEH() { out << "Name"; }
                     TABLEH() { out << "S/N"; }
+                    TABLEH() { out << "Model"; }
                     TABLEH() { out << "State"; }
                     TABLEH() { out << "State Ts"; }
                     TABLEH() { out << "State Message"; }
@@ -344,6 +345,7 @@ void TDiskRegistryActor::RenderDevicesWithDetails(
                     }
                     TABLED() { out << device.GetDeviceName(); }
                     TABLED() { out << device.GetSerialNumber(); }
+                    TABLED() { out << device.GetDeviceModel();}
                     TABLED() {
                         DumpDeviceState(
                             out,
@@ -468,6 +470,7 @@ void TDiskRegistryActor::RenderDeviceHtmlInfo(
 
         DIV() { out << "Name: " << device.GetDeviceName(); }
         DIV() { out << "S/N: " << device.GetSerialNumber(); }
+        DIV() { out << "Model: " << device.GetDeviceModel(); }
         DIV() { out << "Block size: " << device.GetBlockSize(); }
         DIV() {
             const auto bytes = device.GetBlocksCount() * device.GetBlockSize();

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -345,7 +345,7 @@ void TDiskRegistryActor::RenderDevicesWithDetails(
                     }
                     TABLED() { out << device.GetDeviceName(); }
                     TABLED() { out << device.GetSerialNumber(); }
-                    TABLED() { out << device.GetDeviceModel();}
+                    TABLED() { out << device.GetDeviceModel(); }
                     TABLED() {
                         DumpDeviceState(
                             out,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -12757,6 +12757,33 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 UNIT_ASSERT(!canAllocateLater(1));
             });
     }
+
+    Y_UNIT_TEST(ShouldPreserveDeviceModelAfterRegisterAgent)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            db.InitSchema();
+        });
+
+        TDeviceConfig dev = Device("dev-1", "uuid-1", "rack-1");
+        dev.SetSerialNumber("SN-001");
+        dev.SetDeviceModel("SAMSUNG-980PRO");
+
+        const auto agentConfig = AgentConfig(1, {dev});
+
+        auto statePtr = TDiskRegistryStateBuilder().Build();
+        TDiskRegistryState& state = *statePtr;
+
+        executor.WriteTx([&] (TDiskRegistryDatabase db) {
+            UpdateConfig(state, db, {agentConfig});
+            UNIT_ASSERT_SUCCESS(RegisterAgent(state, db, agentConfig));
+        });
+
+        const auto* device = state.FindDevice("uuid-1");
+        UNIT_ASSERT(device);
+        UNIT_ASSERT_VALUES_EQUAL("SAMSUNG-980PRO", device->GetDeviceModel());
+        UNIT_ASSERT_VALUES_EQUAL("SN-001", device->GetSerialNumber());
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/protos/disk.proto
+++ b/cloud/blockstore/libs/storage/protos/disk.proto
@@ -195,6 +195,9 @@ message TDeviceConfig
 
     // Physical offset in bytes.
     uint64 PhysicalOffset = 19;
+
+    // Device model.
+    string DeviceModel = 20;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
  This PR is a rework of #5555.
  
  The original PR had a compilation error: NVMeIdentifyCtrl was called without the required AdminCmdTimeout argument. Since I don't have write access to that branch, I'm duplicating the
  implementation here with the fix applied. #5555 will be closed in favour of this PR.

  Disk Agent reads and exposes the hardware model of each device during initialization.

  - For NVMe devices, the model is read from the Identify Controller data structure (ctrl.mn)
  - For rotational devices (HDD), it is read from the ATA IDENTIFY response (hd.model)
  - The model is stored in TDeviceConfig.DeviceModel and propagated through the registration flow
  - The Disk Agent monitoring page gains a "Model" column next to the serial number
  - The Disk Registry monitoring page gains a "Model" column in the devices table and a "Model" field on the per-device info page

<img width="1280" height="458" alt="image" src="https://github.com/user-attachments/assets/d8441377-74d9-44d9-82ce-69ff9158b223" />
<img width="859" height="483" alt="image" src="https://github.com/user-attachments/assets/fcdb1ac0-75b1-4d57-988c-11777bd67591" />
