### PR TITLE
issue-4961: Keep service session actors per subsession to align with tablet state

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -190,7 +190,7 @@ private:
 
     TInFlightRequest* FindInFlightRequest(ui64 cookie);
 
-    bool RemoveSession(
+    bool RemoveSubSession(
         const TString& sessionId,
         ui64 seqNo,
         const NActors::TActorContext& ctx);

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -195,10 +195,6 @@ private:
         ui64 seqNo,
         const NActors::TActorContext& ctx);
 
-    void RemoveSession(
-        const TString& sessionId,
-        const NActors::TActorContext& ctx);
-
     static ui32 ExtractShardNoSafe(
         const NProto::TFileStore& filestore,
         ui64 entityId);

--- a/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createhandle.cpp
@@ -274,7 +274,9 @@ void TStorageServiceActor::HandleCreateHandle(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvCreateHandleResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -290,7 +290,9 @@ void TStorageServiceActor::HandleCreateNode(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvCreateNodeResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -765,8 +765,9 @@ void TStorageServiceActor::HandleCreateSession(
         session->CreateDestroyState =
             ESessionCreateDestroyState::STATE_CREATE_SESSION;
 
-        if (session->SessionActor) {
-            return proceed(session->SessionActor);
+        const auto sessionActor = session->GetSessionActor(seqNo);
+        if (sessionActor) {
+            return proceed(*sessionActor);
         }
     }
 
@@ -811,14 +812,24 @@ bool TStorageServiceActor::RemoveSession(
     const TActorContext& ctx)
 {
     if (auto* session = State->FindSession(sessionId, seqNo); session) {
-        if (State->IsLastSubSession(sessionId, seqNo)) {
-            LOG_INFO(ctx, TFileStoreComponents::SERVICE,
-                "[s:%s][n:%lu] remove subsession %s self %s",
-                sessionId.Quote().c_str(),
-                seqNo,
-                ToString(session->SessionActor).c_str(),
-                ToString(SelfId()).c_str());
-        }
+        const auto subSessionCount = session->GetSubSessionCount();
+        const bool isLastSubSession = subSessionCount == 1;
+        const auto* subSession = session->FindSubSession(seqNo);
+        const auto sessionActor =
+            subSession ? subSession->SessionActor : TActorId();
+
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "[s:%s][n:%lu] remove subsession %s, subsessions=%u, last=%s, self "
+            "%s",
+            sessionId.Quote().c_str(),
+            seqNo,
+            ToString(sessionActor).c_str(),
+            subSessionCount,
+            isLastSubSession ? "true" : "false",
+            ToString(SelfId()).c_str());
+
         return State->RemoveSession(sessionId, seqNo);
     }
     return false;
@@ -830,9 +841,9 @@ void TStorageServiceActor::RemoveSession(
 {
     if (auto* session = State->FindSession(sessionId); session) {
         LOG_INFO(ctx, TFileStoreComponents::SERVICE,
-            "[s:%s]remove session %s self %s",
+            "[s:%s]remove session, subsessions=%u self %s",
             sessionId.Quote().c_str(),
-            ToString(session->SessionActor).c_str(),
+            session->GetSubSessionCount(),
             ToString(SelfId()).c_str());
 
         State->RemoveSession(sessionId);
@@ -846,16 +857,26 @@ void TStorageServiceActor::HandleSessionCreated(
     const auto* msg = ev->Get();
 
     auto* session = State->FindSession(msg->SessionId);
+    const auto sessionActor = session
+        ? session->GetSessionActor(msg->SessionSeqNo)
+        : std::optional<TActorId>();
     if (SUCCEEDED(msg->GetStatus())) {
         // in case of vhost restart we don't know session id
         // so inevitably will create new actor
         auto actorId = ev->Sender;
-        if (session &&
-            session->SessionActor &&
-            session->SessionActor != ev->Sender)
+        if (sessionActor && *sessionActor != ev->Sender)
         {
-            ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
-            actorId = session->SessionActor;
+            LOG_INFO(ctx, TFileStoreComponents::SERVICE,
+                "%s kill stale session actor %s, new actor %s",
+                LogTag(
+                    msg->FileStore.GetFileSystemId(),
+                    msg->ClientId,
+                    msg->SessionId,
+                    msg->SessionSeqNo).c_str(),
+                ToString(*sessionActor).c_str(),
+                ToString(ev->Sender).c_str());
+
+            ctx.Send(*sessionActor, new TEvents::TEvPoisonPill());
         }
 
         if (!session) {
@@ -895,13 +916,15 @@ void TStorageServiceActor::HandleSessionCreated(
             session->UpdateSessionState(
                 msg->SessionState,
                 msg->FileStore);
-            session->AddSubSession(msg->SessionSeqNo, msg->ReadOnly);
-            session->SessionActor = actorId;
+            session->AddSubSession(
+                msg->SessionSeqNo,
+                msg->ReadOnly,
+                actorId);
         }
     } else if (session) {
         // else it's an old notify from a dead actor
         session->CreateDestroyState = ESessionCreateDestroyState::STATE_NONE;
-        if (session->SessionActor == ev->Sender) {
+        if (sessionActor && *sessionActor == ev->Sender) {
             // e.g. pipe failed or smth. client will have to restore it
             LOG_WARN(ctx, TFileStoreComponents::SERVICE,
                 "%s session failed (%s)",

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -777,8 +777,9 @@ void TStorageServiceActor::HandleCreateSession(
         session->CreateDestroyState =
             ESessionCreateDestroyState::STATE_CREATE_SESSION;
 
-        if (session->SessionActor) {
-            return proceed(session->SessionActor);
+        const auto sessionActor = session->GetSessionActor(seqNo);
+        if (sessionActor) {
+            return proceed(*sessionActor);
         }
     }
 
@@ -825,14 +826,24 @@ bool TStorageServiceActor::RemoveSession(
     const TActorContext& ctx)
 {
     if (auto* session = State->FindSession(sessionId, seqNo); session) {
-        if (State->IsLastSubSession(sessionId, seqNo)) {
-            LOG_INFO(ctx, TFileStoreComponents::SERVICE,
-                "[s:%s][n:%lu] remove subsession %s self %s",
-                sessionId.Quote().c_str(),
-                seqNo,
-                ToString(session->SessionActor).c_str(),
-                ToString(SelfId()).c_str());
-        }
+        const auto subSessionCount = session->GetSubSessionCount();
+        const bool isLastSubSession = subSessionCount == 1;
+        const auto* subSession = session->FindSubSession(seqNo);
+        const auto sessionActor =
+            subSession ? subSession->SessionActor : TActorId();
+
+        LOG_INFO(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "[s:%s][n:%lu] remove subsession %s, subsessions=%u, last=%s, self "
+            "%s",
+            sessionId.Quote().c_str(),
+            seqNo,
+            ToString(sessionActor).c_str(),
+            subSessionCount,
+            isLastSubSession ? "true" : "false",
+            ToString(SelfId()).c_str());
+
         return State->RemoveSession(sessionId, seqNo);
     }
     return false;
@@ -844,9 +855,9 @@ void TStorageServiceActor::RemoveSession(
 {
     if (auto* session = State->FindSession(sessionId); session) {
         LOG_INFO(ctx, TFileStoreComponents::SERVICE,
-            "[s:%s]remove session %s self %s",
+            "[s:%s]remove session, subsessions=%u self %s",
             sessionId.Quote().c_str(),
-            ToString(session->SessionActor).c_str(),
+            session->GetSubSessionCount(),
             ToString(SelfId()).c_str());
 
         State->RemoveSession(sessionId);
@@ -866,12 +877,22 @@ void TStorageServiceActor::HandleSessionCreated(
     }
     const ui64 storedOwnerGeneration =
         subSession ? subSession->OwnerGeneration : 0;
+    const auto sessionActor = session
+        ? session->GetSessionActor(msg->SessionSeqNo)
+        : std::optional<TActorId>();
+
     if (SUCCEEDED(msg->GetStatus())) {
         // in case of vhost restart we don't know session id
         // so inevitably will create new actor
         auto actorId = ev->Sender;
+        ui64 ownerGeneration = msg->OwnerGeneration;
+        bool staleOwnerGeneration = false;
+
         if (session && storedOwnerGeneration && msg->OwnerGeneration) {
             if (msg->OwnerGeneration < storedOwnerGeneration) {
+                staleOwnerGeneration = true;
+                ownerGeneration = storedOwnerGeneration;
+
                 LOG_WARN(
                     ctx,
                     TFileStoreComponents::SERVICE,
@@ -904,29 +925,50 @@ void TStorageServiceActor::HandleSessionCreated(
             }
         }
 
-        if (session &&
-            session->SessionActor &&
-            session->SessionActor != ev->Sender)
+        if (sessionActor && *sessionActor != ev->Sender)
         {
-            LOG_WARN(
-                ctx,
-                TFileStoreComponents::SERVICE,
-                "%s CreateSession returned session actor mismatch: current "
-                "actor %s generation %lu, notification sender %s generation "
-                "%lu; keeping current actor and poisoning notification sender",
-                LogTag(
-                    msg->FileStore.GetFileSystemId(),
-                    msg->ClientId,
-                    msg->SessionId,
-                    msg->SessionSeqNo)
-                    .c_str(),
-                ToString(session->SessionActor).c_str(),
-                storedOwnerGeneration,
-                ToString(ev->Sender).c_str(),
-                msg->OwnerGeneration);
+            if (staleOwnerGeneration) {
+                LOG_WARN(
+                    ctx,
+                    TFileStoreComponents::SERVICE,
+                    "%s CreateSession returned session actor mismatch: "
+                    "current actor %s generation %lu, notification sender %s "
+                    "generation %lu; keeping current actor and poisoning "
+                    "notification sender",
+                    LogTag(
+                        msg->FileStore.GetFileSystemId(),
+                        msg->ClientId,
+                        msg->SessionId,
+                        msg->SessionSeqNo)
+                        .c_str(),
+                    ToString(*sessionActor).c_str(),
+                    storedOwnerGeneration,
+                    ToString(ev->Sender).c_str(),
+                    msg->OwnerGeneration);
 
-            ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
-            actorId = session->SessionActor;
+                ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
+                actorId = *sessionActor;
+            } else {
+                LOG_INFO(
+                    ctx,
+                    TFileStoreComponents::SERVICE,
+                    "%s CreateSession returned session actor mismatch: "
+                    "current actor %s generation %lu, notification sender %s "
+                    "generation %lu; keeping notification sender and "
+                    "poisoning current actor",
+                    LogTag(
+                        msg->FileStore.GetFileSystemId(),
+                        msg->ClientId,
+                        msg->SessionId,
+                        msg->SessionSeqNo)
+                        .c_str(),
+                    ToString(*sessionActor).c_str(),
+                    storedOwnerGeneration,
+                    ToString(ev->Sender).c_str(),
+                    msg->OwnerGeneration);
+
+                ctx.Send(*sessionActor, new TEvents::TEvPoisonPill());
+            }
         }
 
         if (!session) {
@@ -970,15 +1012,13 @@ void TStorageServiceActor::HandleSessionCreated(
             session->AddSubSession(
                 msg->SessionSeqNo,
                 msg->ReadOnly,
-                actorId == ev->Sender
-                    ? msg->OwnerGeneration
-                    : storedOwnerGeneration);
-            session->SessionActor = actorId;
+                actorId,
+                ownerGeneration);
         }
     } else if (session) {
         // else it's an old notify from a dead actor
         session->CreateDestroyState = ESessionCreateDestroyState::STATE_NONE;
-        if (session->SessionActor == ev->Sender) {
+        if (sessionActor && *sessionActor == ev->Sender) {
             // e.g. pipe failed or smth. client will have to restore it
             LOG_WARN(ctx, TFileStoreComponents::SERVICE,
                 "%s session failed (%s)",

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -820,7 +820,7 @@ void TStorageServiceActor::HandleCreateSession(
         ToString(SelfId()).c_str());
 }
 
-bool TStorageServiceActor::RemoveSession(
+bool TStorageServiceActor::RemoveSubSession(
     const TString& sessionId,
     ui64 seqNo,
     const TActorContext& ctx)
@@ -844,7 +844,7 @@ bool TStorageServiceActor::RemoveSession(
             isLastSubSession ? "true" : "false",
             ToString(SelfId()).c_str());
 
-        return State->RemoveSession(sessionId, seqNo);
+        return State->RemoveSubSession(sessionId, seqNo);
     }
     return false;
 }
@@ -1014,18 +1014,22 @@ void TStorageServiceActor::HandleSessionCreated(
                     msg->SessionSeqNo).c_str(),
                 FormatError(msg->GetError()).c_str());
 
-            if (msg->Shutdown) {
-                if (!RemoveSession(
-                        msg->SessionId,
-                        msg->SessionSeqNo,
-                        ctx))
-                {
-                    session = nullptr;
-                }
-                ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
-            } else if (!RemoveSession(msg->SessionId, msg->SessionSeqNo, ctx)) {
-                ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
+            // RemoveSubSession returns true if it did not remove the whole
+            // session object.
+            const bool sessionAlive = RemoveSubSession(
+                msg->SessionId,
+                msg->SessionSeqNo,
+                ctx);
+            if (!sessionAlive) {
                 session = nullptr;
+            }
+
+            // Shutdown means that the notification sender has already started
+            // its shutdown path, so finish it with a poison pill. For a
+            // regular failure, poison it only when this subsession was the
+            // last one and the whole session object was removed.
+            if (msg->Shutdown || !sessionAlive) {
+                ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
             }
         }
     } else {

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -849,21 +849,6 @@ bool TStorageServiceActor::RemoveSession(
     return false;
 }
 
-void TStorageServiceActor::RemoveSession(
-    const TString& sessionId,
-    const TActorContext& ctx)
-{
-    if (auto* session = State->FindSession(sessionId); session) {
-        LOG_INFO(ctx, TFileStoreComponents::SERVICE,
-            "[s:%s]remove session, subsessions=%u self %s",
-            sessionId.Quote().c_str(),
-            session->GetSubSessionCount(),
-            ToString(SelfId()).c_str());
-
-        State->RemoveSession(sessionId);
-    }
-}
-
 void TStorageServiceActor::HandleSessionCreated(
     const TEvServicePrivate::TEvSessionCreated::TPtr& ev,
     const TActorContext& ctx)
@@ -1030,9 +1015,14 @@ void TStorageServiceActor::HandleSessionCreated(
                 FormatError(msg->GetError()).c_str());
 
             if (msg->Shutdown) {
-                RemoveSession(msg->SessionId, ctx);
+                if (!RemoveSession(
+                        msg->SessionId,
+                        msg->SessionSeqNo,
+                        ctx))
+                {
+                    session = nullptr;
+                }
                 ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
-                session = nullptr;
             } else if (!RemoveSession(msg->SessionId, msg->SessionSeqNo, ctx)) {
                 ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
                 session = nullptr;

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -826,7 +826,7 @@ bool TStorageServiceActor::RemoveSubSession(
     const TActorContext& ctx)
 {
     if (auto* session = State->FindSession(sessionId, seqNo); session) {
-        const auto subSessionCount = session->GetSubSessionCount();
+        const ui32 subSessionCount = session->GetSubSessionCount();
         const bool isLastSubSession = subSessionCount == 1;
         const auto* subSession = session->FindSubSession(seqNo);
         const auto sessionActor =
@@ -873,8 +873,8 @@ void TStorageServiceActor::HandleSessionCreated(
         ui64 ownerGeneration = msg->OwnerGeneration;
         bool staleOwnerGeneration = false;
 
-        if (session && storedOwnerGeneration && msg->OwnerGeneration) {
-            if (msg->OwnerGeneration < storedOwnerGeneration) {
+        if (session && storedOwnerGeneration && ownerGeneration) {
+            if (ownerGeneration < storedOwnerGeneration) {
                 staleOwnerGeneration = true;
                 ownerGeneration = storedOwnerGeneration;
 
@@ -892,7 +892,7 @@ void TStorageServiceActor::HandleSessionCreated(
                     storedOwnerGeneration,
                     msg->OwnerGeneration,
                     ToString(ev->Sender).c_str());
-            } else if (msg->OwnerGeneration > storedOwnerGeneration) {
+            } else if (ownerGeneration > storedOwnerGeneration) {
                 LOG_INFO(
                     ctx,
                     TFileStoreComponents::SERVICE,
@@ -910,48 +910,37 @@ void TStorageServiceActor::HandleSessionCreated(
             }
         }
 
-        if (sessionActor && *sessionActor != ev->Sender)
-        {
-            if (staleOwnerGeneration) {
-                LOG_WARN(
-                    ctx,
-                    TFileStoreComponents::SERVICE,
-                    "%s CreateSession returned session actor mismatch: "
-                    "current actor %s generation %lu, notification sender %s "
-                    "generation %lu; keeping current actor and poisoning "
-                    "notification sender",
-                    LogTag(
-                        msg->FileStore.GetFileSystemId(),
-                        msg->ClientId,
-                        msg->SessionId,
-                        msg->SessionSeqNo)
-                        .c_str(),
-                    ToString(*sessionActor).c_str(),
-                    storedOwnerGeneration,
-                    ToString(ev->Sender).c_str(),
-                    msg->OwnerGeneration);
+        if (sessionActor && *sessionActor != ev->Sender) {
+            const auto logLevel =
+                staleOwnerGeneration ? NLog::PRI_WARN : NLog::PRI_INFO;
+            const auto* action =
+                staleOwnerGeneration
+                    ? "keeping current actor and poisoning notification sender"
+                    : "keeping notification sender and poisoning current actor";
 
+            LOG_LOG(
+                ctx,
+                logLevel,
+                TFileStoreComponents::SERVICE,
+                "%s CreateSession returned session actor mismatch: "
+                "current actor %s generation %lu, notification sender %s "
+                "generation %lu; %s",
+                LogTag(
+                    msg->FileStore.GetFileSystemId(),
+                    msg->ClientId,
+                    msg->SessionId,
+                    msg->SessionSeqNo)
+                    .c_str(),
+                ToString(*sessionActor).c_str(),
+                storedOwnerGeneration,
+                ToString(ev->Sender).c_str(),
+                msg->OwnerGeneration,
+                action);
+
+            if (staleOwnerGeneration) {
                 ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
                 actorId = *sessionActor;
             } else {
-                LOG_INFO(
-                    ctx,
-                    TFileStoreComponents::SERVICE,
-                    "%s CreateSession returned session actor mismatch: "
-                    "current actor %s generation %lu, notification sender %s "
-                    "generation %lu; keeping notification sender and "
-                    "poisoning current actor",
-                    LogTag(
-                        msg->FileStore.GetFileSystemId(),
-                        msg->ClientId,
-                        msg->SessionId,
-                        msg->SessionSeqNo)
-                        .c_str(),
-                    ToString(*sessionActor).c_str(),
-                    storedOwnerGeneration,
-                    ToString(ev->Sender).c_str(),
-                    msg->OwnerGeneration);
-
                 ctx.Send(*sessionActor, new TEvents::TEvPoisonPill());
             }
         }

--- a/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
@@ -272,19 +272,23 @@ void TStorageServiceActor::HandleDestroySession(
         "%s DestroySession",
         LogTag(fsId, clientId, sessionId, seqNo).c_str());
 
-    if (State->IsLastSubSession(sessionId, seqNo)) {
+    const auto sessionActor = session->GetSessionActor(seqNo);
+    if (sessionActor) {
         LOG_INFO(ctx, TFileStoreComponents::SERVICE,
-            "%s Kill session actor %s from %s",
+            "%s Kill subsession actor %s from %s",
             LogTag(fsId, clientId, sessionId, seqNo).c_str(),
-            ToString(session->SessionActor).c_str(),
+            ToString(*sessionActor).c_str(),
             ToString(SelfId()).c_str());
 
         NCloud::Send(
             ctx,
-            session->SessionActor,
+            *sessionActor,
             std::make_unique<TEvents::TEvPoisonPill>());
 
-        session->SessionActor = {};
+        session->SetSessionActor(seqNo, {});
+    }
+
+    if (State->IsLastSubSession(sessionId, seqNo)) {
         session->ShouldStop = true;
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroysession.cpp
@@ -322,7 +322,7 @@ void TStorageServiceActor::HandleSessionDestroyed(
         session->CreateDestroyState = ESessionCreateDestroyState::STATE_NONE;
         const auto fsId = session->FileStore.GetFileSystemId();
         const auto clientId = session->ClientId;
-        if (!State->RemoveSession(msg->SessionId, msg->SeqNo)) {
+        if (!State->RemoveSubSession(msg->SessionId, msg->SeqNo)) {
             StatsRegistry->Unregister(fsId, clientId);
         }
     } else {

--- a/cloud/filestore/libs/storage/service/service_actor_forward.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_forward.cpp
@@ -153,7 +153,9 @@ void TStorageServiceActor::ForwardRequest(
         msg->CallContext->RequestId);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<typename TMethod::TResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));
@@ -216,7 +218,9 @@ void TStorageServiceActor::ForwardRequestToShard(
         msg->CallContext->RequestId);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<typename TMethod::TResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getnodeattr.cpp
@@ -250,7 +250,9 @@ void TStorageServiceActor::HandleGetNodeAttr(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvGetNodeAttrResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_getsessionevents.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_getsessionevents.cpp
@@ -19,14 +19,22 @@ void TStorageServiceActor::HandleGetSessionEvents(
     const auto sessionId = GetSessionId(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || sessionId != session->SessionId) {
+    const auto sessionActor = session
+        ? session->GetSessionActor(seqNo)
+        : std::optional<TActorId>();
+
+    if (!session ||
+        session->ClientId != clientId ||
+        sessionId != session->SessionId ||
+        !sessionActor)
+    {
         auto response = std::make_unique<TEvService::TEvGetSessionEventsResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));
     }
 
     // forward request to the session actor
-    ctx.Send(ev->Forward(session->SessionActor));
+    ctx.Send(ev->Forward(*sessionActor));
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_listnodes.cpp
@@ -672,7 +672,9 @@ void TStorageServiceActor::HandleListNodes(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvListNodesResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_pingsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_pingsession.cpp
@@ -26,10 +26,14 @@ void TStorageServiceActor::HandlePingSession(
         sessionId.Quote().c_str());
 
     auto* session = State->FindSession(sessionId, seqNo);
+    const auto sessionActor = session
+        ? session->GetSessionActor(seqNo)
+        : std::optional<TActorId>();
+
     if (!session ||
         session->ClientId != clientId ||
         sessionId != session->SessionId ||
-        !session->SessionActor)
+        !sessionActor)
     {
         auto response = std::make_unique<TEvService::TEvPingSessionResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
@@ -42,7 +46,7 @@ void TStorageServiceActor::HandlePingSession(
 
     NCloud::Send(
         ctx,
-        session->SessionActor,
+        *sessionActor,
         std::make_unique<TEvServicePrivate::TEvPingSession>());
 
     auto response = std::make_unique<TEvService::TEvPingSessionResponse>();

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -942,7 +942,9 @@ void TStorageServiceActor::HandleReadData(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvReadDataResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -1049,7 +1049,9 @@ void TStorageServiceActor::HandleReadData(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvReadDataResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_statfs.cpp
@@ -186,16 +186,17 @@ void TStorageServiceActor::HandleStatFileStore(
     const auto* msg = ev->Get();
 
     const auto& headers = msg->Record.GetHeaders();
+    const ui64 seqNo = headers.GetSessionSeqNo();
     const auto* session =
-        State->FindSession(headers.GetSessionId(), headers.GetSessionSeqNo());
+        State->FindSession(headers.GetSessionId(), seqNo);
     if (!session || session->ClientId != headers.GetClientId() ||
-        !session->SessionActor)
+        !session->GetSessionActor(seqNo))
     {
         auto response = std::make_unique<TEvService::TEvStatFileStoreResponse>(
             ErrorInvalidSession(
                 headers.GetClientId(),
                 headers.GetSessionId(),
-                headers.GetSessionSeqNo()));
+                seqNo));
         NCloud::Reply(ctx, *ev, std::move(response));
 
         return;

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -944,7 +944,9 @@ void TStorageServiceActor::HandleWriteData(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvWriteDataResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -1004,7 +1004,9 @@ void TStorageServiceActor::HandleWriteData(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     auto* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session || session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<TEvService::TEvWriteDataResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         return NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_xattr.cpp
@@ -122,7 +122,10 @@ TSessionInfo* TStorageServiceActor::GetAndValidateSession(
     const ui64 seqNo = GetSessionSeqNo(msg->Record);
 
     TSessionInfo* session = State->FindSession(sessionId, seqNo);
-    if (!session || session->ClientId != clientId || !session->SessionActor) {
+    if (!session ||
+        session->ClientId != clientId ||
+        !session->GetSessionActor(seqNo))
+    {
         auto response = std::make_unique<typename TMethod::TResponse>(
             ErrorInvalidSession(clientId, sessionId, seqNo));
         NCloud::Reply(ctx, *ev, std::move(response));

--- a/cloud/filestore/libs/storage/service/service_state.cpp
+++ b/cloud/filestore/libs/storage/service/service_state.cpp
@@ -192,7 +192,6 @@ TSessionInfo* TStorageServiceState::CreateSession(
         session->SessionState = std::move(sessionState);
         session->MediaKind = mediaKind,
         session->RequestStats = std::move(requestStats);
-        session->SessionActor = sessionActor;
         session->TabletId = tabletId;
 
         Sessions.PushBack(session.get());
@@ -205,7 +204,7 @@ TSessionInfo* TStorageServiceState::CreateSession(
         sessionInfo = it->second;
     }
 
-    sessionInfo->AddSubSession(seqNo, readOnly);
+    sessionInfo->AddSubSession(seqNo, readOnly, sessionActor);
 
     return sessionInfo;
 }

--- a/cloud/filestore/libs/storage/service/service_state.cpp
+++ b/cloud/filestore/libs/storage/service/service_state.cpp
@@ -193,7 +193,6 @@ TSessionInfo* TStorageServiceState::CreateSession(
         session->SessionState = std::move(sessionState);
         session->MediaKind = mediaKind,
         session->RequestStats = std::move(requestStats);
-        session->SessionActor = sessionActor;
         session->TabletId = tabletId;
 
         Sessions.PushBack(session.get());
@@ -206,7 +205,11 @@ TSessionInfo* TStorageServiceState::CreateSession(
         sessionInfo = it->second;
     }
 
-    sessionInfo->AddSubSession(seqNo, readOnly, ownerGeneration);
+    sessionInfo->AddSubSession(
+        seqNo,
+        readOnly,
+        sessionActor,
+        ownerGeneration);
 
     return sessionInfo;
 }

--- a/cloud/filestore/libs/storage/service/service_state.cpp
+++ b/cloud/filestore/libs/storage/service/service_state.cpp
@@ -236,7 +236,7 @@ TSessionInfo* TStorageServiceState::FindSession(const TString& sessionId) const
     return nullptr;
 }
 
-bool TStorageServiceState::RemoveSession(
+bool TStorageServiceState::RemoveSubSession(
     const TString& sessionId,
     ui64 seqNo)
 {

--- a/cloud/filestore/libs/storage/service/service_state.cpp
+++ b/cloud/filestore/libs/storage/service/service_state.cpp
@@ -253,17 +253,6 @@ bool TStorageServiceState::RemoveSession(
     return true;
 }
 
-void TStorageServiceState::RemoveSession(const TString& sessionId)
-{
-    auto it = SessionById.find(sessionId);
-    if (it != SessionById.end()) {
-        auto* session = it->second;
-        std::unique_ptr<TSessionInfo> holder(session);
-        SessionById.erase(session->SessionId);
-        session->Unlink();
-    }
-}
-
 bool TStorageServiceState::IsLastSubSession(
     const TString& sessionId,
     ui64 seqNo)

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <optional>
+
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
 #include <cloud/filestore/libs/diagnostics/incomplete_requests.h>
@@ -310,6 +312,13 @@ using TShardStatePtr = TIntrusivePtr<TShardState>;
 struct TSessionInfo
     : public TIntrusiveListItem<TSessionInfo>
 {
+    struct TSubSessionInfo
+    {
+        bool ReadOnly = false;
+        TInstant LastPing;
+        NActors::TActorId SessionActor;
+    };
+
     TString ClientId;
     NProto::TFileStore FileStore;
     TString SessionId;
@@ -317,10 +326,9 @@ struct TSessionInfo
     NCloud::NProto::EStorageMediaKind MediaKind;
     IRequestStatsPtr RequestStats;
 
-    NActors::TActorId SessionActor;
     ui64 TabletId = 0;
 
-    THashMap<ui64, std::pair<bool, TInstant>> SubSessions;
+    THashMap<ui64, TSubSessionInfo> SubSessions;
     ESessionCreateDestroyState CreateDestroyState =
         ESessionCreateDestroyState::STATE_NONE;
 
@@ -338,7 +346,7 @@ struct TSessionInfo
         info.SetSessionSeqNo(seqNo);
         auto it = SubSessions.find(seqNo);
         if (it != SubSessions.end()) {
-            info.SetReadOnly(it->second.first);
+            info.SetReadOnly(it->second.ReadOnly);
         }
     }
 
@@ -348,9 +356,43 @@ struct TSessionInfo
         FileStore = std::move(fileStore);
     }
 
-    void AddSubSession(ui64 seqNo, bool readOnly)
+    const TSubSessionInfo* FindSubSession(ui64 seqNo) const
     {
-        SubSessions[seqNo] = std::make_pair(readOnly, TInstant::Now());
+        auto it = SubSessions.find(seqNo);
+        if (it != SubSessions.end()) {
+            return &it->second;
+        }
+        return nullptr;
+    }
+
+    std::optional<NActors::TActorId> GetSessionActor(ui64 seqNo) const
+    {
+        if (const auto* subSession = FindSubSession(seqNo)) {
+            if (subSession->SessionActor) {
+                return subSession->SessionActor;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    void SetSessionActor(ui64 seqNo, const NActors::TActorId& sessionActor)
+    {
+        auto it = SubSessions.find(seqNo);
+        if (it != SubSessions.end()) {
+            it->second.SessionActor = sessionActor;
+        }
+    }
+
+    void AddSubSession(
+        ui64 seqNo,
+        bool readOnly,
+        const NActors::TActorId& sessionActor)
+    {
+        auto& subSession = SubSessions[seqNo];
+        subSession.ReadOnly = readOnly;
+        subSession.LastPing = TInstant::Now();
+        subSession.SessionActor = sessionActor;
     }
 
     bool RemoveSubSession(ui64 seqNo)
@@ -364,10 +406,15 @@ struct TSessionInfo
         return SubSessions.count(seqNo) > 0;
     }
 
+    ui32 GetSubSessionCount() const
+    {
+        return SubSessions.size();
+    }
+
     void UpdateSubSession(ui64 seqNo, TInstant now)
     {
         if (auto it = SubSessions.find(seqNo); it != SubSessions.end()) {
-            it->second.second = now;
+            it->second.LastPing = now;
         }
     }
 

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -398,6 +398,7 @@ struct TSessionInfo
         subSession.OwnerGeneration = ownerGeneration;
     }
 
+    // Returns true if there are still subsessions left after removal.
     bool RemoveSubSession(ui64 seqNo)
     {
         SubSessions.erase(seqNo);
@@ -526,10 +527,9 @@ public:
 
     TSessionInfo* FindSession(const TString& sessionId) const;
 
-    // removes session with sessionid and seqno
-    // returns false if there are no more sessions
-    // with given sessionid remain
-    bool RemoveSession(
+    // Removes the subsession. If it was the last one, removes the whole
+    // session. Returns true if the session object is still alive after removal.
+    bool RemoveSubSession(
         const TString& sessionId,
         ui64 seqNo);
 

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <optional>
+
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
 #include <cloud/filestore/libs/diagnostics/incomplete_requests.h>
@@ -315,6 +317,7 @@ struct TSessionInfo
         bool ReadOnly = false;
         TInstant LastPing;
         ui64 OwnerGeneration = 0;
+        NActors::TActorId SessionActor;
     };
 
     TString ClientId;
@@ -324,7 +327,6 @@ struct TSessionInfo
     NCloud::NProto::EStorageMediaKind MediaKind;
     IRequestStatsPtr RequestStats;
 
-    NActors::TActorId SessionActor;
     ui64 TabletId = 0;
 
     THashMap<ui64, TSubSessionInfo> SubSessions;
@@ -355,14 +357,44 @@ struct TSessionInfo
         FileStore = std::move(fileStore);
     }
 
+    const TSubSessionInfo* FindSubSession(ui64 seqNo) const
+    {
+        auto it = SubSessions.find(seqNo);
+        if (it != SubSessions.end()) {
+            return &it->second;
+        }
+        return nullptr;
+    }
+
+    std::optional<NActors::TActorId> GetSessionActor(ui64 seqNo) const
+    {
+        if (const auto* subSession = FindSubSession(seqNo)) {
+            if (subSession->SessionActor) {
+                return subSession->SessionActor;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    void SetSessionActor(ui64 seqNo, const NActors::TActorId& sessionActor)
+    {
+        auto it = SubSessions.find(seqNo);
+        if (it != SubSessions.end()) {
+            it->second.SessionActor = sessionActor;
+        }
+    }
+
     void AddSubSession(
         ui64 seqNo,
         bool readOnly,
+        const NActors::TActorId& sessionActor,
         ui64 ownerGeneration)
     {
         auto& subSession = SubSessions[seqNo];
         subSession.ReadOnly = readOnly;
         subSession.LastPing = TInstant::Now();
+        subSession.SessionActor = sessionActor;
         subSession.OwnerGeneration = ownerGeneration;
     }
 
@@ -377,10 +409,9 @@ struct TSessionInfo
         return SubSessions.count(seqNo) > 0;
     }
 
-    const TSubSessionInfo* FindSubSession(ui64 seqNo) const
+    ui32 GetSubSessionCount() const
     {
-        auto it = SubSessions.find(seqNo);
-        return it != SubSessions.end() ? &it->second : nullptr;
+        return SubSessions.size();
     }
 
     void UpdateSubSession(ui64 seqNo, TInstant now)

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -533,8 +533,6 @@ public:
         const TString& sessionId,
         ui64 seqNo);
 
-    void RemoveSession(const TString& sessionId);
-
     bool IsLastSubSession(
         const TString& sessionId,
         ui64 seqNo);

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -907,6 +907,89 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.DestroySession(headers);
     }
 
+    Y_UNIT_TEST(ShouldKeepDifferentSessionActorsForSeveralSubSessions)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        auto& runtime = env.GetRuntime();
+
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateFileStore("test", 1000);
+
+        TActorId subSessionActor0;
+        TActorId subSessionActor1;
+        ui32 subSessionActor0Pings = 0;
+        ui32 subSessionActor1Pings = 0;
+        bool capturePings = false;
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvServicePrivate::EvSessionCreated: {
+                    const auto* msg =
+                        event->Get<TEvServicePrivate::TEvSessionCreated>();
+                    if (msg->ClientId == "client" &&
+                        msg->FileStore.GetFileSystemId() == "test")
+                    {
+                        if (msg->SessionSeqNo == 0) {
+                            subSessionActor0 = event->Sender;
+                        } else if (msg->SessionSeqNo == 1) {
+                            subSessionActor1 = event->Sender;
+                        }
+                    }
+
+                    break;
+                }
+
+                case TEvServicePrivate::EvPingSession: {
+                    if (capturePings) {
+                        if (event->Recipient == subSessionActor0) {
+                            ++subSessionActor0Pings;
+                        } else if (event->Recipient == subSessionActor1) {
+                            ++subSessionActor1Pings;
+                        }
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        auto headers = service.InitSession("test", "client");
+        service.PingSession(headers);
+
+        THeaders restoredHeaders;
+        // Recover the same client session without specifying SessionId.
+        // The tablet should return the same SessionId and create a new
+        // subsession for seqNo=1.
+        service.InitSession(
+            restoredHeaders,
+            "test",
+            "client",
+            "",     // checkpointId
+            true,   // restoreClientSession
+            1);
+
+        UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, restoredHeaders.SessionId);
+        UNIT_ASSERT(subSessionActor0);
+        UNIT_ASSERT(subSessionActor1);
+        UNIT_ASSERT_VALUES_UNEQUAL(subSessionActor0, subSessionActor1);
+
+        capturePings = true;
+        service.PingSession(headers);
+        service.PingSession(restoredHeaders);
+        capturePings = false;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, subSessionActor0Pings);
+        UNIT_ASSERT_VALUES_EQUAL(1, subSessionActor1Pings);
+
+        service.DestroySession(restoredHeaders);
+        service.DestroySession(headers);
+    }
+
     Y_UNIT_TEST(ShouldNotPingAndDestroyInvalidSession)
     {
         TTestEnv env;

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -1036,6 +1036,89 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.DestroySession(headers);
     }
 
+    Y_UNIT_TEST(ShouldKeepDifferentSessionActorsForSeveralSubSessions)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        auto& runtime = env.GetRuntime();
+
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateFileStore("test", 1000);
+
+        TActorId subSessionActor0;
+        TActorId subSessionActor1;
+        ui32 subSessionActor0Pings = 0;
+        ui32 subSessionActor1Pings = 0;
+        bool capturePings = false;
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvServicePrivate::EvSessionCreated: {
+                    const auto* msg =
+                        event->Get<TEvServicePrivate::TEvSessionCreated>();
+                    if (msg->ClientId == "client" &&
+                        msg->FileStore.GetFileSystemId() == "test")
+                    {
+                        if (msg->SessionSeqNo == 0) {
+                            subSessionActor0 = event->Sender;
+                        } else if (msg->SessionSeqNo == 1) {
+                            subSessionActor1 = event->Sender;
+                        }
+                    }
+
+                    break;
+                }
+
+                case TEvServicePrivate::EvPingSession: {
+                    if (capturePings) {
+                        if (event->Recipient == subSessionActor0) {
+                            ++subSessionActor0Pings;
+                        } else if (event->Recipient == subSessionActor1) {
+                            ++subSessionActor1Pings;
+                        }
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        auto headers = service.InitSession("test", "client");
+        service.PingSession(headers);
+
+        THeaders restoredHeaders;
+        // Recover the same client session without specifying SessionId.
+        // The tablet should return the same SessionId and create a new
+        // subsession for seqNo=1.
+        service.InitSession(
+            restoredHeaders,
+            "test",
+            "client",
+            "",     // checkpointId
+            true,   // restoreClientSession
+            1);
+
+        UNIT_ASSERT_VALUES_EQUAL(headers.SessionId, restoredHeaders.SessionId);
+        UNIT_ASSERT(subSessionActor0);
+        UNIT_ASSERT(subSessionActor1);
+        UNIT_ASSERT_VALUES_UNEQUAL(subSessionActor0, subSessionActor1);
+
+        capturePings = true;
+        service.PingSession(headers);
+        service.PingSession(restoredHeaders);
+        capturePings = false;
+
+        UNIT_ASSERT_VALUES_EQUAL(1, subSessionActor0Pings);
+        UNIT_ASSERT_VALUES_EQUAL(1, subSessionActor1Pings);
+
+        service.DestroySession(restoredHeaders);
+        service.DestroySession(headers);
+    }
+
     Y_UNIT_TEST(ShouldNotPingAndDestroyInvalidSession)
     {
         TTestEnv env;


### PR DESCRIPTION
### Notes
The tablet tracks ownership per subsession: each `(sessionId, seqNo)` has its own owner actor. The service state used to keep only one `SessionActor` for the whole `TSessionInfo`, so creating or recovering one subsession could replace or kill the actor that still belonged to another active subsession.

This change stores `SessionActor` inside `TSubSessionInfo` and makes service-side validation and routing use the actor for the exact `(sessionId, seqNo)`. This keeps the service state consistent with the tablet state and prevents recovery of one subsession from invalidating other active subsessions.

detailed explanation of problem the https://github.com/ydb-platform/nbs/issues/4961#issuecomment-4606262675

### Issue
#4961 