### PR TITLE
[Blockstore] Fix the computation of throttling delay for compaction and cleanup

### DIFF
--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
@@ -18,11 +18,13 @@ TDuration CalculateBackgroundOpThrottleDelay(
 
     auto delay = minDelay;
     if (maxExecTimePerSecond) {
-        const auto throttlingFactor =
-            static_cast<double>(lastOperationExecTime.GetValue()) /
-            maxExecTimePerSecond.GetValue();
+        const auto permittedExecutionPart =
+            static_cast<double>(maxExecTimePerSecond.GetValue()) /
+            TDuration::Seconds(1).GetValue();
+        const auto permittedExecutionAndDelayInterval =
+            lastOperationExecTime / permittedExecutionPart;
         const auto throttleDelay =
-            TDuration::Seconds(1) * throttlingFactor - lastOperationExecTime;
+            permittedExecutionAndDelayInterval - lastOperationExecTime;
 
         delay = Max(delay, throttleDelay);
     }

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
@@ -15,21 +15,19 @@ TDuration CalculateBackgroundOpThrottleDelay(
     if (!maxDelay) {
         return {};
     }
+    Y_DEBUG_ABORT_UNLESS(minDelay <= maxDelay);
 
-    auto delay = minDelay;
+    TDuration delay = TDuration::Zero();
     if (maxExecTimePerSecond) {
         const auto permittedExecutionPart =
             static_cast<double>(maxExecTimePerSecond.GetValue()) /
             TDuration::Seconds(1).GetValue();
         const auto permittedExecutionAndDelayInterval =
             lastOperationExecTime / permittedExecutionPart;
-        const auto throttleDelay =
-            permittedExecutionAndDelayInterval - lastOperationExecTime;
-
-        delay = Max(delay, throttleDelay);
+        delay = permittedExecutionAndDelayInterval - lastOperationExecTime;
     }
 
-    return Min(delay, maxDelay);
+    return std::clamp(delay, minDelay, maxDelay);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
@@ -1,0 +1,33 @@
+#include "background_ops_throttling.h"
+
+#include <util/generic/algorithm.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDuration CalculateBackgroundOpThrottleDelay(
+    TDuration execTimeForLastSecond,
+    TDuration maxExecTimePerSecond,
+    TDuration minDelay,
+    TDuration maxDelay)
+{
+    if (!maxDelay) {
+        return {};
+    }
+
+    auto delay = minDelay;
+    if (maxExecTimePerSecond) {
+        const auto throttlingFactor =
+            static_cast<double>(execTimeForLastSecond.GetValue()) /
+            maxExecTimePerSecond.GetValue();
+        const auto throttleDelay =
+            TDuration::Seconds(1) * throttlingFactor - execTimeForLastSecond;
+
+        delay = Max(delay, throttleDelay);
+    }
+
+    return Min(delay, maxDelay);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.cpp
@@ -7,7 +7,7 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 ////////////////////////////////////////////////////////////////////////////////
 
 TDuration CalculateBackgroundOpThrottleDelay(
-    TDuration execTimeForLastSecond,
+    TDuration lastOperationExecTime,
     TDuration maxExecTimePerSecond,
     TDuration minDelay,
     TDuration maxDelay)
@@ -19,10 +19,10 @@ TDuration CalculateBackgroundOpThrottleDelay(
     auto delay = minDelay;
     if (maxExecTimePerSecond) {
         const auto throttlingFactor =
-            static_cast<double>(execTimeForLastSecond.GetValue()) /
+            static_cast<double>(lastOperationExecTime.GetValue()) /
             maxExecTimePerSecond.GetValue();
         const auto throttleDelay =
-            TDuration::Seconds(1) * throttlingFactor - execTimeForLastSecond;
+            TDuration::Seconds(1) * throttlingFactor - lastOperationExecTime;
 
         delay = Max(delay, throttleDelay);
     }

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
@@ -11,16 +11,20 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 // Background ops (compaction, cleanup) are throttled by limiting how much
 // tablet-thread time they are allowed to consume per second
 // (maxExecTimePerSecond). The delay is derived from execution time of the
-// previous run (execTimeForLastSecond).
+// previous run (lastOperationExecTime).
 //
-// For example, assume that maxExecTimePerSecond is 50ms. If the operation spent
-// 25ms in the tablet thread, the next operation is postponed by
-// 475ms (500ms − 25ms). If it spent 100ms, the next one is postponed by
-// 1.9s (2s − 100ms), and so on.
+// The logic is as follows: maxExecTimePerSecond determines the share of time
+// the tablet is allowed to spend on the operation. When throttling, we
+// calculate a delay so that the share of operation execution time in the
+// (operation + delay) interval is maxExecTimePerSecond / 1s.
+//
+// For example, assume that maxExecTimePerSecond is 50ms. Then the tablet is
+// allowed to spend 5% of time on the operation. If lastOperationExecTime is
+// 25ms, the next operation is postponed by 475ms, because 25ms is 5% of 500ms.
 //
 // The delay is clamped by minDelay and maxDelay.
 TDuration CalculateBackgroundOpThrottleDelay(
-    TDuration execTimeForLastSecond,
+    TDuration lastOperationExecTime,
     TDuration maxExecTimePerSecond,
     TDuration minDelay,
     TDuration maxDelay);

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
@@ -10,7 +10,7 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 // Background ops (compaction, cleanup) are throttled by limiting how much
 // tablet-thread time they are allowed to consume per second
-// (maxExecTimePerSecond). The delay is derived from execution time of the
+// (maxExecTimePerSecond). The delay is derived from the execution time of the
 // previous run (lastOperationExecTime).
 //
 // The logic is as follows: maxExecTimePerSecond determines the share of time
@@ -19,8 +19,9 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 // (operation + delay) interval is maxExecTimePerSecond / 1s.
 //
 // For example, assume that maxExecTimePerSecond is 50ms. Then the tablet is
-// allowed to spend 5% of time on the operation. If lastOperationExecTime is
-// 25ms, the next operation is postponed by 475ms, because 25ms is 5% of 500ms.
+// allowed to spend 5% of the time on the operation. If lastOperationExecTime is
+// 25ms, the next operation is postponed by 500 - 25 = 475 ms, because 25ms is
+// 5% of 500ms.
 //
 // The delay is clamped by minDelay and maxDelay.
 TDuration CalculateBackgroundOpThrottleDelay(

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
@@ -15,8 +15,10 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 //
 // The logic is as follows: maxExecTimePerSecond determines the share of time
 // the tablet is allowed to spend on the operation. When throttling, we
-// calculate a delay so that the share of operation execution time in the
-// (operation + delay) interval is maxExecTimePerSecond / 1s.
+// calculate a delay so that the share of operation execution time matches the
+// target:
+//
+// lastOperationExecTime / (lastOperationExecTime + delay) = maxExecTimePerSecond / 1s
 //
 // For example, assume that maxExecTimePerSecond is 50ms. Then the tablet is
 // allowed to spend 5% of the time on the operation. If lastOperationExecTime is

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "public.h"
+
+#include <util/datetime/base.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Background ops (compaction, cleanup) are throttled by limiting how much
+// tablet-thread time they are allowed to consume per second
+// (maxExecTimePerSecond). The delay is derived from execution time of the
+// previous run (execTimeForLastSecond).
+//
+// For example, assume that maxExecTimePerSecond is 50ms. If the operation spent
+// 25ms in the tablet thread, the next operation is postponed by
+// 475ms (500ms − 25ms). If it spent 100ms, the next one is postponed by
+// 1.9s (2s − 100ms), and so on.
+//
+// The delay is clamped by minDelay and maxDelay.
+TDuration CalculateBackgroundOpThrottleDelay(
+    TDuration execTimeForLastSecond,
+    TDuration maxExecTimePerSecond,
+    TDuration minDelay,
+    TDuration maxDelay);
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
@@ -9,12 +9,12 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 void CheckBudgetInvariant(
-    TDuration execTimeForLastSecond,
+    TDuration lastOperationExecTime,
     TDuration delay,
     TDuration maxExecTimePerSecond)
 {
-    const double execRatio = static_cast<double>(execTimeForLastSecond.GetValue())
-        / (execTimeForLastSecond.GetValue() + delay.GetValue());
+    const double execRatio = static_cast<double>(lastOperationExecTime.GetValue())
+        / (lastOperationExecTime.GetValue() + delay.GetValue());
     const double budgetRatio = static_cast<double>(maxExecTimePerSecond.GetValue())
         / TDuration::Seconds(1).GetValue();
 
@@ -145,6 +145,46 @@ Y_UNIT_TEST_SUITE(TBackgroundOpsThrottlingTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldScaleDelayCorrectlyWhenExecTimeIsSecondOrGreater)
+    {
+        {
+            const auto execTime = TDuration::MilliSeconds(1000);
+            const auto maxExec = TDuration::MilliSeconds(400);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Hours(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(1500), delay);
+            CheckBudgetInvariant(execTime, delay, maxExec);
+        }
+
+        {
+            const auto execTime = TDuration::MilliSeconds(1500);
+            const auto maxExec = TDuration::MilliSeconds(400);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Hours(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(2250), delay);
+            CheckBudgetInvariant(execTime, delay, maxExec);
+        }
+
+        {
+            const auto execTime = TDuration::MilliSeconds(1500);
+            const auto maxExec = TDuration::MilliSeconds(1500);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Hours(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(0), delay);
+        }
+    }
 
     Y_UNIT_TEST(ShouldBoundDelayByMinDelay)
     {

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
@@ -13,15 +13,18 @@ void CheckBudgetInvariant(
     TDuration delay,
     TDuration maxExecTimePerSecond)
 {
-    const double execRatio =
+    const double realExecutionPart =
         static_cast<double>(lastOperationExecTime.GetValue()) /
         (lastOperationExecTime.GetValue() + delay.GetValue());
-    const double budgetRatio =
+    const double permittedExecutionPart =
         static_cast<double>(maxExecTimePerSecond.GetValue()) /
         TDuration::Seconds(1).GetValue();
 
     static constexpr double Epsilon = 1e-6;
-    UNIT_ASSERT_DOUBLES_EQUAL(budgetRatio, execRatio, Epsilon);
+    UNIT_ASSERT_DOUBLES_EQUAL(
+        permittedExecutionPart,
+        realExecutionPart,
+        Epsilon);
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
@@ -13,10 +13,12 @@ void CheckBudgetInvariant(
     TDuration delay,
     TDuration maxExecTimePerSecond)
 {
-    const double execRatio = static_cast<double>(lastOperationExecTime.GetValue())
-        / (lastOperationExecTime.GetValue() + delay.GetValue());
-    const double budgetRatio = static_cast<double>(maxExecTimePerSecond.GetValue())
-        / TDuration::Seconds(1).GetValue();
+    const double execRatio =
+        static_cast<double>(lastOperationExecTime.GetValue()) /
+        (lastOperationExecTime.GetValue() + delay.GetValue());
+    const double budgetRatio =
+        static_cast<double>(maxExecTimePerSecond.GetValue()) /
+        TDuration::Seconds(1).GetValue();
 
     static constexpr double Epsilon = 1e-6;
     UNIT_ASSERT_DOUBLES_EQUAL(budgetRatio, execRatio, Epsilon);

--- a/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/model/background_ops_throttling_ut.cpp
@@ -1,0 +1,192 @@
+#include "background_ops_throttling.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void CheckBudgetInvariant(
+    TDuration execTimeForLastSecond,
+    TDuration delay,
+    TDuration maxExecTimePerSecond)
+{
+    const double execRatio = static_cast<double>(execTimeForLastSecond.GetValue())
+        / (execTimeForLastSecond.GetValue() + delay.GetValue());
+    const double budgetRatio = static_cast<double>(maxExecTimePerSecond.GetValue())
+        / TDuration::Seconds(1).GetValue();
+
+    static constexpr double Epsilon = 1e-6;
+    UNIT_ASSERT_DOUBLES_EQUAL(budgetRatio, execRatio, Epsilon);
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TBackgroundOpsThrottlingTest)
+{
+    Y_UNIT_TEST(ShouldNotDelayWhenMaxDelayIsZero)
+    {
+        const auto delay = CalculateBackgroundOpThrottleDelay(
+            TDuration::MilliSeconds(50),
+            TDuration::MilliSeconds(100),
+            TDuration::MilliSeconds(10),
+            TDuration::Zero());
+
+        UNIT_ASSERT(!delay);
+    }
+
+    Y_UNIT_TEST(ShouldNotDelayWhenMaxExecTimePerSecondIsZero)
+    {
+        const auto minDelay = TDuration::MilliSeconds(10);
+        const auto delay = CalculateBackgroundOpThrottleDelay(
+            TDuration::MilliSeconds(100),
+            TDuration::Zero(),
+            minDelay,
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(minDelay, delay);
+    }
+
+    Y_UNIT_TEST(ShouldNotDelayWhenMaxExecTimeForLastSecondIsZero)
+    {
+        const auto minDelay = TDuration::MilliSeconds(10);
+        const auto delay = CalculateBackgroundOpThrottleDelay(
+            TDuration::Zero(),
+            TDuration::MilliSeconds(100),
+            minDelay,
+            TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(minDelay, delay);
+    }
+
+    Y_UNIT_TEST(ShouldNotDelayWhenMaxExecTimePerSecondIsSecondOrGreater)
+    {
+        {
+            const auto execTime = TDuration::MilliSeconds(500);
+            const auto maxExec = TDuration::MilliSeconds(1000);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Seconds(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), delay);
+        }
+
+        {
+            const auto execTime = TDuration::MilliSeconds(500);
+            const auto maxExec = TDuration::MilliSeconds(1500);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Seconds(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::Zero(), delay);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldScaleDelayCorrectly)
+    {
+        {
+            const auto execTime = TDuration::MilliSeconds(25);
+            const auto maxExec = TDuration::MilliSeconds(50);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Hours(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(475), delay);
+            CheckBudgetInvariant(execTime, delay, maxExec);
+        }
+
+        {
+            const auto execTime = TDuration::MilliSeconds(100);
+            const auto maxExec = TDuration::MilliSeconds(50);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Hours(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(1900), delay);
+            CheckBudgetInvariant(execTime, delay, maxExec);
+        }
+
+        {
+            const auto execTime = TDuration::MilliSeconds(50);
+            const auto maxExec = TDuration::MilliSeconds(50);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Hours(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(950), delay);
+            CheckBudgetInvariant(execTime, delay, maxExec);
+        }
+
+        {
+            const auto execTime = TDuration::MilliSeconds(25);
+            const auto maxExec = TDuration::MilliSeconds(100);
+            const auto delay = CalculateBackgroundOpThrottleDelay(
+                execTime,
+                maxExec,
+                TDuration::Zero(),
+                TDuration::Hours(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(TDuration::MilliSeconds(225), delay);
+            CheckBudgetInvariant(execTime, delay, maxExec);
+        }
+    }
+
+
+    Y_UNIT_TEST(ShouldBoundDelayByMinDelay)
+    {
+        const auto execTime = TDuration::MilliSeconds(10);
+        const auto maxExec = TDuration::MilliSeconds(50);
+        const auto minDelay = TDuration::MilliSeconds(300);
+
+        const auto delay = CalculateBackgroundOpThrottleDelay(
+            execTime,
+            maxExec,
+            minDelay,
+            TDuration::Hours(1));
+        const auto delayWithoutMinDelay = CalculateBackgroundOpThrottleDelay(
+            execTime,
+            maxExec,
+            TDuration::Zero(),
+            TDuration::Hours(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(minDelay, delay);
+        UNIT_ASSERT(delay > delayWithoutMinDelay);
+    }
+
+    Y_UNIT_TEST(ShouldBoundDelayByMaxDelay)
+    {
+        const auto execTime = TDuration::MilliSeconds(50);
+        const auto maxExec = TDuration::MilliSeconds(100);
+        const auto maxDelay = TDuration::MilliSeconds(300);
+
+        const auto delay = CalculateBackgroundOpThrottleDelay(
+            execTime,
+            maxExec,
+            TDuration::Zero(),
+            maxDelay);
+        const auto delayWithoutMaxDelay = CalculateBackgroundOpThrottleDelay(
+            execTime,
+            maxExec,
+            TDuration::Zero(),
+            TDuration::Hours(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(maxDelay, delay);
+        UNIT_ASSERT(delay < delayWithoutMaxDelay);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/model/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(cloud/blockstore/libs/storage/partition/model)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 SRCS(
+    background_ops_throttling_ut.cpp
     barrier_ut.cpp
     block_index_ut.cpp
     block_mask_ut.cpp

--- a/cloud/blockstore/libs/storage/partition/model/ya.make
+++ b/cloud/blockstore/libs/storage/partition/model/ya.make
@@ -6,6 +6,7 @@ GENERATE_ENUM_SERIALIZATION(mixed_index_cache.h)
 GENERATE_ENUM_SERIALIZATION(operation_status.h)
 
 SRCS(
+    background_ops_throttling.cpp
     barrier.cpp
     blob_index.cpp
     blob_to_confirm.cpp

--- a/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
@@ -3,6 +3,7 @@
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
+#include <cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h>
 
 #include <util/generic/size_literals.h>
 
@@ -63,20 +64,12 @@ void TPartitionActor::EnqueueCleanupIfNeeded(const TActorContext& ctx)
     const auto throttlingAllowed = State->GetCleanupQueue().GetQueueBytes()
         < Config->GetCleanupQueueBytesLimitForThrottling();
 
-    if (throttlingAllowed && Config->GetMaxCleanupDelay()) {
-        // TODO: unify this code and compaction delay-related code
-        auto execTime = State->GetCleanupExecTimeForLastSecond(ctx.Now());
-        auto delay = Config->GetMinCleanupDelay();
-        if (Config->GetMaxCleanupExecTimePerSecond()) {
-            auto throttlingFactor = double(execTime.GetValue())
-                / Config->GetMaxCleanupExecTimePerSecond().GetValue();
-            const auto throttleDelay = (TDuration::Seconds(1) - execTime) * throttlingFactor;
-
-            delay = Max(delay, throttleDelay);
-        }
-
-        delay = Min(delay, Config->GetMaxCleanupDelay());
-        State->SetCleanupDelay(delay);
+    if (throttlingAllowed) {
+        State->SetCleanupDelay(CalculateBackgroundOpThrottleDelay(
+            State->GetCleanupExecTimeForLastSecond(ctx.Now()),
+            Config->GetMaxCleanupExecTimePerSecond(),
+            Config->GetMinCleanupDelay(),
+            Config->GetMaxCleanupDelay()));
     } else {
         State->SetCleanupDelay({});
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -9,6 +9,7 @@
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
+#include <cloud/blockstore/libs/storage/partition/model/background_ops_throttling.h>
 
 #include <cloud/storage/core/libs/common/alloc.h>
 #include <cloud/storage/core/libs/common/block_buffer.h>
@@ -1432,22 +1433,12 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
         }
     }
 
-    if (info->ThrottlingAllowed && Config->GetMaxCompactionDelay()) {
-        const auto execTime =
-            State->GetCompactionExecTimeForLastSecond(ctx.Now());
-        auto delay = Config->GetMinCompactionDelay();
-        if (maxCompactionExecTimePerSecond) {
-            const auto throttlingFactor =
-                static_cast<double>(execTime.GetValue()) /
-                maxCompactionExecTimePerSecond.GetValue();
-            const auto throttleDelay =
-                (TDuration::Seconds(1) - execTime) * throttlingFactor;
-
-            delay = Max(delay, throttleDelay);
-        }
-
-        delay = Min(delay, Config->GetMaxCompactionDelay());
-        State->SetCompactionDelay(delay);
+    if (info->ThrottlingAllowed) {
+        State->SetCompactionDelay(CalculateBackgroundOpThrottleDelay(
+            State->GetCompactionExecTimeForLastSecond(ctx.Now()),
+            maxCompactionExecTimePerSecond,
+            Config->GetMinCompactionDelay(),
+            Config->GetMaxCompactionDelay()));
     } else {
         State->SetCompactionDelay({});
     }


### PR DESCRIPTION
There was a bug in the logic of computation of throttling delay for cleanup and compaction. Real delay duration was slightly different from the duration that is supposed to be by design. In particular, if we set  maxExecTimePerSecond=1000ms, the delay was nonzero; this is strange.

In this pr we:
- Fix the bug: replace `(TDuration::Seconds(1) - execTime) * throttlingFactor` by `TDuration::Seconds(1) * throttlingFactor - execTimeForLastSecond`
- Deduplicate code of throttle for compaction and cleanup
- Add unit tests

### Issue
#5815
