### PR TITLE
[Filestore] TFileRingBuffer: add atomic to synchronize reads and writes

### DIFF
--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -423,28 +423,25 @@ private:
         Data->WriteEntryHeader(pos, {});
     }
 
-    void SyncRead()
+    void SyncLoad()
     {
-        __atomic_fetch_add(&Header()->Sync, 1, __ATOMIC_ACQUIRE);
-    }
+        auto readPos = __atomic_load_n(&Header()->ReadPos, __ATOMIC_ACQUIRE);
+        auto writePos = __atomic_load_n(&Header()->WritePos, __ATOMIC_ACQUIRE);
 
-    void SyncWrite()
-    {
-        __atomic_fetch_add(&Header()->Sync, 1, __ATOMIC_RELEASE);
+        Y_UNUSED(readPos);
+        Y_UNUSED(writePos);
     }
 
     // Ensures that the prior writes are visible before updating read position
     void SyncAndUpdateReadPosition(ui64 pos)
     {
-        SyncWrite();
-        Header()->ReadPos = pos;
+        __atomic_store_n(&Header()->ReadPos, pos, __ATOMIC_RELEASE);
     }
 
     // Ensures that the prior writes are visible before updating write position
     void SyncAndUpdateWritePosition(ui64 pos)
     {
-        SyncWrite();
-        Header()->WritePos = pos;
+        __atomic_store_n(&Header()->WritePos, pos, __ATOMIC_RELEASE);
     }
 
     bool ValidateAccess(const char* name) const
@@ -484,7 +481,12 @@ public:
             static_cast<ui32>(Header()->Version),
             args.FilePath.c_str());
 
-        SyncRead();
+        // We need to maintain data consistency on crash when another process
+        // starts working with the same shared memory (memory-mapped file).
+        // We need to ensure that memory writes are observed in the correct
+        // order - it is achieved by treating ReadPos and WritePos pointing
+        // to shared memory as atomics and using acquire and release semantics.
+        SyncLoad();
 
         ValidateStructure();
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -425,6 +425,10 @@ private:
 
     void SyncLoad()
     {
+        // It is important to use the same shared memory address because
+        // paired release-acquire operations guarantee ordering and visibility
+        // of memory writes only when using the same atomic.
+
         auto readPos = __atomic_load_n(&Header()->ReadPos, __ATOMIC_ACQUIRE);
         auto writePos = __atomic_load_n(&Header()->WritePos, __ATOMIC_ACQUIRE);
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -487,9 +487,13 @@ public:
 
         // We need to maintain data consistency on crash when another process
         // starts working with the same shared memory (memory-mapped file).
+        //
         // We need to ensure that memory writes are observed in the correct
         // order - it is achieved by treating ReadPos and WritePos pointing
         // to shared memory as atomics and using acquire and release semantics.
+        //
+        // Note that concurrent access to the buffer is still not allowed and
+        // should be managed at a higher level.
         SyncLoad();
 
         ValidateStructure();
@@ -584,7 +588,7 @@ public:
                 // we need to reset both ReadPos and WritePos to 0.
                 //
                 // We cannot do this atomically - we need to ensure that
-                // the state can be restored from the intermediate state
+                // the state can be restored from the intermediate state.
 
                 WriteSlackSpaceMarker(Header()->WritePos);
                 SyncAndUpdateWritePosition(0);

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -261,7 +261,7 @@ private:
         if (cur.ActualPos != Header()->ReadPos) {
             if (cur.ActualPos == 0 && Header()->WritePos == 0) {
                 // Valid situation when Alloc was interrupted for empty buffer
-                Header()->ReadPos = 0;
+                SyncAndUpdateReadPosition(0);
             } else {
                 SetCorrupted();
                 return;
@@ -410,7 +410,7 @@ private:
         if (front.IsInvalid()) {
             SetCorrupted();
         } else {
-            Header()->ReadPos = front.ActualPos;
+            SyncAndUpdateReadPosition(front.ActualPos);
         }
 
         if (IsMigrationNeeded()) {
@@ -421,6 +421,30 @@ private:
     void WriteSlackSpaceMarker(ui64 pos)
     {
         Data->WriteEntryHeader(pos, {});
+    }
+
+    void SyncRead()
+    {
+        __atomic_fetch_add(&Header()->Sync, 1, __ATOMIC_ACQUIRE);
+    }
+
+    void SyncWrite()
+    {
+        __atomic_fetch_add(&Header()->Sync, 1, __ATOMIC_RELEASE);
+    }
+
+    // Ensures that the prior writes are visible before updating read position
+    void SyncAndUpdateReadPosition(ui64 pos)
+    {
+        SyncWrite();
+        Header()->ReadPos = pos;
+    }
+
+    // Ensures that the prior writes are visible before updating write position
+    void SyncAndUpdateWritePosition(ui64 pos)
+    {
+        SyncWrite();
+        Header()->WritePos = pos;
     }
 
     bool ValidateAccess(const char* name) const
@@ -459,6 +483,8 @@ public:
             "Unsupported current FileRingBuffer version - %u, file: %s",
             static_cast<ui32>(Header()->Version),
             args.FilePath.c_str());
+
+        SyncRead();
 
         ValidateStructure();
 
@@ -549,17 +575,14 @@ public:
         if (Empty()) {
             if (Header()->WritePos != 0) {
                 // In order to fully utilize space when the buffer is empty,
-                // we need to reset read and write positions and ensure that
+                // we need to reset both ReadPos and WritePos to 0.
+                //
+                // We cannot do this atomically - we need to ensure that
                 // the state can be restored from the intermediate state
-                WriteSlackSpaceMarker(Header()->WritePos);
 
-                // A compiler-only fence is sufficient here because there is no
-                // concurrent access to the memory and we just need to ensure
-                // that a compiler does not reorder writes.
-                std::atomic_signal_fence(std::memory_order_seq_cst);
-                Header()->WritePos = 0;
-                std::atomic_signal_fence(std::memory_order_seq_cst);
-                Header()->ReadPos = 0;
+                WriteSlackSpaceMarker(Header()->WritePos);
+                SyncAndUpdateWritePosition(0);
+                SyncAndUpdateReadPosition(0);
                 writePos = 0;
             }
         } else {
@@ -617,14 +640,9 @@ public:
 
         Y_ABORT_UNLESS(written);
 
-        // A compiler-only fence is sufficient here because there is no
-        // concurrent access to the memory and we just need to ensure
-        // that a compiler does not reorder writes.
-        std::atomic_signal_fence(std::memory_order_seq_cst);
-
-        Header()->WritePos =
+        SyncAndUpdateWritePosition(
             CurrentAllocation.ActualPos +
-            Data->GetEntrySize(CurrentAllocation.Header.DataSize);
+            Data->GetEntrySize(CurrentAllocation.Header.DataSize));
 
         EntryMap[CurrentAllocation.Data] = CurrentAllocation.ActualPos;
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -78,8 +78,8 @@ struct TFileRingBufferHeader
     ui64 DataCapacity = 0;
     ui64 ReadPos = 0;
     ui64 WritePos = 0;
-    // Used for multi-threading synchronization
-    ui64 Sync = 0;
+    // Previously was: LastEntrySize
+    ui64 Unused = 0;
     ui64 DataOffset = 0;
     ui64 MetadataCapacity = 0;
     ui64 MetadataOffset = 0;

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -78,8 +78,8 @@ struct TFileRingBufferHeader
     ui64 DataCapacity = 0;
     ui64 ReadPos = 0;
     ui64 WritePos = 0;
-    // Previously was: LastEntrySize
-    ui64 Unused = 0;
+    // Used for multi-threading synchronization
+    ui64 Sync = 0;
     ui64 DataOffset = 0;
     ui64 MetadataCapacity = 0;
     ui64 MetadataOffset = 0;


### PR DESCRIPTION
### Notes
There is no guarantee that after process termination writes to TFileRingBuffer will be observed in the consistent state.
In this PR, explicit acquire and release barriers are added.

### Issue
Related to https://github.com/ydb-platform/nbs/issues/1751
