### PR TITLE
[codex] fix RDMA write request buffer lifetime

### DIFF
--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -359,15 +359,12 @@ private:
         Y_ENSURE_RETURN(requestData.length() > 0, "invalid request");
         Y_ENSURE_RETURN(request->GetBlockSize() != 0, "empty BlockSize");
 
-        TGuardedBuffer dataBuffer(
-            TString(requestData.data(), requestData.length()));
-
         auto [sglist, error] = SgListNormalize(
-            TBlockDataRef{dataBuffer.Get().data(), dataBuffer.Get().length()},
+            {requestData.data(), requestData.length()},
             request->GetBlockSize());
         Y_ENSURE_RETURN(error.GetCode() == 0, "cannot create sgList");
 
-        auto guardedSgList = dataBuffer.CreateGuardedSgList(std::move(sglist));
+        TGuardedSgList guardedSgList(sglist);
 
         auto req = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         req->CopyFrom(*request);
@@ -380,7 +377,6 @@ private:
 
         future.Subscribe(
             [=,
-             dataBuffer = std::move(dataBuffer),
              guardedSgList = std::move(guardedSgList),
              taskQueue = TaskQueue,
              endpoint = Endpoint,
@@ -391,7 +387,6 @@ private:
 
                 taskQueue->ExecuteSimple(
                     [=,
-                     dataBuffer = std::move(dataBuffer),
                      guardedSgList = std::move(guardedSgList),
                      response = std::move(response)]() mutable
                     {
@@ -402,6 +397,8 @@ private:
                             response.MutableDeprecatedTrace()->Clear();
                             response.MutableHeaders()->ClearTrace();
                         }
+
+                        guardedSgList.Close();
 
                         ui32 flags = 0;
                         SetProtoFlag(

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -357,12 +357,17 @@ private:
         LWTRACK(RequestReceived_RdmaTarget, callContext->LWOrbit);
 
         Y_ENSURE_RETURN(requestData.length() > 0, "invalid request");
+        Y_ENSURE_RETURN(request->GetBlockSize() != 0, "empty BlockSize");
+
+        TGuardedBuffer dataBuffer(
+            TString(requestData.data(), requestData.length()));
+
         auto [sglist, error] = SgListNormalize(
-            {requestData.data(), requestData.length()},
+            TBlockDataRef{dataBuffer.Get().data(), dataBuffer.Get().length()},
             request->GetBlockSize());
         Y_ENSURE_RETURN(error.GetCode() == 0, "cannot create sgList");
 
-        TGuardedSgList guardedSgList(sglist);
+        auto guardedSgList = dataBuffer.CreateGuardedSgList(std::move(sglist));
 
         auto req = std::make_shared<NProto::TWriteBlocksLocalRequest>();
         req->CopyFrom(*request);
@@ -375,15 +380,20 @@ private:
 
         future.Subscribe(
             [=,
+             dataBuffer = std::move(dataBuffer),
+             guardedSgList = std::move(guardedSgList),
              taskQueue = TaskQueue,
              endpoint = Endpoint,
-             weakSelf = weak_from_this()](auto future)
+             weakSelf = weak_from_this()](auto future) mutable
             {
                 auto response = ExtractResponse(future);
                 FillResponse(callContext, response);
 
                 taskQueue->ExecuteSimple(
-                    [=, response = std::move(response)]() mutable
+                    [=,
+                     dataBuffer = std::move(dataBuffer),
+                     guardedSgList = std::move(guardedSgList),
+                     response = std::move(response)]() mutable
                     {
                         if (response.ByteSizeLong() > MaxRealProtoSize) {
                             // TODO: consider variable length proto size


### PR DESCRIPTION
### What changed

`HandleWriteBlocksRequest` keeps the write request sglist backed by RDMA `requestData`, but now carries that `TGuardedSgList` into the response path and calls `Close()` before sending `SendResponse` or `SendError`.

This makes the response path a lifetime barrier: once we are about to let the RDMA request complete and release/reuse its input buffer, all active sglist readers must have released their guards.

The write path also now rejects zero block size requests before `SgListNormalize`/`BlocksCount` calculations, matching the existing read path guard.

### Why

ASAN caught a `heap-use-after-free` in:

```text
NCloud::SgListCopy(...)
NCloud::NBlockStore::NStorage::TNonreplicatedPartitionActor::HandleWriteBlocksLocal(...)
```

The freed allocation was an RDMA buffer chunk released from `TBufferPool::TImpl::ReleaseChunk` on the RDMA completion thread. The old write path built `TGuardedSgList` over `requestData`, but did not close it before responding, so RDMA could complete/release the request while async local write handling still had access to the sglist.

This keeps the zero-copy write path and uses the existing `TGuardedSgList` contract as the synchronization point.

### Validation

Not run locally. This workspace is configured only for remote debugging and explicitly forbids build/test commands (`build`, `cmake`, `make`, `ninja`, `ya make`, compilation, or build artifacts).