### PR TITLE
issue-1559: [Disk Manager] Make onListedNodes, finishedCheck members of traverser

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/scrubbing/scrub_filesystem_task.go
@@ -74,25 +74,7 @@ func (t *scrubFilesystemTask) Run(
 	)
 
 	rootNodeAlreadyScheduled := t.state.GetRootNodeScheduled()
-	traverser, err := traversal.NewFilesystemTraverser(
-		t.getSnapshotID(execCtx),
-		filesystem.GetFilesystemId(),
-		t.request.GetFilesystemCheckpointId(),
-		filesystemListerFactory,
-		t.storage,
-		func(ctx context.Context) error {
-			t.state.RootNodeScheduled = true
-			return execCtx.SaveState(ctx)
-		},
-		t.config.GetTraversalConfig(),
-		rootNodeAlreadyScheduled,
-		nfs.RootNodeID,
-	)
-	if err != nil {
-		return err
-	}
-
-	return traverser.Traverse(ctx, func(
+	onListedNodes := func(
 		ctx context.Context,
 		nodes []nfs.Node,
 		_ listers.FilesystemLister,
@@ -104,7 +86,29 @@ func (t *scrubFilesystemTask) Run(
 		}
 
 		return nil
-	}, nil)
+	}
+
+	traverser, err := traversal.NewFilesystemTraverser(
+		t.getSnapshotID(execCtx),
+		filesystem.GetFilesystemId(),
+		t.request.GetFilesystemCheckpointId(),
+		filesystemListerFactory,
+		t.storage,
+		func(ctx context.Context) error {
+			t.state.RootNodeScheduled = true
+			return execCtx.SaveState(ctx)
+		},
+		onListedNodes,
+		nil,
+		t.config.GetTraversalConfig(),
+		rootNodeAlreadyScheduled,
+		nfs.RootNodeID,
+	)
+	if err != nil {
+		return err
+	}
+
+	return traverser.Traverse(ctx)
 }
 
 func (t *scrubFilesystemTask) Cancel(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/transfer_from_filesystem_to_snapshot_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/transfer_from_filesystem_to_snapshot_task.go
@@ -66,25 +66,7 @@ func (t *transferFromFilesystemToSnapshotTask) Run(
 		false, // ignoreNotFound
 	)
 
-	traverser, err := traversal.NewFilesystemTraverser(
-		snapshotID,
-		filesystem.GetFilesystemId(),
-		t.request.GetCheckpointId(),
-		filesystemListerFactory,
-		t.traversalStorage,
-		func(ctx context.Context) error {
-			t.state.RootNodeScheduled = true
-			return execCtx.SaveState(ctx)
-		},
-		t.config.GetTraversalConfig(),
-		t.state.GetRootNodeScheduled(),
-		nfs.RootNodeID,
-	)
-	if err != nil {
-		return err
-	}
-
-	return traverser.Traverse(ctx, func(
+	onListedNodes := func(
 		ctx context.Context,
 		nodes []nfs.Node,
 		filesystemLister listers.FilesystemLister,
@@ -132,7 +114,29 @@ func (t *transferFromFilesystemToSnapshotTask) Run(
 		)
 
 		return nil
-	}, nil)
+	}
+
+	traverser, err := traversal.NewFilesystemTraverser(
+		snapshotID,
+		filesystem.GetFilesystemId(),
+		t.request.GetCheckpointId(),
+		filesystemListerFactory,
+		t.traversalStorage,
+		func(ctx context.Context) error {
+			t.state.RootNodeScheduled = true
+			return execCtx.SaveState(ctx)
+		},
+		onListedNodes,
+		nil,
+		t.config.GetTraversalConfig(),
+		t.state.GetRootNodeScheduled(),
+		nfs.RootNodeID,
+	)
+	if err != nil {
+		return err
+	}
+
+	return traverser.Traverse(ctx)
 }
 
 func (t *transferFromFilesystemToSnapshotTask) Cancel(

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/transfer_from_snapshot_to_filesystem_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/transfer_from_snapshot_to_filesystem_task.go
@@ -292,28 +292,10 @@ func (t *transferFromSnapshotToFilesystemTask) Run(
 		int(t.config.GetFetchNodesFromStorageLimit()),
 	)
 
-	traverser, err := traversal.NewFilesystemTraverser(
-		t.traversalID(execCtx),
-		t.filesystemID(),
-		t.snapshotID(), //  use snapshotID as checkpointID to read nodes from snapshot storage
-		filesystemListerFactory,
-		t.traversalStorage,
-		func(ctx context.Context) error {
-			t.state.RootNodeScheduled = true
-			return execCtx.SaveState(ctx)
-		},
-		t.config.GetTraversalConfig(),
-		t.state.GetRootNodeScheduled(),
-		nfs.RootNodeID,
-	)
-	if err != nil {
-		return err
-	}
-
-	err = traverser.Traverse(ctx, func(
+	onListedNodes := func(
 		ctx context.Context,
 		nodes []nfs.Node,
-		filesystemLister listers.FilesystemLister,
+		_ listers.FilesystemLister,
 	) error {
 		if len(nodes) == 0 {
 			return nil
@@ -378,7 +360,29 @@ func (t *transferFromSnapshotToFilesystemTask) Run(
 		}
 
 		return nil
-	}, nil)
+	}
+
+	traverser, err := traversal.NewFilesystemTraverser(
+		t.traversalID(execCtx),
+		t.filesystemID(),
+		t.snapshotID(), //  use snapshotID as checkpointID to read nodes from snapshot storage
+		filesystemListerFactory,
+		t.traversalStorage,
+		func(ctx context.Context) error {
+			t.state.RootNodeScheduled = true
+			return execCtx.SaveState(ctx)
+		},
+		onListedNodes,
+		nil,
+		t.config.GetTraversalConfig(),
+		t.state.GetRootNodeScheduled(),
+		nfs.RootNodeID,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = traverser.Traverse(ctx)
 	if err != nil {
 		return err
 	}

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal.go
@@ -36,6 +36,8 @@ type FilesystemTraverser struct {
 	filesystemListerFactory  listers.FilesystemListerFactory
 	storage                  storage.Storage
 	stateSaver               StateSaver
+	onListedNodes            OnListedNodesFunc
+	finishedCheck            func(context.Context) error
 	config                   *config.FilesystemTraversalConfig
 	finishedCheckInterval    time.Duration
 	rootNodeAlreadyScheduled bool
@@ -67,6 +69,8 @@ func NewFilesystemTraverser(
 	filesystemListerFactory listers.FilesystemListerFactory,
 	snapshotStorage storage.Storage,
 	stateSaver StateSaver,
+	onListedNodes OnListedNodesFunc,
+	finishedCheck func(context.Context) error,
 	config *config.FilesystemTraversalConfig,
 	rootNodeAlreadyScheduled bool,
 	rootNodeID uint64,
@@ -94,6 +98,8 @@ func NewFilesystemTraverser(
 		filesystemListerFactory:  filesystemListerFactory,
 		storage:                  snapshotStorage,
 		stateSaver:               stateSaver,
+		onListedNodes:            onListedNodes,
+		finishedCheck:            finishedCheck,
 		config:                   config,
 		finishedCheckInterval:    finishedCheckInterval,
 		rootNodeAlreadyScheduled: rootNodeAlreadyScheduled,
@@ -101,11 +107,7 @@ func NewFilesystemTraverser(
 	}, nil
 }
 
-func (t *FilesystemTraverser) Traverse(
-	ctx context.Context,
-	onListedNodes OnListedNodesFunc,
-	finishedCheck func(context.Context) error,
-) error {
+func (t *FilesystemTraverser) Traverse(ctx context.Context) error {
 
 	ctx = logging.WithFields(
 		ctx,
@@ -144,30 +146,24 @@ func (t *FilesystemTraverser) Traverse(
 	})
 	for i := uint32(0); i < t.config.GetTraversalWorkersCount(); i++ {
 		eg.Go(func() error {
-			return t.directoryLister(ctx, onListedNodes)
+			return t.directoryLister(ctx)
 		})
 	}
-	if finishedCheck != nil {
+	if t.finishedCheck != nil {
 		eg.Go(func() error {
-			return t.periodicRunFinishedCheck(
-				finishedCheckCtx,
-				finishedCheck,
-			)
+			return t.periodicRunFinishedCheck(finishedCheckCtx)
 		})
 	}
 
 	return eg.Wait()
 }
 
-func (t *FilesystemTraverser) periodicRunFinishedCheck(
-	ctx context.Context,
-	finishedCheck func(context.Context) error,
-) error {
+func (t *FilesystemTraverser) periodicRunFinishedCheck(ctx context.Context) error {
 
 	ticker := time.NewTicker(t.finishedCheckInterval)
 	defer ticker.Stop()
 
-	if err := t.checkFinished(ctx, finishedCheck); err != nil {
+	if err := t.checkFinished(ctx); err != nil {
 		return err
 	}
 
@@ -176,19 +172,16 @@ func (t *FilesystemTraverser) periodicRunFinishedCheck(
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := t.checkFinished(ctx, finishedCheck); err != nil {
+			if err := t.checkFinished(ctx); err != nil {
 				return err
 			}
 		}
 	}
 }
 
-func (t *FilesystemTraverser) checkFinished(
-	ctx context.Context,
-	finishedCheck func(context.Context) error,
-) error {
+func (t *FilesystemTraverser) checkFinished(ctx context.Context) error {
 
-	if err := finishedCheck(ctx); err != nil {
+	if err := t.finishedCheck(ctx); err != nil {
 		if ctx.Err() != nil {
 			return nil
 		}
@@ -258,10 +251,7 @@ func (t *FilesystemTraverser) directoryScheduler(ctx context.Context) error {
 	}
 }
 
-func (t *FilesystemTraverser) directoryLister(
-	ctx context.Context,
-	onListedNodes OnListedNodesFunc,
-) error {
+func (t *FilesystemTraverser) directoryLister(ctx context.Context) error {
 
 	filesystemLister, err := t.filesystemListerFactory.CreateLister(
 		ctx,
@@ -293,7 +283,7 @@ func (t *FilesystemTraverser) directoryLister(
 				return nil
 			}
 
-			err := t.listNode(ctx, filesystemLister, node, onListedNodes)
+			err := t.listNode(ctx, filesystemLister, node)
 			if err != nil {
 				return err
 			}
@@ -311,7 +301,6 @@ func (t *FilesystemTraverser) listNode(
 	ctx context.Context,
 	filesystemLister listers.FilesystemLister,
 	node *storage.NodeQueueEntry,
-	onListedNodes OnListedNodesFunc,
 ) error {
 
 	cookie := node.Cookie
@@ -326,7 +315,7 @@ func (t *FilesystemTraverser) listNode(
 		}
 
 		if len(children) > 0 {
-			err = onListedNodes(ctx, children, filesystemLister)
+			err = t.onListedNodes(ctx, children, filesystemLister)
 			if err != nil {
 				return err
 			}

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal.go
@@ -108,7 +108,6 @@ func NewFilesystemTraverser(
 }
 
 func (t *FilesystemTraverser) Traverse(ctx context.Context) error {
-
 	ctx = logging.WithFields(
 		ctx,
 		logging.Bool("FILESYSTEM_TRAVERSAL_IN_PROGRESS", true),
@@ -159,7 +158,6 @@ func (t *FilesystemTraverser) Traverse(ctx context.Context) error {
 }
 
 func (t *FilesystemTraverser) periodicRunFinishedCheck(ctx context.Context) error {
-
 	ticker := time.NewTicker(t.finishedCheckInterval)
 	defer ticker.Stop()
 

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/traversal/traversal_test.go
@@ -147,6 +147,23 @@ func (f *fixture) getFilesAfterTraversal(
 
 	workersCount := uint32(10)
 	selectNodesToListLimit := uint64(10)
+	actualNodeNames := []string{}
+	nodesMutex := &sync.Mutex{}
+	onListedNodes := func(
+		ctx context.Context,
+		nodes []nfs.Node,
+		_ listers.FilesystemLister,
+	) error {
+
+		nodesMutex.Lock()
+		defer nodesMutex.Unlock()
+		for _, node := range nodes {
+			actualNodeNames = append(actualNodeNames, node.Name)
+		}
+
+		return nil
+	}
+
 	traverser, err := NewFilesystemTraverser(
 		fmt.Sprintf("snapshot_%v", filesystemID),
 		filesystemID,
@@ -162,6 +179,8 @@ func (f *fixture) getFilesAfterTraversal(
 		func(ctx context.Context) error {
 			return nil
 		},
+		onListedNodes,
+		checkContextNotCancelled,
 		&traversal_config.FilesystemTraversalConfig{
 			TraversalWorkersCount:  &workersCount,
 			SelectNodesToListLimit: &selectNodesToListLimit,
@@ -171,26 +190,7 @@ func (f *fixture) getFilesAfterTraversal(
 	)
 	require.NoError(t, err)
 
-	actualNodeNames := []string{}
-	nodesMutex := &sync.Mutex{}
-	err = traverser.Traverse(
-		f.ctx,
-		func(
-			ctx context.Context,
-			nodes []nfs.Node,
-			_ listers.FilesystemLister,
-		) error {
-
-			nodesMutex.Lock()
-			defer nodesMutex.Unlock()
-			for _, node := range nodes {
-				actualNodeNames = append(actualNodeNames, node.Name)
-			}
-
-			return nil
-		},
-		checkContextNotCancelled,
-	)
+	err = traverser.Traverse(f.ctx)
 	require.NoError(t, err)
 
 	return actualNodeNames
@@ -290,6 +290,36 @@ func TestTraversalFinishedCheckError(t *testing.T) {
 	workersCount := uint32(2)
 	selectNodesToListLimit := uint64(100)
 	finishedCheckInterval := "1ms"
+	expectedError := task_errors.NewNonRetriableErrorf("finished check error")
+	listingCountToInterrupt := 2
+	listingCount := 0
+	listingCountMutex := &sync.Mutex{}
+	listingCountReached := make(chan int, 1)
+	onListedNodes := func(
+		ctx context.Context,
+		nodes []nfs.Node,
+		_ listers.FilesystemLister,
+	) error {
+
+		listingCountMutex.Lock()
+		listingCount++
+		if listingCount == listingCountToInterrupt {
+			listingCountReached <- listingCount
+		}
+		listingCountMutex.Unlock()
+
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}
+	finishedCheck := func(ctx context.Context) error {
+		select {
+		case <-listingCountReached:
+			return expectedError
+		default:
+			return ctx.Err()
+		}
+	}
+
 	traverser, err := NewFilesystemTraverser(
 		fmt.Sprintf("snapshot_%v", filesystemID),
 		filesystemID,
@@ -305,6 +335,8 @@ func TestTraversalFinishedCheckError(t *testing.T) {
 		func(ctx context.Context) error {
 			return nil
 		},
+		onListedNodes,
+		finishedCheck,
 		&traversal_config.FilesystemTraversalConfig{
 			TraversalWorkersCount:  &workersCount,
 			SelectNodesToListLimit: &selectNodesToListLimit,
@@ -315,39 +347,7 @@ func TestTraversalFinishedCheckError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	expectedError := task_errors.NewNonRetriableErrorf("finished check error")
-	listingCountToInterrupt := 2
-	listingCount := 0
-	listingCountMutex := &sync.Mutex{}
-	listingCountReached := make(chan int, 1)
-
-	err = traverser.Traverse(
-		fixture.ctx,
-		func(
-			ctx context.Context,
-			nodes []nfs.Node,
-			_ listers.FilesystemLister,
-		) error {
-
-			listingCountMutex.Lock()
-			listingCount++
-			if listingCount == listingCountToInterrupt {
-				listingCountReached <- listingCount
-			}
-			listingCountMutex.Unlock()
-
-			time.Sleep(10 * time.Millisecond)
-			return nil
-		},
-		func(ctx context.Context) error {
-			select {
-			case <-listingCountReached:
-				return expectedError
-			default:
-				return ctx.Err()
-			}
-		},
-	)
+	err = traverser.Traverse(fixture.ctx)
 	require.ErrorIs(t, err, expectedError)
 }
 
@@ -379,6 +379,15 @@ func TestTraversalShouldCloseSessionOnError(t *testing.T) {
 
 	workersCount := uint32(10)
 	selectNodesToListLimit := uint64(10)
+	expectedError := fmt.Errorf("some error")
+	onListedNodes := func(
+		ctx context.Context,
+		nodes []nfs.Node,
+		_ listers.FilesystemLister,
+	) error {
+		return expectedError
+	}
+
 	traverser, err := NewFilesystemTraverser(
 		fmt.Sprintf("snapshot_%v", filesystemID),
 		filesystemID,
@@ -394,6 +403,8 @@ func TestTraversalShouldCloseSessionOnError(t *testing.T) {
 		func(ctx context.Context) error {
 			return nil
 		},
+		onListedNodes,
+		checkContextNotCancelled,
 		&traversal_config.FilesystemTraversalConfig{
 			TraversalWorkersCount:  &workersCount,
 			SelectNodesToListLimit: &selectNodesToListLimit,
@@ -403,18 +414,7 @@ func TestTraversalShouldCloseSessionOnError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	expectedError := fmt.Errorf("some error")
-	err = traverser.Traverse(
-		fixture.ctx,
-		func(
-			ctx context.Context,
-			nodes []nfs.Node,
-			_ listers.FilesystemLister,
-		) error {
-			return expectedError
-		},
-		checkContextNotCancelled,
-	)
+	err = traverser.Traverse(fixture.ctx)
 	require.Error(t, err)
 	require.ErrorIs(t, err, expectedError)
 }
@@ -554,6 +554,14 @@ func TestTraversalFiltersInvalidNodeIDs(t *testing.T) {
 
 	listerMock.On("Close", mock.Anything).Return(nil)
 
+	onListedNodes := func(
+		ctx context.Context,
+		nodes []nfs.Node,
+		_ listers.FilesystemLister,
+	) error {
+		return nil
+	}
+
 	traverser, err := NewFilesystemTraverser(
 		snapshotID,
 		filesystemID,
@@ -563,23 +571,15 @@ func TestTraversalFiltersInvalidNodeIDs(t *testing.T) {
 		func(ctx context.Context) error {
 			return nil
 		},
+		onListedNodes,
+		nil,
 		config,
 		false, // rootNodeAlreadyScheduled
 		nfs.RootNodeID,
 	)
 	require.NoError(t, err)
 
-	err = traverser.Traverse(
-		ctx,
-		func(
-			ctx context.Context,
-			nodes []nfs.Node,
-			_ listers.FilesystemLister,
-		) error {
-			return nil
-		},
-		nil,
-	)
+	err = traverser.Traverse(ctx)
 	require.NoError(t, err)
 
 	storageMock.AssertExpectations(t)


### PR DESCRIPTION
### Notes
finishedCheck and onListedNodes are transfered across the code. Instead, make them members of traverse.

### Issue
#1559