### PR TITLE
issue-5432: unsafe flags that make tablet Create/DestroyHandle ops commit asynchronously

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -802,4 +802,10 @@ message TStorageConfig
     optional uint64 FlushBytesThresholdForBackpressureSoft = 509;
     optional uint64 FlushBytesItemCountThresholdForBackpressureSoft = 510;
     optional uint64 CollectGarbageThresholdForBackpressureSoft = 511;
+
+    // Makes tablet's CreateHandle op handler reply before the tx is committed.
+    optional bool TabletUnsafeAsyncReadOnlyCreateHandleEnabled = 512;
+
+    // Makes tablet's DestroyHandle op handler reply before the tx is committed.
+    optional bool TabletUnsafeAsyncDestroyHandleEnabled = 513;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -252,16 +252,18 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(UseUnlimitedBTreeNodeRefsCacheInMainTablet,     bool,       false     )\
     xxx(UseUnlimitedBTreeNodeRefsCacheInShards,         bool,       false     )\
                                                                                \
-    xxx(NonNetworkMetricsBalancingFactor,               ui32,      1_KB       )\
+    xxx(NonNetworkMetricsBalancingFactor,               ui32,       1_KB      )\
                                                                                \
-    xxx(AsyncDestroyHandleEnabled,     bool,       false                      )\
+    xxx(AsyncDestroyHandleEnabled,                      bool,       false     )\
+    xxx(TabletUnsafeAsyncReadOnlyCreateHandleEnabled,   bool,       false     )\
+    xxx(TabletUnsafeAsyncDestroyHandleEnabled,          bool,       false     )\
     xxx(AsyncHandleOperationPeriod,    TDuration,  TDuration::MilliSeconds(50))\
                                                                                \
     xxx(NodeRegistrationMaxAttempts,         ui32,      10                    )\
     xxx(NodeRegistrationTimeout,             TDuration, TDuration::Seconds(5) )\
     xxx(NodeRegistrationErrorTimeout,        TDuration, TDuration::Seconds(1) )\
                                                                                \
-    xxx(MultipleStageRequestThrottlingEnabled,          bool,      false      )\
+    xxx(MultipleStageRequestThrottlingEnabled,          bool,       false     )\
                                                                                \
     xxx(ConfigDispatcherSettings,                                              \
         NCloud::NProto::TConfigDispatcherSettings,                             \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -270,6 +270,8 @@ public:
     bool GetUseUnlimitedBTreeNodeRefsCacheInShards() const;
 
     bool GetAsyncDestroyHandleEnabled() const;
+    bool GetTabletUnsafeAsyncReadOnlyCreateHandleEnabled() const;
+    bool GetTabletUnsafeAsyncDestroyHandleEnabled() const;
     TDuration GetAsyncHandleOperationPeriod() const;
 
     void Dump(IOutputStream& out) const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -598,6 +598,14 @@ private:
         const NActors::TActorContext& ctx,
         TTxIndexTablet::TListNodes& args);
 
+    void CompleteCreateHandle(
+        const NActors::TActorContext& ctx,
+        TTxIndexTablet::TCreateHandle& args);
+
+    void CompleteDestroyHandle(
+        const NActors::TActorContext& ctx,
+        TTxIndexTablet::TDestroyHandle& args);
+
     //
     // Common event handlers.
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -505,12 +505,28 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         Config->GetDupCacheEntryCount());
 
     EnqueueTruncateIfNeeded(ctx);
+
+    constexpr ui32 wflags = (ProtoFlag(NProto::TCreateHandleRequest::E_CREATE)
+         | ProtoFlag(NProto::TCreateHandleRequest::E_WRITE)
+         | ProtoFlag(NProto::TCreateHandleRequest::E_APPEND)
+         | ProtoFlag(NProto::TCreateHandleRequest::E_TRUNCATE));
+
+    const bool isReadOnly = (args.Flags & wflags) == 0;
+
+    if (Config->GetTabletUnsafeAsyncReadOnlyCreateHandleEnabled() && isReadOnly)
+    {
+        CompleteCreateHandle(ctx, args);
+    }
 }
 
-void TIndexTabletActor::CompleteTx_CreateHandle(
+void TIndexTabletActor::CompleteCreateHandle(
     const TActorContext& ctx,
     TTxIndexTablet::TCreateHandle& args)
 {
+    Y_DEFER {
+        args.Completed = true;
+    };
+
     for (auto nodeId: args.UpdatedNodes) {
         InvalidateReadAheadCache(nodeId);
     }
@@ -577,6 +593,17 @@ void TIndexTabletActor::CompleteTx_CreateHandle(
         GetFileSystemId(),
         args.Error,
         ProfileLog);
+}
+
+void TIndexTabletActor::CompleteTx_CreateHandle(
+    const TActorContext& ctx,
+    TTxIndexTablet::TCreateHandle& args)
+{
+    if (args.Completed) {
+        return;
+    }
+
+    CompleteCreateHandle(ctx, args);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -515,6 +515,13 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
 
     if (Config->GetTabletUnsafeAsyncReadOnlyCreateHandleEnabled() && isReadOnly)
     {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s Async create handle: @%lu -> %lu",
+            LogTag.c_str(),
+            args.NodeId,
+            args.Response.GetHandle());
         CompleteCreateHandle(ctx, args);
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -121,12 +121,20 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
     }
 
     EnqueueTruncateIfNeeded(ctx);
+
+    if (Config->GetTabletUnsafeAsyncDestroyHandleEnabled()) {
+        CompleteDestroyHandle(ctx, args);
+    }
 }
 
-void TIndexTabletActor::CompleteTx_DestroyHandle(
+void TIndexTabletActor::CompleteDestroyHandle(
     const TActorContext& ctx,
     TTxIndexTablet::TDestroyHandle& args)
 {
+    Y_DEFER {
+        args.Completed = true;
+    };
+
     RemoveInFlightRequest(*args.RequestInfo);
 
     if (!HasError(args.Error)) {
@@ -144,6 +152,17 @@ void TIndexTabletActor::CompleteTx_DestroyHandle(
         ctx);
 
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+void TIndexTabletActor::CompleteTx_DestroyHandle(
+    const TActorContext& ctx,
+    TTxIndexTablet::TDestroyHandle& args)
+{
+    if (args.Completed) {
+        return;
+    }
+
+    CompleteDestroyHandle(ctx, args);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -123,6 +123,13 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
     EnqueueTruncateIfNeeded(ctx);
 
     if (Config->GetTabletUnsafeAsyncDestroyHandleEnabled()) {
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::TABLET,
+            "%s Async destroy handle: @%lu -> %lu",
+            LogTag.c_str(),
+            args.Node->NodeId,
+            args.Request.GetHandle());
         CompleteDestroyHandle(ctx, args);
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -1886,6 +1886,7 @@ struct TTxIndexTablet
         NProto::TOpLogEntry OpLogEntry;
 
         NProto::TCreateHandleResponse Response;
+        bool Completed = false;
 
         TCreateHandle(
                 TRequestInfoPtr requestInfo,
@@ -1923,6 +1924,7 @@ struct TTxIndexTablet
             OpLogEntry.Clear();
 
             Response.Clear();
+            Completed = false;
 
             // deliberately not calling TProfileAware::Clear()
         }
@@ -1942,6 +1944,7 @@ struct TTxIndexTablet
         const NProto::TDestroyHandleRequest Request;
 
         TMaybe<IIndexTabletDatabase::TNode> Node;
+        bool Completed = false;
 
         TDestroyHandle(
                 TRequestInfoPtr requestInfo,
@@ -1957,6 +1960,7 @@ struct TTxIndexTablet
             TIndexStateNodeUpdates::Clear();
 
             Node.Clear();
+            Completed = false;
         }
     };
 

--- a/cloud/filestore/tests/fmdtest/configs/nfs-storage-unsafe.txt
+++ b/cloud/filestore/tests/fmdtest/configs/nfs-storage-unsafe.txt
@@ -1,0 +1,8 @@
+LargeDeletionMarkersEnabled: true
+MaxFileBlocks: 536870912
+AutomaticShardCreationEnabled: true
+ShardAllocationUnit: 1073741824
+AutomaticallyCreatedShardSize: 1073741824
+DirectoryCreationInShardsEnabled: true
+TabletUnsafeAsyncReadOnlyCreateHandleEnabled: true
+TabletUnsafeAsyncDestroyHandleEnabled: true

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/canondata/result.json
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/canondata/result.json
@@ -1,0 +1,5 @@
+{
+    "test.test_create_unlink_steal": {
+        "uri": "file://test.test_create_unlink_steal/create_unlink_steal_results.txt"
+    }
+}

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
@@ -1,0 +1,15 @@
+{
+    "create": true,
+    "create-lat-us": true,
+    "unlink": true,
+    "unlink-lat-us": true,
+    "rename": true,
+    "rename-lat-us": true,
+    "stat": true,
+    "stat-lat-us": true,
+    "list": true,
+    "list-lat-us": true,
+    "list-w": true,
+    "list-wlat-us": true,
+    "errors": false
+}

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/test.py
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/test.py
@@ -1,0 +1,44 @@
+import json
+import os
+
+import yatest.common as common
+
+from cloud.storage.core.tools.testing.qemu.lib.common import (
+    env_with_guest_index,
+    SshToGuest,
+)
+
+
+def do_test(test_name, aux_params):
+    port = int(os.getenv(env_with_guest_index("QEMU_FORWARDING_PORT", 0)))
+    ssh_key = os.getenv("QEMU_SSH_KEY")
+    mount_dir = os.getenv("NFS_MOUNT_PATH")
+
+    ssh = SshToGuest(user="qemu", port=port, key=ssh_key)
+
+    fmdtest_bin = common.binary_path(
+        "cloud/filestore/tools/testing/fmdtest/bin/fmdtest")
+
+    working_dir = os.path.join(mount_dir, test_name + "_wd")
+    report_file = "report.json"
+
+    ssh(f"{fmdtest_bin} --test-dir {working_dir} --report-path {report_file}"
+        f" {aux_params}")
+
+    ret = ssh(f"sudo cat {report_file}")
+    report = json.loads(ret.stdout.decode("utf8"))
+    for k, v in report.items():
+        report[k] = v > 0
+
+    results_path = f"{common.output_path()}/{test_name}_results.txt"
+    with open(results_path, 'w') as results:
+        results.write(json.dumps(report, indent=4))
+
+    ret = common.canonical_file(results_path, local=True)
+    return ret
+
+
+def test_create_unlink_steal():
+    return do_test(
+        "create_unlink_steal",
+        "--duration 60s --stealer-threads 1")

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/ya.make
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-unsafe-test/ya.make
@@ -1,0 +1,39 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+SPLIT_FACTOR(1)
+
+TEST_SRCS(
+    test.py
+)
+
+DEPENDS(
+    cloud/filestore/apps/client
+    cloud/filestore/tools/testing/fmdtest/bin
+)
+
+PEERDIR(
+    cloud/filestore/public/sdk/python/client
+    cloud/filestore/tests/python/lib
+
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/fmdtest/configs/nfs-storage-unsafe.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_INSTANCE_COUNT 1)
+SET(FILESTORE_VHOST_ENDPOINT_COUNT 1)
+SET(FILESTORE_BLOCKS_COUNT 5242880)
+SET(VIRTIOFS_SERVER_COUNT 1)
+SET(QEMU_INVOKE_TEST NO)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/fmdtest/ya.make
+++ b/cloud/filestore/tests/fmdtest/ya.make
@@ -2,4 +2,5 @@ RECURSE_FOR_TESTS(
     qemu-kikimr-memshard-nemesis-test
     qemu-kikimr-memshard-test
     qemu-kikimr-nemesis-test
+    qemu-kikimr-unsafe-test
 )


### PR DESCRIPTION
### Notes
Implemented 2 flags that will let us check what kind of perf improvement we'll get in some scenarios if we optimize Create/DestroyHandle latency to localdb read latency + rtt.

Added an fmdtest testcase for this - it's basically a smoke test - checks that with these flags everything works, not that these flags do exactly what they're intended to do. 

Tested the perf improvement manually on my locally bootstrapped filestore instance.
Without these flags:
```
qemu@ubuntu:~/mnt/dirtree_wd/producer_0$ strace -ttt -T grep -r "xxx" file_0_999
...
1781277264.505407 openat(AT_FDCWD, "file_0_999", O_RDONLY|O_NOCTTY) = 3 <0.005976>
...
1781277264.518031 close(3)              = 0 <0.003499>
...
```

With these flags:
```
...
1781277395.657155 openat(AT_FDCWD, "file_0_999", O_RDONLY|O_NOCTTY) = 3 <0.001272>
...
1781277395.664013 close(3)              = 0 <0.000974>
...
```
It's a test on a VM inside a VM with a network-ssd based filestore + ydbd stack so everything's supposed to be slow. The test shows that with these flag there's a big relative perf improvement.

### Issue
https://github.com/ydb-platform/nbs/issues/5432