### PR TITLE
feat: add actionlint check for github actions/workflows

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - runner_light
+    - runner_heavy

--- a/.github/actions/nebius_calculate_pr_matrix/action.yaml
+++ b/.github/actions/nebius_calculate_pr_matrix/action.yaml
@@ -10,6 +10,18 @@ outputs:
   matrix_include:
     description: "JSON for strategy.matrix (include)"
     value: ${{ steps.plan.outputs.matrix_include }}
+  matrix_include_asan:
+    description: "JSON for ASAN strategy.matrix (include)"
+    value: ${{ steps.plan.outputs.matrix_include_asan }}
+  matrix_include_tsan:
+    description: "JSON for TSAN strategy.matrix (include)"
+    value: ${{ steps.plan.outputs.matrix_include_tsan }}
+  matrix_include_msan:
+    description: "JSON for MSAN strategy.matrix (include)"
+    value: ${{ steps.plan.outputs.matrix_include_msan }}
+  matrix_include_ubsan:
+    description: "JSON for UBSAN strategy.matrix (include)"
+    value: ${{ steps.plan.outputs.matrix_include_ubsan }}
 
 runs:
   using: "composite"

--- a/.github/actions/nebius_runner_populate/action.yaml
+++ b/.github/actions/nebius_runner_populate/action.yaml
@@ -34,6 +34,9 @@ inputs:
     description: "Nebius CLI config.yaml content for SDK authentication"
 
 outputs:
+  RUNNING_VMS_COUNT:
+    value: ${{ steps.populate.outputs.RUNNING_VMS_COUNT }}
+    description: "running vms count"
   VMS_TO_CREATE:
     value: ${{ steps.populate.outputs.VMS_TO_CREATE }}
     description: "vms to create"
@@ -43,6 +46,9 @@ outputs:
   BROKEN_VMS_TO_REMOVE:
     value: ${{ steps.populate.outputs.BROKEN_VMS_TO_REMOVE }}
     description: "broken vms to remove"
+  DATE:
+    value: ${{ steps.populate.outputs.DATE }}
+    description: "schedule calculation timestamp"
 
 runs:
   using: composite

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -71,6 +71,9 @@ outputs:
   failed_tests:
     description: "List of failed tests"
     value: ${{ steps.check_test_results.outputs.failed_tests }}
+  test_failed:
+    description: "Whether tests failed"
+    value: ${{ steps.check_test_results.outputs.failed_tests }}
 
 runs:
   using: composite

--- a/.github/packer/scripts/github-release-tools.txt
+++ b/.github/packer/scripts/github-release-tools.txt
@@ -1,4 +1,5 @@
 action-validator==v0.9.0
+actionlint==v1.7.12
 shellcheck==v0.11.0
 shfmt==v3.13.1
 yq==v4.49.2

--- a/.github/packer/scripts/install-github-release-tools.sh
+++ b/.github/packer/scripts/install-github-release-tools.sh
@@ -6,6 +6,7 @@ INSTALL_CMD=${INSTALL_CMD:-/usr/bin/install}
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 TOOL_VERSIONS_FILE=${TOOL_VERSIONS_FILE:-"${SCRIPT_DIR}/github-release-tools.txt"}
 ACTION_VALIDATOR_VERSION=
+ACTIONLINT_VERSION=
 SHELLCHECK_VERSION=
 SHFMT_VERSION=
 YQ_VERSION=
@@ -54,6 +55,9 @@ load_tool_versions() {
             action-validator)
                 ACTION_VALIDATOR_VERSION=${version}
                 ;;
+            actionlint)
+                ACTIONLINT_VERSION=${version}
+                ;;
             shellcheck)
                 SHELLCHECK_VERSION=${version}
                 ;;
@@ -94,6 +98,9 @@ installed_tool_version() {
     case "${tool}" in
         action-validator)
             "${bin}" --version 2> /dev/null | awk '{print $2; exit}'
+            ;;
+        actionlint)
+            "${bin}" -version 2> /dev/null | awk '{print $1; exit}'
             ;;
         shellcheck)
             "${bin}" --version 2> /dev/null | awk -F': ' '/^version:/ {print $2; exit}'
@@ -163,6 +170,23 @@ install_action_validator() {
     "${INSTALL_DIR}/action-validator" --version
 }
 
+install_actionlint() {
+    local archive tmp_dir url version_without_v
+    require_tool_version actionlint "${ACTIONLINT_VERSION}"
+    version_without_v=${ACTIONLINT_VERSION#v}
+    archive="actionlint_${version_without_v}_linux_amd64.tar.gz"
+    url="https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/${archive}"
+    tmp_dir=$(mktemp -d)
+
+    ensure_install_dir
+    curl -fsSL -o "${tmp_dir}/${archive}" -L "${url}"
+    tar -xzf "${tmp_dir}/${archive}" -C "${tmp_dir}"
+    "${INSTALL_CMD}" -m 0755 "${tmp_dir}/actionlint" "${INSTALL_DIR}/actionlint"
+    rm -rf "${tmp_dir}"
+
+    "${INSTALL_DIR}/actionlint" -version
+}
+
 install_shfmt() {
     local url
     require_tool_version shfmt "${SHFMT_VERSION}"
@@ -206,6 +230,10 @@ install_tool() {
             version=${ACTION_VALIDATOR_VERSION}
             require_tool_version "${tool}" "${version}"
             ;;
+        actionlint)
+            version=${ACTIONLINT_VERSION}
+            require_tool_version "${tool}" "${version}"
+            ;;
         shellcheck)
             version=${SHELLCHECK_VERSION}
             require_tool_version "${tool}" "${version}"
@@ -238,6 +266,9 @@ install_tool() {
         action-validator)
             install_action_validator
             ;;
+        actionlint)
+            install_actionlint
+            ;;
         shellcheck)
             install_shellcheck
             ;;
@@ -251,7 +282,7 @@ install_tool() {
 }
 
 if [ "$#" -eq 0 ]; then
-    set -- action-validator shellcheck shfmt yq
+    set -- action-validator actionlint shellcheck shfmt yq
 fi
 
 load_tool_versions

--- a/.github/workflows/nightly-asan.yaml
+++ b/.github/workflows/nightly-asan.yaml
@@ -1,8 +1,8 @@
 name: Nightly build (asan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Nightly build (asan) (manual)')
-      || format('Nightly build (asan) (schedule)')
+      && 'Nightly build (asan) (manual)'
+      || 'Nightly build (asan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly-msan.yaml
+++ b/.github/workflows/nightly-msan.yaml
@@ -1,8 +1,8 @@
 name: Nightly build (msan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Nightly build (msan) (manual)')
-      || format('Nightly build (msan) (schedule)')
+      && 'Nightly build (msan) (manual)'
+      || 'Nightly build (msan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly-packer-build.yaml
+++ b/.github/workflows/nightly-packer-build.yaml
@@ -1,8 +1,8 @@
 name: Nightly Packer build
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Nightly Packer build (manual)')
-      || format('Nightly Packer build (schedule)')
+      && 'Nightly Packer build (manual)'
+      || 'Nightly Packer build (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly-tsan.yaml
+++ b/.github/workflows/nightly-tsan.yaml
@@ -1,8 +1,8 @@
 name: Nightly build (tsan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Nightly build (tsan) (manual)')
-      || format('Nightly build (tsan) (schedule)')
+      && 'Nightly build (tsan) (manual)'
+      || 'Nightly build (tsan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly-ubsan.yaml
+++ b/.github/workflows/nightly-ubsan.yaml
@@ -1,8 +1,8 @@
 name: Nightly build (ubsan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Nightly build (ubsan) (manual)')
-      || format('Nightly build (ubsan) (schedule)')
+      && 'Nightly build (ubsan) (manual)'
+      || 'Nightly build (ubsan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,11 +1,11 @@
 name: Nightly build
 run-name: |
   ${{ github.event_name == 'schedule'
-      && format('Nightly build (schedule)')
+      && 'Nightly build (schedule)'
       || (
             inputs.comment != ''
             && format('Nightly build (manual) (comment: {0})', inputs.comment)
-            || format('Nightly build (manual)')
+            || 'Nightly build (manual)'
           )
     }}
 on:

--- a/.github/workflows/on_demand_build_and_test.yaml
+++ b/.github/workflows/on_demand_build_and_test.yaml
@@ -47,6 +47,7 @@ on:
         default: "unittest"
         description: "type of tests to run"
         options:
+          - unittest
           - unittest,clang_tidy,gtest
           - py3test,py2test,pytest,flake8,black,py2_flake8
           - go_test,gofmt

--- a/.github/workflows/on_hybrid_build_and_test.yaml
+++ b/.github/workflows/on_hybrid_build_and_test.yaml
@@ -47,6 +47,7 @@ on:
         default: "unittest"
         description: "type of tests to run"
         options:
+          - unittest
           - unittest,clang_tidy,gtest
           - py3test,py2test,pytest,flake8,black,py2_flake8
           - go_test,gofmt

--- a/.github/workflows/orchestrator-heavy.yaml
+++ b/.github/workflows/orchestrator-heavy.yaml
@@ -1,5 +1,5 @@
 name: Orchestrator (heavy)
-run-name: ${{ format('Orchestrator (heavy)')  }}
+run-name: Orchestrator (heavy)
       
 on:
   # schedule:

--- a/.github/workflows/orchestrator-light.yaml
+++ b/.github/workflows/orchestrator-light.yaml
@@ -1,5 +1,5 @@
 name: Orchestrator (light)
-run-name: ${{ format('Orchestrator (light)')  }}
+run-name: Orchestrator (light)
       
 on:
   schedule:

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -449,10 +449,11 @@ jobs:
         shell: bash
         run: echo "HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
-      - name: install action-validator
-        run: bash .github/packer/scripts/install-github-release-tools.sh action-validator
+      - name: install workflow linters
+        run: bash .github/packer/scripts/install-github-release-tools.sh action-validator actionlint
 
       - name: Prepare s3
+        if: ${{ env.ACT != 'true' }}
         id: s3
         uses: ./.github/actions/s3cmd
         with:
@@ -467,15 +468,17 @@ jobs:
 
       - name: check workflows syntax
         id: lint
+        continue-on-error: true
         run: |
           set -x
-          export TMP_OUT=$(mktemp)
-          {
-              find .github/workflows .github/actions -type f \( -iname \*.yaml -o -iname \*.yml \) -print | while read -r path; do
+          TMP_OUT=$(mktemp)
+          status=0
+          while read -r path; do
+              {
                   echo "Checking $path"
-                  action-validator --verbose "$path"
-              done
-          } > "$TMP_OUT"
+                  action-validator --verbose "$path" || status=1
+              } >> "$TMP_OUT"
+          done < <(find .github/workflows .github/actions -type f \( -iname \*.yaml -o -iname \*.yml \) -print)
 
           echo "WORKFLOW_LINT=$(cat $TMP_OUT | awk -v ORS='\\n' 1)"
           cat $TMP_OUT >> "$GITHUB_STEP_SUMMARY"
@@ -483,27 +486,63 @@ jobs:
           echo "S3_WEBSITE_PREFIX=$TMP_OUT" | tee -a "$GITHUB_ENV" | tee -a "$GITHUB_OUTPUT"
           echo "OUTPUT_FILE=$TMP_OUT" | tee -a "$GITHUB_ENV" | tee -a "$GITHUB_OUTPUT"
           chmod 644 $TMP_OUT
+          exit "$status"
       - name: upload workflow lint results
-        if: ${{ always() }}
+        if: ${{ env.ACT != 'true' && always() }}
         id: upload-workflow-lint-to-s3
         run: |
           set -x
           aws s3 cp --acl public-read --follow-symlinks --no-progress "$OUTPUT_FILE" "$S3_BUCKET_PATH/workflow_lint/workflow-lint.txt"
+
+      - name: actionlint
+        id: actionlint
+        uses: ./.github/actions/lint_report
+        with:
+          title: "GitHub Actions actionlint"
+          tool: command
+          report_name: ga-workflows-actionlint
+          command: actionlint -config-file .github/actionlint.yml -shellcheck= -pyflakes=
+
       - name: comment on issue
         uses: actions/github-script@v9
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ env.ACT != 'true' && github.event_name == 'pull_request' && always() }}
         env:
-          STEP_OUTCOME: ${{ steps.lint.outcome }}
+          ACTION_VALIDATOR_OUTCOME: ${{ steps.lint.outcome }}
+          ACTIONLINT_EXIT_CODE: ${{ steps.actionlint.outputs.exit_code }}
         with:
           script: |
-            const outcome = process.env.STEP_OUTCOME;
-            const status_emoji = outcome == 'success' ? ':green_circle:' : ':red_circle:';
+            const actionValidatorStatus = process.env.ACTION_VALIDATOR_OUTCOME == 'success' ? ':green_circle:' : ':red_circle:';
+            const actionlintStatus = process.env.ACTIONLINT_EXIT_CODE == '0' ? ':green_circle:' : ':red_circle:';
+            const success = process.env.ACTION_VALIDATOR_OUTCOME == 'success' && process.env.ACTIONLINT_EXIT_CODE == '0';
+            const status_emoji = success ? ':green_circle:' : ':red_circle:';
+            const s3_path = process.env.S3_URL_PREFIX;
+            const comment =
+              'status: ' + status_emoji +
+              '\n\naction-validator - ' + actionValidatorStatus + ' [log](' + s3_path + '/workflow_lint/workflow-lint.txt)' +
+              '\nactionlint - ' + actionlintStatus + ' [log](' + s3_path + '/test_reports/ga-workflows-actionlint.log)';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'status: ' + status_emoji + ' [workflow lint result (s3)](' + process.env.S3_URL_PREFIX + '/workflow_lint/workflow-lint.txt)'
+              body: comment
             })
+
+      - name: fail on workflow checks
+        if: ${{ always() }}
+        env:
+          ACTION_VALIDATOR_OUTCOME: ${{ steps.lint.outcome }}
+          ACTIONLINT_EXIT_CODE: ${{ steps.actionlint.outputs.exit_code }}
+        run: |
+          status=0
+          if [ "${ACTION_VALIDATOR_OUTCOME}" != "success" ]; then
+              echo "::error::action-validator failed"
+              status=1
+          fi
+          if [ "${ACTIONLINT_EXIT_CODE:-1}" != "0" ]; then
+              echo "::error::actionlint failed"
+              status=1
+          fi
+          exit "$status"
   create-build-and-test-target-var:
     needs:
       - check-trigger-label

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -53,12 +53,12 @@ on:
       max_vms_to_create:
         description: 'Max VMs to create'
         type: string
-        required: true
+        required: false
         default: "1"
       vms_ttl:
         description: 'VMs TTL (seconds)'
         type: string
-        required: true
+        required: false
         default: "86400"
       maximum_amount_of_vms_to_have:
         description: 'Maximum amount of VMs to have'
@@ -73,12 +73,12 @@ on:
       flavor:
         description: 'Runner flavor'
         type: string
-        required: true
+        required: false
         default: 'light'
       provision_mode:
         description: 'Provision mode (if set to initial it will use ubuntu-latest image)'
         type: string
-        required: true
+        required: false
         default: 'regular'
       loop:
         description: 'Loop the action'


### PR DESCRIPTION
Run `actionlint` from the PR GitHub Actions workflow and publish its log through the existing lint report/S3 path.

Pin actionlint in the GitHub release tool installer, add runner label config, and declare missing composite action outputs so actionlint can validate the workflows cleanly.