### PR TITLE
issue-5894: TTCPSideChannel is now aware of shards and can properly work with multiple fastshard servers, added e2e qemu<->side-channel<->fastshard tests

### DIFF
--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -1,6 +1,7 @@
 #include "side_channel.h"
 
 #include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
+#include <cloud/filestore/libs/storage/model/utils.h>
 
 #include <cloud/filestore/public/api/protos/data.pb.h>
 #include <cloud/filestore/public/api/protos/headers.pb.h>
@@ -84,7 +85,7 @@ using TEndpointPoolPtr = TIntrusivePtr<TEndpointPool>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TTCPSideChannel: public ISideChannel
+class TFileSystemTCPSideChannel: public TThrRefBase
 {
 private:
     TAdaptiveLock Lock;
@@ -92,59 +93,24 @@ private:
     TString Host;
     ui16 Port = 0;
 
+    const TString ActualFileSystemId;
     TLog Log;
     std::shared_ptr<IAsyncClient> Client;
     TEndpointPoolPtr EndpointPool;
 
 public:
-    TTCPSideChannel(
-            ILoggingService& logging,
+    TFileSystemTCPSideChannel(
+            TString actualFileSystemId,
+            TLog log,
             std::shared_ptr<IAsyncClient> client)
-        : Log(logging.CreateLog("TCP_SIDE_CHANNEL"))
+        : ActualFileSystemId(std::move(actualFileSystemId))
+        , Log(std::move(log))
         , Client(std::move(client))
         , EndpointPool(MakeIntrusive<TEndpointPool>(Log))
     {}
 
 public:
-    // TODO(#5894) zero-copy io support
-
-    bool ExecuteRequest(
-        TCallContextPtr callContext,
-        std::shared_ptr<NProto::TReadDataRequest> request,
-        TPromise<NProto::TReadDataResponse> response) override
-    {
-        Y_UNUSED(callContext);
-
-        return Dispatch(
-            *request,
-            std::move(response),
-            [](TRequest& req, const NProto::TReadDataRequest& body) {
-                *req.MutableReadData() = body;
-            },
-            [](NProto::TReadDataResponse& resp, TResponse& r) {
-                resp = std::move(*r.MutableReadData());
-            });
-    }
-
-    bool ExecuteRequest(
-        TCallContextPtr callContext,
-        std::shared_ptr<NProto::TWriteDataRequest> request,
-        TPromise<NProto::TWriteDataResponse> response) override
-    {
-        Y_UNUSED(callContext);
-
-        return Dispatch(
-            *request,
-            std::move(response),
-            [](TRequest& req, const NProto::TWriteDataRequest& body) {
-                *req.MutableWriteData() = body;
-            },
-            [](NProto::TWriteDataResponse& resp, TResponse& r) {
-                resp = std::move(*r.MutableWriteData());
-            });
-    }
-
-    void Update(const NProto::TBackendInfo& backendInfo) override
+    void Update(const NProto::TBackendInfo& backendInfo)
     {
         const ui32 port = backendInfo.GetFastShardPort();
         const TString& host = backendInfo.GetFastShardHost();
@@ -156,6 +122,7 @@ public:
                 STORAGE_INFO("updated side channel connection params"
                     << ": host=" << host
                     << ", port=" << port
+                    << ", fileSystemId=" << backendInfo.GetActualFileSystemId()
                     << ", generation=" << generation);
             }
 
@@ -177,7 +144,6 @@ public:
             });
     }
 
-private:
     template <typename TReq,
               typename TResp,
               typename TFillBody,
@@ -188,6 +154,10 @@ private:
         TFillBody fillBody,
         TExtractBody extractBody)
     {
+        STORAGE_TRACE("dispatching request for"
+            << ": address=" << GetAddressDebugString()
+            << ", fileSystemId=" << ActualFileSystemId);
+
         ui32 generation = 0;
         IAsyncEndpointPtr e = EndpointPool->Pop(&generation);
 
@@ -220,7 +190,7 @@ private:
         };
 
         TRequest req;
-        req.SetFileSystemId(request.GetFileSystemId());
+        req.SetFileSystemId(ActualFileSystemId);
         fillBody(req, request);
 
         if (e) {
@@ -234,11 +204,18 @@ private:
                 complete(std::move(e), generation, UnsafeExtractValue(f));
             });
 
+            STORAGE_TRACE("sent request for"
+                << ": address=" << GetAddressDebugString()
+                << ", fileSystemId=" << ActualFileSystemId);
+
             return true;
         }
 
         auto connection = TryConnect();
         if (!connection.Initialized()) {
+            STORAGE_TRACE("conn not initialized for"
+                << ": address=" << GetAddressDebugString()
+                << ", fileSystemId=" << ActualFileSystemId);
             return false;
         }
 
@@ -268,9 +245,13 @@ private:
             });
         });
 
+        STORAGE_TRACE("connecting:"
+            << ": address=" << GetAddressDebugString()
+            << ", fileSystemId=" << ActualFileSystemId);
         return true;
     }
 
+private:
     TFuture<IAsyncEndpointPtr> TryConnect()
     {
         TString host;
@@ -299,6 +280,135 @@ private:
         });
 
         return connection;
+    }
+
+    TString GetAddressDebugString() const
+    {
+        TString host;
+        ui16 port = 0;
+        with_lock(Lock) {
+            host = Host;
+            port = Port;
+        }
+
+        return TStringBuilder() << "[" << host << "]:" << port;
+    }
+};
+
+using TFileSystemTCPSideChannelPtr = TIntrusivePtr<TFileSystemTCPSideChannel>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTCPSideChannel: public ISideChannel
+{
+private:
+    TAdaptiveLock Lock;
+
+    THashMap<TString, TFileSystemTCPSideChannelPtr> Id2Channel;
+
+    TLog Log;
+    std::shared_ptr<IAsyncClient> Client;
+
+public:
+    TTCPSideChannel(
+            ILoggingService& logging,
+            std::shared_ptr<IAsyncClient> client)
+        : Log(logging.CreateLog("TCP_SIDE_CHANNEL"))
+        , Client(std::move(client))
+    {}
+
+public:
+    // TODO(#5894) zero-copy io support
+
+    bool ExecuteRequest(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TReadDataRequest> request,
+        TPromise<NProto::TReadDataResponse> response) override
+    {
+        Y_UNUSED(callContext);
+
+        auto channel = AccessFileSystemChannel(*request);
+
+        return channel->Dispatch(
+            *request,
+            std::move(response),
+            [](TRequest& req, const NProto::TReadDataRequest& body) {
+                *req.MutableReadData() = body;
+            },
+            [](NProto::TReadDataResponse& resp, TResponse& r) {
+                resp = std::move(*r.MutableReadData());
+            });
+    }
+
+    bool ExecuteRequest(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteDataRequest> request,
+        TPromise<NProto::TWriteDataResponse> response) override
+    {
+        Y_UNUSED(callContext);
+
+        auto channel = AccessFileSystemChannel(*request);
+
+        return channel->Dispatch(
+            *request,
+            std::move(response),
+            [](TRequest& req, const NProto::TWriteDataRequest& body) {
+                *req.MutableWriteData() = body;
+            },
+            [](NProto::TWriteDataResponse& resp, TResponse& r) {
+                resp = std::move(*r.MutableWriteData());
+            });
+    }
+
+    void Update(const NProto::TBackendInfo& backendInfo) override
+    {
+        auto channel = AccessFileSystemChannel(
+            backendInfo.GetActualFileSystemId());
+
+        channel->Update(backendInfo);
+    }
+
+private:
+    TString MakeFileSystemId(const TString& mainFileSystemId, ui32 shardNo)
+        const
+    {
+        // TODO(#5894): Properly obtain shardNo -> shardFileSystemId mapping.
+        //  This code is a temporary hack intended to be used in the prototype.
+        if (!shardNo) {
+            return mainFileSystemId;
+        }
+
+        constexpr TStringBuf ShardNumPrefix = "_s";
+        return TStringBuilder() << mainFileSystemId
+            << ShardNumPrefix << shardNo;
+    }
+
+    TFileSystemTCPSideChannelPtr AccessFileSystemChannel(
+        const TString& actualFileSystemId)
+    {
+        with_lock (Lock) {
+            auto& channel = Id2Channel[actualFileSystemId];
+            if (!channel) {
+                STORAGE_INFO("initializing channel for fileSystemId="
+                    << actualFileSystemId);
+                channel = MakeIntrusive<TFileSystemTCPSideChannel>(
+                    actualFileSystemId,
+                    Log,
+                    Client);
+            }
+
+            return channel;
+        }
+    }
+
+    template <typename T>
+    TFileSystemTCPSideChannelPtr AccessFileSystemChannel(const T& request)
+    {
+        auto fileSystemId = MakeFileSystemId(
+            request.GetFileSystemId(),
+            NStorage::ExtractShardNo(request.GetHandle()));
+
+        return AccessFileSystemChannel(fileSystemId);
     }
 };
 

--- a/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel_ut.cpp
@@ -1,6 +1,7 @@
 #include "side_channel.h"
 
 #include <cloud/filestore/libs/storage/fastshard/client/async_client.h>
+#include <cloud/filestore/libs/storage/model/utils.h>
 
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
@@ -12,6 +13,10 @@ using namespace NThreading;
 using namespace NStorage::NFastShard;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr TStringBuf FileSystemId = "fs";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -32,13 +37,16 @@ struct TTestAsyncEndpoint: public IAsyncEndpoint
         return Response;
     }
 
-    void Reply(NProtoSrv::TResponse r)
+    bool Reply(NProtoSrv::TResponse r)
     {
         auto g = Guard(Lock);
-        UNIT_ASSERT(RequestReceived);
+        if (!RequestReceived) {
+            return false;
+        }
         RequestReceived = false;
         UNIT_ASSERT(Response.Initialized());
         Response.SetValue(std::move(r));
+        return true;
     }
 };
 
@@ -104,6 +112,7 @@ auto CC()
 auto ReadReq(ui64 handle, ui64 offset, ui64 len)
 {
     auto r = std::make_shared<NProto::TReadDataRequest>();
+    r->SetFileSystemId(TString(FileSystemId));
     r->SetHandle(handle);
     r->SetOffset(offset);
     r->SetLength(len);
@@ -113,6 +122,7 @@ auto ReadReq(ui64 handle, ui64 offset, ui64 len)
 auto WriteReq(ui64 handle, ui64 offset, TString data)
 {
     auto r = std::make_shared<NProto::TWriteDataRequest>();
+    r->SetFileSystemId(TString(FileSystemId));
     r->SetHandle(handle);
     r->SetOffset(offset);
     r->SetBuffer(std::move(data));
@@ -134,6 +144,15 @@ auto ReadResp(NProto::TError e, TString data)
     *rd->MutableError() = std::move(e);
     rd->SetBuffer(std::move(data));
     return r;
+}
+
+auto BackendInfo()
+{
+    NProto::TBackendInfo backendInfo;
+    backendInfo.SetFastShardHost("h1");
+    backendInfo.SetFastShardPort(111);
+    backendInfo.SetActualFileSystemId(TString(FileSystemId));
+    return backendInfo;
 }
 
 }   // namespace
@@ -162,10 +181,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
             readResponse);
         UNIT_ASSERT(!success);
 
-        NProto::TBackendInfo backendInfo;
-        backendInfo.SetFastShardHost("h1");
-        backendInfo.SetFastShardPort(111);
-        sideChannel->Update(backendInfo);
+        sideChannel->Update(BackendInfo());
 
         TConnInfo connInfo;
         auto e = client->CompleteConnection(&connInfo);
@@ -186,7 +202,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
             e->Req.GetWriteData().GetBuffer());
         UNIT_ASSERT(!writeResponse.HasValue());
 
-        e->Reply(WriteResp(MakeError(S_ALREADY)));
+        UNIT_ASSERT(e->Reply(WriteResp(MakeError(S_ALREADY))));
         UNIT_ASSERT(writeResponse.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(
             S_ALREADY,
@@ -202,7 +218,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         UNIT_ASSERT_VALUES_EQUAL(1_KB, e->Req.GetReadData().GetLength());
         UNIT_ASSERT(!readResponse.HasValue());
 
-        e->Reply(ReadResp(MakeError(S_OK), TString(1_KB, 'a')));
+        UNIT_ASSERT(e->Reply(ReadResp(MakeError(S_OK), TString(1_KB, 'a'))));
         UNIT_ASSERT(readResponse.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(
             S_OK,
@@ -218,10 +234,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         auto client = std::make_shared<TTestAsyncClient>();
         auto sideChannel = CreateTCPSideChannel(*logging, client);
 
-        NProto::TBackendInfo backendInfo;
-        backendInfo.SetFastShardHost("h1");
-        backendInfo.SetFastShardPort(111);
-        sideChannel->Update(backendInfo);
+        sideChannel->Update(BackendInfo());
 
         auto writeResponse = NewPromise<NProto::TWriteDataResponse>();
         bool success = sideChannel->ExecuteRequest(
@@ -248,7 +261,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
             e->Req.GetWriteData().GetBuffer());
         UNIT_ASSERT(!writeResponse.HasValue());
 
-        e->Reply(WriteResp(MakeError(S_ALREADY)));
+        UNIT_ASSERT(e->Reply(WriteResp(MakeError(S_ALREADY))));
         UNIT_ASSERT(writeResponse.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(
             S_ALREADY,
@@ -261,10 +274,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         auto client = std::make_shared<TTestAsyncClient>();
         auto sideChannel = CreateTCPSideChannel(*logging, client);
 
-        NProto::TBackendInfo backendInfo;
-        backendInfo.SetFastShardHost("h1");
-        backendInfo.SetFastShardPort(111);
-        sideChannel->Update(backendInfo);
+        sideChannel->Update(BackendInfo());
 
         TConnInfo connInfo;
         auto e = client->CompleteConnection(&connInfo);
@@ -307,7 +317,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         }
 
         for (ui32 i = 0; i < writeCount; ++i) {
-            es[i]->Reply(WriteResp(MakeError(S_ALREADY)));
+            UNIT_ASSERT(es[i]->Reply(WriteResp(MakeError(S_ALREADY))));
             UNIT_ASSERT(writeResponses[i].HasValue());
             UNIT_ASSERT_VALUES_EQUAL(
                 S_ALREADY,
@@ -321,10 +331,7 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
         auto client = std::make_shared<TTestAsyncClient>();
         auto sideChannel = CreateTCPSideChannel(*logging, client);
 
-        NProto::TBackendInfo backendInfo;
-        backendInfo.SetFastShardHost("h1");
-        backendInfo.SetFastShardPort(111);
-        sideChannel->Update(backendInfo);
+        sideChannel->Update(BackendInfo());
 
         TConnInfo connInfo;
         client->FailConnection(&connInfo);
@@ -351,6 +358,101 @@ Y_UNIT_TEST_SUITE(TSideChannelTest)
             E_UNAVAILABLE,
             writeResponse.GetValue().GetError().GetCode(),
             writeResponse.GetValue().GetError().GetMessage());
+    }
+
+    Y_UNIT_TEST(ShouldSendRequestsToCorrectEndpoint)
+    {
+        auto logging = CreateLoggingService("console", { TLOG_RESOURCES });
+        auto client = std::make_shared<TTestAsyncClient>();
+        auto sideChannel = CreateTCPSideChannel(*logging, client);
+
+        sideChannel->Update(BackendInfo());
+
+        TConnInfo connInfo;
+        auto e = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e);
+        UNIT_ASSERT_VALUES_EQUAL("h1", connInfo.Host);
+        UNIT_ASSERT_VALUES_EQUAL(111, connInfo.Port);
+        TVector<std::shared_ptr<TTestAsyncEndpoint>> es;
+        es.push_back(std::move(e));
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+
+        constexpr ui32 Sid1 = 10;
+        constexpr ui32 Sid2 = 15;
+
+        auto w1 = NewPromise<NProto::TWriteDataResponse>();
+        bool success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(NStorage::ShardedId(1, Sid1), 1_KB, TString(1_KB, 'a')),
+            w1);
+        UNIT_ASSERT(!success);
+
+        auto backendInfo1 = BackendInfo();
+        backendInfo1.SetFastShardHost("h2");
+        backendInfo1.SetActualFileSystemId(
+            TStringBuilder() << FileSystemId << "_s10");
+        sideChannel->Update(backendInfo1);
+
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(NStorage::ShardedId(1, Sid1), 1_KB, TString(1_KB, 'a')),
+            w1);
+        UNIT_ASSERT(success);
+        UNIT_ASSERT(!w1.HasValue());
+
+        auto e11 = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e11);
+        UNIT_ASSERT_VALUES_EQUAL("h2", connInfo.Host);
+        auto e12 = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e12);
+        UNIT_ASSERT_VALUES_EQUAL("h2", connInfo.Host);
+        UNIT_ASSERT(e12->Reply(WriteResp(MakeError(S_ALREADY))));
+        UNIT_ASSERT(w1.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, w1.GetValue().GetError().GetCode());
+
+        w1 = NewPromise<NProto::TWriteDataResponse>();
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(NStorage::ShardedId(1, Sid1), 1_KB, TString(1_KB, 'a')),
+            w1);
+        UNIT_ASSERT(success);
+        UNIT_ASSERT(!w1.HasValue());
+
+        UNIT_ASSERT(!client->CompleteConnection(&connInfo));
+        UNIT_ASSERT(e11->Reply(WriteResp(MakeError(S_FALSE))));
+        UNIT_ASSERT(w1.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(S_FALSE, w1.GetValue().GetError().GetCode());
+
+        auto w2 = NewPromise<NProto::TWriteDataResponse>();
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(NStorage::ShardedId(1, Sid2), 1_KB, TString(1_KB, 'a')),
+            w2);
+        UNIT_ASSERT(!success);
+
+        auto backendInfo2 = BackendInfo();
+        backendInfo2.SetFastShardHost("h3");
+        backendInfo2.SetActualFileSystemId(
+            TStringBuilder() << FileSystemId << "_s15");
+        sideChannel->Update(backendInfo2);
+
+        success = sideChannel->ExecuteRequest(
+            CC(),
+            WriteReq(NStorage::ShardedId(1, Sid2), 1_KB, TString(1_KB, 'a')),
+            w2);
+        UNIT_ASSERT(success);
+        UNIT_ASSERT(!w2.HasValue());
+
+        auto e21 = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e21);
+        UNIT_ASSERT_VALUES_EQUAL("h3", connInfo.Host);
+        auto e22 = client->CompleteConnection(&connInfo);
+        UNIT_ASSERT(e22);
+        UNIT_ASSERT_VALUES_EQUAL("h3", connInfo.Host);
+        UNIT_ASSERT(e22->Reply(WriteResp(MakeError(E_IO))));
+        UNIT_ASSERT(w2.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(E_IO, w2.GetValue().GetError().GetCode());
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -59,6 +59,7 @@ namespace NCloud::NFileStore::NStorage {
 inline void BuildBackendInfo(
     const TStorageConfig& config,
     const TSystemCounters& systemCounters,
+    TString fileSystemId,
     ui32 tabletActorCpuUsageRate,
     NProto::TBackendInfo* backendInfo)
 {
@@ -73,12 +74,15 @@ inline void BuildBackendInfo(
         backendInfo->SetFastShardHost(FQDNHostName());
         backendInfo->SetFastShardPort(fastShardPort);
     }
+
+    backendInfo->SetActualFileSystemId(std::move(fileSystemId));
 }
 
 template <typename T>
 void BuildBackendInfo(
     const TStorageConfig& config,
     const TSystemCounters& systemCounters,
+    TString fileSystemId,
     ui32 tabletActorCpuUsageRate,
     T& response)
 {
@@ -88,6 +92,7 @@ void BuildBackendInfo(
         BuildBackendInfo(
             config,
             systemCounters,
+            std::move(fileSystemId),
             tabletActorCpuUsageRate,
             backendInfo);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -274,6 +274,7 @@ void TIndexTabletActor::CompleteTx_AddData(
     BuildBackendInfo(
         *Config,
         *SystemCounters,
+        GetFileSystemId(),
         Metrics.CPUUsageRate,
         &backendInfo);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -1132,6 +1132,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
     BuildBackendInfo(
         *Config,
         *SystemCounters,
+        GetFileSystemId(),
         Metrics.CPUUsageRate,
         &backendInfo);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_request.cpp
@@ -117,6 +117,7 @@ void TIndexTabletActor::CompleteResponse(
     BuildBackendInfo(
         *Config,
         *SystemCounters,
+        GetFileSystemId(),
         Metrics.CPUUsageRate,
         response);
     if constexpr (HasResponseHeaders<decltype(response)>()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -497,6 +497,7 @@ void TIndexTabletActor::CompleteTx_WriteData(
     BuildBackendInfo(
         *Config,
         *SystemCounters,
+        GetFileSystemId(),
         Metrics.CPUUsageRate,
         &backendInfo);
 

--- a/cloud/filestore/public/api/protos/headers.proto
+++ b/cloud/filestore/public/api/protos/headers.proto
@@ -82,6 +82,11 @@ message TBackendInfo
     // connection for latency-critical IO, bypassing the actor system.
     string FastShardHost = 2;
     uint32 FastShardPort = 3;
+
+    // The id of the filesystem shard if this response comes from the shard and
+    // the id of the filesystem itself if this response comes from the main
+    // tablet.
+    string ActualFileSystemId = 4;
 }
 
 message TResponseHeaders

--- a/cloud/filestore/tests/fmdtest/configs/vhost-sidechannel.txt
+++ b/cloud/filestore/tests/fmdtest/configs/vhost-sidechannel.txt
@@ -1,0 +1,1 @@
+SideChannelType: SCT_TCP

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/canondata/result.json
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/canondata/result.json
@@ -1,0 +1,5 @@
+{
+    "test.test_create_unlink_steal": {
+        "uri": "file://test.test_create_unlink_steal/create_unlink_steal_results.txt"
+    }
+}

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/canondata/test.test_create_unlink_steal/create_unlink_steal_results.txt
@@ -1,0 +1,15 @@
+{
+    "create": true,
+    "create-lat-us": true,
+    "unlink": true,
+    "unlink-lat-us": true,
+    "rename": true,
+    "rename-lat-us": true,
+    "stat": true,
+    "stat-lat-us": true,
+    "list": true,
+    "list-lat-us": true,
+    "list-w": true,
+    "list-wlat-us": true,
+    "errors": false
+}

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/test.py
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/test.py
@@ -1,0 +1,54 @@
+import json
+import os
+
+import yatest.common as common
+
+from cloud.filestore.tests.python.lib.fastshard import configure_fastshard
+from cloud.storage.core.tools.testing.qemu.lib.common import (
+    env_with_guest_index,
+    SshToGuest,
+)
+
+
+def do_test(test_name, aux_params):
+    fast_shard_config = {
+        "MemConfig": {}
+    }
+
+    configure_fastshard(
+        shard_count=20,
+        file_shard_count=10,
+        fast_shard_config=fast_shard_config)
+
+    port = int(os.getenv(env_with_guest_index("QEMU_FORWARDING_PORT", 0)))
+    ssh_key = os.getenv("QEMU_SSH_KEY")
+    mount_dir = os.getenv("NFS_MOUNT_PATH")
+
+    ssh = SshToGuest(user="qemu", port=port, key=ssh_key)
+
+    fmdtest_bin = common.binary_path(
+        "cloud/filestore/tools/testing/fmdtest/bin/fmdtest")
+
+    working_dir = os.path.join(mount_dir, test_name + "_wd")
+    report_file = "report.json"
+
+    ssh(f"{fmdtest_bin} --test-dir {working_dir} --report-path {report_file}"
+        f" {aux_params}")
+
+    ret = ssh(f"sudo cat {report_file}")
+    report = json.loads(ret.stdout.decode("utf8"))
+    for k, v in report.items():
+        report[k] = v > 0
+
+    results_path = f"{common.output_path()}/{test_name}_results.txt"
+    with open(results_path, 'w') as results:
+        results.write(json.dumps(report, indent=4))
+
+    ret = common.canonical_file(results_path, local=True)
+    return ret
+
+
+def test_create_unlink_steal():
+    return do_test(
+        "create_unlink_steal",
+        "--duration 60s --stealer-threads 1")

--- a/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/ya.make
+++ b/cloud/filestore/tests/fmdtest/qemu-kikimr-sidechannel-test/ya.make
@@ -1,0 +1,46 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+SPLIT_FACTOR(1)
+
+TEST_SRCS(
+    test.py
+)
+
+DEPENDS(
+    cloud/filestore/apps/client
+    cloud/filestore/tools/testing/fmdtest/bin
+)
+
+PEERDIR(
+    cloud/filestore/public/sdk/python/client
+    cloud/filestore/tests/python/lib
+
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/fmdtest/configs/nfs-storage.txt
+)
+
+SET(
+    NFS_SERVICE_CONFIG_PATCH
+    cloud/filestore/tests/fmdtest/configs/vhost-sidechannel.txt
+)
+
+SET(USE_FAST_SHARD_PORT yes)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_INSTANCE_COUNT 1)
+SET(FILESTORE_VHOST_ENDPOINT_COUNT 1)
+SET(FILESTORE_BLOCKS_COUNT 5242880)
+SET(VIRTIOFS_SERVER_COUNT 1)
+SET(QEMU_INVOKE_TEST NO)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/fmdtest/ya.make
+++ b/cloud/filestore/tests/fmdtest/ya.make
@@ -2,5 +2,6 @@ RECURSE_FOR_TESTS(
     qemu-kikimr-memshard-nemesis-test
     qemu-kikimr-memshard-test
     qemu-kikimr-nemesis-test
+    qemu-kikimr-sidechannel-test
     qemu-kikimr-unsafe-test
 )


### PR DESCRIPTION
### Notes
* `TTCPSideChannel` now has a mapping between `ActualFileSystemId` (main tablet or shard) and `TFileSystemTCPSideChannel` - needed because different tablets can run on different filestore-server instances
* added more logging to `TTCPSideChannel`
* added e2e tests with qemu that use side-channel

### Issue
https://github.com/ydb-platform/nbs/issues/5894