### PR TITLE
[Blockstore] log_title: add TChildLogTitle::GetChild() for multi-level child titles

### DIFF
--- a/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -326,6 +326,40 @@ TChildLogTitle::TChildLogTitle(TString cachedPrefix, ui64 startTime)
     , StartTime(startTime)
 {}
 
+TChildLogTitle TChildLogTitle::GetChild(const ui64 startTime) const
+{
+    TStringBuilder childPrefix;
+    childPrefix << CachedPrefix;
+    const auto duration = CyclesToDurationSafe(startTime - StartTime);
+    childPrefix << " + " << FormatDuration(duration);
+    return {childPrefix, startTime};
+}
+
+TChildLogTitle TChildLogTitle::GetChildWithTags(
+    const ui64 startTime,
+    const TPrintableParams& additionalTags) const
+{
+    TStringBuilder childPrefix;
+    childPrefix << CachedPrefix;
+
+    if (!additionalTags.empty()) {
+        childPrefix << " " << PrintParams(additionalTags);
+    }
+
+    const auto duration = CyclesToDurationSafe(startTime - StartTime);
+    childPrefix << " + " << FormatDuration(duration);
+
+    return {childPrefix, startTime};
+}
+
+TChildLogTitle TChildLogTitle::GetChildWithTags(
+    const ui64 startTime,
+    std::initializer_list<std::pair<TStringBuf, TPrintableValue>>
+        additionalTags) const
+{
+    return GetChildWithTags(startTime, TPrintableParams(additionalTags));
+}
+
 TString TChildLogTitle::GetWithTime() const
 {
     const auto duration = CyclesToDurationSafe(GetCycleCount() - StartTime);

--- a/cloud/blockstore/libs/storage/model/log_title.h
+++ b/cloud/blockstore/libs/storage/model/log_title.h
@@ -164,6 +164,17 @@ private:
     TChildLogTitle(TString cachedPrefix, ui64 startTime);
 
 public:
+    [[nodiscard]] TChildLogTitle GetChild(const ui64 startTime) const;
+
+    [[nodiscard]] TChildLogTitle GetChildWithTags(
+        ui64 startTime,
+        const TPrintableParams& additionalTags) const;
+
+    [[nodiscard]] TChildLogTitle GetChildWithTags(
+        ui64 startTime,
+        std::initializer_list<std::pair<TStringBuf, TPrintableValue>>
+            additionalTags) const;
+
     [[nodiscard]] TString GetWithTime() const;
 };
 

--- a/cloud/blockstore/libs/storage/model/log_title_ut.cpp
+++ b/cloud/blockstore/libs/storage/model/log_title_ut.cpp
@@ -310,6 +310,60 @@ Y_UNIT_TEST_SUITE(TLogTitleTest)
             "buf:bufvalue cstr:cstring empty t:1.001s + ");
     }
 
+    Y_UNIT_TEST(GetChildOfChild)
+    {
+        const ui64 startTime = 0;
+        TLogTitle logTitle{
+            startTime,
+            TLogTitle::TPartitionNonrepl{.DiskId = "disk1"}};
+
+        const ui64 childTime = GetCyclesPerMillisecond() * 1001;
+        const ui64 grandChildTime =
+            childTime + GetCyclesPerMillisecond() * 1001;
+        const ui64 greatGrandChildTime =
+            grandChildTime + GetCyclesPerMillisecond() * 1001;
+
+        auto child = logTitle.GetChild(childTime);
+        auto grandChild = child.GetChild(grandChildTime);
+        auto greatGrandChild = grandChild.GetChild(greatGrandChildTime);
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            child.GetWithTime(),
+            "[nrd:disk1 t:1.001s + ");
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            grandChild.GetWithTime(),
+            "[nrd:disk1 t:1.001s + 1.001s + ");
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            greatGrandChild.GetWithTime(),
+            "[nrd:disk1 t:1.001s + 1.001s + 1.001s + ");
+    }
+
+    Y_UNIT_TEST(GetChildOfChildWithTags)
+    {
+        const ui64 startTime = 0;
+        TLogTitle logTitle{
+            startTime,
+            TLogTitle::TPartitionNonrepl{.DiskId = "disk1"}};
+
+        const ui64 childTime = GetCyclesPerMillisecond() * 1001;
+        const ui64 grandChildTime =
+            childTime + GetCyclesPerMillisecond() * 1001;
+
+        auto child = logTitle.GetChildWithTags(childTime, {{"cp", "123"}});
+        auto grandChild =
+            child.GetChildWithTags(grandChildTime, {{"rq", "456"}});
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            child.GetWithTime(),
+            "[nrd:disk1 cp:123 t:1.001s + ");
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            grandChild.GetWithTime(),
+            "[nrd:disk1 cp:123 t:1.001s rq:456 + 1.001s + ");
+    }
+
     Y_UNIT_TEST(GetForDiskRegistry)
     {
         TLogTitle logTitle{


### PR DESCRIPTION
#5969 
Adds TChildLogTitle::GetChild() and GetChildWithTags() to support multi-level nested log titles.
  [prefix tag₀ t:T₀ tag₁ + T₁ tag₂ + T₂ + elapsed]
                   ↑root  ↑child     ↑grandchild  ↑current
