### PR TITLE
[Filestore] fix test with WaitForTabletStart after ResizeFileStore

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -8236,6 +8236,11 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             true /* directoryCreationInShards */,
             true /* forceDirectoryCreationInShards */);
 
+        // ResizeFileStore triggers tablet suicide (shard reconfiguration),
+        // need to re-establish the session after restart
+        WaitForTabletStart(service);
+        headers = service.InitSession(fsConfig.FsId, "client");
+
         //
         // dir2, dir3, subdir2 - managed by shards.
         //


### PR DESCRIPTION
### Notes

## Fix test `ShouldSwitchOnDirectoryCreationInShardsForExistingFilesystem` 

### Problem

The test crashes with `E_FS_INVALID_SESSION` on `CreateNode` calls after `ResizeFileStore`.

`ResizeFileStore` with shard reconfiguration triggers `ConfigureShards` transaction on the main tablet, which intentionally calls `Suicide()` to force clients to re-fetch the updated shard list via `CreateSession`. After the tablet restarts, the old session is no longer valid, and any subsequent requests using stale session headers fail with `E_FS_INVALID_SESSION`.

### Fix

Added `WaitForTabletStart` and `InitSession` after the `ResizeFileStore` call, following the same pattern used throughout the test file (e.g., lines 5893–5895).

### Issue
Put links to the related issues here
