### PR TITLE
feat: add PR-triggered nightly checks

### DIFF
--- a/.github/actions/nightly_pr_check/action.yaml
+++ b/.github/actions/nightly_pr_check/action.yaml
@@ -1,0 +1,29 @@
+name: Nightly PR check
+description: Dispatch nightly workflows for a PR and mirror their results back to the PR
+
+inputs:
+  mode:
+    required: false
+    default: "dispatch-and-collect"
+    description: "dispatch-and-collect or cancel"
+  github_token:
+    required: true
+    description: "GitHub token with actions:write and issues:write access"
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: pip install -r .github/scripts/requirements.txt
+
+    - name: Run nightly PR check collector
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+        export PYTHONPATH="${PYTHONPATH:-}:$GITHUB_WORKSPACE/.github"
+        python3 -m scripts.nightly_pr_check \
+            --mode "$MODE"

--- a/.github/actions/s3cmd/action.yaml
+++ b/.github/actions/s3cmd/action.yaml
@@ -116,11 +116,19 @@ runs:
                 exit 1
                 ;;
         esac
-        # shellcheck disable=SC2129
-        echo "S3_BUCKET_PATH=s3://${S3_BUCKET}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}" >> "$GITHUB_ENV"
-        echo "S3_URL_PREFIX=${S3_ENDPOINT}/${S3_BUCKET}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}" >> "$GITHUB_ENV"
-        echo "S3_WEBSITE_PREFIX=https://${S3_BUCKET}.${S3_WEBSITE_SUFFIX}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}" >> "$GITHUB_ENV"
-        echo "S3_WEBSITE_SUFFIX=${S3_WEBSITE_SUFFIX}" >> "$GITHUB_ENV"
+        workflow_file="${GITHUB_WORKFLOW_REF%%@*}"
+        workflow_file="${workflow_file##*/}"
+        if [ -z "$workflow_file" ]; then
+            workflow_file="${GITHUB_WORKFLOW_NO_SPACES}"
+        fi
+        {
+            echo "S3_BUCKET_PATH=s3://${S3_BUCKET}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}"
+            echo "S3_URL_PREFIX=${S3_ENDPOINT}/${S3_BUCKET}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}"
+            echo "S3_WEBSITE_PREFIX=https://${S3_BUCKET}.${S3_WEBSITE_SUFFIX}/${{ github.repository }}/${GITHUB_WORKFLOW_NO_SPACES}/${{ github.run_id }}/${{ github.run_attempt || '1' }}/${S3_FOLDER_PREFIX}${folder}"
+            echo "S3_REPORTS_BUCKET_PATH=s3://${S3_BUCKET}/reports/${{ github.repository }}/${workflow_file}/${{ github.run_id }}/${{ github.run_attempt || '1' }}"
+            echo "S3_REPORTS_WEBSITE_PREFIX=https://${S3_BUCKET}.${S3_WEBSITE_SUFFIX}/reports/${{ github.repository }}/${workflow_file}/${{ github.run_id }}/${{ github.run_attempt || '1' }}"
+            echo "S3_WEBSITE_SUFFIX=${S3_WEBSITE_SUFFIX}"
+        } >> "$GITHUB_ENV"
     - name: test awscli
       shell: bash
       run: aws s3 ls

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -482,6 +482,11 @@ runs:
 
             echo "::group::s3-sync"
             aws s3 sync --acl public-read --follow-symlinks --no-progress "$ARTIFACTS_DIR/" "$S3_BUCKET_PATH/"
+            if [ -n "${S3_REPORTS_BUCKET_PATH:-}" ] && [ -f "$ARTIFACTS_DIR/summary/${COMPONENT_DIR}${i}/summary.json" ]; then
+                aws s3 cp --acl public-read --follow-symlinks --no-progress \
+                    "$ARTIFACTS_DIR/summary/${COMPONENT_DIR}${i}/summary.json" \
+                    "$S3_REPORTS_BUCKET_PATH/${COMPONENT_DIR}${i}/summary.json"
+            fi
             touch "$LOG_DIR/${i}_artifacts_synced"
             echo "::endgroup::"
 

--- a/.github/scripts/helpers.py
+++ b/.github/scripts/helpers.py
@@ -11,7 +11,9 @@ import time
 from dataclasses import dataclass
 import datetime
 from typing import Callable, List, Tuple
-from urllib.parse import urlparse
+from urllib.error import HTTPError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
 
 SENSITIVE_DATA_VALUES = {}
 if os.environ.get("GITHUB_TOKEN"):
@@ -48,6 +50,133 @@ SAN_PRESET_BY_SAN = {
     "msan": "release-msan",
     "ubsan": "release-ubsan",
 }
+
+
+def get_build_preset_from_workflow_name(workflow_name: str) -> str | None:
+    normalized = workflow_name.strip().lower()
+    if normalized in ("nightly.yaml", "nightly build"):
+        return "relwithdebinfo"
+
+    match = re.fullmatch(
+        r"nightly(?: build)? \((?P<san>asan|tsan|msan|ubsan)\)", normalized
+    )
+    if match is not None:
+        return SAN_PRESET_BY_SAN[match.group("san")]
+
+    match = re.fullmatch(r"nightly-(?P<san>asan|tsan|msan|ubsan)\.yaml", normalized)
+    if match is not None:
+        return SAN_PRESET_BY_SAN[match.group("san")]
+
+    return None
+
+
+def get_s3_website_origin(
+    bucket: str | None = None, website_suffix: str | None = None
+) -> str:
+    bucket = (bucket or os.environ.get("S3_BUCKET") or "").strip()
+    website_suffix = (
+        website_suffix or os.environ.get("S3_WEBSITE_SUFFIX") or ""
+    ).strip()
+    if not bucket or not website_suffix:
+        return ""
+    return f"https://{bucket}.{website_suffix}"
+
+
+def get_s3_report_uri(path: str, bucket: str | None = None) -> str:
+    bucket = (bucket or os.environ.get("S3_BUCKET") or "").strip()
+    if not bucket or not path:
+        return ""
+    return f"s3://{bucket}/{path}"
+
+
+def get_s3_report_url(
+    path: str,
+    bucket: str | None = None,
+    website_suffix: str | None = None,
+) -> str:
+    origin = get_s3_website_origin(bucket=bucket, website_suffix=website_suffix)
+    if not origin or not path:
+        return ""
+    return f"{origin}/{quote(path, safe='/')}"
+
+
+def get_s3_workflow_reports_path(
+    *,
+    repository: str,
+    workflow_file: str,
+    run_id: int | str,
+    run_attempt: int | str,
+    relative_path: str = "",
+) -> str:
+    return (
+        f"reports/{repository}/{workflow_file}/{run_id}/{run_attempt}/"
+        f"{relative_path.lstrip('/')}"
+    )
+
+
+def get_run_url() -> str:
+    return f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+
+
+def fetch_jobs() -> list[dict]:
+    owner, repo = os.environ["GITHUB_REPOSITORY"].split("/", 1)
+    run_id = os.environ["GITHUB_RUN_ID"]
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "1")
+    url = (
+        f"https://api.github.com/repos/{owner}/{repo}/actions/runs/"
+        f"{run_id}/attempts/{run_attempt}/jobs?per_page=100"
+    )
+    request = Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urlopen(request) as response:
+        payload = json.load(response)
+    return payload.get("jobs", [])
+
+
+def job_name_matches(expected_name: str, actual_name: str) -> bool:
+    if actual_name == expected_name:
+        return True
+
+    reusable_prefix = f"/ {expected_name}"
+    if actual_name.endswith(reusable_prefix):
+        return True
+
+    return False
+
+
+def find_current_job_url(current_job_name: str, runner_name: str) -> str:
+    try:
+        jobs = fetch_jobs()
+    except HTTPError:
+        return get_run_url()
+
+    matching_jobs = [
+        job
+        for job in jobs
+        if job_name_matches(current_job_name, job.get("name", ""))
+        and job.get("status") in ("queued", "in_progress", "completed")
+    ]
+
+    if runner_name:
+        for job in matching_jobs:
+            if job.get("runner_name") != runner_name:
+                continue
+            html_url = job.get("html_url")
+            if html_url:
+                return html_url
+
+    for job in matching_jobs:
+        html_url = job.get("html_url")
+        if html_url:
+            return html_url
+
+    return get_run_url()
 
 
 DEFAULT_BUILD_TARGET = "cloud/blockstore/apps/,cloud/filestore/apps/,cloud/disk_manager/,cloud/tasks/,cloud/storage/"

--- a/.github/scripts/nightly_pr_check.py
+++ b/.github/scripts/nightly_pr_check.py
@@ -1,0 +1,1093 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import boto3
+import requests
+from botocore.exceptions import BotoCoreError, ClientError
+from github import Auth as GithubAuth, Github
+from github.PullRequest import PullRequest
+from github.Repository import Repository
+from github.WorkflowRun import WorkflowRun as GithubWorkflowRun
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from .helpers import (
+    find_current_job_url,
+    format_github_response_debug,
+    github_api_headers,
+    get_build_preset_from_workflow_name,
+    get_s3_report_uri,
+    get_s3_report_url,
+    get_s3_workflow_reports_path,
+    parse_s3_path,
+    retry,
+    setup_logger,
+)
+from .tests import generate_summary as gs
+
+SCRIPT_DIR = os.path.dirname(__file__)
+LABEL_TO_WORKFLOWS = {
+    "nightly-tests": ["nightly.yaml"],
+    "nightly-asan": ["nightly-asan.yaml"],
+    "nightly-tsan": ["nightly-tsan.yaml"],
+    "nightly-msan": ["nightly-msan.yaml"],
+    "nightly-ubsan": ["nightly-ubsan.yaml"],
+    "nightly-sanitizers": [
+        "nightly-asan.yaml",
+        "nightly-tsan.yaml",
+        "nightly-msan.yaml",
+        "nightly-ubsan.yaml",
+    ],
+    "nightly-all": [
+        "nightly.yaml",
+        "nightly-asan.yaml",
+        "nightly-tsan.yaml",
+        "nightly-msan.yaml",
+        "nightly-ubsan.yaml",
+    ],
+}
+
+COMMENT_MARKER_PREFIX = "<!-- nbs-nightly-pr-check"
+CANCEL_VERIFY_INTERVAL_SECONDS = 5
+CANCEL_VERIFY_TIMEOUT_SECONDS = 300
+CANCEL_VERIFY_RETRY_ATTEMPTS = (
+    CANCEL_VERIFY_TIMEOUT_SECONDS // CANCEL_VERIFY_INTERVAL_SECONDS + 1
+)
+INITIAL_DISCOVERY_INTERVAL_SECONDS = 5
+INITIAL_DISCOVERY_TIMEOUT_SECONDS = 60
+INITIAL_DISCOVERY_RETRY_ATTEMPTS = (
+    INITIAL_DISCOVERY_TIMEOUT_SECONDS // INITIAL_DISCOVERY_INTERVAL_SECONDS + 1
+)
+DISPATCH_DISCOVERY_GRACE_SECONDS = 2
+COLLECTOR_POLL_INTERVAL_SECONDS = 60
+COLLECTOR_TIMEOUT_SECONDS = 28800
+COLLECTOR_POLL_RETRY_ATTEMPTS = (
+    COLLECTOR_TIMEOUT_SECONDS // COLLECTOR_POLL_INTERVAL_SECONDS + 1
+)
+logger = setup_logger()
+
+S3_REPORT_CONTEXT_ENV_KEYS = (
+    "S3_BUCKET",
+    "S3_BUCKET_PATH",
+    "S3_REPORTS_BUCKET_PATH",
+    "S3_WEBSITE_SUFFIX",
+)
+
+
+@dataclass
+class WorkflowRun:
+    workflow: str
+    label: str
+    run_id: int | None = None
+    url: str = ""
+    status: str = "dispatching"
+    conclusion: str | None = None
+    summaries: list[dict[str, str]] = field(default_factory=list)
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class CancelRequestResult:
+    accepted: bool
+    status_code: int
+    debug: str
+
+
+class CancellationRequested(BaseException):
+    pass
+
+
+def request_cancellation(signum: int, _frame: Any) -> None:  # noqa: U101
+    raise CancellationRequested(f"received signal {signum}")
+
+
+def load_event() -> dict[str, Any]:
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def get_github_context(
+    token: str, repository: str, event: dict[str, Any]
+) -> tuple[Repository, PullRequest]:
+    gh = Github(auth=GithubAuth.Token(token))
+    repo = gh.get_repo(repository)
+    pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
+    return repo, pr
+
+
+def selected_workflows(labels: set[str]) -> list[WorkflowRun]:
+    workflows: dict[str, str] = {}
+    for label, label_workflows in LABEL_TO_WORKFLOWS.items():
+        if label not in labels:
+            continue
+        for workflow in label_workflows:
+            workflows[workflow] = label
+
+    return [
+        WorkflowRun(workflow=workflow, label=label)
+        for workflow, label in sorted(workflows.items())
+    ]
+
+
+def dispatch_workflow(
+    repo: Repository,
+    workflow: str,
+    ref: str,
+    marker: str,
+) -> None:
+    logger.info("Dispatching %s on ref %s with marker %s", workflow, ref, marker)
+    repo.get_workflow(workflow).create_dispatch(
+        ref=ref,
+        inputs={"comment": marker},
+        throw=True,
+    )
+
+
+def find_workflow_run(
+    repo: Repository,
+    workflow: str,
+    branch: str,
+    marker: str,
+    dispatched_at: datetime | None = None,
+) -> GithubWorkflowRun | None:
+    candidates = []
+    workflow_runs = repo.get_workflow(workflow).get_runs(
+        branch=branch,
+        event="workflow_dispatch",
+    )
+    for index, run in enumerate(workflow_runs):
+        if index >= 50:
+            break
+        title = run.display_title or run.name or ""
+        if marker not in title:
+            continue
+        created_at = run.created_at
+        if created_at is not None and created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        if (
+            dispatched_at is not None
+            and created_at
+            and created_at
+            < dispatched_at - timedelta(seconds=DISPATCH_DISCOVERY_GRACE_SECONDS)
+        ):
+            logger.info(
+                "Skipping older run workflow=%s id=%s created_at=%s dispatched_at=%s marker=%s",
+                workflow,
+                run.id,
+                created_at,
+                dispatched_at,
+                marker,
+            )
+            continue
+        candidates.append(run)
+
+    if not candidates:
+        logger.info(
+            "No run found yet for workflow=%s branch=%s marker=%s",
+            workflow,
+            branch,
+            marker,
+        )
+        return None
+
+    result = sorted(candidates, key=lambda run: run.run_number, reverse=True)[0]
+    logger.info(
+        "Found run workflow=%s id=%s status=%s conclusion=%s url=%s",
+        workflow,
+        result.id,
+        result.status,
+        result.conclusion,
+        result.html_url,
+    )
+    return result
+
+
+def get_summary_label(workflow: str, summary_json_uri: str = "") -> str:
+    build_preset = get_build_preset_from_workflow_name(workflow)
+    if summary_json_uri:
+        component = get_summary_component(summary_json_uri)
+        if component:
+            return f"{build_preset or workflow}/{component}"
+    if build_preset is not None:
+        return build_preset
+    return workflow
+
+
+def link_count(value: int, url: str, anchor: str | None = None) -> str:
+    if value == 0:
+        return "0"
+    href = f"{url}#{anchor}" if anchor else url
+    return f"[{value}]({href})"
+
+
+def get_run_attempt(workflow_run: GithubWorkflowRun) -> int:
+    return getattr(workflow_run, "run_attempt", None) or 1
+
+
+def get_reports_bucket() -> str:
+    bucket = os.environ.get("S3_BUCKET", "").strip()
+    if bucket:
+        return bucket
+
+    for env_name in ("S3_REPORTS_BUCKET_PATH", "S3_BUCKET_PATH"):
+        env_value = os.environ.get(env_name, "").strip()
+        if not env_value:
+            continue
+        try:
+            bucket, _key = parse_s3_path(env_value)
+        except ValueError as error:
+            logger.warning(
+                "Cannot derive S3 bucket from %s=%r: %s", env_name, env_value, error
+            )
+            continue
+        logger.info("Derived S3 bucket %s from %s", bucket, env_name)
+        return bucket
+
+    logger.warning(
+        "Cannot derive S3 bucket: none of %s are set to a usable value",
+        ", ".join(S3_REPORT_CONTEXT_ENV_KEYS),
+    )
+    return ""
+
+
+def log_s3_report_context() -> None:
+    logger.info(
+        "S3 report context: %s",
+        {
+            env_name: os.environ.get(env_name, "")
+            for env_name in S3_REPORT_CONTEXT_ENV_KEYS
+        },
+    )
+
+
+def fetch_summary_payload(s3: Any, summary_json_uri: str) -> dict[str, Any] | None:
+    logger.info("Fetching summary json %s", summary_json_uri)
+    try:
+        bucket, key = parse_s3_path(summary_json_uri)
+        response = s3.get_object(Bucket=bucket, Key=key)
+        return json.loads(response["Body"].read().decode("utf-8"))
+    except (
+        BotoCoreError,
+        ClientError,
+        json.JSONDecodeError,
+        KeyError,
+        UnicodeDecodeError,
+        ValueError,
+    ) as error:
+        logger.info("Failed to fetch summary json %s: %s", summary_json_uri, error)
+        return None
+
+
+def list_summary_json_uris(
+    s3: Any,
+    repo: Repository,
+    workflow_file: str,
+    workflow_run: GithubWorkflowRun,
+) -> list[str]:
+    prefix = get_s3_workflow_reports_path(
+        repository=repo.full_name,
+        workflow_file=workflow_file,
+        run_id=workflow_run.id,
+        run_attempt=get_run_attempt(workflow_run),
+    )
+    reports_bucket = get_reports_bucket()
+    prefix_uri = get_s3_report_uri(prefix, bucket=reports_bucket)
+    if not prefix_uri:
+        logger.warning(
+            "Cannot list summary reports: empty S3 URI for workflow=%s run_id=%s attempt=%s bucket=%r prefix=%r",
+            workflow_file,
+            workflow_run.id,
+            get_run_attempt(workflow_run),
+            reports_bucket,
+            prefix,
+        )
+        return []
+
+    try:
+        bucket, key_prefix = parse_s3_path(prefix_uri)
+        logger.info(
+            "Listing summary reports for workflow=%s run_id=%s attempt=%s under bucket=%s prefix=%s uri=%s",
+            workflow_file,
+            workflow_run.id,
+            get_run_attempt(workflow_run),
+            bucket,
+            key_prefix,
+            prefix_uri,
+        )
+        paginator = s3.get_paginator("list_objects_v2")
+        keys = []
+        object_count = 0
+        for page in paginator.paginate(Bucket=bucket, Prefix=key_prefix):
+            contents = page.get("Contents", [])
+            object_count += len(contents)
+            keys.extend(
+                content["Key"]
+                for content in contents
+                if content["Key"].endswith("/summary.json")
+            )
+    except (BotoCoreError, ClientError, KeyError, ValueError) as error:
+        logger.warning("Failed to list summary reports under %s: %s", prefix_uri, error)
+        return []
+
+    def sort_key(key: str) -> tuple[int, str]:
+        try:
+            retry = int(key.rsplit("/", 2)[-2])
+        except ValueError:
+            retry = 0
+        return retry, key
+
+    logger.info(
+        "Found %d objects and %d summary reports under %s: %s",
+        object_count,
+        len(keys),
+        prefix_uri,
+        keys[:20],
+    )
+    return [
+        get_s3_report_uri(key, bucket=bucket)
+        for key in sorted(keys, key=sort_key, reverse=True)
+    ]
+
+
+def get_report_url_from_summary_uri(summary_json_uri: str) -> str:
+    try:
+        bucket, key = parse_s3_path(summary_json_uri)
+    except ValueError:
+        return ""
+    if not key.endswith("/summary.json"):
+        return ""
+    return get_s3_report_url(
+        f"{key.removesuffix('/summary.json')}/ya-test.html",
+        bucket=bucket,
+    )
+
+
+def get_summary_component(summary_json_uri: str) -> str:
+    try:
+        _bucket, key = parse_s3_path(summary_json_uri)
+    except ValueError:
+        return ""
+
+    parts = key.split("/")
+    if len(parts) < 8 or parts[0] != "reports" or parts[-1] != "summary.json":
+        return ""
+
+    relative_parts = parts[6:-1]
+    if len(relative_parts) <= 1:
+        return ""
+    return "/".join(relative_parts[:-1])
+
+
+def render_summary_markdown(
+    payload: dict[str, Any] | None,
+    summary_json_url: str,
+    fallback_report_url: str = "",
+) -> str:
+    if payload is None:
+        return ""
+
+    logger.info(
+        "Using summary json %s schema=%s version=%s",
+        summary_json_url,
+        payload.get("schema") if isinstance(payload, dict) else None,
+        payload.get("schema_version") if isinstance(payload, dict) else None,
+    )
+    reports = payload.get("reports") if isinstance(payload, dict) else None
+    if not reports:
+        logger.info("No summary reports found in %s", summary_json_url)
+        return ""
+
+    report = reports[0]
+    if not isinstance(report, dict):
+        logger.info("Invalid summary report in %s", summary_json_url)
+        return ""
+    report_url = (
+        report.get("report_url")
+        or get_report_url_from_summary_uri(summary_json_url)
+        or fallback_report_url
+    )
+    counts = report.get("counts") or {}
+    total = int(report.get("total") or sum(int(value) for value in counts.values()))
+    statuses = gs.TestStatus.summary_table_order()
+    headers = ["TESTS"] + [status.summary_header for status in statuses]
+    separators = ["---:"] * len(headers)
+    values = [link_count(total, report_url)]
+    values.extend(
+        link_count(int(counts.get(status.name, 0)), report_url, status.report_anchor)
+        for status in statuses
+    )
+
+    return "\n".join(
+        [
+            f"| {' | '.join(headers)} |",
+            f"| {' | '.join(separators)} |",
+            f"| {' | '.join(values)} |",
+        ]
+    )
+
+
+def build_summary_entry(
+    workflow_file: str,
+    summary_json_uri: str,
+    summary_markdown: str,
+) -> dict[str, str]:
+    return {
+        "label": get_summary_label(workflow_file, summary_json_uri),
+        "summary_markdown": summary_markdown,
+    }
+
+
+def fetch_run_summaries(
+    s3: Any,
+    repo: Repository,
+    workflow_file: str,
+    run: GithubWorkflowRun,
+) -> list[dict[str, str]]:
+    summaries = []
+    for summary_json_uri in list_summary_json_uris(s3, repo, workflow_file, run):
+        summary_markdown = render_summary_markdown(
+            fetch_summary_payload(s3, summary_json_uri),
+            summary_json_uri,
+        )
+        if summary_markdown:
+            summaries.append(
+                build_summary_entry(workflow_file, summary_json_uri, summary_markdown)
+            )
+
+    if summaries:
+        return summaries
+
+    logger.warning(
+        "No summary reports found for workflow=%s run_id=%s attempt=%s. Expected at least one summary.json under %s",
+        workflow_file,
+        run.id,
+        get_run_attempt(run),
+        get_s3_report_uri(
+            get_s3_workflow_reports_path(
+                repository=repo.full_name,
+                workflow_file=workflow_file,
+                run_id=run.id,
+                run_attempt=get_run_attempt(run),
+            ),
+            bucket=get_reports_bucket(),
+        ),
+    )
+    return []
+
+
+def cancel_workflow_run(repo: Repository, run_id: int) -> CancelRequestResult:
+    url = f"https://api.github.com/repos/{repo.full_name}/actions/runs/{run_id}/cancel"
+    logger.info("Requesting cancellation for run_id=%s via %s", run_id, url)
+    response = requests.post(
+        url,
+        headers=github_api_headers(os.environ.get("GITHUB_TOKEN")),
+        timeout=30,
+    )
+    debug = format_github_response_debug(response)
+    accepted = response.status_code == 202
+    if accepted:
+        logger.info("Cancellation request for run_id=%s accepted: %s", run_id, debug)
+    else:
+        logger.warning(
+            "Cancellation request for run_id=%s was not accepted: %s",
+            run_id,
+            debug,
+        )
+    return CancelRequestResult(
+        accepted=accepted,
+        status_code=response.status_code,
+        debug=debug,
+    )
+
+
+def status_icon(run: WorkflowRun) -> str:
+    if run.error:
+        return ":red_circle:"
+    if run.status != "completed":
+        return ":yellow_circle:"
+    if run.conclusion == "success":
+        return ":green_circle:"
+    return ":red_circle:"
+
+
+def status_text(run: WorkflowRun) -> str:
+    if run.error:
+        return run.error
+    if run.conclusion:
+        return run.conclusion
+    return run.status
+
+
+def workflow_markdown(run: WorkflowRun) -> str:
+    workflow = f"`{run.workflow}`"
+    if run.url:
+        return f"[`{run.workflow}`]({run.url})"
+    return workflow
+
+
+def render_comment(
+    marker: str,
+    runs: list[WorkflowRun],
+    final: bool,
+    collector_url: str = "",
+) -> str:
+    summaries = [
+        summary
+        for run in runs
+        for summary in run.summaries
+        if summary.get("summary_markdown")
+    ]
+    comment_template = Environment(
+        loader=FileSystemLoader(os.path.join(SCRIPT_DIR, "templates")),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        undefined=StrictUndefined,
+    ).get_template("nightly_pr_comment.md.j2")
+    return comment_template.render(
+        comment_marker=get_comment_marker(marker),
+        workflow_status="finished" if final else "running",
+        collector_url=collector_url,
+        runs=[
+            {
+                "icon": status_icon(run),
+                "workflow": workflow_markdown(run),
+                "status": status_text(run),
+            }
+            for run in runs
+        ],
+        summaries=summaries[:10],
+        omitted_summary_count=max(0, len(summaries) - 10),
+    ).rstrip()
+
+
+def get_comment_marker(marker: str) -> str:
+    return f'{COMMENT_MARKER_PREFIX} marker="{marker}" -->'
+
+
+def upsert_comment(pr: PullRequest, marker: str, body: str) -> None:
+    comment_marker = get_comment_marker(marker)
+    comment = gs.find_pr_comment(pr, comment_marker)
+    if comment is None:
+        logger.info("Creating nightly PR comment for PR #%s", pr.number)
+        pr.create_issue_comment(body)
+        return
+
+    def replace_comment_body(current_body: str) -> str:
+        del current_body
+        return body
+
+    logger.info("Updating nightly PR comment id=%s for PR #%s", comment.id, pr.number)
+    gs.edit_pr_comment(
+        pr=pr,
+        header_prefix=comment_marker,
+        update_body=replace_comment_body,
+        is_applied=lambda current_body: current_body == body
+        or current_body == gs.bump_comment_revision(body),
+        operation=f"nightly PR comment {marker}",
+    )
+
+
+def refresh_run(s3: Any, repo: Repository, run: WorkflowRun) -> None:
+    if run.run_id is None:
+        return
+
+    workflow_run = repo.get_workflow_run(run.run_id)
+    run.status = workflow_run.status or run.status
+    run.conclusion = workflow_run.conclusion
+    run.url = workflow_run.html_url or run.url
+    if run.status == "completed":
+        run.summaries = fetch_run_summaries(s3, repo, run.workflow, workflow_run)
+    logger.info(
+        "Refreshed %s: id=%s status=%s conclusion=%s",
+        run.workflow,
+        run.run_id,
+        run.status,
+        run.conclusion,
+    )
+
+
+def refresh_runs(s3: Any, repo: Repository, runs: list[WorkflowRun]) -> None:
+    for run in runs:
+        refresh_run(s3, repo, run)
+
+
+@retry(
+    attempts=CANCEL_VERIFY_RETRY_ATTEMPTS,
+    interval_sec=CANCEL_VERIFY_INTERVAL_SECONDS,
+    retry_result=lambda result: result is False,
+)
+def wait_for_cancellation(s3: Any, repo: Repository, run: WorkflowRun) -> bool:
+    if run.run_id is None:
+        return False
+
+    refresh_run(s3, repo, run)
+    if run.status == "completed" or run.conclusion == "cancelled":
+        logger.info(
+            "Run %s id=%s stopped after cancellation request: conclusion=%s",
+            run.workflow,
+            run.run_id,
+            run.conclusion,
+        )
+        return True
+
+    logger.info(
+        "Waiting for run %s id=%s to stop after cancellation request: status=%s timeout=%ss",
+        run.workflow,
+        run.run_id,
+        run.status,
+        CANCEL_VERIFY_TIMEOUT_SECONDS,
+    )
+    return False
+
+
+def all_done(runs: list[WorkflowRun]) -> bool:
+    return all(run.error or run.status == "completed" for run in runs)
+
+
+def any_failed(runs: list[WorkflowRun]) -> bool:
+    for run in runs:
+        if run.error:
+            return True
+        if run.status != "completed":
+            return True
+        if run.conclusion != "success":
+            return True
+    return False
+
+
+def discover_missing_runs(
+    repo: Repository,
+    runs: list[WorkflowRun],
+    head_ref: str,
+    marker: str,
+    dispatched_at: datetime | None,
+) -> None:
+    for run in runs:
+        if run.error or run.run_id is not None:
+            continue
+        workflow_run = find_workflow_run(
+            repo,
+            run.workflow,
+            head_ref,
+            marker,
+            dispatched_at,
+        )
+        if workflow_run is None:
+            continue
+        run.run_id = int(workflow_run.id)
+        run.url = workflow_run.html_url or ""
+
+
+def all_discovered(runs: list[WorkflowRun]) -> bool:
+    return all(run.error or run.run_id is not None for run in runs)
+
+
+@retry(
+    attempts=INITIAL_DISCOVERY_RETRY_ATTEMPTS,
+    interval_sec=INITIAL_DISCOVERY_INTERVAL_SECONDS,
+    retry_result=lambda result: result is False,
+)
+def wait_for_initial_discovery(
+    repo: Repository,
+    runs: list[WorkflowRun],
+    head_ref: str,
+    marker: str,
+    dispatched_at: datetime | None,
+) -> bool:
+    discover_missing_runs(repo, runs, head_ref, marker, dispatched_at)
+    if all_discovered(runs):
+        return True
+
+    missing = [run.workflow for run in runs if run.run_id is None and not run.error]
+    logger.info("Waiting to discover spawned runs: %s", missing)
+    return False
+
+
+@retry(
+    attempts=COLLECTOR_POLL_RETRY_ATTEMPTS,
+    interval_sec=COLLECTOR_POLL_INTERVAL_SECONDS,
+    retry_result=lambda result: not result[0],
+)
+def poll_runs_until_done(
+    s3: Any,
+    repo: Repository,
+    pr: PullRequest,
+    runs: list[WorkflowRun],
+    head_ref: str,
+    marker: str,
+    dispatched_at: datetime,
+    collector_url: str,
+    comment_state: dict[str, str],
+) -> tuple[bool, str]:
+    discover_missing_runs(
+        repo,
+        runs,
+        head_ref,
+        marker,
+        dispatched_at,
+    )
+    refresh_runs(s3, repo, runs)
+
+    previous_comment_body = comment_state["body"]
+    if all_done(runs):
+        return True, previous_comment_body
+
+    current_comment_body = render_comment(
+        marker,
+        runs,
+        final=False,
+        collector_url=collector_url,
+    )
+    if current_comment_body != previous_comment_body:
+        upsert_comment(pr, marker, current_comment_body)
+        comment_state["body"] = current_comment_body
+
+    return False, comment_state["body"]
+
+
+def cancel_started_runs(
+    s3: Any,
+    repo: Repository,
+    runs: list[WorkflowRun],
+    cancellation_reason: str = "collector job was cancelled",
+) -> None:
+    for run in runs:
+        if run.run_id is None:
+            if not run.error:
+                logger.warning(
+                    "Cannot cancel %s: spawned run was not discovered",
+                    run.workflow,
+                )
+                run.error = (
+                    f"{cancellation_reason} before the spawned run was discovered"
+                )
+                run.status = "completed"
+                run.conclusion = "cancelled"
+            continue
+
+        if run.status == "completed" or run.conclusion == "cancelled":
+            logger.info(
+                "Skipping cancellation for completed run %s id=%s status=%s conclusion=%s url=%s",
+                run.workflow,
+                run.run_id,
+                run.status,
+                run.conclusion,
+                run.url,
+            )
+            continue
+
+        try:
+            logger.info(
+                "Cancelling run workflow=%s id=%s status=%s conclusion=%s url=%s",
+                run.workflow,
+                run.run_id,
+                run.status,
+                run.conclusion,
+                run.url,
+            )
+            cancel_result = cancel_workflow_run(repo, run.run_id)
+            if wait_for_cancellation(s3, repo, run):
+                continue
+
+            logger.warning(
+                "Run %s id=%s is still %s after %ss cancellation wait",
+                run.workflow,
+                run.run_id,
+                run.status,
+                CANCEL_VERIFY_TIMEOUT_SECONDS,
+            )
+            if cancel_result.accepted:
+                run.error = (
+                    f"{cancellation_reason}; GitHub accepted cancellation, "
+                    f"but the nightly run stayed {run.status}"
+                )
+            else:
+                run.error = (
+                    f"{cancellation_reason}; GitHub did not accept cancellation "
+                    f"({cancel_result.debug}); nightly run stayed {run.status}"
+                )
+        except Exception as error:
+            try:
+                refresh_run(s3, repo, run)
+            except Exception:
+                logger.exception(
+                    "Failed to refresh %s id=%s after cancellation failure",
+                    run.workflow,
+                    run.run_id,
+                )
+            run.error = f"{cancellation_reason}; failed to cancel run: {error}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("dispatch-and-collect", "cancel"),
+        default="dispatch-and-collect",
+    )
+    return parser.parse_args()
+
+
+def load_context() -> tuple[
+    str,
+    str,
+    Repository,
+    dict[str, Any],
+    PullRequest,
+    int,
+    str,
+    str,
+    set[str],
+    list[WorkflowRun],
+    str,
+    str,
+]:
+    token = os.environ["GITHUB_TOKEN"]
+    repository = os.environ["GITHUB_REPOSITORY"]
+    event = load_event()
+    repo, pr_object = get_github_context(token, repository, event)
+    pr = event["pull_request"]
+    pr_number = int(pr["number"])
+    head_ref = pr["head"]["ref"]
+    head_repo = pr["head"]["repo"]["full_name"]
+    labels = {label["name"] for label in pr.get("labels", [])}
+    runs = selected_workflows(labels)
+    marker = f"pr-{pr_number}-run-{os.environ['GITHUB_RUN_ID']}-attempt-{os.environ.get('GITHUB_RUN_ATTEMPT', '1')}"
+    collector_url = find_current_job_url(
+        os.environ.get("GITHUB_JOB", "nightly-builds"),
+        os.environ.get("RUNNER_NAME", ""),
+    )
+    return (
+        token,
+        repository,
+        repo,
+        pr,
+        pr_object,
+        pr_number,
+        head_ref,
+        head_repo,
+        labels,
+        runs,
+        marker,
+        collector_url,
+    )
+
+
+def cancel_mode() -> int:
+    (
+        _token,
+        _repository,
+        repo,
+        _pr,
+        pr_object,
+        pr_number,
+        head_ref,
+        _head_repo,
+        _labels,
+        runs,
+        marker,
+        collector_url,
+    ) = load_context()
+
+    if not runs:
+        logger.info("No nightly PR labels found; nothing to cancel")
+        return 0
+
+    s3 = boto3.client("s3")
+    log_s3_report_context()
+    logger.info(
+        "Cancellation mode started for PR #%s, ref=%s, marker=%s, workflows=%s",
+        pr_number,
+        head_ref,
+        marker,
+        [run.workflow for run in runs],
+    )
+    if not wait_for_initial_discovery(
+        repo,
+        runs,
+        head_ref,
+        marker,
+        dispatched_at=None,
+    ):
+        missing = [run.workflow for run in runs if run.run_id is None and not run.error]
+        logger.warning(
+            "Timed out waiting to discover spawned runs before cancellation: %s",
+            missing,
+        )
+    refresh_runs(s3, repo, runs)
+    cancel_started_runs(s3, repo, runs)
+    upsert_comment(
+        pr_object,
+        marker,
+        render_comment(marker, runs, final=True, collector_url=collector_url),
+    )
+    return 1 if any(run.error for run in runs) else 0
+
+
+def main() -> int:
+    signal.signal(signal.SIGINT, request_cancellation)
+    signal.signal(signal.SIGTERM, request_cancellation)
+
+    args = parse_args()
+    if args.mode == "cancel":
+        return cancel_mode()
+
+    (
+        _token,
+        repository,
+        repo,
+        _pr,
+        pr_object,
+        pr_number,
+        head_ref,
+        head_repo,
+        _labels,
+        runs,
+        marker,
+        collector_url,
+    ) = load_context()
+
+    if not runs:
+        logger.info("No nightly PR labels found; nothing to dispatch")
+        return 0
+
+    s3 = boto3.client("s3")
+    log_s3_report_context()
+    logger.info(
+        "Dispatch-and-collect mode started for PR #%s, ref=%s, marker=%s, workflows=%s",
+        pr_number,
+        head_ref,
+        marker,
+        [run.workflow for run in runs],
+    )
+
+    if head_repo != repository:
+        for run in runs:
+            run.status = "completed"
+            run.conclusion = "skipped"
+            run.error = "workflow_dispatch for PR nightly checks is supported only for same-repository PR branches"
+        upsert_comment(
+            pr_object,
+            marker,
+            render_comment(marker, runs, final=True, collector_url=collector_url),
+        )
+        return 1
+
+    dispatched_at = datetime.now(timezone.utc)
+    try:
+        for run in runs:
+            try:
+                dispatch_workflow(repo, run.workflow, head_ref, marker)
+                run.status = "queued"
+            except Exception as error:
+                run.status = "completed"
+                run.conclusion = "failure"
+                run.error = str(error)
+
+        if not wait_for_initial_discovery(repo, runs, head_ref, marker, dispatched_at):
+            missing = [
+                run.workflow for run in runs if run.run_id is None and not run.error
+            ]
+            logger.warning("Timed out waiting to discover spawned runs: %s", missing)
+        posted_comment_body = render_comment(
+            marker,
+            runs,
+            final=False,
+            collector_url=collector_url,
+        )
+        upsert_comment(pr_object, marker, posted_comment_body)
+
+        poll_done, posted_comment_body = poll_runs_until_done(
+            s3=s3,
+            repo=repo,
+            pr=pr_object,
+            runs=runs,
+            head_ref=head_ref,
+            marker=marker,
+            dispatched_at=dispatched_at,
+            collector_url=collector_url,
+            comment_state={"body": posted_comment_body},
+        )
+        if poll_done:
+            posted_comment_body = render_comment(
+                marker,
+                runs,
+                final=True,
+                collector_url=collector_url,
+            )
+            upsert_comment(
+                pr_object,
+                marker,
+                posted_comment_body,
+            )
+            return 1 if any_failed(runs) else 0
+
+    except CancellationRequested:
+        if not wait_for_initial_discovery(repo, runs, head_ref, marker, dispatched_at):
+            missing = [
+                run.workflow for run in runs if run.run_id is None and not run.error
+            ]
+            logger.warning(
+                "Timed out waiting to discover spawned runs before cancellation: %s",
+                missing,
+            )
+        refresh_runs(s3, repo, runs)
+        cancel_started_runs(s3, repo, runs)
+        upsert_comment(
+            pr_object,
+            marker,
+            render_comment(marker, runs, final=True, collector_url=collector_url),
+        )
+        return 1
+
+    discover_missing_runs(repo, runs, head_ref, marker, dispatched_at)
+    refresh_runs(s3, repo, runs)
+    timed_out_runs = [run for run in runs if run.status != "completed"]
+    if timed_out_runs:
+        logger.warning(
+            "Collector timed out after %ss; cancelling unfinished nightly runs: %s",
+            COLLECTOR_TIMEOUT_SECONDS,
+            [
+                {
+                    "workflow": run.workflow,
+                    "run_id": run.run_id,
+                    "status": run.status,
+                    "conclusion": run.conclusion,
+                    "url": run.url,
+                }
+                for run in timed_out_runs
+            ],
+        )
+        cancel_started_runs(
+            s3,
+            repo,
+            timed_out_runs,
+            cancellation_reason="collector timed out",
+        )
+        for run in timed_out_runs:
+            if not run.error:
+                run.error = (
+                    "timed out waiting for workflow completion; cancellation requested"
+                )
+            if run.status != "completed":
+                run.status = "completed"
+                run.conclusion = "timed_out"
+
+    upsert_comment(
+        pr_object,
+        marker,
+        render_comment(marker, runs, final=True, collector_url=collector_url),
+    )
+    return 1 if timed_out_runs or any_failed(runs) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,2 +1,4 @@
 PyGithub==2.9.1
+boto3
+Jinja2
 nebius==0.3.59

--- a/.github/scripts/templates/nightly_pr_comment.md.j2
+++ b/.github/scripts/templates/nightly_pr_comment.md.j2
@@ -1,0 +1,22 @@
+{{ comment_marker }}
+> [!TIP]
+> Nightly workflows are **{{ workflow_status }}**.
+
+{% if collector_url -%}
+Collector: [nightly-builds job]({{ collector_url }})
+
+{% endif -%}
+{% for run in runs -%}
+- {{ run.icon }} {{ run.workflow }} - `{{ run.status }}`
+{% endfor -%}
+{% if summaries %}
+
+Summaries:
+{% for summary in summaries -%}
+`{{ summary.get("label", "summary") }}`
+{{ summary.summary_markdown }}
+{% endfor -%}
+{% if omitted_summary_count > 0 -%}
+- ... and {{ omitted_summary_count }} more summaries
+{% endif -%}
+{% endif -%}

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -509,7 +509,11 @@ def write_summary_json(
                 "report_url": line.report_url,
                 "total": line.test_count,
                 "counts": {
-                    status.name: line.count(status)
+                    status.name: (
+                        max(build_failed_count, line.count(status))
+                        if status == TestStatus.FAIL_BUILD
+                        else line.count(status)
+                    )
                     for status in TestStatus.summary_table_order()
                 },
                 "tests": [

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -36,8 +36,6 @@ WORKLOAD_COMMENT_EDIT_ATTEMPTS = 5
 WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS = float(
     os.environ.get("WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS", "1.0")
 )
-SUMMARY_JSON_SCHEMA = "nbs-test-summary"
-SUMMARY_JSON_SCHEMA_VERSION = 1
 WORKLOAD_CHECK_STATUS_ICONS = {
     "pending": ":white_circle:",
     "running": ":hourglass_flowing_sand:",
@@ -492,53 +490,6 @@ def write_summary(
                 fp.write(f"{line}\n")
 
         fp.write("\n")
-
-
-def write_summary_json(
-    summary: TestSummary,
-    summary_out_folder: str,
-    build_failed_count: int = 0,
-) -> None:
-    payload = {
-        "schema": SUMMARY_JSON_SCHEMA,
-        "schema_version": SUMMARY_JSON_SCHEMA_VERSION,
-        "aggregate_build_failed_count": build_failed_count,
-        "reports": [
-            {
-                "title": line.title,
-                "report_url": line.report_url,
-                "total": line.test_count,
-                "counts": {
-                    status.name: (
-                        max(build_failed_count, line.count(status))
-                        if status == TestStatus.FAIL_BUILD
-                        else line.count(status)
-                    )
-                    for status in TestStatus.summary_table_order()
-                },
-                "tests": [
-                    {
-                        "classname": test.classname,
-                        "name": test.name,
-                        "full_name": test.full_name,
-                        "status": test.status.name,
-                        "status_label": test.status.label,
-                        "elapsed_seconds": finite_elapsed_seconds(
-                            test.elapsed,
-                            test.classname,
-                            test.name,
-                        ),
-                        "is_timed_out": test.is_timed_out,
-                    }
-                    for test in sorted(line.tests, key=attrgetter("full_name"))
-                ],
-            }
-            for line in summary.lines
-        ],
-    }
-
-    with open(os.path.join(summary_out_folder, "summary.json"), "w") as fp:
-        json.dump(payload, fp, separators=(",", ":"), allow_nan=False)
 
 
 def gen_summary(
@@ -1335,11 +1286,6 @@ def main() -> None:
         write_summary(
             summary,
             args.summary_out_env_path,
-        )
-        write_summary_json(
-            summary,
-            args.summary_out_path,
-            build_failed_count=get_build_failed_count(),
         )
     elif not args.update_workload_status_only:
         LOGGER.error("No summary inputs provided")

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -36,6 +36,8 @@ WORKLOAD_COMMENT_EDIT_ATTEMPTS = 5
 WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS = float(
     os.environ.get("WORKLOAD_COMMENT_EDIT_VERIFY_DELAY_SECONDS", "1.0")
 )
+SUMMARY_JSON_SCHEMA = "nbs-test-summary"
+SUMMARY_JSON_SCHEMA_VERSION = 1
 WORKLOAD_CHECK_STATUS_ICONS = {
     "pending": ":white_circle:",
     "running": ":hourglass_flowing_sand:",
@@ -490,6 +492,49 @@ def write_summary(
                 fp.write(f"{line}\n")
 
         fp.write("\n")
+
+
+def write_summary_json(
+    summary: TestSummary,
+    summary_out_folder: str,
+    build_failed_count: int = 0,
+) -> None:
+    payload = {
+        "schema": SUMMARY_JSON_SCHEMA,
+        "schema_version": SUMMARY_JSON_SCHEMA_VERSION,
+        "aggregate_build_failed_count": build_failed_count,
+        "reports": [
+            {
+                "title": line.title,
+                "report_url": line.report_url,
+                "total": line.test_count,
+                "counts": {
+                    status.name: line.count(status)
+                    for status in TestStatus.summary_table_order()
+                },
+                "tests": [
+                    {
+                        "classname": test.classname,
+                        "name": test.name,
+                        "full_name": test.full_name,
+                        "status": test.status.name,
+                        "status_label": test.status.label,
+                        "elapsed_seconds": finite_elapsed_seconds(
+                            test.elapsed,
+                            test.classname,
+                            test.name,
+                        ),
+                        "is_timed_out": test.is_timed_out,
+                    }
+                    for test in sorted(line.tests, key=attrgetter("full_name"))
+                ],
+            }
+            for line in summary.lines
+        ],
+    }
+
+    with open(os.path.join(summary_out_folder, "summary.json"), "w") as fp:
+        json.dump(payload, fp, separators=(",", ":"), allow_nan=False)
 
 
 def gen_summary(
@@ -1286,6 +1331,11 @@ def main() -> None:
         write_summary(
             summary,
             args.summary_out_env_path,
+        )
+        write_summary_json(
+            summary,
+            args.summary_out_path,
+            build_failed_count=get_build_failed_count(),
         )
     elif not args.update_workload_status_only:
         LOGGER.error("No summary inputs provided")

--- a/.github/scripts/tests/workload_comment.py
+++ b/.github/scripts/tests/workload_comment.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 
 from github import Auth as GithubAuth, Github
 from github.PullRequest import PullRequest
 
-from ..helpers import setup_logger
+from ..helpers import find_current_job_url, setup_logger
 from . import generate_summary as gs
 
 
@@ -26,71 +24,6 @@ def get_pull_request() -> PullRequest:
 def iter_components(matrix_include: str) -> list[str]:
     matrix = json.loads(matrix_include)
     return [entry["component"] for entry in matrix.get("include", [])]
-
-
-def fetch_jobs() -> list[dict]:
-    owner, repo = os.environ["GITHUB_REPOSITORY"].split("/", 1)
-    run_id = os.environ["GITHUB_RUN_ID"]
-    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "1")
-    url = (
-        f"https://api.github.com/repos/{owner}/{repo}/actions/runs/"
-        f"{run_id}/attempts/{run_attempt}/jobs?per_page=100"
-    )
-    request = Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
-    with urlopen(request) as response:
-        payload = json.load(response)
-    return payload.get("jobs", [])
-
-
-def get_run_url() -> str:
-    return f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
-
-
-def job_name_matches(expected_name: str, actual_name: str) -> bool:
-    if actual_name == expected_name:
-        return True
-
-    reusable_prefix = f"/ {expected_name}"
-    if actual_name.endswith(reusable_prefix):
-        return True
-
-    return False
-
-
-def find_current_job_url(current_job_name: str, runner_name: str) -> str:
-    try:
-        jobs = fetch_jobs()
-    except HTTPError:
-        return get_run_url()
-
-    matching_jobs = [
-        job
-        for job in jobs
-        if job_name_matches(current_job_name, job.get("name", ""))
-        and job.get("status") in ("queued", "in_progress", "completed")
-    ]
-
-    if runner_name:
-        for job in matching_jobs:
-            if job.get("runner_name") != runner_name:
-                continue
-            html_url = job.get("html_url")
-            if html_url:
-                return html_url
-
-    for job in matching_jobs:
-        html_url = job.get("html_url")
-        if html_url:
-            return html_url
-
-    return get_run_url()
 
 
 def write_output(path: str, value: str) -> None:

--- a/.github/scripts/tests/workload_comment_test.py
+++ b/.github/scripts/tests/workload_comment_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from scripts import helpers as h
 from scripts.tests import workload_comment as wc
 
 
@@ -24,9 +25,9 @@ def test_iter_components_preserves_matrix_order() -> None:
 def test_find_current_job_url_falls_back_to_run_url(monkeypatch) -> None:
     monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
     monkeypatch.setenv("GITHUB_RUN_ID", "123")
-    monkeypatch.setattr(wc, "fetch_jobs", lambda: [])
+    monkeypatch.setattr(h, "fetch_jobs", lambda: [])
 
-    assert wc.find_current_job_url("job", "runner") == (
+    assert h.find_current_job_url("job", "runner") == (
         "https://github.com/org/repo/actions/runs/123"
     )
 
@@ -35,7 +36,7 @@ def test_find_current_job_url_matches_reusable_workflow_job_name(monkeypatch) ->
     monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
     monkeypatch.setenv("GITHUB_RUN_ID", "123")
     monkeypatch.setattr(
-        wc,
+        h,
         "fetch_jobs",
         lambda: [
             {
@@ -48,7 +49,7 @@ def test_find_current_job_url_matches_reusable_workflow_job_name(monkeypatch) ->
     )
 
     assert (
-        wc.find_current_job_url(
+        h.find_current_job_url(
             "Build and test relwithdebinfo [id=1 ip=10.0.0.1]",
             "runner-1",
         )
@@ -60,7 +61,7 @@ def test_find_current_job_url_prefers_runner_specific_match(monkeypatch) -> None
     monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
     monkeypatch.setenv("GITHUB_RUN_ID", "123")
     monkeypatch.setattr(
-        wc,
+        h,
         "fetch_jobs",
         lambda: [
             {
@@ -79,6 +80,6 @@ def test_find_current_job_url_prefers_runner_specific_match(monkeypatch) -> None
     )
 
     assert (
-        wc.find_current_job_url("Build and test relwithdebinfo", "runner-b")
+        h.find_current_job_url("Build and test relwithdebinfo", "runner-b")
         == "https://github.com/org/repo/actions/runs/123/job/222"
     )

--- a/.github/workflows/check-test-launch-label.yaml
+++ b/.github/workflows/check-test-launch-label.yaml
@@ -39,6 +39,13 @@ jobs:
             rebase
             sleep
             disable_truncate
+            nightly-tests
+            nightly-asan
+            nightly-tsan
+            nightly-msan
+            nightly-ubsan
+            nightly-sanitizers
+            nightly-all
         run: |
           set -euo pipefail
 

--- a/.github/workflows/nightly-asan.yaml
+++ b/.github/workflows/nightly-asan.yaml
@@ -1,13 +1,23 @@
 name: Nightly build (asan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && 'Nightly build (asan) (manual)'
-      || 'Nightly build (asan) (schedule)'
+      && (
+            inputs.comment != ''
+            && format('Nightly build (asan) (manual) (comment: {0})', inputs.comment)
+            || format('Nightly build (asan) (manual)')
+          )
+      || format('Nightly build (asan) (schedule)')
     }}
 on:
   schedule:
     - cron: "30 0 * * *"
   workflow_dispatch:
+    inputs:
+      comment:
+        description: 'Comment'
+        type: string
+        required: false
+        default: ""
 
 jobs:
   build:

--- a/.github/workflows/nightly-asan.yaml
+++ b/.github/workflows/nightly-asan.yaml
@@ -4,9 +4,9 @@ run-name: |
       && (
             inputs.comment != ''
             && format('Nightly build (asan) (manual) (comment: {0})', inputs.comment)
-            || format('Nightly build (asan) (manual)')
+            || 'Nightly build (asan) (manual)'
           )
-      || format('Nightly build (asan) (schedule)')
+      || 'Nightly build (asan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly-msan.yaml
+++ b/.github/workflows/nightly-msan.yaml
@@ -4,9 +4,9 @@ run-name: |
       && (
             inputs.comment != ''
             && format('Nightly build (msan) (manual) (comment: {0})', inputs.comment)
-            || format('Nightly build (msan) (manual)')
+            || 'Nightly build (msan) (manual)'
           )
-      || format('Nightly build (msan) (schedule)')
+      || 'Nightly build (msan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly-msan.yaml
+++ b/.github/workflows/nightly-msan.yaml
@@ -1,13 +1,23 @@
 name: Nightly build (msan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && 'Nightly build (msan) (manual)'
-      || 'Nightly build (msan) (schedule)'
+      && (
+            inputs.comment != ''
+            && format('Nightly build (msan) (manual) (comment: {0})', inputs.comment)
+            || format('Nightly build (msan) (manual)')
+          )
+      || format('Nightly build (msan) (schedule)')
     }}
 on:
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:
+    inputs:
+      comment:
+        description: 'Comment'
+        type: string
+        required: false
+        default: ""
 
 jobs:
   build:

--- a/.github/workflows/nightly-tsan.yaml
+++ b/.github/workflows/nightly-tsan.yaml
@@ -1,13 +1,23 @@
 name: Nightly build (tsan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && 'Nightly build (tsan) (manual)'
-      || 'Nightly build (tsan) (schedule)'
+      && (
+            inputs.comment != ''
+            && format('Nightly build (tsan) (manual) (comment: {0})', inputs.comment)
+            || format('Nightly build (tsan) (manual)')
+          )
+      || format('Nightly build (tsan) (schedule)')
     }}
 on:
   schedule:
     - cron: "30 23 * * *"
   workflow_dispatch:
+    inputs:
+      comment:
+        description: 'Comment'
+        type: string
+        required: false
+        default: ""
 
 jobs:
   build:

--- a/.github/workflows/nightly-tsan.yaml
+++ b/.github/workflows/nightly-tsan.yaml
@@ -4,9 +4,9 @@ run-name: |
       && (
             inputs.comment != ''
             && format('Nightly build (tsan) (manual) (comment: {0})', inputs.comment)
-            || format('Nightly build (tsan) (manual)')
+            || 'Nightly build (tsan) (manual)'
           )
-      || format('Nightly build (tsan) (schedule)')
+      || 'Nightly build (tsan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/nightly-ubsan.yaml
+++ b/.github/workflows/nightly-ubsan.yaml
@@ -1,13 +1,23 @@
 name: Nightly build (ubsan)
 run-name: |
   ${{ github.event_name == 'workflow_dispatch'
-      && 'Nightly build (ubsan) (manual)'
-      || 'Nightly build (ubsan) (schedule)'
+      && (
+            inputs.comment != ''
+            && format('Nightly build (ubsan) (manual) (comment: {0})', inputs.comment)
+            || format('Nightly build (ubsan) (manual)')
+          )
+      || format('Nightly build (ubsan) (schedule)')
     }}
 on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      comment:
+        description: 'Comment'
+        type: string
+        required: false
+        default: ""
 
 jobs:
   build:

--- a/.github/workflows/nightly-ubsan.yaml
+++ b/.github/workflows/nightly-ubsan.yaml
@@ -4,9 +4,9 @@ run-name: |
       && (
             inputs.comment != ''
             && format('Nightly build (ubsan) (manual) (comment: {0})', inputs.comment)
-            || format('Nightly build (ubsan) (manual)')
+            || 'Nightly build (ubsan) (manual)'
           )
-      || format('Nightly build (ubsan) (schedule)')
+      || 'Nightly build (ubsan) (schedule)'
     }}
 on:
   schedule:

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -640,7 +640,7 @@ jobs:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false

--- a/.github/workflows/pr-github-actions.yaml
+++ b/.github/workflows/pr-github-actions.yaml
@@ -615,6 +615,58 @@ jobs:
       sleep_after_tests: ${{ contains(github.event.pull_request.labels.*.name, 'sleep') && '7200' || '1' }}
     secrets: inherit
 
+  nightly-builds:
+    needs: [check-running-allowed, check-trigger-label]
+    if: >-
+      ${{
+        needs.check-running-allowed.outputs.result == 'true' &&
+        needs.check-trigger-label.outputs.allowed == 'true' &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'nightly-tests') ||
+          contains(github.event.pull_request.labels.*.name, 'nightly-asan') ||
+          contains(github.event.pull_request.labels.*.name, 'nightly-tsan') ||
+          contains(github.event.pull_request.labels.*.name, 'nightly-msan') ||
+          contains(github.event.pull_request.labels.*.name, 'nightly-ubsan') ||
+          contains(github.event.pull_request.labels.*.name, 'nightly-sanitizers') ||
+          contains(github.event.pull_request.labels.*.name, 'nightly-all')
+        )
+      }}
+    runs-on: [self-hosted, "self-hosted", "runner_light"]
+    timeout-minutes: 540
+    steps:
+      - name: checkout workflow scripts
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
+        if: ${{ always() }}
+        run: git config core.sparseCheckout false
+        continue-on-error: true
+      - name: Prepare s3cmd
+        uses: ./.github/actions/s3cmd
+        continue-on-error: true
+        with:
+          s3_bucket: ${{ vars.POOLED_HEAVY_AWS_BUCKET }}
+          s3_endpoint: ${{ vars.POOLED_HEAVY_AWS_ENDPOINT }}
+          s3_website_suffix: ${{ vars.POOLED_HEAVY_AWS_WEBSITE_SUFFIX }}
+          s3_key_id: ${{ secrets.POOLED_HEAVY_AWS_KEY_ID }}
+          s3_key_secret: ${{ secrets.POOLED_HEAVY_AWS_SECRET_KEY }}
+          folder_prefix: nebius-
+          build_preset: relwithdebinfo
+      - name: Dispatch and collect nightly builds
+        uses: ./.github/actions/nightly_pr_check
+        with:
+          github_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      - name: Cancel dispatched nightly builds
+        if: ${{ cancelled() }}
+        uses: ./.github/actions/nightly_pr_check
+        with:
+          mode: cancel
+          github_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
   finalize-build-and-test-comments:
     needs: [check-running-allowed, create-build-and-test-target-var, build_and_test]
     if: ${{ always() && needs.check-running-allowed.outputs.result == 'true' && needs.create-build-and-test-target-var.outputs.matrix_include != '' }}

--- a/GITHUB.md
+++ b/GITHUB.md
@@ -13,6 +13,15 @@ There is also a list of labels that slightly alters how and which tests are run:
 7. `disable_truncate`, by default, `.err`/`.log`/`.out` files are truncated to 1GiB, this disables that for this PR
 8. `rebase`, tries to rebase current branch to fresh main
 
+For PRs that change `.github/**`, there are additional labels specific to the
+`.github` checks. They dispatch the corresponding nightly workflow from the PR
+branch and report the result back to the PR comment:
+
+1. `nightly-tests` launches the regular `nightly.yaml` workflow.
+2. `nightly-asan`, `nightly-tsan`, `nightly-msan`, `nightly-ubsan` launch the corresponding sanitizer nightly workflow.
+3. `nightly-sanitizers` launches all sanitizer nightly workflows.
+4. `nightly-all` launches the regular nightly workflow and all sanitizer nightly workflows.
+
 Also, you can launch [ya make](https://github.com/ydb-platform/nbs/actions/workflows/on_demand_build_and_test.yaml) builds on your branch with any timeout you want (but please do not do more than 12 hours, VMs are expensive). You can find the internal IP of the VM in the header of the job in the workflow (e.g. 10.24.0.58). To log into it you must be member of NBS team and use SSH key that you use to commit to Github.
 
 You can use command `ssh -J github@185.82.69.80:2222 github@10.24.0.58` or add following to `.ssh/config`:
@@ -49,4 +58,3 @@ On the top level, you can expect a directory structure like this:
 Files in `test_data` are synced only for failed tests and the list of folders to sync is determined by [script fail_checker.py](https://github.com/ydb-platform/nbs/blob/main/.github/scripts/tests/fail_checker.py)
 
 Availability of other logs in the summary report is dependent on what ya make decide to add in junit report.
-


### PR DESCRIPTION
This PR adds ability, during pr-github-actions.yaml workflow to launch nightly builds. It will be used to t

Additionally it introduces saving summary as json and saving it in reports dir on s3 to fetch summary from aforementioned nightly builds and also will be useful later for collecting stats to be used in dashboards.

This feature had been tested in https://github.com/ydb-platform/nbs/pull/6160 here I reverted checking out from head commit to base commit and since those changes do not exist in main yet - it will fail