### PR TITLE
Allow to run qemu tests on arm

### DIFF
--- a/cloud/storage/core/tests/recipes/virtiofs-server/__main__.py
+++ b/cloud/storage/core/tests/recipes/virtiofs-server/__main__.py
@@ -102,6 +102,9 @@ def stop_server(args, index):
             logger.info("will kill virtiofs-server with pid `%s`", pid)
             try:
                 os.kill(int(pid), signal.SIGTERM)
+            except ProcessLookupError:
+                logger.info("virtiofs-server pid `%s` already exited", pid)
+                continue
             except OSError:
                 logger.exception("While killing pid `%s`", pid)
                 raise

--- a/cloud/storage/core/tools/testing/qemu/lib/common.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/common.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 import tarfile
 import yatest.common as common
 
@@ -89,9 +90,18 @@ def _unpack_qemu_bindir(bindir):
         tf.extractall(bindir)
 
 
+def is_arm():
+    return platform.machine().lower() in ("aarch64", "arm64")
+
+
 def get_qemu_kvm():
     bindir = _get_qemu_bindir()
-    qemu_kvm = os.path.join(bindir, "usr", "bin", "qemu-system-x86_64")
+    if is_arm():
+        qemu_system_bin = "qemu-system-aarch64"
+    else:
+        qemu_system_bin = "qemu-system-x86_64"
+
+    qemu_kvm = os.path.join(bindir, "usr", "bin", qemu_system_bin)
     if not os.path.exists(qemu_kvm):
         _unpack_qemu_bindir(bindir)
 
@@ -105,3 +115,15 @@ def get_qemu_firmware():
         _unpack_qemu_bindir(bindir)
 
     return qemu_firmware
+
+
+def get_qemu_bios():
+    if not is_arm():
+        return None
+
+    bindir = _get_qemu_bindir()
+    qemu_bios = os.path.join(bindir, "usr", "share", "qemu-efi-aarch64", "QEMU_EFI.fd")
+    if not os.path.exists(qemu_bios):
+        _unpack_qemu_bindir(bindir)
+
+    return qemu_bios

--- a/cloud/storage/core/tools/testing/qemu/lib/common.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/common.py
@@ -96,10 +96,9 @@ def is_arm():
 
 def get_qemu_kvm():
     bindir = _get_qemu_bindir()
+    qemu_system_bin = "qemu-system-x86_64"
     if is_arm():
         qemu_system_bin = "qemu-system-aarch64"
-    else:
-        qemu_system_bin = "qemu-system-x86_64"
 
     qemu_kvm = os.path.join(bindir, "usr", "bin", qemu_system_bin)
     if not os.path.exists(qemu_kvm):
@@ -117,8 +116,11 @@ def get_qemu_firmware():
     return qemu_firmware
 
 
-def get_qemu_bios():
-    if not is_arm():
+def get_qemu_bios(is_arm_host=None):
+    if is_arm_host is None:
+        is_arm_host = is_arm()
+
+    if not is_arm_host:
         return None
 
     bindir = _get_qemu_bindir()

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu.py
@@ -115,8 +115,11 @@ class Qemu:
             if is_arm is None
             else is_arm
         )
+
+        # TODO(proller): Temporary disable reconnect and migration for arm, while preparing proper qemu binary
         self.reconnect = reconnect if reconnect is not None else 0 if self.is_arm else 1
         self.migration = "" if self.is_arm else ",migration=external"
+
         self.virtio_options = self._get_virtio_options(self.virtio, vhost_socket)
         self.enable_kvm = enable_kvm
         self.backup_rootfs = backup_rootfs

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu.py
@@ -160,16 +160,12 @@ class Qemu:
 
         cmd = [
             "-chardev",
-            "socket,id=vhost0,path={},reconnect={}".format(
-                vhost_socket, self.reconnect
-            ),
+            f"socket,id=vhost0,path={vhost_socket},reconnect={self.reconnect}",
         ]
         cmd += [
             "-device",
             "vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,"
-            "num-request-queues={},queue-size=512{}".format(
-                self.num_request_queues, self.migration
-            ),
+            f"num-request-queues={self.num_request_queues},queue-size=512{self.migration}",
         ]
         return cmd
 
@@ -299,14 +295,12 @@ class Qemu:
             if self.use_virtiofs_server:
                 cmd += [
                     "-chardev",
-                    "socket,id={},path={},reconnect={}".format(
-                        tag, vhost_socket, self.reconnect
-                    ),
+                    f"socket,id={tag},path={vhost_socket},reconnect={self.reconnect}",
                 ]
                 cmd += [
                     "-device",
-                    "vhost-user-fs-pci,chardev={},id=vhost-user-{},tag={},"
-                    "queue-size=512{}".format(tag, tag, tag, self.migration),
+                    f"vhost-user-fs-pci,chardev={tag},id=vhost-user-{tag},tag={tag},"
+                    f"queue-size=512{self.migration}",
                 ]
             else:
                 cmd += ["-virtfs",

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import platform
 import stat
 import time
 import uuid
@@ -86,7 +87,10 @@ class Qemu:
                  inst_index=0,
                  shared_nic_port=0,
                  use_virtiofs_server=False,
-                 num_request_queues=1):
+                 num_request_queues=1,
+                 is_arm=None,
+                 reconnect=None,
+                 qemu_bios=None):
 
         self.ssh_port = 0
         self.qmp = None
@@ -96,6 +100,7 @@ class Qemu:
 
         self.qemu_kvm = qemu_kvm
         self.qemu_firmware = qemu_firmware
+        self.qemu_bios = qemu_bios
         self.rootfs = rootfs
         self.kernel = kernel
         self.kcmdline = kcmdline
@@ -105,6 +110,13 @@ class Qemu:
         self.virtio = virtio
         self.qemu_options = qemu_options
         self.num_request_queues = num_request_queues
+        self.is_arm = (
+            platform.machine().lower() in ("aarch64", "arm64")
+            if is_arm is None
+            else is_arm
+        )
+        self.reconnect = reconnect if reconnect is not None else 0 if self.is_arm else 1
+        self.migration = "" if self.is_arm else ",migration=external"
         self.virtio_options = self._get_virtio_options(self.virtio, vhost_socket)
         self.enable_kvm = enable_kvm
         self.backup_rootfs = backup_rootfs
@@ -143,11 +155,19 @@ class Qemu:
         if vhost_socket is None:
             raise QemuException("Cannot find nfs vhost socket path")
 
-        cmd = ["-chardev",
-               "socket,id=vhost0,path={},reconnect=1".format(vhost_socket)]
-        cmd += ["-device",
-                "vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,num-request-queues=%s,queue-size=512,migration=external"
-                % self.num_request_queues]
+        cmd = [
+            "-chardev",
+            "socket,id=vhost0,path={},reconnect={}".format(
+                vhost_socket, self.reconnect
+            ),
+        ]
+        cmd += [
+            "-device",
+            "vhost-user-fs-pci,chardev=vhost0,id=vhost-user-fs0,tag=fs0,"
+            "num-request-queues={},queue-size=512{}".format(
+                self.num_request_queues, self.migration
+            ),
+        ]
         return cmd
 
     def _get_virtioblk_options(self, vhost_socket):
@@ -240,6 +260,12 @@ class Qemu:
             "-qmp", "unix:{},server,nowait".format(self.qmp_socket),
         ]
 
+        if self.qemu_bios:
+            cmd += ["-bios", self.qemu_bios]
+
+        if self.is_arm:
+            cmd += ["-machine", "virt"]
+
         if self.shared_nic_port:
             nic_mac = "52:54:00:12:56:{:02x}".format(self.inst_index)
             if self.inst_index == 0:
@@ -268,10 +294,17 @@ class Qemu:
 
         for tag, path, vhost_socket in self.mount_paths:
             if self.use_virtiofs_server:
-                cmd += ["-chardev",
-                        "socket,id={},path={},reconnect=1".format(tag, vhost_socket)]
-                cmd += ["-device",
-                        "vhost-user-fs-pci,chardev={},id=vhost-user-{},tag={},queue-size=512,migration=external".format(tag, tag, tag)]
+                cmd += [
+                    "-chardev",
+                    "socket,id={},path={},reconnect={}".format(
+                        tag, vhost_socket, self.reconnect
+                    ),
+                ]
+                cmd += [
+                    "-device",
+                    "vhost-user-fs-pci,chardev={},id=vhost-user-{},tag={},"
+                    "queue-size=512{}".format(tag, tag, tag, self.migration),
+                ]
             else:
                 cmd += ["-virtfs",
                         "local,path={path},mount_tag={tag},security_model=none".format(tag=tag, path=path)]

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import platform
 import stat
 import time
 import uuid
@@ -9,6 +8,7 @@ import yatest.common
 import yatest.common.network
 
 from contrib.ydb.tests.library.harness.daemon import Daemon
+from .common import get_qemu_bios, is_arm as is_arm_host
 from .qmp import QmpClient
 
 logger = logging.getLogger(__name__)
@@ -100,7 +100,10 @@ class Qemu:
 
         self.qemu_kvm = qemu_kvm
         self.qemu_firmware = qemu_firmware
+        self.is_arm = is_arm_host() if is_arm is None else is_arm
         self.qemu_bios = qemu_bios
+        if self.qemu_bios is None:
+            self.qemu_bios = get_qemu_bios(self.is_arm)
         self.rootfs = rootfs
         self.kernel = kernel
         self.kcmdline = kcmdline
@@ -110,11 +113,6 @@ class Qemu:
         self.virtio = virtio
         self.qemu_options = qemu_options
         self.num_request_queues = num_request_queues
-        self.is_arm = (
-            platform.machine().lower() in ("aarch64", "arm64")
-            if is_arm is None
-            else is_arm
-        )
 
         # TODO(proller): Temporary disable reconnect and migration for arm, while preparing proper qemu binary
         self.reconnect = reconnect if reconnect is not None else 0 if self.is_arm else 1

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu_with_migration.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu_with_migration.py
@@ -2,7 +2,12 @@ import logging
 import yatest.common as common
 import time
 
-from .common import get_mount_paths, get_qemu_kvm, get_qemu_firmware
+from .common import (
+    get_mount_paths,
+    get_qemu_bios,
+    get_qemu_firmware,
+    get_qemu_kvm,
+)
 from .qemu import Qemu
 
 EMU_NET = "10.0.2.0/24"
@@ -16,6 +21,7 @@ class QemuWithMigration:
         self.qemu = Qemu(
             qemu_kvm=get_qemu_kvm(),
             qemu_firmware=get_qemu_firmware(),
+            qemu_bios=get_qemu_bios(),
             rootfs=common.build_path("cloud/storage/core/tools/testing/qemu/image/rootfs.img"),
             kernel=None,
             kcmdline=None,

--- a/cloud/storage/core/tools/testing/qemu/lib/recipe.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/recipe.py
@@ -12,7 +12,14 @@ from library.python.retry import retry
 import library.python.testing.recipe
 
 from .qemu import Qemu
-from .common import SshToGuest, get_mount_paths, env_with_guest_index, get_qemu_kvm, get_qemu_firmware
+from .common import (
+    SshToGuest,
+    env_with_guest_index,
+    get_mount_paths,
+    get_qemu_bios,
+    get_qemu_firmware,
+    get_qemu_kvm,
+)
 from cloud.storage.core.tests.common import (
     append_recipe_err_files,
     process_recipe_err_files,
@@ -82,6 +89,7 @@ def start_instance(args, inst_index):
 
     qemu = Qemu(qemu_kvm=_get_qemu_kvm(args),
                 qemu_firmware=_get_qemu_firmware(args),
+                qemu_bios=get_qemu_bios(),
                 rootfs=_get_rootfs(args),
                 kernel=_get_kernel(args),
                 kcmdline=_get_kcmdline(args),


### PR DESCRIPTION
## Summary

Allow QEMU-based tests to run on ARM hosts.

## Changes

- Detect ARM hosts (`aarch64` / `arm64`) and use `qemu-system-aarch64`.
- Add ARM QEMU BIOS lookup via `QEMU_EFI.fd`.
- Pass BIOS into QEMU recipes and migration wrapper.
- Add `-machine virt` for ARM QEMU runs.
- Temporarily disable reconnect and external migration options on ARM until a proper QEMU binary is prepared.
- Make virtiofs-server shutdown tolerant of already-exited processes.

## Testing

- Existing QEMU test recipes should continue working on x86_64.
- QEMU recipes can now be run on ARM hosts.