### PR TITLE
issue-1751: [Filestore] TFileRingBuffer: add multi-version support, introduce V6 with headers alignment

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -32,7 +32,11 @@ public:
         TLog log,
         TString logTag)
         : Stats(std::move(stats))
-        , Storage(config.FilePath, config.DataCapacity, config.MetadataCapacity)
+        , Storage(
+              config.FilePath,
+              config.DataCapacity,
+              config.MetadataCapacity,
+              EFileRingBufferVersion::V6)
         , Config(std::move(config))
         , Log(std::move(log))
         , LogTag(std::move(logTag))

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -322,7 +322,10 @@ private:
             return;
         }
 
-        // Transition V4 -> V5 can be made without emptying the buffer
+        // WriteBackCache needs functionality of V5+ (tags) for entries created
+        // in older version (V4) - we need to make migration immediately to
+        // at least V5 in order to provide this functionality.
+        // Transition V4 -> V5 can be made without emptying the buffer.
         if (Header()->Version == EVersion::V4 && Args.Version > EVersion::V4) {
             // Parse entry headers using newer version
             CreateDataProcessor(EVersion::V5);
@@ -454,7 +457,7 @@ public:
             IsSupportedFileRingBufferVersion(
                 static_cast<EVersion>(Header()->Version)),
             "Unsupported current FileRingBuffer version - %u, file: %s",
-            Header()->Version,
+            static_cast<ui32>(Header()->Version),
             args.FilePath.c_str());
 
         ValidateStructure();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -22,13 +22,10 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using EVersion = EFileRingBufferVersion;
 using THeader = TFileRingBufferHeader;
 using TEntryHeader = TFileRingBufferEntryHeader;
 
-////////////////////////////////////////////////////////////////////////////////
-
-constexpr ui32 VERSION_PREV = 4;
-constexpr ui32 VERSION = 5;
 constexpr ui64 INVALID_POS = Max<ui64>();
 
 // Reserve some space after header so adding new fields will not require data
@@ -36,6 +33,16 @@ constexpr ui64 INVALID_POS = Max<ui64>();
 constexpr ui64 HeaderReserveSize = 256;
 
 static_assert(sizeof(THeader) <= HeaderReserveSize);
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFileRingBufferArgs
+{
+    TString FilePath;
+    ui64 DataCapacity = 0;
+    ui64 MetadataCapacity = 0;
+    EFileRingBufferVersion Version = EFileRingBufferVersion::NotInitialized;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -99,16 +106,16 @@ struct TEntryInfo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-THeader InitHeader(ui64 dataCapacity, ui64 metadataCapacity)
+THeader InitHeader(const TFileRingBufferArgs& args)
 {
     THeader res;
-    res.Version = VERSION;
+    res.Version = args.Version;
     res.HeaderSize = sizeof(THeader);
     res.MetadataOffset = HeaderReserveSize;
-    res.MetadataCapacity = metadataCapacity;
+    res.MetadataCapacity = args.MetadataCapacity;
     res.DataOffset =
         AlignUp(res.MetadataOffset + res.MetadataCapacity, sizeof(ui64));
-    res.DataCapacity = dataCapacity;
+    res.DataCapacity = args.DataCapacity;
     return res;
 }
 
@@ -119,6 +126,7 @@ THeader InitHeader(ui64 dataCapacity, ui64 metadataCapacity)
 class TFileRingBuffer::TImpl
 {
 private:
+    const TFileRingBufferArgs Args;
     TFileMap Map;
 
     std::unique_ptr<IFileRingBufferDataProcessor> Data;
@@ -157,9 +165,17 @@ private:
             const auto eh = Data->ReadEntryHeader(pos);
             if (eh.DataSize != 0) {
                 const auto* data = Data->GetEntryDataPtr(pos, eh.DataSize);
-                return data != nullptr
-                    ? TEntryInfo::Create(pos, eh, data)
-                    : TEntryInfo::CreateInvalid();
+                if (data == nullptr) {
+                    return TEntryInfo::CreateInvalid();
+                }
+
+                if (eh.FreeFlag && eh.DataChecksum != 0 &&
+                    Capabilities.EntryHeaderIsCoveredByChecksum)
+                {
+                    return TEntryInfo::CreateInvalid();
+                }
+
+                return TEntryInfo::Create(pos, eh, data);
             }
             pos = 0;
         }
@@ -190,6 +206,12 @@ private:
             return TEntryInfo::CreateInvalid();
         }
 
+        if (eh.FreeFlag && eh.DataChecksum != 0 &&
+            Capabilities.EntryHeaderIsCoveredByChecksum)
+        {
+            return TEntryInfo::CreateInvalid();
+        }
+
         return TEntryInfo::Create(pos, eh, data);
     }
 
@@ -205,12 +227,13 @@ private:
             : TEntryInfo::CreateInvalid();
     }
 
-    void CreateDataProcessor()
+    void CreateDataProcessor(EVersion version)
     {
         Data = CreateFileRingBufferDataProcessor(
+            version,
             GetMappedData(Header()->DataOffset, Header()->DataCapacity));
 
-        Capabilities = Data->GetCapabilities();
+        Capabilities = Data->GetCapabilities(true);
     }
 
     void ValidateStructure()
@@ -218,7 +241,6 @@ private:
         const ui64 mapLength = static_cast<ui64>(Map.Length());
         const auto& h = *Header();
 
-        Y_ABORT_UNLESS(h.Version == VERSION);
         Y_ABORT_UNLESS(sizeof(THeader) == h.HeaderSize);
         Y_ABORT_UNLESS(h.HeaderSize <= h.MetadataOffset);
         Y_ABORT_UNLESS(h.MetadataOffset <= h.DataOffset);
@@ -282,15 +304,36 @@ private:
         MemCopy(dst.data(), src.data(), size);
     }
 
-    void Migrate()
+    bool IsMigrationNeeded() const
     {
-        // In the new version, the highest bits of the entry size are treated as
-        // a tag value - need to ensure that nobody use it
-        VisitEntries([](const TEntryInfo& e)
-                     { Y_ABORT_UNLESS(e.GetTag() == 0); });
+        return Header()->Version != Args.Version;
+    }
 
-        Header()->Version = VERSION;
-        Header()->Unused = 0;
+    void TryMigrate()
+    {
+        if (!IsMigrationNeeded() || IsCorrupted()) {
+            return;
+        }
+
+        // Migration to any version can be performed when the buffer is empty
+        if (Empty()) {
+            Header()->Version = Args.Version;
+            CreateDataProcessor(Args.Version);
+            return;
+        }
+
+        // Transition V4 -> V5 can be made without emptying the buffer
+        if (Header()->Version == EVersion::V4 && Args.Version > EVersion::V4) {
+            // Parse entry headers using newer version
+            CreateDataProcessor(EVersion::V5);
+
+            // In the new version, the highest bits of the entry size are
+            // treated as a tag value - need to ensure that they are not used
+            VisitEntries([](const TEntryInfo& e)
+                         { Y_ABORT_UNLESS(e.Header.Tag == 0); });
+
+            Header()->Version = EVersion::V5;
+        }
     }
 
     void ResizeMetadata(ui64 desiredMetadataCapacity)
@@ -366,6 +409,10 @@ private:
         } else {
             Header()->ReadPos = front.ActualPos;
         }
+
+        if (IsMigrationNeeded()) {
+            TryMigrate();
+        }
     }
 
     void WriteSlackSpaceMarker(ui64 pos)
@@ -386,30 +433,37 @@ private:
     }
 
 public:
-    TImpl(const TString& filePath, ui64 dataCapacity, ui64 metadataCapacity)
-        : Map(filePath, TMemoryMapCommon::oRdWr)
+    explicit TImpl(const TFileRingBufferArgs& args)
+        : Args(args)
+        , Map(args.FilePath, TMemoryMapCommon::oRdWr)
     {
+        Y_ABORT_UNLESS(
+            IsSupportedFileRingBufferVersion(args.Version),
+            "Unsupported requested FileRingBuffer version - %u",
+            static_cast<ui32>(args.Version));
+
         if (static_cast<ui64>(Map.Length()) < sizeof(THeader)) {
-            auto header = InitHeader(dataCapacity, metadataCapacity);
+            auto header = InitHeader(args);
             Map.ResizeAndRemap(0, header.DataOffset + header.DataCapacity);
             *Header() = header;
         } else {
             Map.Map(0, Map.Length());
         }
 
-        if (Header()->Version == VERSION_PREV) {
-            // Migration needs access to entries
-            CreateDataProcessor();
-            Migrate();
-        }
+        Y_ABORT_UNLESS(
+            IsSupportedFileRingBufferVersion(
+                static_cast<EVersion>(Header()->Version)),
+            "Unsupported current FileRingBuffer version - %u, file: %s",
+            Header()->Version,
+            args.FilePath.c_str());
 
         ValidateStructure();
 
-        if (Header()->MetadataCapacity != metadataCapacity) {
-            ResizeMetadata(metadataCapacity);
+        if (Header()->MetadataCapacity != Args.MetadataCapacity) {
+            ResizeMetadata(Args.MetadataCapacity);
         }
 
-        CreateDataProcessor();
+        CreateDataProcessor(Header()->Version);
 
         ValidateDataStructure();
 
@@ -463,6 +517,12 @@ public:
             return MakeError(
                 E_ARGUMENT,
                 "Zero size allocations are not allowed");
+        }
+
+        if (IsMigrationNeeded()) {
+            // Return "storage is full" error.
+            // Migration will happen when the buffer is emptied.
+            return nullptr;
         }
 
         if (size > Capabilities.MaxAllocationByteCount) {
@@ -733,7 +793,7 @@ public:
 
     ui32 GetVersion() const
     {
-        return Header()->Version;
+        return static_cast<ui32>(Header()->Version);
     }
 
     ui64 GetMaxObservedEntryByteCount() const
@@ -744,6 +804,10 @@ public:
     ui64 GetAvailableByteCount() const
     {
         if (IsCorrupted()) {
+            return 0;
+        }
+
+        if (IsMigrationNeeded()) {
             return 0;
         }
 
@@ -810,10 +874,15 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 TFileRingBuffer::TFileRingBuffer(
-        const TString& filePath,
-        ui64 dataCapacity,
-        ui64 metadataCapacity)
-    : Impl(new TImpl(filePath, dataCapacity, metadataCapacity))
+    const TString& filePath,
+    ui64 dataCapacity,
+    ui64 metadataCapacity,
+    EFileRingBufferVersion version)
+    : Impl(new TImpl(
+          {.FilePath = filePath,
+           .DataCapacity = dataCapacity,
+           .MetadataCapacity = metadataCapacity,
+           .Version = version}))
 {}
 
 TFileRingBuffer::~TFileRingBuffer() = default;

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "file_ring_buffer_format.h"
+
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <util/generic/string.h>
@@ -45,7 +47,8 @@ public:
     TFileRingBuffer(
         const TString& filePath,
         ui64 dataCapacity,
-        ui64 metadataCapacity = 0);
+        ui64 metadataCapacity = 0,
+        EFileRingBufferVersion version = EFileRingBufferVersion::V5);
 
     ~TFileRingBuffer();
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -12,7 +12,7 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <class TEntryHeader>
+template <class TEntryHeader, bool RequireAlignment>
 class TData
 {
 private:
@@ -21,7 +21,13 @@ private:
 public:
     explicit TData(std::span<char> data)
         : Data(data)
-    {}
+    {
+        if constexpr (RequireAlignment) {
+            Y_ABORT_UNLESS(
+                AlignDown(Data.data(), sizeof(ui64)) == Data.data(),
+                "Data buffer is not properly aligned");
+        }
+    }
 
     ui64 Size() const
     {
@@ -35,6 +41,12 @@ public:
     // or is not aligned.
     TEntryHeader* GetEntryHeaderPtr(ui64 pos) const
     {
+        if constexpr (RequireAlignment) {
+            if (AlignDown(pos, sizeof(ui64)) != pos) {
+                return nullptr;
+            }
+        }
+
         const bool valid =
             pos < Data.size() && sizeof(TEntryHeader) <= Data.size() - pos;
 
@@ -44,16 +56,27 @@ public:
 
     // Treats memory at position pos as TEntryHeader and memory right after
     // the header as entry data.
+    // Checks for alignment if RequireAlignment is set.
     // Ensures that [pos, pos + sizeof(TEntryHeader) + dataSize) is within data
     // bounds.
-    // Returns pointer to entry data or nullptr if it is outside data bounds.
+    // Returns pointer to entry data or nullptr if it is outside data bounds
+    // or is not aligned.
     char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const
     {
+        if constexpr (RequireAlignment) {
+            if (AlignDown(pos, sizeof(ui64)) != pos) {
+                return nullptr;
+            }
+        }
+
         if (pos >= Data.size()) {
             return nullptr;
         }
 
-        const ui64 tailSize = Data.size() - pos;
+        ui64 tailSize = Data.size() - pos;
+        if constexpr (RequireAlignment) {
+            tailSize = AlignDown(tailSize, sizeof(ui64));
+        }
 
         const bool valid = sizeof(TEntryHeader) <= tailSize &&
                            dataSize <= tailSize - sizeof(TEntryHeader);
@@ -63,6 +86,10 @@ public:
 
     ui64 GetMaxDataSize(ui64 maxEntrySize) const
     {
+        if constexpr (RequireAlignment) {
+            maxEntrySize = AlignDown(maxEntrySize, sizeof(ui64));
+        }
+
         return maxEntrySize > sizeof(TEntryHeader)
                    ? maxEntrySize - sizeof(TEntryHeader)
                    : 0;
@@ -71,17 +98,12 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TFileRingBufferDataProcessor: public IFileRingBufferDataProcessor
+class TFileRingBufferDataProcessorV4: public IFileRingBufferDataProcessor
 {
 private:
     // Entry header layout (lower bits come first):
-    // [ DataSize (28 bits) | Tag (3 bits) | FreeFlag (1 bit) ]
+    // [ DataSize (31 bits) | FreeFlag (1 bit) ]
     // [ Checksum (32 bits) ]
-    static constexpr ui32 MaxDataSize = (1U << 28U) - 1U;
-    static constexpr ui32 MaxTag = (1U << 3U) - 1U;
-    static constexpr ui32 TagShift = 28U;
-    static constexpr ui32 FreeFlagMask = 1U << 31U;
-
     struct Y_PACKED TEntryHeader
     {
         ui32 DataSize = 0;
@@ -90,18 +112,133 @@ private:
 
     static_assert(sizeof(TEntryHeader) == sizeof(ui64));
 
-    TData<TEntryHeader> Data;
+    TData<TEntryHeader, false> Data;
+
+    static constexpr ui32 MaxDataSize = (1U << 31U) - 1U;
+    static constexpr ui32 FreeFlagMask = 1U << 31U;
 
 public:
-    explicit TFileRingBufferDataProcessor(std::span<char> data)
+    explicit TFileRingBufferDataProcessorV4(std::span<char> data)
         : Data(data)
     {}
 
-    TFileRingBufferCapabilities GetCapabilities() const override
+    TFileRingBufferCapabilities GetCapabilities(
+        bool takeBufferSizeIntoAccount) const override
     {
         return {
-            .MaxAllocationByteCount = GetMaxAllocationByteCount(Data.Size()),
+            .MaxAllocationByteCount =
+                takeBufferSizeIntoAccount
+                    ? GetMaxAllocationByteCount(Data.Size())
+                    : MaxDataSize,
+            .MaxTag = 0,
+            .Alignment = 1,
+            .EntryHeaderIsCoveredByChecksum = false,
+        };
+    }
+
+    TFileRingBufferEntryHeader ReadEntryHeader(ui64 pos) const override
+    {
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return {};
+        }
+
+        return {
+            .DataSize = eh->DataSize & MaxDataSize,
+            .DataChecksum = eh->Checksum,
+            .Tag = 0,
+            .FreeFlag = (eh->DataSize & FreeFlagMask) != 0,
+        };
+    }
+
+    bool WriteEntryHeader(
+        ui64 pos,
+        const TFileRingBufferEntryHeader& header) override
+    {
+        if (header.DataSize > MaxDataSize || header.Tag != 0) {
+            return false;
+        }
+
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return false;
+        }
+
+        eh->DataSize = header.DataSize | (header.FreeFlag ? FreeFlagMask : 0);
+        eh->Checksum = header.DataChecksum;
+        return true;
+    }
+
+    ui64 GetEntrySize(ui64 dataSize) const override
+    {
+        return sizeof(TEntryHeader) + dataSize;
+    }
+
+    ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const override
+    {
+        return Min(
+            Data.GetMaxDataSize(maxEntrySize),
+            static_cast<ui64>(MaxDataSize));
+    }
+
+    const char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+
+    char* GetEntryDataPtr(ui64 pos, ui64 dataSize) override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferDataProcessorV5Base
+{
+protected:
+    // Entry header layout (lower bits come first):
+    // [ DataSize (28 bits) | Tag (3 bits) | FreeFlag (1 bit) ]
+    // [ Checksum (32 bits) ]
+    static constexpr ui32 MaxDataSize = (1U << 28U) - 1U;
+    static constexpr ui32 MaxTag = (1U << 3U) - 1U;
+    static constexpr ui32 TagShift = 28U;
+    static constexpr ui32 FreeFlagMask = 1U << 31U;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferDataProcessorV5
+    : public TFileRingBufferDataProcessorV5Base
+    , public IFileRingBufferDataProcessor
+{
+private:
+    struct Y_PACKED TEntryHeader
+    {
+        ui32 DataSize = 0;
+        ui32 Checksum = 0;
+    };
+
+    static_assert(sizeof(TEntryHeader) == sizeof(ui64));
+
+    TData<TEntryHeader, false> Data;
+
+public:
+    explicit TFileRingBufferDataProcessorV5(std::span<char> data)
+        : Data(data)
+    {}
+
+    TFileRingBufferCapabilities GetCapabilities(
+        bool takeBufferSizeIntoAccount) const override
+    {
+        return {
+            .MaxAllocationByteCount =
+                takeBufferSizeIntoAccount
+                    ? GetMaxAllocationByteCount(Data.Size())
+                    : MaxDataSize,
             .MaxTag = MaxTag,
+            .Alignment = 1,
+            .EntryHeaderIsCoveredByChecksum = false,
         };
     }
 
@@ -162,14 +299,127 @@ public:
     }
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferDataProcessorV6
+    : public TFileRingBufferDataProcessorV5Base
+    , public IFileRingBufferDataProcessor
+{
+private:
+    TData<ui64, true> Data;
+
+public:
+    explicit TFileRingBufferDataProcessorV6(std::span<char> data)
+        : Data(data)
+    {}
+
+    TFileRingBufferCapabilities GetCapabilities(
+        bool takeBufferSizeIntoAccount) const override
+    {
+        return {
+            .MaxAllocationByteCount =
+                takeBufferSizeIntoAccount
+                    ? GetMaxAllocationByteCount(Data.Size())
+                    : MaxDataSize,
+            .MaxTag = MaxTag,
+            .Alignment = sizeof(ui64),
+            .EntryHeaderIsCoveredByChecksum = true,
+        };
+    }
+
+    TFileRingBufferEntryHeader ReadEntryHeader(ui64 pos) const override
+    {
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return {};
+        }
+
+        ui64 value = __atomic_load_n(eh, __ATOMIC_RELAXED);
+        ui32 lower = static_cast<ui32>(value);
+        ui32 upper = static_cast<ui32>(value >> 32U);
+
+        return {
+            .DataSize = lower & MaxDataSize,
+            .DataChecksum = upper ^ IntHash(lower),
+            .Tag = (lower >> TagShift) & MaxTag,
+            .FreeFlag = (lower & FreeFlagMask) != 0,
+        };
+    }
+
+    bool WriteEntryHeader(
+        ui64 pos,
+        const TFileRingBufferEntryHeader& header) override
+    {
+        if (header.DataSize > MaxDataSize || header.Tag > MaxTag) {
+            return false;
+        }
+
+        auto* eh = Data.GetEntryHeaderPtr(pos);
+        if (eh == nullptr) {
+            return false;
+        }
+
+        ui32 lower = header.DataSize | (header.Tag << TagShift) |
+                     (header.FreeFlag ? FreeFlagMask : 0);
+        ui32 upper = header.DataChecksum ^ IntHash(lower);
+        ui64 value = (static_cast<ui64>(upper) << 32U) | lower;
+
+        __atomic_store_n(eh, value, __ATOMIC_RELAXED);
+
+        return true;
+    }
+
+    ui64 GetEntrySize(ui64 dataSize) const override
+    {
+        return sizeof(ui64) + AlignUp(dataSize, sizeof(ui64));
+    }
+
+    ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const override
+    {
+        return Min(
+            Data.GetMaxDataSize(maxEntrySize),
+            static_cast<ui64>(MaxDataSize));
+    }
+
+    const char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+
+    char* GetEntryDataPtr(ui64 pos, ui64 dataSize) override
+    {
+        return Data.GetEntryDataPtr(pos, dataSize);
+    }
+};
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 std::unique_ptr<IFileRingBufferDataProcessor> CreateFileRingBufferDataProcessor(
+    EFileRingBufferVersion version,
     std::span<char> data)
 {
-    return std::make_unique<TFileRingBufferDataProcessor>(data);
+    switch (version) {
+        case EFileRingBufferVersion::V4:
+            return std::make_unique<TFileRingBufferDataProcessorV4>(data);
+        case EFileRingBufferVersion::V5:
+            return std::make_unique<TFileRingBufferDataProcessorV5>(data);
+        case EFileRingBufferVersion::V6:
+            return std::make_unique<TFileRingBufferDataProcessorV6>(data);
+        default:
+            Y_ABORT_UNLESS(
+                false,
+                "Unsupported file ring buffer version - %u",
+                static_cast<ui32>(version));
+    }
+}
+
+bool IsSupportedFileRingBufferVersion(EFileRingBufferVersion version)
+{
+    return version == EFileRingBufferVersion::V4 ||
+           version == EFileRingBufferVersion::V5 ||
+           version == EFileRingBufferVersion::V6;
 }
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -334,9 +334,8 @@ public:
             return {};
         }
 
-        ui64 value = __atomic_load_n(eh, __ATOMIC_RELAXED);
-        ui32 lower = static_cast<ui32>(value);
-        ui32 upper = static_cast<ui32>(value >> 32U);
+        ui32 lower = static_cast<ui32>(*eh);
+        ui32 upper = static_cast<ui32>(*eh >> 32U);
 
         return {
             .DataSize = lower & MaxDataSize,
@@ -364,6 +363,8 @@ public:
         ui32 upper = header.DataChecksum ^ IntHash(lower);
         ui64 value = (static_cast<ui64>(upper) << 32U) | lower;
 
+        // We need to atomically store header and checksum in order to
+        // maintain data consistency
         __atomic_store_n(eh, value, __ATOMIC_RELAXED);
 
         return true;

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -43,9 +43,37 @@ namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class EFileRingBufferVersion : ui32
+{
+    NotInitialized = 0,
+
+    // Entry headers are not aligned
+    // Maximum allocation size is 2^31-1
+    // Free flag is supported
+    // Tags are not supported
+    // Checksum is calculated over entry data only
+    V4 = 4,
+
+    // Entry headers are not aligned
+    // Maximum allocation size is 2^28-1
+    // Free flag is supported
+    // Tags are supported - small values [0-7]
+    // Checksum is calculated over entry data only
+    V5 = 5,
+
+    // Entry headers are aligned and read/written atomically
+    // Maximum allocation size is 2^28-1
+    // Free flag is supported
+    // Tags are supported - small values [0-7]
+    // Checksum is calculated over entry data and XORed with entry header hash
+    V6 = 6,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TFileRingBufferHeader
 {
-    ui32 Version = 0;
+    EFileRingBufferVersion Version = EFileRingBufferVersion::NotInitialized;
     ui32 HeaderSize = 0;
     ui64 DataCapacity = 0;
     ui64 ReadPos = 0;
@@ -75,6 +103,8 @@ struct TFileRingBufferCapabilities
 {
     ui64 MaxAllocationByteCount = 0;
     ui64 MaxTag = 0;
+    ui64 Alignment = 0;
+    bool EntryHeaderIsCoveredByChecksum = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -83,7 +113,12 @@ struct IFileRingBufferDataProcessor
 {
     virtual ~IFileRingBufferDataProcessor() = default;
 
-    virtual TFileRingBufferCapabilities GetCapabilities() const = 0;
+    /**
+     * Returns maximal values that can be stored in TFileRingBufferEntryHeader
+     * and alignment requirements for entry headers and data.
+     */
+    virtual TFileRingBufferCapabilities GetCapabilities(
+        bool takeBufferSizeIntoAccount) const = 0;
 
     /**
      * Read entry header at the specified position
@@ -123,6 +158,9 @@ struct IFileRingBufferDataProcessor
 ////////////////////////////////////////////////////////////////////////////////
 
 std::unique_ptr<IFileRingBufferDataProcessor> CreateFileRingBufferDataProcessor(
+    EFileRingBufferVersion version,
     std::span<char> data);
+
+bool IsSupportedFileRingBufferVersion(EFileRingBufferVersion version);
 
 }   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format_ut.cpp
@@ -1,0 +1,151 @@
+#include "file_ring_buffer_format.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/vector.h>
+
+namespace NCloud {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<EFileRingBufferVersion> GetVersionsForTest()
+{
+    return {
+        EFileRingBufferVersion::V4,
+        EFileRingBufferVersion::V5,
+        EFileRingBufferVersion::V6};
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TFileRingBufferFormatTest)
+{
+    Y_UNIT_TEST(ShouldStoreAndReadHeaders)
+    {
+        for (const auto& version : GetVersionsForTest()) {
+            TVector<char> data(1024);
+            auto processor = CreateFileRingBufferDataProcessor(version, data);
+
+            for (ui32 i = 0; i < 16; i++) {
+                auto written = processor->WriteEntryHeader(i * sizeof(ui64), {
+                    .DataSize = i,
+                    .DataChecksum = i * 13,
+                    .FreeFlag = (i % 2 == 0),
+                });
+
+                UNIT_ASSERT(written);
+            }
+
+            for (ui32 i = 0; i < 16; i++) {
+                auto header = processor->ReadEntryHeader(i * sizeof(ui64));
+                UNIT_ASSERT_VALUES_EQUAL(i, header.DataSize);
+                UNIT_ASSERT_VALUES_EQUAL(i * 13, header.DataChecksum);
+                UNIT_ASSERT_VALUES_EQUAL((i % 2 == 0), header.FreeFlag);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRespectCapabilities)
+    {
+        for (const auto& version : GetVersionsForTest()) {
+            TVector<char> data(1024);
+            auto processor = CreateFileRingBufferDataProcessor(version, data);
+            auto capabilities = processor->GetCapabilities(false);
+
+            // MaxAllocationByteCount
+            if (capabilities.MaxAllocationByteCount < Max<ui32>()) {
+                auto goodHeader = TFileRingBufferEntryHeader{
+                    .DataSize =
+                        static_cast<ui32>(capabilities.MaxAllocationByteCount),
+                    .DataChecksum = 7,
+                    .FreeFlag = true,
+                };
+
+                auto badHeader = TFileRingBufferEntryHeader{
+                    .DataSize = static_cast<ui32>(
+                        capabilities.MaxAllocationByteCount + 1),
+                    .DataChecksum = 7,
+                    .FreeFlag = true,
+                };
+
+                UNIT_ASSERT(processor->WriteEntryHeader(0, goodHeader));
+                UNIT_ASSERT(!processor->WriteEntryHeader(0, badHeader));
+
+                auto header = processor->ReadEntryHeader(0);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.DataSize, header.DataSize);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    goodHeader.DataChecksum,
+                    header.DataChecksum);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.Tag, header.Tag);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.FreeFlag, header.FreeFlag);
+            }
+
+            // MaxTag
+            if (capabilities.MaxTag < Max<ui32>()) {
+                auto goodHeader = TFileRingBufferEntryHeader{
+                    .DataSize = 11,
+                    .DataChecksum = 7,
+                    .Tag = static_cast<ui32>(capabilities.MaxTag),
+                    .FreeFlag = true,
+                };
+
+                auto badHeader = TFileRingBufferEntryHeader{
+                    .DataSize = 11,
+                    .DataChecksum = 7,
+                    .Tag = static_cast<ui32>(capabilities.MaxTag + 1),
+                    .FreeFlag = true,
+                };
+
+                UNIT_ASSERT(processor->WriteEntryHeader(0, goodHeader));
+                UNIT_ASSERT(!processor->WriteEntryHeader(0, badHeader));
+
+                auto header = processor->ReadEntryHeader(0);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.DataSize, header.DataSize);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    goodHeader.DataChecksum,
+                    header.DataChecksum);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.Tag, header.Tag);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.FreeFlag, header.FreeFlag);
+            }
+
+            // Alignment
+            if (capabilities.Alignment > 1) {
+                auto header = TFileRingBufferEntryHeader{
+                    .DataSize = 11,
+                    .DataChecksum = 7,
+                    .Tag = 0,
+                    .FreeFlag = true,
+                };
+
+                UNIT_ASSERT(processor->WriteEntryHeader(
+                    capabilities.Alignment,
+                    header));
+
+                UNIT_ASSERT(!processor->WriteEntryHeader(
+                    capabilities.Alignment + 1,
+                    header));
+
+                auto badHeader =
+                    processor->ReadEntryHeader(capabilities.Alignment + 1);
+
+                UNIT_ASSERT_VALUES_EQUAL(0, badHeader.DataSize);
+
+                auto goodHeader =
+                    processor->ReadEntryHeader(capabilities.Alignment);
+
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.DataSize, header.DataSize);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    goodHeader.DataChecksum,
+                    header.DataChecksum);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.Tag, header.Tag);
+                UNIT_ASSERT_VALUES_EQUAL(goodHeader.FreeFlag, header.FreeFlag);
+            }
+        }
+    }
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -11,6 +11,8 @@
 
 namespace NCloud {
 
+using EVersion = EFileRingBufferVersion;
+
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -94,13 +96,16 @@ struct TReferenceImplementation
     static constexpr ui32 EntryOverhead = 8;
 
     const ui32 MaxWeight;
+    const EVersion Version;
+
     TDeque<TString> Q;
     ui32 ReadPos = 0;
     ui32 WritePos = 0;
     ui32 SlackSpace = 0;
 
-    explicit TReferenceImplementation(ui32 maxWeight)
+    TReferenceImplementation(ui32 maxWeight, EVersion version)
         : MaxWeight(maxWeight)
+        , Version(version)
     {}
 
     bool PushBack(TStringBuf data)
@@ -109,7 +114,11 @@ struct TReferenceImplementation
             return false;
         }
 
-        const ui32 sz = EntryOverhead + data.size();
+        ui32 sz = EntryOverhead + data.size();
+        if (Version >= EVersion::V6) {
+            sz = AlignUp(sz, static_cast<ui32>(sizeof(ui64)));
+        }
+
         if (sz > MaxWeight) {
             return false;
         }
@@ -155,7 +164,11 @@ struct TReferenceImplementation
             return;
         }
 
-        const ui32 sz = Q.front().size() + EntryOverhead;
+        ui32 sz = Q.front().size() + EntryOverhead;
+        if (Version >= EVersion::V6) {
+            sz = AlignUp(sz, static_cast<ui32>(sizeof(ui64)));
+        }
+
         ReadPos += sz;
         if (MaxWeight - ReadPos <= SlackSpace) {
             UNIT_ASSERT_VALUES_EQUAL(SlackSpace, MaxWeight - ReadPos);
@@ -200,6 +213,11 @@ TString Dump(const TReferenceImplementation& ri)
         sb << entry;
     }
     return sb;
+}
+
+TVector<EFileRingBufferVersion> GetVersionsForTest()
+{
+    return {EVersion::V4, EVersion::V5, EVersion::V6};
 }
 
 }   // namespace
@@ -280,7 +298,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     Y_UNIT_TEST(ShouldPushPopReferenceImplementation)
     {
         const ui32 len = 64;
-        TReferenceImplementation rb(len);
+        TReferenceImplementation rb(len, EVersion::V4);
 
         DoTestShouldPushPop(rb);
     }
@@ -365,18 +383,21 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         ui32 len,
         ui32 testBytes,
         ui32 testUpToEntrySize,
-        ui32 metadataSize)
+        ui32 metadataSize,
+        EVersion version)
     {
         const auto f = TTempFileHandle();
         const double restoreProbability = 0.05;
         std::unique_ptr<TFileRingBuffer> rb;
-        TReferenceImplementation ri(len);
+        TReferenceImplementation ri(len, version);
 
-        auto restore = [&] () {
+        auto restore = [&]()
+        {
             rb = std::make_unique<TFileRingBuffer>(
                 f.GetName(),
                 len,
-                metadataSize);
+                metadataSize,
+                version);
         };
 
         restore();
@@ -432,10 +453,26 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         }
     }
 
+    void DoRandomizedPushPopRestore(
+        ui32 len,
+        ui32 testBytes,
+        ui32 testUpToEntrySize,
+        ui32 metadataSize)
+    {
+        for (auto version: GetVersionsForTest()) {
+            DoRandomizedPushPopRestore(
+                len,
+                testBytes,
+                testUpToEntrySize,
+                metadataSize,
+                version);
+        }
+    }
+
     Y_UNIT_TEST(ShouldNotWriteBeyondBufferWhenEmpty)
     {
         const auto f = TTempFileHandle();
-        auto ri = TReferenceImplementation(64);
+        auto ri = TReferenceImplementation(64, EVersion::V4);
         auto rb = TFileRingBuffer(f.GetName(), 64);
 
         TString data(36, 'a');
@@ -734,7 +771,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb->ValidateMetadata());
 
         {
-            // Corrupt metadata Crc32
+            // Corrupt metadata
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.Map(0, 256);
             char* data = static_cast<char*>(m.Ptr());
@@ -770,32 +807,35 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const ui32 dataLen = 36;
         const ui32 metadataLen = 8;
 
-        const TString fileDumpVer4 =
-            "BAAAAEgAAAAkAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAgBAAAAAAAACA"
-            "AAAAAAAAAAAQAAAAAAAAgAAAD56yynAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAAAAAAAAAEZvcm1hdFY0CAAAABcbOq5Tb21lRGF0YQAAAAAAAAAAAAAAAAAAAAAA"
-            "AAAA";
+        auto rb = std::make_unique<TFileRingBuffer>(
+            f.GetName(),
+            dataLen,
+            metadataLen,
+            EVersion::V4);
+
+        rb->SetMetadata("FormatV4");
+        rb->PushBack("SomeData");
 
         {
-            TString decoded = Base64Decode(fileDumpVer4);
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
-            m.ResizeAndRemap(0, decoded.size());
-            decoded.copy(reinterpret_cast<char*>(m.Ptr()), decoded.size());
+            m.ResizeAndRemap(0, m.Length());
             // Check version before migration
             UNIT_ASSERT_VALUES_EQUAL(4, *reinterpret_cast<ui32*>(m.Ptr()));
         }
 
-        TFileRingBuffer rb(f.GetName(), dataLen, metadataLen);
-        UNIT_ASSERT(!rb.IsCorrupted());
-        UNIT_ASSERT_VALUES_EQUAL("FormatV4", rb.GetMetadata());
-        UNIT_ASSERT_VALUES_EQUAL("SomeData", rb.Front());
+        rb = std::make_unique<TFileRingBuffer>(
+            f.GetName(),
+            dataLen,
+            metadataLen,
+            EVersion::V5);
+
+        UNIT_ASSERT(!rb->IsCorrupted());
+        UNIT_ASSERT_VALUES_EQUAL("FormatV4", rb->GetMetadata());
+        UNIT_ASSERT_VALUES_EQUAL("SomeData", rb->Front());
 
         {
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
-            m.ResizeAndRemap(0, f.GetLength());
+            m.ResizeAndRemap(0, m.Length());
             // Check version after migration
             UNIT_ASSERT_VALUES_EQUAL(5, *reinterpret_cast<ui32*>(m.Ptr()));
         }
@@ -1098,54 +1138,165 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
     Y_UNIT_TEST(ShouldSupportTags)
     {
+        auto check = [](EVersion version)
+        {
+            const auto f = TTempFileHandle();
+            const ui32 len = 36;
+
+            auto rb =
+                std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, version);
+
+            UNIT_ASSERT_VALUES_EQUAL(7, rb->GetMaxTag());
+
+            const TString data1 = "abc";
+            const TString data2 = "defg";
+
+            auto* ptr1 = rb->Alloc(data1.size()).GetResult();
+            UNIT_ASSERT(ptr1 != nullptr);
+            data1.copy(ptr1, data1.size());
+            rb->Commit();
+
+            auto* ptr2 = rb->Alloc(data2.size()).GetResult();
+            UNIT_ASSERT(ptr2 != nullptr);
+            data2.copy(ptr2, data2.size());
+            rb->Commit();
+
+            UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr1));
+            UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr2));
+
+            rb->SetTag(ptr1, 1);
+            rb->SetTag(ptr2, 2);
+
+            UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr1));
+            UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr2));
+
+            // Recreate cache - old pointers become invalid
+            rb =
+                std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, version);
+
+            const auto* ptr3 = Find(*rb, TStringBuf(data1)).data();
+            UNIT_ASSERT(ptr3 != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr3));
+
+            const auto* ptr4 = Find(*rb, TStringBuf(data2)).data();
+            UNIT_ASSERT(ptr4 != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr4));
+
+            rb->PopFront();
+            rb->PopFront();
+            UNIT_ASSERT(rb->Empty());
+
+            // Reuse entry
+            auto* ptr5 = rb->Alloc(data1.size()).GetResult();
+            UNIT_ASSERT(ptr5 != nullptr);
+            data1.copy(ptr5, data1.size());
+            rb->Commit();
+
+            UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr5));
+        };
+
+        check(EVersion::V5);
+        check(EVersion::V6);
+    }
+
+    Y_UNIT_TEST(CheckAlignmentForVersionV6)
+    {
         const auto f = TTempFileHandle();
         const ui32 len = 36;
-        auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
 
-        const TString data1 = "abc";
-        const TString data2 = "defg";
+        TFileRingBuffer rb(f.GetName(), len, 0, EVersion::V6);
 
-        auto* ptr1 = rb->Alloc(data1.size()).GetResult();
+        auto ptr1 = rb.Alloc(2).GetResult();
         UNIT_ASSERT(ptr1 != nullptr);
-        data1.copy(ptr1, data1.size());
-        rb->Commit();
+        ptr1[0] = 'a';
+        ptr1[1] = 'b';
+        UNIT_ASSERT(rb.Commit());
 
-        auto* ptr2 = rb->Alloc(data2.size()).GetResult();
+        auto ptr2 = rb.Alloc(1).GetResult();
         UNIT_ASSERT(ptr2 != nullptr);
-        data2.copy(ptr2, data2.size());
-        rb->Commit();
+        ptr2[0] = 'c';
+        rb.Commit();
 
-        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr1));
-        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr2));
+        UNIT_ASSERT(AlignDown(ptr1, sizeof(ui64)) == ptr1);
+        UNIT_ASSERT(AlignDown(ptr2, sizeof(ui64)) == ptr2);
+    }
 
-        rb->SetTag(ptr1, 1);
-        rb->SetTag(ptr2, 2);
+    Y_UNIT_TEST(ShouldMigrate)
+    {
+        auto check = [](EVersion srcVersion,
+                        EVersion dstVersion,
+                        bool immediateMigration)
+        {
+            const auto f = TTempFileHandle();
+            const ui32 len = 128;
 
-        UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr1));
-        UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr2));
+            auto rb = std::make_unique<TFileRingBuffer>(
+                f.GetName(),
+                len,
+                8,
+                srcVersion);
 
-        // Recreate cache - old pointers become invalid
-        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len);
+            rb->SetMetadata("abc");
+            UNIT_ASSERT(rb->PushBack("123"));
+            UNIT_ASSERT(rb->PushBack("4"));
+            UNIT_ASSERT(rb->PushBack("xz"));
 
-        const auto* ptr3 = Find(*rb, TStringBuf(data1)).data();
-        UNIT_ASSERT(ptr3 != nullptr);
-        UNIT_ASSERT_VALUES_EQUAL(1, rb->GetTag(ptr3));
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui32>(srcVersion),
+                rb->GetVersion());
 
-        const auto* ptr4 = Find(*rb, TStringBuf(data2)).data();
-        UNIT_ASSERT(ptr4 != nullptr);
-        UNIT_ASSERT_VALUES_EQUAL(2, rb->GetTag(ptr4));
+            rb = std::make_unique<TFileRingBuffer>(
+                f.GetName(),
+                len,
+                8,
+                dstVersion);
 
-        rb->PopFront();
-        rb->PopFront();
-        UNIT_ASSERT(rb->Empty());
+            UNIT_ASSERT(rb->Validate().empty());
 
-        // Reuse entry
-        auto* ptr5 = rb->Alloc(data1.size()).GetResult();
-        UNIT_ASSERT(ptr5 != nullptr);
-        data1.copy(ptr5, data1.size());
-        rb->Commit();
+            UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
+            UNIT_ASSERT_VALUES_EQUAL("123, 4, xz", Dump(*rb));
 
-        UNIT_ASSERT_VALUES_EQUAL(0, rb->GetTag(ptr5));
+            UNIT_ASSERT_VALUES_EQUAL(immediateMigration, rb->PushBack("!"));
+
+            if (immediateMigration) {
+                // Migration happened with non-empty buffer
+                UNIT_ASSERT_VALUES_EQUAL("123, 4, xz, !", Dump(*rb));
+
+                rb->PopFront();
+                rb->PopFront();
+                rb->PopFront();
+            } else {
+                // Migration didn't happen - need to empty the buffer first
+                UNIT_ASSERT_VALUES_EQUAL(0, rb->GetAvailableByteCount());
+
+                rb->PopFront();
+                rb->PopFront();
+                rb->PopFront();
+
+                UNIT_ASSERT_LT(0, rb->GetAvailableByteCount());
+
+                UNIT_ASSERT(rb->PushBack("!"));
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL("!", Dump(*rb));
+            UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui32>(dstVersion),
+                rb->GetVersion());
+
+            UNIT_ASSERT(rb->Validate().empty());
+        };
+
+        // Version upgrade
+        check(EVersion::V4, EVersion::V5, true);
+        check(EVersion::V4, EVersion::V6, false);
+        check(EVersion::V5, EVersion::V6, false);
+
+        // Version downgrade
+        check(EVersion::V6, EVersion::V5, false);
+        check(EVersion::V6, EVersion::V4, false);
+        check(EVersion::V5, EVersion::V4, false);
     }
 }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -298,7 +298,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     Y_UNIT_TEST(ShouldPushPopReferenceImplementation)
     {
         const ui32 len = 64;
-        TReferenceImplementation rb(len, EVersion::V4);
+        TReferenceImplementation rb(len, EVersion::V5);
 
         DoTestShouldPushPop(rb);
     }
@@ -472,7 +472,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     Y_UNIT_TEST(ShouldNotWriteBeyondBufferWhenEmpty)
     {
         const auto f = TTempFileHandle();
-        auto ri = TReferenceImplementation(64, EVersion::V4);
+        auto ri = TReferenceImplementation(64, EVersion::V5);
         auto rb = TFileRingBuffer(f.GetName(), 64);
 
         TString data(36, 'a');

--- a/cloud/storage/core/libs/file_backed_containers/ut/ya.make
+++ b/cloud/storage/core/libs/file_backed_containers/ut/ya.make
@@ -15,6 +15,7 @@ SRCS(
     dynamic_persistent_table_ut.cpp
     file_map_memory_limiter_ut.cpp
     file_ring_buffer_ut.cpp
+    file_ring_buffer_format_ut.cpp
     persistent_table_ut.cpp
 )
 


### PR DESCRIPTION
### Notes
Extracted from https://github.com/ydb-platform/nbs/pull/6198

Reliability improvements for TFileRingBuffer:

1. Add support for multiple versions and possibility to migrate to next and previous versions (this is very important in production when release needs to be reverted). Also, the code was extracted and move to a separate file.

2. Add new structure version (V6) that:
- Introduces header and alignment - this is needed to guarantee that entry headers are written atomically;
- Covers entry headers with checksum calculation.

### Issue
Related to https://github.com/ydb-platform/nbs/issues/1751
