### PR TITLE
[Filestore] impl ipc_stub fastshard

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/ipc/ipc_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/ipc/ipc_stub.cpp
@@ -1,5 +1,7 @@
 #include "ipc.h"
 
+#include <util/system/defaults.h>
+
 #include <cerrno>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {

--- a/cloud/filestore/libs/storage/fastshard/ipc/ipc_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/ipc/ipc_stub.cpp
@@ -1,0 +1,21 @@
+#include "ipc.h"
+
+#include <cerrno>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+int RecvAll(int fd, void* buf, size_t len)
+{
+    Y_UNUSED(fd, buf, len);
+    return EIO;
+}
+
+int SendAll(int fd, const void* buf, size_t len)
+{
+    Y_UNUSED(fd, buf, len);
+    return EIO;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/ipc/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/ipc/ya.make
@@ -1,11 +1,17 @@
 LIBRARY()
 
-SRCS(
-    ipc.cpp
-)
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    SRCS(
+        ipc.cpp
+    )
 
-PEERDIR(
-    contrib/libs/silk/src/fibers
-)
+    PEERDIR(
+        contrib/libs/silk/src/fibers
+    )
+ELSE()
+    SRCS(
+        ipc_stub.cpp
+    )
+ENDIF()
 
 END()


### PR DESCRIPTION
### Notes

Fix build with autocheck target `cloud/filestore/libs/storage/fastshard/ipc` without `contrib/silk` in Arcadia

```
$(SOURCE_ROOT)/cloud/filestore/libs/storage/fastshard/ipc/ipc.cpp:3:10: fatal error: 'silk/fibers/fiber.h' file not found
    3 | #include <silk/fibers/fiber.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

### Issue
Put links to the related issues here
