### PR TITLE
issue-4961: Track session owner generation for CreateSession for diagnostics

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -56,6 +56,7 @@ private:
     bool ReadOnly;
     TString SessionId;
     TString SessionState;
+    ui64 OwnerGeneration = 0;
     NProto::TFileStore FileStore;
 
     ui64 TabletId = -1;
@@ -428,6 +429,7 @@ void TCreateSessionActor::HandleCreateSessionResponse(
     }
 
     SessionState = msg->Record.GetSessionState();
+    OwnerGeneration = msg->Record.GetOwnerGeneration();
     FileStore = msg->Record.GetFileStore();
 
     // Some of the features of the filestore are set not by the tablet but also
@@ -588,6 +590,7 @@ void TCreateSessionActor::Notify(
     response->SessionSeqNo = SeqNo;
     response->ReadOnly = ReadOnly;
     response->TabletId = TabletId;
+    response->OwnerGeneration = OwnerGeneration;
     response->FileStore = FileStore;
     response->RequestInfo = std::move(RequestInfo);
     response->Shutdown = shutdown;
@@ -846,14 +849,71 @@ void TStorageServiceActor::HandleSessionCreated(
     const auto* msg = ev->Get();
 
     auto* session = State->FindSession(msg->SessionId);
+    const TSessionInfo::TSubSessionInfo* subSession = nullptr;
+    if (session) {
+        subSession = session->FindSubSession(msg->SessionSeqNo);
+    }
+    const auto storedOwnerGeneration =
+        subSession ? subSession->OwnerGeneration : 0;
     if (SUCCEEDED(msg->GetStatus())) {
         // in case of vhost restart we don't know session id
         // so inevitably will create new actor
         auto actorId = ev->Sender;
+        if (session && storedOwnerGeneration && msg->OwnerGeneration) {
+            if (msg->OwnerGeneration < storedOwnerGeneration) {
+                LOG_WARN(
+                    ctx,
+                    TFileStoreComponents::SERVICE,
+                    "%s CreateSession returned stale session owner "
+                    "generation: stored %lu, notification %lu, sender %s",
+                    LogTag(
+                        msg->FileStore.GetFileSystemId(),
+                        msg->ClientId,
+                        msg->SessionId,
+                        msg->SessionSeqNo)
+                        .c_str(),
+                    storedOwnerGeneration,
+                    msg->OwnerGeneration,
+                    ToString(ev->Sender).c_str());
+            } else if (msg->OwnerGeneration > storedOwnerGeneration) {
+                LOG_INFO(
+                    ctx,
+                    TFileStoreComponents::SERVICE,
+                    "%s CreateSession returned newer session owner "
+                    "generation: stored %lu, notification %lu, sender %s",
+                    LogTag(
+                        msg->FileStore.GetFileSystemId(),
+                        msg->ClientId,
+                        msg->SessionId,
+                        msg->SessionSeqNo)
+                        .c_str(),
+                    storedOwnerGeneration,
+                    msg->OwnerGeneration,
+                    ToString(ev->Sender).c_str());
+            }
+        }
+
         if (session &&
             session->SessionActor &&
             session->SessionActor != ev->Sender)
         {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "%s CreateSession returned session actor mismatch: current "
+                "actor %s generation %lu, notification sender %s generation "
+                "%lu; keeping current actor and poisoning notification sender",
+                LogTag(
+                    msg->FileStore.GetFileSystemId(),
+                    msg->ClientId,
+                    msg->SessionId,
+                    msg->SessionSeqNo)
+                    .c_str(),
+                ToString(session->SessionActor).c_str(),
+                storedOwnerGeneration,
+                ToString(ev->Sender).c_str(),
+                msg->OwnerGeneration);
+
             ctx.Send(ev->Sender, new TEvents::TEvPoisonPill());
             actorId = session->SessionActor;
         }
@@ -888,6 +948,7 @@ void TStorageServiceActor::HandleSessionCreated(
                 mediaKind,
                 std::move(stats),
                 actorId,
+                msg->OwnerGeneration,
                 msg->TabletId);
 
             Y_ABORT_UNLESS(session);
@@ -895,7 +956,12 @@ void TStorageServiceActor::HandleSessionCreated(
             session->UpdateSessionState(
                 msg->SessionState,
                 msg->FileStore);
-            session->AddSubSession(msg->SessionSeqNo, msg->ReadOnly);
+            session->AddSubSession(
+                msg->SessionSeqNo,
+                msg->ReadOnly,
+                actorId == ev->Sender
+                    ? msg->OwnerGeneration
+                    : storedOwnerGeneration);
             session->SessionActor = actorId;
         }
     } else if (session) {

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -853,7 +853,7 @@ void TStorageServiceActor::HandleSessionCreated(
     if (session) {
         subSession = session->FindSubSession(msg->SessionSeqNo);
     }
-    const auto storedOwnerGeneration =
+    const ui64 storedOwnerGeneration =
         subSession ? subSession->OwnerGeneration : 0;
     if (SUCCEEDED(msg->GetStatus())) {
         // in case of vhost restart we don't know session id

--- a/cloud/filestore/libs/storage/service/service_private.h
+++ b/cloud/filestore/libs/storage/service/service_private.h
@@ -38,6 +38,7 @@ struct TEvServicePrivate
         ui64 SessionSeqNo = 0;
         TString SessionState;
         ui64 TabletId = 0;
+        ui64 OwnerGeneration = 0;
         NProto::TFileStore FileStore;
         TRequestInfoPtr RequestInfo;
         bool Shutdown = false;

--- a/cloud/filestore/libs/storage/service/service_state.cpp
+++ b/cloud/filestore/libs/storage/service/service_state.cpp
@@ -180,6 +180,7 @@ TSessionInfo* TStorageServiceState::CreateSession(
     NCloud::NProto::EStorageMediaKind mediaKind,
     IRequestStatsPtr requestStats,
     const TActorId& sessionActor,
+    ui64 ownerGeneration,
     ui64 tabletId)
 {
     TSessionInfo* sessionInfo;
@@ -205,7 +206,7 @@ TSessionInfo* TStorageServiceState::CreateSession(
         sessionInfo = it->second;
     }
 
-    sessionInfo->AddSubSession(seqNo, readOnly);
+    sessionInfo->AddSubSession(seqNo, readOnly, ownerGeneration);
 
     return sessionInfo;
 }

--- a/cloud/filestore/libs/storage/service/service_state.h
+++ b/cloud/filestore/libs/storage/service/service_state.h
@@ -310,6 +310,13 @@ using TShardStatePtr = TIntrusivePtr<TShardState>;
 struct TSessionInfo
     : public TIntrusiveListItem<TSessionInfo>
 {
+    struct TSubSessionInfo
+    {
+        bool ReadOnly = false;
+        TInstant LastPing;
+        ui64 OwnerGeneration = 0;
+    };
+
     TString ClientId;
     NProto::TFileStore FileStore;
     TString SessionId;
@@ -320,7 +327,7 @@ struct TSessionInfo
     NActors::TActorId SessionActor;
     ui64 TabletId = 0;
 
-    THashMap<ui64, std::pair<bool, TInstant>> SubSessions;
+    THashMap<ui64, TSubSessionInfo> SubSessions;
     ESessionCreateDestroyState CreateDestroyState =
         ESessionCreateDestroyState::STATE_NONE;
 
@@ -338,7 +345,7 @@ struct TSessionInfo
         info.SetSessionSeqNo(seqNo);
         auto it = SubSessions.find(seqNo);
         if (it != SubSessions.end()) {
-            info.SetReadOnly(it->second.first);
+            info.SetReadOnly(it->second.ReadOnly);
         }
     }
 
@@ -348,9 +355,15 @@ struct TSessionInfo
         FileStore = std::move(fileStore);
     }
 
-    void AddSubSession(ui64 seqNo, bool readOnly)
+    void AddSubSession(
+        ui64 seqNo,
+        bool readOnly,
+        ui64 ownerGeneration)
     {
-        SubSessions[seqNo] = std::make_pair(readOnly, TInstant::Now());
+        auto& subSession = SubSessions[seqNo];
+        subSession.ReadOnly = readOnly;
+        subSession.LastPing = TInstant::Now();
+        subSession.OwnerGeneration = ownerGeneration;
     }
 
     bool RemoveSubSession(ui64 seqNo)
@@ -364,10 +377,16 @@ struct TSessionInfo
         return SubSessions.count(seqNo) > 0;
     }
 
+    const TSubSessionInfo* FindSubSession(ui64 seqNo) const
+    {
+        auto it = SubSessions.find(seqNo);
+        return it != SubSessions.end() ? &it->second : nullptr;
+    }
+
     void UpdateSubSession(ui64 seqNo, TInstant now)
     {
         if (auto it = SubSessions.find(seqNo); it != SubSessions.end()) {
-            it->second.second = now;
+            it->second.LastPing = now;
         }
     }
 
@@ -467,6 +486,7 @@ public:
         NCloud::NProto::EStorageMediaKind mediaKind,
         IRequestStatsPtr requestStats,
         const NActors::TActorId& sessionActor,
+        ui64 ownerGeneration,
         ui64 tabletId);
 
     TSessionInfo* FindSession(

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -7,6 +7,7 @@
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
 #include <cloud/filestore/libs/storage/model/utils.h>
+#include <cloud/filestore/libs/storage/tablet/subsessions.h>
 #include <cloud/filestore/libs/storage/testlib/service_client.h>
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
@@ -904,6 +905,96 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         );
         UNIT_ASSERT_VALUES_UNEQUAL(headers.SessionId, headers3.SessionId);
 
+        service.DestroySession(headers);
+    }
+
+    Y_UNIT_TEST(ShouldPropagateSessionOwnerGeneration)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateFileStore("test", 1000);
+
+        struct TSessionCreatedNotification
+        {
+            ui64 SessionSeqNo;
+            bool ReadOnly;
+            ui64 OwnerGeneration;
+        };
+
+        TVector<TSessionCreatedNotification> notifications;
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            if (event->GetTypeRewrite() == TEvServicePrivate::EvSessionCreated)
+            {
+                const auto* msg =
+                    event->Get<TEvServicePrivate::TEvSessionCreated>();
+                if (SUCCEEDED(msg->GetStatus()) &&
+                    msg->ClientId == "client" &&
+                    msg->FileStore.GetFileSystemId() == "test")
+                {
+                    notifications.push_back({
+                        msg->SessionSeqNo,
+                        msg->ReadOnly,
+                        msg->OwnerGeneration});
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        auto headers = service.InitSession("test", "client");
+
+        THeaders roHeaders;
+        service.InitSession(
+            roHeaders,
+            "test",
+            "client",
+            "",     // checkpointId
+            true,   // restoreClientSession
+            1,
+            true);  // readOnly
+
+        THeaders rwHeaders;
+        service.InitSession(
+            rwHeaders,
+            "test",
+            "client",
+            "",     // checkpointId
+            true,   // restoreClientSession
+            1,
+            false);  // readOnly
+
+        UNIT_ASSERT_VALUES_EQUAL(3, notifications.size());
+
+        UNIT_ASSERT_VALUES_EQUAL(0, notifications[0].SessionSeqNo);
+        UNIT_ASSERT_VALUES_EQUAL(false, notifications[0].ReadOnly);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            ExtractSubSessionOwnerGeneration(notifications[0].OwnerGeneration));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, notifications[1].SessionSeqNo);
+        UNIT_ASSERT_VALUES_EQUAL(true, notifications[1].ReadOnly);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            ExtractSubSessionOwnerGeneration(notifications[1].OwnerGeneration));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, notifications[2].SessionSeqNo);
+        UNIT_ASSERT_VALUES_EQUAL(false, notifications[2].ReadOnly);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            ExtractSubSessionOwnerGeneration(notifications[2].OwnerGeneration));
+        UNIT_ASSERT_C(
+            notifications[1].OwnerGeneration < notifications[2].OwnerGeneration,
+            "roOwnerGeneration=" << notifications[1].OwnerGeneration
+                                 << ", rwOwnerGeneration="
+                                 << notifications[2].OwnerGeneration);
+
+        runtime.SetObserverFunc(TTestActorRuntime::DefaultObserverFunc);
+
+        service.DestroySession(rwHeaders);
         service.DestroySession(headers);
     }
 

--- a/cloud/filestore/libs/storage/tablet/session.h
+++ b/cloud/filestore/libs/storage/tablet/session.h
@@ -258,9 +258,14 @@ public:
     NActors::TActorId UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
-        const NActors::TActorId& owner)
+        const NActors::TActorId& owner,
+        ui32 tabletGeneration)
     {
-        auto result = SubSessions.UpdateSubSession(seqNo, readOnly, owner);
+        auto result = SubSessions.UpdateSubSession(
+            seqNo,
+            readOnly,
+            owner,
+            tabletGeneration);
         UpdateSeqNo();
         return result;
     }

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -11,7 +11,28 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr size_t MaxSubSessions = 2;
+constexpr ui64 SubSessionOwnerGenerationBits = 32;
+constexpr ui64 SubSessionOwnerGenerationMask =
+    (ui64(1) << SubSessionOwnerGenerationBits) - 1;
 
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ui64 MakeSubSessionOwnerGeneration(ui32 tabletGeneration, ui32 ownerGeneration)
+{
+    return (ui64(tabletGeneration) << SubSessionOwnerGenerationBits) |
+           ownerGeneration;
+}
+
+ui32 ExtractTabletGeneration(ui64 ownerGeneration)
+{
+    return static_cast<ui32>(ownerGeneration >> SubSessionOwnerGenerationBits);
+}
+
+ui32 ExtractSubSessionOwnerGeneration(ui64 ownerGeneration)
+{
+    return static_cast<ui32>(ownerGeneration & SubSessionOwnerGenerationMask);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -19,13 +40,18 @@ constexpr size_t MaxSubSessions = 2;
 NActors::TActorId TSubSessions::AddSubSession(
     ui64 seqNo,
     bool readOnly,
-    const NActors::TActorId& owner)
+    const NActors::TActorId& owner,
+    ui32 tabletGeneration)
 {
     MaxSeenSeqNo = std::max(MaxSeenSeqNo, seqNo);
     if (!readOnly) {
         MaxSeenRwSeqNo = std::max(MaxSeenRwSeqNo, seqNo);
     }
-    SubSessions.push_back({seqNo, readOnly, owner});
+    SubSessions.push_back({
+        seqNo,
+        readOnly,
+        owner,
+        MakeSubSessionOwnerGeneration(tabletGeneration, 1)});
     if (SubSessions.size() > MaxSubSessions) {
         auto loSeqNo = std::min_element(
             SubSessions.begin(),
@@ -43,7 +69,8 @@ NActors::TActorId TSubSessions::AddSubSession(
 NActors::TActorId TSubSessions::UpdateSubSession(
     ui64 seqNo,
     bool readOnly,
-    const NActors::TActorId& owner)
+    const NActors::TActorId& owner,
+    ui32 tabletGeneration)
 {
     MaxSeenSeqNo = std::max(MaxSeenSeqNo, seqNo);
     if (!readOnly) {
@@ -59,11 +86,15 @@ NActors::TActorId TSubSessions::UpdateSubSession(
         if (subsession->Owner != owner) {
             auto toKill = subsession->Owner;
             subsession->Owner = owner;
+            subsession->OwnerGeneration = MakeSubSessionOwnerGeneration(
+                tabletGeneration,
+                ExtractSubSessionOwnerGeneration(
+                    subsession->OwnerGeneration) + 1);
             return toKill;
         }
         return {};
     }
-    return AddSubSession(seqNo, readOnly, owner);
+    return AddSubSession(seqNo, readOnly, owner, tabletGeneration);
 }
 
 ui32 TSubSessions::DeleteSubSession(const NActors::TActorId& owner)

--- a/cloud/filestore/libs/storage/tablet/subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions.cpp
@@ -13,7 +13,7 @@ namespace {
 constexpr size_t MaxSubSessions = 2;
 constexpr ui64 SubSessionOwnerGenerationBits = 32;
 constexpr ui64 SubSessionOwnerGenerationMask =
-    (ui64(1) << SubSessionOwnerGenerationBits) - 1;
+    (1ULL << SubSessionOwnerGenerationBits) - 1;
 
 }   // namespace
 
@@ -21,7 +21,7 @@ constexpr ui64 SubSessionOwnerGenerationMask =
 
 ui64 MakeSubSessionOwnerGeneration(ui32 tabletGeneration, ui32 ownerGeneration)
 {
-    return (ui64(tabletGeneration) << SubSessionOwnerGenerationBits) |
+    return ((1ULL * tabletGeneration) << SubSessionOwnerGenerationBits) |
            ownerGeneration;
 }
 
@@ -47,11 +47,13 @@ NActors::TActorId TSubSessions::AddSubSession(
     if (!readOnly) {
         MaxSeenRwSeqNo = std::max(MaxSeenRwSeqNo, seqNo);
     }
-    SubSessions.push_back({
-        seqNo,
-        readOnly,
-        owner,
-        MakeSubSessionOwnerGeneration(tabletGeneration, 1)});
+    SubSessions.push_back(
+        {seqNo,
+         readOnly,
+         owner,
+         MakeSubSessionOwnerGeneration(
+             tabletGeneration,
+             1 /* ownerGeneration */)});
     if (SubSessions.size() > MaxSubSessions) {
         auto loSeqNo = std::min_element(
             SubSessions.begin(),

--- a/cloud/filestore/libs/storage/tablet/subsessions.h
+++ b/cloud/filestore/libs/storage/tablet/subsessions.h
@@ -18,7 +18,17 @@ struct TSubSession
     ui64 SeqNo;
     bool ReadOnly;
     NActors::TActorId Owner;
+    ui64 OwnerGeneration = 0;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+ui64 MakeSubSessionOwnerGeneration(
+    ui32 tabletGeneration,
+    ui32 ownerGeneration);
+
+ui32 ExtractTabletGeneration(ui64 ownerGeneration);
+ui32 ExtractSubSessionOwnerGeneration(ui64 ownerGeneration);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -37,12 +47,14 @@ public:
     NActors::TActorId AddSubSession(
         ui64 seqNo,
         bool readOnly,
-        const NActors::TActorId& owner);
+        const NActors::TActorId& owner,
+        ui32 tabletGeneration);
 
     NActors::TActorId UpdateSubSession(
         ui64 seqNo,
         bool readOnly,
-        const NActors::TActorId& owner);
+        const NActors::TActorId& owner,
+        ui32 tabletGeneration);
 
     ui32 DeleteSubSession(const NActors::TActorId& owner);
     ui32 DeleteSubSession(ui64 sessionSeqNo);

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -6,8 +6,6 @@ namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
 
-////////////////////////////////////////////////////////////////////////////////
-
 namespace {
 
 constexpr ui32 TabletGeneration = 42;

--- a/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/subsessions_ut.cpp
@@ -8,13 +8,25 @@ using namespace NActors;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace {
+
+constexpr ui32 TabletGeneration = 42;
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
 Y_UNIT_TEST_SUITE(TSubSessions)
 {
     Y_UNIT_TEST(ShouldAddSubSessions)
     {
         TSubSessions subsessions(0, 0);
 
-        subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
     }
 
@@ -22,12 +34,20 @@ Y_UNIT_TEST_SUITE(TSubSessions)
     {
         TSubSessions subsessions(0, 0);
 
-        subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenSeqNo());
         UNIT_ASSERT_VALUES_EQUAL(0, subsessions.GetMaxSeenRwSeqNo());
 
-        subsessions.UpdateSubSession(1, false, TActorId(1, 1));
+        subsessions.UpdateSubSession(
+            1,
+            false,
+            TActorId(1, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenSeqNo());
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetMaxSeenRwSeqNo());
@@ -41,7 +61,11 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         }
 
         {
-            subsessions.UpdateSubSession(2, true, TActorId(2, 1));
+            subsessions.UpdateSubSession(
+                2,
+                true,
+                TActorId(2, 1),
+                TabletGeneration);
             UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
             auto subsession = subsessions.GetSubSessionBySeqNo(2);
             UNIT_ASSERT_VALUES_EQUAL(true, subsession.has_value());
@@ -53,20 +77,88 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         }
     }
 
+    Y_UNIT_TEST(ShouldTrackOwnerGeneration)
+    {
+        TSubSessions subsessions(0, 0);
+
+        subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TabletGeneration);
+        {
+            auto subsession = subsessions.GetSubSessionBySeqNo(1);
+            UNIT_ASSERT(subsession);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TabletGeneration,
+                ExtractTabletGeneration(subsession->OwnerGeneration));
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                ExtractSubSessionOwnerGeneration(
+                    subsession->OwnerGeneration));
+        }
+
+        subsessions.UpdateSubSession(
+            1,
+            false,
+            TActorId(0, 1),
+            TabletGeneration);
+        {
+            auto subsession = subsessions.GetSubSessionBySeqNo(1);
+            UNIT_ASSERT(subsession);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TabletGeneration,
+                ExtractTabletGeneration(subsession->OwnerGeneration));
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                ExtractSubSessionOwnerGeneration(
+                    subsession->OwnerGeneration));
+        }
+
+        subsessions.UpdateSubSession(
+            1,
+            false,
+            TActorId(1, 1),
+            TabletGeneration);
+        {
+            auto subsession = subsessions.GetSubSessionBySeqNo(1);
+            UNIT_ASSERT(subsession);
+            UNIT_ASSERT_VALUES_EQUAL(
+                TabletGeneration,
+                ExtractTabletGeneration(subsession->OwnerGeneration));
+            UNIT_ASSERT_VALUES_EQUAL(
+                2,
+                ExtractSubSessionOwnerGeneration(
+                    subsession->OwnerGeneration));
+        }
+    }
+
     Y_UNIT_TEST(ShouldRemoveSubSessionWithLowestSeqNo)
     {
         TSubSessions subsessions(0, 0);
         TActorId ans;
 
-        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            false,
+            TActorId(1, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(3, true, TActorId(2, 1));
+        ans = subsessions.UpdateSubSession(
+            3,
+            true,
+            TActorId(2, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(0, 1), ans);
 
@@ -80,11 +172,19 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            true,
+            TActorId(1, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
@@ -104,11 +204,19 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(
+            1,
+            false,
+            TActorId(0, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            true,
+            TActorId(1, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
@@ -123,11 +231,19 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, false, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(
+            1,
+            false,
+            TActorId(0, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, true, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            true,
+            TActorId(1, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
@@ -142,11 +258,19 @@ Y_UNIT_TEST_SUITE(TSubSessions)
         TActorId ans;
         ui32 size = 0;
 
-        ans = subsessions.UpdateSubSession(1, true, TActorId(0, 1));
+        ans = subsessions.UpdateSubSession(
+            1,
+            true,
+            TActorId(0, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(1, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
-        ans = subsessions.UpdateSubSession(2, false, TActorId(1, 1));
+        ans = subsessions.UpdateSubSession(
+            2,
+            false,
+            TActorId(1, 1),
+            TabletGeneration);
         UNIT_ASSERT_VALUES_EQUAL(2, subsessions.GetSize());
         UNIT_ASSERT_VALUES_EQUAL(TActorId(), ans);
 
@@ -156,4 +280,3 @@ Y_UNIT_TEST_SUITE(TSubSessions)
 }
 
 }   // namespace NCloud::NFileStore::NStorage
-

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -296,7 +296,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 ctx);
             args.SessionInterrupted = true;
             if (toKill != owner) {
-                const auto subSession =
+                const auto* subSession =
                     session->SubSessions.GetSubSessionBySeqNo(seqNo);
                 if (subSession) {
                     args.OwnerGeneration = subSession->OwnerGeneration;
@@ -354,7 +354,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 readOnly,
                 owner,
                 ctx);
-            const auto subSession =
+            const auto* subSession =
                 session->SubSessions.GetSubSessionBySeqNo(seqNo);
             if (subSession) {
                 args.OwnerGeneration = subSession->OwnerGeneration;
@@ -403,7 +403,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
         readOnly,
         owner,
         sessionOptions);
-    const auto subSession =
+    const auto* subSession =
         newSession->SubSessions.GetSubSessionBySeqNo(seqNo);
     if (subSession) {
         args.OwnerGeneration = subSession->OwnerGeneration;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -296,7 +296,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 ctx);
             args.SessionInterrupted = true;
             if (toKill != owner) {
-                const auto* subSession =
+                const auto subSession =
                     session->SubSessions.GetSubSessionBySeqNo(seqNo);
                 if (subSession) {
                     args.OwnerGeneration = subSession->OwnerGeneration;
@@ -354,7 +354,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 readOnly,
                 owner,
                 ctx);
-            const auto* subSession =
+            const auto subSession =
                 session->SubSessions.GetSubSessionBySeqNo(seqNo);
             if (subSession) {
                 args.OwnerGeneration = subSession->OwnerGeneration;
@@ -403,7 +403,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
         readOnly,
         owner,
         sessionOptions);
-    const auto* subSession =
+    const auto subSession =
         newSession->SubSessions.GetSubSessionBySeqNo(seqNo);
     if (subSession) {
         args.OwnerGeneration = subSession->OwnerGeneration;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -296,6 +296,19 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 ctx);
             args.SessionInterrupted = true;
             if (toKill != owner) {
+                const auto subSession =
+                    session->SubSessions.GetSubSessionBySeqNo(seqNo);
+                if (subSession) {
+                    args.OwnerGeneration = subSession->OwnerGeneration;
+                } else {
+                    LOG_ERROR(ctx, TFileStoreComponents::TABLET,
+                        "%s CreateSession c:%s, s:%s, seqno:%lu recovered "
+                        "by session, but subsession was not found",
+                        LogTag.c_str(),
+                        clientId.c_str(),
+                        session->GetSessionId().c_str(),
+                        seqNo);
+                }
                 LOG_INFO(ctx, TFileStoreComponents::TABLET,
                     "%s CreateSession c:%s, s:%s, seqno:%lu recovered by session",
                     LogTag.c_str(),
@@ -341,6 +354,19 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
                 readOnly,
                 owner,
                 ctx);
+            const auto subSession =
+                session->SubSessions.GetSubSessionBySeqNo(seqNo);
+            if (subSession) {
+                args.OwnerGeneration = subSession->OwnerGeneration;
+            } else {
+                LOG_ERROR(ctx, TFileStoreComponents::TABLET,
+                    "%s CreateSession c:%s, s:%s, seqno:%lu recovered by "
+                    "client, but subsession was not found",
+                    LogTag.c_str(),
+                    clientId.c_str(),
+                    session->GetSessionId().c_str(),
+                    seqNo);
+            }
             args.SessionInterrupted = true;
 
             return;
@@ -367,7 +393,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
 
     auto sessionOptions = TSession::CreateSessionOptions(Config);
 
-    CreateSession(
+    auto* newSession = CreateSession(
         db,
         clientId,
         args.SessionId,
@@ -377,6 +403,19 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
         readOnly,
         owner,
         sessionOptions);
+    const auto subSession =
+        newSession->SubSessions.GetSubSessionBySeqNo(seqNo);
+    if (subSession) {
+        args.OwnerGeneration = subSession->OwnerGeneration;
+    } else {
+        LOG_ERROR(ctx, TFileStoreComponents::TABLET,
+            "%s CreateSession c:%s, s:%s, seqno:%lu created new session, "
+            "but subsession was not found",
+            LogTag.c_str(),
+            clientId.c_str(),
+            newSession->GetSessionId().c_str(),
+            seqNo);
+    }
 }
 
 void TIndexTabletActor::CompleteTx_CreateSession(
@@ -423,6 +462,7 @@ void TIndexTabletActor::CompleteTx_CreateSession(
     auto response = std::make_unique<TResponse>(args.Error);
     response->Record.SetSessionId(std::move(args.SessionId));
     response->Record.SetSessionState(session->GetSessionState());
+    response->Record.SetOwnerGeneration(args.OwnerGeneration);
     if (!args.Request.GetNoFileStoreInfo()) {
         auto& fileStore = *response->Record.MutableFileStore();
         Convert(GetFileSystem(), fileStore);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -728,6 +728,7 @@ void DumpSessions(
                     TABLEH() { out << "Recovery"; }
                     TABLEH() { out << "SeqNo"; }
                     TABLEH() { out << "ReadOnly"; }
+                    TABLEH() { out << "OwnerGeneration"; }
                     TABLEH() { out << "Owner"; }
                     TABLEH() { out << "Deadline"; }
                 }
@@ -750,6 +751,7 @@ void DumpSessions(
                         }
                         TABLED() { out << ss.SeqNo; }
                         TABLED() { out << (ss.ReadOnly ? "True" : "False"); }
+                        TABLED() { out << ss.OwnerGeneration; }
                         TABLED() { out << ToString(ss.Owner); }
                         TABLED() { out << session.InactivityDeadline.ToString(); }
                     }

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -190,7 +190,7 @@ TSession* TIndexTabletState::CreateSession(
     const NProto::TSessionOptions& sessionOptions)
 {
     auto session = std::make_unique<TSession>(proto, sessionOptions);
-    session->UpdateSubSession(seqNo, readOnly, owner);
+    session->UpdateSubSession(seqNo, readOnly, owner, GetGeneration());
 
     Impl->Sessions.PushBack(session.get());
     Impl->SessionById.emplace(session->GetSessionId(), session.get());
@@ -214,7 +214,11 @@ NActors::TActorId TIndexTabletState::RecoverSession(
     const TActorId& owner)
 {
     auto oldOwner =
-        session->UpdateSubSession(sessionSeqNo, readOnly, owner);
+        session->UpdateSubSession(
+            sessionSeqNo,
+            readOnly,
+            owner,
+            GetGeneration());
     if (oldOwner) {
         Impl->SessionByOwner.erase(oldOwner);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -538,6 +538,7 @@ struct TTxIndexTablet
 
         TString SessionId;
         bool SessionInterrupted = false;
+        ui64 OwnerGeneration = 0;
 
         TCreateSession(
                 TRequestInfoPtr requestInfo,
@@ -554,6 +555,7 @@ struct TTxIndexTablet
 
             SessionId.clear();
             SessionInterrupted = false;
+            OwnerGeneration = 0;
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_subsessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_subsessions.cpp
@@ -1,5 +1,7 @@
 #include "tablet.h"
 
+#include "subsessions.h"
+
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
 
@@ -40,6 +42,87 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_SubSessions)
         auto id2 = CreateNode(tclient2, TCreateNodeArgs::File(RootNodeId, "xxx"));
         CreateHandle(tclient2, id2);
         tclient2.UnlinkNode(RootNodeId, "xxx", false);
+    }
+
+    Y_UNIT_TEST(ShouldReturnOwnerGeneration)
+    {
+        TTestEnvConfig envCfg;
+        envCfg.DynamicNodes = 2;
+        TTestEnv env(envCfg);
+
+        ui32 nodeIdx1 = env.AddDynamicNode();
+        ui32 nodeIdx2 = env.AddDynamicNode();
+
+        ui64 tabletId = env.BootIndexTablet(nodeIdx1);
+
+        TIndexTabletClient tclient1(env.GetRuntime(), nodeIdx1, tabletId);
+        TIndexTabletClient tclient2(env.GetRuntime(), nodeIdx2, tabletId);
+
+        auto response = tclient1.InitSession(
+            "client1",
+            "session",
+            "",
+            1,
+            true);
+        const auto initialOwnerGeneration =
+            response->Record.GetOwnerGeneration();
+        const auto tabletGeneration =
+            ExtractTabletGeneration(initialOwnerGeneration);
+        UNIT_ASSERT(tabletGeneration);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            ExtractSubSessionOwnerGeneration(initialOwnerGeneration));
+
+        response = tclient2.InitSession(
+            "client1",
+            "session",
+            "",
+            1,
+            false);
+        const auto recoveredOwnerGeneration =
+            response->Record.GetOwnerGeneration();
+        UNIT_ASSERT_VALUES_EQUAL(
+            tabletGeneration,
+            ExtractTabletGeneration(recoveredOwnerGeneration));
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            ExtractSubSessionOwnerGeneration(recoveredOwnerGeneration));
+
+        response = tclient2.InitSession(
+            "client1",
+            "session",
+            "",
+            1,
+            false);
+        const auto repeatedOwnerGeneration =
+            response->Record.GetOwnerGeneration();
+        UNIT_ASSERT_VALUES_EQUAL(
+            recoveredOwnerGeneration,
+            repeatedOwnerGeneration);
+
+        tclient2.RebootTablet();
+
+        response = tclient2.InitSession(
+            "client1",
+            "session",
+            "",
+            1,
+            false);
+        const auto ownerGenerationAfterReboot =
+            response->Record.GetOwnerGeneration();
+        UNIT_ASSERT_C(
+            ownerGenerationAfterReboot > repeatedOwnerGeneration,
+            "ownerGenerationAfterReboot=" << ownerGenerationAfterReboot
+                << ", repeatedOwnerGeneration=" << repeatedOwnerGeneration);
+        UNIT_ASSERT_C(
+            ExtractTabletGeneration(ownerGenerationAfterReboot) >
+                tabletGeneration,
+            "tabletGenerationAfterReboot="
+                << ExtractTabletGeneration(ownerGenerationAfterReboot)
+                << ", tabletGeneration=" << tabletGeneration);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            ExtractSubSessionOwnerGeneration(ownerGenerationAfterReboot));
     }
 
     Y_UNIT_TEST(ShouldKeepSubSessionsIfAnotherRemoved)
@@ -260,4 +343,3 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_SubSessions)
 }
 
 }   // namespace NCloud::NFileStore::NStorage
-

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -69,6 +69,10 @@ message TCreateSessionResponse
 
     // Filestore description.
     NProto.TFileStore FileStore = 4;
+
+    // Tablet generation and owner generation
+    // for the accepted subsession owner.
+    uint64 OwnerGeneration = 5;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
Add tablet-side owner generation for subsessions and return it in CreateSession responses. The generation is initialized when a subsession owner is accepted and is incremented when the owner changes for the same session seqno.

The returned owner generation also includes the tablet generation in the high bits and the per-subsesson owner generation in the low bits. This makes the value monotonic across tablet restarts: even if the per-subsession counter starts from 1 again after a tablet reboot, the full generation still increases because the tablet generation has advanced.

Propagate this value through TCreateSessionActor to the storage service state. For now this does not change the existing actor replacement behavior: if the service receives a CreateSession notification from an actor different from the currently stored session actor, it still keeps the current actor and poisons the notification sender.

The generation is used only for diagnostics in this change. The service logs stale/newer CreateSession owner generations and actor mismatches, so we can observe whether delayed CreateSession notifications or owner ordering races happen before changing the service-side session model. 

This potential problem was found while implementing the initial plan from https://github.com/ydb-platform/nbs/issues/4961#issuecomment-4614804880 in PR https://github.com/ydb-platform/nbs/pull/6145#discussion_r3373425885.

Before changing the CreateSession actor replacement logic, we want to make sure that the current ordering assumptions are valid and that the change will not break migration/recovery scenarios. This PR adds per-subsession owner generation to CreateSession responses and propagates it to the service side, so we can detect stale or out-of-order CreateSession notifications and use this information later to keep tablet and service session state consistent.

### Issue
#4962 
