### PR TITLE
issue-1751: [Filestore] TFileRingBuffer: add mutable tag to entries

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -84,9 +84,10 @@ public:
     void Visit(const TVisitor& visitor) override
     {
         Storage.Visit(
-            [&visitor](ui32 checksum, TStringBuf entry)
+            [&visitor](ui32 checksum, ui32 tag, TStringBuf entry)
             {
                 Y_UNUSED(checksum);
+                Y_UNUSED(tag);
                 visitor({entry.data(), entry.size()});
             });
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -21,8 +21,8 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr ui32 VERSION_PREV = 3;
-constexpr ui32 VERSION = 4;
+constexpr ui32 VERSION_PREV = 4;
+constexpr ui32 VERSION = 5;
 constexpr ui64 INVALID_POS = Max<ui64>();
 
 // Reserve some space after header so adding new fields will not require data
@@ -52,8 +52,12 @@ static_assert(sizeof(THeader) <= HeaderReserveSize);
 struct Y_PACKED TEntryHeader
 {
 private:
+    static constexpr ui32 TagBits = 3;
+    static constexpr ui32 SizeBits = 31U - TagBits;
+    static constexpr ui32 MaxTag = (1U << TagBits) - 1;
     static constexpr ui32 FreeFlagMask = 1U << 31U;
-    static constexpr ui32 SizeMask = FreeFlagMask - 1;
+    static constexpr ui32 TagMask = MaxTag << SizeBits;
+    static constexpr ui32 SizeMask = (1 << SizeBits) - 1;
 
     ui32 DataSize = 0;
     ui32 Checksum = 0;
@@ -84,6 +88,22 @@ public:
         } else {
             DataSize &= ~FreeFlagMask;
         }
+    }
+
+    static ui32 GetMaxTag()
+    {
+        return MaxTag;
+    }
+
+    ui32 GetTag() const
+    {
+        return (DataSize & TagMask) >> SizeBits;
+    }
+
+    void SetTag(ui32 tag)
+    {
+        Y_ABORT_UNLESS(tag <= MaxTag);
+        DataSize = (DataSize & ~TagMask) | (tag << SizeBits);
     }
 
     ui32 GetChecksum() const
@@ -227,6 +247,11 @@ struct TEntryInfo
     {
         return HasValue() ? TStringBuf(Data, Header->GetDataSize())
                           : TStringBuf();
+    }
+
+    ui32 GetTag() const
+    {
+        return HasValue() ? Header->GetTag() : 0;
     }
 
     ui64 GetNextEntryPos() const
@@ -437,10 +462,10 @@ private:
 
     void Migrate()
     {
-        // In the new version, the highest bit of the entry size is treated as a
-        // free flag - need to ensure that nobody use it
+        // In the new version, the highest bits of the entry size are treated as
+        // a tag value - need to ensure that nobody use it
         VisitEntries([](const TEntryInfo& e)
-                     { Y_ABORT_UNLESS(!e.GetFreeFlag()); });
+                     { Y_ABORT_UNLESS(e.GetTag() == 0); });
 
         Header()->Version = VERSION;
         Header()->Unused = 0;
@@ -684,6 +709,7 @@ public:
 
         CurrentAllocation = Data.GetEntryHeader(writePos);
         CurrentAllocation->SetDataSize(size);
+        CurrentAllocation->SetTag(0);
         CurrentAllocation->SetFreeFlag(false);
 
         char* ptr = Data.GetEntryData(CurrentAllocation);
@@ -738,6 +764,41 @@ public:
         return true;
     }
 
+    ui32 GetMaxTag() const
+    {
+        return TEntryHeader::GetMaxTag();
+    }
+
+    ui32 GetTag(const void* ptr) const
+    {
+        if (!ValidateAccess("GetTag")) {
+            return 0;
+        }
+
+        auto it = EntryMap.find(ptr);
+        if (it == EntryMap.end()) {
+            return 0;
+        }
+
+        const auto* eh = Data.GetEntryHeader(it->second);
+        return eh->GetTag();
+    }
+
+    void SetTag(const void* ptr, ui32 tag)
+    {
+        if (!ValidateAccess("SetTag")) {
+            return;
+        }
+
+        auto it = EntryMap.find(ptr);
+        if (it == EntryMap.end()) {
+            return;
+        }
+
+        auto* eh = Data.GetEntryHeader(it->second);
+        eh->SetTag(tag);
+    }
+
     TStringBuf Front()
     {
         if (!ValidateAccess("Front")) {
@@ -784,7 +845,8 @@ public:
     {
         TVector<TBrokenFileEntry> entries;
 
-        Visit([&] (ui32 checksum, TStringBuf entry) {
+        Visit([&] (ui32 checksum, ui32 tag, TStringBuf entry) {
+            Y_UNUSED(tag);
             const ui32 actualChecksum = Crc32c(entry.data(), entry.size());
             if (actualChecksum != checksum) {
                 entries.push_back({
@@ -807,7 +869,7 @@ public:
             [&](const TEntryInfo& e)
             {
                 if (!e.GetFreeFlag()) {
-                    visitor(e.Header->GetChecksum(), e.GetData());
+                    visitor(e.Header->GetChecksum(), e.GetTag(), e.GetData());
                 }
             });
     }
@@ -869,7 +931,8 @@ public:
         }
 
         return Header()->DataCapacity > sizeof(TEntryHeader)
-                   ? Header()->DataCapacity - sizeof(TEntryHeader)
+                   ? Min(Header()->DataCapacity - sizeof(TEntryHeader),
+                         static_cast<ui64>(TEntryHeader::MaxDataSize))
                    : 0;
     }
 
@@ -938,6 +1001,21 @@ bool TFileRingBuffer::Commit()
 bool TFileRingBuffer::Free(const void* ptr)
 {
     return Impl->Free(ptr);
+}
+
+ui32 TFileRingBuffer::GetMaxTag() const
+{
+    return Impl->GetMaxTag();
+}
+
+ui32 TFileRingBuffer::GetTag(const void* ptr) const
+{
+    return Impl->GetTag(ptr);
+}
+
+void TFileRingBuffer::SetTag(const void* ptr, ui32 tag)
+{
+    Impl->SetTag(ptr, tag);
 }
 
 TStringBuf TFileRingBuffer::Front()

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -49,6 +49,9 @@ struct THeader
 
 static_assert(sizeof(THeader) <= HeaderReserveSize);
 
+// Entry header layout (lower bits come first):
+// [ DataSize (28 bits) | Tag (3 bits) | FreeFlag (1 bit) ]
+// [ Checksum (32 bits) ]
 struct Y_PACKED TEntryHeader
 {
 private:

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -21,7 +21,8 @@ public:
         ui32 ActualChecksum = 0;
     };
 
-    using TVisitor = std::function<void(ui32 checksum, TStringBuf entry)>;
+    using TVisitor =
+        std::function<void(ui32 checksum, ui32 tag, TStringBuf entry)>;
 
 private:
     class TImpl;
@@ -59,6 +60,8 @@ public:
 
     // Calculate checksum for the previously allocated memory using Alloc
     // and advance the write pointer.
+    // Once committed, allocated entries become immutable - it is not allowed
+    // to modify their contents via pointer returned by Alloc.
     bool Commit();
 
     // Free memory block previously allocated with Alloc.
@@ -66,6 +69,11 @@ public:
     // Otherwise, it will be marked for deletion and removed later.
     // Returns true if the pointer was correct and hasn't been freed yet.
     bool Free(const void* ptr);
+
+    // Each entry can be tagged with a small mutable integer value [0-7]
+    ui32 GetMaxTag() const;
+    ui32 GetTag(const void* ptr) const;
+    void SetTag(const void* ptr, ui32 tag);
 
     TStringBuf Front();
     void PopFront();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -50,7 +50,7 @@ TString Dump(TFileRingBuffer& rb)
 {
     TVector<TString> entries;
 
-    rb.Visit([&](ui32, TStringBuf entry)
+    rb.Visit([&](ui32, ui32, TStringBuf entry)
              { entries.push_back(TString(entry)); });
 
     return Dump(entries);
@@ -61,7 +61,7 @@ TStringBuf Find(TFileRingBuffer& rb, TStringBuf entry)
     TStringBuf result;
 
     rb.Visit(
-        [&](ui32, TStringBuf e)
+        [&](ui32, ui32, TStringBuf e)
         {
             if (e == entry) {
                 result = e;
@@ -550,7 +550,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         for (int i = 0; i <= 32; i++) {
             TStateWithCorruptedEntryLength s(i);
             UNIT_ASSERT(!s.RingBuffer.IsCorrupted());
-            s.RingBuffer.Visit([] (ui32, TStringBuf) {});
+            s.RingBuffer.Visit([] (ui32, ui32, TStringBuf) {});
             UNIT_ASSERT_VALUES_EQUAL(i != 2, s.RingBuffer.IsCorrupted());
         }
     }
@@ -735,23 +735,23 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb->ValidateMetadata());
     }
 
-    Y_UNIT_TEST(ShouldBackwardSupportFileFormat_V3_to_V4)
+    Y_UNIT_TEST(ShouldBackwardSupportFileFormat_V4_to_V5)
     {
         const auto f = TTempFileHandle();
         const ui32 dataLen = 36;
         const ui32 metadataLen = 8;
 
-        const TString fileDumpVer3 =
-            "AwAAAEgAAAAkAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAAgBAAAAAAAACA"
-            "AAAAAAAAAAAQAAAAAAAAgAAAASj+ZzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        const TString fileDumpVer4 =
+            "BAAAAEgAAAAkAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAgBAAAAAAAACA"
+            "AAAAAAAAAAAQAAAAAAAAgAAAD56yynAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAEZvcm1hdFYzCAAAABcbOq5Tb21lRGF0YQAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAEZvcm1hdFY0CAAAABcbOq5Tb21lRGF0YQAAAAAAAAAAAAAAAAAAAAAA"
             "AAAA";
 
         {
-            TString decoded = Base64Decode(fileDumpVer3);
+            TString decoded = Base64Decode(fileDumpVer4);
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.ResizeAndRemap(0, decoded.size());
             decoded.copy(reinterpret_cast<char*>(m.Ptr()), decoded.size());
@@ -759,7 +759,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         TFileRingBuffer rb(f.GetName(), dataLen, metadataLen);
         UNIT_ASSERT(!rb.IsCorrupted());
-        UNIT_ASSERT_VALUES_EQUAL("FormatV3", rb.GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL("FormatV4", rb.GetMetadata());
         UNIT_ASSERT_VALUES_EQUAL("SomeData", rb.Front());
     }
 
@@ -1056,6 +1056,58 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         UNIT_ASSERT(!rb->IsCorrupted());
         UNIT_ASSERT_VALUES_EQUAL(data, rb->Front());
+    }
+
+    Y_UNIT_TEST(ShouldSupportTags)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 36;
+        auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        const TString data1 = "abc";
+        const TString data2 = "defg";
+
+        auto* ptr1 = rb->Alloc(data1.size()).GetResult();
+        UNIT_ASSERT(ptr1 != nullptr);
+        data1.copy(ptr1, data1.size());
+        rb->Commit();
+
+        auto* ptr2 = rb->Alloc(data2.size()).GetResult();
+        UNIT_ASSERT(ptr2 != nullptr);
+        data2.copy(ptr2, data2.size());
+        rb->Commit();
+
+        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr1));
+        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr2));
+
+        rb->SetTag(ptr1, 1);
+        rb->SetTag(ptr2, 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr1));
+        UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr2));
+
+        // Recreate cache - old pointers become invalid
+        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+
+        const auto* ptr3 = Find(*rb, TStringBuf(data1)).data();
+        UNIT_ASSERT(ptr3 != nullptr);
+        UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr3));
+
+        const auto* ptr4 = Find(*rb, TStringBuf(data2)).data();
+        UNIT_ASSERT(ptr4 != nullptr);
+        UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr4));
+
+        rb->PopFront();
+        rb->PopFront();
+        UNIT_ASSERT(rb->Empty());
+
+        // Reuse entry
+        auto* ptr5 = rb->Alloc(data1.size()).GetResult();
+        UNIT_ASSERT(ptr5 != nullptr);
+        data1.copy(ptr5, data1.size());
+        rb->Commit();
+
+        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr5));
     }
 }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -755,12 +755,21 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.ResizeAndRemap(0, decoded.size());
             decoded.copy(reinterpret_cast<char*>(m.Ptr()), decoded.size());
+            // Check version before migration
+            UNIT_ASSERT_VALUES_EQUAL(4, *reinterpret_cast<ui32*>(m.Ptr()));
         }
 
         TFileRingBuffer rb(f.GetName(), dataLen, metadataLen);
         UNIT_ASSERT(!rb.IsCorrupted());
         UNIT_ASSERT_VALUES_EQUAL("FormatV4", rb.GetMetadata());
         UNIT_ASSERT_VALUES_EQUAL("SomeData", rb.Front());
+
+        {
+            TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
+            m.ResizeAndRemap(0, f.GetLength());
+            // Check version after migration
+            UNIT_ASSERT_VALUES_EQUAL(5, *reinterpret_cast<ui32*>(m.Ptr()));
+        }
     }
 
     Y_UNIT_TEST(ShouldResizeMetadata)


### PR DESCRIPTION
### Notes
Once allocated, the entries in `TFileRingBuffer` remains immutable.
There is a demand to add some mutable information to each entry.

For example, WriteBackCache needs to mark cached requests as flushed or orphaned (when the handle associated with the request is released).

Proposal: treat the highest bits of the allocation size as tag value.
Is it safe to reduce the maximal allocation size to 256M.

### Issue
To be used in https://github.com/ydb-platform/nbs/issues/1751
