### PR TITLE
do not move request info as it used by TRequestScope timer

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_monitoring_describe.cpp
@@ -437,7 +437,7 @@ void TPartitionActor::HandleDescribeBlob(
     ExecuteTx(
         ctx,
         CreateTx<TDescribeBlob>(
-            std::move(requestInfo),
+            requestInfo,
             MakePartialBlobId(blobId),
             false  // httpInfo
         ));


### PR DESCRIPTION
### Notes
RequestInfo was moved to transaction however it was still used by TRequestScope

### Issue
Put links to the related issues here
