### PR TITLE
issue-5894: TTCPSideChannel implementation

### DIFF
--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -33,6 +33,7 @@
 #include <cloud/filestore/libs/service_null/service.h>
 #include <cloud/filestore/libs/storage/core/probes.h>
 #include <cloud/filestore/libs/storage/fastshard/bootstrap/core.h>
+#include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 #include <cloud/filestore/libs/vfs/probes.h>
 #include <cloud/filestore/libs/vhost/server.h>
 
@@ -218,12 +219,15 @@ private:
         return true;
     }
 
-    static ISideChannelPtr CreateSideChannel(
-        NProto::ESideChannelType sideChannelType)
+    ISideChannelPtr CreateSideChannel(NProto::ESideChannelType sideChannelType)
     {
         switch (sideChannelType) {
             case NProto::SCT_NONE: return nullptr;
-            case NProto::SCT_TCP: return CreateTCPSideChannel();
+            case NProto::SCT_TCP: {
+                return CreateTCPSideChannel(
+                    *Logging,
+                    std::make_shared<NStorage::NFastShard::TAsyncClient>());
+            }
         }
 
         Y_ABORT("sct=%d", static_cast<int>(sideChannelType));

--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -32,6 +32,7 @@
 #include <cloud/filestore/libs/service_local/service.h>
 #include <cloud/filestore/libs/service_null/service.h>
 #include <cloud/filestore/libs/storage/core/probes.h>
+#include <cloud/filestore/libs/storage/fastshard/bootstrap/core.h>
 #include <cloud/filestore/libs/vfs/probes.h>
 #include <cloud/filestore/libs/vhost/server.h>
 
@@ -569,6 +570,11 @@ void TBootstrapVhost::InitLWTrace()
 
 void TBootstrapVhost::StartComponents()
 {
+    const auto& serviceConfig = *Configs->VhostServiceConfig;
+    if (serviceConfig.GetSideChannelType() == NProto::SCT_TCP) {
+        NStorage::NFastShard::Init();
+    }
+
     FILESTORE_LOG_START_COMPONENT(ModuleStatsUpdater);
     FILESTORE_LOG_START_COMPONENT(TcMallocStatsUpdater);
 
@@ -599,6 +605,11 @@ void TBootstrapVhost::StopComponents()
 
     FILESTORE_LOG_STOP_COMPONENT(TcMallocStatsUpdater);
     FILESTORE_LOG_STOP_COMPONENT(ModuleStatsUpdater);
+
+    const auto& serviceConfig = *Configs->VhostServiceConfig;
+    if (serviceConfig.GetSideChannelType() == NProto::SCT_TCP) {
+        NStorage::NFastShard::Destroy();
+    }
 }
 
 void TBootstrapVhost::Drain()

--- a/cloud/filestore/libs/daemon/vhost/ya.make
+++ b/cloud/filestore/libs/daemon/vhost/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     cloud/filestore/libs/service_kikimr
     cloud/filestore/libs/service_local
     cloud/filestore/libs/service_null
+    cloud/filestore/libs/storage/fastshard/bootstrap
     cloud/filestore/libs/vfs_fuse/vhost
     cloud/filestore/libs/vhost
 

--- a/cloud/filestore/libs/daemon/vhost/ya.make
+++ b/cloud/filestore/libs/daemon/vhost/ya.make
@@ -19,6 +19,7 @@ PEERDIR(
     cloud/filestore/libs/service_local
     cloud/filestore/libs/service_null
     cloud/filestore/libs/storage/fastshard/bootstrap
+    cloud/filestore/libs/storage/fastshard/client
     cloud/filestore/libs/vfs_fuse/vhost
     cloud/filestore/libs/vhost
 

--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -17,24 +17,87 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TEndpointPool: public TThrRefBase
+{
+private:
+    TLog Log;
+    TAdaptiveLock Lock;
+    TDeque<IAsyncEndpointPtr> Endpoints;
+    ui32 Generation = 0;
+
+public:
+    explicit TEndpointPool(TLog log)
+        : Log(std::move(log))
+    {}
+
+public:
+    IAsyncEndpointPtr Pop(ui32* generation)
+    {
+        IAsyncEndpointPtr e;
+
+        with_lock(Lock) {
+            if (!Endpoints) {
+                return nullptr;
+            }
+
+            e = Endpoints.front();
+            Endpoints.pop_front();
+            *generation = Generation;
+        }
+
+        STORAGE_DEBUG("endpoint popped from pool, generation=" << *generation);
+        return e;
+    }
+
+    void Push(IAsyncEndpointPtr e, ui32 generation)
+    {
+        with_lock (Lock) {
+            if (generation < Generation) {
+                return;
+            }
+
+            Endpoints.push_back(std::move(e));
+        }
+
+        STORAGE_DEBUG("endpoint added to pool, generation=" << generation);
+    }
+
+    ui32 AddressChanged()
+    {
+        ui32 generation = 0;
+        with_lock (Lock) {
+            Endpoints.clear();
+            generation = ++Generation;
+        }
+
+        STORAGE_DEBUG("address changed, generation=" << generation);
+        return generation;
+    }
+};
+
+using TEndpointPoolPtr = TIntrusivePtr<TEndpointPool>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TTCPSideChannel: public ISideChannel
 {
 private:
     TAdaptiveLock Lock;
 
-    bool IsOverloaded = false;
-    // Set once on the first Update() with a valid port; never reset.
-    bool ConnectStarted = false;
-    TFuture<IAsyncEndpointPtr> ConnectFuture;
-    // Promoted from ConnectFuture once HasValue() is true.
-    // TODO: endpoint pool
-    std::shared_ptr<IAsyncEndpoint> ReadyEndpoint;
+    TString Host;
+    ui16 Port = 0;
 
+    TLog Log;
     std::shared_ptr<IAsyncClient> Client;
+    TEndpointPoolPtr EndpointPool;
 
 public:
-    explicit TTCPSideChannel(std::shared_ptr<IAsyncClient> client)
-        : Client(std::move(client))
+    TTCPSideChannel(
+            ILoggingService& logging,
+            std::shared_ptr<IAsyncClient> client)
+        : Log(logging.CreateLog("TCP_SIDE_CHANNEL"))
+        , Client(std::move(client))
+        , EndpointPool(MakeIntrusive<TEndpointPool>(Log))
     {}
 
 public:
@@ -46,7 +109,7 @@ public:
         Y_UNUSED(callContext);
 
         return Dispatch(
-            std::move(request),
+            *request,
             std::move(response),
             [](TRequest& req, const NProto::TReadDataRequest& body) {
                 *req.MutableReadData() = body;
@@ -64,7 +127,7 @@ public:
         Y_UNUSED(callContext);
 
         return Dispatch(
-            std::move(request),
+            *request,
             std::move(response),
             [](TRequest& req, const NProto::TWriteDataRequest& body) {
                 *req.MutableWriteData() = body;
@@ -78,86 +141,124 @@ public:
     {
         const ui32 port = backendInfo.GetFastShardPort();
         const TString& host = backendInfo.GetFastShardHost();
-        bool shouldConnect = false;
 
+        ui32 generation = 0;
         with_lock (Lock) {
-            IsOverloaded = backendInfo.GetIsOverloaded();
-            shouldConnect = host && port != 0 && !ConnectStarted;
-            if (shouldConnect) {
-                ConnectStarted = true;
+            if (Host != host || Port != port) {
+                generation = EndpointPool->AddressChanged();
+                STORAGE_INFO("updated side channel connection params"
+                    << ": host=" << host
+                    << ", port=" << port
+                    << ", generation=" << generation);
             }
+
+            Host = host;
+            Port = port;
         }
 
-        if (!shouldConnect) {
-            return;
-        }
-
-        with_lock (Lock) {
-            ConnectFuture = Client->Connect(host, port);
-        }
+        TryConnect().Subscribe(
+            [
+                ep = EndpointPool,
+                generation
+            ] (const TFuture<IAsyncEndpointPtr>& f) {
+                ep->Push(UnsafeExtractValue(f), generation);
+            });
     }
 
 private:
-    // Returns the ready endpoint under lock, promoting ConnectFuture if done.
-    // Returns nullptr if not connected yet.
-    std::shared_ptr<IAsyncEndpoint> GetEndpointLocked()
-    {
-        if (ReadyEndpoint) {
-            return ReadyEndpoint;
-        }
-        if (!ConnectFuture.Initialized() || !ConnectFuture.HasValue()) {
-            return nullptr;
-        }
-        auto ep = ConnectFuture.ExtractValue();
-        if (ep) {
-            ReadyEndpoint = std::move(ep);
-        }
-        ConnectFuture = {};
-        return ReadyEndpoint;
-    }
-
-    template <
-        typename TReq,
-        typename TResp,
-        typename FillBody,
-        typename ExtractBody>
+    template <typename TReq,
+              typename TResp,
+              typename TFillBody,
+              typename TExtractBody>
     bool Dispatch(
-        std::shared_ptr<TReq> request,
+        const TReq& request,
         TPromise<TResp> response,
-        FillBody fillBody,
-        ExtractBody extractBody)
+        TFillBody fillBody,
+        TExtractBody extractBody)
     {
-        std::shared_ptr<IAsyncEndpoint> ep;
+        ui32 generation = 0;
+        IAsyncEndpointPtr e = EndpointPool->Pop(&generation);
+
+        auto send = [response = std::move(response), extractBody](
+            TFuture<TResponse> f) mutable
         {
-            auto guard = Guard(Lock);
-            if (IsOverloaded) {
-                return false;
+            auto r = f.ExtractValue();
+            TResp resp;
+            if (r.HasError()) {
+                *resp.MutableError() = r.GetError();
+            } else {
+                extractBody(resp, r);
             }
-            ep = GetEndpointLocked();
+            response.SetValue(std::move(resp));
+        };
+
+        TRequest req;
+        req.SetFileSystemId(request.GetFileSystemId());
+        fillBody(req, request);
+
+        if (e) {
+            auto result = e->Send(std::move(req));
+            result.Subscribe([
+                ep = EndpointPool,
+                e = std::move(e),
+                generation
+            ] (const TFuture<TResponse>&) mutable {
+                ep->Push(std::move(e), generation);
+            });
+            result.Subscribe(std::move(send));
+
+            return true;
         }
-        if (!ep) {
+
+        auto connection = TryConnect();
+        if (!connection.Initialized()) {
             return false;
         }
 
-        TRequest req;
-        req.SetFileSystemId(request->GetFileSystemId());
-        fillBody(req, *request);
-
-        ep->Send(std::move(req)).Subscribe(
-            [response = std::move(response), extractBody](
-                TFuture<TResponse> f) mutable
-            {
-                auto r = f.ExtractValue();
-                TResp resp;
-                if (r.HasError()) {
-                    *resp.MutableError() = r.GetError();
-                } else {
-                    extractBody(resp, r);
-                }
-                response.SetValue(std::move(resp));
+        connection.Subscribe([
+            req = std::move(req),
+            send = std::move(send),
+            ep = EndpointPool,
+            generation
+        ] (const TFuture<IAsyncEndpointPtr>& f) mutable {
+            auto e = UnsafeExtractValue(f);
+            auto result = e->Send(std::move(req));
+            result.Subscribe([
+                ep = std::move(ep),
+                e = std::move(e),
+                generation
+            ] (const TFuture<TResponse>&) mutable {
+                ep->Push(std::move(e), generation);
             });
+            result.Subscribe(std::move(send));
+        });
 
         return true;
+    }
+
+    TFuture<IAsyncEndpointPtr> TryConnect()
+    {
+        TString host;
+        ui16 port = 0;
+        with_lock (Lock) {
+            if (!Host || !Port) {
+                return {};
+            }
+
+            host = Host;
+            port = Port;
+        }
+
+        auto connection = Client->Connect(Host, Port);
+        connection.Subscribe([
+            Log = Log,
+            host = std::move(host),
+            port = port
+        ] (const TFuture<IAsyncEndpointPtr>&) {
+            STORAGE_INFO("connected to host=" << host << ", port=" << port);
+        });
+
+        return connection;
     }
 };
 
@@ -165,9 +266,13 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ISideChannelPtr CreateTCPSideChannel(std::shared_ptr<IAsyncClient> client)
+ISideChannelPtr CreateTCPSideChannel(
+    ILoggingService& logging,
+    std::shared_ptr<IAsyncClient> client)
 {
-    return std::make_shared<TTCPSideChannel>(std::move(client));
+    return std::make_shared<TTCPSideChannel>(
+        logging,
+        std::move(client));
 }
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -1,6 +1,18 @@
 #include "side_channel.h"
 
+#include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
+#include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
+
+#include <cloud/filestore/public/api/protos/data.pb.h>
+#include <cloud/filestore/public/api/protos/headers.pb.h>
+
+#include <util/system/spinlock.h>
+
 namespace NCloud::NFileStore {
+
+using namespace NStorage::NFastShard;
+using namespace NStorage::NFastShard::NProtoSrv;
+using namespace NThreading;
 
 namespace {
 
@@ -8,36 +20,135 @@ namespace {
 
 class TTCPSideChannel: public ISideChannel
 {
+private:
+    TAdaptiveLock Lock;
+
+    bool IsOverloaded = false;
+    // Set once on the first Update() with a valid port; never reset.
+    bool ConnectStarted = false;
+    TFuture<IAsyncEndpointPtr> ConnectFuture;
+    // Promoted from ConnectFuture once HasValue() is true.
+    // TODO: endpoint pool
+    std::shared_ptr<IAsyncEndpoint> ReadyEndpoint;
+
+    TAsyncClient Client;
+
+    // Returns the ready endpoint under lock, promoting ConnectFuture if done.
+    // Returns nullptr if not connected yet.
+    std::shared_ptr<IAsyncEndpoint> GetEndpointLocked()
+    {
+        if (ReadyEndpoint) {
+            return ReadyEndpoint;
+        }
+        if (!ConnectFuture.Initialized() || !ConnectFuture.HasValue()) {
+            return nullptr;
+        }
+        auto ep = ConnectFuture.ExtractValue();
+        if (ep) {
+            ReadyEndpoint = std::move(ep);
+        }
+        ConnectFuture = {};
+        return ReadyEndpoint;
+    }
+
+    template <typename TReq, typename TResp, typename FillBody, typename ExtractBody>
+    bool Dispatch(
+        std::shared_ptr<TReq> request,
+        TPromise<TResp> response,
+        FillBody fillBody,
+        ExtractBody extractBody)
+    {
+        std::shared_ptr<IAsyncEndpoint> ep;
+        {
+            auto guard = Guard(Lock);
+            if (IsOverloaded) {
+                return false;
+            }
+            ep = GetEndpointLocked();
+        }
+        if (!ep) {
+            return false;
+        }
+
+        TRequest req;
+        req.SetFileSystemId(request->GetFileSystemId());
+        fillBody(req, *request);
+
+        ep->Send(std::move(req)).Subscribe(
+            [response = std::move(response), extractBody](
+                TFuture<TResponse> f) mutable
+            {
+                auto r = f.ExtractValue();
+                TResp resp;
+                if (r.HasError()) {
+                    *resp.MutableError() = r.GetError();
+                } else {
+                    extractBody(resp, r);
+                }
+                response.SetValue(std::move(resp));
+            });
+
+        return true;
+    }
+
 public:
     bool ExecuteRequest(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadDataRequest> request,
-        NThreading::TPromise<NProto::TReadDataResponse> response) override
+        TPromise<NProto::TReadDataResponse> response) override
     {
-        Y_UNUSED(callContext, request, response);
+        Y_UNUSED(callContext);
 
-        // TODO(#5894): impl
-
-        return false;
+        return Dispatch(
+            std::move(request),
+            std::move(response),
+            [](TRequest& req, const NProto::TReadDataRequest& body) {
+                *req.MutableReadData() = body;
+            },
+            [](NProto::TReadDataResponse& resp, TResponse& r) {
+                resp = std::move(*r.MutableReadData());
+            });
     }
 
-    virtual bool ExecuteRequest(
+    bool ExecuteRequest(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TWriteDataRequest> request,
-        NThreading::TPromise<NProto::TWriteDataResponse> response) override
+        TPromise<NProto::TWriteDataResponse> response) override
     {
-        Y_UNUSED(callContext, request, response);
+        Y_UNUSED(callContext);
 
-        // TODO(#5894): impl
-
-        return false;
+        return Dispatch(
+            std::move(request),
+            std::move(response),
+            [](TRequest& req, const NProto::TWriteDataRequest& body) {
+                *req.MutableWriteData() = body;
+            },
+            [](NProto::TWriteDataResponse& resp, TResponse& r) {
+                resp = std::move(*r.MutableWriteData());
+            });
     }
 
     void Update(const NProto::TBackendInfo& backendInfo) override
     {
-        Y_UNUSED(backendInfo);
+        const ui32 port = backendInfo.GetFastShardPort();
+        const TString& host = backendInfo.GetFastShardHost();
+        bool shouldConnect = false;
 
-        // TODO(#5894): impl
+        with_lock (Lock) {
+            IsOverloaded = backendInfo.GetIsOverloaded();
+            shouldConnect = host && port != 0 && !ConnectStarted;
+            if (shouldConnect) {
+                ConnectStarted = true;
+            }
+        }
+
+        if (!shouldConnect) {
+            return;
+        }
+
+        with_lock (Lock) {
+            ConnectFuture = Client.Connect(host, port);
+        }
     }
 };
 

--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -36,13 +36,14 @@ public:
         IAsyncEndpointPtr e;
 
         with_lock (Lock) {
+            *generation = Generation;
+
             if (!Endpoints) {
                 return nullptr;
             }
 
             e = Endpoints.front();
             Endpoints.pop_front();
-            *generation = Generation;
         }
 
         STORAGE_DEBUG("endpoint popped from pool, generation=" << *generation);
@@ -105,6 +106,8 @@ public:
     {}
 
 public:
+    // TODO(#5894) zero-copy io support
+
     bool ExecuteRequest(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadDataRequest> request,
@@ -160,7 +163,12 @@ public:
             Port = port;
         }
 
-        TryConnect().Subscribe(
+        auto connection = TryConnect();
+        if (!connection.Initialized()) {
+            return;
+        }
+
+        connection.Subscribe(
             [
                 ep = EndpointPool,
                 generation
@@ -183,17 +191,32 @@ private:
         ui32 generation = 0;
         IAsyncEndpointPtr e = EndpointPool->Pop(&generation);
 
-        auto send = [response = std::move(response), extractBody](
-            TFuture<TResponse> f) mutable
+        auto complete = [
+            response = std::move(response),
+            ep = EndpointPool,
+            extractBody
+        ](IAsyncEndpointPtr e, ui32 generation, TResponse r) mutable
         {
-            auto r = f.ExtractValue();
             TResp resp;
+            bool shardMoved = false;
             if (r.HasError()) {
-                *resp.MutableError() = r.GetError();
+                if (r.GetError().GetCode() == E_NOT_FOUND) {
+                    shardMoved = true;
+                    *resp.MutableError() = MakeError(
+                        E_REJECTED,
+                        TStringBuilder() << "shard moved: "
+                            << FormatError(r.GetError()));
+                } else {
+                    *resp.MutableError() = r.GetError();
+                }
             } else {
                 extractBody(resp, r);
             }
             response.SetValue(std::move(resp));
+
+            if (!shardMoved) {
+                ep->Push(std::move(e), generation);
+            }
         };
 
         TRequest req;
@@ -203,13 +226,13 @@ private:
         if (e) {
             auto result = e->Send(std::move(req));
             result.Subscribe([
+                complete = std::move(complete),
                 ep = EndpointPool,
                 e = std::move(e),
                 generation
-            ] (const TFuture<TResponse>&) mutable {
-                ep->Push(std::move(e), generation);
+            ] (const TFuture<TResponse>& f) mutable {
+                complete(std::move(e), generation, UnsafeExtractValue(f));
             });
-            result.Subscribe(std::move(send));
 
             return true;
         }
@@ -221,7 +244,7 @@ private:
 
         connection.Subscribe([
             req = std::move(req),
-            send = std::move(send),
+            complete = std::move(complete),
             ep = EndpointPool,
             generation
         ] (const TFuture<IAsyncEndpointPtr>& f) mutable {
@@ -230,19 +253,19 @@ private:
             if (!e) {
                 TResponse errorResponse;
                 errorResponse.MutableError()->SetCode(E_UNAVAILABLE);
-                send(MakeFuture(std::move(errorResponse)));
+                complete(nullptr, 0, std::move(errorResponse));
                 return;
             }
 
             auto result = e->Send(std::move(req));
             result.Subscribe([
+                complete = std::move(complete),
                 ep = std::move(ep),
                 e = std::move(e),
                 generation
-            ] (const TFuture<TResponse>&) mutable {
-                ep->Push(std::move(e), generation);
+            ] (const TFuture<TResponse>& f) mutable {
+                complete(std::move(e), generation, UnsafeExtractValue(f));
             });
-            result.Subscribe(std::move(send));
         });
 
         return true;
@@ -261,7 +284,7 @@ private:
             port = Port;
         }
 
-        auto connection = Client->Connect(Host, Port);
+        auto connection = Client->Connect(host, port);
         connection.Subscribe([
             Log = Log,
             host = std::move(host),

--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -1,6 +1,5 @@
 #include "side_channel.h"
 
-#include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 #include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
 
 #include <cloud/filestore/public/api/protos/data.pb.h>
@@ -31,65 +30,12 @@ private:
     // TODO: endpoint pool
     std::shared_ptr<IAsyncEndpoint> ReadyEndpoint;
 
-    TAsyncClient Client;
+    std::shared_ptr<IAsyncClient> Client;
 
-    // Returns the ready endpoint under lock, promoting ConnectFuture if done.
-    // Returns nullptr if not connected yet.
-    std::shared_ptr<IAsyncEndpoint> GetEndpointLocked()
-    {
-        if (ReadyEndpoint) {
-            return ReadyEndpoint;
-        }
-        if (!ConnectFuture.Initialized() || !ConnectFuture.HasValue()) {
-            return nullptr;
-        }
-        auto ep = ConnectFuture.ExtractValue();
-        if (ep) {
-            ReadyEndpoint = std::move(ep);
-        }
-        ConnectFuture = {};
-        return ReadyEndpoint;
-    }
-
-    template <typename TReq, typename TResp, typename FillBody, typename ExtractBody>
-    bool Dispatch(
-        std::shared_ptr<TReq> request,
-        TPromise<TResp> response,
-        FillBody fillBody,
-        ExtractBody extractBody)
-    {
-        std::shared_ptr<IAsyncEndpoint> ep;
-        {
-            auto guard = Guard(Lock);
-            if (IsOverloaded) {
-                return false;
-            }
-            ep = GetEndpointLocked();
-        }
-        if (!ep) {
-            return false;
-        }
-
-        TRequest req;
-        req.SetFileSystemId(request->GetFileSystemId());
-        fillBody(req, *request);
-
-        ep->Send(std::move(req)).Subscribe(
-            [response = std::move(response), extractBody](
-                TFuture<TResponse> f) mutable
-            {
-                auto r = f.ExtractValue();
-                TResp resp;
-                if (r.HasError()) {
-                    *resp.MutableError() = r.GetError();
-                } else {
-                    extractBody(resp, r);
-                }
-                response.SetValue(std::move(resp));
-            });
-
-        return true;
-    }
+public:
+    explicit TTCPSideChannel(std::shared_ptr<IAsyncClient> client)
+        : Client(std::move(client))
+    {}
 
 public:
     bool ExecuteRequest(
@@ -147,8 +93,71 @@ public:
         }
 
         with_lock (Lock) {
-            ConnectFuture = Client.Connect(host, port);
+            ConnectFuture = Client->Connect(host, port);
         }
+    }
+
+private:
+    // Returns the ready endpoint under lock, promoting ConnectFuture if done.
+    // Returns nullptr if not connected yet.
+    std::shared_ptr<IAsyncEndpoint> GetEndpointLocked()
+    {
+        if (ReadyEndpoint) {
+            return ReadyEndpoint;
+        }
+        if (!ConnectFuture.Initialized() || !ConnectFuture.HasValue()) {
+            return nullptr;
+        }
+        auto ep = ConnectFuture.ExtractValue();
+        if (ep) {
+            ReadyEndpoint = std::move(ep);
+        }
+        ConnectFuture = {};
+        return ReadyEndpoint;
+    }
+
+    template <
+        typename TReq,
+        typename TResp,
+        typename FillBody,
+        typename ExtractBody>
+    bool Dispatch(
+        std::shared_ptr<TReq> request,
+        TPromise<TResp> response,
+        FillBody fillBody,
+        ExtractBody extractBody)
+    {
+        std::shared_ptr<IAsyncEndpoint> ep;
+        {
+            auto guard = Guard(Lock);
+            if (IsOverloaded) {
+                return false;
+            }
+            ep = GetEndpointLocked();
+        }
+        if (!ep) {
+            return false;
+        }
+
+        TRequest req;
+        req.SetFileSystemId(request->GetFileSystemId());
+        fillBody(req, *request);
+
+        ep->Send(std::move(req)).Subscribe(
+            [response = std::move(response), extractBody](
+                TFuture<TResponse> f) mutable
+            {
+                auto r = f.ExtractValue();
+                TResp resp;
+                if (r.HasError()) {
+                    *resp.MutableError() = r.GetError();
+                } else {
+                    extractBody(resp, r);
+                }
+                response.SetValue(std::move(resp));
+            });
+
+        return true;
     }
 };
 
@@ -156,9 +165,9 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ISideChannelPtr CreateTCPSideChannel()
+ISideChannelPtr CreateTCPSideChannel(std::shared_ptr<IAsyncClient> client)
 {
-    return std::make_shared<TTCPSideChannel>();
+    return std::make_shared<TTCPSideChannel>(std::move(client));
 }
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -35,7 +35,7 @@ public:
     {
         IAsyncEndpointPtr e;
 
-        with_lock(Lock) {
+        with_lock (Lock) {
             if (!Endpoints) {
                 return nullptr;
             }
@@ -51,6 +51,10 @@ public:
 
     void Push(IAsyncEndpointPtr e, ui32 generation)
     {
+        if (!e) {
+            return;
+        }
+
         with_lock (Lock) {
             if (generation < Generation) {
                 return;
@@ -222,6 +226,14 @@ private:
             generation
         ] (const TFuture<IAsyncEndpointPtr>& f) mutable {
             auto e = UnsafeExtractValue(f);
+
+            if (!e) {
+                TResponse errorResponse;
+                errorResponse.MutableError()->SetCode(E_UNAVAILABLE);
+                send(MakeFuture(std::move(errorResponse)));
+                return;
+            }
+
             auto result = e->Send(std::move(req));
             result.Subscribe([
                 ep = std::move(ep),
@@ -254,8 +266,13 @@ private:
             Log = Log,
             host = std::move(host),
             port = port
-        ] (const TFuture<IAsyncEndpointPtr>&) {
-            STORAGE_INFO("connected to host=" << host << ", port=" << port);
+        ] (const TFuture<IAsyncEndpointPtr>& f) {
+            if (f.GetValue()) {
+                STORAGE_INFO("connected to host=" << host << ", port=" << port);
+            } else {
+                STORAGE_WARN("failed to connect to host=" << host
+                    << ", port=" << port);
+            }
         });
 
         return connection;

--- a/cloud/filestore/libs/service_kikimr/side_channel.h
+++ b/cloud/filestore/libs/service_kikimr/side_channel.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <cloud/filestore/libs/service/context.h>
+#include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 
 #include <cloud/filestore/public/api/protos/headers.pb.h>
 
@@ -31,6 +32,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ISideChannelPtr CreateTCPSideChannel();
+ISideChannelPtr CreateTCPSideChannel(
+    std::shared_ptr<NStorage::NFastShard::IAsyncClient> client);
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/side_channel.h
+++ b/cloud/filestore/libs/service_kikimr/side_channel.h
@@ -7,6 +7,8 @@
 
 #include <cloud/filestore/public/api/protos/headers.pb.h>
 
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
 namespace NCloud::NFileStore {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,6 +35,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 ISideChannelPtr CreateTCPSideChannel(
+    ILoggingService& logging,
     std::shared_ptr<NStorage::NFastShard::IAsyncClient> client);
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
@@ -2,6 +2,8 @@
 
 #include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 
+#include <cloud/storage/core/libs/diagnostics/logging.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NCloud::NFileStore {
@@ -48,31 +50,77 @@ struct TConnInfo
 
 struct TTestAsyncClient: public IAsyncClient
 {
-    TPromise<IAsyncEndpointPtr> Endpoint;
-    TVector<TConnInfo> ConnInfos;
+    TDeque<TPromise<IAsyncEndpointPtr>> Endpoints;
+    TDeque<TConnInfo> ConnInfos;
     TAdaptiveLock Lock;
 
     TFuture<IAsyncEndpointPtr> Connect(const TString& host, ui16 port) override
     {
         auto g = Guard(Lock);
-        Endpoint = NewPromise<IAsyncEndpointPtr>();
+        Endpoints.push_back(NewPromise<IAsyncEndpointPtr>());
         ConnInfos.push_back({host, port});
-        return Endpoint;
+        return Endpoints.back();
     }
 
-    void CompleteConnection(IAsyncEndpointPtr e)
+    std::shared_ptr<TTestAsyncEndpoint> CompleteConnection(TConnInfo* connInfo)
     {
         auto g = Guard(Lock);
-        UNIT_ASSERT(Endpoint.Initialized());
-        Endpoint.SetValue(std::move(e));
-    }
+        if (Endpoints.empty()) {
+            return nullptr;
+        }
 
-    auto GetConnInfos() const
-    {
-        auto g = Guard(Lock);
-        return ConnInfos;
+        UNIT_ASSERT(Endpoints.front().Initialized());
+        auto e = std::make_shared<TTestAsyncEndpoint>();
+        Endpoints.front().SetValue(e);
+        Endpoints.pop_front();
+        *connInfo = std::move(ConnInfos.front());
+        ConnInfos.pop_front();
+
+        return e;
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto CC()
+{
+    return MakeIntrusive<TCallContext>();
+}
+
+auto ReadReq(ui64 handle, ui64 offset, ui64 len)
+{
+    auto r = std::make_shared<NProto::TReadDataRequest>();
+    r->SetHandle(handle);
+    r->SetOffset(offset);
+    r->SetLength(len);
+    return r;
+}
+
+auto WriteReq(ui64 handle, ui64 offset, TString data)
+{
+    auto r = std::make_shared<NProto::TWriteDataRequest>();
+    r->SetHandle(handle);
+    r->SetOffset(offset);
+    r->SetBuffer(std::move(data));
+    return r;
+}
+
+auto WriteResp(NProto::TError e)
+{
+    NProtoSrv::TResponse r;
+    auto* wd = r.MutableWriteData();
+    *wd->MutableError() = std::move(e);
+    return r;
+}
+
+auto ReadResp(NProto::TError e, TString data)
+{
+    NProtoSrv::TResponse r;
+    auto* rd = r.MutableReadData();
+    *rd->MutableError() = std::move(e);
+    rd->SetBuffer(std::move(data));
+    return r;
+}
 
 }   // namespace
 
@@ -82,58 +130,40 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
 {
     Y_UNIT_TEST(ShouldReadWriteAfterUpdate)
     {
+        auto logging = CreateLoggingService("console", { TLOG_DEBUG });
         auto client = std::make_shared<TTestAsyncClient>();
-        auto sideChannel = CreateTCPSideChannel(client);
-        NProto::TBackendInfo backendInfo;
-        backendInfo.SetFastShardHost("h1");
-        backendInfo.SetFastShardPort(111);
-        sideChannel->Update(backendInfo);
-
-        auto connInfos = client->GetConnInfos();
-        UNIT_ASSERT_VALUES_EQUAL(1, connInfos.size());
-        UNIT_ASSERT_VALUES_EQUAL("h1", connInfos[0].Host);
-        UNIT_ASSERT_VALUES_EQUAL(111, connInfos[0].Port);
-
-        auto cc = [] {
-            return MakeIntrusive<TCallContext>();
-        };
-
-        auto readReq = [] (ui64 handle, ui64 offset, ui64 len) {
-            auto r = std::make_shared<NProto::TReadDataRequest>();
-            r->SetHandle(handle);
-            r->SetOffset(offset);
-            r->SetLength(len);
-            return r;
-        };
-
-        auto writeReq = [] (ui64 handle, ui64 offset, TString data) {
-            auto r = std::make_shared<NProto::TWriteDataRequest>();
-            r->SetHandle(handle);
-            r->SetOffset(offset);
-            r->SetBuffer(std::move(data));
-            return r;
-        };
+        auto sideChannel = CreateTCPSideChannel(*logging, client);
 
         auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
         bool success = sideChannel->ExecuteRequest(
-            cc(),
-            writeReq(1, 0, TString(1_KB, 'a')),
+            CC(),
+            WriteReq(1, 0, TString(1_KB, 'a')),
             writeResponse);
         UNIT_ASSERT(!success);
 
         auto readResponse = NewPromise<NProto::TReadDataResponse>();
         success = sideChannel->ExecuteRequest(
-            cc(),
-            readReq(1, 0, 1_KB),
+            CC(),
+            ReadReq(1, 0, 1_KB),
             readResponse);
         UNIT_ASSERT(!success);
 
-        auto e = std::make_shared<TTestAsyncEndpoint>();
-        client->CompleteConnection(e);
+        NProto::TBackendInfo backendInfo;
+        backendInfo.SetFastShardHost("h1");
+        backendInfo.SetFastShardPort(111);
+        sideChannel->Update(backendInfo);
+
+        TConnInfo connInfo;
+        auto e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
 
         success = sideChannel->ExecuteRequest(
-            cc(),
-            writeReq(1, 0, TString(1_KB, 'a')),
+            CC(),
+            WriteReq(1, 0, TString(1_KB, 'a')),
             writeResponse);
         UNIT_ASSERT(success);
         UNIT_ASSERT(e->RequestReceived);
@@ -142,22 +172,15 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
             e->Req.GetWriteData().GetBuffer());
         UNIT_ASSERT(!writeResponse.HasValue());
 
-        auto writeResp = [] (NProto::TError e) {
-            NProtoSrv::TResponse r;
-            auto* wd = r.MutableWriteData();
-            *wd->MutableError() = std::move(e);
-            return r;
-        };
-
-        e->Reply(writeResp(MakeError(S_ALREADY)));
+        e->Reply(WriteResp(MakeError(S_ALREADY)));
         UNIT_ASSERT(writeResponse.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(
             S_ALREADY,
             writeResponse.GetValue().GetError().GetCode());
 
         success = sideChannel->ExecuteRequest(
-            cc(),
-            readReq(1, 0, 1_KB),
+            CC(),
+            ReadReq(1, 0, 1_KB),
             readResponse);
         UNIT_ASSERT(success);
 
@@ -165,15 +188,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         UNIT_ASSERT_VALUES_EQUAL(1_KB, e->Req.GetReadData().GetLength());
         UNIT_ASSERT(!readResponse.HasValue());
 
-        auto readResp = [] (NProto::TError e, TString data) {
-            NProtoSrv::TResponse r;
-            auto* rd = r.MutableReadData();
-            *rd->MutableError() = std::move(e);
-            rd->SetBuffer(std::move(data));
-            return r;
-        };
-
-        e->Reply(readResp(MakeError(S_OK), TString(1_KB, 'a')));
+        e->Reply(ReadResp(MakeError(S_OK), TString(1_KB, 'a')));
         UNIT_ASSERT(readResponse.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(
             S_OK,
@@ -181,6 +196,97 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         UNIT_ASSERT_VALUES_EQUAL(
             TString(1_KB, 'a'),
             readResponse.GetValue().GetBuffer());
+    }
+
+    Y_UNIT_TEST(ShouldProcessRequestsBeforeConnectionCompletes)
+    {
+        auto logging = CreateLoggingService("console", { TLOG_DEBUG });
+        auto client = std::make_shared<TTestAsyncClient>();
+        auto sideChannel = CreateTCPSideChannel(*logging, client);
+
+        NProto::TBackendInfo backendInfo;
+        backendInfo.SetFastShardHost("h1");
+        backendInfo.SetFastShardPort(111);
+        sideChannel->Update(backendInfo);
+
+        auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
+        bool success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(1, 0, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(success);
+
+        TConnInfo connInfo;
+        auto e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+
+        e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+
+        UNIT_ASSERT(e->RequestReceived);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(1_KB, 'a'),
+            e->Req.GetWriteData().GetBuffer());
+        UNIT_ASSERT(!writeResponse.HasValue());
+
+        e->Reply(WriteResp(MakeError(S_ALREADY)));
+        UNIT_ASSERT(writeResponse.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_ALREADY,
+            writeResponse.GetValue().GetError().GetCode());
+    }
+
+    Y_UNIT_TEST(ShouldProcessConcurrentRequests)
+    {
+        auto logging = CreateLoggingService("console", { TLOG_DEBUG });
+        auto client = std::make_shared<TTestAsyncClient>();
+        auto sideChannel = CreateTCPSideChannel(*logging, client);
+
+        NProto::TBackendInfo backendInfo;
+        backendInfo.SetFastShardHost("h1");
+        backendInfo.SetFastShardPort(111);
+        sideChannel->Update(backendInfo);
+
+        TConnInfo connInfo;
+        auto e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+        TVector<std::shared_ptr<TTestAsyncEndpoint>> es;
+        es.push_back(std::move(e));
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+
+        TVector<TPromise<NProto::TWriteDataResponse>> writeResponses;
+        const ui32 writeCount = 10;
+        for (ui32 i = 0; i < writeCount; ++i) {
+            writeResponses.emplace_back(
+                NewPromise<NProto::TWriteDataResponse>());
+        }
+
+        for (ui32 i = 0; i < writeCount; ++i) {
+            bool success = sideChannel->ExecuteRequest(
+                CC(),
+                WriteReq(1, i * 1_KB, TString(1_KB, 'a' + i)),
+                writeResponses[i]);
+            UNIT_ASSERT(success);
+            UNIT_ASSERT(!writeResponses[i].HasValue());
+        }
+
+        for (ui32 i = 0; i < writeCount - 1; ++i) {
+            e = client->CompleteConnection(&connInfo);
+            UNIT_ASSERT(e);
+            UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+            UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+            es.push_back(std::move(e));
+        }
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
     }
 }
 

--- a/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
@@ -78,6 +78,20 @@ struct TTestAsyncClient: public IAsyncClient
 
         return e;
     }
+
+    void FailConnection(TConnInfo* connInfo)
+    {
+        auto g = Guard(Lock);
+        if (Endpoints.empty()) {
+            return;
+        }
+
+        UNIT_ASSERT(Endpoints.front().Initialized());
+        Endpoints.front().SetValue(nullptr);
+        Endpoints.pop_front();
+        *connInfo = std::move(ConnInfos.front());
+        ConnInfos.pop_front();
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -287,6 +301,56 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         }
 
         UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+
+        for (ui32 i = 0; i < writeCount; ++i) {
+            UNIT_ASSERT(!writeResponses[i].HasValue());
+        }
+
+        for (ui32 i = 0; i < writeCount; ++i) {
+            es[i]->Reply(WriteResp(MakeError(S_ALREADY)));
+            UNIT_ASSERT(writeResponses[i].HasValue());
+            UNIT_ASSERT_VALUES_EQUAL(
+                S_ALREADY,
+                writeResponses[i].GetValue().GetError().GetCode());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleConnectionFailure)
+    {
+        auto logging = CreateLoggingService("console", { TLOG_DEBUG });
+        auto client = std::make_shared<TTestAsyncClient>();
+        auto sideChannel = CreateTCPSideChannel(*logging, client);
+
+        NProto::TBackendInfo backendInfo;
+        backendInfo.SetFastShardHost("h1");
+        backendInfo.SetFastShardPort(111);
+        sideChannel->Update(backendInfo);
+
+        TConnInfo connInfo;
+        client->FailConnection(&connInfo);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+
+        auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
+        bool success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(1, 1_KB, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(success);
+
+        client->FailConnection(&connInfo);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+
+        UNIT_ASSERT(writeResponse.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_UNAVAILABLE,
+            writeResponse.GetValue().GetError().GetCode(),
+            writeResponse.GetValue().GetError().GetMessage());
     }
 }
 

--- a/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
@@ -1,0 +1,187 @@
+#include "side_channel.h"
+
+#include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NFileStore {
+
+using namespace NThreading;
+using namespace NStorage::NFastShard;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestAsyncEndpoint: public IAsyncEndpoint
+{
+    TPromise<NProtoSrv::TResponse> Response;
+    NProtoSrv::TRequest Req;
+    bool RequestReceived = false;
+    TAdaptiveLock Lock;
+
+    TFuture<NProtoSrv::TResponse> Send(NProtoSrv::TRequest req) override
+    {
+        auto g = Guard(Lock);
+        UNIT_ASSERT(!RequestReceived);
+        Req = std::move(req);
+        RequestReceived = true;
+        Response = NewPromise<NProtoSrv::TResponse>();
+        return Response;
+    }
+
+    void Reply(NProtoSrv::TResponse r)
+    {
+        auto g = Guard(Lock);
+        UNIT_ASSERT(RequestReceived);
+        RequestReceived = false;
+        UNIT_ASSERT(Response.Initialized());
+        Response.SetValue(std::move(r));
+    }
+};
+
+struct TConnInfo
+{
+    TString Host;
+    ui16 Port = 0;
+};
+
+struct TTestAsyncClient: public IAsyncClient
+{
+    TPromise<IAsyncEndpointPtr> Endpoint;
+    TVector<TConnInfo> ConnInfos;
+    TAdaptiveLock Lock;
+
+    TFuture<IAsyncEndpointPtr> Connect(const TString& host, ui16 port) override
+    {
+        auto g = Guard(Lock);
+        Endpoint = NewPromise<IAsyncEndpointPtr>();
+        ConnInfos.push_back({host, port});
+        return Endpoint;
+    }
+
+    void CompleteConnection(IAsyncEndpointPtr e)
+    {
+        auto g = Guard(Lock);
+        UNIT_ASSERT(Endpoint.Initialized());
+        Endpoint.SetValue(std::move(e));
+    }
+
+    auto GetConnInfos() const
+    {
+        auto g = Guard(Lock);
+        return ConnInfos;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TSideChannelTest)
+{
+    Y_UNIT_TEST(ShouldReadWriteAfterUpdate)
+    {
+        auto client = std::make_shared<TTestAsyncClient>();
+        auto sideChannel = CreateTCPSideChannel(client);
+        NProto::TBackendInfo backendInfo;
+        backendInfo.SetFastShardHost("h1");
+        backendInfo.SetFastShardPort(111);
+        sideChannel->Update(backendInfo);
+
+        auto connInfos = client->GetConnInfos();
+        UNIT_ASSERT_VALUES_EQUAL(1, connInfos.size());
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfos[0].Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfos[0].Port);
+
+        auto cc = [] {
+            return MakeIntrusive<TCallContext>();
+        };
+
+        auto readReq = [] (ui64 handle, ui64 offset, ui64 len) {
+            auto r = std::make_shared<NProto::TReadDataRequest>();
+            r->SetHandle(handle);
+            r->SetOffset(offset);
+            r->SetLength(len);
+            return r;
+        };
+
+        auto writeReq = [] (ui64 handle, ui64 offset, TString data) {
+            auto r = std::make_shared<NProto::TWriteDataRequest>();
+            r->SetHandle(handle);
+            r->SetOffset(offset);
+            r->SetBuffer(std::move(data));
+            return r;
+        };
+
+        auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
+        bool success = sideChannel->ExecuteRequest(
+            cc(),
+            writeReq(1, 0, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(!success);
+
+        auto readResponse = NewPromise<NProto::TReadDataResponse>();
+        success = sideChannel->ExecuteRequest(
+            cc(),
+            readReq(1, 0, 1_KB),
+            readResponse);
+        UNIT_ASSERT(!success);
+
+        auto e = std::make_shared<TTestAsyncEndpoint>();
+        client->CompleteConnection(e);
+
+        success = sideChannel->ExecuteRequest(
+            cc(),
+            writeReq(1, 0, TString(1_KB, 'a')),
+            writeResponse);
+        UNIT_ASSERT(success);
+        UNIT_ASSERT(e->RequestReceived);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(1_KB, 'a'),
+            e->Req.GetWriteData().GetBuffer());
+        UNIT_ASSERT(!writeResponse.HasValue());
+
+        auto writeResp = [] (NProto::TError e) {
+            NProtoSrv::TResponse r;
+            auto* wd = r.MutableWriteData();
+            *wd->MutableError() = std::move(e);
+            return r;
+        };
+
+        e->Reply(writeResp(MakeError(S_ALREADY)));
+        UNIT_ASSERT(writeResponse.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_ALREADY,
+            writeResponse.GetValue().GetError().GetCode());
+
+        success = sideChannel->ExecuteRequest(
+            cc(),
+            readReq(1, 0, 1_KB),
+            readResponse);
+        UNIT_ASSERT(success);
+
+        UNIT_ASSERT(e->RequestReceived);
+        UNIT_ASSERT_VALUES_EQUAL(1_KB, e->Req.GetReadData().GetLength());
+        UNIT_ASSERT(!readResponse.HasValue());
+
+        auto readResp = [] (NProto::TError e, TString data) {
+            NProtoSrv::TResponse r;
+            auto* rd = r.MutableReadData();
+            *rd->MutableError() = std::move(e);
+            rd->SetBuffer(std::move(data));
+            return r;
+        };
+
+        e->Reply(readResp(MakeError(S_OK), TString(1_KB, 'a')));
+        UNIT_ASSERT(readResponse.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            readResponse.GetValue().GetError().GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(1_KB, 'a'),
+            readResponse.GetValue().GetBuffer());
+    }
+}
+
+}   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service_kikimr/ut/ya.make
+++ b/cloud/filestore/libs/service_kikimr/ut/ya.make
@@ -6,6 +6,7 @@ SRCS(
     auth_provider_kikimr_ut.cpp
     kikimr_test_env.cpp
     service_ut.cpp
+    side_channel_ut.cpp
 )
 
 PEERDIR(

--- a/cloud/filestore/libs/service_kikimr/ya.make
+++ b/cloud/filestore/libs/service_kikimr/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     cloud/filestore/libs/service
     cloud/filestore/libs/storage/api
     cloud/filestore/libs/storage/core
+    cloud/filestore/libs/storage/fastshard/client
 
     cloud/storage/core/libs/actors
     cloud/storage/core/libs/api

--- a/cloud/filestore/libs/storage/fastshard/client/async_client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/async_client.cpp
@@ -45,7 +45,7 @@ struct TAsyncEndpoint: IAsyncEndpoint
 {
     std::shared_ptr<IEndpoint> Endpoint;
 
-    explicit TAsyncEndpoint(std::unique_ptr<IEndpoint> ep)
+    explicit TAsyncEndpoint(std::shared_ptr<IEndpoint> ep)
         : Endpoint(std::move(ep))
     {}
 
@@ -100,7 +100,7 @@ int ConnectFiberMain(TConnectParams* params) noexcept
     auto ep = client->Connect(params->Host, params->Port);
     if (ep) {
         params->Promise.SetValue(
-            std::make_unique<TAsyncEndpoint>(std::move(ep)));
+            std::make_shared<TAsyncEndpoint>(std::move(ep)));
     } else {
         params->Promise.SetValue(nullptr);
     }

--- a/cloud/filestore/libs/storage/fastshard/client/async_client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/async_client.cpp
@@ -1,0 +1,142 @@
+#include "async_client.h"
+
+#include "client.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/string/builder.h>
+
+#include <silk/fibers/fiber.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+using silk::FiberScheduler;
+using namespace NProtoSrv;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// Send fiber.
+//
+// TRequest doesn't fit in FIBER_PARAMETERS_SIZE so it lives on the heap
+// via unique_ptr; the other two fields are pointer-sized and fit inline.
+
+struct TSendParams
+{
+    std::shared_ptr<IEndpoint> Endpoint;
+    std::unique_ptr<TRequest> Request;
+    NThreading::TPromise<TResponse> Promise;
+};
+static_assert(sizeof(TSendParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int SendFiberMain(TSendParams* params) noexcept
+{
+    TResponse resp = params->Endpoint->Send(*params->Request);
+    params->Promise.SetValue(std::move(resp));
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Async endpoint.
+
+struct TAsyncEndpoint: IAsyncEndpoint
+{
+    std::shared_ptr<IEndpoint> Endpoint;
+
+    explicit TAsyncEndpoint(std::unique_ptr<IEndpoint> ep)
+        : Endpoint(std::move(ep))
+    {}
+
+    NThreading::TFuture<TResponse> Send(TRequest req) override
+    {
+        auto promise = NThreading::NewPromise<TResponse>();
+        auto future = promise.GetFuture();
+
+        int r = FiberScheduler::run(
+            SendFiberMain,
+            TSendParams{
+                .Endpoint = Endpoint,
+                .Request = std::make_unique<TRequest>(std::move(req)),
+                .Promise = promise,
+            },
+            nullptr);
+        if (r) {
+            TResponse resp;
+            *resp.MutableError() = MakeError(E_FAIL, TStringBuilder()
+                << "Failed to run fiber, code: " << r
+                << ", message: " << ::strerror(r));
+            promise.SetValue(std::move(resp));
+        }
+
+        return future;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Connect fiber.
+//
+// TString is a refcounted pointer (~8 bytes) and TPromise is an intrusive
+// pointer (~8 bytes), so all three fields fit in FIBER_PARAMETERS_SIZE.
+
+struct TConnectParams
+{
+    std::weak_ptr<TClient> Client;
+    TString Host;
+    ui16 Port;
+    NThreading::TPromise<IAsyncEndpointPtr> Promise;
+};
+static_assert(sizeof(TConnectParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int ConnectFiberMain(TConnectParams* params) noexcept
+{
+    auto client = params->Client.lock();
+    if (!client) {
+        params->Promise.SetValue(nullptr);
+        return ECANCELED;
+    }
+
+    auto ep = client->Connect(params->Host, params->Port);
+    if (ep) {
+        params->Promise.SetValue(
+            std::make_unique<TAsyncEndpoint>(std::move(ep)));
+    } else {
+        params->Promise.SetValue(nullptr);
+    }
+
+    return 0;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TAsyncClient::TAsyncClient()
+    : Client(std::make_shared<TClient>())
+{}
+
+NThreading::TFuture<IAsyncEndpointPtr> TAsyncClient::Connect(
+    const TString& host,
+    ui16 port)
+{
+    auto promise = NThreading::NewPromise<IAsyncEndpointPtr>();
+    auto future = promise.GetFuture();
+
+    int r = FiberScheduler::run(
+        ConnectFiberMain,
+        TConnectParams{
+            .Client = Client,
+            .Host = host,
+            .Port = port,
+            .Promise = promise,
+        },
+        nullptr);
+    if (r) {
+        promise.SetValue(nullptr);
+    }
+
+    return future;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/async_client.h
+++ b/cloud/filestore/libs/storage/fastshard/client/async_client.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "client.h"
+
+#include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
+
+#include <library/cpp/threading/future/future.h>
+
+#include <util/generic/string.h>
+#include <util/system/types.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class IAsyncEndpoint
+{
+public:
+    virtual ~IAsyncEndpoint() = default;
+
+    // Spawn a fiber to execute the round-trip and return its result.
+    // Concurrent calls on the same endpoint are not supported; callers
+    // must serialize sends.
+    virtual NThreading::TFuture<NProtoSrv::TResponse> Send(
+        NProtoSrv::TRequest req) = 0;
+};
+
+using IAsyncEndpointPtr = std::unique_ptr<IAsyncEndpoint>;
+
+// TFuture-based wrapper around TClient. May be called from any thread.
+// Requires silk::FiberScheduler to be initialized.
+class TAsyncClient
+{
+public:
+    TAsyncClient();
+
+public:
+    // Returns a future that resolves to a connected endpoint on success,
+    // or to nullptr if the connection could not be established.
+    NThreading::TFuture<IAsyncEndpointPtr> Connect(
+        const TString& host,
+        ui16 port);
+
+private:
+    std::shared_ptr<TClient> Client;
+};
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/async_client.h
+++ b/cloud/filestore/libs/storage/fastshard/client/async_client.h
@@ -27,21 +27,32 @@ public:
         NProtoSrv::TRequest req) = 0;
 };
 
-using IAsyncEndpointPtr = std::unique_ptr<IAsyncEndpoint>;
+using IAsyncEndpointPtr = std::shared_ptr<IAsyncEndpoint>;
+
+class IAsyncClient
+{
+public:
+    virtual ~IAsyncClient() = default;
+
+public:
+    // Returns a future that resolves to a connected endpoint on success,
+    // or to nullptr if the connection could not be established.
+    virtual NThreading::TFuture<IAsyncEndpointPtr> Connect(
+        const TString& host,
+        ui16 port) = 0;
+};
 
 // TFuture-based wrapper around TClient. May be called from any thread.
 // Requires silk::FiberScheduler to be initialized.
-class TAsyncClient
+class TAsyncClient: public IAsyncClient
 {
 public:
     TAsyncClient();
 
 public:
-    // Returns a future that resolves to a connected endpoint on success,
-    // or to nullptr if the connection could not be established.
     NThreading::TFuture<IAsyncEndpointPtr> Connect(
         const TString& host,
-        ui16 port);
+        ui16 port) override;
 
 private:
     std::shared_ptr<TClient> Client;

--- a/cloud/filestore/libs/storage/fastshard/client/async_client_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/async_client_stub.cpp
@@ -1,0 +1,15 @@
+#include "async_client.h"
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NThreading::TFuture<IAsyncEndpointPtr> TAsyncClient::Connect(
+    const TString& host,
+    ui16 port)
+{
+    Y_UNUSED(host, port);
+    return NThreading::MakeFuture<IAsyncEndpointPtr>(nullptr);
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client.cpp
@@ -68,7 +68,7 @@ struct TEndpoint: IEndpoint
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
+std::shared_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
 {
     addrinfo hints{};
     hints.ai_family = AF_UNSPEC;
@@ -122,7 +122,7 @@ std::unique_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
         int one = 1;
         ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
-        return std::make_unique<TEndpoint>(fd);
+        return std::make_shared<TEndpoint>(fd);
     }
 
     return nullptr;

--- a/cloud/filestore/libs/storage/fastshard/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client.cpp
@@ -44,6 +44,7 @@ struct TEndpoint: IEndpoint
 
         ui32 lenBe = htonl(static_cast<ui32>(reqBuf.size()));
         int r = SendAll(Fd, &lenBe, sizeof(lenBe));
+        // TODO(#5894): don't abort, return error in resp instead
         Y_ABORT_UNLESS(r == 0, "send length failed: %d", r);
         r = SendAll(Fd, reqBuf.data(), reqBuf.size());
         Y_ABORT_UNLESS(r == 0, "send body failed: %d", r);

--- a/cloud/filestore/libs/storage/fastshard/client/client.h
+++ b/cloud/filestore/libs/storage/fastshard/client/client.h
@@ -22,7 +22,7 @@ public:
 class TClient
 {
 public:
-    std::unique_ptr<IEndpoint> Connect(const TString& host, ui16 port);
+    std::shared_ptr<IEndpoint> Connect(const TString& host, ui16 port);
 };
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/client/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/client/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     SRCS(
+        async_client.cpp
         client.cpp
     )
 
@@ -12,6 +13,7 @@ IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     )
 ELSE()
     SRCS(
+        async_client_stub.cpp
         client_stub.cpp
     )
 ENDIF()
@@ -20,6 +22,8 @@ PEERDIR(
     cloud/filestore/libs/storage/fastshard/server/protos
 
     cloud/storage/core/libs/common
+
+    library/cpp/threading/future
 )
 
 END()

--- a/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
@@ -1,3 +1,4 @@
+#include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
 #include <cloud/filestore/libs/storage/fastshard/client/client.h>
 #include <cloud/filestore/libs/storage/fastshard/server/server.h>
 #include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
@@ -25,6 +26,10 @@ using silk::FiberFuture;
 using silk::FiberScheduler;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TDuration WaitTimeout = TDuration::Seconds(5);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Silk test environment.
@@ -189,4 +194,68 @@ TEST(ServerTest, UnknownShardReturnsEmptyResponse)
         0);
 
     EXPECT_EQ(result, 0);
+}
+
+TEST(ServerTest, AsyncClientCreateNodeAndGetAttr)
+{
+    NCloud::NFileStore::NProtoPrivate::TMemFastShardConfig cfg;
+    cfg.SetCreateNodeUponAccess(true);
+    auto shard = CreateMemFileSystemShard(1, cfg);
+
+    TServerFixture fixture;
+    fixture.StartServer(shard);
+
+    TAsyncClient client;
+    auto endpoint =
+        client.Connect("localhost", fixture.Port).ExtractValue(WaitTimeout);
+    EXPECT_NE(endpoint, nullptr);
+
+    // CreateNode
+    {
+        TRequest req;
+        req.SetFileSystemId("test-fs");
+        req.MutableCreateNode()->SetNodeId(1);
+        req.MutableCreateNode()->MutableFile()->SetMode(0644);
+        req.MutableCreateNode()->SetName("async.txt");
+        auto resp = endpoint->Send(std::move(req)).ExtractValue(WaitTimeout);
+        EXPECT_TRUE(resp.HasCreateNode());
+    }
+
+    // GetNodeAttr
+    {
+        TRequest req;
+        req.SetFileSystemId("test-fs");
+        req.MutableGetNodeAttr()->SetNodeId(1);
+        req.MutableGetNodeAttr()->SetName("async.txt");
+        auto resp = endpoint->Send(std::move(req)).ExtractValue(WaitTimeout);
+        EXPECT_TRUE(resp.HasGetNodeAttr());
+    }
+
+    fixture.StopServer();
+}
+
+TEST(ServerTest, AsyncClientUnknownShardReturnsError)
+{
+    NCloud::NFileStore::NProtoPrivate::TMemFastShardConfig cfg;
+    auto shard = CreateMemFileSystemShard(1, cfg);
+
+    TServerFixture fixture;
+    fixture.StartServer(shard);
+
+    TAsyncClient client;
+    auto endpoint =
+        client.Connect("localhost", fixture.Port).ExtractValue(WaitTimeout);
+    EXPECT_NE(endpoint, nullptr);
+
+    TRequest req;
+    req.SetFileSystemId("nonexistent-fs");
+    req.MutableGetNodeAttr()->SetNodeId(1);
+    req.MutableGetNodeAttr()->SetName("x");
+    auto resp = endpoint->Send(std::move(req)).ExtractValue(WaitTimeout);
+    EXPECT_TRUE(resp.HasError());
+    EXPECT_EQ(
+        resp.GetError().GetCode(),
+        static_cast<ui32>(NCloud::E_NOT_FOUND));
+
+    fixture.StopServer();
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -40,6 +40,7 @@
 
 #include <util/generic/size_literals.h>
 #include <util/generic/string.h>
+#include <util/system/hostname.h>
 
 #include <atomic>
 
@@ -69,7 +70,7 @@ inline void BuildBackendInfo(
 
     const ui32 fastShardPort = config.GetFastShardServerPort();
     if (fastShardPort) {
-        backendInfo->SetFastShardHost("localhost");
+        backendInfo->SetFastShardHost(FQDNHostName());
         backendInfo->SetFastShardPort(fastShardPort);
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -61,17 +61,17 @@ inline void BuildBackendInfo(
     ui32 tabletActorCpuUsageRate,
     NProto::TBackendInfo* backendInfo)
 {
-    //
-    // Keeping it simple for now - checking only CpuWait and tablet actor cpu
-    // usage. We might decide to add some other metrics into consideration here
-    // - e.g. network usage.
-    //
-
     const ui64 cl = systemCounters.CpuLack.load(std::memory_order_relaxed);
     backendInfo->SetIsOverloaded(
         tabletActorCpuUsageRate
             >= config.GetTabletActorCpuUsageOverloadThreshold()
         || cl >= config.GetCpuLackOverloadThreshold());
+
+    const ui32 fastShardPort = config.GetFastShardServerPort();
+    if (fastShardPort) {
+        backendInfo->SetFastShardHost("localhost");
+        backendInfo->SetFastShardPort(fastShardPort);
+    }
 }
 
 template <typename T>

--- a/cloud/filestore/public/api/protos/headers.proto
+++ b/cloud/filestore/public/api/protos/headers.proto
@@ -74,9 +74,14 @@ message THeaders
 
 message TBackendInfo
 {
-    // Using a single boolean flag for now. Maybe we'll add more details in the
-    // future but for now keeping it simple.
     bool IsOverloaded = 1;
+
+    // Host and port of the fastshard TCP server co-located with this backend.
+    // Non-empty only when the server has a fastshard port configured.
+    // The side channel in the vhost uses these to establish a direct TCP
+    // connection for latency-critical IO, bypassing the actor system.
+    string FastShardHost = 2;
+    uint32 FastShardPort = 3;
 }
 
 message TResponseHeaders

--- a/cloud/filestore/tools/testing/loadtest/lib/request_fastshard.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_fastshard.cpp
@@ -74,7 +74,7 @@ private:
     const ui64 InitialFileSize;
 
     TClient Client;
-    TDeque<std::unique_ptr<IEndpoint>> Endpoints;
+    TDeque<std::shared_ptr<IEndpoint>> Endpoints;
     TAdaptiveLock EndpointsLock;
 
     TVector<std::pair<ui64, NProto::EAction>> Actions;
@@ -183,7 +183,7 @@ private:
             return;
         }
 
-        std::unique_ptr<IEndpoint> e;
+        std::shared_ptr<IEndpoint> e;
         with_lock (ptr->EndpointsLock) {
             Y_ABORT_UNLESS(ptr->Endpoints.size());
             e = std::move(ptr->Endpoints.back());

--- a/cloud/storage/core/libs/common/error.cpp
+++ b/cloud/storage/core/libs/common/error.cpp
@@ -186,7 +186,7 @@ EDiagnosticsErrorKind GetDiagnosticsErrorKind(const NProto::TError& e)
 
 bool IsConnectionError(const NProto::TError& e)
 {
-    return e.GetCode() == E_GRPC_UNAVAILABLE;
+    return e.GetCode() == E_GRPC_UNAVAILABLE || e.GetCode() == E_UNAVAILABLE;
 }
 
 NJson::TJsonValue FormatErrorJson(const NProto::TError& e)

--- a/cloud/storage/core/libs/common/error.h
+++ b/cloud/storage/core/libs/common/error.h
@@ -122,6 +122,7 @@ enum EWellKnownResultCodes: ui32
     E_PRECONDITION_FAILED        = MAKE_ERROR(15),  // Transition to the requested state would violate object's preconditions (e.g. unexpected order of operations, write request in read-only state...). This error is not retryable
     E_TRANSPORT_ERROR            = MAKE_ERROR(16),
     E_BADMSG                     = MAKE_ERROR(17),  // Unable to decode(deserialize) message
+    E_UNAVAILABLE                = MAKE_ERROR(18),
 
     E_GRPC_CANCELLED             = MAKE_GRPC_ERROR(1),
     E_GRPC_UNKNOWN               = MAKE_GRPC_ERROR(2),


### PR DESCRIPTION
### Notes
* implemented `NFastShard::TAsyncClient` which wraps `NFastShard::TClient` with a `TFuture`-based interface
* added `FastShard{Host,Port}` into `NProto::TBackendInfo` to be able to discover fastshard endpoint in storage service
* implemented `TTCPSideChannel` in `TKikimrFileStore` via the aforementioned 2 things
* initializing/destroying fastshard runtime in filestore-vhost if `TTCPSideChannel` is configured

### Issue
https://github.com/ydb-platform/nbs/issues/5894