### PR TITLE
fix govet style err

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go
@@ -175,7 +175,9 @@ func TestCreateFilesystemSnapshot(t *testing.T) {
 
 	client, err := testcommon.NewClient(ctx)
 	require.NoError(t, err)
-	defer client.Close()
+	defer func() {
+		_ = client.Close()
+	}()
 
 	reqCtx := testcommon.GetRequestContext(t, ctx)
 	operation, err := client.CreateFilesystemSnapshot(
@@ -455,7 +457,7 @@ func TestFilesystemSnapshotHardlinks(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-	session.Close(ctx)
+	_ = session.Close(ctx)
 
 	checkCopyFilesystemThroughSnapshot(
 		t,

--- a/cloud/disk_manager/test/mocks/s3-quota-proxy/main.go
+++ b/cloud/disk_manager/test/mocks/s3-quota-proxy/main.go
@@ -38,8 +38,8 @@ type quotaReservation struct {
 	size         uint64
 }
 
-var quotaExceededError = errors.New("Quota limit exceeded")
-var unknownStorageClassError = errors.New("Unknown storage class")
+var errQuotaExceeded = errors.New("Quota limit exceeded")
+var errUnknownStorageClass = errors.New("Unknown storage class")
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -118,11 +118,11 @@ func (p *quotaProxy) reserve(
 			return nil, nil
 		}
 
-		return nil, unknownStorageClassError
+		return nil, errUnknownStorageClass
 	}
 
 	if size > quota {
-		return nil, quotaExceededError
+		return nil, errQuotaExceeded
 	}
 
 	p.quota[storageClass] -= size
@@ -183,7 +183,7 @@ func (p *quotaProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if errors.Is(err, quotaExceededError) {
+	if errors.Is(err, errQuotaExceeded) {
 		replyClientError(
 			w,
 			quotaErrCode,


### PR DESCRIPTION
### Notes

Fix govet style lint checks

cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_nemesis_test
```
$S/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go:458:15: "errcheck: unhandled error"
```

cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test
```
$S/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go:458:15: "errcheck: unhandled error"
```

cloud/disk_manager/test/mocks/s3-quota-proxy
```
$S/cloud/disk_manager/test/mocks/s3-quota-proxy/main.go:41:5: "ST1012: error var quotaExceededError should have name of the form errFoo"
$S/cloud/disk_manager/test/mocks/s3-quota-proxy/main.go:41:5: "ST1012: if you believe this report is false positive, please silence it with //nolint:st1012 comment"
$S/cloud/disk_manager/test/mocks/s3-quota-proxy/main.go:42:5: "ST1012: error var unknownStorageClassError should have name of the form errFoo"
$S/cloud/disk_manager/test/mocks/s3-quota-proxy/main.go:42:5: "ST1012: if you believe this report is false positive, please silence it with //nolint:st1012 comment"
```

### Issue
Put links to the related issues here
