### PR TITLE
Move HandleDescribeBlob()  in proper place

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -1114,7 +1114,6 @@ void TVolumeActor::HandleDescribeBlobResponse(
     ForwardResponse<TEvVolume::TDescribeBlobMethod>(ctx, ev);
 }
 
-
 #define BLOCKSTORE_FORWARD_REQUEST(name, ns)                                   \
     void TVolumeActor::Handle##name(                                           \
         const ns::TEv##name##Request::TPtr& ev,                                \

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -1063,34 +1063,6 @@ void TVolumeActor::ForwardRequest(
         throttlingRequestInfo);
 }
 
-#define BLOCKSTORE_FORWARD_REQUEST(name, ns)                                   \
-    void TVolumeActor::Handle##name(                                           \
-        const ns::TEv##name##Request::TPtr& ev,                                \
-        const TActorContext& ctx)                                              \
-    {                                                                          \
-        BLOCKSTORE_VOLUME_COUNTER(name);                                       \
-        ForwardRequest<ns::T##name##Method>(ctx, ev);                          \
-    }                                                                          \
-                                                                               \
-    void TVolumeActor::Handle##name##Response(                                 \
-        const ns::TEv##name##Response::TPtr& ev,                               \
-        const NActors::TActorContext& ctx)                                     \
-    {                                                                          \
-        ForwardResponse<ns::T##name##Method>(ctx, ev);                         \
-    }                                                                          \
-// BLOCKSTORE_FORWARD_REQUEST
-
-BLOCKSTORE_FORWARD_REQUEST(ReadBlocks,               TEvService)
-BLOCKSTORE_FORWARD_REQUEST(WriteBlocks,              TEvService)
-BLOCKSTORE_FORWARD_REQUEST(ZeroBlocks,               TEvService)
-BLOCKSTORE_FORWARD_REQUEST(CreateCheckpoint,         TEvService)
-BLOCKSTORE_FORWARD_REQUEST(DeleteCheckpoint,         TEvService)
-BLOCKSTORE_FORWARD_REQUEST(GetChangedBlocks,         TEvService)
-BLOCKSTORE_FORWARD_REQUEST(GetCheckpointStatus,      TEvService)
-BLOCKSTORE_FORWARD_REQUEST(ReadBlocksLocal,          TEvService)
-BLOCKSTORE_FORWARD_REQUEST(WriteBlocksLocal,         TEvService)
-
-BLOCKSTORE_FORWARD_REQUEST(DescribeBlocks,           TEvVolume)
 
 void TVolumeActor::HandleDescribeBlob(
     const TEvVolume::TEvDescribeBlobRequest::TPtr& ev,
@@ -1142,6 +1114,35 @@ void TVolumeActor::HandleDescribeBlobResponse(
     ForwardResponse<TEvVolume::TDescribeBlobMethod>(ctx, ev);
 }
 
+
+#define BLOCKSTORE_FORWARD_REQUEST(name, ns)                                   \
+    void TVolumeActor::Handle##name(                                           \
+        const ns::TEv##name##Request::TPtr& ev,                                \
+        const TActorContext& ctx)                                              \
+    {                                                                          \
+        BLOCKSTORE_VOLUME_COUNTER(name);                                       \
+        ForwardRequest<ns::T##name##Method>(ctx, ev);                          \
+    }                                                                          \
+                                                                               \
+    void TVolumeActor::Handle##name##Response(                                 \
+        const ns::TEv##name##Response::TPtr& ev,                               \
+        const NActors::TActorContext& ctx)                                     \
+    {                                                                          \
+        ForwardResponse<ns::T##name##Method>(ctx, ev);                         \
+    }                                                                          \
+// BLOCKSTORE_FORWARD_REQUEST
+
+BLOCKSTORE_FORWARD_REQUEST(ReadBlocks,               TEvService)
+BLOCKSTORE_FORWARD_REQUEST(WriteBlocks,              TEvService)
+BLOCKSTORE_FORWARD_REQUEST(ZeroBlocks,               TEvService)
+BLOCKSTORE_FORWARD_REQUEST(CreateCheckpoint,         TEvService)
+BLOCKSTORE_FORWARD_REQUEST(DeleteCheckpoint,         TEvService)
+BLOCKSTORE_FORWARD_REQUEST(GetChangedBlocks,         TEvService)
+BLOCKSTORE_FORWARD_REQUEST(GetCheckpointStatus,      TEvService)
+BLOCKSTORE_FORWARD_REQUEST(ReadBlocksLocal,          TEvService)
+BLOCKSTORE_FORWARD_REQUEST(WriteBlocksLocal,         TEvService)
+
+BLOCKSTORE_FORWARD_REQUEST(DescribeBlocks,           TEvVolume)
 BLOCKSTORE_FORWARD_REQUEST(GetUsedBlocks,            TEvVolume)
 BLOCKSTORE_FORWARD_REQUEST(GetPartitionInfo,         TEvVolume)
 BLOCKSTORE_FORWARD_REQUEST(CompactRange,             TEvVolume)


### PR DESCRIPTION
### Notes
Move HandleDescribeBlob() in proper place, outside macros block.

