### PR TITLE
[Filestore] make test not so huge to avoid timeouts on sanitizers configs

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -75,6 +75,14 @@ constexpr TStringBuf MetricsComponent = "fs_ut";
 constexpr ui64 dotSize = sizeof(fuse_direntplus) + sizeof(ui64);
 constexpr ui64 dotDotSize = dotSize;
 
+// Small directory listings for the multi-chunk paging tests below, kept tiny
+// so sanitizer builds don't time out building multi-megabyte responses. Each
+// entry serializes to +- 200 bytes; SecondChunkReadOffset lands past the first
+// chunk (~105 KB) to page in the second.
+constexpr ui32 FirstChunkEntryCount = 600;
+constexpr ui32 SecondChunkEntryCount = 300;
+constexpr i64 SecondChunkReadOffset = 120'000;
+
 static const TString FileSystemId = "fs1";
 static const TString SessionId = CreateGuidAsString();
 
@@ -1248,7 +1256,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             NProto::TListNodesResponse result;
 
             if (!request->GetCookie()) {
-                for (ui32 i = 1; i <= 20000; ++i) {
+                for (ui32 i = 1; i <= FirstChunkEntryCount; ++i) {
                     result.AddNames()->assign(
                         "first_chunk_file_" + ToString(i) + ".txt");
                     auto* node = result.AddNodes();
@@ -1258,11 +1266,11 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 result.SetCookie("has_more_data");
             } else {
                 UNIT_ASSERT_VALUES_EQUAL("has_more_data", request->GetCookie());
-                for (ui32 i = 20001; i <= 25100; ++i) {
+                for (ui32 i = 1; i <= SecondChunkEntryCount; ++i) {
                     result.AddNames()->assign(
                         "second_chunk_file_" + ToString(i) + ".txt");
                     auto* node = result.AddNodes();
-                    node->SetId(100 + i);
+                    node->SetId(100 + FirstChunkEntryCount + i);
                     node->SetType(NProto::E_REGULAR_NODE);
                 }
             }
@@ -1343,7 +1351,8 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT(maxOpenHandleCount);
         UNIT_ASSERT_VALUES_EQUAL(1, maxOpenHandleCount->Val());
 
-        auto largeOffset = size1 + 3700000;   // Go beyond the first chunk
+        // Go beyond chunk 1
+        auto largeOffset = size1 + SecondChunkReadOffset;
         read = bootstrap.Fuse->SendRequest<TReadDirRequest>(
             nodeId,
             handleId,
@@ -1447,7 +1456,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             NProto::TListNodesResponse result;
 
             if (!request->GetCookie()) {
-                for (ui32 i = 1; i <= 20000; ++i) {
+                for (ui32 i = 1; i <= FirstChunkEntryCount; ++i) {
                     result.AddNames()->assign(
                         "first_chunk_file_" + ToString(i) + ".txt");
                     auto* node = result.AddNodes();
@@ -1457,11 +1466,11 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 result.SetCookie("has_more_data");
             } else {
                 UNIT_ASSERT_VALUES_EQUAL("has_more_data", request->GetCookie());
-                for (ui32 i = 20001; i <= 25100; ++i) {
+                for (ui32 i = 1; i <= SecondChunkEntryCount; ++i) {
                     result.AddNames()->assign(
                         "second_chunk_file_" + ToString(i) + ".txt");
                     auto* node = result.AddNodes();
-                    node->SetId(100 + i);
+                    node->SetId(100 + FirstChunkEntryCount + i);
                     node->SetType(NProto::E_REGULAR_NODE);
                 }
             }
@@ -1513,7 +1522,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT(read.Wait(LargeDirectoryWaitTimeout));
         UNIT_ASSERT_VALUES_EQUAL(numCalls.load(), 3);
 
-        const auto largeOffset = size1 + 3700000;
+        const auto largeOffset = size1 + SecondChunkReadOffset;
         read = bootstrap.Fuse->SendRequest<TReadDirRequest>(
             nodeId,
             handleId,
@@ -1738,7 +1747,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 NProto::TListNodesResponse result;
 
                 if (!request->GetCookie()) {
-                    for (ui32 i = 1; i <= 20000; ++i) {
+                    for (ui32 i = 1; i <= FirstChunkEntryCount; ++i) {
                         result.AddNames()->assign(
                             "first_chunk_file_" + ToString(i) + ".txt");
                         auto* node = result.AddNodes();
@@ -1751,11 +1760,11 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                     UNIT_ASSERT_VALUES_EQUAL(
                         "has_more_data",
                         request->GetCookie());
-                    for (ui32 i = 20001; i <= 25100; ++i) {
+                    for (ui32 i = 1; i <= SecondChunkEntryCount; ++i) {
                         result.AddNames()->assign(
                             "second_chunk_file_" + ToString(i) + ".txt");
                         auto* node = result.AddNodes();
-                        node->SetId(100 + i);
+                        node->SetId(100 + FirstChunkEntryCount + i);
                         node->SetType(NProto::E_REGULAR_NODE);
                     }
                     ++numCalls2;
@@ -1786,7 +1795,8 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             UNIT_ASSERT_VALUES_EQUAL(numCalls1.load(), 1);
             UNIT_ASSERT_VALUES_EQUAL(numCalls2.load(), 0);
 
-            auto largeOffset = 3700000;   // Go beyond the first chunk
+            // Go beyond the first chunk
+            auto largeOffset = SecondChunkReadOffset;
             read = bootstrap.Fuse->SendRequest<TReadDirRequest>(
                 nodeId,
                 handleId,


### PR DESCRIPTION

### Notes
TTestCaseShouldRetainDirectoryHandlesMaxMetricsUntilWindowExpires::Execute_(NUnitTest::TTestContext &): (read.Wait(LargeDirectoryWaitTimeout)) [[rst]]

