### PR TITLE
[codex] Fix overlapping request future lifetime

### DIFF
--- a/cloud/blockstore/libs/service/overlapping_requests_guard.cpp
+++ b/cloud/blockstore/libs/service/overlapping_requests_guard.cpp
@@ -9,6 +9,8 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 
+#include <exception>
+
 using namespace NThreading;
 
 namespace NCloud::NBlockStore {
@@ -395,15 +397,26 @@ TFuture<TResponse> TOverlappingRequestsGuard::DoExecuteRequest(
             Service.get(),
             std::move(callContext),
             std::move(request));
+        auto promise = NewPromise<TResponse>();
+        auto future = promise.GetFuture();
+
         result.Subscribe(
             [weakSelf = weak_from_this(),
-             requestId](const TFuture<TResponse>& f)
+             requestId,
+             promise = std::move(promise)](const TFuture<TResponse>& f) mutable
             {
-                if (auto self = weakSelf.lock()) {
-                    self->OnRequestFinished(requestId, f.GetValue().GetError());
+                try {
+                    auto response = f.GetValue();
+                    if (auto self = weakSelf.lock()) {
+                        auto error = response.GetError();
+                        self->OnRequestFinished(requestId, error);
+                    }
+                    promise.SetValue(std::move(response));
+                } catch (...) {
+                    promise.SetException(std::current_exception());
                 }
             });
-        return result;
+        return future;
     }
 
     std::unique_ptr<TInflight>& inflightPtr = overlapping->Value;


### PR DESCRIPTION
### What changed

`TOverlappingRequestsGuard::DoExecuteRequest` no longer returns the same future it uses internally to update overlapping-request state.

For non-overlapping write/zero requests, the guard now creates a separate promise/future for external callers. Its internal subscriber copies the service response, updates `InflightRequests` from an owned `TError`, and only then publishes the copied response to external subscribers.

### Why

The crash reproduced under GDB/ASAN as a `heap-use-after-free` in `NProto::TError::CopyFrom` from `TOverlappingRequestsGuard::OnRequestFinished`.

The problematic path was:

- `TOverlappingRequestsGuard` read `f.GetValue().GetError()` from the service future.
- RDMA write handling subscribed to the same future and used `ExtractResponse` / `UnsafeExtractValue`, which moves from `future.GetValue()`.
- Because a subscriber can observe the future as ready and execute concurrently with callbacks already being drained, the external subscriber could move/destroy the protobuf response while the guard still read the embedded `Error` field.

Returning a separate caller future prevents external `UnsafeExtractValue` users from moving the service future value that the guard still needs to inspect.

### Validation

Not run locally. This workspace has explicit instructions forbidding build/test actions such as `ya make`, and there is no local checkout of `ydb-platform/nbs`; the change was made directly through the GitHub app.