### PR TITLE
Fix WriteBlocksLocal response lifetime race in RDMA callback chain

### DIFF
--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -382,7 +382,14 @@ private:
                 taskQueue->ExecuteSimple(
                     [=, responseFuture = future]() mutable
                     {
-                        auto response = ExtractResponse(responseFuture);
+                        NProto::TWriteBlocksLocalResponse response;
+                        try {
+                            response = responseFuture.GetValue();
+                        } catch (...) {
+                            *response.MutableError() = MakeError(
+                                E_REJECTED,
+                                CurrentExceptionMessage());
+                        }
                         FillResponse(callContext, response);
 
                         guardedSgList.Close();

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -389,8 +389,8 @@ private:
                             *response.MutableError() = MakeError(
                                 E_REJECTED,
                                 TStringBuilder()
-                                    << "unable to GetValue from "
-                                       "WriteBlocksLocalResponse: "
+                                    << "Unable to get value from "
+                                       "WriteBlocksLocal response: "
                                     << CurrentExceptionMessage());
                         }
                         FillResponse(callContext, response);

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -382,17 +382,9 @@ private:
                 taskQueue->ExecuteSimple(
                     [=, responseFuture = future]() mutable
                     {
-                        NProto::TWriteBlocksLocalResponse response;
-                        try {
-                            response = responseFuture.GetValue();
-                        } catch (...) {
-                            *response.MutableError() = MakeError(
-                                E_REJECTED,
-                                TStringBuilder()
-                                    << "Unable to get value from "
-                                       "WriteBlocksLocal response: "
-                                    << CurrentExceptionMessage());
-                        }
+                        auto response =
+                            SafeExecute<NProto::TWriteBlocksLocalResponse>(
+                                [&] { return responseFuture.GetValue(); });
                         FillResponse(callContext, response);
 
                         guardedSgList.Close();

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -382,7 +382,7 @@ private:
                 taskQueue->ExecuteSimple(
                     [=, responseFuture = future]() mutable
                     {
-                        auto response = responseFuture.GetValue();
+                        auto response = ExtractResponse(responseFuture);
                         FillResponse(callContext, response);
 
                         guardedSgList.Close();

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -379,12 +379,13 @@ private:
              endpoint = Endpoint,
              weakSelf = weak_from_this()](auto future)
             {
-                auto response = ExtractResponse(future);
-                FillResponse(callContext, response);
-
                 taskQueue->ExecuteSimple(
-                    [=, response = std::move(response)]() mutable
+                    [=, responseFuture = future]() mutable
                     {
+                        auto response = responseFuture.GetValue();
+                        FillResponse(callContext, response);
+
+                        guardedSgList.Close();
                         if (response.ByteSizeLong() > MaxRealProtoSize) {
                             // TODO: consider variable length proto size
                             // or switch from lwtrace to open telemetry like

--- a/cloud/blockstore/libs/service_rdma/rdma_target.cpp
+++ b/cloud/blockstore/libs/service_rdma/rdma_target.cpp
@@ -388,7 +388,10 @@ private:
                         } catch (...) {
                             *response.MutableError() = MakeError(
                                 E_REJECTED,
-                                CurrentExceptionMessage());
+                                TStringBuilder()
+                                    << "unable to GetValue from "
+                                       "WriteBlocksLocalResponse: "
+                                    << CurrentExceptionMessage());
                         }
                         FillResponse(callContext, response);
 

--- a/cloud/blockstore/libs/storage/disk_agent/rdma_target_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/rdma_target_ut.cpp
@@ -232,6 +232,44 @@ Y_UNIT_TEST_SUITE(TRdmaTargetTest)
         UNIT_ASSERT_VALUES_EQUAL(1, rejectedCounter->Val());
     }
 
+    Y_UNIT_TEST(ShouldHandleManyCoveredOverlappedRequests)
+    {
+        TRdmaTestEnvironment env;
+
+        const auto blockRange = TBlockRange64::WithLength(0, 1024);
+
+        // Make first write request to set volume request id state.
+        {
+            auto writeFuture = env.Run(env.MakeWriteRequest(blockRange, 'A', 100));
+            auto writeResponse = writeFuture.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                writeResponse.GetError().GetCode(),
+                writeResponse.GetError().GetMessage());
+        }
+
+        // Blast a lot of fully covered overlapped requests. Under ASAN this
+        // stresses response/error propagation between multiple callbacks.
+        TVector<NThreading::TFuture<NProto::TZeroDeviceBlocksResponse>> futures;
+        futures.reserve(256);
+        for (ui32 i = 0; i < 256; ++i) {
+            futures.push_back(env.Run(env.MakeZeroRequest(blockRange, 99)));
+        }
+
+        for (auto& future: futures) {
+            auto response = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+        }
+
+        auto delayedCounter = env.Counters->GetCounter("Delayed");
+        auto rejectedCounter = env.Counters->GetCounter("Rejected");
+        UNIT_ASSERT_VALUES_EQUAL(0, delayedCounter->Val());
+        UNIT_ASSERT_VALUES_EQUAL(256, rejectedCounter->Val());
+    }
+
     Y_UNIT_TEST(ShouldRespectDeviceErasure)
     {
         TRdmaTestEnvironment env(8_MB, 2);


### PR DESCRIPTION
### Notes
Move `WriteBlocksLocal` future value extraction `GetValue()` into the inner task-queue callback, so response retrieval and response processing happen in the same execution context.

This reduces cross-callback lifetime coupling and removes the fragile pattern where one callback consumes response state while another still depends on it.

### Issue
`WriteBlocksLocal` completion is observed by multiple async callbacks. One callback may finalize/release the response object while another callback still reads fields from it, which can lead to a response-lifetime race in the write path.
