### PR TITLE
issue-1751: [Filestore] WriteBackCache: ReleaseHandle should not hang on flush failure

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
@@ -10,6 +10,7 @@
 
 #include <util/generic/deque.h>
 #include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
 #include <util/generic/intrlist.h>
 #include <util/generic/set.h>
 
@@ -35,8 +36,11 @@ struct TReleaseHandleRequest: public TIntrusiveListItem<TReleaseHandleRequest>
 
 struct THandleState
 {
-    // Number of pending and unflushed requests associated with the handle
-    ui64 ActiveWriteDataRequestCount = 0;
+    // Pending requests from TNodeState::Cache filtered by Handle
+    TIntrusiveList<TPendingWriteDataRequest, THandleStateTag> PendingRequests;
+
+    // Unflushed requests from TNodeState::Cache filtered by Handle
+    TIntrusiveList<TCachedWriteDataRequest, THandleStateTag> UnflushedRequests;
 
     // The field is initialized when ReleaseHandle request is made.
     // Only one ReleaseHandle request may be active at a time for a handle.
@@ -121,11 +125,8 @@ struct TNodeState
     // Key: handle
     THashMap<ui64, THandleState> Handles;
 
-    // Number of handles that have been requested for release.
-    // When HandleToReleaseCount == Handles.size(), the next flush failure
-    // will cause all pending requests to be failed and cached data to be
-    // dropped
-    size_t HandleToReleaseCount = 0;
+    // Handles that have THandleState::ReleaseHandleRequest initialized
+    THashSet<ui64> HandlesWithReleaseRequests;
 
     // Requests with SequenceId > BarrierId are prevented from being flushed
     TMap<ui64, std::unique_ptr<TBarrier>> Barriers;
@@ -136,7 +137,7 @@ struct TNodeState
             Y_ABORT_UNLESS(FlushRequests.empty());
             Y_ABORT_UNLESS(FlushStatus == ENodeFlushStatus::NothingToFlush);
             Y_ABORT_UNLESS(Handles.empty());
-            Y_ABORT_UNLESS(HandleToReleaseCount == 0);
+            Y_ABORT_UNLESS(HandlesWithReleaseRequests.empty());
             return true;
         }
         return false;
@@ -165,7 +166,7 @@ struct TNodeState
                        : ENodeFlushStatus::NothingToFlush;
         }
 
-        if (HandleToReleaseCount > 0) {
+        if (!HandlesWithReleaseRequests.empty()) {
             // Non-zero value of HandleToReleaseCount indicates that there are
             // handles that are requested for release but cannot be released
             // because there are pending or unflushed WriteData requests

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
@@ -45,6 +45,11 @@ struct THandleState
     // The field is initialized when ReleaseHandle request is made.
     // Only one ReleaseHandle request may be active at a time for a handle.
     std::unique_ptr<TReleaseHandleRequest> ReleaseHandleRequest;
+
+    bool HasRequests() const
+    {
+        return !PendingRequests.Empty() || !UnflushedRequests.Empty();
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -167,7 +172,7 @@ struct TNodeState
         }
 
         if (!HandlesWithReleaseRequests.empty()) {
-            // Non-zero value of HandleToReleaseCount indicates that there are
+            // Non-empty HandlesWithReleaseRequests indicates that there are
             // handles that are requested for release but cannot be released
             // because there are pending or unflushed WriteData requests
             // associated with them. We need to flush these requests first.

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -412,7 +412,7 @@ private:
         auto batchBuilder =
             RequestBuilder->CreateWriteDataRequestBatchBuilder(nodeId);
 
-        auto handle = State.VisitUnflushedRequests(
+        State.VisitUnflushedRequests(
             nodeId,
             [&batchBuilder](const TCachedWriteDataRequest* request)
             {
@@ -421,19 +421,7 @@ private:
                     request->GetBuffer());
             });
 
-        if (handle == NProto::E_INVALID_HANDLE) {
-            // It is not possible to flush data when all handles are released
-            // Note: this will not be needed after switching to handleless IO
-            State.FlushFailed(
-                nodeId,
-                MakeError(
-                    E_REJECTED,
-                    "There are no live handles to flush data for node %lu",
-                    nodeId));
-            return;
-        }
-
-        auto writeDataBatch = batchBuilder->Build(handle);
+        auto writeDataBatch = batchBuilder->Build();
 
         auto flushState = std::make_shared<TNodeFlushState>(
             nodeId,
@@ -445,6 +433,22 @@ private:
 
     void ExecuteFlush(std::shared_ptr<TNodeFlushState> flushState)
     {
+        auto handle = State.GetLiveHandle(flushState->GetNodeId());
+
+        if (handle == NProto::E_INVALID_HANDLE) {
+            // It is not possible to flush data when all handles are released
+            // TODO(#6201): this will not be needed after adding support for
+            // handleless IO
+            State.FlushFailed(
+                flushState->GetNodeId(),
+                MakeError(
+                    E_REJECTED,
+                    "There are no known live handles to flush data for node "
+                    "%lu",
+                    flushState->GetNodeId()));
+            return;
+        }
+
         auto requests = flushState->BeginFlush();
 
         for (size_t i = 0; i < requests.size(); ++i) {
@@ -455,6 +459,8 @@ private:
             callContext->RequestSize =
                 NCloud::NFileStore::CalculateByteCount(*request) -
                 request->GetBufferOffset();
+
+            request->SetHandle(handle);
 
             auto callback = [ptr = weak_from_this(), flushState, i](
                                 const auto& future) mutable

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -439,14 +439,26 @@ private:
             // It is not possible to flush data when all handles are released
             // TODO(#6201): this will not be needed after adding support for
             // handleless IO
-            State.FlushFailed(
+            auto retryStatus = State.FlushFailed(
                 flushState->GetNodeId(),
                 MakeError(
                     E_REJECTED,
                     "There are no known live handles to flush data for node "
                     "%lu",
                     flushState->GetNodeId()));
-            return;
+
+            // A live handle could appear between GetLiveHandle and FlushFailed
+            if (retryStatus == EFlushRetryStatus::ShouldNotRetry) {
+                return;
+            }
+
+            handle = State.GetLiveHandle(flushState->GetNodeId());
+
+            Y_ABORT_UNLESS(
+                handle != NProto::E_INVALID_HANDLE,
+                "There are no known live handles to flush data for node %lu, "
+                "but FlushFailed returned ShouldRetry",
+                flushState->GetNodeId());
         }
 
         auto requests = flushState->BeginFlush();

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -412,17 +412,28 @@ private:
         auto batchBuilder =
             RequestBuilder->CreateWriteDataRequestBatchBuilder(nodeId);
 
-        State.VisitUnflushedRequests(
+        auto handle = State.VisitUnflushedRequests(
             nodeId,
             [&batchBuilder](const TCachedWriteDataRequest* request)
             {
                 return batchBuilder->AddRequest(
-                    request->GetHandle(),
                     request->GetOffset(),
                     request->GetBuffer());
             });
 
-        auto writeDataBatch = batchBuilder->Build();
+        if (handle == NProto::E_INVALID_HANDLE) {
+            // It is not possible to flush data when all handles are released
+            // Note: this will not be needed after switching to handleless IO
+            State.FlushFailed(
+                nodeId,
+                MakeError(
+                    E_REJECTED,
+                    "There are no live handles to flush data for node %lu",
+                    nodeId));
+            return;
+        }
+
+        auto writeDataBatch = batchBuilder->Build(handle);
 
         auto flushState = std::make_shared<TNodeFlushState>(
             nodeId,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -174,14 +174,13 @@ public:
     /* Ensures that the handle is safe to be destroyed.
      *
      * The method returns a future that is fulfilled when there are no unflushed
-     * or pending WriteData requests associated with the handle. Unlike
-     * FlushNodeData, it doesn't fail if flush fails and waits instead.
+     * or pending WriteData requests associated with the handle.
      *
-     * If all handles used by WriteBackCache for the node are requested for the
-     * release and flush fails:
-     * - unflushed WriteData requests are dropped;
-     * - pending WriteData requests are failed;
-     * - executing ReleaseHandle requests return an error.
+     * If an error occurs during flushing WriteData requests, returns the error
+     * (the same as for FlushNodeData) and tags unflushed WriteData requests
+     * associated with the handle - they will be attempted to be flushed again
+     * later via another known live handle. If there are no remaining live
+     * handles, all unflushed requests are dropped.
      *
      * Note: the method doesn't call Session::DestroyHandle
      */

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -265,9 +265,30 @@ void TWriteBackCacheState::UnpinNodeStates(TPin pinId)
     Nodes.Unpin(pinId);
 }
 
-ui64 TWriteBackCacheState::VisitUnflushedRequests(
+void TWriteBackCacheState::VisitUnflushedRequests(
     ui64 nodeId,
     const TEntryVisitor& visitor) const
+{
+    auto guard = LockStateAndPostponeQueuedOperations();
+
+    const auto* nodeState = Nodes.GetNodeState(nodeId);
+    if (nodeState == nullptr) {
+        return;
+    }
+
+    Y_ABORT_UNLESS(
+        nodeState->Cache.HasUnflushedRequests(),
+        "Node %lu has no unflushed requests but has live handles",
+        nodeId);
+
+    const ui64 maxSequenceId = nodeState->Barriers.empty()
+                                   ? Max<ui64>()
+                                   : nodeState->Barriers.cbegin()->first;
+
+    nodeState->Cache.VisitUnflushedRequests(visitor, maxSequenceId);
+}
+
+ui64 TWriteBackCacheState::GetLiveHandle(ui64 nodeId) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
@@ -281,20 +302,8 @@ ui64 TWriteBackCacheState::VisitUnflushedRequests(
         return NProto::E_INVALID_HANDLE;
     }
 
-    Y_ABORT_UNLESS(
-        nodeState->Cache.HasUnflushedRequests(),
-        "Node %lu has no unflushed requests but has live handles",
-        nodeId);
-
     // Choose any live handle for flush
-    const ui64 handle = nodeState->Handles.cbegin()->first;
-
-    const ui64 maxSequenceId = nodeState->Barriers.empty()
-                                   ? Max<ui64>()
-                                   : nodeState->Barriers.cbegin()->first;
-
-    nodeState->Cache.VisitUnflushedRequests(visitor, maxSequenceId);
-    return handle;
+    return nodeState->Handles.cbegin()->first;
 }
 
 void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
@@ -411,7 +420,7 @@ EFlushRetryStatus TWriteBackCacheState::FlushFailed(
 
         while (!handleState.UnflushedRequests.Empty()) {
             auto* request = handleState.UnflushedRequests.PopFront();
-            RequestManager.SetHandleReleasedTag(request);
+            RequestManager.SetHandleReleased(request);
         }
 
         if (handleState.ReleaseHandleRequest) {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -321,18 +321,7 @@ void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
         auto* cachedRequest =
             nodeState.Cache.MoveFrontUnflushedRequestToFlushed();
         RequestManager.SetFlushed(cachedRequest);
-
-        auto* handleState =
-            nodeState.Handles.FindPtr(cachedRequest->GetHandle());
-
-        if (handleState) {
-            handleState->UnflushedRequests.Remove(cachedRequest);
-
-            CheckAndProcessEmptyHandleState(
-                nodeState,
-                cachedRequest->GetHandle(),
-                *handleState);
-        }
+        RemoveActiveRequestFromHandleState(nodeState, cachedRequest);
     }
 
     TriggerFlushCompletions(nodeState);
@@ -805,17 +794,41 @@ void TWriteBackCacheState::ProcessPendingRequests()
     }
 }
 
-void TWriteBackCacheState::CheckAndProcessEmptyHandleState(
+void TWriteBackCacheState::RemoveActiveRequestFromHandleState(
+    TNodeState& nodeState,
+    TPendingWriteDataRequest* request)
+{
+    auto handle = request->GetRequest().GetHandle();
+    auto& handleState = nodeState.Handles[handle];
+
+    handleState.PendingRequests.Remove(request);
+    if (!handleState.HasRequests()) {
+        TriggerReleaseHandleCompletion(nodeState, handle, handleState);
+        nodeState.Handles.erase(handle);
+    }
+}
+
+void TWriteBackCacheState::RemoveActiveRequestFromHandleState(
+    TNodeState& nodeState,
+    TCachedWriteDataRequest* request)
+{
+    auto handle = request->GetHandle();
+    auto* handleState = nodeState.Handles.FindPtr(request->GetHandle());
+
+    if (handleState) {
+        handleState->UnflushedRequests.Remove(request);
+        if (!handleState->HasRequests()) {
+            TriggerReleaseHandleCompletion(nodeState, handle, *handleState);
+            nodeState.Handles.erase(handle);
+        }
+    }
+}
+
+void TWriteBackCacheState::TriggerReleaseHandleCompletion(
     TNodeState& nodeState,
     ui64 handle,
     THandleState& handleState)
 {
-    if (!handleState.PendingRequests.Empty() ||
-        !handleState.UnflushedRequests.Empty())
-    {
-        return;
-    }
-
     if (handleState.ReleaseHandleRequest) {
         Stats->RequestCompleted(
             ERequestType::ReleaseHandle,
@@ -826,10 +839,9 @@ void TWriteBackCacheState::CheckAndProcessEmptyHandleState(
 
         nodeState.HandlesWithReleaseRequests.erase(handle);
     }
-
-    nodeState.Handles.erase(handle);
 }
 
+// nodeState becomes unusable after this call
 void TWriteBackCacheState::DropCachedData(
     ui64 nodeId,
     TNodeState& nodeState,
@@ -882,18 +894,7 @@ void TWriteBackCacheState::FailPendingRequest(
         std::move(request->AccessPromise()),
         error);
 
-    auto& handleState = nodeState.Handles[request->GetRequest().GetHandle()];
-
-    handleState.PendingRequests.Remove(request);
-
-    // Since no data loss has taken place and errors have been already
-    // reported by failing WriteData requests, we respond to Flush and
-    // ReleaseHandle with success
-    CheckAndProcessEmptyHandleState(
-        nodeState,
-        request->GetRequest().GetHandle(),
-        handleState);
-
+    RemoveActiveRequestFromHandleState(nodeState, request);
     TriggerFlushCompletions(nodeState);
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -39,8 +39,10 @@ bool TWriteBackCacheState::Init(IPersistentStoragePtr persistentStorage)
         RequestManagerStats);
 
     return RequestManager.Init(
-        [this](std::unique_ptr<TCachedWriteDataRequest> request)
-        { AddRequest(std::move(request)); });
+        [this](
+            std::unique_ptr<TCachedWriteDataRequest> request,
+            bool handleReleased)
+        { AddRequest(std::move(request), handleReleased); });
 }
 
 void TWriteBackCacheState::SetDrainingMode()
@@ -157,7 +159,7 @@ TFuture<TError> TWriteBackCacheState::AddReleaseHandleRequest(
         ReleaseHandleRequests.PushBack(handleState->ReleaseHandleRequest.get());
         Stats->RequestAdded(ERequestType::ReleaseHandle);
 
-        nodeState->HandleToReleaseCount++;
+        nodeState->HandlesWithReleaseRequests.insert(handle);
 
         UpdateFlushStatus(nodeId, *nodeState);
     }
@@ -263,7 +265,7 @@ void TWriteBackCacheState::UnpinNodeStates(TPin pinId)
     Nodes.Unpin(pinId);
 }
 
-void TWriteBackCacheState::VisitUnflushedRequests(
+ui64 TWriteBackCacheState::VisitUnflushedRequests(
     ui64 nodeId,
     const TEntryVisitor& visitor) const
 {
@@ -271,14 +273,28 @@ void TWriteBackCacheState::VisitUnflushedRequests(
 
     const auto* nodeState = Nodes.GetNodeState(nodeId);
     if (nodeState == nullptr) {
-        return;
+        return NProto::E_INVALID_HANDLE;
     }
+
+    if (nodeState->Handles.empty()) {
+        // There are no unflushed requests with live handles
+        return NProto::E_INVALID_HANDLE;
+    }
+
+    Y_ABORT_UNLESS(
+        nodeState->Cache.HasUnflushedRequests(),
+        "Node %lu has no unflushed requests but has live handles",
+        nodeId);
+
+    // Choose any live handle for flush
+    const ui64 handle = nodeState->Handles.cbegin()->first;
 
     const ui64 maxSequenceId = nodeState->Barriers.empty()
                                    ? Max<ui64>()
                                    : nodeState->Barriers.cbegin()->first;
 
     nodeState->Cache.VisitUnflushedRequests(visitor, maxSequenceId);
+    return handle;
 }
 
 void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
@@ -301,9 +317,14 @@ void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
         auto* cachedRequest =
             nodeState.Cache.MoveFrontUnflushedRequestToFlushed();
         RequestManager.SetFlushed(cachedRequest);
-        RemoveActiveRequestFromHandleState(
+
+        auto& handleState = nodeState.Handles[cachedRequest->GetHandle()];
+        handleState.UnflushedRequests.Remove(cachedRequest);
+
+        CheckAndProcessEmptyHandleState(
             nodeState,
-            cachedRequest->GetHandle());
+            cachedRequest->GetHandle(),
+            handleState);
     }
 
     TriggerFlushCompletions(nodeState);
@@ -376,14 +397,42 @@ EFlushRetryStatus TWriteBackCacheState::FlushFailed(
         nodeState.Barriers.erase(it);
     }
 
-    // Fail all pending requests in the case of E_FS_NOSPC
+    // Fail all pending requests for all nodes in the case of E_FS_NOSPC
     if (error.GetCode() == E_FS_NOSPC) {
-        FailPendingRequests(error);
+        FailAllPendingRequests(error);
+    } else {
+        FailNodePendingRequests(nodeState, error);
     }
 
-    if (nodeState.Handles.size() == nodeState.HandleToReleaseCount) {
-        // All handles with active WriteData requests are to be released
-        // Drop node data on flush failure
+    // Fail all ReleaseHandle requests
+    while (!nodeState.HandlesWithReleaseRequests.empty()) {
+        auto handle = *nodeState.HandlesWithReleaseRequests.begin();
+        auto& handleState = nodeState.Handles[handle];
+
+        while (!handleState.UnflushedRequests.Empty()) {
+            auto* request = handleState.UnflushedRequests.PopFront();
+            RequestManager.SetHandleReleasedTag(request);
+        }
+
+        if (handleState.ReleaseHandleRequest) {
+            Stats->RequestFailed(
+                ERequestType::ReleaseHandle,
+                now - handleState.ReleaseHandleRequest->RequestStartTime);
+
+            QueuedOperations.FailFlushOrReleasePromise(
+                std::move(
+                    handleState.ReleaseHandleRequest->ReadyToReleasePromise),
+                error);
+
+            handleState.ReleaseHandleRequest.reset();
+        }
+
+        nodeState.Handles.erase(handle);
+        nodeState.HandlesWithReleaseRequests.erase(handle);
+    }
+
+    if (nodeState.Handles.empty()) {
+        // No live handles remaining - drop all unflushed requests
         nodeState.FlushStatus = ENodeFlushStatus::NothingToFlush;
         Stats->FlushCompleted();
         DropCachedData(nodeId, nodeState, error);
@@ -503,7 +552,9 @@ TFuture<TWriteDataResponse> TWriteBackCacheState::AddRequest(
     auto& nodeState =
         Nodes.GetOrCreateNodeState(request->GetRequest().GetNodeId());
 
-    AddActiveRequestToHandleState(nodeState, request->GetRequest().GetHandle());
+    auto& handleState = nodeState.Handles[request->GetRequest().GetHandle()];
+    handleState.PendingRequests.PushBack(request.get());
+
     nodeState.Cache.EnqueuePendingRequest(std::move(request));
 
     return future;
@@ -512,10 +563,22 @@ TFuture<TWriteDataResponse> TWriteBackCacheState::AddRequest(
 TFuture<TWriteDataResponse> TWriteBackCacheState::AddRequest(
     std::unique_ptr<TCachedWriteDataRequest> request)
 {
+    return AddRequest(std::move(request), /* handleReleased = */ false);
+}
+
+TFuture<TWriteDataResponse> TWriteBackCacheState::AddRequest(
+    std::unique_ptr<TCachedWriteDataRequest> request,
+    bool handleReleased)
+{
     const ui64 nodeId = request->GetNodeId();
 
     auto& nodeState = Nodes.GetOrCreateNodeState(nodeId);
-    AddActiveRequestToHandleState(nodeState, request->GetHandle());
+
+    if (!handleReleased) {
+        auto& handleState = nodeState.Handles[request->GetHandle()];
+        handleState.UnflushedRequests.PushBack(request.get());
+    }
+
     nodeState.Cache.EnqueueUnflushedRequest(std::move(request));
 
     UpdateFlushStatus(nodeId, nodeState);
@@ -724,43 +787,39 @@ void TWriteBackCacheState::ProcessPendingRequests()
         QueuedOperations.CompleteWriteDataPromise(
             std::move(pendingRequest->AccessPromise()));
 
+        auto& handleState = nodeState.Handles[request->GetHandle()];
+        handleState.PendingRequests.Remove(pendingRequest.get());
+        handleState.UnflushedRequests.PushBack(request.get());
+
         nodeState.Cache.EnqueueUnflushedRequest(std::move(request));
 
         UpdateFlushStatus(nodeId, nodeState);
     }
 }
 
-void TWriteBackCacheState::AddActiveRequestToHandleState(
+void TWriteBackCacheState::CheckAndProcessEmptyHandleState(
     TNodeState& nodeState,
-    ui64 handle)
+    ui64 handle,
+    THandleState& handleState)
 {
-    auto& handleState = nodeState.Handles[handle];
-    handleState.ActiveWriteDataRequestCount++;
-}
-
-void TWriteBackCacheState::RemoveActiveRequestFromHandleState(
-    TNodeState& nodeState,
-    ui64 handle)
-{
-    auto& handleState = nodeState.Handles[handle];
-    Y_ABORT_UNLESS(handleState.ActiveWriteDataRequestCount > 0);
-
-    if (--handleState.ActiveWriteDataRequestCount == 0) {
-        if (handleState.ReleaseHandleRequest) {
-            Y_ABORT_UNLESS(nodeState.HandleToReleaseCount > 0);
-            nodeState.HandleToReleaseCount--;
-
-            Stats->RequestCompleted(
-                ERequestType::ReleaseHandle,
-                Timer->Now() -
-                    handleState.ReleaseHandleRequest->RequestStartTime);
-
-            QueuedOperations.CompleteFlushOrReleasePromise(
-                std::move(
-                    handleState.ReleaseHandleRequest->ReadyToReleasePromise));
-        }
-        nodeState.Handles.erase(handle);
+    if (!handleState.PendingRequests.Empty() ||
+        !handleState.UnflushedRequests.Empty())
+    {
+        return;
     }
+
+    if (handleState.ReleaseHandleRequest) {
+        Stats->RequestCompleted(
+            ERequestType::ReleaseHandle,
+            Timer->Now() - handleState.ReleaseHandleRequest->RequestStartTime);
+
+        QueuedOperations.CompleteFlushOrReleasePromise(
+            std::move(handleState.ReleaseHandleRequest->ReadyToReleasePromise));
+
+        nodeState.HandlesWithReleaseRequests.erase(handle);
+    }
+
+    nodeState.Handles.erase(handle);
 }
 
 void TWriteBackCacheState::DropCachedData(
@@ -801,12 +860,47 @@ void TWriteBackCacheState::DropCachedData(
     }
 
     nodeState.Handles.clear();
-    nodeState.HandleToReleaseCount = 0;
+    nodeState.HandlesWithReleaseRequests.clear();
 
     EvictUnpinnedFlushedEntries(nodeId, nodeState);
 }
 
-void TWriteBackCacheState::FailPendingRequests(
+void TWriteBackCacheState::FailPendingRequest(
+    TNodeState& nodeState,
+    TPendingWriteDataRequest* request,
+    const NCloud::NProto::TError& error)
+{
+    QueuedOperations.FailWriteDataPromise(
+        std::move(request->AccessPromise()),
+        error);
+
+    auto& handleState = nodeState.Handles[request->GetRequest().GetHandle()];
+
+    handleState.PendingRequests.Remove(request);
+
+    // Since no data loss has taken place and errors have been already
+    // reported by failing WriteData requests, we respond to Flush and
+    // ReleaseHandle with success
+    CheckAndProcessEmptyHandleState(
+        nodeState,
+        request->GetRequest().GetHandle(),
+        handleState);
+
+    TriggerFlushCompletions(nodeState);
+}
+
+void TWriteBackCacheState::FailNodePendingRequests(
+    TNodeState& nodeState,
+    const NCloud::NProto::TError& error)
+{
+    while (nodeState.Cache.HasPendingRequests()) {
+        auto request = nodeState.Cache.DequeuePendingRequest();
+        FailPendingRequest(nodeState, request.get(), error);
+        RequestManager.Remove(std::move(request));
+    }
+}
+
+void TWriteBackCacheState::FailAllPendingRequests(
     const NCloud::NProto::TError& error)
 {
     while (auto* request = RequestManager.TryPopFrontPendingRequest()) {
@@ -820,18 +914,7 @@ void TWriteBackCacheState::FailPendingRequests(
         // Both queues are ordered with respect to their SequenceId
         Y_ABORT_UNLESS(pendingRequest.get() == request);
 
-        QueuedOperations.FailWriteDataPromise(
-            std::move(request->AccessPromise()),
-            error);
-
-        // Since no data loss has taken place and errors have been already
-        // reported by failing WriteData requests, we respond to Flush and
-        // ReleaseHandle with success
-        RemoveActiveRequestFromHandleState(
-            nodeState,
-            request->GetRequest().GetHandle());
-
-        TriggerFlushCompletions(nodeState);
+        FailPendingRequest(nodeState, request, error);
 
         if (nodeState.CanBeDeleted()) {
             Nodes.DeleteNodeState(nodeId);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -322,13 +322,17 @@ void TWriteBackCacheState::FlushSucceeded(ui64 nodeId, size_t requestCount)
             nodeState.Cache.MoveFrontUnflushedRequestToFlushed();
         RequestManager.SetFlushed(cachedRequest);
 
-        auto& handleState = nodeState.Handles[cachedRequest->GetHandle()];
-        handleState.UnflushedRequests.Remove(cachedRequest);
+        auto* handleState =
+            nodeState.Handles.FindPtr(cachedRequest->GetHandle());
 
-        CheckAndProcessEmptyHandleState(
-            nodeState,
-            cachedRequest->GetHandle(),
-            handleState);
+        if (handleState) {
+            handleState->UnflushedRequests.Remove(cachedRequest);
+
+            CheckAndProcessEmptyHandleState(
+                nodeState,
+                cachedRequest->GetHandle(),
+                *handleState);
+        }
     }
 
     TriggerFlushCompletions(nodeState);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -276,11 +276,6 @@ void TWriteBackCacheState::VisitUnflushedRequests(
         return;
     }
 
-    Y_ABORT_UNLESS(
-        nodeState->Cache.HasUnflushedRequests(),
-        "Node %lu has no unflushed requests but has live handles",
-        nodeId);
-
     const ui64 maxSequenceId = nodeState->Barriers.empty()
                                    ? Max<ui64>()
                                    : nodeState->Barriers.cbegin()->first;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -132,8 +132,11 @@ public:
     TPin PinNodeStates();
     void UnpinNodeStates(TPin pinId);
 
-    // Visit unflushed cached requests in the increasing order of SequenceId
-    void VisitUnflushedRequests(
+    // Visit unflushed cached requests in the increasing order of SequenceId.
+    // Returns a live handle that should be used for flushing requests or
+    // NProto::E_INVALID_HANDLE if there are no unflushed requests with live
+    // handles.
+    ui64 VisitUnflushedRequests(
         ui64 nodeId,
         const TEntryVisitor& visitor) const;
 
@@ -177,6 +180,10 @@ private:
     NThreading::TFuture<NProto::TWriteDataResponse> AddRequest(
         std::unique_ptr<TCachedWriteDataRequest> request);
 
+    NThreading::TFuture<NProto::TWriteDataResponse> AddRequest(
+        std::unique_ptr<TCachedWriteDataRequest> request,
+        bool handleReleased);
+
     void TriggerFlushAll(bool includePendingRequests);
 
     ENodeFlushStatus GetFlushStatus(const TNodeState& nodeState) const;
@@ -187,15 +194,31 @@ private:
     void CheckAndAcquireBarriers(TNodeState& nodeState);
     void ProcessPendingRequests();
 
-    void AddActiveRequestToHandleState(TNodeState& nodeState, ui64 handle);
-    void RemoveActiveRequestFromHandleState(TNodeState& nodeState, ui64 handle);
+    // Checks if there exist pending or unflushed WriteData requests
+    // associated with the handle. If there are no, then:
+    // - completes corresponding ReleaseHandle request (if initialized);
+    // - removes handle state from node state.
+    // Note: handleState will become unusable after this call.
+    void CheckAndProcessEmptyHandleState(
+        TNodeState& nodeState,
+        ui64 handle,
+        THandleState& handleState);
 
     void DropCachedData(
         ui64 nodeId,
         TNodeState& nodeState,
         const NCloud::NProto::TError& error);
 
-    void FailPendingRequests(const NCloud::NProto::TError& error);
+    void FailPendingRequest(
+        TNodeState& nodeState,
+        TPendingWriteDataRequest* request,
+        const NCloud::NProto::TError& error);
+
+    void FailNodePendingRequests(
+        TNodeState& nodeState,
+        const NCloud::NProto::TError& error);
+
+    void FailAllPendingRequests(const NCloud::NProto::TError& error);
 };
 
 }   // namespace NCloud::NFileStore::NFuse::NWriteBackCache

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -132,7 +132,7 @@ public:
     TPin PinNodeStates();
     void UnpinNodeStates(TPin pinId);
 
-    // Visit unflushed cached requests in the increasing order of SequenceId.
+    // Visit unflushed cached requests in the increasing order of SequenceId
     void VisitUnflushedRequests(
         ui64 nodeId,
         const TEntryVisitor& visitor) const;
@@ -196,12 +196,15 @@ private:
     void CheckAndAcquireBarriers(TNodeState& nodeState);
     void ProcessPendingRequests();
 
-    // Checks if there exist pending or unflushed WriteData requests
-    // associated with the handle. If there are no, then:
-    // - completes corresponding ReleaseHandle request (if initialized);
-    // - removes handle state from node state.
-    // Note: handleState will become unusable after this call.
-    void CheckAndProcessEmptyHandleState(
+    void RemoveActiveRequestFromHandleState(
+        TNodeState& nodeState,
+        TPendingWriteDataRequest* request);
+
+    void RemoveActiveRequestFromHandleState(
+        TNodeState& nodeState,
+        TCachedWriteDataRequest* request);
+
+    void TriggerReleaseHandleCompletion(
         TNodeState& nodeState,
         ui64 handle,
         THandleState& handleState);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -133,12 +133,14 @@ public:
     void UnpinNodeStates(TPin pinId);
 
     // Visit unflushed cached requests in the increasing order of SequenceId.
-    // Returns a live handle that should be used for flushing requests or
-    // NProto::E_INVALID_HANDLE if there are no unflushed requests with live
-    // handles.
-    ui64 VisitUnflushedRequests(
+    void VisitUnflushedRequests(
         ui64 nodeId,
         const TEntryVisitor& visitor) const;
+
+    // Returns a known live handle that should be used for flushing requests or
+    // NProto::E_INVALID_HANDLE if there are no unflushed requests with live
+    // handles
+    ui64 GetLiveHandle(ui64 nodeId) const;
 
     // Inform that the first |requestCount| unflushed changes requests have
     // been flushed

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -471,7 +471,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         UNIT_ASSERT(b.Add(1, 102, 2, "123").GetValue());
 
         auto w1 = b.Add(1, 102, 4, "def");
-        auto w2 = b.Add(1, 103, 5, "456");
+        auto w2 = b.AddAndGetError(1, 103, 5, "456");
 
         UNIT_ASSERT(!w1.HasValue());
         UNIT_ASSERT(!w2.HasValue());
@@ -504,23 +504,27 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         // Nothing happens until all handles are requested to be released
         b.State->FlushFailed(1, error);
 
-        UNIT_ASSERT(!c3.HasValue());
+        // All pending WriteData requests are failed on flush failure
+        UNIT_ASSERT(w2.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(error, w2.GetValue());
+
+        // Failure of pending WriteData requests doesn't affect ReleaseHandle
+        UNIT_ASSERT(c3.HasValue());
+        UNIT_ASSERT(!HasError(c3.GetValue()));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            b.Metrics.WriteDataRequestDroppedCount->Get());
 
         auto c2 = b.State->AddReleaseHandleRequest(1, 102);
 
         UNIT_ASSERT(!c2.HasValue());
 
-        // Cache should be emptied and pending requests should be failed
-        // Two requests are dropped
+        // Cache should be emptied
         b.State->FlushFailed(1, error);
-
-        UNIT_ASSERT(w2.HasValue());
-        UNIT_ASSERT(!w2.GetValue());
 
         UNIT_ASSERT(c2.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(error, c2.GetValue());
-        UNIT_ASSERT(c3.HasValue());
-        UNIT_ASSERT_VALUES_EQUAL(error, c3.GetValue());
 
         b.State->SetDrainingMode();
         UNIT_ASSERT(b.State->IsDrained());
@@ -1252,6 +1256,59 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         UNIT_ASSERT(!b2.HasValue());
         UNIT_ASSERT(b3.HasValue());
         UNIT_ASSERT(!HasError(b3.GetValue().GetError()));
+    }
+
+    Y_UNIT_TEST(ShouldChooseCorrectHandleAfterHandleReleased)
+    {
+        TBootstrap b;
+
+        b.Add(1, 101, 0, "abc");
+        b.Add(1, 102, 1, "def");
+
+        auto error = MakeError(E_FAIL, "Flush failed");
+
+        b.State->AddReleaseHandleRequest(1, 101);
+
+        auto handle1 =
+            b.State->VisitUnflushedRequests(1, [](auto) { return true; });
+
+        // Note: the code depends on the implementation of THashMap
+        // If the implementation changes, this test may need to be updated
+        UNIT_ASSERT_VALUES_EQUAL(101, handle1);
+
+        b.State->FlushFailed(1, error);
+
+        auto handle2 =
+            b.State->VisitUnflushedRequests(1, [](auto) { return true; });
+
+        UNIT_ASSERT_VALUES_EQUAL(102, handle2);
+    }
+
+    Y_UNIT_TEST(ShouldFailPendingRequestsOnFlushFailure)
+    {
+        TBootstrap b;
+
+        b.Storage->SetCapacity(2);
+
+        b.Add(1, 101, 0, "abc");
+        b.Add(2, 202, 1, "def");
+
+        auto w1 = b.AddAndGetError(1, 102, 2, "ghi");
+        auto w2 = b.AddAndGetError(2, 203, 3, "jkl");
+
+        UNIT_ASSERT(!w1.HasValue());
+        UNIT_ASSERT(!w2.HasValue());
+
+        b.State->FlushFailed(1, MakeError(E_FAIL, "Flush failed"));
+
+        UNIT_ASSERT(w1.HasValue());
+        UNIT_ASSERT(w1.GetValue().GetCode() == E_FAIL);
+        UNIT_ASSERT(!w2.HasValue());
+
+        b.State->FlushFailed(1, MakeError(E_FS_NOSPC, "No space left"));
+
+        UNIT_ASSERT(w2.HasValue());
+        UNIT_ASSERT(w2.GetValue().GetCode() == E_FS_NOSPC);
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -1269,19 +1269,13 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
 
         b.State->AddReleaseHandleRequest(1, 101);
 
-        auto handle1 =
-            b.State->VisitUnflushedRequests(1, [](auto) { return true; });
-
         // Note: the code depends on the implementation of THashMap
         // If the implementation changes, this test may need to be updated
-        UNIT_ASSERT_VALUES_EQUAL(101, handle1);
+        UNIT_ASSERT_VALUES_EQUAL(101, b.State->GetLiveHandle(1));
 
         b.State->FlushFailed(1, error);
 
-        auto handle2 =
-            b.State->VisitUnflushedRequests(1, [](auto) { return true; });
-
-        UNIT_ASSERT_VALUES_EQUAL(102, handle2);
+        UNIT_ASSERT_VALUES_EQUAL(102, b.State->GetLiveHandle(1));
     }
 
     Y_UNIT_TEST(ShouldFailPendingRequestsOnFlushFailure)
@@ -1302,13 +1296,13 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         b.State->FlushFailed(1, MakeError(E_FAIL, "Flush failed"));
 
         UNIT_ASSERT(w1.HasValue());
-        UNIT_ASSERT(w1.GetValue().GetCode() == E_FAIL);
+        UNIT_ASSERT_VALUES_EQUAL(E_FAIL, w1.GetValue().GetCode());
         UNIT_ASSERT(!w2.HasValue());
 
         b.State->FlushFailed(1, MakeError(E_FS_NOSPC, "No space left"));
 
         UNIT_ASSERT(w2.HasValue());
-        UNIT_ASSERT(w2.GetValue().GetCode() == E_FS_NOSPC);
+        UNIT_ASSERT_VALUES_EQUAL(E_FS_NOSPC, w2.GetValue().GetCode());
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2270,11 +2270,13 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         });
 
         TVector<TPromise<NProto::TWriteDataResponse>> writeRequests;
+        TVector<ui64> writeHandles;
 
-        b.Session->WriteDataHandler = [&](auto, auto)
+        b.Session->WriteDataHandler = [&](auto, auto request)
         {
             auto promise = NewPromise<NProto::TWriteDataResponse>();
             writeRequests.push_back(promise);
+            writeHandles.push_back(request->GetHandle());
             return promise;
         };
 
@@ -2291,6 +2293,10 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         auto releaseFuture = b.Cache.ReleaseHandle(1, 102);
 
+        // An attempt to flush via handle=101 should have been made
+        UNIT_ASSERT_VALUES_EQUAL(1, writeHandles.size());
+        UNIT_ASSERT_VALUES_EQUAL(101, writeHandles[0]);
+
         NProto::TWriteDataResponse errorResponse;
         errorResponse.MutableError()->SetCode(E_FAIL);
         completeNext(std::move(errorResponse));
@@ -2303,6 +2309,11 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         auto flushFuture = b.Cache.FlushNodeData(1);
         b.RunAllScheduledTasks();
+
+        // An attempt to retry flush via handle=101 should have been made
+        UNIT_ASSERT_VALUES_EQUAL(2, writeHandles.size());
+        UNIT_ASSERT_VALUES_EQUAL(101, writeHandles[0]);
+
         completeNext({});
 
         // After a successful flush attempt, WriteBackCache contains 1 WriteData
@@ -2312,9 +2323,46 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         UNIT_ASSERT(flushFuture.HasValue());
         UNIT_ASSERT(HasError(flushFuture.GetValue()));
 
+        UNIT_ASSERT_VALUES_EQUAL(2, writeHandles.size());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
             b.Metrics.WriteDataRequestDroppedCount->Get());
+    }
+
+    Y_UNIT_TEST(ShouldRetryFlushWithLiveHandle)
+    {
+        TBootstrap b({
+            .MaxWriteRequestsCount = 1,
+            .UseTestTimerAndScheduler = true,
+        });
+
+        TVector<ui64> writeHandles;
+
+        b.Session->WriteDataHandler = [&](auto, auto request)
+        {
+            writeHandles.push_back(request->GetHandle());
+            NProto::TWriteDataResponse errorResponse;
+            errorResponse.MutableError()->SetCode(E_FAIL);
+            return MakeFuture(std::move(errorResponse));
+        };
+
+        b.WriteToCacheSync(1, 101, 1, "abc");
+        b.WriteToCacheSync(1, 102, 10, "123");
+
+        auto releaseFuture = b.Cache.ReleaseHandle(1, 101);
+
+        // An attempt to flush via handle=101 should have been made
+        UNIT_ASSERT_VALUES_EQUAL(1, writeHandles.size());
+        UNIT_ASSERT_VALUES_EQUAL(101, writeHandles[0]);
+
+        // Confirm that handle 101 is released
+        UNIT_ASSERT(releaseFuture.HasValue());
+        UNIT_ASSERT(HasError(releaseFuture.GetValue()));
+
+        // Flush should be retried using handle 102
+        b.RunAllScheduledTasks();
+        UNIT_ASSERT_VALUES_EQUAL(2, writeHandles.size());
+        UNIT_ASSERT_VALUES_EQUAL(102, writeHandles[1]);
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -1855,6 +1855,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         auto request = std::make_shared<NProto::TWriteDataRequest>();
         request->SetNodeId(1);
         request->SetOffset(0);
+        request->SetHandle(101);
 
         auto* iovec1 = request->AddIovecs();
         iovec1->SetBase(base + 3);
@@ -1955,6 +1956,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         auto request = std::make_shared<NProto::TWriteDataRequest>();
         request->SetNodeId(1);
+        request->SetHandle(101);
         request->SetOffset(0);
         auto* iovec = request->AddIovecs();
         iovec->SetBase(base);
@@ -2258,6 +2260,61 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         // Ensure that WriteData request is evicted
         UNIT_ASSERT_VALUES_EQUAL(1, b.Metrics.UnflushedQueue.Count->Get());
         UNIT_ASSERT_VALUES_EQUAL(0, b.Metrics.FlushedQueue.Count->Get());
+    }
+
+    Y_UNIT_TEST(ShouldDropCachedDataWhenThereAreNoLiveHandles)
+    {
+        TBootstrap b({
+            .MaxWriteRequestsCount = 1,
+            .UseTestTimerAndScheduler = true,
+        });
+
+        TVector<TPromise<NProto::TWriteDataResponse>> writeRequests;
+
+        b.Session->WriteDataHandler = [&](auto, auto)
+        {
+            auto promise = NewPromise<NProto::TWriteDataResponse>();
+            writeRequests.push_back(promise);
+            return promise;
+        };
+
+        auto completeNext = [&](NProto::TWriteDataResponse response)
+        {
+            UNIT_ASSERT(!writeRequests.empty());
+            auto promise = writeRequests.front();
+            writeRequests.erase(writeRequests.begin());
+            promise.SetValue(std::move(response));
+        };
+
+        b.WriteToCacheSync(1, 101, 1, "abc");
+        b.WriteToCacheSync(1, 102, 10, "123");
+
+        auto releaseFuture = b.Cache.ReleaseHandle(1, 102);
+
+        NProto::TWriteDataResponse errorResponse;
+        errorResponse.MutableError()->SetCode(E_FAIL);
+        completeNext(std::move(errorResponse));
+
+        UNIT_ASSERT(releaseFuture.HasValue());
+        UNIT_ASSERT(HasError(releaseFuture.GetValue()));
+
+        // Current state: WriteBackCache contains 2 WriteData requests for
+        // handle 101 and 102 but only handle 101 is live
+
+        auto flushFuture = b.Cache.FlushNodeData(1);
+        b.RunAllScheduledTasks();
+        completeNext({});
+
+        // After a successful flush attempt, WriteBackCache contains 1 WriteData
+        // requests for handle 102 that is already released.
+        // The next flush attempt executes immediately and fails.
+
+        UNIT_ASSERT(flushFuture.HasValue());
+        UNIT_ASSERT(HasError(flushFuture.GetValue()));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            b.Metrics.WriteDataRequestDroppedCount->Get());
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request.h
@@ -10,6 +10,7 @@
 namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
 class TWriteDataRequestManager;
+struct THandleStateTag;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -42,6 +43,7 @@ protected:
 
 class TPendingWriteDataRequest
     : public TWriteDataRequestBase<TPendingWriteDataRequest>
+    , public TIntrusiveListItem<TPendingWriteDataRequest, THandleStateTag>
 {
 private:
     std::shared_ptr<NProto::TWriteDataRequest> Request;
@@ -84,6 +86,7 @@ struct Y_PACKED TSerializedWriteDataRequestHeader
 
 class TCachedWriteDataRequest
     : public TWriteDataRequestBase<TCachedWriteDataRequest>
+    , public TIntrusiveListItem<TCachedWriteDataRequest, THandleStateTag>
 {
 private:
     // WriteData request header serialized to the persistent storage

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
@@ -212,8 +212,6 @@ private:
     const TWriteDataRequestBuilderConfig Config;
 
     TWriteRequestCounter WriteDataRequestCounter;
-
-    ui64 Handle = 0;
     TVector<TWriteDataRequestPart> InputRequests;
 
 public:
@@ -225,13 +223,9 @@ public:
         , WriteDataRequestCounter(Config.MaxWriteRequestSize)
     {}
 
-    bool AddRequest(ui64 handle, ui64 offset, TStringBuf data) override
+    bool AddRequest(ui64 offset, TStringBuf data) override
     {
         Y_ABORT_UNLESS(!data.empty(), "Empty requests are not allowed");
-
-        if (InputRequests.empty()) {
-            Handle = handle;
-        }
 
         WriteDataRequestCounter.AddInterval(offset, offset + data.size());
 
@@ -248,7 +242,7 @@ public:
         return true;
     }
 
-    TWriteDataRequestBatch Build() override
+    TWriteDataRequestBatch Build(ui64 handle) override
     {
         if (InputRequests.empty()) {
             return {};
@@ -257,7 +251,7 @@ public:
         auto dataParts = BuildDisjointRequestDataParts(InputRequests);
 
         TWriteDataRequestBatch res;
-        res.Requests = BuildRequestsFromParts(dataParts);
+        res.Requests = BuildRequestsFromParts(dataParts, handle);
         res.AffectedRequestCount = InputRequests.size();
 
         return res;
@@ -265,7 +259,8 @@ public:
 
 private:
     TVector<std::shared_ptr<NProto::TWriteDataRequest>> BuildRequestsFromParts(
-        const TVector<TWriteDataRequestPart>& dataParts)
+        const TVector<TWriteDataRequestPart>& dataParts,
+        ui64 handle)
     {
         TVector<std::shared_ptr<NProto::TWriteDataRequest>> res;
 
@@ -291,7 +286,7 @@ private:
                 auto request = std::make_shared<NProto::TWriteDataRequest>();
                 request->SetFileSystemId(Config.FileSystemId);
                 request->SetNodeId(NodeId);
-                request->SetHandle(Handle);
+                request->SetHandle(handle);
                 request->SetOffset(reader.GetOffset());
 
                 if (Config.ZeroCopyWriteEnabled) {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
@@ -242,7 +242,7 @@ public:
         return true;
     }
 
-    TWriteDataRequestBatch Build(ui64 handle) override
+    TWriteDataRequestBatch Build() override
     {
         if (InputRequests.empty()) {
             return {};
@@ -251,7 +251,7 @@ public:
         auto dataParts = BuildDisjointRequestDataParts(InputRequests);
 
         TWriteDataRequestBatch res;
-        res.Requests = BuildRequestsFromParts(dataParts, handle);
+        res.Requests = BuildRequestsFromParts(dataParts);
         res.AffectedRequestCount = InputRequests.size();
 
         return res;
@@ -259,8 +259,7 @@ public:
 
 private:
     TVector<std::shared_ptr<NProto::TWriteDataRequest>> BuildRequestsFromParts(
-        const TVector<TWriteDataRequestPart>& dataParts,
-        ui64 handle)
+        const TVector<TWriteDataRequestPart>& dataParts)
     {
         TVector<std::shared_ptr<NProto::TWriteDataRequest>> res;
 
@@ -286,7 +285,6 @@ private:
                 auto request = std::make_shared<NProto::TWriteDataRequest>();
                 request->SetFileSystemId(Config.FileSystemId);
                 request->SetNodeId(NodeId);
-                request->SetHandle(handle);
                 request->SetOffset(reader.GetOffset());
 
                 if (Config.ZeroCopyWriteEnabled) {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.h
@@ -31,9 +31,9 @@ struct IWriteDataRequestBatchBuilder
     // Returns true if the request was added.
     // Returns false if the request was rejected to due conditions in the
     // configuration (e.g. max request count exceeded)
-    virtual bool AddRequest(ui64 handle, ui64 offset, TStringBuf data) = 0;
+    virtual bool AddRequest(ui64 offset, TStringBuf data) = 0;
 
-    virtual TWriteDataRequestBatch Build() = 0;
+    virtual TWriteDataRequestBatch Build(ui64 handle) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.h
@@ -33,7 +33,7 @@ struct IWriteDataRequestBatchBuilder
     // configuration (e.g. max request count exceeded)
     virtual bool AddRequest(ui64 offset, TStringBuf data) = 0;
 
-    virtual TWriteDataRequestBatch Build(ui64 handle) = 0;
+    virtual TWriteDataRequestBatch Build() = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder_ut.cpp
@@ -109,7 +109,7 @@ struct TBootstrap
             requestCount++;
         }
 
-        auto res = batchBuilder->Build(0);
+        auto res = batchBuilder->Build();
 
         Y_ABORT_UNLESS(res.AffectedRequestCount == requestCount);
         return res.AffectedRequestCount;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder_ut.cpp
@@ -103,13 +103,13 @@ struct TBootstrap
             const auto& e = entries.Entries[i];
             const auto& buffer = entries.Buffers[i];
 
-            if (!batchBuilder->AddRequest(/* handle = */ 0, e.Offset, buffer)) {
+            if (!batchBuilder->AddRequest(e.Offset, buffer)) {
                 break;
             }
             requestCount++;
         }
 
-        auto res = batchBuilder->Build();
+        auto res = batchBuilder->Build(0);
 
         Y_ABORT_UNLESS(res.AffectedRequestCount == requestCount);
         return res.AffectedRequestCount;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -320,7 +320,7 @@ void TWriteDataRequestManager::SetFlushed(TCachedWriteDataRequest* request)
         static_cast<ui32>(ECachedWriteDataRequestTag::Flushed));
 }
 
-void TWriteDataRequestManager::SetHandleReleasedTag(
+void TWriteDataRequestManager::SetHandleReleased(
     TCachedWriteDataRequest* request)
 {
     PersistentStorage->SetTag(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.cpp
@@ -172,12 +172,28 @@ bool TWriteDataRequestManager::Init(const TCachedRequestVisitor& visitor)
     }
 
     for (auto& request: loadedRequests) {
-        if (request.Tag == ECachedWriteDataRequestTag::Flushed) {
-            // There are no pins that may prevent flushed requests from eviction
-            PersistentStorage->Free(request.Request->GetAllocationPtr());
-        } else {
-            UnflushedRequestsPushBack(request.Request.get());
-            visitor(std::move(request.Request));
+        switch (request.Tag) {
+            case ECachedWriteDataRequestTag::Unflushed: {
+                UnflushedRequestsPushBack(request.Request.get());
+                visitor(
+                    std::move(request.Request),
+                    /* handleReleased = */ false);
+                break;
+            }
+            case ECachedWriteDataRequestTag::UnflushedHandleReleased: {
+                UnflushedRequestsPushBack(request.Request.get());
+                visitor(
+                    std::move(request.Request),
+                    /* handleReleased = */ true);
+                break;
+            }
+            case ECachedWriteDataRequestTag::Flushed: {
+                // There could be pins that prevented flushed requests from
+                // eviction before restart, but they are erased on restart
+                // so nothing prevents flushed requests from being removed
+                PersistentStorage->Free(request.Request->GetAllocationPtr());
+                break;
+            }
         }
     }
 
@@ -302,6 +318,14 @@ void TWriteDataRequestManager::SetFlushed(TCachedWriteDataRequest* request)
     PersistentStorage->SetTag(
         request->GetAllocationPtr(),
         static_cast<ui32>(ECachedWriteDataRequestTag::Flushed));
+}
+
+void TWriteDataRequestManager::SetHandleReleasedTag(
+    TCachedWriteDataRequest* request)
+{
+    PersistentStorage->SetTag(
+        request->GetAllocationPtr(),
+        static_cast<ui32>(ECachedWriteDataRequestTag::UnflushedHandleReleased));
 }
 
 void TWriteDataRequestManager::Evict(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
@@ -105,7 +105,7 @@ public:
      * the persistent storage.
      * This allows the request to be properly handled after restart.
      */
-    void SetHandleReleasedTag(TCachedWriteDataRequest* request);
+    void SetHandleReleased(TCachedWriteDataRequest* request);
 
     // Removes previously flushed request from the persistent storage
     void Evict(std::unique_ptr<TCachedWriteDataRequest> request);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_manager.h
@@ -34,8 +34,9 @@ public:
         std::unique_ptr<TPendingWriteDataRequest>,
         std::unique_ptr<TCachedWriteDataRequest>>;
 
-    using TCachedRequestVisitor =
-        TFunctionRef<void(std::unique_ptr<TCachedWriteDataRequest> request)>;
+    using TCachedRequestVisitor = TFunctionRef<void(
+        std::unique_ptr<TCachedWriteDataRequest> request,
+        bool handleReleased)>;
 
     TWriteDataRequestManager() = default;
     TWriteDataRequestManager(TWriteDataRequestManager&&) = default;
@@ -98,6 +99,13 @@ public:
      * It continues residing in the persistent storage until Evict is called
      */
     void SetFlushed(TCachedWriteDataRequest* request);
+
+    /**
+     * Marks the request as related to a released handle and stores this in
+     * the persistent storage.
+     * This allows the request to be properly handled after restart.
+     */
+    void SetHandleReleasedTag(TCachedWriteDataRequest* request);
 
     // Removes previously flushed request from the persistent storage
     void Evict(std::unique_ptr<TCachedWriteDataRequest> request);


### PR DESCRIPTION
### Notes
WriteBackCache is allowed to drop cached data only when all handles are requested to release. At the same time, WriteBackCache is not allowed to keep cached requests for released handles because an attempt to flush them will result in `E_FS_BADHANDLE`.

This may cause a problem when a file has several handles while flush cannot progress: if a client waits for the first `close()` before calling the second one, it will hang.

Proposal:
- Allow having WriteData requests in WriteBackCache with released handles — these requests will be marked with a corresponding tag that is stored in the persistent storage;
- Change logic for choosing handle to execute WriteData requests — take handles only from untagged requests;
- In the case of flush error — all ReleaseHandle requests are failed;
- In the case of no live handle exists — drop cached data.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
