### PR TITLE
[Blockstore] Fix crash in WriteBlocksLocal split service on sub-request error

### DIFF
--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -252,15 +252,6 @@ private:
         } else {
             promise.SetValue(std::move(response));
         }
-
-        if constexpr (TBlockStoreMethodTraits<TRequest>::IsLocalRequest()) {
-            if (hasError) {
-                // Cancel all sub requests in case of error.
-                for (auto& subRequest: SubRequests) {
-                    subRequest->Sglist.Close();
-                }
-            }
-        }
     }
 };
 

--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -169,7 +169,7 @@ private:
     const TVector<std::shared_ptr<TRequest>> SubRequests;
     TVector<TResponse> SubResponses;
     TPromise<TResponse> Promise = NewPromise<TResponse>();
-
+    std::shared_ptr<TRequest> Request;
     TAdaptiveLock Lock;
     size_t SubResponseReceived = 0;
 
@@ -179,9 +179,10 @@ public:
         const TVector<TBlockRange64>& subRanges,
         ui32 blockSize)
         : SubRequests(
-              CreateSubRequests(std::move(request), subRanges, blockSize))
+              CreateSubRequests(request, subRanges, blockSize))
     {
         SubResponses.resize(SubRequests.size());
+        Request = std::move(request);
     }
 
     TFuture<TResponse> RunSubRequests(
@@ -251,6 +252,12 @@ private:
                          : MergeReadResponses(SubResponses));
         } else {
             promise.SetValue(std::move(response));
+        }
+        if constexpr (TBlockStoreMethodTraits<TRequest>::IsLocalRequest()) {
+            if (hasError) {
+                // Cancel all sub requests in case of error.
+                Request->Sglist.Close();
+            }
         }
     }
 };

--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -169,6 +169,7 @@ private:
     const TVector<std::shared_ptr<TRequest>> SubRequests;
     TVector<TResponse> SubResponses;
     TPromise<TResponse> Promise = NewPromise<TResponse>();
+
     std::shared_ptr<TRequest> Request;
     TAdaptiveLock Lock;
     size_t SubResponseReceived = 0;
@@ -253,6 +254,7 @@ private:
         } else {
             promise.SetValue(std::move(response));
         }
+
         if constexpr (TBlockStoreMethodTraits<TRequest>::IsLocalRequest()) {
             if (hasError) {
                 // Cancel all sub requests in case of error.

--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -166,47 +166,45 @@ class TCompositeRequest
           TCompositeRequest<TRequest, TResponse>>
 {
 private:
-    const TVector<std::shared_ptr<TRequest>> SubRequests;
+    std::shared_ptr<TRequest> Request;
     TVector<TResponse> SubResponses;
     TPromise<TResponse> Promise = NewPromise<TResponse>();
 
-    std::shared_ptr<TRequest> Request;
     TAdaptiveLock Lock;
     size_t SubResponseReceived = 0;
 
 public:
-    explicit TCompositeRequest(
-        std::shared_ptr<TRequest> request,
-        const TVector<TBlockRange64>& subRanges,
-        ui32 blockSize)
-        : SubRequests(
-              CreateSubRequests(request, subRanges, blockSize))
-    {
-        SubResponses.resize(SubRequests.size());
-        Request = std::move(request);
-    }
+    explicit TCompositeRequest(std::shared_ptr<TRequest> request)
+        : Request(std::move(request))
+    {}
 
     TFuture<TResponse> RunSubRequests(
         TCallContextPtr callContext,
-        IBlockStore* service)
+        IBlockStore* service,
+        const TVector<TBlockRange64>& subRanges,
+        ui32 blockSize)
     {
-        if (SubRequests.empty()) {
+        auto subRequests = CreateSubRequests(Request, subRanges, blockSize);
+
+        if (subRequests.empty()) {
             TResponse response;
             *response.MutableError() =
                 MakeError(E_CANCELLED, "failed to acquire sglist");
             return MakeFuture(std::move(response));
         }
 
+        SubResponses.resize(subRequests.size());
+
         // Acquire the future before subscribing to sub-request callbacks.
         // A sub-request can be completed synchronously and swapped with another
         // Promise inside the OnSubResponse() function.
         auto future = Promise.GetFuture();
 
-        for (size_t i = 0; i < SubRequests.size(); ++i) {
+        for (size_t i = 0; i < subRequests.size(); ++i) {
             auto subFuture = TBlockStoreAdapter::Execute(
                 service,
                 callContext,
-                SubRequests[i]);
+                subRequests[i]);
             subFuture.Subscribe(
                 [self = this->shared_from_this(), requestIndex = i]   //
                 (const TFuture<TResponse>& f)
@@ -237,7 +235,7 @@ private:
             }
 
             const bool isLastResponse =
-                SubResponseReceived == SubRequests.size();
+                SubResponseReceived == SubResponses.size();
 
             if (!isLastResponse && !hasError) {
                 return;
@@ -509,13 +507,13 @@ TFuture<TResponse> TSplitRequestService::ExecuteRequestWithSplit(
 
     auto compositeRequest =
         std::make_shared<TCompositeRequest<TRequest, TResponse>>(
-            std::move(request),
-            config->Split(range),
-            config->BlockSize);
+            std::move(request));
 
     return compositeRequest->RunSubRequests(
         std::move(callContext),
-        Service.get());
+        Service.get(),
+        config->Split(range),
+        config->BlockSize);
 }
 
 void TSplitRequestService::OnMountVolume(

--- a/cloud/blockstore/libs/service/split_request_service_ut.cpp
+++ b/cloud/blockstore/libs/service/split_request_service_ut.cpp
@@ -872,6 +872,60 @@ Y_UNIT_TEST_SUITE(TSplitRequestServiceTest)
             FormatError(result.GetError()));
     }
 
+    Y_UNIT_TEST(ShouldCancelSubRequestSglistsOnWriteBlocksLocalError)
+    {
+        TTestEnvironment env;
+        env.MountVolume();
+        TTestBlockStore& testBlockStore = *env.Storage;
+
+        const TString data = "aabbccddeeffgghhjjkk";
+        auto range =
+            TBlockRange64::WithLength(1, data.size() / DefaultBlockSize);
+
+        auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
+        env.SetupRequest(request, range, data);
+        auto future = env.SplitRequestService->WriteBlocksLocal(
+            MakeIntrusive<TCallContext>(),
+            std::move(request));
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            testBlockStore.WriteBlocksLocalPromises.size());
+        auto* firstWrite = testBlockStore.WriteBlocksLocalPromises.FindPtr(
+            TBlockRange64::WithLength(1, 5));
+        auto* secondWrite = testBlockStore.WriteBlocksLocalPromises.FindPtr(
+            TBlockRange64::WithLength(6, 5));
+        UNIT_ASSERT(firstWrite != nullptr);
+        UNIT_ASSERT(secondWrite != nullptr);
+
+        // Second sub-request sglist is valid before first error
+        {
+            auto guard = secondWrite->Request->Sglist.Acquire();
+            UNIT_ASSERT(guard);
+        }
+
+        // Complete first sub-request with error
+        {
+            NProto::TWriteBlocksLocalResponse response;
+            *response.MutableError() = MakeError(E_REJECTED);
+            firstWrite->Promise.SetValue(std::move(response));
+        }
+
+        const auto& result = future.GetValue(TDuration::MilliSeconds(1));
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            result.GetError().GetCode(),
+            FormatError(result.GetError()));
+
+        // Second sub-request sglist must be closed after parent sglist is
+        // closed
+        {
+            auto guard = secondWrite->Request->Sglist.Acquire();
+            UNIT_ASSERT(!guard);
+        }
+    }
+
     Y_UNIT_TEST(ShouldReplyErrorWithoutMount)
     {
         TTestEnvironment env;


### PR DESCRIPTION

https://pastebin.com/raw/fvqacbD6

In the split request service, WriteBlocksLocal requests were crashing on sub-request error, the sglist of the original request became null after being passed into CreateSubRequests, and calling Close() in the loop over sub-requests caused a crash. Fixed by storing the original request and closing its sglist directly, which automatically closes all sub-request sglists via CreateDepender.

