### PR TITLE
[Blockstore] set and unsed used blocks when compact fresh

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp
@@ -104,7 +104,9 @@ public:
             const auto& blob = Args.MixedBlobs[i];
             ProcessNewBlob(ctx, db, blob);
             UpdateCompactionCounters(blob);
-            if (Args.Mode == EAddBlobMode::ADD_WRITE_RESULT) {
+            if (Args.Mode == EAddBlobMode::ADD_WRITE_RESULT ||
+                Args.Mode == ADD_COMPACTION_RESULT)
+            {
                 UpdateUsedBlocks(db, blob);
             }
 
@@ -129,7 +131,9 @@ public:
             const auto& blob = Args.MergedBlobs[i];
             ProcessNewBlob(ctx, db, blob);
             UpdateCompactionCounters(blob);
-            if (Args.Mode == EAddBlobMode::ADD_WRITE_RESULT) {
+            if (Args.Mode == EAddBlobMode::ADD_WRITE_RESULT ||
+                Args.Mode == ADD_COMPACTION_RESULT)
+            {
                 UpdateUsedBlocks(db, blob);
             }
 
@@ -581,10 +585,27 @@ private:
 
     void UpdateUsedBlocks(TPartitionDatabase& db, const TAddMergedBlob& blob)
     {
+        if (blob.SkipMask.Empty()) {
+            if (IsDeletionMarker(blob.BlobId)) {
+                State.UnsetUsedBlocks(db, blob.BlockRange);
+            } else {
+                State.SetUsedBlocks(db, blob.BlockRange);
+            }
+            return;
+        }
+
+        TVector<ui32> blocks;
+        blocks.reserve(blob.BlockRange.Size() - blob.SkipMask.Count());
+        for (const auto blockIndex: xrange(blob.BlockRange)) {
+            if (!blob.SkipMask.Get(blockIndex - blob.BlockRange.Start)) {
+                blocks.push_back(blockIndex);
+            }
+        }
+
         if (IsDeletionMarker(blob.BlobId)) {
-            State.UnsetUsedBlocks(db, blob.BlockRange);
+            State.UnsetUsedBlocks(db, blocks);
         } else {
-            State.SetUsedBlocks(db, blob.BlockRange, blob.SkipMask.Count());
+            State.SetUsedBlocks(db, blocks);
         }
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -323,7 +323,7 @@ void TPartitionActor::ExecuteWriteBlocks(
         // update counters
         State->DecrementFreshBlocksInFlight(sr.Range.Size());
 
-        State->SetUsedBlocks(db, sr.Range, 0);
+        State->SetUsedBlocks(db, sr.Range);
     }
 
     db.WriteMeta(State->GetMeta());

--- a/cloud/blockstore/libs/storage/partition/part_state.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state.cpp
@@ -536,14 +536,13 @@ TOperationState& TPartitionState::GetCompactionState(ECompactionType type)
 
 void TPartitionState::SetUsedBlocks(
     TPartitionDatabase& db,
-    const TBlockRange32& range,
-    ui32 skipCount)
+    const TBlockRange32& range)
 {
-    auto blockCount = GetUsedBlocks().Set(range.Start, range.End + 1) - skipCount;
+    auto blockCount = GetUsedBlocks().Set(range.Start, range.End + 1);
     ui32 logicalBlockCount = 0;
 
     if (GetBaseDiskId()) {
-        logicalBlockCount = GetLogicalUsedBlocks().Set(range.Start, range.End + 1) - skipCount;
+        logicalBlockCount = GetLogicalUsedBlocks().Set(range.Start, range.End + 1);
     } else {
         logicalBlockCount = blockCount;
     }

--- a/cloud/blockstore/libs/storage/partition/part_state.h
+++ b/cloud/blockstore/libs/storage/partition/part_state.h
@@ -721,7 +721,7 @@ public:
         return GetUsedBlocksCount() + GetNewlyZeroedBlocks();
     }
 
-    void SetUsedBlocks(TPartitionDatabase& db, const TBlockRange32& range, ui32 skipCount);
+    void SetUsedBlocks(TPartitionDatabase& db, const TBlockRange32& range);
     void SetUsedBlocks(TPartitionDatabase& db, const TVector<ui32>& blocks);
     void UnsetUsedBlocks(TPartitionDatabase& db, const TBlockRange32& range);
     void UnsetUsedBlocks(TPartitionDatabase& db, const TVector<ui32>& blocks);

--- a/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_state_ut.cpp
@@ -238,8 +238,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             [&](TPartitionDatabase db) {
                 state.SetUsedBlocks(
                     db,
-                    TBlockRange32::MakeClosedInterval(100, 110),
-                    0);
+                    TBlockRange32::MakeClosedInterval(100, 110));
             });
         UNIT_ASSERT_EQUAL(11, state.GetUsedBlocksCount());
         UNIT_ASSERT_EQUAL(21, state.GetLogicalUsedBlocksCount());
@@ -248,8 +247,7 @@ Y_UNIT_TEST_SUITE(TPartitionStateTest)
             [&](TPartitionDatabase db) {
                 state.SetUsedBlocks(
                     db,
-                    TBlockRange32::MakeClosedInterval(105, 130),
-                    0);
+                    TBlockRange32::MakeClosedInterval(105, 130));
             });
         UNIT_ASSERT_EQUAL(31, state.GetUsedBlocksCount());
         UNIT_ASSERT_EQUAL(41, state.GetLogicalUsedBlocksCount());

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -4629,6 +4629,276 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldSetUsedBlocksOnCompactionWithBlocksInFreshChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+        config.SetWriteBlobThresholdSSD(2_MB);
+        // In this test we want compaction and cleanup to be triggered only
+        // manually.
+        config.SetCleanupThreshold(1000);
+        config.SetSSDMaxBlobsPerRange(1000);
+        config.SetFlushThreshold(1000_MB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto rangeLarge = TBlockRange32::WithLength(0, 512);
+        partition.WriteBlocks(rangeLarge);
+        const auto rangeSmall = TBlockRange32::WithLength(512, 1);
+        partition.WriteBlocks(rangeSmall);
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 512);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        options.set(ToBit(ECompactionOption::Forced));
+        partition.Compaction(0 /* range */, options);
+        partition.Cleanup();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 513);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 513);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        partition.Flush();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 513);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 513);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        partition.Compaction(0 /* range */, options);
+        partition.Cleanup();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 513);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 513);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldUnsetUsedBlocksOnCompactionWithZeroBlocksInFreshChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+        config.SetWriteBlobThresholdSSD(2_MB);
+        // In this test we want compaction and cleanup to be triggered only
+        // manually.
+        config.SetCleanupThreshold(1000);
+        config.SetSSDMaxBlobsPerRange(1000);
+        config.SetFlushThreshold(1000_MB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto rangeLarge = TBlockRange32::WithLength(0, 512);
+        partition.WriteBlocks(rangeLarge);
+        const auto rangeSmall = TBlockRange32::WithLength(0, 1);
+        partition.ZeroBlocks(rangeSmall);
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 512);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        options.set(ToBit(ECompactionOption::Forced));
+        partition.Compaction(0 /* range */, options);
+        partition.Cleanup();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 511);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 511);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        partition.Flush();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 511);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 511);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        partition.Compaction(0 /* range */, options);
+        partition.Cleanup();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 511);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 511);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldTrackUsedBlocksOnCompactionWhenMergedBlobsHaveSkipMask)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+        config.SetWriteBlobThresholdSSD(2_MB);
+        // In this test we want compaction and cleanup to be triggered only
+        // manually.
+        config.SetCleanupThreshold(1000);
+        config.SetSSDMaxBlobsPerRange(1000);
+        config.SetFlushThreshold(1000_MB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range1 = TBlockRange32::MakeClosedInterval(0, 4 - 1);
+        const auto range2 = TBlockRange32::MakeClosedInterval(4, 16 - 1);
+        const auto range3 = TBlockRange32::MakeClosedInterval(16, 64 - 1);
+        const auto range4 = TBlockRange32::MakeClosedInterval(64, 256 - 1);
+
+        partition.WriteBlocks(range1);
+        partition.WriteBlocks(range3);
+        partition.Flush();
+
+        partition.Compaction();
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        options.set(ToBit(ECompactionOption::Forced));
+        partition.Compaction(0 /* range */, options);
+        partition.Cleanup();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMergedBlocksCount(),
+                range1.Size() + range3.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetUsedBlocksCount(),
+                range1.Size() + range3.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        partition.ZeroBlocks(range1);
+        partition.WriteBlocks(range2);
+        partition.ZeroBlocks(range3);
+        partition.WriteBlocks(range4);
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetFreshBlocksCount(),
+                range1.Size() + range2.Size() + range3.Size() + range4.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 4);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMergedBlocksCount(),
+                range1.Size() + range3.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetUsedBlocksCount(),
+                range1.Size() + range3.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+
+        partition.Compaction(0 /* range */, options);
+        partition.Cleanup();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetFreshBlocksCount(),
+                range1.Size() + range2.Size() + range3.Size() + range4.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlobsCount(), 4);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlobsCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetMergedBlocksCount(),
+                range2.Size() + range4.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlobsCount(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(
+                stats.GetUsedBlocksCount(),
+                range2.Size() + range4.Size());
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetCleanupQueueBytes(), 0);
+        }
+    }
+
     Y_UNIT_TEST(ShouldWriteBlobIfCompactionUsesOnlyFreshBlocks)
     {
         auto config = DefaultConfig();


### PR DESCRIPTION
### Notes

Currently, we
1. do not update the mask/counter of used blocks for writes to fresh
2. do not update the mask/counter of used blocks during compaction: https://github.com/ydb-platform/nbs/blob/79c13a367c649e6567d10df2e4a1b97caafacfeb/cloud/blockstore/libs/storage/partition/part_actor_addblobs.cpp#L132

1 is okay, but 2 seems to be a problem.

This leads to the following effect: if we compact fresh blocks, those blocks end up in mixed/merged blobs, but they are not accounted for in the used blocks. As a result, the index data and the used-blocks mask contradict each other.

However, this discrepancy will be resolved after a flush.

Why current behaviour is not very good:

- This may affect garbage compaction, since it relies on the used-blocks counter.
- The value of the used-blocks counter becomes confusing. For example, it is possible for the number of used blocks to exceed the number of blocks in mixed/merged blobs (see screenshot).


<img width="1181" height="194" alt="image" src="https://github.com/user-attachments/assets/d2df0317-ae97-42a4-8515-6dae4b395446" />

---

We propose the following solution to this problem:

- Update used blocks during compaction as well, not only on writes.
- Carefully handle the case of a merged blob with skipped blocks. Previously, this case was not handled correctly, but it was ok because it never occurred.

### Issue
https://github.com/ydb-platform/nbs/issues/6158
