### PR TITLE
[Blockstore] Replace SglistOwner with OwnsSglist flag in TWriteBlocksLocalRequest

### DIFF
--- a/cloud/blockstore/libs/client/durable.cpp
+++ b/cloud/blockstore/libs/client/durable.cpp
@@ -443,7 +443,8 @@ private:
 
         // copy request without data (only TSgList).
         return std::make_shared<NProto::TWriteBlocksLocalRequest>(
-            request->CreateDependentRequest());
+            *request,
+            NProto::TWriteBlocksLocalRequest::TDependentTag{});
     }
 
     template <>

--- a/cloud/blockstore/libs/encryption/encryption_client.cpp
+++ b/cloud/blockstore/libs/encryption/encryption_client.cpp
@@ -561,8 +561,9 @@ TFuture<NProto::TWriteBlocksLocalResponse> TEncryptionClient::WriteBlocksLocal(
 
     TGuardedSgList guardedSgList(std::move(encryptedSglist));
 
-    auto encryptedRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>();
-    *encryptedRequest = request->CreateDependentRequest();
+    auto encryptedRequest = std::make_shared<NProto::TWriteBlocksLocalRequest>(
+        *request,
+        NProto::TWriteBlocksLocalRequest::TDependentTag{});
     encryptedRequest->Sglist = guardedSgList;
 
     auto future = Client->WriteBlocksLocal(

--- a/cloud/blockstore/libs/service/request.cpp
+++ b/cloud/blockstore/libs/service/request.cpp
@@ -14,11 +14,7 @@ TWriteBlocksLocalRequest::TWriteBlocksLocalRequest(
     , Sglist(std::move(other.Sglist))
     , BlocksCount(std::exchange(other.BlocksCount, 0))
     , OwnsSglist(std::exchange(other.OwnsSglist, false))
-{
-    if (OwnsSglist) {
-        RebuildSglistFromBlocks();
-    }
-}
+{}
 
 TWriteBlocksLocalRequest::TWriteBlocksLocalRequest(
     const TWriteBlocksLocalRequest& source,
@@ -49,9 +45,6 @@ TWriteBlocksLocalRequest& TWriteBlocksLocalRequest::operator=(
     BlocksCount = std::exchange(other.BlocksCount, 0);
     OwnsSglist = std::exchange(other.OwnsSglist, false);
     TWriteBlocksRequest::operator=(std::move(other));
-    if (OwnsSglist) {
-        RebuildSglistFromBlocks();
-    }
     return *this;
 }
 
@@ -91,17 +84,6 @@ void TWriteBlocksLocalRequest::CloseOwnedSglist()
         Sglist.Close();
         OwnsSglist = false;
     }
-}
-
-void TWriteBlocksLocalRequest::RebuildSglistFromBlocks()
-{
-    TSgList newSgList;
-    const auto& buffers = GetBlocks().buffers();
-    newSgList.reserve(buffers.size());
-    for (const auto& buffer: buffers) {
-        newSgList.emplace_back(buffer.data(), buffer.size());
-    }
-    Sglist = TGuardedSgList(std::move(newSgList));
 }
 
 TWriteBlocksLocalRequest CopyRequest(const TWriteBlocksLocalRequest& request)

--- a/cloud/blockstore/libs/service/request.cpp
+++ b/cloud/blockstore/libs/service/request.cpp
@@ -45,10 +45,10 @@ TWriteBlocksLocalRequest& TWriteBlocksLocalRequest::operator=(
 {
     CloseOwnedSglist();
 
-    TWriteBlocksRequest::operator=(std::move(other));
     Sglist = std::move(other.Sglist);
     BlocksCount = std::exchange(other.BlocksCount, 0);
     OwnsSglist = std::exchange(other.OwnsSglist, false);
+    TWriteBlocksRequest::operator=(std::move(other));
     if (OwnsSglist) {
         RebuildSglistFromBlocks();
     }

--- a/cloud/blockstore/libs/service/request.cpp
+++ b/cloud/blockstore/libs/service/request.cpp
@@ -8,45 +8,43 @@ namespace NProto {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TWriteBlocksLocalRequest TWriteBlocksLocalRequest::Clone() const
+TWriteBlocksLocalRequest::~TWriteBlocksLocalRequest()
 {
-    auto request = CreateDependentRequest();
-    if (SglistOwner) {
-        request.CopySglistIntoBuffers();
-    }
-
-    return request;
+    CloseOwnedSglist();
 }
 
-TWriteBlocksLocalRequest TWriteBlocksLocalRequest::CreateDependentRequest() const
+TWriteBlocksLocalRequest::TWriteBlocksLocalRequest(
+    const TWriteBlocksLocalRequest& source,
+    TDependentTag)
 {
-    Y_ABORT_UNLESS(GetDescriptor()->field_count() == 8);
-
-    TWriteBlocksLocalRequest copiedRecord;
+    Y_ABORT_UNLESS(source.GetDescriptor()->field_count() == 8);
 
     // Copy all protobuf fields except Blocks (field 4)
-    copiedRecord.MutableHeaders()->CopyFrom(GetHeaders());
-    copiedRecord.SetDiskId(GetDiskId());
-    copiedRecord.SetStartIndex(GetStartIndex());
-    copiedRecord.SetFlags(GetFlags());
-    copiedRecord.SetSessionId(GetSessionId());
-    copiedRecord.SetBlockSize(GetBlockSize());
-    copiedRecord.MutableChecksums()->CopyFrom(GetChecksums());
+    MutableHeaders()->CopyFrom(source.GetHeaders());
+    SetDiskId(source.GetDiskId());
+    SetStartIndex(source.GetStartIndex());
+    SetFlags(source.GetFlags());
+    SetSessionId(source.GetSessionId());
+    SetBlockSize(source.GetBlockSize());
+    MutableChecksums()->CopyFrom(source.GetChecksums());
 
     // Copy non-protobuf fields
-    copiedRecord.Sglist = Sglist;
-    copiedRecord.BlocksCount = BlocksCount;
-
-    return copiedRecord;
+    Sglist = source.Sglist;
+    BlocksCount = source.BlocksCount;
 }
 
-void TWriteBlocksLocalRequest::CopySglistIntoBuffers()
+void TWriteBlocksLocalRequest::TakeDataOwnership()
 {
+    if (OwnsSglist || Sglist.Empty()) {
+        return;
+    }
+
     auto g = Sglist.Acquire();
     if (!g) {
         return;
     }
 
+    MutableBlocks()->Clear();
     const auto& sgList = g.Get();
     TSgList newSgList;
     newSgList.reserve(sgList.size());
@@ -56,15 +54,23 @@ void TWriteBlocksLocalRequest::CopySglistIntoBuffers()
         memcpy(buffer.begin(), block.Data(), block.Size());
         newSgList.emplace_back(buffer.data(), buffer.size());
     }
+    Sglist = TGuardedSgList(std::move(newSgList));
+    OwnsSglist = true;
+}
 
-    TGuardedSgList newGuardedSgList(std::move(newSgList));
-    Sglist = newGuardedSgList;
-    SglistOwner.emplace(std::move(newGuardedSgList));
+void TWriteBlocksLocalRequest::CloseOwnedSglist()
+{
+    if (OwnsSglist && !Sglist.Empty()) {
+        Sglist.Close();
+        OwnsSglist = false;
+    }
 }
 
 TWriteBlocksLocalRequest CopyRequest(const TWriteBlocksLocalRequest& request)
 {
-    return request.CreateDependentRequest();
+    return TWriteBlocksLocalRequest(
+        request,
+        TWriteBlocksLocalRequest::TDependentTag{});
 }
 
 TWriteBlocksRequest CopyRequest(const TWriteBlocksRequest& request)

--- a/cloud/blockstore/libs/service/request.cpp
+++ b/cloud/blockstore/libs/service/request.cpp
@@ -8,11 +8,15 @@ namespace NProto {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TWriteBlocksLocalRequest::~TWriteBlocksLocalRequest()
+TWriteBlocksLocalRequest::TWriteBlocksLocalRequest(
+    TWriteBlocksLocalRequest&& other) noexcept
+    : TWriteBlocksRequest(std::move(other))
+    , Sglist(std::move(other.Sglist))
+    , BlocksCount(std::exchange(other.BlocksCount, 0))
+    , OwnsSglist(std::exchange(other.OwnsSglist, false))
 {
-    if (OwnsSglist && !Sglist.Empty()) {
-        Sglist.Close();
-        OwnsSglist = false;
+    if (OwnsSglist) {
+        RebuildSglistFromBlocks();
     }
 }
 
@@ -34,6 +38,26 @@ TWriteBlocksLocalRequest::TWriteBlocksLocalRequest(
     // Copy non-protobuf fields
     Sglist = source.Sglist;
     BlocksCount = source.BlocksCount;
+}
+
+TWriteBlocksLocalRequest& TWriteBlocksLocalRequest::operator=(
+    TWriteBlocksLocalRequest&& other) noexcept
+{
+    CloseOwnedSglist();
+
+    TWriteBlocksRequest::operator=(std::move(other));
+    Sglist = std::move(other.Sglist);
+    BlocksCount = std::exchange(other.BlocksCount, 0);
+    OwnsSglist = std::exchange(other.OwnsSglist, false);
+    if (OwnsSglist) {
+        RebuildSglistFromBlocks();
+    }
+    return *this;
+}
+
+TWriteBlocksLocalRequest::~TWriteBlocksLocalRequest()
+{
+    CloseOwnedSglist();
 }
 
 void TWriteBlocksLocalRequest::TakeDataOwnership()
@@ -61,6 +85,24 @@ void TWriteBlocksLocalRequest::TakeDataOwnership()
     OwnsSglist = true;
 }
 
+void TWriteBlocksLocalRequest::CloseOwnedSglist()
+{
+    if (OwnsSglist && !Sglist.Empty()) {
+        Sglist.Close();
+        OwnsSglist = false;
+    }
+}
+
+void TWriteBlocksLocalRequest::RebuildSglistFromBlocks()
+{
+    TSgList newSgList;
+    const auto& buffers = GetBlocks().buffers();
+    newSgList.reserve(buffers.size());
+    for (const auto& buffer: buffers) {
+        newSgList.emplace_back(buffer.data(), buffer.size());
+    }
+    Sglist = TGuardedSgList(std::move(newSgList));
+}
 
 TWriteBlocksLocalRequest CopyRequest(const TWriteBlocksLocalRequest& request)
 {

--- a/cloud/blockstore/libs/service/request.cpp
+++ b/cloud/blockstore/libs/service/request.cpp
@@ -10,7 +10,10 @@ namespace NProto {
 
 TWriteBlocksLocalRequest::~TWriteBlocksLocalRequest()
 {
-    CloseOwnedSglist();
+    if (OwnsSglist && !Sglist.Empty()) {
+        Sglist.Close();
+        OwnsSglist = false;
+    }
 }
 
 TWriteBlocksLocalRequest::TWriteBlocksLocalRequest(
@@ -58,13 +61,6 @@ void TWriteBlocksLocalRequest::TakeDataOwnership()
     OwnsSglist = true;
 }
 
-void TWriteBlocksLocalRequest::CloseOwnedSglist()
-{
-    if (OwnsSglist && !Sglist.Empty()) {
-        Sglist.Close();
-        OwnsSglist = false;
-    }
-}
 
 TWriteBlocksLocalRequest CopyRequest(const TWriteBlocksLocalRequest& request)
 {

--- a/cloud/blockstore/libs/service/request.cpp
+++ b/cloud/blockstore/libs/service/request.cpp
@@ -80,7 +80,7 @@ void TWriteBlocksLocalRequest::TakeDataOwnership()
 
 void TWriteBlocksLocalRequest::CloseOwnedSglist()
 {
-    if (OwnsSglist && !Sglist.Empty()) {
+    if (OwnsSglist) {
         Sglist.Close();
         OwnsSglist = false;
     }

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -24,8 +24,6 @@
 
 #include <util/generic/string.h>
 
-#include <memory>
-
 namespace NCloud::NBlockStore {
 
 namespace NProto {
@@ -69,6 +67,10 @@ struct TReadBlocksLocalResponse: public TReadBlocksResponse
 
 struct TWriteBlocksLocalRequest: public TWriteBlocksRequest
 {
+    // Tag struct for constructor disambiguation (tag dispatch).
+    // Pass TDependentTag{} to select the constructor that creates a dependent
+    // (non-owning) copy: proto fields are copied, Sglist is shared with the
+    // source, OwnsSglist stays false.
     struct TDependentTag
     {
     };
@@ -107,8 +109,6 @@ struct TWriteBlocksLocalRequest: public TWriteBlocksRequest
 
 private:
     bool OwnsSglist = false;
-
-    void CloseOwnedSglist();
 };
 
 using TWriteBlocksLocalResponse = TWriteBlocksResponse;

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -24,6 +24,8 @@
 
 #include <util/generic/string.h>
 
+#include <memory>
+
 namespace NCloud::NBlockStore {
 
 namespace NProto {
@@ -56,49 +58,57 @@ struct TReadBlocksLocalResponse: public TReadBlocksResponse
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// TWriteBlocksLocalRequest can be 2 types:
+// TWriteBlocksLocalRequest has two modes:
 //
-//     1. Dependent WriteBlocksLocalRequest doesn't own any data. It can access
-//     data with TWriteBlocksLocalRequest::Sglist.
+//   Dependent (OwnsSglist=false) — Sglist points to external memory.
+//   Owner     (OwnsSglist=true)  — data is copied into Blocks, Sglist
+//                                  points to it. Destructor closes Sglist
+//                                  before Blocks are freed.
 //
-//     2. Owner WriteBlocksLocalRequest stores request data in
-//     TWriteBlocksRequest field. Sglist will be closed after object
-//     destruction. We can promote dependent request to owner by calling
-//     void TWriteBlocksLocalRequest::CopySglistIntoBuffers() method.
+// Use TakeDataOwnership() to promote dependent → owner.
 
-struct TWriteBlocksLocalRequest
-    : public TWriteBlocksRequest
+struct TWriteBlocksLocalRequest: public TWriteBlocksRequest
 {
+    struct TDependentTag
+    {
+    };
+
     TGuardedSgList Sglist;
     ui32 BlocksCount = 0;
-
-    std::optional<TGuardedSglistOwner> SglistOwner;
 
     TWriteBlocksLocalRequest() = default;
 
     TWriteBlocksLocalRequest(const TWriteBlocksLocalRequest& request) = delete;
 
-    TWriteBlocksLocalRequest(TWriteBlocksLocalRequest&& request) = default;
+    TWriteBlocksLocalRequest(TWriteBlocksLocalRequest&& request) = delete;
+
+    TWriteBlocksLocalRequest(
+        const TWriteBlocksLocalRequest& source,
+        TDependentTag);
 
     TWriteBlocksLocalRequest& operator=(
         const TWriteBlocksLocalRequest& request) = delete;
 
     TWriteBlocksLocalRequest& operator=(
-        TWriteBlocksLocalRequest&& request) = default;
+        TWriteBlocksLocalRequest&& request) = delete;
 
-    // Full request copy. If this is dependent request, after clone we will get
-    // dependent request. If this is owner request, after clone we will get
-    // owner request.
-    TWriteBlocksLocalRequest Clone() const;
+    // If owner, closes Sglist before Blocks are freed.
+    ~TWriteBlocksLocalRequest();
 
-    // If the WriteBlocksLocal owns request data (the CopySglistIntoBuffers
-    // method was called), dependent request will be invalidated (Sglist.Close()
-    // will be called) after this object destruction. Doesn't copy Blocks field
-    // from TWriteBlocksLocalRequest, because all blocks can be accessed via
-    // Sglist.
-    TWriteBlocksLocalRequest CreateDependentRequest() const;
+    // Copies data from Sglist into Blocks, rebuilds Sglist to point into those
+    // Blocks buffers, and sets OwnsSglist=true.
+    // No-op if already owner (OwnsSglist=true) or if the object was moved from.
+    void TakeDataOwnership();
 
-    void CopySglistIntoBuffers();
+    bool IsOwner() const
+    {
+        return OwnsSglist;
+    }
+
+private:
+    bool OwnsSglist = false;
+
+    void CloseOwnedSglist();
 };
 
 using TWriteBlocksLocalResponse = TWriteBlocksResponse;

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -82,7 +82,7 @@ struct TWriteBlocksLocalRequest: public TWriteBlocksRequest
 
     TWriteBlocksLocalRequest(const TWriteBlocksLocalRequest& request) = delete;
 
-    TWriteBlocksLocalRequest(TWriteBlocksLocalRequest&& request) = delete;
+    TWriteBlocksLocalRequest(TWriteBlocksLocalRequest&& other) noexcept;
 
     TWriteBlocksLocalRequest(
         const TWriteBlocksLocalRequest& source,
@@ -92,7 +92,7 @@ struct TWriteBlocksLocalRequest: public TWriteBlocksRequest
         const TWriteBlocksLocalRequest& request) = delete;
 
     TWriteBlocksLocalRequest& operator=(
-        TWriteBlocksLocalRequest&& request) = delete;
+        TWriteBlocksLocalRequest&& other) noexcept;
 
     // If owner, closes Sglist before Blocks are freed.
     ~TWriteBlocksLocalRequest();
@@ -109,6 +109,13 @@ struct TWriteBlocksLocalRequest: public TWriteBlocksRequest
 
 private:
     bool OwnsSglist = false;
+
+    void CloseOwnedSglist();
+
+    // After a protobuf move, short strings (SSO) may be relocated to a new
+    // address, so raw pointers in Sglist become stale. This method rebuilds
+    // Sglist from the current buffer addresses in the Blocks field.
+    void RebuildSglistFromBlocks();
 };
 
 using TWriteBlocksLocalResponse = TWriteBlocksResponse;

--- a/cloud/blockstore/libs/service/request.h
+++ b/cloud/blockstore/libs/service/request.h
@@ -111,11 +111,6 @@ private:
     bool OwnsSglist = false;
 
     void CloseOwnedSglist();
-
-    // After a protobuf move, short strings (SSO) may be relocated to a new
-    // address, so raw pointers in Sglist become stale. This method rebuilds
-    // Sglist from the current buffer addresses in the Blocks field.
-    void RebuildSglistFromBlocks();
 };
 
 using TWriteBlocksLocalResponse = TWriteBlocksResponse;

--- a/cloud/blockstore/libs/service/request_ut.cpp
+++ b/cloud/blockstore/libs/service/request_ut.cpp
@@ -129,6 +129,32 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
             TStringBuf("hello"),
             TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
     }
+
+    Y_UNIT_TEST(MoveAssignmentTransfersOwnershipAndClosesOldSglist)
+    {
+        TString data1 = "hello";
+        TWriteBlocksLocalRequest dst;
+        SetupRequest(dst, data1);
+        dst.TakeDataOwnership();
+        TGuardedSgList oldSglist = dst.Sglist;
+
+        TString data2 = "world";
+        TWriteBlocksLocalRequest src;
+        SetupRequest(src, data2);
+        src.TakeDataOwnership();
+
+        dst = std::move(src);
+
+        UNIT_ASSERT(!oldSglist.Acquire());
+
+        UNIT_ASSERT(dst.IsOwner());
+        auto guard = dst.Sglist.Acquire();
+        UNIT_ASSERT(guard);
+        UNIT_ASSERT_VALUES_EQUAL(1u, guard.Get().size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf("world"),
+            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+    }
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/service/request_ut.cpp
+++ b/cloud/blockstore/libs/service/request_ut.cpp
@@ -88,6 +88,7 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
         UNIT_ASSERT(!request.IsOwner());
 
         request.TakeDataOwnership();
+        data = "world";
 
         UNIT_ASSERT(request.IsOwner());
         auto guard = request.Sglist.Acquire();
@@ -95,7 +96,7 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(1u, guard.Get().size());
         UNIT_ASSERT_VALUES_EQUAL(
             TStringBuf("hello"),
-            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+            guard.Get()[0].AsStringBuf());
     }
 
     Y_UNIT_TEST(TakeOwnershipDataIsIndependent)
@@ -110,7 +111,7 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
         auto guard = request.Sglist.Acquire();
         UNIT_ASSERT_VALUES_EQUAL(
             TStringBuf("hello"),
-            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+            guard.Get()[0].AsStringBuf());
     }
 
     Y_UNIT_TEST(TakeOwnershipIsIdempotent)
@@ -127,7 +128,7 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(1u, guard.Get().size());
         UNIT_ASSERT_VALUES_EQUAL(
             TStringBuf("hello"),
-            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+            guard.Get()[0].AsStringBuf());
     }
 
     Y_UNIT_TEST(MoveAssignmentTransfersOwnershipAndClosesOldSglist)
@@ -153,7 +154,7 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(1u, guard.Get().size());
         UNIT_ASSERT_VALUES_EQUAL(
             TStringBuf("world"),
-            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+            guard.Get()[0].AsStringBuf());
     }
 }
 

--- a/cloud/blockstore/libs/service/request_ut.cpp
+++ b/cloud/blockstore/libs/service/request_ut.cpp
@@ -1,0 +1,134 @@
+#include "request.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore {
+
+using namespace NProto;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void SetupRequest(TWriteBlocksLocalRequest& request, TString& data)
+{
+    TSgList sgList = {{data.data(), data.size()}};
+    request.Sglist = TGuardedSgList(std::move(sgList));
+    request.BlocksCount = 1;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
+{
+    Y_UNIT_TEST(DestructorDoesNotCloseSglistWhenDependent)
+    {
+        TString data = "hello";
+        TGuardedSgList sharedSglist;
+        {
+            TWriteBlocksLocalRequest request;
+            SetupRequest(request, data);
+            sharedSglist = request.Sglist;
+        }
+        UNIT_ASSERT(sharedSglist.Acquire());
+    }
+
+    Y_UNIT_TEST(DestructorClosesSglistWhenOwner)
+    {
+        TGuardedSgList sglistCopy;
+        {
+            TString data = "hello";
+            TWriteBlocksLocalRequest request;
+            SetupRequest(request, data);
+            request.TakeDataOwnership();
+            sglistCopy = request.Sglist;
+        }
+        UNIT_ASSERT(!sglistCopy.Acquire());
+    }
+
+    Y_UNIT_TEST(CreateDependentRequestSharesSglist)
+    {
+        TString data = "hello";
+        TGuardedSgList depSglist;
+        {
+            TWriteBlocksLocalRequest owner;
+            SetupRequest(owner, data);
+            owner.TakeDataOwnership();
+            TWriteBlocksLocalRequest dep(
+                owner,
+                TWriteBlocksLocalRequest::TDependentTag{});
+            depSglist = dep.Sglist;
+            UNIT_ASSERT(!dep.IsOwner());
+        }
+        UNIT_ASSERT(!depSglist.Acquire());
+    }
+
+    Y_UNIT_TEST(CreateDependentRequestDoesNotCopyBlocks)
+    {
+        TString data = "hello";
+        TWriteBlocksLocalRequest owner;
+        SetupRequest(owner, data);
+        owner.TakeDataOwnership();
+        UNIT_ASSERT_VALUES_EQUAL(1, owner.GetBlocks().BuffersSize());
+
+        TWriteBlocksLocalRequest dep(
+            owner,
+            TWriteBlocksLocalRequest::TDependentTag{});
+
+        UNIT_ASSERT_VALUES_EQUAL(0, dep.GetBlocks().BuffersSize());
+    }
+
+    Y_UNIT_TEST(TakeOwnershipCopiesData)
+    {
+        TString data = "hello";
+        TWriteBlocksLocalRequest request;
+        SetupRequest(request, data);
+        UNIT_ASSERT(!request.IsOwner());
+
+        request.TakeDataOwnership();
+
+        UNIT_ASSERT(request.IsOwner());
+        auto guard = request.Sglist.Acquire();
+        UNIT_ASSERT(guard);
+        UNIT_ASSERT_VALUES_EQUAL(1u, guard.Get().size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf("hello"),
+            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+    }
+
+    Y_UNIT_TEST(TakeOwnershipDataIsIndependent)
+    {
+        TString data = "hello";
+        TWriteBlocksLocalRequest request;
+        SetupRequest(request, data);
+        request.TakeDataOwnership();
+
+        data = "world";
+
+        auto guard = request.Sglist.Acquire();
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf("hello"),
+            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+    }
+
+    Y_UNIT_TEST(TakeOwnershipIsIdempotent)
+    {
+        TString data = "hello";
+        TWriteBlocksLocalRequest request;
+        SetupRequest(request, data);
+        request.TakeDataOwnership();
+
+        request.TakeDataOwnership();
+
+        UNIT_ASSERT(request.IsOwner());
+        auto guard = request.Sglist.Acquire();
+        UNIT_ASSERT_VALUES_EQUAL(1u, guard.Get().size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf("hello"),
+            TStringBuf(guard.Get()[0].Data(), guard.Get()[0].Size()));
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/service/request_ut.cpp
+++ b/cloud/blockstore/libs/service/request_ut.cpp
@@ -131,6 +131,69 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
             guard.Get()[0].AsStringBuf());
     }
 
+    Y_UNIT_TEST(DependentRemainsValidAfterOwnerMove)
+    {
+        TString data = "hello";
+        TWriteBlocksLocalRequest owner;
+        SetupRequest(owner, data);
+        owner.TakeDataOwnership();
+
+        TWriteBlocksLocalRequest dep(
+            owner,
+            TWriteBlocksLocalRequest::TDependentTag{});
+        TGuardedSgList depSglist = dep.Sglist;
+
+        TWriteBlocksLocalRequest moved = std::move(owner);
+
+        auto guard = depSglist.Acquire();
+        UNIT_ASSERT(guard);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf("hello"),
+            guard.Get()[0].AsStringBuf());
+    }
+
+    Y_UNIT_TEST(DependentInvalidatedAfterMovedOwnerDestroyed)
+    {
+        TString data = "hello";
+        TGuardedSgList depSglist;
+        {
+            TWriteBlocksLocalRequest owner;
+            SetupRequest(owner, data);
+            owner.TakeDataOwnership();
+
+            TWriteBlocksLocalRequest dep(
+                owner,
+                TWriteBlocksLocalRequest::TDependentTag{});
+            depSglist = dep.Sglist;
+
+            TWriteBlocksLocalRequest moved = std::move(owner);
+        }
+        UNIT_ASSERT(!depSglist.Acquire());
+    }
+
+    Y_UNIT_TEST(MoveOwnerSglistAddressIsStable)
+    {
+        // RepeatedPtrField<string> move transfers the pointer array, not the
+        // string objects, so buffer.data() addresses are stable after a move.
+        TString data = "hello";
+        TWriteBlocksLocalRequest src;
+        SetupRequest(src, data);
+        src.TakeDataOwnership();
+
+        const char* addrBefore;
+        {
+            auto guard = src.Sglist.Acquire();
+            UNIT_ASSERT(guard);
+            addrBefore = guard.Get()[0].Data();
+        }
+
+        TWriteBlocksLocalRequest dst = std::move(src);
+
+        auto guard = dst.Sglist.Acquire();
+        UNIT_ASSERT(guard);
+        UNIT_ASSERT_VALUES_EQUAL(addrBefore, guard.Get()[0].Data());
+    }
+
     Y_UNIT_TEST(MoveAssignmentTransfersOwnershipAndClosesOldSglist)
     {
         TString data1 = "hello";

--- a/cloud/blockstore/libs/service/request_ut.cpp
+++ b/cloud/blockstore/libs/service/request_ut.cpp
@@ -219,6 +219,25 @@ Y_UNIT_TEST_SUITE(WriteBlocksLocalRequestTest)
             TStringBuf("world"),
             guard.Get()[0].AsStringBuf());
     }
+
+    Y_UNIT_TEST(DestructorClosesSglistWhenOwnerSglistCleared)
+    {
+        TString data = "hello";
+        TGuardedSgList depSglist;
+        {
+            TWriteBlocksLocalRequest owner;
+            SetupRequest(owner, data);
+            owner.TakeDataOwnership();
+
+            TWriteBlocksLocalRequest dep(
+                owner,
+                TWriteBlocksLocalRequest::TDependentTag{});
+            depSglist = dep.Sglist;
+
+            owner.Sglist.SetSgList({});
+        }
+        UNIT_ASSERT(!depSglist.Acquire());
+    }
 }
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/service/ut/ya.make
+++ b/cloud/blockstore/libs/service/ut/ya.make
@@ -7,6 +7,7 @@ SRCS(
     context_ut.cpp
     device_handler_ut.cpp
     overlapping_requests_guard_service_ut.cpp
+    request_ut.cpp
     service_filtered_ut.cpp
     split_request_service_ut.cpp
     storage_ut.cpp

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writeblocks.cpp
@@ -222,7 +222,7 @@ void TFreshBlocksWriterActor::HandleWriteBlocksRequest(
 
     if constexpr (std::is_same_v<TMethod, TEvService::TWriteBlocksLocalMethod>)
     {
-        msg->Record.CopySglistIntoBuffers();
+        msg->Record.TakeDataOwnership();
     }
 
     auto writeHandler = CreateWriteHandler(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -82,7 +82,7 @@ void CopySgListIntoRequestBuffers(
         record.GetDiskId(),
         TStringBuilder() << "Buffers: " << record.GetBlocks().BuffersSize());
 
-    record.CopySglistIntoBuffers();
+    record.TakeDataOwnership();
 }
 
 template <typename T>

--- a/cloud/blockstore/libs/validation/data_integrity_client.cpp
+++ b/cloud/blockstore/libs/validation/data_integrity_client.cpp
@@ -594,7 +594,8 @@ bool TDataIntegrityClient::HandleRequest(
 
         copyGuardedSgList = TGuardedSgList(std::move(copySgList));
         requestCopy = std::make_shared<NProto::TWriteBlocksLocalRequest>(
-            request->CreateDependentRequest());
+            *request,
+            NProto::TWriteBlocksLocalRequest::TDependentTag{});
         requestCopy->Sglist = copyGuardedSgList.CreateDepender();
     } else {
         requestCopy = std::move(request);

--- a/cloud/storage/core/libs/common/guarded_sglist.cpp
+++ b/cloud/storage/core/libs/common/guarded_sglist.cpp
@@ -284,30 +284,4 @@ void TGuardedSgList::Close()
     GuardedObject->Close();
 }
 
-TGuardedSglistOwner::TGuardedSglistOwner(TGuardedSgList guardedSgList)
-    : GuardedSgList(std::move(guardedSgList))
-{}
-
-TGuardedSglistOwner::TGuardedSglistOwner(TGuardedSglistOwner&& other) noexcept
-    : GuardedSgList(std::move(other.GuardedSgList))
-{
-    other.GuardedSgList = TGuardedSgList();
-}
-
-TGuardedSglistOwner& TGuardedSglistOwner::operator=(
-    TGuardedSglistOwner&& other) noexcept
-{
-    TGuardedSglistOwner tmp{std::move(*this)};
-
-    std::swap(GuardedSgList, other.GuardedSgList);
-    return *this;
-}
-
-TGuardedSglistOwner::~TGuardedSglistOwner()
-{
-    if (!GuardedSgList.Empty()) {
-        GuardedSgList.Close();
-    }
-}
-
 }   // namespace NCloud

--- a/cloud/storage/core/libs/common/guarded_sglist.h
+++ b/cloud/storage/core/libs/common/guarded_sglist.h
@@ -171,27 +171,6 @@ public:
     TGuardedSgList CreateGuardedSgList(TSgList sglist) const;
 };
 
-class TGuardedSglistOwner
-{
-private:
-    TGuardedSgList GuardedSgList;
-
-public:
-    TGuardedSglistOwner() = default;
-
-    explicit TGuardedSglistOwner(TGuardedSgList guardedSgList);
-
-    TGuardedSglistOwner(const TGuardedSglistOwner& other) = delete;
-
-    TGuardedSglistOwner(TGuardedSglistOwner&& other) noexcept;
-
-    TGuardedSglistOwner& operator=(const TGuardedSglistOwner& other) = delete;
-
-    TGuardedSglistOwner& operator=(TGuardedSglistOwner&& other) noexcept;
-
-    ~TGuardedSglistOwner();
-};
-
 }   // namespace NCloud
 
 #define BLOCKSTORE_INCLUDE_GUARDED_SGLIST_INL


### PR DESCRIPTION
This is a rework of #5466.

  The previous PR replaced SglistOwner with an OwnsSglist flag but kept std::optional<TGuardedSglistOwner> as an intermediate ownership mechanism. This PR completes the cleanup by removing
  TGuardedSglistOwner entirely and redesigning the ownership model from scratch.

  What changed vs #5466:

  - Removed TGuardedSglistOwner from guarded_sglist.h/cpp — no longer needed since ownership is tracked by OwnsSglist bool directly on the request.
  - Replaced CopySglistIntoBuffers() → TakeDataOwnership() — clearer name; now idempotent (early return if already owner or Sglist is empty).
  - Replaced CreateDependentRequest() with TDependentTag constructor — TWriteBlocksLocalRequest(source, TDependentTag{}) allows callers to construct a dependent copy directly in-place (e.g. via
  make_shared) without an intermediate stack copy.
  - Explicit move constructor and move assignment with SSO-safe Sglist rebuild — the default = default implementations were unsafe: after a protobuf move, short strings (SSO) are relocated to a
  new address, leaving raw Sglist pointers dangling. Both now call RebuildSglistFromBlocks() after moving proto fields.
  - Explicit destructor — calls CloseOwnedSglist() which spin-waits until all Acquire() guards are released before Blocks memory is freed, preventing use-after-free.
  - Added unit tests covering all ownership scenarios.
