### PR TITLE
silk: temporary PAGE_SIZE const/macro fix

### DIFF
--- a/contrib/libs/silk/include/silk/util/platform.h
+++ b/contrib/libs/silk/include/silk/util/platform.h
@@ -38,8 +38,9 @@ extern "C" ptrdiff_t rseq_offset;
 namespace silk
 {
 
-/** System page size in bytes. */
-static constexpr uint64_t PAGE_SIZE = 4096;
+#ifndef PAGE_SIZE
+#   define PAGE_SIZE 4096
+#endif
 
 /** Cache line size in bytes. */
 static constexpr uint64_t CACHELINE_SIZE = 64;


### PR DESCRIPTION
### Notes
We override `PAGE_SIZE` via a macro in some of our builds which breaks silk build.

The issue will be resolved in upstream here: https://github.com/ClickHouse/silk/issues/64

Temporarily patching silk locally in our repo for now

### Issue
https://github.com/ydb-platform/nbs/issues/5895
