### PR TITLE
[NBS] Local NVMe service: track requests, reject concurrent ops, handle idempotenceId

### DIFF
--- a/cloud/blockstore/libs/local_nvme/service.cpp
+++ b/cloud/blockstore/libs/local_nvme/service.cpp
@@ -30,9 +30,13 @@ public:
             TVector<NProto::TNVMeDevice>{});
     }
 
-    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
+    [[nodiscard]] auto AcquireNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId)
         -> TFuture<TResultOrError<NProto::TNVMeDevice>> final
     {
+        Y_UNUSED(idempotenceId);
+
         if (!serialNumber) {
             return MakeFuture<TResultOrError<NProto::TNVMeDevice>>(
                 MakeError(E_ARGUMENT, "Serial number is empty"));
@@ -44,9 +48,12 @@ public:
                 << "Device " << serialNumber.Quote() << " not found"));
     }
 
-    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> final
+    [[nodiscard]] auto ReleaseNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId) -> TFuture<NProto::TError> final
     {
+        Y_UNUSED(idempotenceId);
+
         if (!serialNumber) {
             return MakeFuture(MakeError(E_ARGUMENT, "Serial number is empty"));
         }

--- a/cloud/blockstore/libs/local_nvme/service.h
+++ b/cloud/blockstore/libs/local_nvme/service.h
@@ -23,10 +23,14 @@ struct ILocalNVMeService: public IStartable
     [[nodiscard]] virtual auto ListNVMeDevices() -> NThreading::TFuture<
         TResultOrError<TVector<NProto::TNVMeDevice>>> = 0;
 
-    [[nodiscard]] virtual auto AcquireNVMeDevice(const TString& serialNumber)
+    [[nodiscard]] virtual auto AcquireNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId)
         -> NThreading::TFuture<TResultOrError<NProto::TNVMeDevice>> = 0;
 
-    [[nodiscard]] virtual auto ReleaseNVMeDevice(const TString& serialNumber)
+    [[nodiscard]] virtual auto ReleaseNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId)
         -> NThreading::TFuture<NProto::TError> = 0;
 };
 

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -421,8 +421,6 @@ auto TLocalNVMeService::BindDeviceToDriver(
             SysFs->BindPCIDeviceToDriver(device.GetPCIAddress(), driverName);
             return MakeError(S_OK);
         });
-
-    return {};
 }
 
 auto TLocalNVMeService::AcquireDevice(TCont* c, const TString& serialNumber)

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -662,7 +662,7 @@ auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
     // appear.
     // Retry to avoid racing with asynchronous vfio<N> creation.
 
-    for (ui32 attempt = 0;; ++attempt) {
+    for (ui32 attempt = 0; attempt != VfioDeviceMaxRetries; ++attempt) {
         auto [vfioDevice, error] = SafeExecute<TResultOrError<TString>>(
             [&] { return SysFs->GetVfioDeviceForPCIDevice(pciAddress); });
 
@@ -670,32 +670,28 @@ auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
             return error;
         }
 
-        if (!vfioDevice && attempt < VfioDeviceMaxRetries) {
-            STORAGE_DEBUG(
-                "vfio device for PCI address "
-                << pciAddress << " was not found, retry (attempts: "
-                << attempt + 1 << "/" << VfioDeviceMaxRetries << ")");
-
-            const int ec = c->SleepT(VfioDeviceRetryDelay);
-            if (ec == ECANCELED) {
-                return ServiceDestroyedError;
-            }
-
-            Y_DEBUG_ABORT_UNLESS(ec == ETIMEDOUT, "SleepT: %d", ec);
-
-            continue;
+        if (vfioDevice) {
+            return vfioDevice;
         }
 
-        if (!vfioDevice) {
-            return MakeError(
-                E_NOT_FOUND,
-                TStringBuilder() << "vfio device for PCI address " << pciAddress
-                                 << " was not found after "
-                                 << VfioDeviceMaxRetries << " retries");
+        STORAGE_DEBUG(
+            "vfio device for PCI address "
+            << pciAddress << " was not found, retry (attempts: " << attempt + 1
+            << "/" << VfioDeviceMaxRetries << ")");
+
+        const int ec = c->SleepT(VfioDeviceRetryDelay);
+        if (ec == ECANCELED) {
+            return ServiceDestroyedError;
         }
 
-        return vfioDevice;
+        Y_DEBUG_ABORT_UNLESS(ec == ETIMEDOUT, "SleepT: %d", ec);
     }
+
+    return MakeError(
+        E_NOT_FOUND,
+        TStringBuilder() << "vfio device for PCI address " << pciAddress
+                         << " was not found after " << VfioDeviceMaxRetries
+                         << " retries");
 }
 
 auto TLocalNVMeService::GetNVMeCtrlPath(const NProto::TNVMeDevice& device)

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -77,6 +77,10 @@ bool SleepCont(TDuration dt)
     TCont* c = RunningCont();
     Y_DEBUG_ABORT_UNLESS(c);
 
+    if (!c) {
+        return false;
+    }
+
     const int ec = c->SleepT(dt);
     if (ec == ECANCELED) {
         return false;
@@ -89,14 +93,12 @@ bool SleepCont(TDuration dt)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TAcquireOperationResult
+struct TAcquireOperationResult: TFuture<TAcquireResult>
 {
-    TFuture<TAcquireResult> Result;
 };
 
-struct TReleaseOperationResult
+struct TReleaseOperationResult: TFuture<NProto::TError>
 {
-    TFuture<NProto::TError> Result;
 };
 
 using TOperationResult =
@@ -114,8 +116,6 @@ struct TOperation
 };
 
 using TOperationPtr = std::shared_ptr<TOperation>;
-
-using TOperations = THashMap<TSerialNumber, TOperationPtr>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -140,16 +140,16 @@ private:
     const ISysFsPtr SysFs;
 
     std::atomic<EServiceState> ServiceState = EServiceState::NotReady;
-    TCont* InitializeCont = nullptr;
-    TFuture<void> Ready;
 
     TLog Log;
     bool IsVfioDevSupported = false;
 
+    TFuture<void> Ready;
+    TCont* InitializeCont = nullptr;
+
     THashMap<TSerialNumber, NProto::TNVMeDevice> Devices;
     THashSet<TSerialNumber> AcquiredDevices;
-
-    TOperations Operations;
+    THashMap<TSerialNumber, TOperationPtr> Operations;
 
 public:
     TLocalNVMeService(
@@ -178,19 +178,18 @@ public:
         const TString& idempotenceId) -> TFuture<NProto::TError> final;
 
 private:
+    auto ListDevices() const -> TVector<NProto::TNVMeDevice>;
+
     auto AcquireDevice(
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<TAcquireResult>;
-
-    auto AcquireDeviceImpl(NProto::TNVMeDevice device) -> TAcquireResult;
 
     auto ReleaseDevice(
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<NProto::TError>;
 
+    auto AcquireDeviceImpl(NProto::TNVMeDevice device) -> TAcquireResult;
     auto ReleaseDeviceImpl(const NProto::TNVMeDevice& device) -> NProto::TError;
-
-    auto ListDevices() const -> TVector<NProto::TNVMeDevice>;
 
     static auto EnsureIsReady(
         const std::weak_ptr<TLocalNVMeService>& weakService)
@@ -213,13 +212,14 @@ private:
 
     auto StopImpl() -> TFuture<void>;
 
-    template <typename TOpResult, typename TFnResult>
-    auto TryEarlyResponse(
+    template <typename TOpResult>
+    auto GetOperationResult(
         const TSerialNumber& serialNumber,
-        const TString& idempotenceId) -> std::optional<TFuture<TFnResult>>;
+        const TString& idempotenceId)
+        -> std::optional<TFuture<typename TOpResult::value_type>>;
 
     template <typename TOpResult, typename TFnResult, typename TFn>
-    auto StartDeviceOperation(
+    auto StartOperation(
         TFn fn,
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<TFnResult>;
@@ -242,10 +242,56 @@ TLocalNVMeService::TLocalNVMeService(
     , SysFs(std::move(sysFs))
 {}
 
+void TLocalNVMeService::Initialize()
+{
+    // Store a pointer to the current continuation so Initialize can be stopped
+    // if Stop is called.
+    InitializeCont = RunningCont();
+    Y_DEBUG_ABORT_UNLESS(InitializeCont);
+
+    Y_DEFER
+    {
+        InitializeCont = nullptr;
+    };
+
+    if (!TryRestoreStateFromCache()) {
+        for (;;) {
+            STORAGE_INFO("Fetching NVMe devices from the provider");
+
+            auto error = FetchDevices();
+            if (!HasError(error)) {
+                break;
+            }
+
+            STORAGE_ERROR(
+                "Failed to fetch NVMe devices from the provider: "
+                << FormatError(error));
+
+            if (!SleepCont(FetchDevicesRetryTimeout)) {
+                STORAGE_INFO("Initialization has been cancelled");
+                return;
+            }
+        }
+    }
+
+    EServiceState state = EServiceState::Initializing;
+    if (!ServiceState.compare_exchange_strong(state, EServiceState::Running)) {
+        Y_DEBUG_ABORT_UNLESS(state == EServiceState::Stopped);
+    }
+}
+
 void TLocalNVMeService::Start()
 {
-    Y_DEBUG_ABORT_UNLESS(ServiceState == EServiceState::NotReady);
-    ServiceState = EServiceState::Initializing;
+    if (EServiceState expected = EServiceState::NotReady;
+        !ServiceState.compare_exchange_strong(
+            expected,
+            EServiceState::Initializing))
+    {
+        Y_DEBUG_ABORT(
+            "Unexpected ServiceState: %d",
+            static_cast<int>(expected));
+        return;
+    }
 
     Log = Logging->CreateLog("BLOCKSTORE_LOCAL_NVME");
 
@@ -274,16 +320,15 @@ auto TLocalNVMeService::StopImpl() -> TFuture<void>
     TVector<TFuture<void>> futures;
     futures.reserve(Operations.size() + 1);
 
+    futures.push_back(Ready);
     if (InitializeCont) {
-        futures.push_back(Ready.IgnoreResult());
-
         InitializeCont->Cancel();
     }
 
     for (const auto& [_, op]: Operations) {
         futures.emplace_back(
             std::visit(
-                [](const auto& r) { return r.Result.IgnoreResult(); },
+                [](const auto& r) { return r.IgnoreResult(); },
                 op->Result));
 
         if (op->Cont) {
@@ -296,24 +341,16 @@ auto TLocalNVMeService::StopImpl() -> TFuture<void>
 
 void TLocalNVMeService::Stop()
 {
-    const EServiceState state = ServiceState;
-    if (state == EServiceState::Stopped || state == EServiceState::NotReady) {
+    const EServiceState prevState =
+        ServiceState.exchange(EServiceState::Stopped);
+    if (prevState == EServiceState::Stopped ||
+        prevState == EServiceState::NotReady)
+    {
         // Service is not running
         return;
     }
 
-    ServiceState = EServiceState::Stopped;
-
-    auto future = Executor->Execute(
-        [weakSelf = weak_from_this()]
-        {
-            auto self = weakSelf.lock();
-            if (self) {
-                return self->StopImpl();
-            }
-
-            return MakeFuture();
-        });
+    auto future = Executor->Execute([this] { return StopImpl(); });
     future.Wait();
 }
 
@@ -392,11 +429,13 @@ auto TLocalNVMeService::EnsureIsReady(
         return ServiceDestroyedError;
     }
 
-    if (service->ServiceState == EServiceState::Stopped) {
+    const EServiceState state = service->ServiceState;
+
+    if (state == EServiceState::Stopped) {
         return ServiceStoppedError;
     }
 
-    if (service->ServiceState != EServiceState::Running) {
+    if (state != EServiceState::Running) {
         return ServiceNotReadyError;
     }
 
@@ -533,49 +572,6 @@ bool TLocalNVMeService::TryRestoreStateFromCache()
     return true;
 }
 
-void TLocalNVMeService::Initialize()
-{
-    // Store a pointer to the current continuation so Initialize can be stopped
-    // if Stop is called.
-    InitializeCont = RunningCont();
-    Y_DEBUG_ABORT_UNLESS(InitializeCont);
-
-    Y_DEFER
-    {
-        InitializeCont = nullptr;
-    };
-
-    if (!TryRestoreStateFromCache()) {
-        for (;;) {
-            STORAGE_INFO("Fetching NVMe devices from the provider");
-
-            auto error = FetchDevices();
-            if (!HasError(error)) {
-                break;
-            }
-
-            STORAGE_ERROR(
-                "Failed to fetch NVMe devices from the provider: "
-                << FormatError(error));
-
-            if (!SleepCont(FetchDevicesRetryTimeout)) {
-                STORAGE_INFO("Initialization has been cancelled");
-                return;
-            }
-        }
-    }
-
-    EServiceState state = ServiceState;
-    if (state != EServiceState::Initializing) {
-        Y_DEBUG_ABORT_UNLESS(state == EServiceState::Stopped);
-        return;
-    }
-
-    if (!ServiceState.compare_exchange_strong(state, EServiceState::Running)) {
-        Y_DEBUG_ABORT_UNLESS(state == EServiceState::Stopped);
-    }
-}
-
 auto TLocalNVMeService::BindDeviceToDriver(
     const NProto::TNVMeDevice& device,
     const TString& driverName) -> NProto::TError
@@ -592,14 +588,16 @@ auto TLocalNVMeService::BindDeviceToDriver(
         });
 }
 
-template <typename TOpResult, typename TFnResult>
-auto TLocalNVMeService::TryEarlyResponse(
+template <typename TOpResult>
+auto TLocalNVMeService::GetOperationResult(
     const TSerialNumber& serialNumber,
-    const TString& idempotenceId) -> std::optional<TFuture<TFnResult>>
+    const TString& idempotenceId)
+    -> std::optional<TFuture<typename TOpResult::value_type>>
 {
     auto makeErrorFuture = [](ui32 code, TString msg)
     {
-        return MakeFuture<TFnResult>(MakeError(code, std::move(msg)));
+        return MakeFuture<typename TOpResult::value_type>(
+            MakeError(code, std::move(msg)));
     };
 
     auto it = Operations.find(serialNumber);
@@ -616,29 +614,31 @@ auto TLocalNVMeService::TryEarlyResponse(
         if (!typedOp) {
             return makeErrorFuture(
                 E_ARGUMENT,
-                "idempotence id was used for a different operation type");
+                TStringBuilder()
+                    << "idempotence id was used for a different operation type "
+                       "("
+                    << op.Name << ", started at " << op.StartTime << ")");
         }
 
         if (!op.FinishTime) {
             return makeErrorFuture(E_TRY_AGAIN, "Operation is in progress");
         }
 
-        return typedOp->Result;
+        return *typedOp;
     }
 
     if (!op.FinishTime) {
         return makeErrorFuture(
             E_TRY_AGAIN,
-            TStringBuilder()
-                << "Another operation (" << op.Name << ", started at "
-                << op.StartTime << ") is in progress");
+            TStringBuilder() << "Another operation is in progress (" << op.Name
+                             << ", started at " << op.StartTime << ")");
     }
 
     return std::nullopt;
 }
 
 template <typename TOpResult, typename TFnResult, typename TFn>
-auto TLocalNVMeService::StartDeviceOperation(
+auto TLocalNVMeService::StartOperation(
     TFn fn,
     const TSerialNumber& serialNumber,
     const TString& idempotenceId) -> TFuture<TFnResult>
@@ -652,10 +652,10 @@ auto TLocalNVMeService::StartDeviceOperation(
                 << "Device " << serialNumber.Quote() << " not found"));
     }
 
-    if (auto earlyResponse =
-            TryEarlyResponse<TOpResult, TFnResult>(serialNumber, idempotenceId))
+    if (auto opResult =
+            GetOperationResult<TOpResult>(serialNumber, idempotenceId))
     {
-        return *earlyResponse;
+        return *opResult;
     }
 
     auto op = std::make_shared<TOperation>();
@@ -682,22 +682,25 @@ auto TLocalNVMeService::StartDeviceOperation(
     op->Result = TOpResult{future};
     Operations[serialNumber] = op;
 
-    // If idempotenceId isn't provided - wait operation synchronously
-    if (!idempotenceId) {
-        return future;
-    }
-
-    return MakeFuture<TFnResult>(MakeError(E_TRY_AGAIN, "started"));
+    return future;
 }
 
 auto TLocalNVMeService::AcquireDevice(
     const TSerialNumber& serialNumber,
     const TString& idempotenceId) -> TFuture<TAcquireResult>
 {
-    return StartDeviceOperation<TAcquireOperationResult, TAcquireResult>(
+    auto future = StartOperation<TAcquireOperationResult, TAcquireResult>(
         &TLocalNVMeService::AcquireDeviceImpl,
         serialNumber,
         idempotenceId);
+
+    // If idempotenceId isn't provided - wait operation synchronously
+    if (!idempotenceId || future.IsReady()) {
+        return future;
+    }
+
+    return MakeFuture<TAcquireResult>(
+        MakeError(E_TRY_AGAIN, "Acquire in progress"));
 }
 
 auto TLocalNVMeService::AcquireDeviceImpl(NProto::TNVMeDevice device)
@@ -845,10 +848,18 @@ auto TLocalNVMeService::ReleaseDevice(
     const TSerialNumber& serialNumber,
     const TString& idempotenceId) -> TFuture<NProto::TError>
 {
-    return StartDeviceOperation<TReleaseOperationResult, NProto::TError>(
+    auto future = StartOperation<TReleaseOperationResult, NProto::TError>(
         &TLocalNVMeService::ReleaseDeviceImpl,
         serialNumber,
         idempotenceId);
+
+    // If idempotenceId isn't provided - wait operation synchronously
+    if (!idempotenceId || future.IsReady()) {
+        return future;
+    }
+
+    return MakeFuture<NProto::TError>(
+        MakeError(E_TRY_AGAIN, "Release in progress"));
 }
 
 auto TLocalNVMeService::ReleaseDeviceImpl(const NProto::TNVMeDevice& device)

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -16,6 +16,7 @@
 #include <util/folder/path.h>
 #include <util/generic/algorithm.h>
 #include <util/generic/hash_set.h>
+#include <util/generic/scope.h>
 #include <util/stream/str.h>
 #include <util/string/builder.h>
 #include <util/system/fs.h>
@@ -32,9 +33,16 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+const NProto::TError ServiceNotReadyError =
+    MakeError(E_REJECTED, "Local NVMe service is not ready");
+
+const NProto::TError ServiceStoppedError =
+    MakeError(E_REJECTED, "Local NVMe service is stopped");
+
 const NProto::TError ServiceDestroyedError =
     MakeError(E_REJECTED, "Local NVMe service is destroyed");
 
+const TDuration FetchDevicesRetryTimeout = TDuration::Seconds(1);
 const TDuration SanitizeStatusProbeTimeout = TDuration::MilliSeconds(100);
 const TDuration VfioDeviceRetryDelay = TDuration::MilliSeconds(100);
 const ui32 VfioDeviceMaxRetries = 100;
@@ -62,6 +70,21 @@ TString NormalizePCIAddr(const TString& pciAddr)
         return "0000:" + pciAddr;
     }
     return pciAddr;
+}
+
+bool SleepCont(TDuration dt)
+{
+    TCont* c = RunningCont();
+    Y_DEBUG_ABORT_UNLESS(c);
+
+    const int ec = c->SleepT(dt);
+    if (ec == ECANCELED) {
+        return false;
+    }
+
+    Y_DEBUG_ABORT_UNLESS(ec == ETIMEDOUT, "SleepT: %d", ec);
+
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,6 +123,14 @@ class TLocalNVMeService final
     : public std::enable_shared_from_this<TLocalNVMeService>
     , public ILocalNVMeService
 {
+    enum class EServiceState
+    {
+        NotReady,
+        Initializing,
+        Running,
+        Stopped
+    };
+
 private:
     const TLocalNVMeConfigPtr Config;
     const ILoggingServicePtr Logging;
@@ -108,8 +139,11 @@ private:
     const TExecutorPtr Executor;
     const ISysFsPtr SysFs;
 
+    std::atomic<EServiceState> ServiceState = EServiceState::NotReady;
+    TCont* InitializeCont = nullptr;
+    TFuture<void> Ready;
+
     TLog Log;
-    TFuture<NProto::TError> Ready;
     bool IsVfioDevSupported = false;
 
     THashMap<TSerialNumber, NProto::TNVMeDevice> Devices;
@@ -148,25 +182,26 @@ private:
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<TAcquireResult>;
 
-    auto AcquireDeviceImpl(TCont* c, NProto::TNVMeDevice device)
-        -> TAcquireResult;
+    auto AcquireDeviceImpl(NProto::TNVMeDevice device) -> TAcquireResult;
 
     auto ReleaseDevice(
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<NProto::TError>;
 
-    auto ReleaseDeviceImpl(TCont* c, const NProto::TNVMeDevice& device)
-        -> NProto::TError;
+    auto ReleaseDeviceImpl(const NProto::TNVMeDevice& device) -> NProto::TError;
 
     auto ListDevices() const -> TVector<NProto::TNVMeDevice>;
 
-    auto EnsureIsReady() const -> NProto::TError;
-    auto Initialize() -> NProto::TError;
+    static auto EnsureIsReady(
+        const std::weak_ptr<TLocalNVMeService>& weakService)
+        -> TResultOrError<std::shared_ptr<TLocalNVMeService>>;
+
+    void Initialize();
     auto FetchDevices() -> NProto::TError;
     bool TryRestoreStateFromCache();
     void UpdateStateCache();
     auto CreateStateSnapshot() -> NProto::TLocalNVMeServiceState;
-    auto SanitizeNVMeDevice(TCont* c, const NProto::TNVMeDevice& device)
+    auto SanitizeNVMeDevice(const NProto::TNVMeDevice& device)
         -> NProto::TError;
     auto ResetToSingleNamespace(const NProto::TNVMeDevice& device)
         -> NProto::TError;
@@ -174,8 +209,7 @@ private:
     auto BindDeviceToDriver(
         const NProto::TNVMeDevice& device,
         const TString& driverName) -> NProto::TError;
-    auto GetVfioDevName(TCont* c, const TString& pciAddress)
-        -> TResultOrError<TString>;
+    auto GetVfioDevName(const TString& pciAddress) -> TResultOrError<TString>;
 
     auto StopImpl() -> TFuture<void>;
 
@@ -186,7 +220,6 @@ private:
 
     template <typename TOpResult, typename TFnResult, typename TFn>
     auto StartDeviceOperation(
-        const char* name,
         TFn fn,
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<TFnResult>;
@@ -211,6 +244,9 @@ TLocalNVMeService::TLocalNVMeService(
 
 void TLocalNVMeService::Start()
 {
+    Y_DEBUG_ABORT_UNLESS(ServiceState == EServiceState::NotReady);
+    ServiceState = EServiceState::Initializing;
+
     Log = Logging->CreateLog("BLOCKSTORE_LOCAL_NVME");
 
     auto [supported, error] = SafeExecute<TResultOrError<bool>>(
@@ -226,17 +262,23 @@ void TLocalNVMeService::Start()
         [weakSelf = weak_from_this()]
         {
             if (auto self = weakSelf.lock()) {
-                return self->Initialize();
+                self->Initialize();
             }
-
-            return ServiceDestroyedError;
         });
 }
 
 auto TLocalNVMeService::StopImpl() -> TFuture<void>
 {
+    Y_DEBUG_ABORT_UNLESS(ServiceState == EServiceState::Stopped);
+
     TVector<TFuture<void>> futures;
-    futures.reserve(Operations.size());
+    futures.reserve(Operations.size() + 1);
+
+    if (InitializeCont) {
+        futures.push_back(Ready.IgnoreResult());
+
+        InitializeCont->Cancel();
+    }
 
     for (const auto& [_, op]: Operations) {
         futures.emplace_back(
@@ -254,12 +296,22 @@ auto TLocalNVMeService::StopImpl() -> TFuture<void>
 
 void TLocalNVMeService::Stop()
 {
+    EServiceState state = ServiceState;
+    if (state == EServiceState::Stopped || state == EServiceState::NotReady) {
+        // Service is not running
+        return;
+    }
+
+    ServiceState = EServiceState::Stopped;
+
     auto future = Executor->Execute(
         [weakSelf = weak_from_this()]
         {
-            if (auto self = weakSelf.lock()) {
+            auto self = weakSelf.lock();
+            if (self) {
                 return self->StopImpl();
             }
+
             return MakeFuture();
         });
     future.Wait();
@@ -269,17 +321,16 @@ auto TLocalNVMeService::ListNVMeDevices() -> TFuture<TListDevicesResult>
 {
     STORAGE_INFO("List NVMe devices");
 
-    if (auto error = EnsureIsReady(); HasError(error)) {
-        return MakeFuture<TListDevicesResult>(error);
-    }
-
     return Executor->Execute(
         [weakSelf = weak_from_this()]() -> TListDevicesResult
         {
-            if (auto self = weakSelf.lock()) {
-                return self->ListDevices();
+            auto [self, error] = EnsureIsReady(weakSelf);
+
+            if (HasError(error)) {
+                return error;
             }
-            return ServiceDestroyedError;
+
+            return self->ListDevices();
         });
 }
 
@@ -291,19 +342,17 @@ auto TLocalNVMeService::AcquireNVMeDevice(
         "Acquire NVMe device " << serialNumber.Quote()
                                << " idempotenceId: " << idempotenceId);
 
-    if (auto error = EnsureIsReady(); HasError(error)) {
-        return MakeFuture<TAcquireResult>(error);
-    }
-
     auto weakSelf = weak_from_this();
 
     return Executor->Execute(
         [weakSelf, serialNumber, idempotenceId]() mutable
         {
-            auto self = weakSelf.lock();
-            if (!self) {
-                return MakeFuture<TAcquireResult>(ServiceDestroyedError);
+            auto [self, error] = EnsureIsReady(weakSelf);
+
+            if (HasError(error)) {
+                return MakeFuture<TAcquireResult>(error);
             }
+
             return self->AcquireDevice(serialNumber, idempotenceId);
         });
 }
@@ -316,46 +365,50 @@ auto TLocalNVMeService::ReleaseNVMeDevice(
         "Release NVMe device " << serialNumber.Quote()
                                << " idempotenceId: " << idempotenceId);
 
-    if (auto error = EnsureIsReady(); HasError(error)) {
-        return MakeFuture(error);
-    }
-
     auto weakSelf = weak_from_this();
 
     return Executor->Execute(
         [weakSelf, serialNumber, idempotenceId]() mutable
         {
-            auto self = weakSelf.lock();
-            if (!self) {
-                return MakeFuture(ServiceDestroyedError);
+            auto [self, error] = EnsureIsReady(weakSelf);
+
+            if (HasError(error)) {
+                return MakeFuture(error);
             }
+
             return self->ReleaseDevice(serialNumber, idempotenceId);
         });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-auto TLocalNVMeService::EnsureIsReady() const -> NProto::TError
+auto TLocalNVMeService::EnsureIsReady(
+    const std::weak_ptr<TLocalNVMeService>& weakService)
+    -> TResultOrError<std::shared_ptr<TLocalNVMeService>>
 {
-    if (Ready.HasValue()) {
-        return Ready.GetValue();
+    auto service = weakService.lock();
+
+    if (!service) {
+        return ServiceDestroyedError;
     }
 
-    Y_DEBUG_ABORT_UNLESS(!Ready.HasException());
+    if (service->ServiceState == EServiceState::Stopped) {
+        return ServiceStoppedError;
+    }
 
-    return MakeError(E_REJECTED, "not ready");
+    if (service->ServiceState != EServiceState::Running) {
+        return ServiceNotReadyError;
+    }
+
+    return service;
 }
 
 auto TLocalNVMeService::FetchDevices() -> NProto::TError
 {
     auto future = DeviceProvider->ListNVMeDevices();
-
     auto [devices, error] = Executor->ResultOrError(future);
 
     if (HasError(error)) {
-        STORAGE_ERROR(
-            "Failed to fetch NVMe devices from the provider: "
-            << FormatError(error));
         return error;
     }
 
@@ -443,6 +496,8 @@ bool TLocalNVMeService::TryRestoreStateFromCache()
     if (!Config->GetStateCacheFilePath() ||
         !NFs::Exists(Config->GetStateCacheFilePath()))
     {
+        STORAGE_DEBUG("Cache not configured");
+
         return false;
     }
 
@@ -456,13 +511,18 @@ bool TLocalNVMeService::TryRestoreStateFromCache()
         return false;
     }
 
+    if (!proto.DevicesSize()) {
+        STORAGE_INFO("No NVMe devices in the cache");
+        return false;
+    }
+
     STORAGE_INFO(
         "Found in cache NVMe devices ("
         << proto.DevicesSize() << "): " << Join(", ", proto.GetDevices())
         << "; acquired devices: " << Join(", ", proto.GetAcquiredDevices())
         << ";");
 
-    for (auto& device: proto.GetDevices()) {
+    for (const auto& device: proto.GetDevices()) {
         Devices.emplace(device.GetSerialNumber(), device);
     }
 
@@ -473,21 +533,46 @@ bool TLocalNVMeService::TryRestoreStateFromCache()
     return true;
 }
 
-auto TLocalNVMeService::Initialize() -> NProto::TError
+void TLocalNVMeService::Initialize()
 {
+    STORAGE_INFO("Initializing... " << int(ServiceState.load()));
+
+    // Store a pointer to the current continuation so Initialize can be stopped
+    // if Stop is called.
+    InitializeCont = RunningCont();
+    Y_DEBUG_ABORT_UNLESS(InitializeCont);
+
+    Y_DEFER
+    {
+        InitializeCont = nullptr;
+    };
+
     if (!TryRestoreStateFromCache()) {
-        STORAGE_DEBUG("Cache restore failed, fetching from provider");
+        for (;;) {
+            STORAGE_INFO("Fetching NVMe devices from the provider");
 
-        return FetchDevices();
+            auto error = FetchDevices();
+            if (!HasError(error)) {
+                break;
+            }
+
+            STORAGE_ERROR(
+                "Failed to fetch NVMe devices from the provider: "
+                << FormatError(error));
+
+            if (!SleepCont(FetchDevicesRetryTimeout)) {
+                STORAGE_INFO("Initialization has been cancelled");
+                return;
+            }
+        }
     }
 
-    if (Devices.empty()) {
-        STORAGE_INFO("No NVMe devices in the cache, fetching from provider");
-
-        return FetchDevices();
+    EServiceState state = ServiceState;
+    if (state == EServiceState::Initializing) {
+        ServiceState.compare_exchange_strong(state, EServiceState::Running);
     }
 
-    return {};
+    STORAGE_INFO("Service initialized:" << int(state));
 }
 
 auto TLocalNVMeService::BindDeviceToDriver(
@@ -553,7 +638,6 @@ auto TLocalNVMeService::TryEarlyResponse(
 
 template <typename TOpResult, typename TFnResult, typename TFn>
 auto TLocalNVMeService::StartDeviceOperation(
-    const char* name,
     TFn fn,
     const TSerialNumber& serialNumber,
     const TString& idempotenceId) -> TFuture<TFnResult>
@@ -573,37 +657,33 @@ auto TLocalNVMeService::StartDeviceOperation(
         return *earlyResponse;
     }
 
-    auto promise = NewPromise<TFnResult>();
-
     auto op = std::make_shared<TOperation>();
-    op->Name = name;
+    op->Name = TypeName<TOpResult>();
     op->IdempotenceId = idempotenceId;
     op->StartTime = Now();
-    op->Result = TOpResult{promise.GetFuture()};
 
     auto weakSelf = weak_from_this();
 
-    auto* e = Executor->GetContExecutor();
-    auto* cont = e->CreateOwned(
-        [op, promise, weakSelf, fn, device = *device](TCont* c) mutable
+    auto future = Executor->Execute(
+        [op, weakSelf, fn, device = *device]() mutable
         {
+            op->Cont = RunningCont();
+
             auto self = weakSelf.lock();
             TFnResult r =
-                self ? std::invoke(fn, self, c, device) : ServiceDestroyedError;
+                self ? std::invoke(fn, self, device) : ServiceDestroyedError;
 
             op->FinishTime = Now();
             op->Cont = nullptr;
-            promise.SetValue(r);
-        },
-        name);
+            return r;
+        });
 
-    op->Cont = cont;
-
+    op->Result = TOpResult{future};
     Operations[serialNumber] = op;
 
     // If idempotenceId isn't provided - wait operation synchronously
     if (!idempotenceId) {
-        return promise.GetFuture();
+        return future;
     }
 
     return MakeFuture<TFnResult>(MakeError(E_TRY_AGAIN, "started"));
@@ -614,13 +694,12 @@ auto TLocalNVMeService::AcquireDevice(
     const TString& idempotenceId) -> TFuture<TAcquireResult>
 {
     return StartDeviceOperation<TAcquireOperationResult, TAcquireResult>(
-        "Acquire",
         &TLocalNVMeService::AcquireDeviceImpl,
         serialNumber,
         idempotenceId);
 }
 
-auto TLocalNVMeService::AcquireDeviceImpl(TCont* c, NProto::TNVMeDevice device)
+auto TLocalNVMeService::AcquireDeviceImpl(NProto::TNVMeDevice device)
     -> TResultOrError<NProto::TNVMeDevice>
 {
     const auto& serialNumber = device.GetSerialNumber();
@@ -643,7 +722,7 @@ auto TLocalNVMeService::AcquireDeviceImpl(TCont* c, NProto::TNVMeDevice device)
         return device;
     }
 
-    auto [vfioDev, error] = GetVfioDevName(c, device.GetPCIAddress());
+    auto [vfioDev, error] = GetVfioDevName(device.GetPCIAddress());
     if (HasError(error)) {
         STORAGE_ERROR(
             "Failed to get vfio device for " << device << ": "
@@ -655,7 +734,7 @@ auto TLocalNVMeService::AcquireDeviceImpl(TCont* c, NProto::TNVMeDevice device)
     return device;
 }
 
-auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
+auto TLocalNVMeService::GetVfioDevName(const TString& pciAddress)
     -> TResultOrError<TString>
 {
     // Binding to vfio-pci completes before the vfio-dev sysfs entry may
@@ -679,12 +758,9 @@ auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
             << pciAddress << " was not found, retry (attempts: " << attempt + 1
             << "/" << VfioDeviceMaxRetries << ")");
 
-        const int ec = c->SleepT(VfioDeviceRetryDelay);
-        if (ec == ECANCELED) {
+        if (!SleepCont(VfioDeviceRetryDelay)) {
             return ServiceDestroyedError;
         }
-
-        Y_DEBUG_ABORT_UNLESS(ec == ETIMEDOUT, "SleepT: %d", ec);
     }
 
     return MakeError(
@@ -708,9 +784,8 @@ auto TLocalNVMeService::GetNVMeCtrlPath(const NProto::TNVMeDevice& device)
     return TFsPath{"/dev"} / ctrlName;
 }
 
-auto TLocalNVMeService::SanitizeNVMeDevice(
-    TCont* c,
-    const NProto::TNVMeDevice& device) -> NProto::TError
+auto TLocalNVMeService::SanitizeNVMeDevice(const NProto::TNVMeDevice& device)
+    -> NProto::TError
 try {
     STORAGE_INFO("Sanitize " << device.GetSerialNumber().Quote());
 
@@ -735,17 +810,13 @@ try {
             return r.Status;
         }
 
-        const int ec = c->SleepT(SanitizeStatusProbeTimeout);
-
-        if (ec == ECANCELED) {
+        if (!SleepCont(SanitizeStatusProbeTimeout)) {
             STORAGE_INFO(
                 "Status polling of sanitize operation for "
                 << device.GetSerialNumber().Quote() << " was cancelled");
 
             return ServiceDestroyedError;
         }
-
-        Y_DEBUG_ABORT_UNLESS(ec == ETIMEDOUT, "SleepT: %d", ec);
     }
 
     return {};
@@ -774,21 +845,19 @@ auto TLocalNVMeService::ReleaseDevice(
     const TString& idempotenceId) -> TFuture<NProto::TError>
 {
     return StartDeviceOperation<TReleaseOperationResult, NProto::TError>(
-        "Release",
         &TLocalNVMeService::ReleaseDeviceImpl,
         serialNumber,
         idempotenceId);
 }
 
-auto TLocalNVMeService::ReleaseDeviceImpl(
-    TCont* c,
-    const NProto::TNVMeDevice& device) -> NProto::TError
+auto TLocalNVMeService::ReleaseDeviceImpl(const NProto::TNVMeDevice& device)
+    -> NProto::TError
 {
     if (auto error = BindDeviceToDriver(device, "nvme"); HasError(error)) {
         return error;
     }
 
-    if (auto error = SanitizeNVMeDevice(c, device); HasError(error)) {
+    if (auto error = SanitizeNVMeDevice(device); HasError(error)) {
         return error;
     }
 

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -296,7 +296,7 @@ auto TLocalNVMeService::StopImpl() -> TFuture<void>
 
 void TLocalNVMeService::Stop()
 {
-    EServiceState state = ServiceState;
+    const EServiceState state = ServiceState;
     if (state == EServiceState::Stopped || state == EServiceState::NotReady) {
         // Service is not running
         return;
@@ -535,8 +535,6 @@ bool TLocalNVMeService::TryRestoreStateFromCache()
 
 void TLocalNVMeService::Initialize()
 {
-    STORAGE_INFO("Initializing... " << int(ServiceState.load()));
-
     // Store a pointer to the current continuation so Initialize can be stopped
     // if Stop is called.
     InitializeCont = RunningCont();
@@ -568,11 +566,14 @@ void TLocalNVMeService::Initialize()
     }
 
     EServiceState state = ServiceState;
-    if (state == EServiceState::Initializing) {
-        ServiceState.compare_exchange_strong(state, EServiceState::Running);
+    if (state != EServiceState::Initializing) {
+        Y_DEBUG_ABORT_UNLESS(state == EServiceState::Stopped);
+        return;
     }
 
-    STORAGE_INFO("Service initialized:" << int(state));
+    if (!ServiceState.compare_exchange_strong(state, EServiceState::Running)) {
+        Y_DEBUG_ABORT_UNLESS(state == EServiceState::Stopped);
+    }
 }
 
 auto TLocalNVMeService::BindDeviceToDriver(

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -24,11 +24,15 @@ namespace NCloud::NBlockStore {
 
 using namespace NThreading;
 
+using TSerialNumber = TString;
+using TListDevicesResult = TResultOrError<TVector<NProto::TNVMeDevice>>;
+using TAcquireResult = TResultOrError<NProto::TNVMeDevice>;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const TErrorResponse ServiceDestroyedError =
+const NProto::TError ServiceDestroyedError =
     MakeError(E_REJECTED, "Local NVMe service is destroyed");
 
 const TDuration SanitizeStatusProbeTimeout = TDuration::MilliSeconds(100);
@@ -62,12 +66,40 @@ TString NormalizePCIAddr(const TString& pciAddr)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TAcquireOperationResult
+{
+    TFuture<TAcquireResult> Result;
+};
+
+struct TReleaseOperationResult
+{
+    TFuture<NProto::TError> Result;
+};
+
+using TOperationResult =
+    std::variant<TAcquireOperationResult, TReleaseOperationResult>;
+
+struct TOperation
+{
+    TString Name;
+    TString IdempotenceId;
+    TInstant StartTime;
+    TInstant FinishTime;
+    TCont* Cont = nullptr;
+
+    TOperationResult Result;
+};
+
+using TOperationPtr = std::shared_ptr<TOperation>;
+
+using TOperations = THashMap<TSerialNumber, TOperationPtr>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TLocalNVMeService final
     : public std::enable_shared_from_this<TLocalNVMeService>
     , public ILocalNVMeService
 {
-    using TListDevicesResult = TResultOrError<TVector<NProto::TNVMeDevice>>;
-
 private:
     const TLocalNVMeConfigPtr Config;
     const ILoggingServicePtr Logging;
@@ -80,8 +112,10 @@ private:
     TFuture<NProto::TError> Ready;
     bool IsVfioDevSupported = false;
 
-    THashMap<TString, NProto::TNVMeDevice> Devices;
-    THashSet<TString> AcquiredDevices;
+    THashMap<TSerialNumber, NProto::TNVMeDevice> Devices;
+    THashSet<TSerialNumber> AcquiredDevices;
+
+    TOperations Operations;
 
 public:
     TLocalNVMeService(
@@ -101,17 +135,30 @@ public:
 
     [[nodiscard]] auto ListNVMeDevices() -> TFuture<TListDevicesResult> final;
 
-    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
-        -> TFuture<TResultOrError<NProto::TNVMeDevice>> final;
+    [[nodiscard]] auto AcquireNVMeDevice(
+        const TSerialNumber& serialNumber,
+        const TString& idempotenceId) -> TFuture<TAcquireResult> final;
 
-    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> final;
+    [[nodiscard]] auto ReleaseNVMeDevice(
+        const TSerialNumber& serialNumber,
+        const TString& idempotenceId) -> TFuture<NProto::TError> final;
 
 private:
-    auto AcquireDevice(TCont* c, const TString& serialNumber)
-        -> TResultOrError<NProto::TNVMeDevice>;
-    auto ReleaseDevice(TCont* c, const TString& serialNumber) -> NProto::TError;
-    auto ListDevices(TCont* c) const -> TVector<NProto::TNVMeDevice>;
+    auto AcquireDevice(
+        const TSerialNumber& serialNumber,
+        const TString& idempotenceId) -> TFuture<TAcquireResult>;
+
+    auto AcquireDeviceImpl(TCont* c, NProto::TNVMeDevice device)
+        -> TAcquireResult;
+
+    auto ReleaseDevice(
+        const TSerialNumber& serialNumber,
+        const TString& idempotenceId) -> TFuture<NProto::TError>;
+
+    auto ReleaseDeviceImpl(TCont* c, const NProto::TNVMeDevice& device)
+        -> NProto::TError;
+
+    auto ListDevices() const -> TVector<NProto::TNVMeDevice>;
 
     auto EnsureIsReady() const -> NProto::TError;
     auto Initialize() -> NProto::TError;
@@ -130,33 +177,19 @@ private:
     auto GetVfioDevName(TCont* c, const TString& pciAddress)
         -> TResultOrError<TString>;
 
-    // Spawn a coroutine with a name `name` to execute `fn`
-    template <typename R, typename TSelf, typename F, typename... TArgs>
-    static auto
-    ExecuteAsync(TSelf&& service, const char* name, F fn, TArgs&&... args)
-        -> TFuture<R>
-    {
-        auto promise = NewPromise<R>();
-        auto weakSelf = service.weak_from_this();
+    auto StopImpl() -> TFuture<void>;
 
-        service.Executor->Execute(
-            [weakSelf, name, promise, fn, args...]() mutable
-            {
-                if (auto self = weakSelf.lock()) {
-                    auto* e = self->Executor->GetContExecutor();
-                    e->CreateOwned(
-                        [promise, fn, self, args...](TCont* c) mutable
-                        {
-                            promise.SetValue(std::invoke(fn, self, c, args...));
-                        },
-                        name);
-                } else {
-                    promise.SetValue(ServiceDestroyedError);
-                }
-            });
+    template <typename TOpResult, typename TFnResult>
+    auto TryEarlyResponse(
+        const TSerialNumber& serialNumber,
+        const TString& idempotenceId) -> std::optional<TFuture<TFnResult>>;
 
-        return promise.GetFuture();
-    }
+    template <typename TOpResult, typename TFnResult, typename TFn>
+    auto StartDeviceOperation(
+        const char* name,
+        TFn fn,
+        const TSerialNumber& serialNumber,
+        const TString& idempotenceId) -> TFuture<TFnResult>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -190,7 +223,7 @@ void TLocalNVMeService::Start()
     }
 
     Ready = Executor->Execute(
-        [weakSelf = weak_from_this()]() -> NProto::TError
+        [weakSelf = weak_from_this()]
         {
             if (auto self = weakSelf.lock()) {
                 return self->Initialize();
@@ -200,8 +233,37 @@ void TLocalNVMeService::Start()
         });
 }
 
+auto TLocalNVMeService::StopImpl() -> TFuture<void>
+{
+    TVector<TFuture<void>> futures;
+    futures.reserve(Operations.size());
+
+    for (const auto& [_, op]: Operations) {
+        futures.emplace_back(
+            std::visit(
+                [](const auto& r) { return r.Result.IgnoreResult(); },
+                op->Result));
+
+        if (op->Cont) {
+            op->Cont->Cancel();
+        }
+    }
+
+    return WaitAll(futures);
+}
+
 void TLocalNVMeService::Stop()
-{}
+{
+    auto future = Executor->Execute(
+        [weakSelf = weak_from_this()]
+        {
+            if (auto self = weakSelf.lock()) {
+                return self->StopImpl();
+            }
+            return MakeFuture();
+        });
+    future.Wait();
+}
 
 auto TLocalNVMeService::ListNVMeDevices() -> TFuture<TListDevicesResult>
 {
@@ -211,42 +273,64 @@ auto TLocalNVMeService::ListNVMeDevices() -> TFuture<TListDevicesResult>
         return MakeFuture<TListDevicesResult>(error);
     }
 
-    return ExecuteAsync<TListDevicesResult>(
-        *this,
-        "list",
-        &TLocalNVMeService::ListDevices);
+    return Executor->Execute(
+        [weakSelf = weak_from_this()]() -> TListDevicesResult
+        {
+            if (auto self = weakSelf.lock()) {
+                return self->ListDevices();
+            }
+            return ServiceDestroyedError;
+        });
 }
 
-auto TLocalNVMeService::AcquireNVMeDevice(const TString& serialNumber)
-    -> TFuture<TResultOrError<NProto::TNVMeDevice>>
+auto TLocalNVMeService::AcquireNVMeDevice(
+    const TSerialNumber& serialNumber,
+    const TString& idempotenceId) -> TFuture<TAcquireResult>
 {
-    STORAGE_INFO("Acquire NVMe device " << serialNumber.Quote());
+    STORAGE_INFO(
+        "Acquire NVMe device " << serialNumber.Quote()
+                               << " idempotenceId: " << idempotenceId);
 
     if (auto error = EnsureIsReady(); HasError(error)) {
-        return MakeFuture(TResultOrError<NProto::TNVMeDevice>(error));
+        return MakeFuture<TAcquireResult>(error);
     }
 
-    return ExecuteAsync<TResultOrError<NProto::TNVMeDevice>>(
-        *this,
-        "acquire",
-        &TLocalNVMeService::AcquireDevice,
-        serialNumber);
+    auto weakSelf = weak_from_this();
+
+    return Executor->Execute(
+        [weakSelf, serialNumber, idempotenceId]() mutable
+        {
+            auto self = weakSelf.lock();
+            if (!self) {
+                return MakeFuture<TAcquireResult>(ServiceDestroyedError);
+            }
+            return self->AcquireDevice(serialNumber, idempotenceId);
+        });
 }
 
-auto TLocalNVMeService::ReleaseNVMeDevice(const TString& serialNumber)
-    -> TFuture<NProto::TError>
+auto TLocalNVMeService::ReleaseNVMeDevice(
+    const TSerialNumber& serialNumber,
+    const TString& idempotenceId) -> TFuture<NProto::TError>
 {
-    STORAGE_INFO("Release NVMe device " << serialNumber.Quote());
+    STORAGE_INFO(
+        "Release NVMe device " << serialNumber.Quote()
+                               << " idempotenceId: " << idempotenceId);
 
     if (auto error = EnsureIsReady(); HasError(error)) {
         return MakeFuture(error);
     }
 
-    return ExecuteAsync<NProto::TError>(
-        *this,
-        "release",
-        &TLocalNVMeService::ReleaseDevice,
-        serialNumber);
+    auto weakSelf = weak_from_this();
+
+    return Executor->Execute(
+        [weakSelf, serialNumber, idempotenceId]() mutable
+        {
+            auto self = weakSelf.lock();
+            if (!self) {
+                return MakeFuture(ServiceDestroyedError);
+            }
+            return self->ReleaseDevice(serialNumber, idempotenceId);
+        });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -294,9 +378,8 @@ auto TLocalNVMeService::FetchDevices() -> NProto::TError
 
         const auto pciAddr = NormalizePCIAddr(src.GetPCIAddress());
 
-        auto [device, deviceError] =
-            SafeExecute<TResultOrError<NProto::TNVMeDevice>>(
-                [&] { return SysFs->GetNVMeDeviceFromPCIAddr(pciAddr); });
+        auto [device, deviceError] = SafeExecute<TAcquireResult>(
+            [&] { return SysFs->GetNVMeDeviceFromPCIAddr(pciAddr); });
 
         if (HasError(deviceError)) {
             STORAGE_ERROR(
@@ -423,48 +506,153 @@ auto TLocalNVMeService::BindDeviceToDriver(
         });
 }
 
-auto TLocalNVMeService::AcquireDevice(TCont* c, const TString& serialNumber)
-    -> TResultOrError<NProto::TNVMeDevice>
+template <typename TOpResult, typename TFnResult>
+auto TLocalNVMeService::TryEarlyResponse(
+    const TSerialNumber& serialNumber,
+    const TString& idempotenceId) -> std::optional<TFuture<TFnResult>>
+{
+    auto makeErrorFuture = [](ui32 code, TString msg)
+    {
+        return MakeFuture<TFnResult>(MakeError(code, std::move(msg)));
+    };
+
+    auto it = Operations.find(serialNumber);
+    if (it == Operations.end()) {
+        return std::nullopt;
+    }
+
+    const auto& op = *it->second;
+
+    const bool sameId = idempotenceId && idempotenceId == op.IdempotenceId;
+
+    if (sameId) {
+        const auto* typedOp = std::get_if<TOpResult>(&op.Result);
+        if (!typedOp) {
+            return makeErrorFuture(
+                E_ARGUMENT,
+                "idempotence id was used for a different operation type");
+        }
+
+        if (!op.FinishTime) {
+            return makeErrorFuture(E_TRY_AGAIN, "Operation is in progress");
+        }
+
+        return typedOp->Result;
+    }
+
+    if (!op.FinishTime) {
+        return makeErrorFuture(
+            E_TRY_AGAIN,
+            TStringBuilder()
+                << "Another operation (" << op.Name << ", started at "
+                << op.StartTime << ") is in progress");
+    }
+
+    return std::nullopt;
+}
+
+template <typename TOpResult, typename TFnResult, typename TFn>
+auto TLocalNVMeService::StartDeviceOperation(
+    const char* name,
+    TFn fn,
+    const TSerialNumber& serialNumber,
+    const TString& idempotenceId) -> TFuture<TFnResult>
 {
     const auto* device = Devices.FindPtr(serialNumber);
 
     if (!device) {
-        return MakeError(
+        return MakeFuture<TFnResult>(MakeError(
             E_NOT_FOUND,
             TStringBuilder()
-                << "Device " << serialNumber.Quote() << " not found");
+                << "Device " << serialNumber.Quote() << " not found"));
     }
+
+    if (auto earlyResponse =
+            TryEarlyResponse<TOpResult, TFnResult>(serialNumber, idempotenceId))
+    {
+        return *earlyResponse;
+    }
+
+    auto promise = NewPromise<TFnResult>();
+
+    auto op = std::make_shared<TOperation>();
+    op->Name = name;
+    op->IdempotenceId = idempotenceId;
+    op->StartTime = Now();
+    op->Result = TOpResult{promise.GetFuture()};
+
+    auto weakSelf = weak_from_this();
+
+    auto* e = Executor->GetContExecutor();
+    auto* cont = e->CreateOwned(
+        [op, promise, weakSelf, fn, device = *device](TCont* c) mutable
+        {
+            auto self = weakSelf.lock();
+            TFnResult r =
+                self ? std::invoke(fn, self, c, device) : ServiceDestroyedError;
+
+            op->FinishTime = Now();
+            op->Cont = nullptr;
+            promise.SetValue(r);
+        },
+        name);
+
+    op->Cont = cont;
+
+    Operations[serialNumber] = op;
+
+    // If idempotenceId isn't provided - wait operation synchronously
+    if (!idempotenceId) {
+        return promise.GetFuture();
+    }
+
+    return MakeFuture<TFnResult>(MakeError(E_TRY_AGAIN, "started"));
+}
+
+auto TLocalNVMeService::AcquireDevice(
+    const TSerialNumber& serialNumber,
+    const TString& idempotenceId) -> TFuture<TAcquireResult>
+{
+    return StartDeviceOperation<TAcquireOperationResult, TAcquireResult>(
+        "Acquire",
+        &TLocalNVMeService::AcquireDeviceImpl,
+        serialNumber,
+        idempotenceId);
+}
+
+auto TLocalNVMeService::AcquireDeviceImpl(TCont* c, NProto::TNVMeDevice device)
+    -> TResultOrError<NProto::TNVMeDevice>
+{
+    const auto& serialNumber = device.GetSerialNumber();
 
     auto [_, ok] = AcquiredDevices.insert(serialNumber);
     if (!ok) {
         return MakeError(
-            E_ARGUMENT,
+            E_INVALID_STATE,
             TStringBuilder()
                 << "Device " << serialNumber.Quote() << " already acquired");
     }
 
     UpdateStateCache();
 
-    if (auto error = BindDeviceToDriver(*device, "vfio-pci"); HasError(error)) {
+    if (auto error = BindDeviceToDriver(device, "vfio-pci"); HasError(error)) {
         return error;
     }
 
-    NProto::TNVMeDevice r = *device;
-
     if (!IsVfioDevSupported) {
-        return r;
+        return device;
     }
 
-    auto [vfioDev, error] = GetVfioDevName(c, r.GetPCIAddress());
+    auto [vfioDev, error] = GetVfioDevName(c, device.GetPCIAddress());
     if (HasError(error)) {
         STORAGE_ERROR(
-            "Failed to get vfio device for " << r << ": "
+            "Failed to get vfio device for " << device << ": "
                                              << FormatError(error));
     } else {
-        r.SetVfioDevName(std::move(vfioDev));
+        device.SetVfioDevName(std::move(vfioDev));
     }
 
-    return r;
+    return device;
 }
 
 auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
@@ -487,7 +675,14 @@ auto TLocalNVMeService::GetVfioDevName(TCont* c, const TString& pciAddress)
                 "vfio device for PCI address "
                 << pciAddress << " was not found, retry (attempts: "
                 << attempt + 1 << "/" << VfioDeviceMaxRetries << ")");
-            c->SleepT(VfioDeviceRetryDelay);
+
+            const int ec = c->SleepT(VfioDeviceRetryDelay);
+            if (ec == ECANCELED) {
+                return ServiceDestroyedError;
+            }
+
+            Y_DEBUG_ABORT_UNLESS(ec == ETIMEDOUT, "SleepT: %d", ec);
+
             continue;
         }
 
@@ -544,7 +739,17 @@ try {
             return r.Status;
         }
 
-        c->SleepT(SanitizeStatusProbeTimeout);
+        const int ec = c->SleepT(SanitizeStatusProbeTimeout);
+
+        if (ec == ECANCELED) {
+            STORAGE_INFO(
+                "Status polling of sanitize operation for "
+                << device.GetSerialNumber().Quote() << " was cancelled");
+
+            return ServiceDestroyedError;
+        }
+
+        Y_DEBUG_ABORT_UNLESS(ec == ETIMEDOUT, "SleepT: %d", ec);
     }
 
     return {};
@@ -568,42 +773,42 @@ auto TLocalNVMeService::ResetToSingleNamespace(
         });
 }
 
-auto TLocalNVMeService::ReleaseDevice(TCont* c, const TString& serialNumber)
-    -> NProto::TError
+auto TLocalNVMeService::ReleaseDevice(
+    const TSerialNumber& serialNumber,
+    const TString& idempotenceId) -> TFuture<NProto::TError>
 {
-    const auto* device = Devices.FindPtr(serialNumber);
+    return StartDeviceOperation<TReleaseOperationResult, NProto::TError>(
+        "Release",
+        &TLocalNVMeService::ReleaseDeviceImpl,
+        serialNumber,
+        idempotenceId);
+}
 
-    if (!device) {
-        return MakeError(
-            E_NOT_FOUND,
-            TStringBuilder()
-                << "Device " << serialNumber.Quote() << " not found");
-    }
-
-    if (auto error = BindDeviceToDriver(*device, "nvme"); HasError(error)) {
+auto TLocalNVMeService::ReleaseDeviceImpl(
+    TCont* c,
+    const NProto::TNVMeDevice& device) -> NProto::TError
+{
+    if (auto error = BindDeviceToDriver(device, "nvme"); HasError(error)) {
         return error;
     }
 
-    if (auto error = SanitizeNVMeDevice(c, *device); HasError(error)) {
+    if (auto error = SanitizeNVMeDevice(c, device); HasError(error)) {
         return error;
     }
 
-    if (auto error = ResetToSingleNamespace(*device); HasError(error)) {
+    if (auto error = ResetToSingleNamespace(device); HasError(error)) {
         return error;
     }
 
-    AcquiredDevices.erase(serialNumber);
+    AcquiredDevices.erase(device.GetSerialNumber());
 
     UpdateStateCache();
 
     return {};
 }
 
-auto TLocalNVMeService::ListDevices(TCont* c) const
-    -> TVector<NProto::TNVMeDevice>
+auto TLocalNVMeService::ListDevices() const -> TVector<NProto::TNVMeDevice>
 {
-    Y_UNUSED(c);
-
     TVector<NProto::TNVMeDevice> devices;
     devices.reserve(Devices.size());
 

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -101,7 +101,7 @@ public:
         auto& info = SanitizeInfo[ctrlPath];
         if (info.Status.GetCode() == E_TRY_AGAIN) {
             return MakeError(
-                E_TRY_AGAIN,
+                E_INVALID_STATE,
                 "previous sanitize operation has not been completed yet");
         }
 
@@ -222,6 +222,8 @@ struct TTestSysFs final: ISysFs
 
 struct TFixtureBase: public NUnitTest::TBaseFixture
 {
+    const TString EmptyIdempotenceId;
+
     TString StateCacheFile;
     TVector<NProto::TNVMeDevice> Devices;
 
@@ -527,7 +529,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             return vfioDev;
         };
 
-        auto future = Service->AcquireNVMeDevice(device.GetSerialNumber());
+        auto future = Service->AcquireNVMeDevice(
+            device.GetSerialNumber(),
+            EmptyIdempotenceId);
 
         const auto& [r, error] = future.GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(S_OK, error.GetCode(), FormatError(error));
@@ -544,7 +548,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         for (const auto& sn: {serialNumber, TString("UNK")}) {
             {
-                auto future = Service->AcquireNVMeDevice(sn);
+                auto future =
+                    Service->AcquireNVMeDevice(sn, EmptyIdempotenceId);
                 const auto& [_, error] = future.GetValueSync();
                 UNIT_ASSERT_VALUES_EQUAL_C(
                     E_REJECTED,
@@ -553,7 +558,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             }
 
             {
-                auto future = Service->ReleaseNVMeDevice(sn);
+                auto future =
+                    Service->ReleaseNVMeDevice(sn, EmptyIdempotenceId);
                 const auto& error = future.GetValueSync();
                 UNIT_ASSERT_VALUES_EQUAL_C(
                     E_REJECTED,
@@ -577,7 +583,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
 
         {
-            auto future = Service->AcquireNVMeDevice("UNK");
+            auto future = Service->AcquireNVMeDevice("UNK", EmptyIdempotenceId);
             const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_NOT_FOUND,
@@ -586,7 +592,7 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
 
         {
-            auto future = Service->ReleaseNVMeDevice("UNK");
+            auto future = Service->ReleaseNVMeDevice("UNK", EmptyIdempotenceId);
             const auto& error = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_NOT_FOUND,
@@ -608,7 +614,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 return {};
             };
 
-            auto future = Service->AcquireNVMeDevice(serialNumber);
+            auto future =
+                Service->AcquireNVMeDevice(serialNumber, EmptyIdempotenceId);
             const auto& [device, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
@@ -628,7 +635,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 0,
                 NVMeManager->GetSanitizeInfo(ctrlPath).Count);
 
-            auto future = Service->ReleaseNVMeDevice(serialNumber);
+            auto future =
+                Service->ReleaseNVMeDevice(serialNumber, EmptyIdempotenceId);
 
             NVMeManager->WaitSanitizeRequested();
             UNIT_ASSERT_VALUES_EQUAL(
@@ -696,10 +704,14 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
                     for (int i = 0; i != requestNum; ++i) {
                         futures.push_back(
-                            Service->AcquireNVMeDevice("UNK").Apply(
-                                [](const auto& future)
-                                { return future.GetValue().GetError(); }));
-                        futures.push_back(Service->ReleaseNVMeDevice("UNK"));
+                            Service
+                                ->AcquireNVMeDevice("UNK", EmptyIdempotenceId)
+                                .Apply(
+                                    [](const auto& future)
+                                    { return future.GetValue().GetError(); }));
+                        futures.push_back(Service->ReleaseNVMeDevice(
+                            "UNK",
+                            EmptyIdempotenceId));
                         Sleep(10ms);
                     }
 
@@ -756,7 +768,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
 
         {
-            auto future = Service->AcquireNVMeDevice("NVME_0");
+            auto future =
+                Service->AcquireNVMeDevice("NVME_0", EmptyIdempotenceId);
             const auto& [device, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
@@ -766,7 +779,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
 
         {
-            auto future = Service->AcquireNVMeDevice("NVME_2");
+            auto future =
+                Service->AcquireNVMeDevice("NVME_2", EmptyIdempotenceId);
             const auto& [device, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
@@ -798,7 +812,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         {
             const TString ctrlPath = "/dev/nvme0";
-            auto future = Service->ReleaseNVMeDevice("NVME_0");
+            auto future =
+                Service->ReleaseNVMeDevice("NVME_0", EmptyIdempotenceId);
 
             NVMeManager->WaitSanitizeRequested();
             NVMeManager->UpdateSanitizeStatus(ctrlPath, MakeError(S_OK), 100.0);
@@ -864,18 +879,20 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
 
         {
-            auto future =
-                Service->AcquireNVMeDevice(Devices[0].GetSerialNumber());
+            auto future = Service->AcquireNVMeDevice(
+                Devices[0].GetSerialNumber(),
+                EmptyIdempotenceId);
             const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_ARGUMENT,
+                E_INVALID_STATE,
                 error.GetCode(),
                 FormatError(error));
         }
 
         {
-            auto future =
-                Service->AcquireNVMeDevice(Devices[1].GetSerialNumber());
+            auto future = Service->AcquireNVMeDevice(
+                Devices[1].GetSerialNumber(),
+                EmptyIdempotenceId);
             const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
@@ -884,11 +901,12 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         }
 
         {
-            auto future =
-                Service->AcquireNVMeDevice(Devices[2].GetSerialNumber());
+            auto future = Service->AcquireNVMeDevice(
+                Devices[2].GetSerialNumber(),
+                EmptyIdempotenceId);
             const auto& [_, error] = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_ARGUMENT,
+                E_INVALID_STATE,
                 error.GetCode(),
                 FormatError(error));
         }
@@ -970,14 +988,18 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         const TString ctrlPath1 = "/dev/nvme0";
         const TString ctrlPath2 = "/dev/nvme1";
 
-        auto future1 = Service->ReleaseNVMeDevice(Devices[0].GetSerialNumber());
+        auto future1 = Service->ReleaseNVMeDevice(
+            Devices[0].GetSerialNumber(),
+            EmptyIdempotenceId);
         NVMeManager->WaitSanitizeRequested();
         UNIT_ASSERT_VALUES_EQUAL(
             1,
             NVMeManager->GetSanitizeInfo(ctrlPath1).Count);
         UNIT_ASSERT(!future1.HasValue());
 
-        auto future2 = Service->ReleaseNVMeDevice(Devices[1].GetSerialNumber());
+        auto future2 = Service->ReleaseNVMeDevice(
+            Devices[1].GetSerialNumber(),
+            EmptyIdempotenceId);
         NVMeManager->WaitSanitizeRequested();
         UNIT_ASSERT_VALUES_EQUAL(
             1,
@@ -1057,7 +1079,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         const TString ctrlPath = "/dev/nvme0";
 
-        auto future = Service->ReleaseNVMeDevice(Devices[0].GetSerialNumber());
+        auto future = Service->ReleaseNVMeDevice(
+            Devices[0].GetSerialNumber(),
+            EmptyIdempotenceId);
         NVMeManager->WaitSanitizeRequested();
         NVMeManager->UpdateSanitizeStatus(
             ctrlPath,
@@ -1071,6 +1095,243 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
 
         const auto& error = future.GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(E_FAIL, error.GetCode(), FormatError(error));
+    }
+
+    Y_UNIT_TEST_F(ShouldNotAllowConcurrentRequestsForSameDevice, TFixture)
+    {
+        SetProviderReady();
+        {
+            auto [_, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        const auto& sn = Devices[0].GetSerialNumber();
+        const TString ctrlPath = "/dev/nvme0";
+
+        auto future1 = Service->ReleaseNVMeDevice(sn, EmptyIdempotenceId);
+        NVMeManager->WaitSanitizeRequested();
+
+        {
+            auto future2 = Service->ReleaseNVMeDevice(sn, EmptyIdempotenceId);
+            const auto& error = future2.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        NVMeManager->UpdateSanitizeStatus(ctrlPath, MakeError(S_OK), 100.0);
+
+        {
+            const auto& error = future1.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldExecuteOperationIdempotentlyByIdempotenceId, TFixture)
+    {
+        SetProviderReady();
+        {
+            auto [_, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        const auto& device = Devices[0];
+        const auto& sn = device.GetSerialNumber();
+        const TString ctrlPath = "/dev/nvme0";
+
+        SysFs->GetVfioDeviceForPCIDeviceImpl =
+            [&](const TString& pciAddr) -> TString
+        {
+            if (pciAddr == device.GetPCIAddress()) {
+                return "vfio0";
+            }
+            return {};
+        };
+
+        {
+            auto future = Service->ReleaseNVMeDevice(sn, "idempotence-id-1");
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+        }
+        {
+            auto future = Service->ReleaseNVMeDevice(sn, "xxx");
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            auto future = Service->ReleaseNVMeDevice(sn, EmptyIdempotenceId);
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        NVMeManager->WaitSanitizeRequested();
+        NVMeManager->UpdateSanitizeStatus(ctrlPath, MakeError(S_OK), 100.0);
+
+        for (;;) {
+            auto future = Service->ReleaseNVMeDevice(sn, "idempotence-id-1");
+            const auto& error = future.GetValueSync();
+            if (!HasError(error)) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    S_OK,
+                    error.GetCode(),
+                    FormatError(error));
+                break;
+            }
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+            Sleep(100ms);
+        }
+
+        {
+            auto future = Service->ReleaseNVMeDevice(sn, "idempotence-id-1");
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        // Start a new operation (sync)
+        {
+            auto future = Service->ReleaseNVMeDevice(sn, EmptyIdempotenceId);
+
+            NVMeManager->WaitSanitizeRequested();
+            NVMeManager->UpdateSanitizeStatus(ctrlPath, MakeError(S_OK), 100.0);
+
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        for (;;) {
+            auto future = Service->AcquireNVMeDevice(sn, "idempotence-id-2");
+            const auto& [_, error] = future.GetValueSync();
+            if (!HasError(error)) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    S_OK,
+                    error.GetCode(),
+                    FormatError(error));
+                break;
+            }
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+            Sleep(100ms);
+        }
+
+        {
+            auto future = Service->AcquireNVMeDevice(sn, "idempotence-id-2");
+            const auto& [device, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        {
+            auto future = Service->AcquireNVMeDevice(sn, "idempotence-id-3");
+            const auto& [device, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        for (;;) {
+            auto future = Service->AcquireNVMeDevice(sn, "idempotence-id-3");
+            const auto& [_, error] = future.GetValueSync();
+
+            UNIT_ASSERT_C(HasError(error), FormatError(error));
+
+            if (error.GetCode() == E_INVALID_STATE) {
+                break;
+            }
+
+            Sleep(100ms);
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldCancelOperationOnStopping, TFixture)
+    {
+        SetProviderReady();
+        {
+            auto [_, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        const TString ctrlPath = "/dev/nvme0";
+        const TString idempotenceId1 = "1";
+
+        {
+            auto future1 =
+                Service->ReleaseNVMeDevice(Devices[0].GetSerialNumber(), "xxx");
+            const auto& error = future1.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_TRY_AGAIN,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        NVMeManager->WaitSanitizeRequested();
+
+        auto future2 =
+            Service->ReleaseNVMeDevice(Devices[1].GetSerialNumber(), "");
+
+        NVMeManager->WaitSanitizeRequested();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            NVMeManager->GetSanitizeInfo(ctrlPath).Count);
+
+        UNIT_ASSERT(!future2.HasValue());
+
+        Service->Stop();
+
+        {
+            auto future1 =
+                Service->ReleaseNVMeDevice(Devices[0].GetSerialNumber(), "xxx");
+            const auto& error = future1.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        UNIT_ASSERT(future2.HasValue());
+
+        const auto& error = future2.GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            error.GetCode(),
+            FormatError(error));
     }
 
     Y_UNIT_TEST_F(ShouldGetDevicesFromInfra, TFixtureInfra)

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -753,6 +753,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             error.GetMessage(),
             "is stopped",
             FormatError(error));
+
+        promise.SetValue();
     }
 
     Y_UNIT_TEST_F(ShouldAcquireAndReleaseDeviceMT, TFixture)
@@ -1234,13 +1236,47 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 E_TRY_AGAIN,
                 error.GetCode(),
                 FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "Release in progress",
+                FormatError(error));
         }
+
         {
             auto future = Service->ReleaseNVMeDevice(sn, "xxx");
             const auto& error = future.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_TRY_AGAIN,
                 error.GetCode(),
+                FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "Another operation is in progress",
+                FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "Release",
+                FormatError(error));
+        }
+
+        {
+            auto future = Service->AcquireNVMeDevice(sn, "idempotence-id-1");
+            const auto& [_, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                error.GetCode(),
+                FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "idempotence id was used for a different operation type",
+                FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "Release",
                 FormatError(error));
         }
 
@@ -1250,6 +1286,10 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_TRY_AGAIN,
                 error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "Another operation is in progress",
                 FormatError(error));
         }
 
@@ -1282,7 +1322,36 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 FormatError(error));
         }
 
-        // Start a new operation (sync)
+        {
+            auto future = Service->AcquireNVMeDevice(sn, "idempotence-id-1");
+            const auto& [_, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_ARGUMENT,
+                error.GetCode(),
+                FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "idempotence id was used for a different operation type",
+                FormatError(error));
+
+            UNIT_ASSERT_STRING_CONTAINS_C(
+                error.GetMessage(),
+                "Release",
+                FormatError(error));
+        }
+
+        // Start new operation (sync)
+
+        {
+            auto future = Service->AcquireNVMeDevice(sn, EmptyIdempotenceId);
+            const auto& [_, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
         {
             auto future = Service->ReleaseNVMeDevice(sn, EmptyIdempotenceId);
 

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -38,10 +38,15 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+const TDuration DefaultTimeout = 5s;
+
 struct TTestLocalNVMeDeviceProvider final: ILocalNVMeDeviceProvider
 {
-    TPromise<TVector<NProto::TNVMeDevice>> Promise =
-        NewPromise<TVector<NProto::TNVMeDevice>>();
+    using TListNVMeDevicesFn =
+        std::function<TFuture<TVector<NProto::TNVMeDevice>>()>;
+
+    TPromise<TListNVMeDevicesFn> ListNVMeDevicesImpl =
+        NewPromise<TListNVMeDevicesFn>();
 
     void Start() final
     {}
@@ -52,7 +57,12 @@ struct TTestLocalNVMeDeviceProvider final: ILocalNVMeDeviceProvider
     [[nodiscard]] auto ListNVMeDevices()
         -> TFuture<TVector<NProto::TNVMeDevice>> final
     {
-        return Promise;
+        return ListNVMeDevicesImpl.GetFuture().Apply(
+            [](const auto& future)
+            {
+                const auto& func = future.GetValue();
+                return func();
+            });
     }
 };
 
@@ -254,8 +264,12 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
 
     void TearDown(NUnitTest::TTestContext& /* testContext */) override
     {
+        if (Service) {
         Service->Stop();
+        }
+
         Executor->Stop();
+
         Logging->Stop();
 
         if (StateCacheFile) {
@@ -395,11 +409,10 @@ struct TFixture: public TFixtureBase
     void TearDown(NUnitTest::TTestContext& testContext) override
     {
         TFixtureBase::TearDown(testContext);
-
         DeviceProvider.reset();
     }
 
-    void SetProviderReady()
+    auto CreateDeviceList() const -> TVector<NProto::TNVMeDevice>
     {
         TVector<NProto::TNVMeDevice> devices;
 
@@ -428,7 +441,13 @@ struct TFixture: public TFixtureBase
             device.SetSerialNumber("unexpected");
         }
 
-        DeviceProvider->Promise.SetValue(devices);
+        return devices;
+    }
+
+    void SetProviderReady()
+    {
+        DeviceProvider->ListNVMeDevicesImpl.SetValue(
+            [&] { return MakeFuture(CreateDeviceList()); });
     }
 };
 
@@ -664,26 +683,80 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         UNIT_ASSERT_VALUES_EQUAL("nvme", SysFs->AddrToDriver[pciAddr]);
     }
 
-    Y_UNIT_TEST_F(ShouldHandleListDevicesError, TFixture)
+    Y_UNIT_TEST_F(ShouldRetryListDevicesError, TFixture)
     {
-        DeviceProvider->Promise.SetException(
-            std::make_exception_ptr(std::runtime_error{"fail"}));
+        const ui32 successfulAttempt = 3;
 
-        {
-            auto [_, error] = ListNVMeDevices();
+        std::atomic<ui32> attempts = 0;
+
+        DeviceProvider->ListNVMeDevicesImpl.SetValue(
+            [&]
+            {
+                ++attempts;
+                if (attempts < successfulAttempt) {
+                    return MakeErrorFuture<TVector<NProto::TNVMeDevice>>(
+                        std::make_exception_ptr(
+                            TServiceError{E_IO} << "fail #"
+                                                << attempts.load()));
+                }
+
+                return MakeFuture(CreateDeviceList());
+            });
+
+        for (;;) {
+            auto future = Service->ListNVMeDevices();
+            const auto& [devices, error] = future.GetValueSync();
+
+            UNIT_ASSERT_GE(successfulAttempt, attempts);
+
+            if (!HasError(error)) {
+                UNIT_ASSERT_VALUES_EQUAL(successfulAttempt, attempts.load());
+                UNIT_ASSERT_VALUES_EQUAL(Devices.size(), devices.size());
+
+                break;
+            }
+
             UNIT_ASSERT_VALUES_EQUAL_C(
-                E_FAIL,
+                E_REJECTED,
                 error.GetCode(),
                 FormatError(error));
-        }
 
-        {
-            auto [_, error] = ListNVMeDevices();
-            UNIT_ASSERT_VALUES_EQUAL_C(
-                E_FAIL,
-                error.GetCode(),
-                FormatError(error));
+            Sleep(100ms);
         }
+    }
+
+    Y_UNIT_TEST_F(ShouldCancelInitializationOnStop, TFixture)
+    {
+        TAutoEvent shouldStop;
+
+        TPromise<void> promise = NewPromise();
+        DeviceProvider->ListNVMeDevicesImpl.SetValue(
+            [&]
+            {
+                shouldStop.Signal();
+
+                return promise.GetFuture().Apply(
+                    [](const auto&) -> TVector<NProto::TNVMeDevice>
+                    { ythrow TServiceError{E_IO} << "fail"; });
+            });
+
+        const bool ok = shouldStop.WaitT(DefaultTimeout);
+        UNIT_ASSERT(ok);
+
+        Service->Stop();
+
+        auto future = Service->ListNVMeDevices();
+        const auto& [devices, error] = future.GetValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            error.GetCode(),
+            FormatError(error));
+
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            error.GetMessage(),
+            "is stopped",
+            FormatError(error));
     }
 
     Y_UNIT_TEST_F(ShouldAcquireAndReleaseDeviceMT, TFixture)
@@ -948,6 +1021,10 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         Service->Stop();
         Service = nullptr;
 
+        Cerr << "====================================" << Endl;
+
+        //  DeviceProvider->ListNVMeDevicesImpl.SetValue(
+
         {
             TFileOutput file{Config->GetStateCacheFilePath()};
             file << "broken ;;";
@@ -957,6 +1034,15 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         Service->Start();
 
         SetProviderReady();
+
+        Cerr << "============== Stop ..." << Endl;
+
+        // XXX
+        Service->Stop();
+
+        Cerr << "============== End ======================" << Endl;
+
+        /*
 
         {
             auto [devices, error] = ListNVMeDevices();
@@ -972,6 +1058,8 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                     "#" << i);
             }
         }
+
+        //*/
     }
 
     Y_UNIT_TEST_F(ShouldHandleRequestsAsync, TFixture)

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -264,12 +264,8 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
 
     void TearDown(NUnitTest::TTestContext& /* testContext */) override
     {
-        if (Service) {
         Service->Stop();
-        }
-
         Executor->Stop();
-
         Logging->Stop();
 
         if (StateCacheFile) {
@@ -1021,10 +1017,6 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         Service->Stop();
         Service = nullptr;
 
-        Cerr << "====================================" << Endl;
-
-        //  DeviceProvider->ListNVMeDevicesImpl.SetValue(
-
         {
             TFileOutput file{Config->GetStateCacheFilePath()};
             file << "broken ;;";
@@ -1034,15 +1026,6 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         Service->Start();
 
         SetProviderReady();
-
-        Cerr << "============== Stop ..." << Endl;
-
-        // XXX
-        Service->Stop();
-
-        Cerr << "============== End ======================" << Endl;
-
-        /*
 
         {
             auto [devices, error] = ListNVMeDevices();
@@ -1058,8 +1041,6 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                     "#" << i);
             }
         }
-
-        //*/
     }
 
     Y_UNIT_TEST_F(ShouldHandleRequestsAsync, TFixture)

--- a/cloud/blockstore/libs/local_nvme/service_proxy.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_proxy.cpp
@@ -102,7 +102,10 @@ public:
     {
         Y_UNUSED(ctx);
 
-        return LocalNVMeService->AcquireNVMeDevice(request->GetSerialNumber())
+        return LocalNVMeService
+            ->AcquireNVMeDevice(
+                request->GetSerialNumber(),
+                request->GetHeaders().GetIdempotenceId())
             .Apply(
                 [](const auto& future)
                 {
@@ -123,7 +126,10 @@ public:
     {
         Y_UNUSED(ctx);
 
-        return LocalNVMeService->ReleaseNVMeDevice(request->GetSerialNumber())
+        return LocalNVMeService
+            ->ReleaseNVMeDevice(
+                request->GetSerialNumber(),
+                request->GetHeaders().GetIdempotenceId())
             .Apply(
                 [](const auto& future)
                 {

--- a/cloud/blockstore/libs/local_nvme/service_proxy_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_proxy_ut.cpp
@@ -61,18 +61,21 @@ struct TTestLocalNVMeService: public ILocalNVMeService
             Devices);
     }
 
-    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
+    [[nodiscard]] auto AcquireNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId)
         -> TFuture<TResultOrError<NProto::TNVMeDevice>> override
     {
-        Y_UNUSED(serialNumber);
+        Y_UNUSED(serialNumber, idempotenceId);
 
         return MakeFuture<TResultOrError<NProto::TNVMeDevice>>(MakeError(S_OK));
     }
 
-    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> override
+    [[nodiscard]] auto ReleaseNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId) -> TFuture<NProto::TError> override
     {
-        Y_UNUSED(serialNumber);
+        Y_UNUSED(serialNumber, idempotenceId);
 
         return MakeFuture(MakeError(S_OK));
     }

--- a/cloud/blockstore/libs/local_nvme/service_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_ut.cpp
@@ -24,14 +24,14 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceStubTest)
         }
 
         {
-            auto future = service->AcquireNVMeDevice("foo");
+            auto future = service->AcquireNVMeDevice("foo", "idempotence-id");
             const auto& [_, error] = future.GetValueSync();
 
             UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, error.GetCode());
         }
 
         {
-            auto future = service->ReleaseNVMeDevice("foo");
+            auto future = service->ReleaseNVMeDevice("foo", "idempotence-id");
             const auto& error = future.GetValueSync();
 
             UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, error.GetCode());

--- a/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_local_nvme.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/disk_agent_actor_local_nvme.cpp
@@ -58,7 +58,7 @@ void TDiskAgentActor::HandleAcquireNVMeDevice(
 
     auto* msg = ev->Get();
 
-    LocalNVMeService->AcquireNVMeDevice(msg->SerialNumber)
+    LocalNVMeService->AcquireNVMeDevice(msg->SerialNumber, TString())
         .Subscribe(
             [actorSystem = TActivationContext::ActorSystem(),
              replyTo = ev->Sender,
@@ -96,7 +96,7 @@ void TDiskAgentActor::HandleReleaseNVMeDevice(
 
     auto* msg = ev->Get();
 
-    LocalNVMeService->ReleaseNVMeDevice(msg->SerialNumber)
+    LocalNVMeService->ReleaseNVMeDevice(msg->SerialNumber, TString())
         .Subscribe(
             [actorSystem = TActivationContext::ActorSystem(),
              replyTo = ev->Sender,

--- a/cloud/blockstore/libs/storage/testlib/disk_agent_mock.cpp
+++ b/cloud/blockstore/libs/storage/testlib/disk_agent_mock.cpp
@@ -40,7 +40,7 @@ void TDiskAgentMock::HandleAcquireNVMeDevice(
 {
     auto* msg = ev->Get();
 
-    LocalNVMeService->AcquireNVMeDevice(msg->SerialNumber)
+    LocalNVMeService->AcquireNVMeDevice(msg->SerialNumber, TString())
         .Subscribe(
             [actorSystem = TActivationContext::ActorSystem(),
              replyTo = ev->Sender,
@@ -69,7 +69,7 @@ void TDiskAgentMock::HandleReleaseNVMeDevice(
 {
     auto* msg = ev->Get();
 
-    LocalNVMeService->ReleaseNVMeDevice(msg->SerialNumber)
+    LocalNVMeService->ReleaseNVMeDevice(msg->SerialNumber, TString())
         .Subscribe(
             [actorSystem = TActivationContext::ActorSystem(),
              replyTo = ev->Sender,

--- a/cloud/blockstore/libs/storage/testlib/local_nvme_mock.cpp
+++ b/cloud/blockstore/libs/storage/testlib/local_nvme_mock.cpp
@@ -36,9 +36,13 @@ public:
             Devices);
     }
 
-    [[nodiscard]] auto AcquireNVMeDevice(const TString& serialNumber)
+    [[nodiscard]] auto AcquireNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId)
         -> TFuture<TResultOrError<NProto::TNVMeDevice>> final
     {
+        Y_UNUSED(idempotenceId);
+
         const auto* disk = FindIfPtr(
             Devices,
             [&](const auto& disk)
@@ -55,9 +59,12 @@ public:
                 << "Disk " << serialNumber.Quote() << " not found"));
     }
 
-    [[nodiscard]] auto ReleaseNVMeDevice(const TString& serialNumber)
-        -> TFuture<NProto::TError> final
+    [[nodiscard]] auto ReleaseNVMeDevice(
+        const TString& serialNumber,
+        const TString& idempotenceId) -> TFuture<NProto::TError> final
     {
+        Y_UNUSED(idempotenceId);
+
         const auto* disk = FindIfPtr(
             Devices,
             [&](const auto& disk)


### PR DESCRIPTION
This change adds per-device request tracking and idempotency support.

The service now keeps a per-device map of operations, recording the operation type, its `idempotenceId`, timing and resulting future. A request for a device with an already-running operation is rejected with `E_TRY_AGAIN`; a request whose `idempotenceId` matches a finished operation returns its cached result (idempotent replay); reusing an `idempotenceId` for a different operation type returns `E_ARGUMENT`.

`AcquireNVMeDevice` / `ReleaseNVMeDevice` now take an `idempotenceId`, which also selects the calling model: without it the call stays synchronous (waits for completion); with it the call is non-blocking — the first call starts the
operation and returns `E_TRY_AGAIN`, and the caller polls with the same id until the result is ready.