### PR TITLE
do not crash on rdma allocations error

### DIFF
--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -823,13 +823,21 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         std::move(handler),
         std::move(context));
 
-    with_lock (AllocationLock) {
-        if (requestBytes) {
-            req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
+    try {
+        with_lock (AllocationLock) {
+            if (requestBytes) {
+                req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
+            }
+            if (responseBytes) {
+                req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
+            }
         }
-        if (responseBytes) {
-            req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
-        }
+    } catch (...) {
+        return MakeError(
+            E_RDMA_UNAVAILABLE,
+            TStringBuilder()
+                << "unable to allocate request with exception: "
+                << CurrentExceptionMessage());
     }
 
     req->RequestBuffer = TStringBuf {

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -833,11 +833,15 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
             }
         }
     } catch (...) {
-        TryForceReconnect();
+        RDMA_ERROR(
+            "failed to allocate request with exception: "
+            << CurrentExceptionMessage());
+        Counters->Error();
+        Disconnect();
         return MakeError(
             E_RDMA_UNAVAILABLE,
             TStringBuilder()
-                << "unable to allocate request with exception: "
+                << "failed to allocate request with exception: "
                 << CurrentExceptionMessage());
     }
 

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -833,6 +833,7 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
             }
         }
     } catch (...) {
+        TryForceReconnect();
         return MakeError(
             E_RDMA_UNAVAILABLE,
             TStringBuilder()


### PR DESCRIPTION
### Notes
`Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: NCloud::NBlockStore::TUnalignedDeviceHandler::Write(TIntrusivePtr<NCloud::NBlockStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NBlockStore::TCallContext>>, unsigned long, unsigned long, NCloud::TGuardedSgList)+969 (0x556BFDDBFBB9)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: NCloud::NBlockStore::TWriteRequest::DoExecute()+252 (0x556BFDDB990C)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: NCloud::NBlockStore::TAlignedDeviceHandler::ExecuteWriteRequest(TIntrusivePtr<NCloud::NBlockStore::TCallContext, TDefaultIntrusivePtrOps<NCloud::NBlockStore::TCallContext>>, NCloud::NBlockStore::TBlocksInfo, NCloud::TGuardedSgList)+730 (0x556BFDD81CBA)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C080CDDC5)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C080B2DB4)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C080BEE72)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C080BF988)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07E79306)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07E90E7B)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07E997D5)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07DCA113)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07FC83A4)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C08064E8D)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07F8A76D)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07ED119B)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C07E05500)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C14F8B7BB)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C150BC1EF)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C0852826C)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556BFC8CD3CE)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: std::terminate()+41 (0x556BFD6362A9)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ========== Terminate handler stack ==========
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C08528073)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C085324B2)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C0853286C)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ??+0 (0x556C08533D03)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: __cxa_throw+342 (0x556BFD6368A6)
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: (NCloud::TServiceError) /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/storage/core/libs/rdma/impl/verbs.cpp:77: SEVERITY_ERROR | FACILITY_SYSTEM | 12 | ibv_reg_mr failed with error 12: Cannot allocate memory
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: Caught:
Jun 11 01:27:24 vla04-2ct28-34b.cloud.yandex.net NBS_SERVER[2307765]: ========== Uncaught exception + stack =======
`

### Issue
Put links to the related issues here
