### PR TITLE
[Filestore] fix ydb static node_ids for tests

### DIFF
--- a/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
@@ -219,6 +219,7 @@ public:
 
         Ydb::Discovery::NodeRegistrationResult result;
         result.set_node_id(1001);
+        result.set_expire(Max<ui64>());
         result.set_scope_tablet_id(72057594037968897);
         result.set_scope_path_id(1);
 
@@ -227,12 +228,16 @@ public:
         staticNode->set_address("localhost");
         staticNode->set_host("localhost");
         staticNode->set_port(StaticNodeIcPort);
+        staticNode->set_resolve_host("localhost");
+        staticNode->set_address("localhost");
 
         auto* selfNode = result.add_nodes();
         selfNode->set_node_id(1001);
         selfNode->set_address("localhost");
         selfNode->set_host("localhost");
         selfNode->set_port(DynamicNodeIcPort);
+        selfNode->set_resolve_host("localhost");
+        selfNode->set_address("localhost");
 
         operation->mutable_result()->PackFrom(result);
 

--- a/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap_ut.cpp
@@ -196,11 +196,13 @@ class TFakeYdbDiscoveryService final
     : public Ydb::Discovery::V1::DiscoveryService::Service
 {
 private:
+    ui64 StaticNodeIcPort;
     ui64 DynamicNodeIcPort;
 
 public:
-    explicit TFakeYdbDiscoveryService(ui64 dynamicNodeIcPort)
-        : DynamicNodeIcPort(dynamicNodeIcPort)
+    TFakeYdbDiscoveryService(ui64 staticNodeIcPort, ui64 dynamicNodeIcPort)
+        : StaticNodeIcPort(staticNodeIcPort)
+        , DynamicNodeIcPort(dynamicNodeIcPort)
     {}
 
     grpc::Status NodeRegistration(
@@ -216,15 +218,21 @@ public:
         operation->set_status(Ydb::StatusIds::SUCCESS);
 
         Ydb::Discovery::NodeRegistrationResult result;
-        result.set_node_id(1);
+        result.set_node_id(1001);
         result.set_scope_tablet_id(72057594037968897);
         result.set_scope_path_id(1);
 
-        auto* node = result.add_nodes();
-        node->set_node_id(2);
-        node->set_address("localhost");
-        node->set_host("localhost");
-        node->set_port(DynamicNodeIcPort);
+        auto* staticNode = result.add_nodes();
+        staticNode->set_node_id(1);
+        staticNode->set_address("localhost");
+        staticNode->set_host("localhost");
+        staticNode->set_port(StaticNodeIcPort);
+
+        auto* selfNode = result.add_nodes();
+        selfNode->set_node_id(1001);
+        selfNode->set_address("localhost");
+        selfNode->set_host("localhost");
+        selfNode->set_port(DynamicNodeIcPort);
 
         operation->mutable_result()->PackFrom(result);
 
@@ -244,8 +252,8 @@ private:
     ui16 Port = 0;
 
 public:
-    TestYdbDiscoveryServer(ui64 dynamicNodeIcPort)
-        : Service(dynamicNodeIcPort)
+    TestYdbDiscoveryServer(ui64 staticNodeIcPort, ui64 dynamicNodeIcPort)
+        : Service(staticNodeIcPort, dynamicNodeIcPort)
     {}
 
     ~TestYdbDiscoveryServer()
@@ -292,7 +300,7 @@ Y_UNIT_TEST_SUITE(TBootstrapVhostTest)
         const auto staticNodeIcPort = PortManager.GetPort();
         const auto dynamicNodeIcPort = PortManager.GetPort();
 
-        TestYdbDiscoveryServer ydbDiscoveryServer(dynamicNodeIcPort);
+        TestYdbDiscoveryServer ydbDiscoveryServer(staticNodeIcPort, dynamicNodeIcPort);
         ydbDiscoveryServer.Start();
 
         auto moduleFactories = std::make_shared<NKikimr::TModuleFactories>();


### PR DESCRIPTION
### Notes

## Fix `ShouldNotWaitForRequestsWhenNodeLeaseIsExpired` test crash in Arcadia

### Problem

The test crashes with `SIGABRT` in Arcadia due to a `Y_ABORT_UNLESS(found)` assertion in `TDistributedConfigKeeper::ApplyNewNodeList()` (`contrib/ydb/core/blobstorage/nodewarden/distconf_binding.cpp:52`).

The fake discovery service in the test was assigning `node_id=1` to the dynamic node. Since `MaxStaticNodeId` defaults to 1000 in the `TDynamicNameserviceConfig` proto, the node with ID 1 is treated as a static node (`1 <= 1000`). During shutdown, `TDistributedConfigKeeper` receives `TEvNodesInfo` containing only the static nodes from `NsConfig`. However, after registration `NsConfig` was cleared and repopulated with only node 2 (the sole node returned by the fake service). As a result, the node cannot find itself (ID 1) in the static node list, and the assertion fires.

### Why this doesn't happen on GitHub

The `Y_ABORT_UNLESS(found)` assertion was introduced in a recent YDB import (`0ac0a2eb`, 2025-07-29). The pinned `contrib/ydb/` in the GitHub NBS repository still contains the older version of `distconf_binding.cpp` without this assertion. In Arcadia, YDB is updated independently and already includes this change.

### Fix

- Changed the dynamic node ID from 1 to 1001 (above the default `MaxStaticNodeId` of 1000), so the node is correctly identified as dynamic and takes the early-return path in `ApplyNewNodeList`.
- Added the original static node (ID 1) to the fake registration response, so `NsConfig` retains a valid static node entry after registration.
- Passed `staticNodeIcPort` to the fake discovery service for correct static node info.

### Backward compatibility

These changes are safe for the older YDB version on GitHub:

- A dynamic node with ID 1001 will be correctly classified as dynamic (`1001 > MaxStaticNodeId`), taking the `!IsSelfStatic` branch which returns early — no assertion is reached.
- Including the static node in the registration response makes the mock more realistic and matches real NodeBroker behavior.
- The previous setup (`node_id=1`) was subtly incorrect even without the assertion — the node was misidentified as static, and `SelfNode` was left uninitialized after the lookup failed silently.

### Issue

```
2026-06-10T15:09:04.809565Z :BS_PROXY NOTICE: dsproxy_state.cpp:284: Group# 4294967295 HasInvalidGroupId# 1 Bootstrap -> StateEjected Marker# DSP42
2026-06-10T15:09:04.858127Z :NFS_VHOST INFO: cloud/filestore/libs/daemon/vhost/bootstrap.cpp:592: Stopped Server
2026-06-10T15:09:04.860352Z :NFS_VHOST INFO: cloud/filestore/libs/daemon/vhost/bootstrap.cpp:593: Stopped EndpointManager
2026-06-10T15:09:04.860409Z :NFS_VHOST INFO: cloud/filestore/libs/daemon/vhost/bootstrap.cpp:594: Stopped FileStoreEndpoints
2026-06-10T15:09:04.860694Z :NFS_VHOST INFO: cloud/filestore/libs/daemon/vhost/bootstrap.cpp:601: Stopped ModuleStatsUpdater
2026-06-10T15:09:04.860728Z :NFS_VHOST INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:121: Stopped RequestStatsUpdater
2026-06-10T15:09:04.860758Z :NFS_VHOST INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:122: Stopped ProfileLog
2026-06-10T15:09:04.861062Z :NFS_VHOST INFO: cloud/filestore/libs/daemon/common/bootstrap.cpp:123: Stopped BackgroundThreadPool
2026-06-10T15:09:04.861304Z :INTERCONNECT NOTICE: interconnect_tcp_proxy.cpp:785: Proxy [1:7649784052424844329:2048] [node 2] ICP32 transit to hold-by-error state Explanation# terminated
VERIFY failed (2026-06-10T15:09:04.810001Z): SelfNodeId# 1 NewNodeList# [:13397/2]
  contrib/ydb/core/blobstorage/nodewarden/distconf_binding.cpp:60
  ApplyNewNodeList(): requirement found failed
NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char>>, char const*, unsigned long)+910 (0x1E65DA6E)
NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+571 (0x1E649DFB)
NKikimr::NStorage::TDistributedConfigKeeper::ApplyNewNodeList(std::__y1::span<std::__y1::tuple<NKikimr::NStorage::TNodeIdentifier, NActors::TNodeLocation>, 18446744073709551615ul>)+11553 (0x4A7F0FD1)
NKikimr::NStorage::TDistributedConfigKeeper::Handle(TAutoPtr<NActors::TEventHandle<NActors::TEvInterconnect::TEvNodesInfo>, TDelete>)+2630 (0x4A7ED956)
NKikimr::NStorage::TDistributedConfigKeeper::StateWaitForInit(TAutoPtr<NActors::IEventHandle, TDelete>&)+2111 (0x4A6EB9DF)
NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&)+602 (0x2075C53A)
NActors::TExecutorThread::Execute(NActors::TMailbox*, bool)+8854 (0x2085BA96)
??+0 (0x208664FC)
NActors::TExecutorThread::ProcessExecutorPool()+1486 (0x20865A2E)
NActors::TExecutorThread::ThreadProc()+399 (0x20867CEF)
??+0 (0x1E662AB0)
??+0 (0x1E2DF3D7)
??+0 (0x7F0A1761F609)
clone+67 (0x7F0A17544353)
```
