### PR TITLE
issue-5894: fixing msan and ubsan errors in silk-based code

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client.cpp
@@ -4,6 +4,7 @@
 
 #include <silk/fibers/fiber.h>
 
+#include <util/generic/scope.h>
 #include <util/generic/string.h>
 
 #include <arpa/inet.h>
@@ -84,6 +85,10 @@ std::unique_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
     if (gai != 0) {
         return nullptr;
     }
+
+    Y_DEFER {
+        ::freeaddrinfo(res);
+    };
 
     for (addrinfo* ai = res; ai != nullptr; ai = ai->ai_next) {
         int fd = ::socket(

--- a/contrib/libs/silk/src/fibers/ya.make
+++ b/contrib/libs/silk/src/fibers/ya.make
@@ -6,6 +6,10 @@ LICENSE_TEXTS(${ARCADIA_ROOT}/contrib/libs/silk/LICENSE)
 
 CXXFLAGS(-std=c++20)
 
+IF (SANITIZER_TYPE == undefined)
+    CXXFLAGS(-fno-sanitize=function)
+ENDIF()
+
 PEERDIR(
     contrib/libs/silk/src/util
     contrib/libs/liburing


### PR DESCRIPTION
### Notes
* forgot to free `addrinfo` in `NFastShard::TClient::Connect`
* for some reason `-fsanitize=function` gets enabled for `contrib/libs/silk`, generates errors that are formally UB but in reality they are fine - I'll discuss it with silk authors

### Issue
https://github.com/ydb-platform/nbs/issues/5894
