### PR TITLE
[Filestore] Fix path to qemu-bin.tar.gz

### DIFF
--- a/cloud/filestore/README.md
+++ b/cloud/filestore/README.md
@@ -29,6 +29,12 @@ To build run the following command from the repository root folder:
 ./ya make --build=profile -- cloud/filestore/buildall
 ```
 
+Create `qemu-bin.tar.gz` required for qemu runs:
+
+```bash
+./ya make --build=release -- cloud/storage/core/tools/testing/qemu/bin
+```
+
 ### 2. Configuring
 - prepare bin directory
 ```bash

--- a/cloud/filestore/README.md
+++ b/cloud/filestore/README.md
@@ -29,12 +29,6 @@ To build run the following command from the repository root folder:
 ./ya make --build=profile -- cloud/filestore/buildall
 ```
 
-Create `qemu-bin.tar.gz` required for qemu runs:
-
-```bash
-./ya make --build=release -- cloud/storage/core/tools/testing/qemu/bin
-```
-
 ### 2. Configuring
 - prepare bin directory
 ```bash

--- a/cloud/filestore/bin/run_test_qemu.sh
+++ b/cloud/filestore/bin/run_test_qemu.sh
@@ -7,8 +7,7 @@ find_bin_dir() {
 }
 
 BIN_DIR=`find_bin_dir`
-STORAGE_DIR=$BIN_DIR/../../storage
-QEMU_DIR=$STORAGE_DIR/core/tools/testing/qemu
+QEMU_DIR=$BIN_DIR/../buildall/cloud/storage/core/tools/testing/qemu
 
 : ${QEMU_BIN_DIR:=$QEMU_DIR/bin}
 


### PR DESCRIPTION
## Notes
File `qemu-bin.tar.gz` was not present at expected location.
    
```
./run_test_qemu.sh
tar (child): /home/moisiuk/git/nbs/cloud/filestore/bin/../../storage/core/tools/testing/qemu/bin/qemu-bin.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
```
    
When running `./ya make -- cloud/filestore/buildall` tar.gz file created
under `cloud/filestore/buildall` folder.
    
```
find -L . -name qemu-bin.tar.gz
./cloud/filestore/buildall/cloud/storage/core/tools/testing/qemu/bin/qemu-bin.tar.gz
```
