### PR TITLE
[codex] Fix RDMA request lifetime during flush

### DIFF
--- a/cloud/blockstore/libs/client_rdma/rdma_client.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client.cpp
@@ -249,7 +249,7 @@ private:
             dst);
 
         STORAGE_VERIFY(
-            bytesRead == dstSize,
+            bytesRead == srcSize,
             TWellKnownEntityTypes::DISK,
             GetDiskId(Request->GetDiskId()));
 

--- a/cloud/blockstore/libs/client_rdma/rdma_client_ut.cpp
+++ b/cloud/blockstore/libs/client_rdma/rdma_client_ut.cpp
@@ -346,6 +346,40 @@ Y_UNIT_TEST_SUITE(TRdmaClientTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldReadIntoLargerSglist)
+    {
+        TTestEnv env;
+        auto endpoint = env.CreateDataEndpoint();
+
+        TString firstBlock(DefaultBlockSize, 'x');
+        TString secondBlock(DefaultBlockSize, 'q');
+
+        auto request = std::make_shared<NProto::TReadBlocksLocalRequest>();
+        request->SetStartIndex(0);
+        request->SetBlocksCount(1);
+        request->SetBlockSize(DefaultBlockSize);
+
+        TSgList sglist{
+            {const_cast<char*>(firstBlock.data()), firstBlock.size()},
+            {const_cast<char*>(secondBlock.data()), secondBlock.size()},
+        };
+        request->Sglist = TGuardedSgList(std::move(sglist));
+
+        auto future = endpoint->ReadBlocksLocal(
+            MakeIntrusive<TCallContext>(),
+            std::move(request));
+
+        UNIT_ASSERT_C(future.HasValue(), "Value not set");
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            future.GetValue().GetError().GetCode());
+
+        UNIT_ASSERT_VALUES_EQUAL(TString(DefaultBlockSize, 0), firstBlock);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'q'),
+            secondBlock);
+    }
+
     Y_UNIT_TEST(ShouldFailReadWhenSglistClosed)
     {
         TTestEnv env;

--- a/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
+++ b/cloud/blockstore/libs/endpoints_rdma/rdma_server.cpp
@@ -127,6 +127,7 @@ void TRdmaEndpoint::HandleRequest(
 {
     TaskQueue->ExecuteSimple(
         [self = weak_from_this(),
+         endpoint = Endpoint,
          context,
          callContext = ToBlockStoreCallContext(std::move(callContext)),
          in,
@@ -150,12 +151,10 @@ void TRdmaEndpoint::HandleRequest(
                 });
 
             if (HasError(error)) {
-                if (auto p = self.lock()) {
-                    p->Endpoint->SendError(
-                        context,
-                        error.GetCode(),
-                        error.GetMessage());
-                }
+                endpoint->SendError(
+                    context,
+                    error.GetCode(),
+                    error.GetMessage());
             }
         });
 }
@@ -225,7 +224,7 @@ NProto::TError TRdmaEndpoint::HandleReadBlocksRequest(
         std::move(req));
 
     future.Subscribe(
-        [self = weak_from_this(),
+        [endpoint = Endpoint,
          taskQueue = TaskQueue,
          guardedSgList = std::move(guardedSgList),
          buffer = std::move(buffer),
@@ -233,27 +232,25 @@ NProto::TError TRdmaEndpoint::HandleReadBlocksRequest(
          context](TFuture<NProto::TReadBlocksLocalResponse> future) mutable
         {
             taskQueue->ExecuteSimple(
-                [self = std::move(self),
+                [endpoint = std::move(endpoint),
                  guardedSgList = std::move(guardedSgList),
                  buffer = std::move(buffer),
                  out,
                  response = ExtractResponse(future),
                  context]()
                 {
-                    if (auto p = self.lock()) {
-                        auto guard = guardedSgList.Acquire();
-                        Y_ENSURE(guard);
+                    auto guard = guardedSgList.Acquire();
+                    Y_ENSURE(guard);
 
-                        const auto& sglist = guard.Get();
-                        size_t responseBytes = NCloud::NStorage::NRdma::
-                            TProtoMessageSerializer::SerializeWithData(
-                                out,
-                                TBlockStoreProtocol::ReadBlocksResponse,
-                                0,   // flags
-                                response, sglist);
+                    const auto& sglist = guard.Get();
+                    size_t responseBytes = NCloud::NStorage::NRdma::
+                        TProtoMessageSerializer::SerializeWithData(
+                            out,
+                            TBlockStoreProtocol::ReadBlocksResponse,
+                            0,   // flags
+                            response, sglist);
 
-                        p->Endpoint->SendResponse(context, responseBytes);
-                    }
+                    endpoint->SendResponse(context, responseBytes);
                 });
         });
 
@@ -283,14 +280,14 @@ NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
         std::move(req));
 
     future.Subscribe(
-        [self = weak_from_this(),
+        [endpoint = Endpoint,
          taskQueue = TaskQueue,
          guardedSgList = std::move(guardedSgList),
          out,
          context](TFuture<NProto::TWriteBlocksLocalResponse> future) mutable
         {
             taskQueue->ExecuteSimple(
-                [self = std::move(self),
+                [endpoint = std::move(endpoint),
                  guardedSgList = std::move(guardedSgList),
                  out,
                  response = ExtractResponse(future),
@@ -299,15 +296,13 @@ NProto::TError TRdmaEndpoint::HandleWriteBlocksRequest(
                     // enlarge lifetime of guardedSgList
                     Y_UNUSED(guardedSgList);
 
-                    if (auto p = self.lock()) {
-                        size_t responseBytes = NCloud::NStorage::NRdma::
-                            TProtoMessageSerializer::Serialize(
-                                out,
-                                TBlockStoreProtocol::WriteBlocksResponse,
-                                0,   // flags
-                                response);
-                        p->Endpoint->SendResponse(context, responseBytes);
-                    }
+                    size_t responseBytes = NCloud::NStorage::NRdma::
+                        TProtoMessageSerializer::Serialize(
+                            out,
+                            TBlockStoreProtocol::WriteBlocksResponse,
+                            0,   // flags
+                            response);
+                    endpoint->SendResponse(context, responseBytes);
                 });
         });
 
@@ -330,20 +325,18 @@ NProto::TError TRdmaEndpoint::HandleZeroBlocksRequest(
         std::move(req));
 
     future.Subscribe(
-        [self = weak_from_this(), out, context](
+        [endpoint = Endpoint, out, context](
             TFuture<NProto::TZeroBlocksResponse> future)
         {
-            if (auto p = self.lock()) {
-                auto response = ExtractResponse(future);
+            auto response = ExtractResponse(future);
 
-                size_t responseBytes =
-                    NCloud::NStorage::NRdma::TProtoMessageSerializer::Serialize(
-                        out,
-                        TBlockStoreProtocol::ZeroBlocksResponse,
-                        0,   // flags
-                        response);
-                p->Endpoint->SendResponse(context, responseBytes);
-            }
+            size_t responseBytes =
+                NCloud::NStorage::NRdma::TProtoMessageSerializer::Serialize(
+                    out,
+                    TBlockStoreProtocol::ZeroBlocksResponse,
+                    0,   // flags
+                    response);
+            endpoint->SendResponse(context, responseBytes);
         });
 
     return {};

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -172,9 +172,14 @@ private:
         TStringBuf in,
         TStringBuf out) override
     {
+        auto endpoint = Endpoint.lock();
+        if (!endpoint) {
+            return;
+        }
+
         TaskQueue->ExecuteSimple(
             [=,
-             endpoint = Endpoint,
+             endpoint = std::move(endpoint),
              callContext =
                  ToBlockStoreCallContext(std::move(callContext))]() mutable
             {
@@ -183,12 +188,10 @@ private:
                     { return DoHandleRequest(context, callContext, in, out); });
 
                 if (HasError(error)) {
-                    if (auto ep = endpoint.lock()) {
-                        ep->SendError(
-                            context,
-                            error.GetCode(),
-                            error.GetMessage());
-                    }
+                    endpoint->SendError(
+                        context,
+                        error.GetCode(),
+                        error.GetMessage());
                 }
             });
     }
@@ -255,7 +258,7 @@ private:
             request->GetBlockSize());
         Y_ENSURE_RETURN(error.GetCode() == 0, "cannot create sgList");
 
-        TGuardedSgList guardedSgList(sglist);
+        auto guardedSgList = buffer.CreateGuardedSgList(std::move(sglist));
 
         auto req = std::make_shared<NProto::TReadBlocksLocalRequest>();
         req->CopyFrom(*request);
@@ -270,7 +273,7 @@ private:
              guardedSgList = std::move(guardedSgList),
              blockSize = request->GetBlockSize(),
              taskQueue = TaskQueue,
-             endpoint = Endpoint,
+             endpoint = Endpoint.lock(),
              weakSelf = weak_from_this()](auto future) mutable
             {
                 auto response = ExtractResponse(future);
@@ -321,8 +324,8 @@ private:
                             *response.MutableError() = MakeError(
                                 E_REJECTED,
                                 "Unable to serialize ReadBlocks response");
-                            if (auto ep = endpoint.lock()) {
-                                ep->SendError(
+                            if (endpoint) {
+                                endpoint->SendError(
                                     context,
                                     E_REJECTED,
                                     "unable to serialize ReadBlocks response");
@@ -330,8 +333,8 @@ private:
                             return;
                         }
 
-                        if (auto ep = endpoint.lock()) {
-                            ep->SendResponse(context, responseBytes);
+                        if (endpoint) {
+                            endpoint->SendResponse(context, responseBytes);
                         }
                     });
             });
@@ -376,7 +379,7 @@ private:
         future.Subscribe(
             [=,
              taskQueue = TaskQueue,
-             endpoint = Endpoint,
+             endpoint = Endpoint.lock(),
              weakSelf = weak_from_this()](auto future)
             {
                 auto response = ExtractResponse(future);
@@ -417,16 +420,16 @@ private:
                             *response.MutableError() = MakeError(
                                 E_REJECTED,
                                 "Unable to serialize WriteBlocks response");
-                            if (auto ep = endpoint.lock()) {
-                                ep->SendError(
+                            if (endpoint) {
+                                endpoint->SendError(
                                     context,
                                     E_REJECTED,
                                     "unable to serialize WriteBlocks response");
                             }
                             return;
                         }
-                        if (auto ep = endpoint.lock()) {
-                            ep->SendResponse(context, responseBytes);
+                        if (endpoint) {
+                            endpoint->SendResponse(context, responseBytes);
                         }
                     });
             });
@@ -461,7 +464,7 @@ private:
         future.Subscribe(
             [out = out,
              context = context,
-             endpoint = Endpoint,
+             endpoint = Endpoint.lock(),
              callContext = std::move(callContext),
              weakSelf = weak_from_this()](auto future)
             {
@@ -499,16 +502,16 @@ private:
                         MakeError(
                             E_REJECTED,
                             "Unable to serialize ZeroBlocks response");
-                    if (auto ep = endpoint.lock()) {
-                        ep->SendError(
+                    if (endpoint) {
+                        endpoint->SendError(
                             context,
                             E_REJECTED,
                             "unable to serialize ZeroBlocks response");
                     }
                     return;
                 }
-                if (auto ep = endpoint.lock()) {
-                    ep->SendResponse(context, responseBytes);
+                if (endpoint) {
+                    endpoint->SendResponse(context, responseBytes);
                 }
             });
 
@@ -574,7 +577,7 @@ private:
         future.Subscribe(
             [out = out,
              context = context,
-             endpoint = Endpoint,
+             endpoint = Endpoint.lock(),
              callContext = std::move(callContext),
              weakSelf = weak_from_this()](auto future)
             {
@@ -599,8 +602,8 @@ private:
                         MakeError(
                             E_REJECTED,
                             "Unable to serialize MountVolume response");
-                    if (auto ep = endpoint.lock()) {
-                        ep->SendError(
+                    if (endpoint) {
+                        endpoint->SendError(
                             context,
                             E_REJECTED,
                             "unable to serialize MountVolume response");
@@ -608,8 +611,8 @@ private:
                     return;
                 }
 
-                if (auto ep = endpoint.lock()) {
-                    ep->SendResponse(context, responseBytes);
+                if (endpoint) {
+                    endpoint->SendResponse(context, responseBytes);
                 }
             });
 
@@ -643,7 +646,7 @@ private:
         future.Subscribe(
             [out = out,
              context = context,
-             endpoint = Endpoint,
+             endpoint = Endpoint.lock(),
              callContext = std::move(callContext),
              weakSelf = weak_from_this()](auto future)
             {
@@ -668,8 +671,8 @@ private:
                         MakeError(
                             E_REJECTED,
                             "Unable to serialize UnmountVolume response");
-                    if (auto ep = endpoint.lock()) {
-                        ep->SendError(
+                    if (endpoint) {
+                        endpoint->SendError(
                             context,
                             E_REJECTED,
                             "unable to serialize UnmountVolume response");
@@ -677,8 +680,8 @@ private:
                     return;
                 }
 
-                if (auto ep = endpoint.lock()) {
-                    ep->SendResponse(context, responseBytes);
+                if (endpoint) {
+                    endpoint->SendResponse(context, responseBytes);
                 }
             });
 

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target.cpp
@@ -55,6 +55,7 @@ struct TRequestDetails
     void* Context = nullptr;
     TStringBuf Out;
     TStringBuf DataBuffer; // if non empty, zero copy is possible
+    NCloud::NStorage::NRdma::IServerEndpointPtr Endpoint;
     TString DeviceUUID;
     TString ClientId;
 
@@ -187,9 +188,14 @@ public:
         TStringBuf in,
         TStringBuf out) override
     {
+        auto endpoint = Endpoint.lock();
+        if (!endpoint) {
+            return;
+        }
+
         TaskQueue->ExecuteSimple(
             [self = shared_from_this(),
-             endpoint = Endpoint,
+             endpoint = std::move(endpoint),
              context = context,
              callContext = ToBlockStoreCallContext(std::move(callContext)),
              in = in,
@@ -210,12 +216,10 @@ public:
                     });
 
                 if (error.GetCode()) {
-                    if (auto ep = endpoint.lock()) {
-                        ep->SendError(
-                            context,
-                            error.GetCode(),
-                            error.GetMessage());
-                    }
+                    endpoint->SendError(
+                        context,
+                        error.GetCode(),
+                        error.GetMessage());
                 }
             });
     }
@@ -590,6 +594,7 @@ private:
                 .Context = context,
                 .Out = out,
                 .DataBuffer = dataBuffer,
+                .Endpoint = Endpoint.lock(),
                 .DeviceUUID = request.GetDeviceUUID(),
                 .ClientId = request.GetHeaders().GetClientId()},
             &TRequestHandler::HandleReadBlocksResponse);
@@ -648,8 +653,8 @@ private:
                     flags, proto, parts);
         }
 
-        if (auto ep = Endpoint.lock()) {
-            ep->SendResponse(requestDetails.Context, bytes);
+        if (requestDetails.Endpoint) {
+            requestDetails.Endpoint->SendResponse(requestDetails.Context, bytes);
         }
     }
 
@@ -701,6 +706,7 @@ private:
                 {.Context = context,
                  .Out = out,
                  .DataBuffer = dataBuffer,
+                 .Endpoint = Endpoint.lock(),
                  .DeviceUUID = request.GetDeviceUUID(),
                  .ClientId = request.GetHeaders().GetClientId(),
                  .VolumeRequestId = request.GetVolumeRequestId(),
@@ -793,8 +799,8 @@ private:
                 0,   // flags
                 proto);
 
-        if (auto ep = Endpoint.lock()) {
-            ep->SendResponse(requestDetails.Context, bytes);
+        if (requestDetails.Endpoint) {
+            requestDetails.Endpoint->SendResponse(requestDetails.Context, bytes);
         }
     }
 
@@ -830,6 +836,7 @@ private:
                 {.Context = context,
                  .Out = out,
                  .DataBuffer = {},
+                 .Endpoint = Endpoint.lock(),
                  .DeviceUUID = deviceUUID,
                  .ClientId = req->GetHeaders().GetClientId(),
                  .VolumeRequestId = req->GetVolumeRequestId(),
@@ -919,8 +926,8 @@ private:
                 0,   // flags
                 proto);
 
-        if (auto ep = Endpoint.lock()) {
-            ep->SendResponse(requestDetails.Context, bytes);
+        if (requestDetails.Endpoint) {
+            requestDetails.Endpoint->SendResponse(requestDetails.Context, bytes);
         }
     }
 
@@ -949,6 +956,7 @@ private:
                 {.Context = context,
                  .Out = out,
                  .DataBuffer = {},   // no data buffer
+                 .Endpoint = Endpoint.lock(),
                  .DeviceUUID = request.GetDeviceUUID(),
                  .ClientId = request.GetHeaders().GetClientId(),
                  .VolumeRequestId = request.GetVolumeRequestId(),
@@ -1039,8 +1047,8 @@ private:
                 0,   // flags
                 proto);
 
-        if (auto ep = Endpoint.lock()) {
-            ep->SendResponse(requestDetails.Context, bytes);
+        if (requestDetails.Endpoint) {
+            requestDetails.Endpoint->SendResponse(requestDetails.Context, bytes);
         }
     }
 
@@ -1079,6 +1087,7 @@ private:
                 .Context = context,
                 .Out = out,
                 .DataBuffer = {},   // no data buffer
+                .Endpoint = Endpoint.lock(),
                 .DeviceUUID = request.GetDeviceUUID(),
                 .ClientId = request.GetHeaders().GetClientId()},
             &TRequestHandler::HandleChecksumBlocksResponse);
@@ -1119,8 +1128,8 @@ private:
                 0,   // flags
                 proto);
 
-        if (auto ep = Endpoint.lock()) {
-            ep->SendResponse(requestDetails.Context, bytes);
+        if (requestDetails.Endpoint) {
+            requestDetails.Endpoint->SendResponse(requestDetails.Context, bytes);
         }
     }
 };

--- a/cloud/storage/core/libs/rdma/impl/server.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server.cpp
@@ -97,6 +97,7 @@ struct TRequest
 
     TPooledBuffer InBuffer {};
     TPooledBuffer OutBuffer {};
+    bool HandlerOwned = false;
 
     TRequest(std::weak_ptr<TServerSession> session)
         : Session(std::move(session))
@@ -294,6 +295,7 @@ private:
     TLockFreeList<TRequest> InputRequests;
     TSimpleList<TRequest> QueuedRequests;
     TEventHandle RequestEvent;
+    TAtomic ActiveRequestsInHandlers = 0;
     bool FlushStarted = false;
 
 public:
@@ -330,6 +332,7 @@ public:
     bool HandleInputRequests() noexcept;
     bool HandleCompletionEvents() noexcept;
     bool IsFlushed() const;
+    bool CanReleaseAfterStop() const;
 
 private:
     // called from CQ thread
@@ -627,6 +630,10 @@ void TServerSession::Flush() noexcept
 {
     RDMA_DEBUG("flush queues");
 
+    if (FlushStarted) {
+        return;
+    }
+
     try {
         struct ibv_qp_attr attr = {.qp_state = IBV_QPS_ERR};
         Verbs->ModifyQP(Connection->qp, &attr, IBV_QP_STATE);
@@ -641,8 +648,15 @@ void TServerSession::Flush() noexcept
 bool TServerSession::IsFlushed() const
 {
     return FlushStarted
+        && AtomicGet(ActiveRequestsInHandlers) == 0
         && SendQueue.Size() == Config->SendQueueSize
         && RecvQueue.Size() == Config->RecvQueueSize;
+}
+
+bool TServerSession::CanReleaseAfterStop() const
+{
+    return FlushStarted
+        && AtomicGet(ActiveRequestsInHandlers) == 0;
 }
 
 int TServerSession::ValidateCompletion(ibv_wc* wc) noexcept
@@ -799,6 +813,10 @@ void TServerSession::FreeRequest(TRequestPtr req, TSendWr* send) noexcept
 {
     if (req == nullptr) {
         return;
+    }
+    if (req->HandlerOwned) {
+        req->HandlerOwned = false;
+        AtomicDecrement(ActiveRequestsInHandlers);
     }
     RecvBuffers.ReleaseBuffer(req->InBuffer);
     SendBuffers.ReleaseBuffer(req->OutBuffer);
@@ -1009,6 +1027,9 @@ void TServerSession::ExecuteRequest(TRequestPtr req) noexcept
         ExecuteRequest,
         req->CallContext->LWOrbit,
         req->CallContext->RequestId);
+
+    req->HandlerOwned = true;
+    AtomicIncrement(ActiveRequestsInHandlers);
 
     Handler->HandleRequest(req.get(), req->CallContext, in, out);
 
@@ -1397,6 +1418,18 @@ public:
         return Sessions.Get();
     }
 
+    bool HasSessions()
+    {
+        return !Sessions.Get()->empty();
+    }
+
+    void FlushSessions()
+    {
+        for (const auto& session: *Sessions.Get()) {
+            session->Flush();
+        }
+    }
+
 private:
     bool ShouldStop() const
     {
@@ -1467,14 +1500,17 @@ private:
         return hasWork;
     }
 
-    void DisconnectFlushed()
+    void DisconnectFlushed(bool stopRequested)
     {
         auto sessions = Sessions.Get();
 
         for (const auto& session: *sessions) {
-            if (session->IsFlushed()) {
-                Release(session.get());
+            if (!session->IsFlushed() &&
+                !(stopRequested && session->CanReleaseAfterStop()))
+            {
+                continue;
             }
+            Release(session.get());
         }
     }
 
@@ -1484,8 +1520,23 @@ private:
         TAdaptiveWait aw(
             Config->AdaptiveWaitSleepDuration,
             Config->AdaptiveWaitSleepDelay);
+        bool flushStarted = false;
 
-        while (!ShouldStop()) {
+        while (true) {
+            if (ShouldStop()) {
+                if (!flushStarted) {
+                    if (WaitMode == EWaitMode::Poll) {
+                        StopEvent.Clear();
+                    }
+                    FlushSessions();
+                    flushStarted = true;
+                }
+
+                if (!HasSessions()) {
+                    break;
+                }
+            }
+
             switch (WaitMode) {
                 case EWaitMode::Poll:
                     HandlePollEvents();
@@ -1503,7 +1554,7 @@ private:
                     }
             }
 
-            DisconnectFlushed();
+            DisconnectFlushed(ShouldStop());
         }
     }
 };

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <thread>
 
 namespace NCloud::NStorage::NRdma {
 
@@ -83,6 +84,49 @@ struct TServerHandler
         Y_UNUSED(out);
     }
 };
+
+struct TDelayedServerHandler final
+    : IServerHandler
+{
+    NThreading::TPromise<void> RequestReceived =
+        NThreading::NewPromise<void>();
+
+    void* Context = nullptr;
+    TStringBuf Out;
+
+    TCallContextBasePtr CreateCallContext() override
+    {
+        return MakeIntrusive<TCallContextBase>(ui64{0});
+    }
+
+    void HandleRequest(
+        void* context,
+        TCallContextBasePtr callContext,
+        TStringBuf in,
+        TStringBuf out) override
+    {
+        Y_UNUSED(callContext);
+        Y_UNUSED(in);
+
+        Context = context;
+        Out = out;
+        RequestReceived.SetValue();
+    }
+};
+
+template <typename TPredicate>
+bool WaitUntil(TPredicate predicate, TDuration timeout = TDuration::Seconds(5))
+{
+    const auto start = GetCycleCount();
+    while (!predicate()) {
+        const auto now = GetCycleCount();
+        if (CyclesToDurationSafe(now - start) > timeout) {
+            return false;
+        }
+        SpinLockPause();
+    }
+    return true;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -174,6 +218,10 @@ TEST(TRdmaServerTest, ShouldUseConfiguredQpParamsOnAcceptAndSetupQp)
     testContext->ModifyQP = [&](ibv_qp* qp, ibv_qp_attr* attr, int mask)
     {
         Y_UNUSED(qp);
+
+        if ((mask & IBV_QP_STATE) && attr->qp_state == IBV_QPS_ERR) {
+            return;
+        }
 
         const int expectedMask = IBV_QP_TIMEOUT | IBV_QP_MIN_RNR_TIMER;
 
@@ -424,6 +472,225 @@ TEST(TRdmaServerTest, ShouldHandleErrors)
     wait(activeRecv, 8);
     wait(abortedRequests, 1);
     wait(activeRequests, 0);
+}
+
+
+TEST(TRdmaServerTest, ShouldKeepSessionAliveUntilHandlerCompletes)
+{
+    auto context = MakeIntrusive<NVerbs::TTestContext>();
+
+    std::atomic<rdma_cm_id*> sessionId = nullptr;
+    NThreading::TPromise<void> sessionDestroyed =
+        NThreading::NewPromise<void>();
+
+    context->HandleAccept = [&] (rdma_cm_id* id, rdma_conn_param* param) {
+        Y_UNUSED(param);
+        sessionId.store(id);
+    };
+
+    context->DestroyQP = [&] (rdma_cm_id* id) {
+        Y_UNUSED(id);
+        sessionDestroyed.TrySetValue();
+    };
+
+    auto verbs = NVerbs::CreateTestVerbs(context);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto serverConfig = std::make_shared<TServerConfig>();
+    serverConfig->QueueSize = 2;
+    serverConfig->SendQueueSize = 2;
+    serverConfig->RecvQueueSize = 2;
+
+    auto logging = CreateLoggingService(
+        "console",
+        TLogSettings{TLOG_RESOURCES});
+
+    auto server = CreateTestServer(
+        verbs,
+        logging,
+        monitoring,
+        serverConfig);
+
+    server->Start();
+    Y_DEFER
+    {
+        server->Stop();
+    };
+
+    auto handler = std::make_shared<TDelayedServerHandler>();
+    auto endpoint = server->StartEndpoint("::", 10020, handler);
+    Y_UNUSED(endpoint);
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->SendQueueSize),
+        static_cast<ui16>(serverConfig->RecvQueueSize),
+        serverConfig->MaxBufferSize);
+
+    ASSERT_TRUE(WaitUntil([&] {
+        return sessionId.load() != nullptr &&
+            AtomicGet(context->PostRecvCounter) >= serverConfig->RecvQueueSize;
+    }));
+
+    with_lock (context->CompletionLock) {
+        ASSERT_FALSE(context->RecvEvents.empty());
+
+        auto* recv = context->RecvEvents.back();
+        context->RecvEvents.pop_back();
+
+        auto* msg = reinterpret_cast<TRequestMessage*>(recv->sg_list[0].addr);
+        memset(msg, 0, sizeof(*msg));
+        InitMessageHeader(msg, RDMA_PROTO_VERSION);
+        msg->ReqId = 42;
+        msg->Out.Length = 4_KB;
+
+        context->ProcessedRecvEvents.push_back(recv);
+        context->CompletionHandle.Set();
+    }
+
+    ASSERT_TRUE(
+        handler->RequestReceived.GetFuture().Wait(TDuration::Seconds(5)));
+    ASSERT_NE(nullptr, handler->Context);
+    ASSERT_EQ(4_KB, handler->Out.length());
+
+    verbs->Disconnect(sessionId.load());
+
+    with_lock (context->CompletionLock) {
+        context->HandleCompletionEvent = [] (ibv_wc* wc) {
+            wc->status = IBV_WC_WR_FLUSH_ERR;
+            wc->opcode = static_cast<ibv_wc_opcode>(0);
+        };
+
+        while (context->RecvEvents) {
+            context->ProcessedRecvEvents.push_back(context->RecvEvents.front());
+            context->RecvEvents.pop_front();
+        }
+        context->CompletionHandle.Set();
+    }
+
+    const bool destroyedBeforeHandlerCompleted =
+        sessionDestroyed.GetFuture().Wait(TDuration::MilliSeconds(100));
+
+    EXPECT_FALSE(destroyedBeforeHandlerCompleted)
+        << "RDMA session was destroyed while the handler still owns the raw "
+        << "request context and output buffer";
+
+    endpoint->SendResponse(handler->Context, 0);
+
+    ASSERT_TRUE(sessionDestroyed.GetFuture().Wait(TDuration::Seconds(5)));
+}
+
+TEST(TRdmaServerTest, ShouldKeepSessionAliveUntilHandlerCompletesOnStop)
+{
+    auto context = MakeIntrusive<NVerbs::TTestContext>();
+
+    std::atomic<rdma_cm_id*> sessionId = nullptr;
+    NThreading::TPromise<void> sessionDestroyed =
+        NThreading::NewPromise<void>();
+
+    context->HandleAccept = [&] (rdma_cm_id* id, rdma_conn_param* param) {
+        Y_UNUSED(param);
+        sessionId.store(id);
+    };
+
+    context->DestroyQP = [&] (rdma_cm_id* id) {
+        Y_UNUSED(id);
+        sessionDestroyed.TrySetValue();
+    };
+
+    auto verbs = NVerbs::CreateTestVerbs(context);
+    auto monitoring = CreateMonitoringServiceStub();
+    auto serverConfig = std::make_shared<TServerConfig>();
+    serverConfig->QueueSize = 2;
+    serverConfig->SendQueueSize = 2;
+    serverConfig->RecvQueueSize = 2;
+
+    auto logging = CreateLoggingService(
+        "console",
+        TLogSettings{TLOG_RESOURCES});
+
+    auto server = CreateTestServer(
+        verbs,
+        logging,
+        monitoring,
+        serverConfig);
+
+    server->Start();
+
+    auto handler = std::make_shared<TDelayedServerHandler>();
+    auto endpoint = server->StartEndpoint("::", 10020, handler);
+    Y_UNUSED(endpoint);
+
+    NVerbs::CreateConnection(
+        context,
+        static_cast<ui16>(serverConfig->SendQueueSize),
+        static_cast<ui16>(serverConfig->RecvQueueSize),
+        serverConfig->MaxBufferSize);
+
+    ASSERT_TRUE(WaitUntil([&] {
+        return sessionId.load() != nullptr &&
+            AtomicGet(context->PostRecvCounter) >= serverConfig->RecvQueueSize;
+    }));
+
+    with_lock (context->CompletionLock) {
+        ASSERT_FALSE(context->RecvEvents.empty());
+
+        auto* recv = context->RecvEvents.back();
+        context->RecvEvents.pop_back();
+
+        auto* msg = reinterpret_cast<TRequestMessage*>(recv->sg_list[0].addr);
+        memset(msg, 0, sizeof(*msg));
+        InitMessageHeader(msg, RDMA_PROTO_VERSION);
+        msg->ReqId = 42;
+        msg->Out.Length = 4_KB;
+
+        context->ProcessedRecvEvents.push_back(recv);
+        context->CompletionHandle.Set();
+    }
+
+    ASSERT_TRUE(
+        handler->RequestReceived.GetFuture().Wait(TDuration::Seconds(5)));
+    ASSERT_NE(nullptr, handler->Context);
+    ASSERT_EQ(4_KB, handler->Out.length());
+
+    with_lock (context->CompletionLock) {
+        context->HandleCompletionEvent = [] (ibv_wc* wc) {
+            wc->status = IBV_WC_WR_FLUSH_ERR;
+            wc->opcode = static_cast<ibv_wc_opcode>(0);
+        };
+
+        while (context->RecvEvents) {
+            context->ProcessedRecvEvents.push_back(context->RecvEvents.front());
+            context->RecvEvents.pop_front();
+        }
+        context->CompletionHandle.Set();
+    }
+
+    std::atomic<bool> stopCompleted = false;
+    std::thread stopThread([&] {
+        server->Stop();
+        stopCompleted = true;
+    });
+    Y_DEFER
+    {
+        if (stopThread.joinable()) {
+            stopThread.join();
+        }
+    };
+
+    Sleep(TDuration::MilliSeconds(100));
+    EXPECT_FALSE(stopCompleted.load())
+        << "RDMA server stopped while the handler still owns the raw "
+        << "request context and output buffer";
+    EXPECT_FALSE(sessionDestroyed.GetFuture().Wait(TDuration::MilliSeconds(100)))
+        << "RDMA session was destroyed while the handler still owns the raw "
+        << "request context and output buffer";
+
+    endpoint->SendResponse(handler->Context, 0);
+
+    ASSERT_TRUE(WaitUntil([&] {
+        return stopCompleted.load();
+    }));
+    ASSERT_TRUE(sessionDestroyed.GetFuture().Wait(TDuration::Seconds(5)));
 }
 
 TEST(TRdmaServerTest, ShouldRejectConnectionOnConfigMismatchInStrictValidation)

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -73,6 +73,26 @@ void EnqueueConnectionEvent(
     context->ConnectionHandle.Set();
 }
 
+void FlushCompletions(TTestContextPtr context)
+{
+    with_lock (context->CompletionLock) {
+        context->HandleCompletionEvent = [] (ibv_wc* wc) {
+            wc->status = IBV_WC_WR_FLUSH_ERR;
+            wc->opcode = static_cast<ibv_wc_opcode>(0);
+        };
+
+        std::move(
+            context->RecvEvents.begin(),
+            context->RecvEvents.end(),
+            std::back_inserter(context->ProcessedRecvEvents));
+
+        context->RecvEvents.clear();
+        context->ReqIds.clear();
+    }
+
+    context->CompletionHandle.Set();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // TODO: implement queue pairs (qp) - right now the code in this file completely
@@ -664,22 +684,7 @@ void Disconnect(TTestContextPtr context)
         RDMA_CM_EVENT_DISCONNECTED,
         static_cast<rdma_cm_id*>(context->Connection));
 
-    with_lock (context->CompletionLock) {
-        context->HandleCompletionEvent = [] (ibv_wc* wc) {
-            wc->status = IBV_WC_WR_FLUSH_ERR;
-            wc->opcode = static_cast<ibv_wc_opcode>(0);
-        };
-
-        std::move(
-            context->RecvEvents.begin(),
-            context->RecvEvents.end(),
-            std::back_inserter(context->ProcessedRecvEvents));
-
-        context->RecvEvents.clear();
-        context->ReqIds.clear();
-    }
-
-    context->CompletionHandle.Set();
+    FlushCompletions(std::move(context));
 }
 
 }   // namespace NCloud::NStorage::NRdma::NVerbs


### PR DESCRIPTION
## Summary

Fixes an RDMA server lifetime bug where a session could be considered flushed after WR queues drained while an application handler still owned the raw request context and RDMA pool-backed output buffer.

The session now tracks requests handed to `IServerHandler` and keeps the session alive until the request returns through `SendResponse`/`SendError`. This prevents async callbacks from serializing into freed RDMA pool memory after disconnect/flush.

Also pins RDMA server endpoints across async blockstore endpoint callbacks and fixes the local read SGList lifetime/path covered by the current tests.

## Validation

- `git --no-pager diff --check`
- `./ya make -tt cloud/storage/core/libs/rdma/impl/ut`
- `./ya make -tt cloud/blockstore/libs/client_rdma/ut`
- `./ya make cloud/blockstore/libs/service_rdma cloud/blockstore/libs/endpoints_rdma cloud/blockstore/libs/storage/disk_agent`
- `./ya make -tt cloud/blockstore/libs/storage/disk_agent/ut`