### PR TITLE
filestore: TFuture::ExtractValue() -> UnsafeExtractValue()

### DIFF
--- a/cloud/filestore/apps/client/lib/command.h
+++ b/cloud/filestore/apps/client/lib/command.h
@@ -119,7 +119,7 @@ protected:
                 return TErrorResponse(E_REJECTED, "request cancelled");
             }
         }
-        return extract ? future.ExtractValue() : future.GetValue();
+        return extract ? UnsafeExtractValue(future) : future.GetValue();
     }
 
 private:

--- a/cloud/filestore/libs/client/durable.cpp
+++ b/cloud/filestore/libs/client/durable.cpp
@@ -87,7 +87,7 @@ template <typename T>
 void ExtractResponse(TFuture<T>& future, T& response)
 {
     try {
-        response = future.ExtractValue();
+        response = UnsafeExtractValue(future);
     } catch (const TServiceError& e) {
         auto& error = *response.MutableError();
         error.SetCode(e.GetCode());

--- a/cloud/filestore/libs/client/session.cpp
+++ b/cloud/filestore/libs/client/session.cpp
@@ -116,7 +116,7 @@ template <typename T>
 void ExtractResponse(TFuture<T>& future, T& response)
 {
     try {
-        response = future.ExtractValue();
+        response = UnsafeExtractValue(future);
     } catch (const TServiceError& e) {
         auto& error = *response.MutableError();
         error.SetCode(e.GetCode());

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_attr.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_attr.cpp
@@ -133,7 +133,8 @@ void TFileSystem::GetAttr(
         .Subscribe(
             [=, ptr = weak_from_this()](auto future)
             {
-                NProto::TGetNodeAttrResponse response = future.ExtractValue();
+                NProto::TGetNodeAttrResponse response =
+                    UnsafeExtractValue(future);
                 auto self = ptr.lock();
                 if (CheckResponse(self, *callContext, req, response)) {
                     auto* attr = response.MutableNode();

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_list.cpp
@@ -154,7 +154,8 @@ void TFileSystem::ReadDir(
                     }
                 };
 
-                NProto::TListNodesResponse response = future.ExtractValue();
+                NProto::TListNodesResponse response =
+                    UnsafeExtractValue(future);
                 if (!CheckResponse(self, *callContext, req, response)) {
                     return;
                 }

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_node.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_node.cpp
@@ -42,7 +42,8 @@ void TFileSystem::Lookup(
     Session->GetNodeAttr(callContext, std::move(request))
         .Subscribe([=, ptr = weak_from_this()] (auto future) {
             if (auto self = ptr.lock()) {
-                NProto::TGetNodeAttrResponse response = future.ExtractValue();
+                NProto::TGetNodeAttrResponse response =
+                    UnsafeExtractValue(future);
                 const auto& error = response.GetError();
                 if (!HasError(response)) {
                     self->AdjustNodeSize(*response.MutableNode());

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -237,7 +237,7 @@ public:
                          responseBuilder = std::move(responseBuilder),
                          pinId](TFuture<NProto::TReadDataResponse> future)
         {
-            auto response = future.ExtractValue();
+            auto response = UnsafeExtractValue(future);
 
             if (auto self = ptr.lock()) {
                 if (!HasError(response)) {


### PR DESCRIPTION
### Notes
The problem was originally found and described here: https://github.com/ydb-platform/nbs/pull/5318

```
/*
The semantics of TFuture::ExtractValue() are broken because it requires that
there be no GetValue() before ExtractValue(). Since a chain of subscribers is
usually built from the creation of the promise to the point of invocation where
the future is saved, it is impossible to guarantee that a new subscriber will
appear later in the chain who will read from the future, which means that the
code written a long time ago will break in an unobvious way, since
ExtractValue() will start throwing an exception, which can be even worse. not
for every call if getValue() occurs under a condition.

ExtractValue() should be called with care, only at the very end of the call
chain, in the furthest subscriber, the one that was bound at the point of the
initial creation call. Otherwise, subscribers that will be called later will
receive an empty value.
*/
```

I ran into this problem while working on https://github.com/ydb-platform/nbs/issues/5894 - if there's a subscriber which calls `TFuture::ExtractValue()` then you just can't add another subscriber **before** that one that would do `TFuture::GetValue()` even though it should be perfectly valid

Replacing all `TFuture::ExtractValue()` calls in `cloud/filestore/` with `UnsafeExtractValue()`

Probably we should do a similar thing in `cloud/storage` and `cloud/blockstore`

### Issue
https://github.com/ydb-platform/nbs/issues/5894
