### PR TITLE
issue-6183: [Filestore] Fix performance profile params dropped on resize

### DIFF
--- a/cloud/filestore/apps/client/lib/performance_profile_params.cpp
+++ b/cloud/filestore/apps/client/lib/performance_profile_params.cpp
@@ -11,9 +11,8 @@ TPerformanceProfileParams::TPerformanceProfileParams(NLastGetopt::TOpts& opts)
     opts.AddLongOption(
             "performance-profile-throttling-enabled",
             "Enables/disables throttling")
-        .RequiredArgument("NUM")
         .NoArgument()
-        .SetFlag(&ThrottlingEnabled);
+        .StoreValue(&ThrottlingEnabled, true);
 
     opts.AddLongOption(
             "performance-profile-max-read-bandwidth",

--- a/cloud/filestore/apps/client/lib/performance_profile_params.h
+++ b/cloud/filestore/apps/client/lib/performance_profile_params.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <util/system/types.h>
-
 #include <util/generic/maybe.h>
+
+#include <util/system/types.h>
 
 namespace NLastGetopt {
     class TOpts;

--- a/cloud/filestore/apps/client/lib/performance_profile_params.h
+++ b/cloud/filestore/apps/client/lib/performance_profile_params.h
@@ -2,6 +2,8 @@
 
 #include <util/system/types.h>
 
+#include <util/generic/maybe.h>
+
 namespace NLastGetopt {
     class TOpts;
 }   // namespace NLastGetopt
@@ -13,20 +15,20 @@ namespace NCloud::NFileStore::NClient {
 class TPerformanceProfileParams
 {
 private:
-    bool ThrottlingEnabled = false;
+    TMaybe<bool> ThrottlingEnabled;
     ui64 MaxReadBandwidth = 0;
     ui32 MaxReadIops = 0;
     ui64 MaxWriteBandwidth = 0;
     ui32 MaxWriteIops = 0;
-    ui32 BoostTime = 0;
-    ui32 BoostRefillTime = 0;
+    TMaybe<ui32> BoostTime;
+    TMaybe<ui32> BoostRefillTime;
     ui32 BoostPercentage = 0;
-    ui32 BurstPercentage = 0;
-    ui64 DefaultPostponedRequestWeight = 0;
-    ui64 MaxPostponedWeight = 0;
-    ui32 MaxWriteCostMultiplier = 0;
-    ui32 MaxPostponedTime = 0;
-    ui32 MaxPostponedCount = 0;
+    TMaybe<ui32> BurstPercentage;
+    TMaybe<ui64> DefaultPostponedRequestWeight;
+    TMaybe<ui64> MaxPostponedWeight;
+    TMaybe<ui32> MaxWriteCostMultiplier;
+    TMaybe<ui32> MaxPostponedTime;
+    TMaybe<ui32> MaxPostponedCount;
 
 public:
     TPerformanceProfileParams(NLastGetopt::TOpts& opts);
@@ -35,20 +37,39 @@ public:
     void FillRequest(TRequest& request) const
     {
         auto pp = request.MutablePerformanceProfile();
-        pp->SetThrottlingEnabled(ThrottlingEnabled);
+        if (ThrottlingEnabled.Defined()) {
+            pp->SetThrottlingEnabled(*ThrottlingEnabled);
+        }
         pp->SetMaxReadBandwidth(MaxReadBandwidth);
         pp->SetMaxReadIops(MaxReadIops);
         pp->SetMaxWriteBandwidth(MaxWriteBandwidth);
         pp->SetMaxWriteIops(MaxWriteIops);
-        pp->SetBoostTime(BoostTime);
-        pp->SetBoostRefillTime(BoostRefillTime);
+        if (BoostTime.Defined()) {
+            pp->SetBoostTime(*BoostTime);
+        }
+        if (BoostRefillTime.Defined()) {
+            pp->SetBoostRefillTime(*BoostRefillTime);
+        }
         pp->SetBoostPercentage(BoostPercentage);
-        pp->SetBurstPercentage(BurstPercentage);
-        pp->SetDefaultPostponedRequestWeight(DefaultPostponedRequestWeight);
-        pp->SetMaxPostponedWeight(MaxPostponedWeight);
-        pp->SetMaxWriteCostMultiplier(MaxWriteCostMultiplier);
-        pp->SetMaxPostponedTime(MaxPostponedTime);
-        pp->SetMaxPostponedCount(MaxPostponedCount);
+        if (BurstPercentage.Defined()) {
+            pp->SetBurstPercentage(*BurstPercentage);
+        }
+        if (DefaultPostponedRequestWeight.Defined()) {
+            pp->SetDefaultPostponedRequestWeight(
+                *DefaultPostponedRequestWeight);
+        }
+        if (MaxPostponedWeight.Defined()) {
+            pp->SetMaxPostponedWeight(*MaxPostponedWeight);
+        }
+        if (MaxWriteCostMultiplier.Defined()) {
+            pp->SetMaxWriteCostMultiplier(*MaxWriteCostMultiplier);
+        }
+        if (MaxPostponedTime.Defined()) {
+            pp->SetMaxPostponedTime(*MaxPostponedTime);
+        }
+        if (MaxPostponedCount.Defined()) {
+            pp->SetMaxPostponedCount(*MaxPostponedCount);
+        }
     }
 };
 

--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -470,18 +470,19 @@ void SetupFileStorePerformanceAndChannels(
     OverrideStorageMediaKind(config, fileStore);
 
 #define SETUP_PARAMETER_SIMPLE(name, ...)                                      \
-    fileStore.SetPerformanceProfile##name(                                     \
-        clientProfile.Get##name()                                              \
-            ? clientProfile.Get##name()                                        \
-            : name(config, fileStore));                                        \
-// SETUP_PARAMETER_AU
+    if (clientProfile.Has##name()) {                                           \
+        fileStore.SetPerformanceProfile##name(clientProfile.Get##name());      \
+    } else if (!fileStore.HasPerformanceProfile##name()) {                     \
+        fileStore.SetPerformanceProfile##name(name(config, fileStore));        \
+    };                                                                         \
+// SETUP_PARAMETER_SIMPLE
 
 #define SETUP_PARAMETER_AU(name, ...)                                          \
     fileStore.SetPerformanceProfile##name(                                     \
         clientProfile.Get##name()                                              \
             ? clientProfile.Get##name()                                        \
             : name(config, fileStore, allocationUnitCount));                   \
-// SETUP_PARAMETER_SIMPLE
+// SETUP_PARAMETER_AU
 
     PERFORMANCE_PROFILE_PARAMETERS_SIMPLE(SETUP_PARAMETER_SIMPLE);
     PERFORMANCE_PROFILE_PARAMETERS_AU(SETUP_PARAMETER_AU);

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -87,6 +87,67 @@ struct TConfigs
     {}
 };
 
+void CheckPerformanceProfile(
+    const NProto::TFileStorePerformanceProfile& profile,
+    const NKikimrFileStore::TConfig& config)
+{
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetThrottlingEnabled(),
+        config.GetPerformanceProfileThrottlingEnabled());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxReadIops(),
+        config.GetPerformanceProfileMaxReadIops());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxReadBandwidth(),
+        config.GetPerformanceProfileMaxReadBandwidth());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxWriteIops(),
+        config.GetPerformanceProfileMaxWriteIops());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxWriteBandwidth(),
+        config.GetPerformanceProfileMaxWriteBandwidth());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetBoostTime(),
+        config.GetPerformanceProfileBoostTime());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetBoostRefillTime(),
+        config.GetPerformanceProfileBoostRefillTime());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetBoostPercentage(),
+        config.GetPerformanceProfileBoostPercentage());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetBurstPercentage(),
+        config.GetPerformanceProfileBurstPercentage());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetDefaultPostponedRequestWeight(),
+        config.GetPerformanceProfileDefaultPostponedRequestWeight());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxPostponedWeight(),
+        config.GetPerformanceProfileMaxPostponedWeight());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxWriteCostMultiplier(),
+        config.GetPerformanceProfileMaxWriteCostMultiplier());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxPostponedTime(),
+        config.GetPerformanceProfileMaxPostponedTime());
+    UNIT_ASSERT_VALUES_EQUAL(
+        profile.GetMaxPostponedCount(),
+        config.GetPerformanceProfileMaxPostponedCount());
+}
+
+void ClearOptional(NProto::TFileStorePerformanceProfile& profile)
+{
+    profile.ClearThrottlingEnabled();
+    profile.ClearBoostTime();
+    profile.ClearBoostRefillTime();
+    profile.ClearBurstPercentage();
+    profile.ClearDefaultPostponedRequestWeight();
+    profile.ClearMaxPostponedWeight();
+    profile.ClearMaxWriteCostMultiplier();
+    profile.ClearMaxPostponedTime();
+    profile.ClearMaxPostponedCount();
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1584,37 +1645,13 @@ Y_UNIT_TEST_SUITE(TModel)
 
 #undef CHECK_CHANNEL
 
-    void SetupPerformanceProfile(
-        ui32 storageType,
-        ui32 allocationUnits,
-        ui32 unitReadIops,
-        ui32 unitReadBandwidth,
-        ui32 unitWriteIops,
-        ui32 unitWriteBandwidth,
-        ui32 maxReadIops,
-        ui32 maxReadBandwidth,
-        ui32 maxWriteIops,
-        ui32 maxWriteBandwidth,
-        ui32 boostTimeMs,
-        ui32 boostRefillTimeMs,
-        ui32 unitBoost,
-        ui32 burstPercentage,
-        ui32 defaultPostponedRequestWeight,
-        ui32 maxPostponedWeight,
-        ui32 maxWriteCostMultiplier,
-        ui32 maxPostponedTimeMs,
-        ui32 maxPostponedCount,
-        NKikimrFileStore::TConfig& kikimrConfig,
-        NProto::TStorageConfig& storageConfig,
-        const TMaybe<NProto::TFileStorePerformanceProfile>& performanceProfile)
+    void SetupStorageConfigRandomly(NProto::TStorageConfig& storageConfig)
     {
         std::random_device rd;
         std::array<int, std::mt19937::state_size> state;
         std::generate(std::begin(state), std::end(state), std::ref(rd));
         std::seed_seq sq(std::begin(state), std::end(state));
         std::mt19937 engine(sq);
-
-        kikimrConfig.SetStorageMediaKind(storageType);
 
         std::uniform_int_distribution<ui32> dist(1, 100'000'000);
 
@@ -1657,6 +1694,35 @@ Y_UNIT_TEST_SUITE(TModel)
         storageConfig.SetHDDMaxWriteCostMultiplier(dist(engine));
         storageConfig.SetHDDMaxPostponedTime(dist(engine));
         storageConfig.SetHDDMaxPostponedCount(dist(engine));
+    }
+
+    void SetupPerformanceProfile(
+        ui32 storageType,
+        ui32 allocationUnits,
+        ui32 unitReadIops,
+        ui32 unitReadBandwidth,
+        ui32 unitWriteIops,
+        ui32 unitWriteBandwidth,
+        ui32 maxReadIops,
+        ui32 maxReadBandwidth,
+        ui32 maxWriteIops,
+        ui32 maxWriteBandwidth,
+        ui32 boostTimeMs,
+        ui32 boostRefillTimeMs,
+        ui32 unitBoost,
+        ui32 burstPercentage,
+        ui32 defaultPostponedRequestWeight,
+        ui32 maxPostponedWeight,
+        ui32 maxWriteCostMultiplier,
+        ui32 maxPostponedTimeMs,
+        ui32 maxPostponedCount,
+        NKikimrFileStore::TConfig& kikimrConfig,
+        NProto::TStorageConfig& storageConfig,
+        const TMaybe<NProto::TFileStorePerformanceProfile>& performanceProfile)
+    {
+        SetupStorageConfigRandomly(storageConfig);
+
+        kikimrConfig.SetStorageMediaKind(storageType);
 
         if (performanceProfile.Defined()) {
             SetupFileStorePerformanceAndChannels(
@@ -2233,6 +2299,36 @@ Y_UNIT_TEST_SUITE(TModel)
     }
 
 #undef DO_TEST
+
+    Y_UNIT_TEST_F(ShouldNotDropOptionalPerformanceProfileFields, TConfigs)
+    {
+        SetupStorageConfigRandomly(StorageConfig);
+
+        KikimrConfig.SetStorageMediaKind(::NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        // Set up performance profile in KikimrConfig using
+        // ClientPerformanceProfile.
+        SetupFileStorePerformanceAndChannels(
+            false,
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile);
+        CheckPerformanceProfile(ClientPerformanceProfile, KikimrConfig);
+
+        // Drop optional fields in profileWithClearedOptional.
+        auto profileWithClearedOptional = ClientPerformanceProfile;
+        ClearOptional(profileWithClearedOptional);
+
+        // Set up performance profile in KikimrConfig using
+        // profileWithClearedOptional and check that cleared optional fields are
+        // not changed.
+        SetupFileStorePerformanceAndChannels(
+            false,
+            StorageConfig,
+            KikimrConfig,
+            profileWithClearedOptional);
+        CheckPerformanceProfile(ClientPerformanceProfile, KikimrConfig);
+    }
 
     Y_UNIT_TEST_F(ShouldCreateProperNumberOfShards, TConfigs)
     {

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -103,35 +103,35 @@ message TFileStorePerformanceProfile
     uint64 MaxWriteBandwidth = 4;
 
     // Max sum of all postponed requests weights (in bytes).
-    uint64 MaxPostponedWeight = 5;
+    optional uint64 MaxPostponedWeight = 5;
 
     // Max sum of delays for all postponed requests in buffer (in ms).
-    uint32 MaxPostponedTime = 6;
+    optional uint32 MaxPostponedTime = 6;
 
     // Max count of postponed requests in buffer (not used now).
-    uint32 MaxPostponedCount = 7;
+    optional uint32 MaxPostponedCount = 7;
 
     // Max time for working on boosted speed (in ms).
-    uint32 BoostTime = 8;
+    optional uint32 BoostTime = 8;
 
     // Time for working on standard speed after which boost time completely
     // refills (in ms).
-    uint32 BoostRefillTime = 9;
+    optional uint32 BoostRefillTime = 9;
 
     // Max percent of boost budget which can be spent for single request.
     uint32 BoostPercentage = 10;
 
     // Max percent of burst rate which can be spent for single request.
-    uint32 BurstPercentage = 11;
+    optional uint32 BurstPercentage = 11;
 
     // Max multiplier for write requests (used for backpressure).
-    double MaxWriteCostMultiplier = 12;
+    optional double MaxWriteCostMultiplier = 12;
 
     // Default request weight (used for requests without payload).
-    uint64 DefaultPostponedRequestWeight = 13;
+    optional uint64 DefaultPostponedRequestWeight = 13;
 
     // Throttling enabled.
-    bool ThrottlingEnabled = 14;
+    optional bool ThrottlingEnabled = 14;
 }
 
 message TFileStoreModel


### PR DESCRIPTION
### Notes
PERFORMANCE_PROFILE_PARAMETERS_SIMPLE 
https://github.com/ydb-platform/nbs/blob/b0235195a6908e6cfdcb60d1af71c985e7514a35/cloud/filestore/libs/storage/core/model.cpp#L441
are made optional and preserve their values when they are not explicitly specified in resize command.

### Issue
#6183
