### PR TITLE
guardedSgList is not bound to a buffer lifetime

### DIFF
--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -255,7 +255,7 @@ private:
             request->GetBlockSize());
         Y_ENSURE_RETURN(error.GetCode() == 0, "cannot create sgList");
 
-        TGuardedSgList guardedSgList(sglist);
+        auto guardedSgList = buffer.CreateGuardedSgList(std::move(sglist));
 
         auto req = std::make_shared<NProto::TReadBlocksLocalRequest>();
         req->CopyFrom(*request);


### PR DESCRIPTION
### Notes
TGuardedSgList(sglist) does not hold a reference to the TGuardedBuffer whose memory sglist points to. buffer.CreateGuardedSgList(std::move(sglist)) creates a guardedSgList as a co-owner of the buffer—lifetime is correct.

### Issue

