### PR TITLE
issue-1751: [Filestore] TWriteBackCache: evict flushed WriteData requests on restart

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -89,8 +89,7 @@ public:
             [&visitor](ui32 checksum, ui32 tag, TStringBuf entry)
             {
                 Y_UNUSED(checksum);
-                Y_UNUSED(tag);
-                visitor({entry.data(), entry.size()});
+                visitor(tag, {entry.data(), entry.size()});
             });
 
         SetCounters();
@@ -118,6 +117,11 @@ public:
         bool success = Storage.Free(ptr);
         Y_ENSURE(success, "Failed to free pointer " << ptr);
         SetCounters();
+    }
+
+    void SetTag(const void* ptr, ui32 tag) override
+    {
+        Storage.SetTag(ptr, tag);
     }
 
     void UpdateStats() const override

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -16,7 +16,7 @@ namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 // Non-thread safe
 struct IPersistentStorage
 {
-    using TVisitor = TFunctionRef<void(TStringBuf buffer)>;
+    using TVisitor = TFunctionRef<void(ui32 tag, TStringBuf buffer)>;
     using TAllocationWriter = TFunctionRef<void(char* ptr, size_t size)>;
 
     virtual ~IPersistentStorage() = default;
@@ -58,6 +58,10 @@ struct IPersistentStorage
 
     // Frees a previously allocated buffer.
     virtual void Free(const void* ptr) = 0;
+
+    // Once committed, entries should remain immutable.
+    // But it is possible to assign a small mutable tag to the entry.
+    virtual void SetTag(const void* ptr, ui32 tag) = 0;
 
     virtual void UpdateStats() const = 0;
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -99,8 +99,9 @@ struct TBootstrap
     {
         TString res;
         Storage->Visit(
-            [&res](TStringBuf entry)
+            [&res](ui32 tag, TStringBuf entry)
             {
+                Y_UNUSED(tag);
                 if (!res.empty()) {
                     res += ",";
                 }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.cpp
@@ -16,7 +16,7 @@ bool TTestStorage::Empty() const
 void TTestStorage::Visit(const TVisitor& visitor)
 {
     for (const auto& it: List) {
-        visitor(it.Data);
+        visitor(it.Tag, it.Data);
     }
 }
 
@@ -54,6 +54,14 @@ void TTestStorage::Free(const void* ptr)
     Data.erase(it);
 
     SetStats();
+}
+
+void TTestStorage::SetTag(const void* ptr, ui32 tag)
+{
+    auto it = Data.find(ptr);
+    Y_ENSURE(it != Data.end(), "Entry not found");
+
+    it->second->Tag = tag;
 }
 
 void TTestStorage::UpdateStats() const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/test/test_persistent_storage.h
@@ -16,6 +16,7 @@ private:
     struct TEntry: public TIntrusiveListItem<TEntry>
     {
         TString Data;
+        ui32 Tag = 0;
     };
 
     const IPersistentStorageStatsPtr Stats;
@@ -33,6 +34,7 @@ public:
     TResultOrError<char*> Alloc(size_t size) override;
     void Commit() override;
     void Free(const void* ptr) override;
+    void SetTag(const void* ptr, ui32 tag) override;
     void UpdateStats() const override;
 
     void SetCapacity(size_t capacity);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2228,6 +2228,37 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, error.GetCode());
         UNIT_ASSERT(drain.HasValue());
     }
+
+    Y_UNIT_TEST(ShouldEvictFlushedRequestsOnRestart)
+    {
+        TBootstrap b;
+
+        auto readPromise = NewPromise<NProto::TReadDataResponse>();
+
+        b.Session->ReadDataHandler = [&](auto, auto)
+        {
+            return readPromise.GetFuture();
+        };
+
+        b.WriteToCacheSync(1, 0, "abc");
+        b.WriteToCacheSync(2, 0, "def");
+
+        // Prevent WriteData request from eviction by starting overlapping
+        // ReadData request that will never complete
+        auto readFuture = b.ReadFromCache(1, 0, 10);
+        UNIT_ASSERT(!readFuture.HasValue());
+
+        b.FlushCache(1);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, b.Metrics.UnflushedQueue.Count->Get());
+        UNIT_ASSERT_VALUES_EQUAL(1, b.Metrics.FlushedQueue.Count->Get());
+
+        b.RecreateCache();
+
+        // Ensure that WriteData request is evicted
+        UNIT_ASSERT_VALUES_EQUAL(1, b.Metrics.UnflushedQueue.Count->Get());
+        UNIT_ASSERT_VALUES_EQUAL(0, b.Metrics.FlushedQueue.Count->Get());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -10,6 +10,32 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class ECachedWriteDataRequestTag
+{
+    // No specific actions should be taken
+    Unflushed = 0,
+
+    // Handle associated with the request has been released.
+    // Attempts to flush the request should be made using another handle.
+    UnflushedHandleReleased = 1,
+
+    // Request has been flushed and should be evicted on restart
+    Flushed = 2,
+
+    // Used to validate deserialization
+    Max = Flushed
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TLoadedWriteDataRequest
+{
+    ECachedWriteDataRequestTag Tag = ECachedWriteDataRequestTag::Unflushed;
+    std::unique_ptr<TCachedWriteDataRequest> Request;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 TStringBuf SerializeWriteDataRequest(
     const NProto::TWriteDataRequest& request,
     TMemoryOutput& memoryOutput)
@@ -116,11 +142,16 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
 {
     bool success = true;
 
-    TVector<std::unique_ptr<TCachedWriteDataRequest>> loadedRequests;
+    TVector<TLoadedWriteDataRequest> loadedRequests;
 
     PersistentStorage->Visit(
-        [this, &success, &loadedRequests](const TStringBuf allocation)
+        [this, &success, &loadedRequests](ui32 tag, const TStringBuf allocation)
         {
+            if (tag > static_cast<ui32>(ECachedWriteDataRequestTag::Max)) {
+                success = false;
+                return false;
+            }
+
             auto request = DeserializeWriteDataRequest(
                 SequenceIdGenerator->GenerateId(),
                 Timer->Now(),
@@ -131,7 +162,10 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
                 return false;
             }
 
-            loadedRequests.push_back(std::move(request));
+            loadedRequests.push_back(
+                {.Tag = static_cast<ECachedWriteDataRequestTag>(tag),
+                 .Request = std::move(request)});
+
             return true;
         });
 
@@ -140,8 +174,8 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
     }
 
     for (auto& request: loadedRequests) {
-        UnflushedRequestsPushBack(request.get());
-        visitor(std::move(request));
+        UnflushedRequestsPushBack(request.Request.get());
+        visitor(std::move(request.Request));
     }
 
     PendingRequests.Clear();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -149,7 +149,7 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
         {
             if (tag > static_cast<ui32>(ECachedWriteDataRequestTag::Max)) {
                 success = false;
-                return false;
+                return;
             }
 
             auto request = DeserializeWriteDataRequest(
@@ -159,14 +159,12 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
 
             if (!request) {
                 success = false;
-                return false;
+                return;
             }
 
             loadedRequests.push_back(
                 {.Tag = static_cast<ECachedWriteDataRequestTag>(tag),
                  .Request = std::move(request)});
-
-            return true;
         });
 
     if (!success) {
@@ -174,8 +172,13 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
     }
 
     for (auto& request: loadedRequests) {
-        UnflushedRequestsPushBack(request.Request.get());
-        visitor(std::move(request.Request));
+        if (request.Tag == ECachedWriteDataRequestTag::Flushed) {
+            // There are no pins that may prevent flushed requests from eviction
+            PersistentStorage->Free(request.Request->GetAllocationPtr());
+        } else {
+            UnflushedRequestsPushBack(request.Request.get());
+            visitor(std::move(request.Request));
+        }
     }
 
     PendingRequests.Clear();
@@ -295,6 +298,10 @@ void TWriteDataRequestManager::SetFlushed(TCachedWriteDataRequest* request)
     UnflushedRequestsRemove(request);
     request->Time = Timer->Now();
     FlushedRequestsPushBack(request);
+
+    PersistentStorage->SetTag(
+        request->GetAllocationPtr(),
+        static_cast<ui32>(ECachedWriteDataRequestTag::Flushed));
 }
 
 void TWriteDataRequestManager::Evict(


### PR DESCRIPTION
### Notes
Flushed WriteData requests may resurrect after vhost restart and be flushed again.
This doesn't break data consistency but if the handle associated with the WriteData requests is released, it may result in `E_FS_BADHANDLE` loop.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
