### PR TITLE
[NBS] Tweak rdma_disks tests

### DIFF
--- a/cloud/blockstore/tests/rdma_disks/test.py
+++ b/cloud/blockstore/tests/rdma_disks/test.py
@@ -66,7 +66,7 @@ def start_nbs_daemon(ydb):
 
     yield nbs
 
-    nbs.kill()
+    nbs.stop()
 
 
 def _remove_host(client, agent_id):
@@ -167,7 +167,7 @@ def test_m3_rdma_simple_io(ydb, nbs):
     session.unmount_volume()
 
     for disk_agent in disk_agents:
-        disk_agent.kill()
+        disk_agent.stop()
 
 
 def test_m3_rdma_restart_disk_agent_during_migration(ydb, nbs):
@@ -259,4 +259,4 @@ def test_m3_rdma_restart_disk_agent_during_migration(ydb, nbs):
     session.unmount_volume()
 
     for disk_agent in disk_agents:
-        disk_agent.kill()
+        disk_agent.stop()


### PR DESCRIPTION
Tweak rdma_disks tests: use stop instead of kill to stop NBS & Disk Agent processes.