### PR TITLE
issue-1751: [Filestore] Add feature ServerWriteBackCacheFlushWritesInParallelEnabled

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -115,5 +115,5 @@ message TFileSystemConfig
     // This significantly improves flushing performance but an external reader
     // may observe the effects of newer writes before older ones.
     // With parallel writes off, only sequential writes will be optimized.
-    optional bool ServerWriteBackCacheParallelWritesEnabled = 34;
+    optional bool ServerWriteBackCacheFlushWritesInParallelEnabled = 34;
 }

--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -110,4 +110,10 @@ message TFileSystemConfig
 
     // Maximum serialized size of one persistent handle.
     optional uint64 DirectoryHandlesPersistentHandleMaxSize = 33;
+
+    // Allows flushing WriteData requests to the underlying storage in parallel.
+    // This significantly improves flushing performance but an external reader
+    // may observe the effects of newer writes before older ones.
+    // With parallel writes off, only sequential writes will be optimized.
+    optional bool ServerWriteBackCacheParallelWritesEnabled = 34;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -808,4 +808,10 @@ message TStorageConfig
 
     // Makes tablet's DestroyHandle op handler reply before the tx is committed.
     optional bool TabletUnsafeAsyncDestroyHandleEnabled = 513;
+
+    // Allows flushing WriteData requests to the underlying storage in parallel.
+    // This significantly improves flushing performance but an external reader
+    // may observe the effects of newer writes before older ones.
+    // With parallel writes off, only sequential writes will be optimized.
+    optional bool ServerWriteBackCacheParallelWritesEnabled = 514;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -813,5 +813,5 @@ message TStorageConfig
     // This significantly improves flushing performance but an external reader
     // may observe the effects of newer writes before older ones.
     // With parallel writes off, only sequential writes will be optimized.
-    optional bool ServerWriteBackCacheParallelWritesEnabled = 514;
+    optional bool ServerWriteBackCacheFlushWritesInParallelEnabled = 514;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -280,8 +280,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(GuestPageCacheDisabled,                    bool,     false            )\
     xxx(ExtendedAttributesDisabled,                bool,     false            )\
                                                                                \
-    xxx(ServerWriteBackCacheEnabled,               bool,     false            )\
-    xxx(ServerWriteBackCacheParallelWritesEnabled, bool,     false            )\
+    xxx(ServerWriteBackCacheEnabled,                      bool,     false     )\
+    xxx(ServerWriteBackCacheFlushWritesInParallelEnabled, bool,     false     )\
                                                                                \
     xxx(GuestKeepCacheAllowed,                     bool,      false           )\
     xxx(GuestCachingType,                                                      \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -280,7 +280,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(GuestPageCacheDisabled,                    bool,     false            )\
     xxx(ExtendedAttributesDisabled,                bool,     false            )\
                                                                                \
-    xxx(ServerWriteBackCacheEnabled,    bool,      false                      )\
+    xxx(ServerWriteBackCacheEnabled,               bool,     false            )\
+    xxx(ServerWriteBackCacheParallelWritesEnabled, bool,     false            )\
                                                                                \
     xxx(GuestKeepCacheAllowed,                     bool,      false           )\
     xxx(GuestCachingType,                                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -342,7 +342,7 @@ public:
     bool GetExtendedAttributesDisabled() const;
 
     bool GetServerWriteBackCacheEnabled() const;
-    bool GetServerWriteBackCacheParallelWritesEnabled() const;
+    bool GetServerWriteBackCacheFlushWritesInParallelEnabled() const;
 
     bool GetGuestKeepCacheAllowed() const;
     NProto::EGuestCachingType GetGuestCachingType() const;

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -342,6 +342,7 @@ public:
     bool GetExtendedAttributesDisabled() const;
 
     bool GetServerWriteBackCacheEnabled() const;
+    bool GetServerWriteBackCacheParallelWritesEnabled() const;
 
     bool GetGuestKeepCacheAllowed() const;
     NProto::EGuestCachingType GetGuestCachingType() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -60,8 +60,8 @@ void FillFeatures(
 
     features->SetServerWriteBackCacheEnabled(
         config.GetServerWriteBackCacheEnabled());
-    features->SetServerWriteBackCacheParallelWritesEnabled(
-        config.GetServerWriteBackCacheParallelWritesEnabled());
+    features->SetServerWriteBackCacheFlushWritesInParallelEnabled(
+        config.GetServerWriteBackCacheFlushWritesInParallelEnabled());
 
     features->SetParentlessFilesOnly(config.GetParentlessFilesOnly());
     features->SetAllowHandlelessIO(config.GetAllowHandlelessIO());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -60,6 +60,8 @@ void FillFeatures(
 
     features->SetServerWriteBackCacheEnabled(
         config.GetServerWriteBackCacheEnabled());
+    features->SetServerWriteBackCacheParallelWritesEnabled(
+        config.GetServerWriteBackCacheParallelWritesEnabled());
 
     features->SetParentlessFilesOnly(config.GetParentlessFilesOnly());
     features->SetAllowHandlelessIO(config.GetAllowHandlelessIO());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -825,6 +825,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetGuestPageCacheDisabled(true);
         config.SetExtendedAttributesDisabled(true);
         config.SetServerWriteBackCacheEnabled(true);
+        config.SetServerWriteBackCacheParallelWritesEnabled(true);
         config.SetParentlessFilesOnly(true);
         config.SetAllowHandlelessIO(true);
         config.SetDirectoryHandlesStorageEnabled(true);
@@ -853,6 +854,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetGuestPageCacheDisabled(true);
         features.SetExtendedAttributesDisabled(true);
         features.SetServerWriteBackCacheEnabled(true);
+        features.SetServerWriteBackCacheParallelWritesEnabled(true);
         features.SetParentlessFilesOnly(true);
         features.SetAllowHandlelessIO(true);
         features.SetDirectoryHandlesStorageEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -825,7 +825,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetGuestPageCacheDisabled(true);
         config.SetExtendedAttributesDisabled(true);
         config.SetServerWriteBackCacheEnabled(true);
-        config.SetServerWriteBackCacheParallelWritesEnabled(true);
+        config.SetServerWriteBackCacheFlushWritesInParallelEnabled(true);
         config.SetParentlessFilesOnly(true);
         config.SetAllowHandlelessIO(true);
         config.SetDirectoryHandlesStorageEnabled(true);
@@ -854,7 +854,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetGuestPageCacheDisabled(true);
         features.SetExtendedAttributesDisabled(true);
         features.SetServerWriteBackCacheEnabled(true);
-        features.SetServerWriteBackCacheParallelWritesEnabled(true);
+        features.SetServerWriteBackCacheFlushWritesInParallelEnabled(true);
         features.SetParentlessFilesOnly(true);
         features.SetAllowHandlelessIO(true);
         features.SetDirectoryHandlesStorageEnabled(true);

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -40,8 +40,8 @@ namespace {
     xxx(GuestPageCacheDisabled,     bool,       false                         )\
     xxx(ExtendedAttributesDisabled, bool,       false                         )\
                                                                                \
-    xxx(ServerWriteBackCacheEnabled,               bool,     false            )\
-    xxx(ServerWriteBackCacheParallelWritesEnabled, bool,     false            )\
+    xxx(ServerWriteBackCacheEnabled,                      bool,     false     )\
+    xxx(ServerWriteBackCacheFlushWritesInParallelEnabled, bool,     false     )\
                                                                                \
     xxx(DirectoryHandlesStorageEnabled, bool,   false                         )\
                                                                                \

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -40,7 +40,8 @@ namespace {
     xxx(GuestPageCacheDisabled,     bool,       false                         )\
     xxx(ExtendedAttributesDisabled, bool,       false                         )\
                                                                                \
-    xxx(ServerWriteBackCacheEnabled,  bool,     false                         )\
+    xxx(ServerWriteBackCacheEnabled,               bool,     false            )\
+    xxx(ServerWriteBackCacheParallelWritesEnabled, bool,     false            )\
                                                                                \
     xxx(DirectoryHandlesStorageEnabled, bool,   false                         )\
                                                                                \

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -51,7 +51,7 @@ public:
     bool GetExtendedAttributesDisabled() const;
 
     bool GetServerWriteBackCacheEnabled() const;
-    bool GetServerWriteBackCacheParallelWritesEnabled() const;
+    bool GetServerWriteBackCacheFlushWritesInParallelEnabled() const;
 
     bool GetDirectoryHandlesStorageEnabled() const;
 

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -51,6 +51,7 @@ public:
     bool GetExtendedAttributesDisabled() const;
 
     bool GetServerWriteBackCacheEnabled() const;
+    bool GetServerWriteBackCacheParallelWritesEnabled() const;
 
     bool GetDirectoryHandlesStorageEnabled() const;
 

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -5398,6 +5398,89 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
         UNIT_ASSERT(stopFuture.Wait(WaitTimeout));
     }
+
+    Y_UNIT_TEST(ShouldHandleServerWriteBackCacheParallelWritesEnabledFeature)
+    {
+        // Sends 3 WriteData requests to WriteBackCache: [0, 3), [6, 9), [3, 6)
+        //
+        // WriteBackCache uses greedy algorithm to build WriteData requests
+        // for flush and takes requests from the unflushed queue while the
+        // condition is met.
+        //
+        // When parallel writes are disabled:
+        // - after taking [0, 3) and [6, 9) there will be 2 WriteData requests
+        //   so it will flush only [0, 3)
+        // - then it takes [6, 9) and [3, 6) then are consolidated to [3, 9)
+        //
+        // When parallel writes are enabled:
+        // - take [0, 3) and [6, 9) - 2 WriteData requests in parallel are ok
+        // - take [6, 9) - consolidate to [0, 9)
+
+        auto test = [&](bool parallelWritesEnabled)
+        {
+            NProto::TFileStoreFeatures features;
+            features.SetServerWriteBackCacheEnabled(true);
+            features.SetServerWriteBackCacheParallelWritesEnabled(
+                parallelWritesEnabled);
+
+            TBootstrap bootstrap(
+                CreateWallClockTimer(),
+                CreateScheduler(),
+                 features,
+                 /* handleOpsQueueSize = */ 0,
+                 /* writeBackCacheAutomaticFlushPeriodMs = */ 0);
+
+            const ui64 nodeId = 123;
+            const ui64 handleId = 456;
+
+            std::atomic<ui64> writeDataCalled = 0;
+
+            bootstrap.Service->WriteDataHandler = [&](auto, auto)
+            {
+                writeDataCalled++;
+                return MakeFuture<NProto::TWriteDataResponse>({});
+            };
+
+            bootstrap.Start();
+            Y_DEFER
+            {
+                bootstrap.Stop();
+            };
+
+            auto write1 = bootstrap.Fuse->SendRequest<TWriteRequest>(
+                nodeId,
+                handleId,
+                0,
+                "abc");
+
+            UNIT_ASSERT_NO_EXCEPTION(write1.GetValue(WaitTimeout));
+
+            auto write2 = bootstrap.Fuse->SendRequest<TWriteRequest>(
+                nodeId,
+                handleId,
+                6,
+                "ghi");
+
+            UNIT_ASSERT_NO_EXCEPTION(write2.GetValue(WaitTimeout));
+
+            auto write3 = bootstrap.Fuse->SendRequest<TWriteRequest>(
+                nodeId,
+                handleId,
+                3,
+                "def");
+
+            UNIT_ASSERT_NO_EXCEPTION(write3.GetValue(WaitTimeout));
+
+            auto flush =
+                bootstrap.Fuse->SendRequest<TFlushRequest>(nodeId, handleId);
+            UNIT_ASSERT_NO_EXCEPTION(flush.GetValue(WaitTimeout));
+
+            return writeDataCalled.load();
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(1, test(true));
+        UNIT_ASSERT_VALUES_EQUAL(2, test(false));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -5399,7 +5399,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT(stopFuture.Wait(WaitTimeout));
     }
 
-    Y_UNIT_TEST(ShouldHandleServerWriteBackCacheParallelWritesEnabledFeature)
+    Y_UNIT_TEST(ShouldHandleServerWriteBackCacheFlushWritesInParallelEnabledFeature)
     {
         // Sends 3 WriteData requests to WriteBackCache: [0, 3), [6, 9), [3, 6)
         //
@@ -5420,7 +5420,7 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         {
             NProto::TFileStoreFeatures features;
             features.SetServerWriteBackCacheEnabled(true);
-            features.SetServerWriteBackCacheParallelWritesEnabled(
+            features.SetServerWriteBackCacheFlushWritesInParallelEnabled(
                 parallelWritesEnabled);
 
             TBootstrap bootstrap(

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -5416,12 +5416,12 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         // - take [0, 3) and [6, 9) - 2 WriteData requests in parallel are ok
         // - take [6, 9) - consolidate to [0, 9)
 
-        auto test = [&](bool parallelWritesEnabled)
+        auto test = [&](bool flushWritesInParallelEnabled)
         {
             NProto::TFileStoreFeatures features;
             features.SetServerWriteBackCacheEnabled(true);
             features.SetServerWriteBackCacheFlushWritesInParallelEnabled(
-                parallelWritesEnabled);
+                flushWritesInParallelEnabled);
 
             TBootstrap bootstrap(
                 CreateWallClockTimer(),

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1062,7 +1062,10 @@ private:
                              Config
                                  ->GetWriteBackCacheFlushMaxSumWriteRequestsSize(),
                          .ZeroCopyWriteEnabled =
-                             FileSystemConfig->GetZeroCopyWriteEnabled()});
+                             FileSystemConfig->GetZeroCopyWriteEnabled(),
+                         .ParallelWritesEnabled =
+                             FileSystemConfig
+                                 ->GetServerWriteBackCacheParallelWritesEnabled()});
 
                     if (!FileSystemConfig->GetServerWriteBackCacheEnabled()) {
                         auto future = WriteBackCache.Drain();
@@ -1274,6 +1277,8 @@ private:
 
         config.SetServerWriteBackCacheEnabled(
             features.GetServerWriteBackCacheEnabled());
+        config.SetServerWriteBackCacheParallelWritesEnabled(
+            features.GetServerWriteBackCacheParallelWritesEnabled());
 
         config.SetDirectoryHandlesStorageEnabled(
             features.GetDirectoryHandlesStorageEnabled());

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1063,9 +1063,9 @@ private:
                                  ->GetWriteBackCacheFlushMaxSumWriteRequestsSize(),
                          .ZeroCopyWriteEnabled =
                              FileSystemConfig->GetZeroCopyWriteEnabled(),
-                         .ParallelWritesEnabled =
+                         .FlushWritesInParallelEnabled =
                              FileSystemConfig
-                                 ->GetServerWriteBackCacheParallelWritesEnabled()});
+                                 ->GetServerWriteBackCacheFlushWritesInParallelEnabled()});
 
                     if (!FileSystemConfig->GetServerWriteBackCacheEnabled()) {
                         auto future = WriteBackCache.Drain();
@@ -1277,8 +1277,8 @@ private:
 
         config.SetServerWriteBackCacheEnabled(
             features.GetServerWriteBackCacheEnabled());
-        config.SetServerWriteBackCacheParallelWritesEnabled(
-            features.GetServerWriteBackCacheParallelWritesEnabled());
+        config.SetServerWriteBackCacheFlushWritesInParallelEnabled(
+            features.GetServerWriteBackCacheFlushWritesInParallelEnabled());
 
         config.SetDirectoryHandlesStorageEnabled(
             features.GetDirectoryHandlesStorageEnabled());

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -81,7 +81,9 @@ public:
         , RequestBuilder(CreateWriteDataRequestBuilder(
               {.FileSystemId = args.FileSystemId,
                .MaxWriteRequestSize = args.FlushMaxWriteRequestSize,
-               .MaxWriteRequestsCount = args.FlushMaxWriteRequestsCount,
+               .MaxWriteRequestsCount = args.ParallelWritesEnabled
+                                            ? args.FlushMaxWriteRequestsCount
+                                            : 1,
                .MaxSumWriteRequestsSize = args.FlushMaxSumWriteRequestsSize,
                .ZeroCopyWriteEnabled = args.ZeroCopyWriteEnabled}))
         , SequenceIdGenerator(std::make_shared<TSequenceIdGenerator>())

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -81,7 +81,7 @@ public:
         , RequestBuilder(CreateWriteDataRequestBuilder(
               {.FileSystemId = args.FileSystemId,
                .MaxWriteRequestSize = args.FlushMaxWriteRequestSize,
-               .MaxWriteRequestsCount = args.ParallelWritesEnabled
+               .MaxWriteRequestsCount = args.FlushWritesInParallelEnabled
                                             ? args.FlushMaxWriteRequestsCount
                                             : 1,
                .MaxSumWriteRequestsSize = args.FlushMaxSumWriteRequestsSize,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -73,7 +73,7 @@ struct TWriteBackCacheArgs
     // This significantly improves flushing performance but an external reader
     // may observe the effects of newer writes before older ones.
     // With parallel writes off, only sequential writes will be optimized.
-    bool ParallelWritesEnabled = false;
+    bool FlushWritesInParallelEnabled = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -68,6 +68,12 @@ struct TWriteBackCacheArgs
     // If the flag is enabled, WriteBackCache will generate WriteData requests
     // with iovecs.
     bool ZeroCopyWriteEnabled = false;
+
+    // Allows flushing WriteData requests to the underlying storage in parallel.
+    // This significantly improves flushing performance but an external reader
+    // may observe the effects of newer writes before older ones.
+    // With parallel writes off, only sequential writes will be optimized.
+    bool ParallelWritesEnabled = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -195,7 +195,7 @@ struct TBootstrap
     ui32 MaxSumWriteRequestsSize = 0;
     bool ZeroCopyWriteEnabled = false;
     bool DoNotCheckWriteDataRequestBuffer = false;
-    bool ParallelWritesEnabled = false;
+    bool FlushWritesInParallelEnabled = false;
     bool DisableExpectedDataValidation = false;
 
     TCallContextPtr CallContext;
@@ -227,7 +227,7 @@ struct TBootstrap
         , ZeroCopyWriteEnabled(args.ZeroCopyWriteEnabled)
         , DoNotCheckWriteDataRequestBuffer(
               args.DoNotCheckWriteDataRequestBuffer)
-        , ParallelWritesEnabled(args.ParallelWritesEnabled)
+        , FlushWritesInParallelEnabled(args.ParallelWritesEnabled)
     {
         CacheFlushRetryPeriod = FlushRetryPeriod;
 
@@ -381,7 +381,7 @@ struct TBootstrap
              .FlushMaxWriteRequestsCount = MaxWriteRequestsCount,
              .FlushMaxSumWriteRequestsSize = MaxSumWriteRequestsSize,
              .ZeroCopyWriteEnabled = ZeroCopyWriteEnabled,
-             .ParallelWritesEnabled = ParallelWritesEnabled});
+             .FlushWritesInParallelEnabled = FlushWritesInParallelEnabled});
 
         ModuleStats = Cache.CreateModuleStats();
     }
@@ -2439,11 +2439,13 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         TShouldMaintainVisibilityOrderWhenParallelWritesDisabledTest()
             : TBootstrap(
                   {.AutomaticFlushPeriod = TDuration::MilliSeconds(1),
+                   .MaxWriteRequestSize = 1024,
                    .UseTestTimerAndScheduler = false,
                    // WriteBackCache may execute Flush before ExpectedData is
                    // updated in WriteData future callback in a multi-threaded
                    // environment
-                   .DoNotCheckWriteDataRequestBuffer = true})
+                   .DoNotCheckWriteDataRequestBuffer = true,
+                   .ParallelWritesEnabled = false})
         {}
 
         struct TReaderResult

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -169,6 +169,7 @@ struct TBootstrapArgs
     bool UseTestTimerAndScheduler = true;
     bool ZeroCopyWriteEnabled = false;
     bool DoNotCheckWriteDataRequestBuffer = false;
+    bool ParallelWritesEnabled = true;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -194,6 +195,7 @@ struct TBootstrap
     ui32 MaxSumWriteRequestsSize = 0;
     bool ZeroCopyWriteEnabled = false;
     bool DoNotCheckWriteDataRequestBuffer = false;
+    bool ParallelWritesEnabled = false;
 
     TCallContextPtr CallContext;
 
@@ -219,7 +221,7 @@ struct TBootstrap
 
     std::atomic<int> SessionWriteDataHandlerCalled;
 
-    TBootstrap(const TBootstrapArgs& args = {})
+    explicit TBootstrap(const TBootstrapArgs& args = {})
         : CacheAutomaticFlushPeriod(args.AutomaticFlushPeriod)
         , MaxWriteRequestSize(args.MaxWriteRequestSize)
         , MaxWriteRequestsCount(args.MaxWriteRequestsCount)
@@ -227,6 +229,7 @@ struct TBootstrap
         , ZeroCopyWriteEnabled(args.ZeroCopyWriteEnabled)
         , DoNotCheckWriteDataRequestBuffer(
               args.DoNotCheckWriteDataRequestBuffer)
+        , ParallelWritesEnabled(args.ParallelWritesEnabled)
     {
         CacheFlushRetryPeriod = FlushRetryPeriod;
 
@@ -405,7 +408,8 @@ struct TBootstrap
              .FlushMaxWriteRequestSize = MaxWriteRequestSize,
              .FlushMaxWriteRequestsCount = MaxWriteRequestsCount,
              .FlushMaxSumWriteRequestsSize = MaxSumWriteRequestsSize,
-             .ZeroCopyWriteEnabled = ZeroCopyWriteEnabled});
+             .ZeroCopyWriteEnabled = ZeroCopyWriteEnabled,
+             .ParallelWritesEnabled = ParallelWritesEnabled});
 
         ModuleStats = Cache.CreateModuleStats();
     }
@@ -1558,21 +1562,22 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
     Y_UNIT_TEST(ShouldTryToFlushWhenRequestSizeIsGreaterThanLimit)
     {
-        TBootstrap b({.MaxWriteRequestSize = 2, .MaxWriteRequestsCount = 1});
+        TBootstrap b({.MaxWriteRequestSize = 2, .MaxWriteRequestsCount = 2});
 
         TWriteDataRequestLogger logger;
         logger.Subscribe(b);
 
         b.WriteToCacheSync(1, 0, "a");
-        // Flush will have two requests (1, 2) and (3, 2) despite the limit
-        b.WriteToCacheSync(1, 1, "bbbb");
-        b.WriteToCacheSync(1, 5, "c");
-        b.WriteToCacheSync(1, 6, "d");
+        // Flush will have three requests (1, 2), (3, 2) and (5, 1) despite the
+        // limit
+        b.WriteToCacheSync(1, 1, "bbbbb");
+        b.WriteToCacheSync(1, 6, "c");
+        b.WriteToCacheSync(1, 7, "d");
 
         b.Cache.FlushNodeData(1).GetValueSync();
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "(0, 1), (1, 2), (3, 2), (5, 2)",
+            "(0, 1), (1, 2), (3, 2), (5, 1), (6, 2)",
             logger.RangesToString(1));
     }
 
@@ -2363,6 +2368,81 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         b.RunAllScheduledTasks();
         UNIT_ASSERT_VALUES_EQUAL(2, writeHandles.size());
         UNIT_ASSERT_VALUES_EQUAL(102, writeHandles[1]);
+    }
+
+    Y_UNIT_TEST(ShouldHandleParallelWritesEnabled)
+    {
+        auto test = [&](bool parallelWritesEnabled)
+        {
+            TBootstrap b({
+                .UseTestTimerAndScheduler = true,
+                // Easier calculation of the request size
+                .ZeroCopyWriteEnabled = false,
+                .ParallelWritesEnabled = parallelWritesEnabled,
+            });
+
+            TStringBuilder sb;
+
+            b.Session->WriteDataHandler = [&](auto, auto request)
+            {
+                sb << "[" << request->GetOffset() << ","
+                   << request->GetOffset() + request->GetBuffer().size() << ")";
+                return MakeFuture<NProto::TWriteDataResponse>({});
+            };
+
+            b.WriteToCacheSync(1, 6, "def");
+            b.WriteToCacheSync(1, 9, "ghi");
+            b.WriteToCacheSync(1, 3, "abc");
+            b.WriteToCacheSync(1, 13, "123");
+            b.WriteToCacheSync(1, 12, "jkl");
+            b.WriteToCacheSync(1, 0, "000");
+
+            auto future = b.Cache.FlushNodeData(1);
+            while (!future.HasValue()) {
+                UNIT_ASSERT(!future.HasException());
+                b.RunAllScheduledTasks();
+            }
+
+            return TString(sb);
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL("[3,12)[12,16)[0,3)", test(false));
+        UNIT_ASSERT_VALUES_EQUAL("[0,16)", test(true));
+    }
+
+    Y_UNIT_TEST(ShouldNeverSplitRequestsWhenParallelWritesDisabled)
+    {
+        auto test = [&](bool parallelWritesEnabled)
+        {
+            TBootstrap b({
+                .MaxWriteRequestSize = 2,
+                .UseTestTimerAndScheduler = true,
+                .ParallelWritesEnabled = parallelWritesEnabled,
+            });
+
+            int writeCount = 0;
+
+            TStringBuilder sb;
+
+            b.Session->WriteDataHandler = [&](auto, auto)
+            {
+                writeCount++;
+                return MakeFuture<NProto::TWriteDataResponse>({});
+            };
+
+            b.WriteToCacheSync(1, 3, "abc");
+
+            auto future = b.Cache.FlushNodeData(1);
+            while (!future.HasValue()) {
+                UNIT_ASSERT(!future.HasException());
+                b.RunAllScheduledTasks();
+            }
+
+            return writeCount;
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(1, test(false));
+        UNIT_ASSERT_VALUES_EQUAL(2, test(true));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -196,6 +196,7 @@ struct TBootstrap
     bool ZeroCopyWriteEnabled = false;
     bool DoNotCheckWriteDataRequestBuffer = false;
     bool ParallelWritesEnabled = false;
+    bool DisableExpectedDataValidation = false;
 
     TCallContextPtr CallContext;
 
@@ -215,9 +216,6 @@ struct TBootstrap
     TMutex FlushedDataMutex;
 
     ui32 RecreationCount = 0;
-
-    THashMap<ui64, TInFlightRequestTracker> InFlightReadRequestTracker;
-    THashMap<ui64, TInFlightRequestTracker> InFlightWriteRequestTracker;
 
     std::atomic<int> SessionWriteDataHandlerCalled;
 
@@ -250,18 +248,6 @@ struct TBootstrap
 
         Session->ReadDataHandler = [&] (auto, auto request) {
             const auto nodeId = request->GetNodeId();
-            const auto offset = request->GetOffset();
-            const auto length = request->GetLength();
-
-            // Overlapping write requests are not allowed
-            UNIT_ASSERT_VALUES_EQUAL(
-                0,
-                InFlightWriteRequestTracker[nodeId].Count(offset, length));
-
-            InFlightReadRequestTracker[nodeId].Add(offset, length);
-            Y_DEFER {
-                InFlightReadRequestTracker[nodeId].Remove(offset, length);
-            };
 
             std::unique_lock lock(FlushedDataMutex);
 
@@ -301,21 +287,6 @@ struct TBootstrap
         Session->WriteDataHandler = [&] (auto, auto request) {
             MoveIovecsToBuffer(*request);
             const auto nodeId = request->GetNodeId();
-            const auto offset = request->GetOffset();
-            const auto length = request->GetBuffer().length();
-
-            // Overlapping read requests are not allowed
-            UNIT_ASSERT_VALUES_EQUAL(
-                0,
-                InFlightReadRequestTracker[nodeId].Count(offset, length));
-
-            // Overlapping write requests are not allowed
-            UNIT_ASSERT_VALUES_EQUAL(
-                0,
-                InFlightWriteRequestTracker[nodeId].Add(offset, length));
-            Y_DEFER {
-                InFlightWriteRequestTracker[nodeId].Remove(offset, length);
-            };
 
             std::unique_lock lock1(ExpectedDataMutex);
             std::unique_lock lock2(FlushedDataMutex);
@@ -324,28 +295,29 @@ struct TBootstrap
                 << " to @" << request->GetNodeId()
                 << " at offset " << request->GetOffset());
 
-            UNIT_ASSERT(ExpectedData.contains(nodeId));
-
-            const auto expected = ExpectedData[nodeId];
-            UNIT_ASSERT_LE(
-                request->GetOffset() + request->GetBuffer().length(),
-                expected.length());
-
             auto from = TStringBuf(request->GetBuffer());
-
-            if (!DoNotCheckWriteDataRequestBuffer) {
-                auto expectedData = TStringBuf(expected).SubString(
-                    request->GetOffset(),
-                    request->GetBuffer().length());
-                UNIT_ASSERT_VALUES_EQUAL(expectedData, from);
-            }
 
             auto& flushed = FlushedData[nodeId];
             Write(flushed, request->GetOffset(), request->GetBuffer());
             FlushedDataWritten += request->GetBuffer().length();
 
-            if (RecreationCount == 1) {
-                UNIT_ASSERT_LE(FlushedDataWritten, ExpectedDataWritten);
+            if (!DoNotCheckWriteDataRequestBuffer) {
+                UNIT_ASSERT(ExpectedData.contains(nodeId));
+
+                const auto expected = ExpectedData[nodeId];
+                UNIT_ASSERT_LE(
+                    request->GetOffset() + request->GetBuffer().length(),
+                    expected.length());
+
+                auto expectedData = TStringBuf(expected).SubString(
+                    request->GetOffset(),
+                    request->GetBuffer().length());
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedData, from);
+
+                if (RecreationCount == 1) {
+                    UNIT_ASSERT_LE(FlushedDataWritten, ExpectedDataWritten);
+                }
             }
 
             SessionWriteDataHandlerCalled++;
@@ -1049,10 +1021,13 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
     {
         bool WithCacheRecreation = false;
         bool ZeroCopyWriteEnabled = false;
+        bool ParallelWritesEnabled = false;
     };
 
     void TestShouldReadAfterWriteRandomized(const TTestArgs& args) {
-        TBootstrap b({.ZeroCopyWriteEnabled = args.ZeroCopyWriteEnabled});
+        TBootstrap b(
+            {.ZeroCopyWriteEnabled = args.ZeroCopyWriteEnabled,
+             .ParallelWritesEnabled = args.ParallelWritesEnabled});
 
         const TString alphabet = "abcdefghijklmnopqrstuvwxyz";
 
@@ -1134,22 +1109,31 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
     Y_UNIT_TEST(ShouldReadAfterWriteRandomized)
     {
         TestShouldReadAfterWriteRandomized({});
+        TestShouldReadAfterWriteRandomized({.ParallelWritesEnabled = true});
     }
 
     Y_UNIT_TEST(ShouldReadAfterWriteRandomizedWithRecreation)
     {
         TestShouldReadAfterWriteRandomized({.WithCacheRecreation = true});
+        TestShouldReadAfterWriteRandomized(
+            {.WithCacheRecreation = true, .ParallelWritesEnabled = true});
     }
 
     Y_UNIT_TEST(ShouldReadAfterWriteRandomizedWithZeroCopy)
     {
         TestShouldReadAfterWriteRandomized({.ZeroCopyWriteEnabled = true});
+        TestShouldReadAfterWriteRandomized(
+            {.ZeroCopyWriteEnabled = true, .ParallelWritesEnabled = true});
     }
 
     Y_UNIT_TEST(ShouldReadAfterWriteRandomizedWithRecreationAndZeroCopy)
     {
         TestShouldReadAfterWriteRandomized(
             {.WithCacheRecreation = true, .ZeroCopyWriteEnabled = true});
+        TestShouldReadAfterWriteRandomized(
+            {.WithCacheRecreation = true,
+             .ZeroCopyWriteEnabled = true,
+             .ParallelWritesEnabled = true});
     }
 
     Y_UNIT_TEST(FullyRandomizedWithWriteFailures)
@@ -2443,6 +2427,130 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, test(false));
         UNIT_ASSERT_VALUES_EQUAL(2, test(true));
+    }
+
+    struct TShouldMaintainVisibilityOrderWhenParallelWritesDisabledTest
+        : TBootstrap
+    {
+        const ui64 BytesToWrite = 16 * 1024 * 1024;
+        const ui64 MaxBytesPerWrite = 256;
+        const ui64 NodeId = 1;
+
+        TShouldMaintainVisibilityOrderWhenParallelWritesDisabledTest()
+            : TBootstrap(
+                  {.AutomaticFlushPeriod = TDuration::MilliSeconds(1),
+                   .UseTestTimerAndScheduler = false,
+                   // WriteBackCache may execute Flush before ExpectedData is
+                   // updated in WriteData future callback in a multi-threaded
+                   // environment
+                   .DoNotCheckWriteDataRequestBuffer = true})
+        {}
+
+        struct TReaderResult
+        {
+            ui64 FirstCharCount = 0;
+            ui64 LastCharCount = 0;
+            bool Valid = false;
+        };
+
+        TReaderResult Read(char firstChar, char lastChar)
+        {
+            auto ctx = MakeIntrusive<TCallContext>();
+            auto rq = std::make_shared<NProto::TReadDataRequest>();
+            rq->SetNodeId(NodeId);
+            rq->SetOffset(0);
+            rq->SetLength(BytesToWrite);
+
+            auto resp =
+                Session->ReadData(std::move(ctx), std::move(rq)).GetValue();
+
+            auto data =
+                TStringBuf(resp.GetBuffer()).Skip(resp.GetBufferOffset());
+
+            TReaderResult res;
+            while (res.FirstCharCount < data.size() &&
+                   data[res.FirstCharCount] == firstChar)
+            {
+                res.FirstCharCount++;
+            }
+
+            while (res.FirstCharCount + res.LastCharCount < data.size() &&
+                   data[res.FirstCharCount + res.LastCharCount] == lastChar)
+            {
+                res.LastCharCount++;
+            }
+
+            res.Valid = res.FirstCharCount + res.LastCharCount == data.size();
+
+            return res;
+        }
+
+        void Write(bool forward, char fillChar)
+        {
+            ui64 remaining = BytesToWrite;
+            while (remaining > 0) {
+                auto len = RandomNumber(Min(remaining, MaxBytesPerWrite)) + 1;
+                auto data = TString(len, fillChar);
+                if (forward) {
+                    WriteToCacheSync(NodeId, BytesToWrite - remaining, data);
+                } else {
+                    WriteToCacheSync(NodeId, remaining - len, data);
+                }
+                remaining -= len;
+            }
+        }
+    };
+
+    Y_UNIT_TEST(ShouldMaintainVisibilityOrderWhenParallelWritesDisabled)
+    {
+        TShouldMaintainVisibilityOrderWhenParallelWritesDisabledTest b;
+
+        // Test 1: write 'X' in forward order
+
+        std::thread writerThread1([&]() { b.Write(true, 'X'); });
+        ui64 prevFirstCharCount = 0;
+
+        while (true)
+        {
+            auto r = b.Read('X', '\0');
+
+            UNIT_ASSERT_LE(prevFirstCharCount, r.FirstCharCount);
+            UNIT_ASSERT_VALUES_EQUAL(0, r.LastCharCount);
+            UNIT_ASSERT(r.Valid);
+
+            if (r.FirstCharCount == b.BytesToWrite) {
+                break;
+            }
+
+            prevFirstCharCount = r.FirstCharCount;
+        }
+
+        UNIT_ASSERT_LT_C(0, prevFirstCharCount, "Non-trivial reads expected");
+
+        writerThread1.join();
+
+        // Test 2: overwrite 'Y' in backward order
+
+        std::thread writerThread2([&]() { b.Write(false, 'Y'); });
+        ui64 prevLastCharCount = 0;
+
+        while (true)
+        {
+            auto r = b.Read('X', 'Y');
+
+            UNIT_ASSERT_LE(prevLastCharCount, r.LastCharCount);
+            UNIT_ASSERT(r.Valid);
+
+            if (r.LastCharCount == b.BytesToWrite) {
+                break;
+            }
+
+            prevLastCharCount = r.LastCharCount;
+        }
+
+        UNIT_ASSERT_LT_C(0, prevLastCharCount, "Non-trivial reads expected");
+
+        writerThread2.join();
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -1025,9 +1025,11 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
     };
 
     void TestShouldReadAfterWriteRandomized(const TTestArgs& args) {
-        TBootstrap b(
-            {.ZeroCopyWriteEnabled = args.ZeroCopyWriteEnabled,
-             .ParallelWritesEnabled = args.ParallelWritesEnabled});
+        TBootstrap b({
+            .ZeroCopyWriteEnabled = args.ZeroCopyWriteEnabled,
+            .DoNotCheckWriteDataRequestBuffer = !args.ParallelWritesEnabled,
+            .ParallelWritesEnabled = args.ParallelWritesEnabled,
+        });
 
         const TString alphabet = "abcdefghijklmnopqrstuvwxyz";
 
@@ -1091,9 +1093,15 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 stats.GetNodeCount(),
                 b.Metrics.Nodes.Count->Get());
-            UNIT_ASSERT_VALUES_EQUAL(
-                stats.FlushCount,
-                b.Metrics.Flush.CompletedCount->Get());
+
+            if (args.ParallelWritesEnabled) {
+                // If parallel writes are disabled, multiple Flush operations
+                // will be needed to flush all unflushed data - these values
+                // will be different
+                UNIT_ASSERT_VALUES_EQUAL(
+                    stats.FlushCount,
+                    b.Metrics.Flush.CompletedCount->Get());
+            }
         }
 
         if (args.WithCacheRecreation) {

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -169,7 +169,7 @@ struct TBootstrapArgs
     bool UseTestTimerAndScheduler = true;
     bool ZeroCopyWriteEnabled = false;
     bool DoNotCheckWriteDataRequestBuffer = false;
-    bool ParallelWritesEnabled = true;
+    bool FlushWritesInParallelEnabled = true;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -227,7 +227,7 @@ struct TBootstrap
         , ZeroCopyWriteEnabled(args.ZeroCopyWriteEnabled)
         , DoNotCheckWriteDataRequestBuffer(
               args.DoNotCheckWriteDataRequestBuffer)
-        , FlushWritesInParallelEnabled(args.ParallelWritesEnabled)
+        , FlushWritesInParallelEnabled(args.FlushWritesInParallelEnabled)
     {
         CacheFlushRetryPeriod = FlushRetryPeriod;
 
@@ -1021,14 +1021,15 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
     {
         bool WithCacheRecreation = false;
         bool ZeroCopyWriteEnabled = false;
-        bool ParallelWritesEnabled = false;
+        bool FlushWritesInParallelEnabled = false;
     };
 
     void TestShouldReadAfterWriteRandomized(const TTestArgs& args) {
         TBootstrap b({
             .ZeroCopyWriteEnabled = args.ZeroCopyWriteEnabled,
-            .DoNotCheckWriteDataRequestBuffer = !args.ParallelWritesEnabled,
-            .ParallelWritesEnabled = args.ParallelWritesEnabled,
+            .DoNotCheckWriteDataRequestBuffer =
+                !args.FlushWritesInParallelEnabled,
+            .FlushWritesInParallelEnabled = args.FlushWritesInParallelEnabled,
         });
 
         const TString alphabet = "abcdefghijklmnopqrstuvwxyz";
@@ -1094,7 +1095,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
                 stats.GetNodeCount(),
                 b.Metrics.Nodes.Count->Get());
 
-            if (args.ParallelWritesEnabled) {
+            if (args.FlushWritesInParallelEnabled) {
                 // If parallel writes are disabled, multiple Flush operations
                 // will be needed to flush all unflushed data - these values
                 // will be different
@@ -1117,21 +1118,24 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
     Y_UNIT_TEST(ShouldReadAfterWriteRandomized)
     {
         TestShouldReadAfterWriteRandomized({});
-        TestShouldReadAfterWriteRandomized({.ParallelWritesEnabled = true});
+        TestShouldReadAfterWriteRandomized(
+            {.FlushWritesInParallelEnabled = true});
     }
 
     Y_UNIT_TEST(ShouldReadAfterWriteRandomizedWithRecreation)
     {
         TestShouldReadAfterWriteRandomized({.WithCacheRecreation = true});
         TestShouldReadAfterWriteRandomized(
-            {.WithCacheRecreation = true, .ParallelWritesEnabled = true});
+            {.WithCacheRecreation = true,
+             .FlushWritesInParallelEnabled = true});
     }
 
     Y_UNIT_TEST(ShouldReadAfterWriteRandomizedWithZeroCopy)
     {
         TestShouldReadAfterWriteRandomized({.ZeroCopyWriteEnabled = true});
         TestShouldReadAfterWriteRandomized(
-            {.ZeroCopyWriteEnabled = true, .ParallelWritesEnabled = true});
+            {.ZeroCopyWriteEnabled = true,
+             .FlushWritesInParallelEnabled = true});
     }
 
     Y_UNIT_TEST(ShouldReadAfterWriteRandomizedWithRecreationAndZeroCopy)
@@ -1141,7 +1145,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         TestShouldReadAfterWriteRandomized(
             {.WithCacheRecreation = true,
              .ZeroCopyWriteEnabled = true,
-             .ParallelWritesEnabled = true});
+             .FlushWritesInParallelEnabled = true});
     }
 
     Y_UNIT_TEST(FullyRandomizedWithWriteFailures)
@@ -2362,15 +2366,15 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         UNIT_ASSERT_VALUES_EQUAL(102, writeHandles[1]);
     }
 
-    Y_UNIT_TEST(ShouldHandleParallelWritesEnabled)
+    Y_UNIT_TEST(ShouldHandleFlushWritesInParallelEnabled)
     {
-        auto test = [&](bool parallelWritesEnabled)
+        auto test = [&](bool flushWritesInParallelEnabled)
         {
             TBootstrap b({
                 .UseTestTimerAndScheduler = true,
                 // Easier calculation of the request size
                 .ZeroCopyWriteEnabled = false,
-                .ParallelWritesEnabled = parallelWritesEnabled,
+                .FlushWritesInParallelEnabled = flushWritesInParallelEnabled,
             });
 
             TStringBuilder sb;
@@ -2402,14 +2406,14 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         UNIT_ASSERT_VALUES_EQUAL("[0,16)", test(true));
     }
 
-    Y_UNIT_TEST(ShouldNeverSplitRequestsWhenParallelWritesDisabled)
+    Y_UNIT_TEST(ShouldNeverSplitRequestsWhenFlushWritesInParallelDisabled)
     {
-        auto test = [&](bool parallelWritesEnabled)
+        auto test = [&](bool flushWritesInParallelEnabled)
         {
             TBootstrap b({
                 .MaxWriteRequestSize = 2,
                 .UseTestTimerAndScheduler = true,
-                .ParallelWritesEnabled = parallelWritesEnabled,
+                .FlushWritesInParallelEnabled = flushWritesInParallelEnabled,
             });
 
             int writeCount = 0;
@@ -2437,14 +2441,14 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         UNIT_ASSERT_VALUES_EQUAL(2, test(true));
     }
 
-    struct TShouldMaintainVisibilityOrderWhenParallelWritesDisabledTest
+    struct TShouldMaintainVisibilityOrderWhenFlushWritesInParallelDisabledTest
         : TBootstrap
     {
         const ui64 BytesToWrite = 16 * 1024 * 1024;
         const ui64 MaxBytesPerWrite = 256;
         const ui64 NodeId = 1;
 
-        TShouldMaintainVisibilityOrderWhenParallelWritesDisabledTest()
+        TShouldMaintainVisibilityOrderWhenFlushWritesInParallelDisabledTest()
             : TBootstrap(
                   {.AutomaticFlushPeriod = TDuration::MilliSeconds(1),
                    .MaxWriteRequestSize = 1024,
@@ -2453,7 +2457,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
                    // updated in WriteData future callback in a multi-threaded
                    // environment
                    .DoNotCheckWriteDataRequestBuffer = true,
-                   .ParallelWritesEnabled = false})
+                   .FlushWritesInParallelEnabled = false})
         {}
 
         struct TReaderResult
@@ -2511,9 +2515,9 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
         }
     };
 
-    Y_UNIT_TEST(ShouldMaintainVisibilityOrderWhenParallelWritesDisabled)
+    Y_UNIT_TEST(ShouldMaintainVisibilityOrderWhenFlushWritesInParallelDisabled)
     {
-        TShouldMaintainVisibilityOrderWhenParallelWritesDisabledTest b;
+        TShouldMaintainVisibilityOrderWhenFlushWritesInParallelDisabledTest b;
 
         // Test 1: write 'X' in forward order
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
@@ -289,7 +289,7 @@ private:
             //
             // At the same time, the restriction MaxWriteRequestsCount == 1
             // should be treated as a special case when the request must never
-            // be split and should be sent as it.
+            // be split and should be sent as is.
 
             auto maxWriteRequestSize = Config.MaxWriteRequestsCount > 1
                 ? Config.MaxWriteRequestSize

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_data_request_builder.cpp
@@ -281,6 +281,20 @@ private:
                 dataParts.begin() + partIndex,
                 dataParts.begin() + rangeEndIndex);
 
+            // TWriteDataRequestBatchBuilder accepts the first cached WriteData
+            // request for flushing even if it exceeds MaxWriteRequestsCount -
+            // this is a special case to allow processing requests without being
+            // blocked by the request limits. If this happens, it results in
+            // chopping the request and sending more requests in parallel.
+            //
+            // At the same time, the restriction MaxWriteRequestsCount == 1
+            // should be treated as a special case when the request must never
+            // be split and should be sent as it.
+
+            auto maxWriteRequestSize = Config.MaxWriteRequestsCount > 1
+                ? Config.MaxWriteRequestSize
+                : Max<ui32>();
+
             while (reader.GetRemainingSize() > 0) {
                 auto request = std::make_shared<NProto::TWriteDataRequest>();
                 request->SetFileSystemId(Config.FileSystemId);
@@ -288,7 +302,7 @@ private:
                 request->SetOffset(reader.GetOffset());
 
                 if (Config.ZeroCopyWriteEnabled) {
-                    auto remainingBytes = Config.MaxWriteRequestSize;
+                    auto remainingBytes = maxWriteRequestSize;
                     while (remainingBytes > 0) {
                         auto part = reader.ReadInPlace(remainingBytes);
                         if (part.empty()) {
@@ -301,7 +315,7 @@ private:
                         iovec->SetLength(part.size());
                     }
                 } else {
-                    request->SetBuffer(reader.Read(Config.MaxWriteRequestSize));
+                    request->SetBuffer(reader.Read(maxWriteRequestSize));
                 }
 
                 res.push_back(std::move(request));

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -56,6 +56,7 @@ message TFileStoreFeatures
     bool UseListNodesInternal = 41;
     bool UseCustomReadDataResponseParser = 42;
     optional uint64 DirectoryHandlesPersistentHandleMaxSize = 43;
+    bool ServerWriteBackCacheParallelWritesEnabled = 44;
 }
 
 message TFileStore

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -56,7 +56,7 @@ message TFileStoreFeatures
     bool UseListNodesInternal = 41;
     bool UseCustomReadDataResponseParser = 42;
     optional uint64 DirectoryHandlesPersistentHandleMaxSize = 43;
-    bool ServerWriteBackCacheParallelWritesEnabled = 44;
+    bool ServerWriteBackCacheFlushWritesInParallelEnabled = 44;
 }
 
 message TFileStore


### PR DESCRIPTION
### Notes
During flush, WriteBackCache may aggresively combine and execute WriteData requests in parallel.
External clients who are unaware of WriteBackCache may observe inconsistent state in the storage.
Example scenario: periodic rsync running on another filesystem client.

This PR adds an option to turn on and off flushing WriteData requests in parallel.
When the option is disabled, only sequential WriteData requests will be consolidated, but external readers will observe the effects of WriteData requests in order.

Note: this affect flush within the same node, multiple nodes will continue flushing in parallel independent of each other.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
