### PR TITLE
[NBS] validate RDMA response message type before cast

### DIFF
--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -130,6 +130,7 @@ using TCritEventParams =
     xxx(SetupChannelsOnWrongMediaKindVolume)                                   \
     xxx(DiskRegistryDetachPathWithDependentDisk)                               \
     xxx(DiskDevicesSizeViolation)                                              \
+    xxx(RdmaMessageTypeMismatch)                                               \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_checksumblocks.cpp
@@ -64,6 +64,7 @@ private:
 public:
     using TRequestContext = TDeviceChecksumRequestContext;
     using TResponseProto = NProto::TChecksumDeviceBlocksResponse;
+    static constexpr ui32 ExpectedMsgId = TBlockStoreProtocol::ChecksumDeviceBlocksResponse;
 
     using TBase::TBase;
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks.cpp
@@ -41,6 +41,7 @@ private:
 public:
     using TRequestContext = TDeviceReadRequestContext;
     using TResponseProto = NProto::TReadDeviceBlocksResponse;
+    static constexpr ui32 ExpectedMsgId = TBlockStoreProtocol::ReadDeviceBlocksResponse;
 
     TRdmaRequestReadBlocksHandler(
             TActorSystem* actorSystem,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_readblocks_local.cpp
@@ -43,6 +43,7 @@ private:
 public:
     using TRequestContext = TDeviceReadRequestContext;
     using TResponseProto = NProto::TReadDeviceBlocksResponse;
+    static constexpr ui32 ExpectedMsgId = TBlockStoreProtocol::ReadDeviceBlocksResponse;
 
     TRdmaRequestReadBlocksLocalHandler(
             TActorSystem* actorSystem,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks.cpp
@@ -85,6 +85,7 @@ private:
 public:
     using TRequestContext = TDeviceRequestRdmaContext;
     using TResponseProto = NProto::TWriteDeviceBlocksResponse;
+    static constexpr ui32 ExpectedMsgId = TBlockStoreProtocol::WriteDeviceBlocksResponse;
 
     TRdmaWriteBlocksResponseHandler(
             TActorSystem* actorSystem,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks_multi_agent.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_writeblocks_multi_agent.cpp
@@ -48,6 +48,7 @@ private:
 public:
     using TRequestContext = TDeviceRequestRdmaContext;
     using TResponseProto = NProto::TWriteDeviceBlocksResponse;
+    static constexpr ui32 ExpectedMsgId = TBlockStoreProtocol::WriteDeviceBlocksResponse;
 
     TRdmaMultiWriteBlocksResponseHandler(
             TActorSystem* actorSystem,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_rdma_actor_zeroblocks.cpp
@@ -35,6 +35,7 @@ class TRdmaRequestZeroBlocksHandler final
 public:
     using TRequestContext = TDeviceRequestRdmaContext;
     using TResponseProto = NProto::TZeroDeviceBlocksResponse;
+    static constexpr ui32 ExpectedMsgId = TBlockStoreProtocol::ZeroDeviceBlocksResponse;
 
     using TBase::TBase;
 

--- a/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
@@ -144,11 +144,15 @@ private:
         }
 
         if (result.MsgId != TDerived::ExpectedMsgId) {
-            return MakeError(
-                E_FAIL,
-                TStringBuilder() << "RDMA response message type mismatch:"
-                                 << " expected " << TDerived::ExpectedMsgId
-                                 << ", got " << result.MsgId);
+            auto msg = TStringBuilder()
+                       << "RDMA response message type mismatch:"
+                       << " expected " << TDerived::ExpectedMsgId << ", got "
+                       << result.MsgId;
+            ReportRdmaMessageTypeMismatch(
+                msg,
+                {{"MsgId", result.MsgId},
+                 {"ExpectedMsgId", TDerived::ExpectedMsgId}});
+            return MakeError(E_FAIL, std::move(msg));
         }
 
         auto& proto =

--- a/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
@@ -143,6 +143,14 @@ private:
             return error;
         }
 
+        if (result.MsgId != TDerived::ExpectedMsgId) {
+            return MakeError(
+                E_FAIL,
+                TStringBuilder() << "RDMA response message type mismatch:"
+                                 << " expected " << TDerived::ExpectedMsgId
+                                 << ", got " << result.MsgId);
+        }
+
         auto& proto =
             static_cast<typename TDerived::TResponseProto&>(*result.Proto);
         if (HasError(proto.GetError())) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h
@@ -152,7 +152,7 @@ private:
                 msg,
                 {{"MsgId", result.MsgId},
                  {"ExpectedMsgId", TDerived::ExpectedMsgId}});
-            return MakeError(E_FAIL, std::move(msg));
+            return MakeError(E_REJECTED, std::move(msg));
         }
 
         auto& proto =


### PR DESCRIPTION
### Notes
Add a compile-time ExpectedMsgId constant to each RDMA request handler and validate the parsed MsgId against it in TRdmaDeviceRequestHandlerBase::ProcessSubResponse before performing the static_cast to the concrete response proto type. On mismatch, return E_FAIL with a diagnostic message containing both expected and actual message IDs.

TODO: need to investigate why we received the "WriteResponce" in the "Read" handler

### Issue
`Process blockstore-server crashed on klg06-7ct8-32b.cloud.yandex.net cluster prod

Core was generated by `/usr/bin/blockstore-server --domain klg --ic-port 29015 --mon-port 8766 --node-'.
#0 0x000055f34aad3f65 in google::protobuf::internal::RepeatedPtrFieldBase::DestroyProtos (this=0x72057f9bf4d0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/protobuf/src/google/protobuf/repeated_ptr_field.cc:108
[Current thread is 7921 (LWP 1750208)]

Thread 7921 (LWP 1750208):
#0 google::protobuf::internal::RepeatedPtrFieldBase::DestroyProtos (this=0x72057f9bf4d0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/protobuf/src/google/protobuf/repeated_ptr_field.cc +108
#1 google::protobuf::RepeatedPtrField<NCloud::NProto::TError>::~RepeatedPtrField (this=0x72057f9bf4d0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/protobuf/src/google/protobuf/repeated_ptr_field.h +1286
#2 NCloud::NBlockStore::NProto::TWriteDeviceBlocksResponse::SharedDtor (this=0x72057f9bf4c0) at /-B/cloud/blockstore/libs/storage/protos/disk.pb.cc +23270
#3 NCloud::NBlockStore::NProto::TWriteDeviceBlocksResponse::~TWriteDeviceBlocksResponse (this=0x72057f9bf4c0) at /-B/cloud/blockstore/libs/storage/protos/disk.pb.cc +23265
#4 NCloud::NBlockStore::NProto::**TWriteDeviceBlocksResponse::~TWriteDeviceBlocksResponse** (this=0x7203da0f1600) at /-B/cloud/blockstore/libs/storage/protos/disk.pb.cc +23259
#5 std::__y1::default_delete<google::protobuf::Message>::operator()[abi:ne200000](google::protobuf::Message*) const (this=0x7f25ccfbda40, __ptr=0x7203da0f1600) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h +70
#6 std::__y1::unique_ptr<google::protobuf::Message, std::__y1::default_delete<google::protobuf::Message> >::reset[abi:ne200000](google::protobuf::Message*) (this=0x7f25ccfbda40, __p=0x0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h +286
#7 std::__y1::unique_ptr<google::protobuf::Message, std::__y1::default_delete<google::protobuf::Message> >::~unique_ptr[abi:ne200000]() (this=0x7f25ccfbda40) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h +255
#8 NCloud::NStorage::NRdma::TProtoMessageSerializer::TParseResult::~TParseResult (this=0x7f25ccfbda38) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/storage/core/libs/rdma/iface/protobuf.h +79
#9 NCloud::TResultOrError<NCloud::NStorage::NRdma::TProtoMessageSerializer::TParseResult>::~TResultOrError (this=0x7f25ccfbda38) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/storage/core/libs/common/error.h +314
#10 NCloud::NBlockStore::NStorage::TRdmaDeviceRequestHandlerBase<NCloud::NBlockStore::NStorage::(anonymous namespace)::**TRdmaRequestReadBlocksLocalHandler**>::ProcessSubResponse (this=0x720515be8958, ctx=..., buffer=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/partition_nonrepl/rdma_device_request_handler.h +156
`
