### PR TITLE
issue-1559: [Disk Manager] Make UnsafeCreateNode, UnsafeCreateNodeRef idempotent

### DIFF
--- a/cloud/disk_manager/internal/pkg/clients/nfs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/client.go
@@ -495,7 +495,12 @@ func (c *client) UnsafeCreateNode(
 		return err
 	}
 
-	return checkActionError(response.Error)
+	err = checkActionError(response.Error)
+	if err == nil || isAlreadyExistsError(err) {
+		return nil
+	}
+
+	return err
 }
 
 func (c *client) UnsafeCreateNodeRef(
@@ -525,10 +530,19 @@ func (c *client) UnsafeCreateNodeRef(
 		response,
 	)
 	if err != nil {
+		if isAlreadyExistsError(err) {
+			return nil
+		}
+
 		return err
 	}
 
-	return checkActionError(response.Error)
+	err = checkActionError(response.Error)
+	if err != nil && isAlreadyExistsError(err) {
+		return nil
+	}
+
+	return err
 }
 
 func (c *client) ConfigureAsShard(

--- a/cloud/disk_manager/internal/pkg/clients/nfs/client.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/client.go
@@ -492,15 +492,14 @@ func (c *client) UnsafeCreateNode(
 		response,
 	)
 	if err != nil {
+		if isAlreadyExistsError(err) {
+			return nil
+		}
+
 		return err
 	}
 
-	err = checkActionError(response.Error)
-	if err == nil || isAlreadyExistsError(err) {
-		return nil
-	}
-
-	return err
+	return checkActionError(response.Error)
 }
 
 func (c *client) UnsafeCreateNodeRef(
@@ -537,12 +536,7 @@ func (c *client) UnsafeCreateNodeRef(
 		return err
 	}
 
-	err = checkActionError(response.Error)
-	if err != nil && isAlreadyExistsError(err) {
-		return nil
-	}
-
-	return err
+	return checkActionError(response.Error)
 }
 
 func (c *client) ConfigureAsShard(

--- a/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
+++ b/cloud/disk_manager/internal/pkg/clients/nfs/tests/client_test.go
@@ -597,7 +597,9 @@ func newInMemoryTestShardBackup(
 
 func (i inMemoryTestShardBackup) restore(ctx context.Context) {
 	for _, node := range i.nodesInShard {
-		i.restoreNode(ctx, node)
+		for attempt := 0; attempt < 2; attempt++ {
+			i.restoreNode(ctx, node)
+		}
 	}
 
 	for _, node := range i.nodesInShard {
@@ -606,7 +608,9 @@ func (i inMemoryTestShardBackup) restore(ctx context.Context) {
 		}
 
 		for _, child := range i.nodesByParent[node.NodeID] {
-			i.createChildRef(ctx, node.NodeID, child)
+			for attempt := 0; attempt < 2; attempt++ {
+				i.createChildRef(ctx, node.NodeID, child)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Notes
For fs shard restoration, we need idempotent unsafe operations.

### Issue
#1559