### PR TITLE
issue-1751: [Filestore] TFileRingBuffer: add V6 format

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -32,7 +32,13 @@ public:
         TLog log,
         TString logTag)
         : Stats(std::move(stats))
-        , Storage(config.FilePath, config.DataCapacity, config.MetadataCapacity)
+        , Storage(
+              TFileRingBufferArgs{
+                  .FilePath = config.FilePath,
+                  .DataCapacity = config.DataCapacity,
+                  .MetadataCapacity = config.MetadataCapacity,
+                  .Version = EFileRingBufferVersion::V6,
+              })
         , Config(std::move(config))
         , Log(std::move(log))
         , LogTag(std::move(logTag))

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -148,12 +148,20 @@ private:
                 return TEntryInfo::CreateInvalid();
             }
 
-            auto eh = Data->ReadEntryHeader(pos);
+            const auto eh = Data->ReadEntryHeader(pos);
             if (eh.DataSize != 0) {
                 const auto* data = Data->GetEntryDataPtr(pos, eh.DataSize);
-                return data != nullptr
-                    ? TEntryInfo::Create(pos, eh, data)
-                    : TEntryInfo::CreateInvalid();
+                if (data == nullptr) {
+                    return TEntryInfo::CreateInvalid();
+                }
+
+                if (eh.FreeFlag && eh.DataChecksum != 0 &&
+                    Header()->Version >= EVersion::V6)
+                {
+                    return TEntryInfo::CreateInvalid();
+                }
+
+                return TEntryInfo::Create(pos, eh, data);
             }
             pos = 0;
         }
@@ -164,13 +172,12 @@ private:
 
         Y_ABORT_UNLESS(pos < Header()->WritePos);
 
-        if (pos < Header()->ReadPos &&
-            Header()->ReadPos <= Header()->WritePos)
+        if (pos < Header()->ReadPos && Header()->ReadPos <= Header()->WritePos)
         {
             return TEntryInfo::CreateInvalid();
         }
 
-        auto eh = Data->ReadEntryHeader(pos);
+        const auto eh = Data->ReadEntryHeader(pos);
         if (eh.DataSize == 0) {
             return TEntryInfo::CreateInvalid();
         }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -21,219 +21,37 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-constexpr ui32 VERSION_PREV = 4;
-constexpr ui32 VERSION = 5;
+using EVersion = EFileRingBufferVersion;
+using THeader = TFileRingBufferHeader;
+using TEntryHeader = TFileRingBufferEntryHeader;
+
 constexpr ui64 INVALID_POS = Max<ui64>();
 
 // Reserve some space after header so adding new fields will not require data
 // migration
 constexpr ui64 HeaderReserveSize = 256;
 
-////////////////////////////////////////////////////////////////////////////////
-
-struct THeader
-{
-    ui32 Version = 0;
-    ui32 HeaderSize = 0;
-    ui64 DataCapacity = 0;
-    ui64 ReadPos = 0;
-    ui64 WritePos = 0;
-    // Previously was: LastEntrySize
-    ui64 Unused = 0;
-    ui64 DataOffset = 0;
-    ui64 MetadataCapacity = 0;
-    ui64 MetadataOffset = 0;
-    ui32 MetadataSize = 0;
-    ui32 MetadataChecksum = 0;
-};
-
 static_assert(sizeof(THeader) <= HeaderReserveSize);
 
-// Entry header layout (lower bits come first):
-// [ DataSize (28 bits) | Tag (3 bits) | FreeFlag (1 bit) ]
-// [ Checksum (32 bits) ]
-struct Y_PACKED TEntryHeader
-{
-private:
-    static constexpr ui32 TagBits = 3;
-    static constexpr ui32 SizeBits = 31U - TagBits;
-    static constexpr ui32 MaxTag = (1U << TagBits) - 1;
-    static constexpr ui32 FreeFlagMask = 1U << 31U;
-    static constexpr ui32 TagMask = MaxTag << SizeBits;
-    static constexpr ui32 SizeMask = (1 << SizeBits) - 1;
-
-    ui32 DataSize = 0;
-    ui32 Checksum = 0;
-
-public:
-    static constexpr ui32 MaxDataSize = SizeMask;
-
-    ui32 GetDataSize() const
-    {
-        return DataSize & SizeMask;
-    }
-
-    void SetDataSize(size_t value)
-    {
-        Y_ABORT_UNLESS(value <= MaxDataSize);
-        DataSize = (DataSize & ~SizeMask) | static_cast<ui32>(value);
-    }
-
-    bool GetFreeFlag() const
-    {
-        return (DataSize & FreeFlagMask) != 0;
-    }
-
-    void SetFreeFlag(bool value)
-    {
-        if (value) {
-            DataSize |= FreeFlagMask;
-        } else {
-            DataSize &= ~FreeFlagMask;
-        }
-    }
-
-    static ui32 GetMaxTag()
-    {
-        return MaxTag;
-    }
-
-    ui32 GetTag() const
-    {
-        return (DataSize & TagMask) >> SizeBits;
-    }
-
-    void SetTag(ui32 tag)
-    {
-        Y_ABORT_UNLESS(tag <= MaxTag);
-        DataSize = (DataSize & ~TagMask) | (tag << SizeBits);
-    }
-
-    ui32 GetChecksum() const
-    {
-        return Checksum;
-    }
-
-    void SetChecksum(ui32 value)
-    {
-        Checksum = value;
-    }
-};
-
-//  Structure contract:
-//
-//  1. Empty buffer:
-//    - ReadPos == WritePos
-//  or
-//    - ReadPos points to a slack space
-//    - WritePos == 0
-//    This may happen when Alloc was terminated in the middle of the operation.
-//    ReadPos is corrected to 0 during validation.
-//
-//  2. Non-empty buffer:
-//    - ReadPos != WritePos
-//    - ReadPos points to the first byte of the first valid entry
-//    - WritePos points to the first byte right after the last valid entry
-//
-//  3. Valid entry:
-//    - Size > 0
-//    - The entry takes sizeof(TEntryHeader) + Size contiguous bytes in
-//      the occupied part of the buffer
-//
-//  4. Occupied part of the buffer:
-//     - ReadPos < WritePos: [ReadPos, WritePos)
-//     - ReadPos > WritePos: [ReadPos, Capacity) + [0, WritePos)
-//
-//  5. Slack space entry marker:
-//     - Size = 0
-//     - Instructs to read the next entry at pos = 0
-//     - Can appear only when ReadPos > WritePos in [ReadPos, Capacity) part
-//
-//  6. Implicit slack space marker:
-//     - pos + sizeof(TEntryHeader) > Capacity
-
 ////////////////////////////////////////////////////////////////////////////////
 
-class TEntriesData
+bool IsSupportedVersion(EVersion version)
 {
-private:
-    std::span<char> Data;
-
-    template <class T = char>
-    T* GetPtr(ui64 pos, ui64 size = sizeof(T)) const
-    {
-        return pos < Data.size() && size <= Data.size() - pos
-                   ? reinterpret_cast<T*>(Data.data() + pos)
-                   : nullptr;
-    }
-
-    char* DoGetEntryData(const TEntryHeader* eh) const
-    {
-        Y_ABORT_UNLESS(eh != nullptr);
-        Y_ABORT_UNLESS(eh->GetDataSize() != 0);
-
-        ui64 pos = GetEntryPos(eh);
-        return GetPtr(pos + sizeof(TEntryHeader), eh->GetDataSize());
-    }
-
-public:
-    TEntriesData() = default;
-
-    explicit TEntriesData(std::span<char> data)
-        : Data(data)
-    {}
-
-    TEntryHeader* GetEntryHeader(ui64 pos)
-    {
-        return GetPtr<TEntryHeader>(pos);
-    }
-
-    const TEntryHeader* GetEntryHeader(ui64 pos) const
-    {
-        return GetPtr<TEntryHeader>(pos);
-    }
-
-    ui64 GetEntryPos(const TEntryHeader* eh) const
-    {
-        Y_ABORT_UNLESS(eh != nullptr);
-        return reinterpret_cast<const char*>(eh) - Data.data();
-    }
-
-    char* GetEntryData(TEntryHeader* eh)
-    {
-        return DoGetEntryData(eh);
-    }
-
-    const char* GetEntryData(const TEntryHeader* eh) const
-    {
-        return DoGetEntryData(eh);
-    }
-
-    void WriteEntry(ui64 pos, TStringBuf data)
-    {
-        auto* eh = GetEntryHeader(pos);
-        Y_ABORT_UNLESS(eh != nullptr);
-
-        eh->SetDataSize(data.size());
-        eh->SetChecksum(Crc32c(data.data(), data.size()));
-
-        auto* dst = GetEntryData(eh);
-        Y_ABORT_UNLESS(dst != nullptr);
-        memcpy(dst, data.data(), data.size());
-    }
-};
+    return version == EVersion::V4 || version == EVersion::V5 ||
+           version == EVersion::V6;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TEntryInfo
 {
     ui64 ActualPos = 0;
-    const TEntryHeader* Header = nullptr;
+    TEntryHeader Header = {};
     const char* Data = nullptr;
 
     bool HasValue() const
     {
-        return Header != nullptr;
+        return Header.DataSize != 0;
     }
 
     bool IsInvalid() const
@@ -241,37 +59,19 @@ struct TEntryInfo
         return ActualPos == INVALID_POS;
     }
 
-    bool GetFreeFlag() const
-    {
-        return Header->GetFreeFlag();
-    }
-
     TStringBuf GetData() const
     {
-        return HasValue() ? TStringBuf(Data, Header->GetDataSize())
+        return HasValue() ? TStringBuf(Data, Header.DataSize)
                           : TStringBuf();
-    }
-
-    ui32 GetTag() const
-    {
-        return HasValue() ? Header->GetTag() : 0;
-    }
-
-    ui64 GetNextEntryPos() const
-    {
-        return Header != nullptr && Header->GetDataSize() > 0
-            ? ActualPos + sizeof(TEntryHeader) + Header->GetDataSize()
-            : INVALID_POS;
     }
 
     static TEntryInfo Create(
         ui64 pos,
-        const TEntryHeader* header,
+        const TEntryHeader& header,
         const char* data)
     {
         Y_ABORT_UNLESS(pos != INVALID_POS);
-        Y_ABORT_UNLESS(header != nullptr);
-        Y_ABORT_UNLESS(header->GetDataSize() > 0);
+        Y_ABORT_UNLESS(header.DataSize > 0);
         Y_ABORT_UNLESS(data != nullptr);
 
         return TEntryInfo{.ActualPos = pos, .Header = header, .Data = data};
@@ -292,17 +92,17 @@ struct TEntryInfo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-THeader InitHeader(ui64 dataCapacity, ui64 metadataCapacity)
+THeader InitHeader(const TFileRingBufferArgs& args)
 {
-    THeader res;
-    res.Version = VERSION;
-    res.HeaderSize = sizeof(THeader);
-    res.MetadataOffset = HeaderReserveSize;
-    res.MetadataCapacity = metadataCapacity;
-    res.DataOffset =
-        AlignUp(res.MetadataOffset + res.MetadataCapacity, sizeof(ui64));
-    res.DataCapacity = dataCapacity;
-    return res;
+    return {
+        .Version = args.Version,
+        .HeaderSize = sizeof(THeader),
+        .DataCapacity = args.DataCapacity,
+        .DataOffset =
+            AlignUp(HeaderReserveSize + args.MetadataCapacity, sizeof(ui64)),
+        .MetadataCapacity = args.MetadataCapacity,
+        .MetadataOffset = HeaderReserveSize,
+    };
 }
 
 }   // namespace
@@ -312,12 +112,14 @@ THeader InitHeader(ui64 dataCapacity, ui64 metadataCapacity)
 class TFileRingBuffer::TImpl
 {
 private:
+    const TFileRingBufferArgs Args;
     TFileMap Map;
 
-    TEntriesData Data;
+    std::unique_ptr<IFileRingBufferDataProcessor> Data;
+    TFileRingBufferCapabilities Capabilities;
     bool Corrupted = false;
 
-    TEntryHeader* CurrentAllocation = nullptr;
+    TEntryInfo CurrentAllocation = TEntryInfo::CreateInvalid();
     ui64 MaxObservedEntryByteCount = 0;
 
     // Map of non-free entries: data ptr -> pos
@@ -346,9 +148,9 @@ private:
                 return TEntryInfo::CreateInvalid();
             }
 
-            const auto* eh = Data.GetEntryHeader(pos);
-            if (eh != nullptr && eh->GetDataSize() != 0) {
-                const auto* data = Data.GetEntryData(eh);
+            auto eh = Data->ReadEntryHeader(pos);
+            if (eh.DataSize != 0) {
+                const auto* data = Data->GetEntryDataPtr(pos, eh.DataSize);
                 return data != nullptr
                     ? TEntryInfo::Create(pos, eh, data)
                     : TEntryInfo::CreateInvalid();
@@ -368,22 +170,21 @@ private:
             return TEntryInfo::CreateInvalid();
         }
 
-        const auto* eh = Data.GetEntryHeader(pos);
-        if (eh == nullptr || eh->GetDataSize() == 0) {
+        auto eh = Data->ReadEntryHeader(pos);
+        if (eh.DataSize == 0) {
             return TEntryInfo::CreateInvalid();
         }
 
-        const auto* data = Data.GetEntryData(eh);
+        const auto* data = Data->GetEntryDataPtr(pos, eh.DataSize);
         if (data == nullptr) {
             return TEntryInfo::CreateInvalid();
         }
 
-        auto res = TEntryInfo::Create(pos, eh, data);
-        if (res.GetNextEntryPos() > Header()->WritePos) {
+        if (pos + Data->GetEntrySize(eh.DataSize) > Header()->WritePos) {
             return TEntryInfo::CreateInvalid();
         }
 
-        return res;
+        return TEntryInfo::Create(pos, eh, data);
     }
 
     TEntryInfo GetFrontEntry() const
@@ -394,8 +195,17 @@ private:
     TEntryInfo GetNextEntry(const TEntryInfo& e) const
     {
         return e.HasValue()
-            ? GetEntry(e.GetNextEntryPos())
+            ? GetEntry(e.ActualPos + Data->GetEntrySize(e.Header.DataSize))
             : TEntryInfo::CreateInvalid();
+    }
+
+    void CreateDataProcessor(EVersion version)
+    {
+        Data = CreateFileRingBufferDataProcessor(
+            version,
+            GetMappedData(Header()->DataOffset, Header()->DataCapacity));
+
+        Capabilities = Data->GetCapabilities();
     }
 
     void ValidateStructure()
@@ -403,7 +213,6 @@ private:
         const ui64 mapLength = static_cast<ui64>(Map.Length());
         const auto& h = *Header();
 
-        Y_ABORT_UNLESS(h.Version == VERSION);
         Y_ABORT_UNLESS(sizeof(THeader) == h.HeaderSize);
         Y_ABORT_UNLESS(h.HeaderSize <= h.MetadataOffset);
         Y_ABORT_UNLESS(h.MetadataOffset <= h.DataOffset);
@@ -443,6 +252,7 @@ private:
     void ResizeAndRemap(ui64 fileSize)
     {
         Map.ResizeAndRemap(0, fileSize);
+        Data.reset();
     }
 
     std::span<char> GetMappedData(ui64 offset, ui64 size) const
@@ -464,15 +274,45 @@ private:
         MemCopy(dst.data(), src.data(), size);
     }
 
+    bool IsMigrationNeeded() const
+    {
+        return Header()->Version != Args.Version;
+    }
+
+    bool TryMigrate()
+    {
+        if (!IsMigrationNeeded()) {
+            return true;
+        }
+
+        if (Empty()) {
+            Header()->Version = Args.Version;
+            CreateDataProcessor(Args.Version);
+            return true;
+        }
+
+        // Transition V4 -> V5 can be made without emptying the buffer
+        if (Header()->Version == EVersion::V4 && Args.Version > EVersion::V4) {
+            // Parse entry headers using newer version
+            CreateDataProcessor(EVersion::V5);
+
+            // In the new version, the highest bits of the entry size are
+            // treated as a tag value - need to ensure that they are not used
+            VisitEntries([](const TEntryInfo& e)
+                         { Y_ABORT_UNLESS(e.Header.Tag == 0); });
+
+            Header()->Version = EVersion::V5;
+        }
+
+        return !IsMigrationNeeded();
+    }
+
+    // Migration to any version can be performed when the buffer is empty
     void Migrate()
     {
-        // In the new version, the highest bits of the entry size are treated as
-        // a tag value - need to ensure that nobody use it
-        VisitEntries([](const TEntryInfo& e)
-                     { Y_ABORT_UNLESS(e.GetTag() == 0); });
-
-        Header()->Version = VERSION;
-        Header()->Unused = 0;
+        Y_ABORT_UNLESS(Empty());
+        Header()->Version = Args.Version;
+        CreateDataProcessor(Args.Version);
     }
 
     void ResizeMetadata(ui64 desiredMetadataCapacity)
@@ -520,6 +360,16 @@ private:
         ResizeAndRemap(newFileSize);
 
         Header()->MetadataCapacity = newMetadataCapacity;
+
+        // After metadata resizing, previous memory mapping becomes invalid
+        CreateDataProcessor(static_cast<EVersion>(Header()->Version));
+
+        ValidateDataStructure();
+
+        Y_ABORT_UNLESS(
+            !IsCorrupted(),
+            "Corruption detected after metadata resize, file: %s",
+            Args.FilePath.c_str());
     }
 
     void VisitEntries(auto&& visitor)
@@ -539,7 +389,7 @@ private:
     void EraseFreeEntriesFromFront()
     {
         auto front = GetFrontEntry();
-        while (front.HasValue() && front.GetFreeFlag()) {
+        while (front.HasValue() && front.Header.FreeFlag) {
             front = GetNextEntry(front);
         }
 
@@ -552,10 +402,7 @@ private:
 
     void WriteSlackSpaceMarker(ui64 pos)
     {
-        auto* eh = Data.GetEntryHeader(pos);
-        if (eh != nullptr) {
-            eh->SetDataSize(0);
-        }
+        Data->WriteEntryHeader(pos, {});
     }
 
     bool ValidateAccess(const char* name) const
@@ -571,50 +418,60 @@ private:
     }
 
 public:
-    TImpl(const TString& filePath, ui64 dataCapacity, ui64 metadataCapacity)
-        : Map(filePath, TMemoryMapCommon::oRdWr)
+    TImpl(const TFileRingBufferArgs& args)
+        : Args(args)
+        , Map(args.FilePath, TMemoryMapCommon::oRdWr)
     {
-        Y_ABORT_UNLESS(sizeof(TEntryHeader) <= dataCapacity);
+        Y_ABORT_UNLESS(
+            IsSupportedVersion(args.Version),
+            "Unsupported requested FileRingBuffer version - %u",
+            static_cast<ui32>(args.Version));
 
         if (static_cast<ui64>(Map.Length()) < sizeof(THeader)) {
-            auto header = InitHeader(dataCapacity, metadataCapacity);
+            auto header = InitHeader(args);
             Map.ResizeAndRemap(0, header.DataOffset + header.DataCapacity);
             *Header() = header;
         } else {
             Map.Map(0, Map.Length());
         }
 
-        if (Header()->Version == VERSION_PREV) {
-            // Migration needs access to entries
-            Data = TEntriesData(
-                GetMappedData(Header()->DataOffset, Header()->DataCapacity));
-            Migrate();
-        }
+        Y_ABORT_UNLESS(
+            IsSupportedVersion(static_cast<EVersion>(Header()->Version)),
+            "Unsupported current FileRingBuffer version - %u, file: %s",
+            Header()->Version,
+            args.FilePath.c_str());
+
+        CreateDataProcessor(static_cast<EVersion>(Header()->Version));
 
         ValidateStructure();
+        ValidateDataStructure();
 
-        if (Header()->MetadataCapacity != metadataCapacity) {
-            ResizeMetadata(metadataCapacity);
+        if (IsCorrupted()) {
+            return;
         }
 
-        Data = TEntriesData(
-            GetMappedData(Header()->DataOffset, Header()->DataCapacity));
-
-        ValidateDataStructure();
+        if (Header()->MetadataCapacity != Args.MetadataCapacity) {
+            ResizeMetadata(Args.MetadataCapacity);
+        }
 
         VisitEntries(
             [&](const TEntryInfo& e)
             {
-                if (!e.GetFreeFlag()) {
+                if (!e.Header.FreeFlag) {
                     EntryMap[e.Data] = e.ActualPos;
-                    MaxObservedEntryByteCount = Max<ui64>(
-                        MaxObservedEntryByteCount,
-                        e.Header->GetDataSize());
+                    MaxObservedEntryByteCount =
+                        Max<ui64>(MaxObservedEntryByteCount, e.Header.DataSize);
                 }
             });
 
-        if (!IsCorrupted()) {
-            EraseFreeEntriesFromFront();
+        if (IsCorrupted()) {
+            return;
+        }
+
+        EraseFreeEntriesFromFront();
+
+        if (IsMigrationNeeded()) {
+            TryMigrate();
         }
     }
 
@@ -638,7 +495,7 @@ public:
 
     TResultOrError<char*> Alloc(size_t size)
     {
-        if (CurrentAllocation != nullptr) {
+        if (CurrentAllocation.HasValue()) {
             return MakeError(
                 E_INVALID_STATE,
                 "Previous allocation is not committed");
@@ -654,15 +511,21 @@ public:
                 "Zero size allocations are not allowed");
         }
 
-        if (size > TEntryHeader::MaxDataSize) {
+        if (IsMigrationNeeded() && !TryMigrate()) {
+            // Return "storage is full" error.
+            // Migration will happen when the buffer is emptied.
+            return nullptr;
+        }
+
+        if (size > Capabilities.MaxAllocationByteCount) {
             return MakeError(
                 E_ARGUMENT,
                 TStringBuilder() << "Allocation data size (" << size
                                  << ") exceeds maximum allowed size ("
-                                 << TEntryHeader::MaxDataSize << ")");
+                                 << Capabilities.MaxAllocationByteCount << ")");
         }
 
-        const auto sz = size + sizeof(TEntryHeader);
+        const auto sz = Data->GetEntrySize(size);
         if (sz > Header()->DataCapacity) {
             return MakeError(
                 E_ARGUMENT,
@@ -717,40 +580,44 @@ public:
         MaxObservedEntryByteCount =
             Max(MaxObservedEntryByteCount, size);
 
-        CurrentAllocation = Data.GetEntryHeader(writePos);
-        CurrentAllocation->SetDataSize(size);
-        CurrentAllocation->SetTag(0);
-        CurrentAllocation->SetFreeFlag(false);
-
-        char* ptr = Data.GetEntryData(CurrentAllocation);
+        char* ptr = Data->GetEntryDataPtr(writePos, size);
         Y_ABORT_UNLESS(ptr != nullptr);
+
+        CurrentAllocation = TEntryInfo::Create(
+            writePos,
+            {.DataSize = static_cast<ui32>(size)},
+            ptr);
+
         return ptr;
     }
 
     bool Commit()
     {
-        if (CurrentAllocation == nullptr) {
+        if (!CurrentAllocation.HasValue()) {
             return false;
         }
 
-        char* ptr = Data.GetEntryData(CurrentAllocation);
-        Y_ABORT_UNLESS(ptr != nullptr);
+        CurrentAllocation.Header.DataChecksum =
+            Crc32c(CurrentAllocation.Data, CurrentAllocation.Header.DataSize);
 
-        CurrentAllocation->SetChecksum(
-            Crc32c(ptr, CurrentAllocation->GetDataSize()));
+        bool written = Data->WriteEntryHeader(
+            CurrentAllocation.ActualPos,
+            CurrentAllocation.Header);
+
+        Y_ABORT_UNLESS(written);
 
         // A compiler-only fence is sufficient here because there is no
         // concurrent access to the memory and we just need to ensure
         // that a compiler does not reorder writes.
         std::atomic_signal_fence(std::memory_order_seq_cst);
 
-        auto writePos = Data.GetEntryPos(CurrentAllocation);
-        auto sz = sizeof(TEntryHeader) + CurrentAllocation->GetDataSize();
+        Header()->WritePos =
+            CurrentAllocation.ActualPos +
+            Data->GetEntrySize(CurrentAllocation.Header.DataSize);
 
-        Header()->WritePos = writePos + sz;
-        EntryMap[ptr] = writePos;
+        EntryMap[CurrentAllocation.Data] = CurrentAllocation.ActualPos;
 
-        CurrentAllocation = nullptr;
+        CurrentAllocation = TEntryInfo::CreateInvalid();
         return true;
     }
 
@@ -765,8 +632,10 @@ public:
             return false;
         }
 
-        auto* eh = Data.GetEntryHeader(it->second);
-        eh->SetFreeFlag(true);
+        auto eh = Data->ReadEntryHeader(it->second);
+        eh.FreeFlag = true;
+        Data->WriteEntryHeader(it->second, eh);
+
         EntryMap.erase(it);
 
         EraseFreeEntriesFromFront();
@@ -776,7 +645,7 @@ public:
 
     ui32 GetMaxTag() const
     {
-        return TEntryHeader::GetMaxTag();
+        return Capabilities.MaxTag;
     }
 
     ui32 GetTag(const void* ptr) const
@@ -790,8 +659,8 @@ public:
             return 0;
         }
 
-        const auto* eh = Data.GetEntryHeader(it->second);
-        return eh->GetTag();
+        auto eh = Data->ReadEntryHeader(it->second);
+        return eh.Tag;
     }
 
     void SetTag(const void* ptr, ui32 tag)
@@ -805,8 +674,9 @@ public:
             return;
         }
 
-        auto* eh = Data.GetEntryHeader(it->second);
-        eh->SetTag(tag);
+        auto eh = Data->ReadEntryHeader(it->second);
+        eh.Tag = tag;
+        Data->WriteEntryHeader(it->second, eh);
     }
 
     TStringBuf Front()
@@ -836,7 +706,7 @@ public:
             return;
         }
 
-        Free(cur.GetData().data());
+        Free(cur.Data);
     }
 
     ui64 Size() const
@@ -878,8 +748,8 @@ public:
         VisitEntries(
             [&](const TEntryInfo& e)
             {
-                if (!e.GetFreeFlag()) {
-                    visitor(e.Header->GetChecksum(), e.GetTag(), e.GetData());
+                if (!e.Header.FreeFlag) {
+                    visitor(e.Header.DataChecksum, e.Header.Tag, e.GetData());
                 }
             });
     }
@@ -914,7 +784,7 @@ public:
 
     ui32 GetVersion() const
     {
-        return Header()->Version;
+        return static_cast<ui32>(Header()->Version);
     }
 
     ui64 GetMaxObservedEntryByteCount() const
@@ -922,9 +792,13 @@ public:
         return MaxObservedEntryByteCount;
     }
 
-    ui64 GetAvailableByteCount() const
+    ui64 GetAvailableByteCount()
     {
         if (IsCorrupted()) {
+            return 0;
+        }
+
+        if (IsMigrationNeeded() && !TryMigrate()) {
             return 0;
         }
 
@@ -939,9 +813,8 @@ public:
         } else {
             maxRawSize = Header()->ReadPos - Header()->WritePos - 1;
         }
-        return maxRawSize > sizeof(TEntryHeader)
-                   ? maxRawSize - sizeof(TEntryHeader)
-                   : 0;
+
+        return Data->GetMaxAllocationByteCount(maxRawSize);
     }
 
     ui64 GetMaxSupportedAllocationByteCount() const
@@ -950,10 +823,7 @@ public:
             return 0;
         }
 
-        return Header()->DataCapacity > sizeof(TEntryHeader)
-                   ? Min(Header()->DataCapacity - sizeof(TEntryHeader),
-                         static_cast<ui64>(TEntryHeader::MaxDataSize))
-                   : 0;
+        return Capabilities.MaxAllocationByteCount;
     }
 
     bool ValidateMetadata() const
@@ -994,11 +864,18 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TFileRingBuffer::TFileRingBuffer(const TFileRingBufferArgs& args)
+    : Impl(new TImpl(args))
+{}
+
 TFileRingBuffer::TFileRingBuffer(
-        const TString& filePath,
-        ui64 dataCapacity,
-        ui64 metadataCapacity)
-    : Impl(new TImpl(filePath, dataCapacity, metadataCapacity))
+    const TString& filePath,
+    ui64 dataCapacity,
+    ui64 metadataCapacity)
+    : TFileRingBuffer(
+          {.FilePath = filePath,
+           .DataCapacity = dataCapacity,
+           .MetadataCapacity = metadataCapacity})
 {}
 
 TFileRingBuffer::~TFileRingBuffer() = default;

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -285,16 +285,17 @@ private:
         return Header()->Version != Args.Version;
     }
 
-    bool TryMigrate()
+    void TryMigrate()
     {
-        if (!IsMigrationNeeded()) {
-            return true;
+        if (!IsMigrationNeeded() || IsCorrupted()) {
+            return;
         }
 
+        // Migration to any version can be performed when the buffer is empty
         if (Empty()) {
             Header()->Version = Args.Version;
             CreateDataProcessor(Args.Version);
-            return true;
+            return;
         }
 
         // Transition V4 -> V5 can be made without emptying the buffer
@@ -309,16 +310,6 @@ private:
 
             Header()->Version = EVersion::V5;
         }
-
-        return !IsMigrationNeeded();
-    }
-
-    // Migration to any version can be performed when the buffer is empty
-    void Migrate()
-    {
-        Y_ABORT_UNLESS(Empty());
-        Header()->Version = Args.Version;
-        CreateDataProcessor(Args.Version);
     }
 
     void ResizeMetadata(ui64 desiredMetadataCapacity)
@@ -404,6 +395,10 @@ private:
         } else {
             Header()->ReadPos = front.ActualPos;
         }
+
+        if (IsMigrationNeeded()) {
+            TryMigrate();
+        }
     }
 
     void WriteSlackSpaceMarker(ui64 pos)
@@ -424,7 +419,7 @@ private:
     }
 
 public:
-    TImpl(const TFileRingBufferArgs& args)
+    explicit TImpl(const TFileRingBufferArgs& args)
         : Args(args)
         , Map(args.FilePath, TMemoryMapCommon::oRdWr)
     {
@@ -470,14 +465,8 @@ public:
                 }
             });
 
-        if (IsCorrupted()) {
-            return;
-        }
-
-        EraseFreeEntriesFromFront();
-
-        if (IsMigrationNeeded()) {
-            TryMigrate();
+        if (!IsCorrupted()) {
+            EraseFreeEntriesFromFront();
         }
     }
 
@@ -517,7 +506,7 @@ public:
                 "Zero size allocations are not allowed");
         }
 
-        if (IsMigrationNeeded() && !TryMigrate()) {
+        if (IsMigrationNeeded()) {
             // Return "storage is full" error.
             // Migration will happen when the buffer is emptied.
             return nullptr;
@@ -799,13 +788,13 @@ public:
         return MaxObservedEntryByteCount;
     }
 
-    ui64 GetAvailableByteCount()
+    ui64 GetAvailableByteCount() const
     {
         if (IsCorrupted()) {
             return 0;
         }
 
-        if (IsMigrationNeeded() && !TryMigrate()) {
+        if (IsMigrationNeeded()) {
             return 0;
         }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -184,6 +184,12 @@ private:
             return TEntryInfo::CreateInvalid();
         }
 
+        if (eh.FreeFlag && eh.DataChecksum != 0 &&
+            Header()->Version >= EVersion::V6)
+        {
+            return TEntryInfo::CreateInvalid();
+        }
+
         return TEntryInfo::Create(pos, eh, data);
     }
 
@@ -633,6 +639,7 @@ public:
         }
 
         auto eh = Data->ReadEntryHeader(it->second);
+        eh.DataChecksum = 0;
         eh.FreeFlag = true;
         Data->WriteEntryHeader(it->second, eh);
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "file_ring_buffer_format.h"
+
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/generic/string.h>
@@ -8,6 +10,16 @@
 #include <functional>
 
 namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFileRingBufferArgs
+{
+    TString FilePath;
+    ui64 DataCapacity = 0;
+    ui64 MetadataCapacity = 0;
+    EFileRingBufferVersion Version = EFileRingBufferVersion::V4;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -42,6 +54,8 @@ public:
     * specified capacity, the metadata area is shrunk to fit the existing
     * metadata.
     */
+    explicit TFileRingBuffer(const TFileRingBufferArgs& args);
+
     TFileRingBuffer(
         const TString& filePath,
         ui64 dataCapacity,

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -221,7 +221,7 @@ public:
     {
         return {
             .MaxAllocationByteCount = GetMaxAllocationByteCount(Data.Size()),
-            .MaxTag = 0,
+            .MaxTag = MaxTag,
         };
     }
 
@@ -303,7 +303,7 @@ public:
     {
         return {
             .MaxAllocationByteCount = GetMaxAllocationByteCount(Data.Size()),
-            .MaxTag = 0,
+            .MaxTag = MaxTag,
         };
     }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -1,11 +1,10 @@
 #include "file_ring_buffer_format.h"
 
+#include <util/digest/numeric.h>
 #include <util/generic/utility.h>
 #include <util/system/align.h>
 #include <util/system/compiler.h>
 #include <util/system/yassert.h>
-
-#include <atomic>
 
 namespace NCloud {
 
@@ -58,7 +57,7 @@ public:
     // Treats memory at position pos as TEntryHeader and memory right after
     // the header as entry data.
     // Checks for alignment if RequireAlignment is set.
-    // Ensures that [pos, pos + sizeof(TEntryHeader + dataSize) is within data
+    // Ensures that [pos, pos + sizeof(TEntryHeader) + dataSize is within data
     // bounds.
     // Returns pointer to entry data or nullptr if it is outside data bounds
     // or is not aligned.
@@ -111,6 +110,8 @@ private:
         ui32 Checksum = 0;
     };
 
+    static_assert(sizeof(TEntryHeader) == sizeof(ui64));
+
     TData<TEntryHeader, false> Data;
 
     static constexpr ui32 MaxDataSize = (1U << 31U) - 1U;
@@ -147,8 +148,9 @@ public:
         ui64 pos,
         const TFileRingBufferEntryHeader& header) override
     {
-        Y_ABORT_UNLESS(header.DataSize <= MaxDataSize);
-        Y_ABORT_UNLESS(header.Tag == 0);
+        if (header.DataSize > MaxDataSize || header.Tag != 0) {
+            return false;
+        }
 
         auto* eh = Data.GetEntryHeaderPtr(pos);
         if (eh == nullptr) {
@@ -210,6 +212,8 @@ private:
         ui32 Checksum = 0;
     };
 
+    static_assert(sizeof(TEntryHeader) == sizeof(ui64));
+
     TData<TEntryHeader, false> Data;
 
 public:
@@ -243,8 +247,9 @@ public:
         ui64 pos,
         const TFileRingBufferEntryHeader& header) override
     {
-        Y_ABORT_UNLESS(header.DataSize <= MaxDataSize);
-        Y_ABORT_UNLESS(header.Tag <= MaxTag);
+        if (header.DataSize > MaxDataSize || header.Tag > MaxTag) {
+            return false;
+        }
 
         auto* eh = Data.GetEntryHeaderPtr(pos);
         if (eh == nullptr) {
@@ -287,12 +292,7 @@ class TFileRingBufferDataProcessorV6
     , public IFileRingBufferDataProcessor
 {
 private:
-    struct TEntryHeader
-    {
-        std::atomic<ui64> Value = 0;
-    };
-
-    TData<TEntryHeader, true> Data;
+    TData<ui64, true> Data;
 
 public:
     explicit TFileRingBufferDataProcessorV6(std::span<char> data)
@@ -313,13 +313,13 @@ public:
         if (eh == nullptr) {
             return {};
         }
-        ui64 value = eh->Value.load(std::memory_order_relaxed);
+        ui64 value = __atomic_load_n(eh, __ATOMIC_RELAXED);
         ui32 lower = static_cast<ui32>(value);
         ui32 upper = static_cast<ui32>(value >> 32U);
 
         return {
             .DataSize = lower & MaxDataSize,
-            .DataChecksum = upper ^ lower,
+            .DataChecksum = upper ^ IntHash(lower),
             .Tag = (lower >> TagShift) & MaxTag,
             .FreeFlag = (lower & FreeFlagMask) != 0,
         };
@@ -329,8 +329,9 @@ public:
         ui64 pos,
         const TFileRingBufferEntryHeader& header) override
     {
-        Y_ABORT_UNLESS(header.DataSize <= MaxDataSize);
-        Y_ABORT_UNLESS(header.Tag <= MaxTag);
+        if (header.DataSize > MaxDataSize || header.Tag > MaxTag) {
+            return false;
+        }
 
         auto* eh = Data.GetEntryHeaderPtr(pos);
         if (eh == nullptr) {
@@ -339,18 +340,17 @@ public:
 
         ui32 lower = header.DataSize | (header.Tag << TagShift) |
                      (header.FreeFlag ? FreeFlagMask : 0);
-        ui32 upper = header.DataChecksum ^ lower;
+        ui32 upper = header.DataChecksum ^ IntHash(lower);
+        ui64 value = (static_cast<ui64>(upper) << 32U) | lower;
 
-        eh->Value.store(
-            (static_cast<ui64>(upper) << 32U) | lower,
-            std::memory_order_relaxed);
+        __atomic_store_n(eh, value, __ATOMIC_RELAXED);
 
         return true;
     }
 
     ui64 GetEntrySize(ui64 dataSize) const override
     {
-        return sizeof(TEntryHeader) + AlignUp(dataSize, sizeof(ui64));
+        return sizeof(ui64) + AlignUp(dataSize, sizeof(ui64));
     }
 
     ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const override

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -1,0 +1,397 @@
+#include "file_ring_buffer_format.h"
+
+#include <util/generic/utility.h>
+#include <util/system/align.h>
+#include <util/system/compiler.h>
+#include <util/system/yassert.h>
+
+#include <atomic>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <class TEntryHeader, bool RequireAlignment>
+class TData
+{
+private:
+    std::span<char> Data;
+
+public:
+    explicit TData(std::span<char> data)
+        : Data(data)
+    {
+        if constexpr (RequireAlignment) {
+            Y_ABORT_UNLESS(
+                AlignDown(Data.data(), sizeof(ui64)) == Data.data(),
+                "Data buffer is not properly aligned");
+        }
+    }
+
+    ui64 Size() const
+    {
+        return Data.size();
+    }
+
+    // Treats memory at position pos as TEntryHeader.
+    // Checks for alignment if RequireAlignment is set.
+    // Ensures that [pos, pos + sizeof(TEntryHeader) is within data bounds.
+    // Returns pointer to the header or nullptr if it is outside data bounds
+    // or is not aligned.
+    TEntryHeader* GetEntryHeaderPtr(ui64 pos) const
+    {
+        if constexpr (RequireAlignment) {
+            if (AlignDown(pos, sizeof(ui64)) != pos) {
+                return nullptr;
+            }
+        }
+
+        const bool valid =
+            pos < Data.size() && sizeof(TEntryHeader) <= Data.size() - pos;
+
+        return valid ? reinterpret_cast<TEntryHeader*>(Data.data() + pos)
+                     : nullptr;
+    }
+
+    // Treats memory at position pos as TEntryHeader and memory right after
+    // the header as entry data.
+    // Checks for alignment if RequireAlignment is set.
+    // Ensures that [pos, pos + sizeof(TEntryHeader + dataSize) is within data
+    // bounds.
+    // Returns pointer to entry data or nullptr if it is outside data bounds
+    // or is not aligned.
+    char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const
+    {
+        if constexpr (RequireAlignment) {
+            if (AlignDown(pos, sizeof(ui64)) != pos) {
+                return nullptr;
+            }
+        }
+
+        if (pos >= Data.size()) {
+            return nullptr;
+        }
+
+        ui64 tailSize = Data.size() - pos;
+        if constexpr (RequireAlignment) {
+            tailSize = AlignDown(tailSize, sizeof(ui64));
+        }
+
+        const bool valid = sizeof(TEntryHeader) <= tailSize &&
+                           dataSize <= tailSize - sizeof(TEntryHeader);
+
+        return valid ? Data.data() + pos + sizeof(TEntryHeader) : nullptr;
+    }
+
+    ui64 GetMaxDataSize(ui64 maxEntrySize) const
+    {
+        if constexpr (RequireAlignment) {
+            maxEntrySize = AlignDown(maxEntrySize, sizeof(ui64));
+        }
+
+        return maxEntrySize > sizeof(TEntryHeader)
+                   ? maxEntrySize - sizeof(TEntryHeader)
+                   : 0;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferDataProcessorV4: public IFileRingBufferDataProcessor
+{
+private:
+    // Entry header layout (lower bits come first):
+    // [ DataSize (31 bits) | FreeFlag (1 bit) ]
+    // [ Checksum (32 bits) ]
+    struct Y_PACKED TEntryHeader
+    {
+        ui32 DataSize = 0;
+        ui32 Checksum = 0;
+    };
+
+    TData<TEntryHeader, false> Data;
+
+    static constexpr ui32 MaxDataSize = (1U << 31U) - 1U;
+    static constexpr ui32 FreeFlagMask = 1U << 31U;
+
+public:
+    explicit TFileRingBufferDataProcessorV4(std::span<char> data)
+        : Data(data)
+    {}
+
+    TFileRingBufferCapabilities GetCapabilities() const override
+    {
+        return {
+            .MaxAllocationByteCount = GetMaxAllocationByteCount(Data.Size()),
+            .MaxTag = 0,
+        };
+    }
+
+    TFileRingBufferEntryHeader ReadEntryHeader(ui64 pos) const override
+    {
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return {};
+        }
+        return {
+            .DataSize = eh->DataSize & MaxDataSize,
+            .DataChecksum = eh->Checksum,
+            .Tag = 0,
+            .FreeFlag = (eh->DataSize & FreeFlagMask) != 0,
+        };
+    }
+
+    bool WriteEntryHeader(
+        ui64 pos,
+        const TFileRingBufferEntryHeader& header) override
+    {
+        Y_ABORT_UNLESS(header.DataSize <= MaxDataSize);
+        Y_ABORT_UNLESS(header.Tag == 0);
+
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return false;
+        }
+
+        eh->DataSize = header.DataSize | (header.FreeFlag ? FreeFlagMask : 0);
+        eh->Checksum = header.DataChecksum;
+        return true;
+    }
+
+    ui64 GetEntrySize(ui64 dataSize) const override
+    {
+        return sizeof(TEntryHeader) + dataSize;
+    }
+
+    ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const override
+    {
+        return Min(
+            Data.GetMaxDataSize(maxEntrySize),
+            static_cast<ui64>(MaxDataSize));
+    }
+
+    const char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+
+    char* GetEntryDataPtr(ui64 pos, ui64 dataSize) override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferDataProcessorV5Base
+{
+protected:
+    // Entry header layout (lower bits come first):
+    // [ DataSize (28 bits) | Tag (3 bits) | FreeFlag (1 bit) ]
+    // [ Checksum (32 bits) ]
+    static constexpr ui32 MaxDataSize = (1U << 28U) - 1U;
+    static constexpr ui32 MaxTag = (1U << 3U) - 1U;
+    static constexpr ui32 TagShift = 28U;
+    static constexpr ui32 FreeFlagMask = 1U << 31U;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferDataProcessorV5
+    : public TFileRingBufferDataProcessorV5Base
+    , public IFileRingBufferDataProcessor
+{
+private:
+    struct Y_PACKED TEntryHeader
+    {
+        ui32 DataSize = 0;
+        ui32 Checksum = 0;
+    };
+
+    TData<TEntryHeader, false> Data;
+
+public:
+    explicit TFileRingBufferDataProcessorV5(std::span<char> data)
+        : Data(data)
+    {}
+
+    TFileRingBufferCapabilities GetCapabilities() const override
+    {
+        return {
+            .MaxAllocationByteCount = GetMaxAllocationByteCount(Data.Size()),
+            .MaxTag = 0,
+        };
+    }
+
+    TFileRingBufferEntryHeader ReadEntryHeader(ui64 pos) const override
+    {
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return {};
+        }
+        return {
+            .DataSize = eh->DataSize & MaxDataSize,
+            .DataChecksum = eh->Checksum,
+            .Tag = (eh->DataSize >> TagShift) & MaxTag,
+            .FreeFlag = (eh->DataSize & FreeFlagMask) != 0,
+        };
+    }
+
+    bool WriteEntryHeader(
+        ui64 pos,
+        const TFileRingBufferEntryHeader& header) override
+    {
+        Y_ABORT_UNLESS(header.DataSize <= MaxDataSize);
+        Y_ABORT_UNLESS(header.Tag <= MaxTag);
+
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return false;
+        }
+
+        eh->DataSize = header.DataSize | (header.Tag << TagShift) |
+                       (header.FreeFlag ? FreeFlagMask : 0);
+        eh->Checksum = header.DataChecksum;
+        return true;
+    }
+
+    ui64 GetEntrySize(ui64 dataSize) const override
+    {
+        return sizeof(TEntryHeader) + dataSize;
+    }
+
+    ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const override
+    {
+        return Min(
+            Data.GetMaxDataSize(maxEntrySize),
+            static_cast<ui64>(MaxDataSize));
+    }
+
+    const char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+
+    char* GetEntryDataPtr(ui64 pos, ui64 dataSize) override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferDataProcessorV6
+    : public TFileRingBufferDataProcessorV5Base
+    , public IFileRingBufferDataProcessor
+{
+private:
+    struct TEntryHeader
+    {
+        std::atomic<ui64> Value = 0;
+    };
+
+    TData<TEntryHeader, true> Data;
+
+public:
+    explicit TFileRingBufferDataProcessorV6(std::span<char> data)
+        : Data(data)
+    {}
+
+    TFileRingBufferCapabilities GetCapabilities() const override
+    {
+        return {
+            .MaxAllocationByteCount = GetMaxAllocationByteCount(Data.Size()),
+            .MaxTag = 0,
+        };
+    }
+
+    TFileRingBufferEntryHeader ReadEntryHeader(ui64 pos) const override
+    {
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return {};
+        }
+        ui64 value = eh->Value.load(std::memory_order_relaxed);
+        ui32 lower = static_cast<ui32>(value);
+        ui32 upper = static_cast<ui32>(value >> 32U);
+
+        return {
+            .DataSize = lower & MaxDataSize,
+            .DataChecksum = upper ^ lower,
+            .Tag = (lower >> TagShift) & MaxTag,
+            .FreeFlag = (lower & FreeFlagMask) != 0,
+        };
+    }
+
+    bool WriteEntryHeader(
+        ui64 pos,
+        const TFileRingBufferEntryHeader& header) override
+    {
+        Y_ABORT_UNLESS(header.DataSize <= MaxDataSize);
+        Y_ABORT_UNLESS(header.Tag <= MaxTag);
+
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return false;
+        }
+
+        ui32 lower = header.DataSize | (header.Tag << TagShift) |
+                     (header.FreeFlag ? FreeFlagMask : 0);
+        ui32 upper = header.DataChecksum ^ lower;
+
+        eh->Value.store(
+            (static_cast<ui64>(upper) << 32U) | lower,
+            std::memory_order_relaxed);
+
+        return true;
+    }
+
+    ui64 GetEntrySize(ui64 dataSize) const override
+    {
+        return sizeof(TEntryHeader) + AlignUp(dataSize, sizeof(ui64));
+    }
+
+    ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const override
+    {
+        return Min(
+            Data.GetMaxDataSize(maxEntrySize),
+            static_cast<ui64>(MaxDataSize));
+    }
+
+    const char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+
+    char* GetEntryDataPtr(ui64 pos, ui64 dataSize) override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<IFileRingBufferDataProcessor> CreateFileRingBufferDataProcessor(
+    EFileRingBufferVersion version,
+    std::span<char> data)
+{
+    switch (version) {
+        case EFileRingBufferVersion::V4:
+            return std::make_unique<TFileRingBufferDataProcessorV4>(data);
+        case EFileRingBufferVersion::V5:
+            return std::make_unique<TFileRingBufferDataProcessorV5>(data);
+        case EFileRingBufferVersion::V6:
+            return std::make_unique<TFileRingBufferDataProcessorV6>(data);
+        default:
+            Y_ABORT_UNLESS(
+                false,
+                "Unsupported file ring buffer version - %u",
+                static_cast<ui32>(version));
+    }
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -136,6 +136,7 @@ public:
         if (eh == nullptr) {
             return {};
         }
+
         return {
             .DataSize = eh->DataSize & MaxDataSize,
             .DataChecksum = eh->Checksum,
@@ -235,6 +236,7 @@ public:
         if (eh == nullptr) {
             return {};
         }
+
         return {
             .DataSize = eh->DataSize & MaxDataSize,
             .DataChecksum = eh->Checksum,
@@ -313,6 +315,7 @@ public:
         if (eh == nullptr) {
             return {};
         }
+
         ui64 value = __atomic_load_n(eh, __ATOMIC_RELAXED);
         ui32 lower = static_cast<ui32>(value);
         ui32 upper = static_cast<ui32>(value >> 32U);

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -48,24 +48,24 @@ enum class EFileRingBufferVersion : ui32
     NotInitialized = 0,
 
     // Entry headers are not aligned
-    // Maximum allocation size is 2^31
+    // Maximum allocation size is 2^31-1
     // Free flag is supported
     // Tags are not supported
     // Checksum is calculated over entry data only
     V4 = 4,
 
     // Entry headers are not aligned
-    // Maximum allocation size is 2^28
+    // Maximum allocation size is 2^28-1
     // Free flag is supported
     // Tags are supported - small values [0-7]
     // Checksum is calculated over entry data only
     V5 = 5,
 
     // Entry headers are aligned and read/written atomically
-    // Maximum allocation size is 2^28
+    // Maximum allocation size is 2^28-1
     // Free flag is supported
     // Tags are supported - small values [0-7]
-    // Checksum is calculated over both entry data and entry header
+    // Checksum is calculated over entry data and XORed with entry header hash
     V6 = 6,
 };
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <util/system/types.h>
+
+#include <memory>
+#include <span>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//  Structure contract:
+//
+//  1. Empty buffer:
+//    - ReadPos == WritePos
+//  or
+//    - ReadPos points to a slack space
+//    - WritePos == 0
+//    This may happen when Alloc was terminated in the middle of the operation.
+//    ReadPos is corrected to 0 during validation.
+//
+//  2. Non-empty buffer:
+//    - ReadPos != WritePos
+//    - ReadPos points to the first byte of the first valid entry
+//    - WritePos points to the first byte right after the last valid entry
+//
+//  3. Valid entry:
+//    - Size > 0
+//    - The entry takes sizeof(TEntryHeader) + Size contiguous bytes in
+//      the occupied part of the buffer
+//
+//  4. Occupied part of the buffer:
+//     - ReadPos < WritePos: [ReadPos, WritePos)
+//     - ReadPos > WritePos: [ReadPos, Capacity) + [0, WritePos)
+//
+//  5. Slack space entry marker:
+//     - Size = 0
+//     - Instructs to read the next entry at pos = 0
+//     - Can appear only when ReadPos > WritePos in [ReadPos, Capacity) part
+//
+//  6. Implicit slack space marker:
+//     - pos + sizeof(TEntryHeader) > Capacity
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EFileRingBufferVersion : ui32
+{
+    NotInitialized = 0,
+
+    // Entry headers are not aligned
+    // Maximum allocation size is 2^31
+    // Free flag is supported
+    // Tags are not supported
+    // Checksum is calculated over entry data only
+    V4 = 4,
+
+    // Entry headers are not aligned
+    // Maximum allocation size is 2^28
+    // Free flag is supported
+    // Tags are supported - small values [0-7]
+    // Checksum is calculated over entry data only
+    V5 = 5,
+
+    // Entry headers are aligned and read/written atomically
+    // Maximum allocation size is 2^28
+    // Free flag is supported
+    // Tags are supported - small values [0-7]
+    // Checksum is calculated over both entry data and entry header
+    V6 = 6,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFileRingBufferHeader
+{
+    EFileRingBufferVersion Version = EFileRingBufferVersion::NotInitialized;
+    ui32 HeaderSize = 0;
+    ui64 DataCapacity = 0;
+    ui64 ReadPos = 0;
+    ui64 WritePos = 0;
+    ui64 Unused = 0;
+    ui64 DataOffset = 0;
+    ui64 MetadataCapacity = 0;
+    ui64 MetadataOffset = 0;
+    ui32 MetadataSize = 0;
+    ui32 MetadataChecksum = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFileRingBufferEntryHeader
+{
+    ui32 DataSize = 0;
+    ui32 DataChecksum = 0;
+    ui32 Tag = 0;
+    bool FreeFlag = false;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFileRingBufferCapabilities
+{
+    ui64 MaxAllocationByteCount = 0;
+    ui64 MaxTag = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IFileRingBufferDataProcessor
+{
+    virtual ~IFileRingBufferDataProcessor() = default;
+
+    virtual TFileRingBufferCapabilities GetCapabilities() const = 0;
+
+    /**
+     * Read entry header at the specified position
+     * If position lies outside data region, returns the default value
+     */
+    virtual TFileRingBufferEntryHeader ReadEntryHeader(ui64 pos) const = 0;
+
+    /**
+     * Write entry header at the specified position
+     * Returns true if header has been written or false if position lies
+     * outside data region
+     */
+    virtual bool WriteEntryHeader(
+        ui64 pos,
+        const TFileRingBufferEntryHeader& header) = 0;
+
+    /**
+     * Get total entry size including header and data
+     * Takes alignment into account
+     */
+    virtual ui64 GetEntrySize(ui64 dataSize) const = 0;
+
+    /**
+     * Get maximum amount of data that can be stored in an entry that
+     * has size no more than maxEntrySize.
+     */
+    virtual ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const = 0;
+
+    /**
+     * Get data pointer to entry data at the specified position.
+     * Returns nullptr if the requested range lays outside data mapping.
+     */
+    virtual const char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const = 0;
+    virtual char* GetEntryDataPtr(ui64 pos, ui64 dataSize) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<IFileRingBufferDataProcessor> CreateFileRingBufferDataProcessor(
+    EFileRingBufferVersion version,
+    std::span<char> data);
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -118,6 +118,7 @@ struct TReferenceImplementation
         if (Version >= EVersion::V6) {
             sz = AlignUp(sz, static_cast<ui32>(sizeof(ui64)));
         }
+
         if (sz > MaxWeight) {
             return false;
         }
@@ -167,6 +168,7 @@ struct TReferenceImplementation
         if (Version >= EVersion::V6) {
             sz = AlignUp(sz, static_cast<ui32>(sizeof(ui64)));
         }
+
         ReadPos += sz;
         if (MaxWeight - ReadPos <= SlackSpace) {
             UNIT_ASSERT_VALUES_EQUAL(SlackSpace, MaxWeight - ReadPos);

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -11,6 +11,8 @@
 
 namespace NCloud {
 
+using EVersion = EFileRingBufferVersion;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -94,13 +96,16 @@ struct TReferenceImplementation
     static constexpr ui32 EntryOverhead = 8;
 
     const ui32 MaxWeight;
+    const EVersion Version;
+
     TDeque<TString> Q;
     ui32 ReadPos = 0;
     ui32 WritePos = 0;
     ui32 SlackSpace = 0;
 
-    explicit TReferenceImplementation(ui32 maxWeight)
+    TReferenceImplementation(ui32 maxWeight, EVersion version)
         : MaxWeight(maxWeight)
+        , Version(version)
     {}
 
     bool PushBack(TStringBuf data)
@@ -109,7 +114,10 @@ struct TReferenceImplementation
             return false;
         }
 
-        const ui32 sz = EntryOverhead + data.size();
+        ui32 sz = EntryOverhead + data.size();
+        if (Version >= EVersion::V6) {
+            sz = AlignUp(sz, static_cast<ui32>(sizeof(ui64)));
+        }
         if (sz > MaxWeight) {
             return false;
         }
@@ -155,7 +163,10 @@ struct TReferenceImplementation
             return;
         }
 
-        const ui32 sz = Q.front().size() + EntryOverhead;
+        ui32 sz = Q.front().size() + EntryOverhead;
+        if (Version >= EVersion::V6) {
+            sz = AlignUp(sz, static_cast<ui32>(sizeof(ui64)));
+        }
         ReadPos += sz;
         if (MaxWeight - ReadPos <= SlackSpace) {
             UNIT_ASSERT_VALUES_EQUAL(SlackSpace, MaxWeight - ReadPos);
@@ -200,6 +211,11 @@ TString Dump(const TReferenceImplementation& ri)
         sb << entry;
     }
     return sb;
+}
+
+TVector<EFileRingBufferVersion> GetVersionsForTest()
+{
+    return {EVersion::V4, EVersion::V5, EVersion::V6};
 }
 
 }   // namespace
@@ -280,7 +296,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     Y_UNIT_TEST(ShouldPushPopReferenceImplementation)
     {
         const ui32 len = 64;
-        TReferenceImplementation rb(len);
+        TReferenceImplementation rb(len, EVersion::V4);
 
         DoTestShouldPushPop(rb);
     }
@@ -365,18 +381,23 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         ui32 len,
         ui32 testBytes,
         ui32 testUpToEntrySize,
-        ui32 metadataSize)
+        ui32 metadataSize,
+        EVersion version)
     {
         const auto f = TTempFileHandle();
         const double restoreProbability = 0.05;
         std::unique_ptr<TFileRingBuffer> rb;
-        TReferenceImplementation ri(len);
+        TReferenceImplementation ri(len, version);
 
-        auto restore = [&] () {
-            rb = std::make_unique<TFileRingBuffer>(
-                f.GetName(),
-                len,
-                metadataSize);
+        auto restore = [&]()
+        {
+            auto args = TFileRingBufferArgs{
+                .FilePath = f.GetName(),
+                .DataCapacity = len,
+                .MetadataCapacity = metadataSize,
+                .Version = version};
+
+            rb = std::make_unique<TFileRingBuffer>(args);
         };
 
         restore();
@@ -432,10 +453,26 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         }
     }
 
+    void DoRandomizedPushPopRestore(
+        ui32 len,
+        ui32 testBytes,
+        ui32 testUpToEntrySize,
+        ui32 metadataSize)
+    {
+        for (auto version: GetVersionsForTest()) {
+            DoRandomizedPushPopRestore(
+                len,
+                testBytes,
+                testUpToEntrySize,
+                metadataSize,
+                version);
+        }
+    }
+
     Y_UNIT_TEST(ShouldNotWriteBeyondBufferWhenEmpty)
     {
         const auto f = TTempFileHandle();
-        auto ri = TReferenceImplementation(64);
+        auto ri = TReferenceImplementation(64, EVersion::V4);
         auto rb = TFileRingBuffer(f.GetName(), 64);
 
         TString data(36, 'a');
@@ -734,7 +771,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb->ValidateMetadata());
 
         {
-            // Corrupt metadata Crc32
+            // Corrupt metadata
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.Map(0, 256);
             char* data = static_cast<char*>(m.Ptr());
@@ -770,32 +807,39 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 dataLen = 36;
         const ui32 metadataLen = 8;
 
-        const TString fileDumpVer4 =
-            "BAAAAEgAAAAkAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAgBAAAAAAAACA"
-            "AAAAAAAAAAAQAAAAAAAAgAAAD56yynAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAEZvcm1hdFY0CAAAABcbOq5Tb21lRGF0YQAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAA";
+        auto argsV4 = TFileRingBufferArgs{
+            .FilePath = f.GetName(),
+            .DataCapacity = dataLen,
+            .MetadataCapacity = metadataLen,
+            .Version = EVersion::V4};
+
+        auto rb = std::make_unique<TFileRingBuffer>(argsV4);
+
+        rb->SetMetadata("FormatV4");
+        rb->PushBack("SomeData");
 
         {
-            TString decoded = Base64Decode(fileDumpVer4);
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
-            m.ResizeAndRemap(0, decoded.size());
-            decoded.copy(reinterpret_cast<char*>(m.Ptr()), decoded.size());
+            m.ResizeAndRemap(0, m.Length());
             // Check version before migration
             UNIT_ASSERT_VALUES_EQUAL(4, *reinterpret_cast<ui32*>(m.Ptr()));
         }
 
-        TFileRingBuffer rb(f.GetName(), dataLen, metadataLen);
-        UNIT_ASSERT(!rb.IsCorrupted());
-        UNIT_ASSERT_VALUES_EQUAL("FormatV4", rb.GetMetadata());
-        UNIT_ASSERT_VALUES_EQUAL("SomeData", rb.Front());
+        auto argsV5 = TFileRingBufferArgs{
+            .FilePath = f.GetName(),
+            .DataCapacity = dataLen,
+            .MetadataCapacity = metadataLen,
+            .Version = EVersion::V5};
+
+        rb = std::make_unique<TFileRingBuffer>(argsV5);
+
+        UNIT_ASSERT(!rb->IsCorrupted());
+        UNIT_ASSERT_VALUES_EQUAL("FormatV4", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL("SomeData", rb->Front());
 
         {
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
-            m.ResizeAndRemap(0, f.GetLength());
+            m.ResizeAndRemap(0, m.Length());
             // Check version after migration
             UNIT_ASSERT_VALUES_EQUAL(5, *reinterpret_cast<ui32*>(m.Ptr()));
         }
@@ -1098,54 +1142,175 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
     Y_UNIT_TEST(ShouldSupportTags)
     {
+        auto check = [](EVersion version)
+        {
+            const auto f = TTempFileHandle();
+            const ui32 len = 36;
+
+            auto args = TFileRingBufferArgs{
+                .FilePath = f.GetName(),
+                .DataCapacity = len,
+                .Version = version};
+
+            auto rb = std::make_unique<TFileRingBuffer>(args);
+
+            const TString data1 = "abc";
+            const TString data2 = "defg";
+
+            auto* ptr1 = rb->Alloc(data1.size()).GetResult();
+            UNIT_ASSERT(ptr1 != nullptr);
+            data1.copy(ptr1, data1.size());
+            rb->Commit();
+
+            auto* ptr2 = rb->Alloc(data2.size()).GetResult();
+            UNIT_ASSERT(ptr2 != nullptr);
+            data2.copy(ptr2, data2.size());
+            rb->Commit();
+
+            UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr1));
+            UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr2));
+
+            rb->SetTag(ptr1, 1);
+            rb->SetTag(ptr2, 2);
+
+            UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr1));
+            UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr2));
+
+            // Recreate cache - old pointers become invalid
+            rb = std::make_unique<TFileRingBuffer>(args);
+
+            const auto* ptr3 = Find(*rb, TStringBuf(data1)).data();
+            UNIT_ASSERT(ptr3 != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr3));
+
+            const auto* ptr4 = Find(*rb, TStringBuf(data2)).data();
+            UNIT_ASSERT(ptr4 != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr4));
+
+            rb->PopFront();
+            rb->PopFront();
+            UNIT_ASSERT(rb->Empty());
+
+            // Reuse entry
+            auto* ptr5 = rb->Alloc(data1.size()).GetResult();
+            UNIT_ASSERT(ptr5 != nullptr);
+            data1.copy(ptr5, data1.size());
+            rb->Commit();
+
+            UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr5));
+        };
+
+        check(EVersion::V5);
+        check(EVersion::V6);
+    }
+
+    Y_UNIT_TEST(CheckAlignmentForVersionV6)
+    {
         const auto f = TTempFileHandle();
         const ui32 len = 36;
-        auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
 
-        const TString data1 = "abc";
-        const TString data2 = "defg";
+        auto args = TFileRingBufferArgs{
+            .FilePath = f.GetName(),
+            .DataCapacity = len,
+            .Version = EVersion::V6};
 
-        auto* ptr1 = rb->Alloc(data1.size()).GetResult();
+        TFileRingBuffer rb(args);
+
+        auto ptr1 = rb.Alloc(2).GetResult();
         UNIT_ASSERT(ptr1 != nullptr);
-        data1.copy(ptr1, data1.size());
-        rb->Commit();
+        ptr1[0] = 'a';
+        ptr1[1] = 'b';
+        UNIT_ASSERT(rb.Commit());
 
-        auto* ptr2 = rb->Alloc(data2.size()).GetResult();
+        auto ptr2 = rb.Alloc(1).GetResult();
         UNIT_ASSERT(ptr2 != nullptr);
-        data2.copy(ptr2, data2.size());
-        rb->Commit();
+        ptr2[0] = 'c';
+        rb.Commit();
 
-        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr1));
-        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr2));
+        UNIT_ASSERT(AlignDown(ptr1, sizeof(ui64)) == ptr1);
+        UNIT_ASSERT(AlignDown(ptr2, sizeof(ui64)) == ptr2);
+    }
 
-        rb->SetTag(ptr1, 1);
-        rb->SetTag(ptr2, 2);
+    Y_UNIT_TEST(ShouldMigrate)
+    {
+        auto check = [](EVersion srcVersion,
+                        EVersion dstVersion,
+                        bool immediateMigration)
+        {
+            const auto f = TTempFileHandle();
+            const ui32 len = 128;
 
-        UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr1));
-        UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr2));
+            auto srcArgs = TFileRingBufferArgs{
+                .FilePath = f.GetName(),
+                .DataCapacity = len,
+                .MetadataCapacity = 8,
+                .Version = srcVersion};
 
-        // Recreate cache - old pointers become invalid
-        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+            auto rb = std::make_unique<TFileRingBuffer>(srcArgs);
 
-        const auto* ptr3 = Find(*rb, TStringBuf(data1)).data();
-        UNIT_ASSERT(ptr3 != nullptr);
-        UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr3));
+            rb->SetMetadata("abc");
+            UNIT_ASSERT(rb->PushBack("123"));
+            UNIT_ASSERT(rb->PushBack("4"));
+            UNIT_ASSERT(rb->PushBack("xz"));
 
-        const auto* ptr4 = Find(*rb, TStringBuf(data2)).data();
-        UNIT_ASSERT(ptr4 != nullptr);
-        UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr4));
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui32>(srcVersion),
+                rb->GetVersion());
 
-        rb->PopFront();
-        rb->PopFront();
-        UNIT_ASSERT(rb->Empty());
+            auto dstArgs = TFileRingBufferArgs{
+                .FilePath = f.GetName(),
+                .DataCapacity = len,
+                .MetadataCapacity = 8,
+                .Version = dstVersion};
 
-        // Reuse entry
-        auto* ptr5 = rb->Alloc(data1.size()).GetResult();
-        UNIT_ASSERT(ptr5 != nullptr);
-        data1.copy(ptr5, data1.size());
-        rb->Commit();
+            rb = std::make_unique<TFileRingBuffer>(dstArgs);
 
-        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr5));
+            UNIT_ASSERT(rb->Validate().empty());
+
+            UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
+            UNIT_ASSERT_VALUES_EQUAL("123, 4, xz", Dump(*rb));
+
+            UNIT_ASSERT_VALUES_EQUAL(immediateMigration, rb->PushBack("!"));
+
+            if (immediateMigration) {
+                // Migration happened with non-empty buffer
+                UNIT_ASSERT_VALUES_EQUAL("123, 4, xz, !", Dump(*rb));
+
+                rb->PopFront();
+                rb->PopFront();
+                rb->PopFront();
+            } else {
+                // Migration didn't happen - need to empty the buffer first
+                UNIT_ASSERT_VALUES_EQUAL(0, rb->GetAvailableByteCount());
+
+                rb->PopFront();
+                rb->PopFront();
+                rb->PopFront();
+
+                UNIT_ASSERT_LT(0, rb->GetAvailableByteCount());
+
+                UNIT_ASSERT(rb->PushBack("!"));
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL("!", Dump(*rb));
+            UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui32>(dstVersion),
+                rb->GetVersion());
+
+            UNIT_ASSERT(rb->Validate().empty());
+        };
+
+        // Version upgrade
+        check(EVersion::V4, EVersion::V5, true);
+        check(EVersion::V4, EVersion::V6, false);
+        check(EVersion::V5, EVersion::V6, false);
+
+        // Version downgrade
+        check(EVersion::V6, EVersion::V5, false);
+        check(EVersion::V6, EVersion::V4, false);
+        check(EVersion::V5, EVersion::V4, false);
     }
 }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -1154,6 +1154,8 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
             auto rb = std::make_unique<TFileRingBuffer>(args);
 
+            UNIT_ASSERT_VALUES_EQUAL(7, rb->GetMaxTag());
+
             const TString data1 = "abc";
             const TString data2 = "defg";
 

--- a/cloud/storage/core/libs/file_backed_containers/ya.make
+++ b/cloud/storage/core/libs/file_backed_containers/ya.make
@@ -5,6 +5,7 @@ SRCS(
     dynamic_persistent_table_counters.cpp
     file_map_memory_limiter.cpp
     file_ring_buffer.cpp
+    file_ring_buffer_format.cpp
     persistent_table.cpp
 )
 


### PR DESCRIPTION
### Notes

Reliability improvements for `TFileRingBuffer`:

1. Add support for multiple versions and possibility to migrate to next and previous versions (this is very important in production when release needs to be reverted). Also, the code was extracted and move to a separate file.

2. Add new structure version (V6) that:
- Introduces header and alignment - this is needed to guarantee that entry headers are written atomically;
- Covers entry headers with checksum calculation.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
