### PR TITLE
Fix use-after-free in coroutine wait cancellation path

### DIFF
--- a/cloud/storage/core/libs/coroutine/executor.h
+++ b/cloud/storage/core/libs/coroutine/executor.h
@@ -93,19 +93,26 @@ private:
     template <typename T>
     bool WaitForI(const NThreading::TFuture<T>& future)
     {
-        auto* executor = GetContExecutor();
-        TContSimpleEvent event(executor);
+        auto event = std::make_shared<TContSimpleEvent>(GetContExecutor());
+        std::weak_ptr<TContSimpleEvent> weakEvent(event);
 
-        auto weakPtr = weak_from_this();
+        future.Subscribe(
+            [weakEvent = std::move(weakEvent),
+             weakPtr = weak_from_this()](const auto&)
+            {
+                if (auto ptr = weakPtr.lock()) {
+                    // switch to executor thread
+                    ptr->ExecuteSimple(
+                        [weakEvent]
+                        {
+                            if (auto event = weakEvent.lock()) {
+                                event->Signal();
+                            }
+                        });
+                }
+            });
 
-        future.Subscribe([&, weakPtr = std::move(weakPtr)] (const auto&) {
-            if (auto ptr = weakPtr.lock()) {
-                // switch to executor thread
-                ptr->ExecuteSimple([&] { event.Signal(); });
-            }
-        });
-
-        int result = event.WaitI();
+        int result = event->WaitI();
         return (result != ECANCELED);
     }
 };

--- a/cloud/storage/core/libs/coroutine/executor_ut.cpp
+++ b/cloud/storage/core/libs/coroutine/executor_ut.cpp
@@ -62,6 +62,46 @@ Y_UNIT_TEST_SUITE(TExecutorTest)
         executor->Stop();
     }
 
+    Y_UNIT_TEST(ShouldIgnoreFutureCompletionAfterCanceledWait)
+    {
+        auto executor = TExecutor::Create("TEST");
+        executor->Start();
+
+        auto promise = NewPromise<void>();
+        TCont* cont = nullptr;
+
+        // Start waiting for an unresolved future. ResultOrError() will suspend
+        // inside WaitForI() and keep a stack-local wait event alive only until
+        // the wait is canceled.
+        auto future = executor->Execute([&] {
+            cont = RunningCont();
+            UNIT_ASSERT(cont);
+            return executor->ResultOrError(promise.GetFuture()).GetError();
+        });
+
+        // Cancel the wait before the promise is completed. This makes WaitForI()
+        // return and destroys the stack-local wait event.
+        executor->Execute([&] {
+            UNIT_ASSERT(cont);
+            cont->Cancel();
+        });
+
+        const auto& error = future.GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            error.GetCode(),
+            FormatError(error));
+
+        // Now complete the promise. Its subscription still runs and schedules a
+        // Signal() on the executor. This used to hit the already-destroyed event.
+        promise.SetValue();
+
+        // Pump the executor so the late scheduled callback is actually executed.
+        executor->Execute([]{}).Wait();
+
+        executor->Stop();
+    }
+
     Y_UNIT_TEST(ShouldExtractResponse)
     {
         auto executor = TExecutor::Create("TEST");


### PR DESCRIPTION
This PR fixes a lifetime issue in `WaitForI()` when a future is completed after the waiting coroutine has already been canceled.

Previously, `TContSimpleEvent` was allocated on the stack and captured by reference in the future subscription callback. In the cancellation path, `WaitI()` may return with `ECANCELED`, destroying the stack-local event. If the original future completes later, the subscription callback can still schedule `event.Signal()` on the executor, which may then access the already-destroyed event.

The fix moves the wait event to `std::shared_ptr` and passes only a `std::weak_ptr` into the delayed executor callback. If `WaitForI()` has already returned and the event has been destroyed, the callback simply skips signaling.

This prevents late future completions from touching a destroyed wait event while preserving the existing cancellation behavior.