### PR TITLE
[Filestore] issue-4066: support SchemeCache, part 2: ModifyScheme

### DIFF
--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_modifyscheme.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_modifyscheme.cpp
@@ -37,6 +37,29 @@ NProto::TError GetErrorFromPreconditionFailed(const NProto::TError& error)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ui64 GetTxIdByOperationType(
+    const NKikimrTxUserProxy::TEvProposeTransactionStatus& record,
+    NKikimrSchemeOp::EOperationType opType)
+{
+    ui64 txId = record.GetTxId();
+
+    switch (opType) {
+        case NKikimrSchemeOp::ESchemeOpCreateFileStore:
+        case NKikimrSchemeOp::ESchemeOpCreateBlockStoreVolume:
+            txId = record.GetPathCreateTxId();
+            break;
+        case NKikimrSchemeOp::ESchemeOpDropFileStore:
+        case NKikimrSchemeOp::ESchemeOpDropBlockStoreVolume:
+            txId = record.GetPathDropTxId();
+            break;
+        default:
+            break;
+    }
+    return txId;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TModifySchemeActor final
     : public TActorBootstrapped<TModifySchemeActor>
 {
@@ -45,6 +68,7 @@ private:
     const TSSProxyActor::TRequestInfo RequestInfo;
     const TActorId Owner;
     const NKikimrSchemeOp::TModifyScheme ModifyScheme;
+    const bool UseSchemeCache;
 
     ui64 TxId = 0;
     ui64 SchemeShardTabletId = 0;
@@ -56,7 +80,8 @@ public:
         int logComponent,
         TSSProxyActor::TRequestInfo requestInfo,
         const TActorId& owner,
-        NKikimrSchemeOp::TModifyScheme modifyScheme);
+        NKikimrSchemeOp::TModifyScheme modifyScheme,
+        bool useSchemeCache);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -82,11 +107,13 @@ TModifySchemeActor::TModifySchemeActor(
         int logComponent,
         TSSProxyActor::TRequestInfo requestInfo,
         const TActorId& owner,
-        NKikimrSchemeOp::TModifyScheme modifyScheme)
+        NKikimrSchemeOp::TModifyScheme modifyScheme,
+        bool useSchemeCache)
     : LogComponent(logComponent)
     , RequestInfo(std::move(requestInfo))
     , Owner(owner)
     , ModifyScheme(std::move(modifyScheme))
+    , UseSchemeCache(useSchemeCache)
 {}
 
 void TModifySchemeActor::Bootstrap(const TActorContext& ctx)
@@ -115,19 +142,37 @@ void TModifySchemeActor::HandleStatus(
     auto status = (TEvTxUserProxy::TEvProposeTransactionStatus::EStatus) record.GetStatus();
     switch (status) {
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecComplete:
-            LOG_DEBUG(ctx, LogComponent,
-                "Request %s with TxId# %lu completed immediately",
-                NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str(),
-                TxId);
+            if (!UseSchemeCache) {
+                LOG_DEBUG(ctx, LogComponent,
+                    "Request %s with TxId# %lu completed immediately",
+                    NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str(),
+                    TxId);
 
-            ReplyAndDie(ctx);
-            break;
+                ReplyAndDie(ctx);
+                break;
+            }
+
+            TxId = GetTxIdByOperationType(record, ModifyScheme.GetOperationType());
+            [[fallthrough]];
 
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress: {
             LOG_DEBUG(ctx, LogComponent,
                 "Request %s with TxId# %lu in progress, waiting for completion",
                 NKikimrSchemeOp::EOperationType_Name(ModifyScheme.GetOperationType()).c_str(),
                 TxId);
+
+            if (UseSchemeCache && TxId == 0) {
+                ReplyAndDie(
+                    ctx,
+                    MakeError(
+                        E_REJECTED,
+                        (TStringBuilder()
+                         << "Transaction is in progress, but txId is zero. "
+                         << NKikimrSchemeOp::EOperationType_Name(
+                                ModifyScheme.GetOperationType())
+                         << ": " << SchemeShardReason)));
+                break;
+            }
 
             auto request = std::make_unique<TEvSSProxy::TEvWaitSchemeTxRequest>(
                 SchemeShardTabletId,
@@ -264,7 +309,8 @@ void TSSProxyActor::HandleModifyScheme(
             Config.LogComponent,
             TRequestInfo(ev->Sender, ev->Cookie),
             ctx.SelfID,
-            msg->ModifyScheme));
+            msg->ModifyScheme,
+            Config.UseSchemeCache));
 }
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_ut.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_ut.cpp
@@ -725,6 +725,32 @@ TEvSSProxy::TEvDescribeSchemeResponse::TPtr DescribePath(
             std::move(handle));
 }
 
+void DescribePathWithPathDoesNotExist(
+    TTestBasicRuntime& runtime,
+    const TActorId& ssProxyId,
+    const TString& path)
+{
+    const auto sender = runtime.AllocateEdgeActor(NodeIdx);
+
+    runtime.Send(
+        new IEventHandle(
+            ssProxyId,
+            sender,
+            new TEvSSProxy::TEvDescribeSchemeRequest(path)),
+        NodeIdx);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* response =
+        runtime.GrabEdgeEventRethrow<
+            TEvSSProxy::TEvDescribeSchemeResponse>(handle);
+
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        MAKE_SCHEMESHARD_ERROR(NKikimrScheme::StatusPathDoesNotExist),
+        response->GetError().GetCode(),
+        "describe expected to fail with StatusPathDoesNotExist for path: "
+            << path);
+}
+
 void CreateFileStore(
     TTestBasicRuntime& runtime,
     const TActorId& ssProxyId,
@@ -785,6 +811,103 @@ void CreateBlockStoreVolume(
     config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
     config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
     config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+    const auto sender = runtime.AllocateEdgeActor(NodeIdx);
+
+    runtime.Send(
+        new IEventHandle(
+            ssProxyId,
+            sender,
+            new TEvSSProxy::TEvModifySchemeRequest(
+                std::move(modifyScheme))),
+        NodeIdx);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* response =
+        runtime.GrabEdgeEventRethrow<
+            TEvSSProxy::TEvModifySchemeResponse>(handle);
+
+    UNIT_ASSERT_C(
+        !HasError(response->GetError()),
+        response->GetError());
+}
+
+void DropFileStore(
+    TTestBasicRuntime& runtime,
+    const TActorId& ssProxyId,
+    const TString& fileSystemId,
+    NKikimrScheme::EStatus expectedStatus = NKikimrScheme::StatusAccepted)
+{
+    NKikimrSchemeOp::TModifyScheme modifyScheme;
+    modifyScheme.SetWorkingDir("/MyRoot/nbs");
+    modifyScheme.SetOperationType(
+        NKikimrSchemeOp::ESchemeOpDropFileStore);
+    modifyScheme.MutableDrop()->SetName(fileSystemId);
+
+    const auto sender = runtime.AllocateEdgeActor(NodeIdx);
+
+    runtime.Send(
+        new IEventHandle(
+            ssProxyId,
+            sender,
+            new TEvSSProxy::TEvModifySchemeRequest(
+                std::move(modifyScheme))),
+        NodeIdx);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* response =
+        runtime.GrabEdgeEventRethrow<
+            TEvSSProxy::TEvModifySchemeResponse>(handle);
+
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        expectedStatus,
+        response->Status,
+        response->GetError());
+}
+
+void DropBlockStoreVolume(
+    TTestBasicRuntime& runtime,
+    const TActorId& ssProxyId,
+    const TString& diskId,
+    NKikimrScheme::EStatus expectedStatus = NKikimrScheme::StatusAccepted)
+{
+    NKikimrSchemeOp::TModifyScheme modifyScheme;
+    modifyScheme.SetWorkingDir("/MyRoot/nbs");
+    modifyScheme.SetOperationType(
+        NKikimrSchemeOp::ESchemeOpDropBlockStoreVolume);
+    modifyScheme.MutableDrop()->SetName(diskId);
+
+    const auto sender = runtime.AllocateEdgeActor(NodeIdx);
+
+    runtime.Send(
+        new IEventHandle(
+            ssProxyId,
+            sender,
+            new TEvSSProxy::TEvModifySchemeRequest(
+                std::move(modifyScheme))),
+        NodeIdx);
+
+    TAutoPtr<IEventHandle> handle;
+    auto* response =
+        runtime.GrabEdgeEventRethrow<
+            TEvSSProxy::TEvModifySchemeResponse>(handle);
+
+    UNIT_ASSERT_VALUES_EQUAL_C(
+        expectedStatus,
+        response->Status,
+        response->GetError());
+}
+
+void MakeDirectory(
+    TTestBasicRuntime& runtime,
+    const TActorId& ssProxyId,
+    const TString& workingDir,
+    const TString& name)
+{
+    NKikimrSchemeOp::TModifyScheme modifyScheme;
+    modifyScheme.SetWorkingDir(workingDir);
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpMkDir);
+    modifyScheme.MutableMkDir()->SetName(name);
 
     const auto sender = runtime.AllocateEdgeActor(NodeIdx);
 
@@ -915,12 +1038,155 @@ void TestShouldListFileStoresAndBlockStoreVolumes(
     UNIT_ASSERT(foundBlockStoreVolume);
 }
 
+void TestShouldCreateAndDropFileStore(bool useSchemeCache)
+{
+    TTestBasicRuntime runtime;
+    TTestEnv env(runtime);
+
+    ui64 txId = 100;
+
+    TestMkDir(runtime, ++txId, "/MyRoot", "nbs");
+    env.TestWaitNotification(runtime, txId);
+
+    auto ssProxyId = SetupSSProxy(runtime, useSchemeCache);
+
+    CreateFileStore(runtime, ssProxyId, "fs");
+    {
+        const auto response =
+            DescribePath(runtime, ssProxyId, "/MyRoot/nbs/fs");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrSchemeOp::EPathTypeFileStore,
+            response->Get()->PathDescription.GetSelf().GetPathType());
+    }
+
+    // Check idempotency
+    CreateFileStore(runtime, ssProxyId, "fs");
+    {
+        const auto response =
+            DescribePath(runtime, ssProxyId, "/MyRoot/nbs/fs");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrSchemeOp::EPathTypeFileStore,
+            response->Get()->PathDescription.GetSelf().GetPathType());
+    }
+
+    DropFileStore(runtime, ssProxyId, "fs");
+    DescribePathWithPathDoesNotExist(runtime, ssProxyId, "/MyRoot/nbs/fs");
+
+    // A repeated drop of an already-removed filestore is reported as
+    // StatusPathDoesNotExist rather than a no-op success.
+    DropFileStore(
+        runtime,
+        ssProxyId,
+        "fs",
+        NKikimrScheme::StatusPathDoesNotExist);
+    DescribePathWithPathDoesNotExist(runtime, ssProxyId, "/MyRoot/nbs/fs");
+}
+
+void TestShouldCreateAndDropBlockStoreVolume(bool useSchemeCache)
+{
+    TTestBasicRuntime runtime;
+    TTestEnv env(runtime);
+
+    ui64 txId = 100;
+
+    TestMkDir(runtime, ++txId, "/MyRoot", "nbs");
+    env.TestWaitNotification(runtime, txId);
+
+    auto ssProxyId = SetupSSProxy(runtime, useSchemeCache);
+
+    CreateBlockStoreVolume(runtime, ssProxyId, "volume");
+    {
+        const auto response =
+            DescribePath(runtime, ssProxyId, "/MyRoot/nbs/volume");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrSchemeOp::EPathTypeBlockStoreVolume,
+            response->Get()->PathDescription.GetSelf().GetPathType());
+    }
+
+    // Check idempotency
+    CreateBlockStoreVolume(runtime, ssProxyId, "volume");
+    {
+        const auto response =
+            DescribePath(runtime, ssProxyId, "/MyRoot/nbs/volume");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrSchemeOp::EPathTypeBlockStoreVolume,
+            response->Get()->PathDescription.GetSelf().GetPathType());
+    }
+
+    DropBlockStoreVolume(runtime, ssProxyId, "volume");
+    DescribePathWithPathDoesNotExist(runtime, ssProxyId, "/MyRoot/nbs/volume");
+
+    // A repeated drop of an already-removed volume is reported as
+    // StatusPathDoesNotExist rather than a no-op success.
+    DropBlockStoreVolume(
+        runtime,
+        ssProxyId,
+        "volume",
+        NKikimrScheme::StatusPathDoesNotExist);
+    DescribePathWithPathDoesNotExist(runtime, ssProxyId, "/MyRoot/nbs/volume");
+}
+
+// Creating a directory that already exists makes SchemeShard answer
+// ExecComplete/StatusAlreadyExists and report the existing directory's
+// PathCreateTxId. The proxy must report success and keep the directory
+// resolvable through SchemeCache afterwards.
+void TestShouldCreateDirectoryIdempotently(bool useSchemeCache)
+{
+    TTestBasicRuntime runtime;
+    TTestEnv env(runtime);
+
+    ui64 txId = 100;
+
+    TestMkDir(runtime, ++txId, "/MyRoot", "nbs");
+    env.TestWaitNotification(runtime, txId);
+
+    auto ssProxyId = SetupSSProxy(runtime, useSchemeCache);
+
+    MakeDirectory(runtime, ssProxyId, "/MyRoot/nbs", "dir");
+
+    {
+        const auto response =
+            DescribePath(runtime, ssProxyId, "/MyRoot/nbs/dir");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrSchemeOp::EPathTypeDir,
+            response->Get()->PathDescription.GetSelf().GetPathType());
+    }
+
+    // A subsequent (idempotent) MkDir for the same path must succeed and
+    // the directory must still be resolvable through SchemeCache.
+    MakeDirectory(runtime, ssProxyId, "/MyRoot/nbs", "dir");
+
+    {
+        const auto response =
+            DescribePath(runtime, ssProxyId, "/MyRoot/nbs/dir");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrSchemeOp::EPathTypeDir,
+            response->Get()->PathDescription.GetSelf().GetPathType());
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TSSProxyTest)
 {
+    Y_UNIT_TEST(ShouldCreateDirectoryIdempotentlyWithoutSchemeCache)
+    {
+        TestShouldCreateDirectoryIdempotently(false);
+    }
+
+    Y_UNIT_TEST(ShouldCreateDirectoryIdempotentlyWithSchemeCache)
+    {
+        TestShouldCreateDirectoryIdempotently(true);
+    }
+
     Y_UNIT_TEST(ShouldDescribeFileStoreWithSchemeCache)
     {
         TestShouldDescribeFileStore(true);
@@ -949,6 +1215,26 @@ Y_UNIT_TEST_SUITE(TSSProxyTest)
     Y_UNIT_TEST(ShouldListFileStoresAndBlockStoreVolumesWithoutSchemeCache)
     {
         TestShouldListFileStoresAndBlockStoreVolumes(false);
+    }
+
+    Y_UNIT_TEST(ShouldCreateAndDropFileStoreWithSchemeCache)
+    {
+        TestShouldCreateAndDropFileStore(true);
+    }
+
+    Y_UNIT_TEST(ShouldCreateAndDropFileStoreWithoutSchemeCache)
+    {
+        TestShouldCreateAndDropFileStore(false);
+    }
+
+    Y_UNIT_TEST(ShouldCreateAndDropBlockStoreVolumeWithSchemeCache)
+    {
+        TestShouldCreateAndDropBlockStoreVolume(true);
+    }
+
+    Y_UNIT_TEST(ShouldCreateAndDropBlockStoreVolumeWithoutSchemeCache)
+    {
+        TestShouldCreateAndDropBlockStoreVolume(false);
     }
 }
 


### PR DESCRIPTION
### Notes
Changes to ModifyScheme by analogy with Blockstore https://github.com/ydb-platform/nbs/blob/2feac82aaf3b994862ef944ee91feab8631da178/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_modifyscheme.cpp#L20 

### Issue
#4066 
