### PR TITLE
fix: ignore github error during vm removal

### DIFF
--- a/.github/scripts/nebius_manage_vm.py
+++ b/.github/scripts/nebius_manage_vm.py
@@ -27,6 +27,7 @@ from .helpers import (
 )
 from github import Auth as GithubAuth
 from github import Github
+from github import GithubException
 
 from nebius.sdk import SDK
 from nebius.aio.cli_config import Config
@@ -661,8 +662,19 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
 def remove_runner_from_github(
     client: Github, github_repo_owner: str, github_repo: str, vm_id: str, apply: bool
 ) -> str:
-    runner_id = find_runner_by_name(client, github_repo_owner, github_repo, vm_id)
     repo = os.environ.get("GITHUB_REPOSITORY")
+
+    try:
+        runner_id = find_runner_by_name(client, github_repo_owner, github_repo, vm_id)
+    except GithubException as e:
+        if e.status != 401:
+            raise
+        logger.error(
+            "Failed to check GitHub runner with name %s due to authentication error; continuing VM removal",
+            vm_id,
+            exc_info=True,
+        )
+        return "auth_failed"
 
     if runner_id is None:
         # this is not critical error, just log it and be done with it,
@@ -670,7 +682,19 @@ def remove_runner_from_github(
         logger.info("Runner with name %s not found, skipping", vm_id)
         return "not_found"
 
-    runner = client.get_repo(repo).get_self_hosted_runner(runner_id)
+    try:
+        runner = client.get_repo(repo).get_self_hosted_runner(runner_id)
+    except GithubException as e:
+        if e.status != 401:
+            raise
+        logger.error(
+            "Failed to get GitHub runner with name %s and id %s due to authentication error; continuing VM removal",
+            vm_id,
+            runner_id,
+            exc_info=True,
+        )
+        return "auth_failed"
+
     if runner is None:
         logger.info("Runner with name %s not found, skipping", vm_id)
         return "not_found"
@@ -911,6 +935,11 @@ async def remove_vm(sdk: SDK, args: argparse.Namespace):
         return
     elif result == "failed":
         logger.error("Failed to remove runner with name %s, we can ignore it", args.id)
+    elif result == "auth_failed":
+        logger.error(
+            "Failed to inspect runner with name %s due to GitHub authentication error, we can ignore it",
+            args.id,
+        )
     elif result == "removed" or result == "would_remove":
         logger.info("Runner with name %s removed from github", args.id)
 


### PR DESCRIPTION
After https://www.githubstatus.com/incidents/fcj3088jg1wx
```2026-06-10 16:04:24,173: INFO: Checking whether VM computeinstance-e02t713h81tsxnbc1t is registered as Github Runner
2026-06-10 16:04:25,268: INFO: Runner with name computeinstance-e02t713h81tsxnbc1t found
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/actions-runner/_work/nbs/nbs/.github/scripts/nebius_manage_vm.py", line 1098, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/actions-runner/_work/nbs/nbs/.github/scripts/nebius_manage_vm.py", line 1091, in main
    await args.func(sdk, args)
  File "/actions-runner/_work/nbs/nbs/.github/scripts/nebius_manage_vm.py", line 904, in remove_vm
    result = remove_runner_from_github(
  File "/actions-runner/_work/nbs/nbs/.github/scripts/nebius_manage_vm.py", line 673, in remove_runner_from_github
    runner = client.get_repo(repo).get_self_hosted_runner(runner_id)
  File "/usr/local/lib/python3.10/dist-packages/github/Repository.py", line 3531, in get_self_hosted_runner
    headers, data = self._requester.requestJsonAndCheck("GET", f"{self.url}/actions/runners/{runner_id}")
  File "/usr/local/lib/python3.10/dist-packages/github/Requester.py", line 628, in requestJsonAndCheck
    *self.__check(
  File "/usr/local/lib/python3.10/dist-packages/github/Requester.py", line 867, in __check
    raise self.createException(status, responseHeaders, data)
github.GithubException.GithubException: Requires authentication: 401 {"message": "Requires authentication", "documentation_url": "https://docs.github.com/rest", "status": "401"}
```
