### PR TITLE
[Filestore] add dynamic backpressure between soft and hard limits (#2512)

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -793,4 +793,13 @@ message TStorageConfig
 
     // If this flag is on, new filesystems are created with CompressNodeRef.
     optional bool EnableNodeRefCompression = 504;
+
+    // Feature flag and soft thresholds for backpressure throttling.
+    optional bool EnableSoftBackpressure = 505;
+    optional uint32 FlushThresholdForBackpressureSoft = 506;
+    optional uint32 CleanupThresholdForBackpressureSoft = 507;
+    optional uint32 CompactionThresholdForBackpressureSoft = 508;
+    optional uint64 FlushBytesThresholdForBackpressureSoft = 509;
+    optional uint64 FlushBytesItemCountThresholdForBackpressureSoft = 510;
+    optional uint64 CollectGarbageThresholdForBackpressureSoft = 511;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -795,7 +795,7 @@ message TStorageConfig
     optional bool EnableNodeRefCompression = 504;
 
     // Feature flag and soft thresholds for backpressure throttling.
-    optional bool EnableSoftBackpressure = 505;
+    optional bool SoftBackpressureEnabled = 505;
     optional uint32 FlushThresholdForBackpressureSoft = 506;
     optional uint32 CleanupThresholdForBackpressureSoft = 507;
     optional uint32 CompactionThresholdForBackpressureSoft = 508;

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -356,7 +356,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
                                                                                \
     xxx(EnableNodeRefCompression,               bool,   false                 )\
                                                                                \
-    xxx(EnableSoftBackpressure,                 bool,   false                 )\
+    xxx(SoftBackpressureEnabled,                bool,   false                 )\
     xxx(FlushThresholdForBackpressureSoft,             ui32,    32_MB         )\
     xxx(CleanupThresholdForBackpressureSoft,           ui32,    8192          )\
     xxx(CompactionThresholdForBackpressureSoft,        ui32,    50            )\

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -355,6 +355,15 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(FastShardServerPort,                    ui32,   0                     )\
                                                                                \
     xxx(EnableNodeRefCompression,               bool,   false                 )\
+                                                                               \
+    xxx(EnableSoftBackpressure,                 bool,   false                 )\
+    xxx(FlushThresholdForBackpressureSoft,             ui32,    32_MB         )\
+    xxx(CleanupThresholdForBackpressureSoft,           ui32,    8192          )\
+    xxx(CompactionThresholdForBackpressureSoft,        ui32,    50            )\
+    xxx(FlushBytesThresholdForBackpressureSoft,        ui64,    32_MB         )\
+    xxx(FlushBytesItemCountThresholdForBackpressureSoft,                       \
+                                                       ui64,    125'000       )\
+    xxx(CollectGarbageThresholdForBackpressureSoft,    ui64,    256_GB        )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -413,7 +413,7 @@ public:
 
     [[nodiscard]] bool GetEnableNodeRefCompression() const;
 
-    bool GetEnableSoftBackpressure() const;
+    bool GetSoftBackpressureEnabled() const;
     ui32 GetFlushThresholdForBackpressureSoft() const;
     ui32 GetCleanupThresholdForBackpressureSoft() const;
     ui32 GetCompactionThresholdForBackpressureSoft() const;

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -412,6 +412,14 @@ public:
     [[nodiscard]] ui32 GetFastShardServerPort() const;
 
     [[nodiscard]] bool GetEnableNodeRefCompression() const;
+
+    bool GetEnableSoftBackpressure() const;
+    ui32 GetFlushThresholdForBackpressureSoft() const;
+    ui32 GetCleanupThresholdForBackpressureSoft() const;
+    ui32 GetCompactionThresholdForBackpressureSoft() const;
+    ui64 GetFlushBytesThresholdForBackpressureSoft() const;
+    ui64 GetFlushBytesItemCountThresholdForBackpressureSoft() const;
+    ui64 GetCollectGarbageThresholdForBackpressureSoft() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/throttling_policy.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/throttling_policy.cpp
@@ -240,10 +240,10 @@ ui64 TThrottlingPolicy::CalculatePostponedWeight() const
 void TThrottlingPolicy::UpdateWriteCostMultiplierDueToBackpressure(
     double backpressure)
 {
-    const auto maxMultiplier = Max(
+    const double maxMultiplier = Max(
         Impl->Config.DefaultThresholds.MaxWriteCostMultiplier,
         1.0);
-    const auto clamped = Min(Max(backpressure, 0.0), 1.0);
+    const double clamped = Min(Max(backpressure, 0.0), 1.0);
 
     Impl->WriteCostMultiplier = 1.0 + (clamped * (maxMultiplier - 1.0));
 }

--- a/cloud/filestore/libs/storage/tablet/model/throttling_policy.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/throttling_policy.cpp
@@ -237,6 +237,17 @@ ui64 TThrottlingPolicy::CalculatePostponedWeight() const
     return Impl->PostponedWeight;
 }
 
+void TThrottlingPolicy::UpdateWriteCostMultiplierDueToBackpressure(
+    double backpressure)
+{
+    const auto maxMultiplier = Max(
+        Impl->Config.DefaultThresholds.MaxWriteCostMultiplier,
+        1.0);
+    const auto clamped = Min(Max(backpressure, 0.0), 1.0);
+
+    Impl->WriteCostMultiplier = 1.0 + (clamped * (maxMultiplier - 1.0));
+}
+
 double TThrottlingPolicy::GetWriteCostMultiplier() const
 {
     return Impl->WriteCostMultiplier;

--- a/cloud/filestore/libs/storage/tablet/model/throttling_policy.h
+++ b/cloud/filestore/libs/storage/tablet/model/throttling_policy.h
@@ -92,6 +92,7 @@ public:
     const TThrottlerConfig& GetConfig() const;
     ui32 GetVersion() const;
     ui64 CalculatePostponedWeight() const;
+    void UpdateWriteCostMultiplierDueToBackpressure(double backpressure);
     double GetWriteCostMultiplier() const;
     TDuration GetCurrentBoostBudget() const;
     double CalculateCurrentSpentBudgetShare(TInstant now) const;

--- a/cloud/filestore/libs/storage/tablet/model/throttling_policy_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/throttling_policy_ut.cpp
@@ -4,6 +4,8 @@
 
 #include <util/generic/size_literals.h>
 
+#include <utility>
+
 namespace NCloud::NFileStore::NStorage {
 
 namespace {
@@ -407,6 +409,40 @@ Y_UNIT_TEST_SUITE(TIndexTabletThrottlingPolicyTest)
         DO_TEST(tp, 30'319, 10'010'000, 1_GB, static_cast<ui32>(EOpType::Write));
         DO_TEST(tp, 0, 11'025'900, 1_GB, static_cast<ui32>(EOpType::Read));
         DO_TEST(tp, 0, 11'025'900, 1_GB, static_cast<ui32>(EOpType::Write));
+    }
+
+    Y_UNIT_TEST(WriteCostMultiplierDueToBackpressure)
+    {
+        const auto config = MakeConfig(
+            1_MB,             // maxReadBandwidth
+            1_MB,             // maxWriteBandwidth
+            10,               // maxReadIops
+            10,               // maxWriteIops
+            100,              // burstPercentage
+            0,                // boostTime
+            0,                // boostRefillTime
+            0,                // boostPercentage
+            1_GB,             // maxPostponedWeight
+            TDuration::Max(), // maxPostponedTime
+            5,                // maxWriteCostMultiplier
+            1                 // defaultPostponedRequestWeight
+        );
+        TThrottlingPolicy tp(config);
+
+        for (const auto& [backpressure, multiplier]: {
+                 std::pair<double, double>{0.0, 1.0},
+                 std::pair<double, double>{0.5, 3.0},
+                 std::pair<double, double>{1.0, 5.0},
+                 std::pair<double, double>{2.0, 5.0},
+                 std::pair<double, double>{-1.0, 1.0},
+             })
+        {
+            tp.UpdateWriteCostMultiplierDueToBackpressure(backpressure);
+            UNIT_ASSERT_DOUBLES_EQUAL(
+                multiplier,
+                tp.GetWriteCostMultiplier(),
+                1e-5);
+        }
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -23,6 +23,31 @@ using namespace NCloud::NStorage;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+double CalculateBackpressureFeature(
+    ui64 softLimit,
+    ui64 hardLimit,
+    ui64 value)
+{
+    if (value >= hardLimit) {
+        return 1.0;
+    }
+
+    if (softLimit >= hardLimit || value <= softLimit) {
+        return 0.0;
+    }
+
+    return static_cast<double>(value - softLimit) /
+        static_cast<double>(hardLimit - softLimit);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
 const TIndexTabletActor::TStateInfo TIndexTabletActor::States[STATE_MAX] = {
     { "Boot",   (IActor::TReceiveFunc)&TIndexTabletActor::StateBoot   },
     { "Init",   (IActor::TReceiveFunc)&TIndexTabletActor::StateInit   },
@@ -318,6 +343,22 @@ TThresholds TIndexTabletActor::BuildBackpressureThresholds() const
     };
 }
 
+TThresholds TIndexTabletActor::BuildBackpressureSoftThresholds() const
+{
+    return {
+        .Flush = Config->GetFlushThresholdForBackpressureSoft(),
+        .FlushBytes = Config->GetFlushBytesThresholdForBackpressureSoft(),
+        .FlushBytesItemCount =
+            Config->GetFlushBytesItemCountThresholdForBackpressureSoft(),
+        .CompactionScore =
+            ScaleCompactionThreshold(
+                Config->GetCompactionThresholdForBackpressureSoft()),
+        .CleanupScore = Config->GetCleanupThresholdForBackpressureSoft(),
+        .CollectGarbage =
+            Config->GetCollectGarbageThresholdForBackpressureSoft(),
+    };
+}
+
 TIndexTabletState::TBackpressureValues
 TIndexTabletActor::GetBackpressureValues() const
 {
@@ -333,6 +374,59 @@ TIndexTabletActor::GetBackpressureValues() const
         .CleanupScore = GetRangeToCleanup().Score,
         .CollectGarbage = GetGarbageQueueSize(),
     };
+}
+
+void TIndexTabletActor::UpdateWriteCostMultiplierDueToBackpressure()
+{
+    if (!Config->GetEnableSoftBackpressure()) {
+        AccessThrottlingPolicy().UpdateWriteCostMultiplierDueToBackpressure(0.0);
+        return;
+    }
+
+    const auto bpThresholds = BuildBackpressureThresholds();
+    const auto bpSoftThresholds = BuildBackpressureSoftThresholds();
+    const auto bpValues = GetBackpressureValues();
+
+    double backpressure = 0.0;
+    backpressure = Max(
+        backpressure,
+        CalculateBackpressureFeature(
+            bpSoftThresholds.Flush,
+            bpThresholds.Flush,
+            bpValues.Flush));
+    backpressure = Max(
+        backpressure,
+        CalculateBackpressureFeature(
+            bpSoftThresholds.FlushBytes,
+            bpThresholds.FlushBytes,
+            bpValues.FlushBytes));
+    backpressure = Max(
+        backpressure,
+        CalculateBackpressureFeature(
+            bpSoftThresholds.FlushBytesItemCount,
+            bpThresholds.FlushBytesItemCount,
+            bpValues.FlushBytesItemCount));
+    backpressure = Max(
+        backpressure,
+        CalculateBackpressureFeature(
+            bpSoftThresholds.CompactionScore,
+            bpThresholds.CompactionScore,
+            bpValues.CompactionScore));
+    backpressure = Max(
+        backpressure,
+        CalculateBackpressureFeature(
+            bpSoftThresholds.CleanupScore,
+            bpThresholds.CleanupScore,
+            bpValues.CleanupScore));
+    backpressure = Max(
+        backpressure,
+        CalculateBackpressureFeature(
+            bpSoftThresholds.CollectGarbage,
+            bpThresholds.CollectGarbage,
+            bpValues.CollectGarbage));
+
+    AccessThrottlingPolicy().UpdateWriteCostMultiplierDueToBackpressure(
+        backpressure);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -378,7 +378,7 @@ TIndexTabletActor::GetBackpressureValues() const
 
 void TIndexTabletActor::UpdateWriteCostMultiplierDueToBackpressure()
 {
-    if (!Config->GetEnableSoftBackpressure()) {
+    if (!Config->GetSoftBackpressureEnabled()) {
         AccessThrottlingPolicy().UpdateWriteCostMultiplierDueToBackpressure(0.0);
         return;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -434,9 +434,11 @@ private:
         const NProto::TSessionEvent& event);
 
     TBackpressureThresholds BuildBackpressureThresholds() const;
+    TBackpressureThresholds BuildBackpressureSoftThresholds() const;
     TBackpressureValues GetBackpressureValues() const;
 
     void ResetThrottlingPolicy();
+    void UpdateWriteCostMultiplierDueToBackpressure();
 
     void ExecuteTx_AddBlob_Write(
         const NActors::TActorContext& ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -80,7 +80,7 @@ void TIndexTabletActor::HandleUpdateLeakyBucketCounters(
     const TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters::TPtr& /*ev*/,
     const NActors::TActorContext& ctx)
 {
-    // update write cost mulitplier for metrics
+    // update write cost multiplier for metrics
     UpdateWriteCostMultiplierDueToBackpressure();
 
     const ui64 currentRate = std::ceil(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -80,6 +80,9 @@ void TIndexTabletActor::HandleUpdateLeakyBucketCounters(
     const TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters::TPtr& /*ev*/,
     const NActors::TActorContext& ctx)
 {
+    // update write cost mulitplier for metrics
+    UpdateWriteCostMultiplierDueToBackpressure();
+
     const ui64 currentRate = std::ceil(
         GetThrottlingPolicy().CalculateCurrentSpentBudgetShare(ctx.Now()) * 100);
 
@@ -119,6 +122,9 @@ NProto::TError TIndexTabletActor::Throttle(
     static const auto err = MakeError(E_FS_THROTTLED, "Throttled");
 
     auto* msg = ev->Get();
+
+    // recalculate write cost multiplier before making throttling decision
+    UpdateWriteCostMultiplierDueToBackpressure();
 
     const auto requestInfo = BuildRequestInfo(
         *msg,

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2593,6 +2593,88 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
     }
 
+    TABLET_TEST_16K(ShouldThrottleWritesDueToSoftBackpressureIfEnabled)
+    {
+        const auto block = tabletConfig.BlockSize;
+
+        auto runTest = [&] (bool softBackpressureEnabled) {
+            NProto::TStorageConfig storageConfig;
+            storageConfig.SetThrottlingEnabled(true);
+            storageConfig.SetMultipleStageRequestThrottlingEnabled(true);
+            if (softBackpressureEnabled) {
+                storageConfig.SetEnableSoftBackpressure(true);
+            }
+            storageConfig.SetFlushThresholdForBackpressureSoft(block);
+            storageConfig.SetFlushThresholdForBackpressure(3 * block);
+
+            TTestEnv env({}, storageConfig);
+
+            ui32 nodeIdx = env.AddDynamicNode();
+            ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+            TIndexTabletClient tablet(
+                env.GetRuntime(),
+                nodeIdx,
+                tabletId,
+                tabletConfig);
+            tablet.InitSession("client", "session");
+
+            TFileSystemConfig config = tabletConfig;
+            config.PerformanceProfile.ThrottlingEnabled = true;
+            config.PerformanceProfile.MaxReadIops = 20;
+            config.PerformanceProfile.MaxWriteIops = 20;
+            config.PerformanceProfile.MaxReadBandwidth = block * 4;
+            config.PerformanceProfile.MaxWriteBandwidth = block * 4;
+            config.PerformanceProfile.MaxPostponedWeight = 1; // reject delayed writes
+            config.PerformanceProfile.MaxWriteCostMultiplier = 5;
+            config.PerformanceProfile.MaxPostponedTime =
+                TDuration::Seconds(25).MilliSeconds();
+            config.PerformanceProfile.MaxPostponedCount = 64;
+            config.PerformanceProfile.BurstPercentage = 100;
+            config.PerformanceProfile.DefaultPostponedRequestWeight = 1_KB;
+            tablet.UpdateConfig(config);
+
+            auto id = CreateNode(
+                tablet,
+                TCreateNodeArgs::File(RootNodeId, "test"));
+            ui64 handle = CreateHandle(tablet, id);
+
+            tablet.SendWriteDataRequest(handle, 0, block, 'a');
+            tablet.AssertWriteDataQuickResponse(S_OK);
+
+            tablet.SendWriteDataRequest(handle, block, block, 'b');
+            tablet.AssertWriteDataQuickResponse(S_OK);
+
+            // quota: 4 blocks,
+            // we added 2 blocks
+            // with backpressure our multiplier will increase to 3 and won't fit
+            tablet.SendWriteDataRequest(handle, 2 * block, block, 'c');
+            tablet.AssertWriteDataQuickResponse(
+                softBackpressureEnabled ? E_FS_THROTTLED : S_OK);
+
+            // in case we were throttled, disable throttling and write the new block
+            if (softBackpressureEnabled) {
+                auto request = tablet.CreateWriteDataRequest(
+                    handle,
+                    2 * block,
+                    block,
+                    'c');
+                request->Record.MutableHeaders()->SetThrottlingDisabled(true);
+                tablet.SendRequest(std::move(request));
+                tablet.AssertWriteDataQuickResponse(S_OK);
+            }
+
+            // check that in both cases we reject next write
+            tablet.SendWriteDataRequest(handle, 3 * block, block, 'd');
+            tablet.AssertWriteDataQuickResponse(E_REJECTED);
+
+            tablet.DestroyHandle(handle);
+        };
+
+        runTest(false);
+        runTest(true);
+    }
+
     TABLET_TEST_16K(ShouldRejectWritesDueToBackpressure)
     {
         const auto block = tabletConfig.BlockSize;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2593,86 +2593,93 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
     }
 
+    void DoTestSoftBackpressureWriteThrottling(
+        const TFileSystemConfig& tabletConfig,
+        bool softBackpressureEnabled)
+    {
+        const ui32 block = tabletConfig.BlockSize;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetThrottlingEnabled(true);
+        storageConfig.SetMultipleStageRequestThrottlingEnabled(true);
+        if (softBackpressureEnabled) {
+            storageConfig.SetSoftBackpressureEnabled(true);
+        }
+        storageConfig.SetFlushThresholdForBackpressureSoft(block);
+        storageConfig.SetFlushThresholdForBackpressure(3 * block);
+
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        TFileSystemConfig config = tabletConfig;
+        config.PerformanceProfile.ThrottlingEnabled = true;
+        config.PerformanceProfile.MaxReadIops = 20;
+        config.PerformanceProfile.MaxWriteIops = 20;
+        config.PerformanceProfile.MaxReadBandwidth = block * 4;
+        config.PerformanceProfile.MaxWriteBandwidth = block * 4;
+        config.PerformanceProfile.MaxPostponedWeight = 1; // reject delayed writes
+        config.PerformanceProfile.MaxWriteCostMultiplier = 5;
+        config.PerformanceProfile.MaxPostponedTime =
+            TDuration::Seconds(25).MilliSeconds();
+        config.PerformanceProfile.MaxPostponedCount = 64;
+        config.PerformanceProfile.BurstPercentage = 100;
+        config.PerformanceProfile.DefaultPostponedRequestWeight = 1_KB;
+        tablet.UpdateConfig(config);
+
+        auto id = CreateNode(
+            tablet,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        tablet.SendWriteDataRequest(handle, 0, block, 'a');
+        tablet.AssertWriteDataQuickResponse(S_OK);
+
+        tablet.SendWriteDataRequest(handle, block, block, 'b');
+        tablet.AssertWriteDataQuickResponse(S_OK);
+
+        // quota: 4 blocks,
+        // we added 2 blocks
+        // with backpressure our multiplier will increase to 3 and won't fit
+        tablet.SendWriteDataRequest(handle, 2 * block, block, 'c');
+        tablet.AssertWriteDataQuickResponse(
+            softBackpressureEnabled ? E_FS_THROTTLED : S_OK);
+
+        // in case we were throttled, disable throttling and write the new block
+        if (softBackpressureEnabled) {
+            auto request = tablet.CreateWriteDataRequest(
+                handle,
+                2 * block,
+                block,
+                'c');
+            request->Record.MutableHeaders()->SetThrottlingDisabled(true);
+            tablet.SendRequest(std::move(request));
+            tablet.AssertWriteDataQuickResponse(S_OK);
+        }
+
+        // check that in both cases we reject next write
+        tablet.SendWriteDataRequest(handle, 3 * block, block, 'd');
+        tablet.AssertWriteDataQuickResponse(E_REJECTED);
+
+        tablet.DestroyHandle(handle);
+    }
+
+    TABLET_TEST_16K(ShouldNotThrottleWritesDueToSoftBackpressureIfDisabled)
+    {
+        DoTestSoftBackpressureWriteThrottling(tabletConfig, false);
+    }
+
     TABLET_TEST_16K(ShouldThrottleWritesDueToSoftBackpressureIfEnabled)
     {
-        const auto block = tabletConfig.BlockSize;
-
-        auto runTest = [&] (bool softBackpressureEnabled) {
-            NProto::TStorageConfig storageConfig;
-            storageConfig.SetThrottlingEnabled(true);
-            storageConfig.SetMultipleStageRequestThrottlingEnabled(true);
-            if (softBackpressureEnabled) {
-                storageConfig.SetEnableSoftBackpressure(true);
-            }
-            storageConfig.SetFlushThresholdForBackpressureSoft(block);
-            storageConfig.SetFlushThresholdForBackpressure(3 * block);
-
-            TTestEnv env({}, storageConfig);
-
-            ui32 nodeIdx = env.AddDynamicNode();
-            ui64 tabletId = env.BootIndexTablet(nodeIdx);
-
-            TIndexTabletClient tablet(
-                env.GetRuntime(),
-                nodeIdx,
-                tabletId,
-                tabletConfig);
-            tablet.InitSession("client", "session");
-
-            TFileSystemConfig config = tabletConfig;
-            config.PerformanceProfile.ThrottlingEnabled = true;
-            config.PerformanceProfile.MaxReadIops = 20;
-            config.PerformanceProfile.MaxWriteIops = 20;
-            config.PerformanceProfile.MaxReadBandwidth = block * 4;
-            config.PerformanceProfile.MaxWriteBandwidth = block * 4;
-            config.PerformanceProfile.MaxPostponedWeight = 1; // reject delayed writes
-            config.PerformanceProfile.MaxWriteCostMultiplier = 5;
-            config.PerformanceProfile.MaxPostponedTime =
-                TDuration::Seconds(25).MilliSeconds();
-            config.PerformanceProfile.MaxPostponedCount = 64;
-            config.PerformanceProfile.BurstPercentage = 100;
-            config.PerformanceProfile.DefaultPostponedRequestWeight = 1_KB;
-            tablet.UpdateConfig(config);
-
-            auto id = CreateNode(
-                tablet,
-                TCreateNodeArgs::File(RootNodeId, "test"));
-            ui64 handle = CreateHandle(tablet, id);
-
-            tablet.SendWriteDataRequest(handle, 0, block, 'a');
-            tablet.AssertWriteDataQuickResponse(S_OK);
-
-            tablet.SendWriteDataRequest(handle, block, block, 'b');
-            tablet.AssertWriteDataQuickResponse(S_OK);
-
-            // quota: 4 blocks,
-            // we added 2 blocks
-            // with backpressure our multiplier will increase to 3 and won't fit
-            tablet.SendWriteDataRequest(handle, 2 * block, block, 'c');
-            tablet.AssertWriteDataQuickResponse(
-                softBackpressureEnabled ? E_FS_THROTTLED : S_OK);
-
-            // in case we were throttled, disable throttling and write the new block
-            if (softBackpressureEnabled) {
-                auto request = tablet.CreateWriteDataRequest(
-                    handle,
-                    2 * block,
-                    block,
-                    'c');
-                request->Record.MutableHeaders()->SetThrottlingDisabled(true);
-                tablet.SendRequest(std::move(request));
-                tablet.AssertWriteDataQuickResponse(S_OK);
-            }
-
-            // check that in both cases we reject next write
-            tablet.SendWriteDataRequest(handle, 3 * block, block, 'd');
-            tablet.AssertWriteDataQuickResponse(E_REJECTED);
-
-            tablet.DestroyHandle(handle);
-        };
-
-        runTest(false);
-        runTest(true);
+        DoTestSoftBackpressureWriteThrottling(tabletConfig, true);
     }
 
     TABLET_TEST_16K(ShouldRejectWritesDueToBackpressure)

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_throttling.cpp
@@ -290,8 +290,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Throttling)
         Tick(TDuration::Seconds(5));
         AssertWriteDataResponse(S_OK);
 
-        // TODO: 6. Test backpressure effect (NBS-2278).
-        // TODO: 7. Test max count (NBS-2278).
+        // TODO: Test max count (NBS-2278).
     }
 
     Y_UNIT_TEST_F(ShouldThrottleMultipleStage, TTablet)


### PR DESCRIPTION
### Notes
* Add soft backpressure limits to the config with feature flag (1/4 of existing hard limits, like in blockstore)
* Adjust WriteCostMultiplier according to the position in [soft, high] range
* Add unit and integration tests

### Issue
https://github.com/ydb-platform/nbs/issues/2512
