### PR TITLE
[Filestore] apply features override before tablet

### DIFF
--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -642,6 +642,11 @@ void TStorageConfig::Merge(const NProto::TStorageConfig& storageConfig)
     ProtoConfig.MergeFrom(storageConfig);
 }
 
+void TStorageConfig::Reset(const NProto::TStorageConfig& storageConfig)
+{
+    ProtoConfig = storageConfig;
+}
+
 TStorageConfig::TValueByName TStorageConfig::GetValueByName(
     const TString& name) const
 {

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -66,6 +66,7 @@ public:
     TStorageConfig(const TStorageConfig&) = default;
 
     void Merge(const NProto::TStorageConfig& storageConfig);
+    void Reset(const NProto::TStorageConfig& storageConfig);
 
     TValueByName GetValueByName(const TString& fieldName) const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -84,6 +84,7 @@ TIndexTabletActor::TIndexTabletActor(
     )
     , Config(std::make_shared<TStorageConfig>(*config))
     , DiagConfig(std::move(diagConfig))
+    , BaseStorageConfig(Config->GetStorageConfigProto())
     , BlobCodec(NBlockCodecs::Codec(Config->GetBlobCompressionCodec()))
     , FastShardServer(std::move(fastShardServer))
 {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -176,6 +176,7 @@ private:
 
     // used on monpages
     NProto::TStorageConfig StorageConfigOverride;
+    NProto::TStorageConfig BaseStorageConfig;
 
     ui32 BackpressureErrorCount = 0;
     TInstant BackpressurePeriodStart;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -526,6 +526,12 @@ private:
         const NActors::TActorContext& ctx,
         TTxIndexTablet::TLoadState& args);
 
+    void ApplyStorageConfigOverrides(
+        const NActors::TActorContext& ctx,
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& fileSystemId);
+
     bool IsMainTablet() const;
     bool BehaveAsShard(const NProto::THeaders& headers) const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -207,6 +207,8 @@ void TIndexTabletActor::ApplyStorageConfigOverrides(
     const TString& folderId,
     const TString& fileSystemId)
 {
+    Config->Reset(BaseStorageConfig);
+
     // Features config is applied first, then the per-tablet StorageConfig
     // override is merged on top.
     LOG_INFO_S(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -201,6 +201,32 @@ void TIndexTabletActor::ExecuteTx_LoadState(
         LogTag << " Completed preparing tablet state");
 }
 
+void TIndexTabletActor::ApplyStorageConfigOverrides(
+    const TActorContext& ctx,
+    const TString& cloudId,
+    const TString& folderId,
+    const TString& fileSystemId)
+{
+    // Features config is applied first, then the per-tablet StorageConfig
+    // override is merged on top.
+    LOG_INFO_S(
+        ctx,
+        TFileStoreComponents::TABLET,
+        LogTag << " Setting CloudId=" << cloudId << ", FolderId=" << folderId
+               << ", EntityId=" << fileSystemId
+               << " for the storage config features overrides");
+    Config->SetCloudFolderEntity(cloudId, folderId, fileSystemId);
+
+    if (StorageConfigOverride.ByteSize()) {
+        Config->Merge(StorageConfigOverride);
+        LOG_INFO_S(
+            ctx,
+            TFileStoreComponents::TABLET,
+            LogTag << " Merged per-tablet StorageConfig override on top of "
+                      "features config");
+    }
+}
+
 void TIndexTabletActor::CompleteAdapterLoadState(
     const TActorContext& ctx,
     TTxIndexTablet::TLoadState& args)
@@ -276,17 +302,6 @@ void TIndexTabletActor::CompleteAdapterLoadState(
 
     RunRegularTasks(ctx);
 
-    LOG_INFO_S(
-        ctx,
-        TFileStoreComponents::TABLET,
-        LogTag << " Setting CloudId=" << GetCloudId() << ", FolderId="
-               << GetFolderId() << ", EntityId=" << GetFileSystemId()
-               << " for the storage config features overrides");
-    Config->SetCloudFolderEntity(
-        GetCloudId(),
-        GetFolderId(),
-        GetFileSystemId());
-
     CompleteStateLoad();
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
@@ -299,10 +314,13 @@ void TIndexTabletActor::CompleteTx_LoadState(
 {
     if (args.StorageConfig.Defined()) {
         StorageConfigOverride = *args.StorageConfig;
-        Config->Merge(*args.StorageConfig.Get());
-        LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
-            LogTag << " Merge StorageConfig with config from tablet database");
     }
+
+    ApplyStorageConfigOverrides(
+        ctx,
+        args.FileSystem.GetCloudId(),
+        args.FileSystem.GetFolderId(),
+        args.FileSystem.GetFileSystemId());
 
     if (HasError(args.Error)) {
         LOG_ERROR_S(ctx, TFileStoreComponents::TABLET,
@@ -513,17 +531,6 @@ void TIndexTabletActor::CompleteTx_LoadState(
         LogTag << " Scheduling OpLog ops");
     ReplayOpLog(ctx, args.OpLog);
     RunRegularTasks(ctx);
-
-    LOG_INFO_S(
-        ctx,
-        TFileStoreComponents::TABLET,
-        LogTag << " Setting CloudId=" << GetCloudId() << ", FolderId="
-               << GetFolderId() << ", EntityId=" << GetFileSystemId()
-               << " for the storage config features overrides");
-    Config->SetCloudFolderEntity(
-        GetCloudId(),
-        GetFolderId(),
-        GetFileSystemId());
 
     CompleteStateLoad();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -303,13 +303,8 @@ void TIndexTabletActor::CompleteTx_UpdateConfig(
     RegisterStatCounters(ctx.Now());
     ResetThrottlingPolicy();
 
-    LOG_INFO_S(
+    ApplyStorageConfigOverrides(
         ctx,
-        TFileStoreComponents::TABLET,
-        LogTag << " Setting CloudId=" << GetCloudId() << ", FolderId="
-               << GetFolderId() << ", EntityId=" << GetFileSystemId()
-               << " for the storage config features overrides");
-    Config->SetCloudFolderEntity(
         GetCloudId(),
         GetFolderId(),
         GetFileSystemId());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
@@ -309,6 +309,92 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest)
                     .GetNewCleanupEnabled());
         }
     }
+
+    Y_UNIT_TEST(ShouldPreferStorageConfigOverrideOverFeaturesConfig)
+    {
+        TTestEnv env;
+
+        // A bool feature enabled for the tablet's cloud via the features
+        // config.
+        NCloud::NProto::TFeaturesConfig featuresConfigProto;
+        auto* feature = featuresConfigProto.AddFeatures();
+        feature->SetName("NewCleanupEnabled");
+        feature->MutableWhitelist()->AddCloudIds("test_cloud");
+
+        env.GetStorageConfig()->SetFeaturesConfig(
+            NFeatures::TFeaturesConfig(featuresConfigProto));
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        // Sanity: the features config enables the feature.
+        {
+            auto response = tablet.GetStorageConfig();
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                response->Record.GetStorageConfig().GetNewCleanupEnabled());
+        }
+
+        // A per-tablet override disables the feature. It must win over the
+        // features config, which can only force the bool to true.
+        NProto::TStorageConfig patch;
+        patch.SetNewCleanupEnabled(false);
+        tablet.ChangeStorageConfig(std::move(patch));
+
+        tablet.RebootTablet();
+
+        {
+            auto response = tablet.GetStorageConfig();
+            UNIT_ASSERT_VALUES_EQUAL(
+                false,
+                response->Record.GetStorageConfig().GetNewCleanupEnabled());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldKeepStorageConfigOverrideAfterUpdateConfig)
+    {
+        TTestEnv env;
+
+        NCloud::NProto::TFeaturesConfig featuresConfigProto;
+        auto* feature = featuresConfigProto.AddFeatures();
+        feature->SetName("NewCleanupEnabled");
+        feature->MutableWhitelist()->AddCloudIds("test_cloud");
+
+        env.GetStorageConfig()->SetFeaturesConfig(
+            NFeatures::TFeaturesConfig(featuresConfigProto));
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        NProto::TStorageConfig patch;
+        patch.SetNewCleanupEnabled(false);
+        tablet.ChangeStorageConfig(std::move(patch));
+
+        tablet.RebootTablet();
+
+        // The override wins right after load.
+        {
+            auto response = tablet.GetStorageConfig();
+            UNIT_ASSERT_VALUES_EQUAL(
+                false,
+                response->Record.GetStorageConfig().GetNewCleanupEnabled());
+        }
+
+        // A subsequent UpdateConfig re-applies the features config; the
+        // override must still win afterwards (not only on tablet load).
+        tablet.UpdateConfig({});
+
+        {
+            auto response = tablet.GetStorageConfig();
+            UNIT_ASSERT_VALUES_EQUAL(
+                false,
+                response->Record.GetStorageConfig().GetNewCleanupEnabled());
+        }
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut.cpp
@@ -395,6 +395,31 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest)
                 response->Record.GetStorageConfig().GetNewCleanupEnabled());
         }
     }
+
+    Y_UNIT_TEST(ShouldNotDuplicateRepeatedOverrideFieldsOnUpdateConfig)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        NProto::TStorageConfig patch;
+        patch.AddDestroyFilestoreDenyList("fs-to-deny");
+        tablet.ChangeStorageConfig(std::move(patch));
+
+        tablet.RebootTablet();
+
+        tablet.UpdateConfig({});
+        tablet.UpdateConfig({});
+
+        auto response = tablet.GetStorageConfig();
+        const auto& denyList =
+            response->Record.GetStorageConfig().GetDestroyFilestoreDenyList();
+        UNIT_ASSERT_VALUES_EQUAL(1, denyList.size());
+        UNIT_ASSERT_VALUES_EQUAL("fs-to-deny", denyList[0]);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Notes
Currently if we have some features enabled via features config, we can't disable them on tablet level. This PR rearranged order of overrides to apply features first and then tablet configs


