### PR TITLE
[Blockstore] Force overlapping requests detection for remotely forwarded write requests

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -977,7 +977,12 @@ void TVolumeActor::ForwardRequest(
      *  to the underlying (storage) layer.
      */
     if constexpr (IsWriteMethod<TMethod>) {
-        const auto policy = Config->GetOverlappingRequestsPolicy();
+        auto policy = Config->GetOverlappingRequestsPolicy();
+        if (IsForwardedEvent(*ev)) {
+            // the message arrived from disk remotely, so there's no guarantee
+            // of message order and we're forced to process it locally
+            policy = NProto::EOverlappingRequestsPolicy::ORP_ENABLE;
+        }
 
         if (policy != NProto::EOverlappingRequestsPolicy::ORP_DISABLE) {
             auto addResult = WriteAndZeroRequestsInFlight.TryAddRequest(

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -9239,7 +9239,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         TVolumeClient volume(*runtime);
 
         bool gotVolumeActorId = false;
-        TActorId volumeActor;
+        TActorId volumeActorId;
         TAutoPtr<IEventHandle> delayedRequest;
 
         runtime->SetEventFilter(
@@ -9248,13 +9248,13 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
                 switch (ev->GetTypeRewrite()) {
                     case TEvBlockStore::EvUpdateVolumeConfigResponse: {
                         if (!gotVolumeActorId) {
-                            volumeActor = ev->Sender;
+                            volumeActorId = ev->Sender;
                             gotVolumeActorId = true;
                         }
                         break;
                     }
                     case TEvService::EvWriteBlocksRequest: {
-                        if (!gotVolumeActorId || ev->Sender != volumeActor) {
+                        if (!gotVolumeActorId || ev->Sender != volumeActorId) {
                             break;
                         }
                         if (!delayedRequest) {
@@ -9283,17 +9283,28 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             "AppCriticalEvents/OverlappingRequestsDetected",
             true);
 
-        // Send first request
-        volume.SendToPipe(volume.CreateWriteBlocksRequest(
-            TBlockRange64::WithLength(0, 1024),
-            clientInfo.GetClientId(),
-            1));
+        const TActorId sender = volume.GetSender();
+        runtime->Send(
+            new IEventHandle(
+                volumeActorId,
+                sender,
+                volume.CreateWriteBlocksRequest(
+                    TBlockRange64::WithLength(0, 1024),
+                    clientInfo.GetClientId(),
+                    1)
+                    .release()),
+            0);
 
-        // Send overlapping request
-        volume.SendToPipe(volume.CreateWriteBlocksRequest(
-            TBlockRange64::WithLength(0, 1024),
-            clientInfo.GetClientId(),
-            1));
+        runtime->Send(
+            new IEventHandle(
+                volumeActorId,
+                sender,
+                volume.CreateWriteBlocksRequest(
+                    TBlockRange64::WithLength(0, 1024),
+                    clientInfo.GetClientId(),
+                    1)
+                    .release()),
+            0);
 
         runtime->DispatchEvents({}, TDuration::Seconds(1));
         runtime->Send(delayedRequest.Release());

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -9315,6 +9315,80 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
         UNIT_ASSERT_VALUES_EQUAL(1, overlappingRequestsCounter->Val());
     }
 
+    Y_UNIT_TEST(ShouldNotReportCritEventForForwardedOverlappingRequests)
+    {
+        NProto::TStorageServiceConfig storageServiceConfig;
+        storageServiceConfig.SetOverlappingRequestsPolicy(
+            NProto::EOverlappingRequestsPolicy::ORP_ENABLE_WITH_CRIT_EVENT);
+
+        auto runtime = PrepareTestActorRuntime(std::move(storageServiceConfig));
+
+        TVolumeClient volume(*runtime);
+
+        bool gotVolumeActor = false;
+        TActorId volumeActor;
+        TAutoPtr<IEventHandle> delayedRequest;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvBlockStore::EvUpdateVolumeConfigResponse: {
+                        if (!gotVolumeActor) {
+                            volumeActor = ev->Sender;
+                            gotVolumeActor = true;
+                        }
+                        break;
+                    }
+                    case TEvService::EvWriteBlocksRequest: {
+                        if (!gotVolumeActor || ev->Sender != volumeActor) {
+                            break;
+                        }
+                        if (!delayedRequest) {
+                            delayedRequest = ev.Release();
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            });
+
+        volume.UpdateVolumeConfig();
+        volume.WaitReady();
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            0);
+
+        volume.AddClient(clientInfo);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto overlappingRequestsCounter = counters->GetCounter(
+            "AppCriticalEvents/OverlappingRequestsDetected",
+            true);
+
+        volume.SendToPipe(volume.CreateWriteBlocksRequest(
+            TBlockRange64::WithLength(0, 1024),
+            clientInfo.GetClientId(),
+            1));
+
+        volume.SendToPipe(volume.CreateWriteBlocksRequest(
+            TBlockRange64::WithLength(0, 1024),
+            clientInfo.GetClientId(),
+            1));
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        runtime->Send(delayedRequest.Release());
+
+        volume.RecvWriteBlocksResponse();
+        volume.RecvWriteBlocksResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(0, overlappingRequestsCounter->Val());
+    }
+
     Y_UNIT_TEST(ShouldReportCrossPartitionRequestDetected)
     {
         NProto::TStorageServiceConfig storageServiceConfig;

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -9283,6 +9283,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             "AppCriticalEvents/OverlappingRequestsDetected",
             true);
 
+        // Send first request
         const TActorId sender = volume.GetSender();
         runtime->Send(
             new IEventHandle(
@@ -9295,6 +9296,7 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
                     .release()),
             0);
 
+        // Send overlapping request
         runtime->Send(
             new IEventHandle(
                 volumeActorId,
@@ -9370,11 +9372,13 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
             "AppCriticalEvents/OverlappingRequestsDetected",
             true);
 
+        // Send first request
         volume.SendToPipe(volume.CreateWriteBlocksRequest(
             TBlockRange64::WithLength(0, 1024),
             clientInfo.GetClientId(),
             1));
 
+        // Send overlapping request
         volume.SendToPipe(volume.CreateWriteBlocksRequest(
             TBlockRange64::WithLength(0, 1024),
             clientInfo.GetClientId(),


### PR DESCRIPTION
For write requests that arrived via pipe (IsForwardedEvent returns true Recipient != RecipientRewrite), the policy is forced to ORP_ENABLE regardless of the configured policy, because the message arrived from a remote disk and there is no guarantee of message ordering. This also means that if ORP_ENABLE_WITH_CRIT_EVENT is configured, the crit event will not be fired for forwarded requests.