### PR TITLE
fix TClient::Connect declaration inside client_stub.cpp

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/client/client_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/client_stub.cpp
@@ -8,7 +8,7 @@ using namespace NProtoSrv;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
+std::shared_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
 {
     Y_UNUSED(host, port);
     return nullptr;


### PR DESCRIPTION
### Notes
Fixed the `TClient::Connect` signature in `cloud/filestore/libs/storage/fastshard/client/client_stub.cpp` to match the declaration in `client.h`.

- before: `std::unique_ptr<IEndpoint>`
- after: `std::shared_ptr<IEndpoint>`

### Issue
Build fails with the fastshard client stub due to a `TClient::Connect` signature mismatch. 

```
$(SOURCE_ROOT)/cloud/filestore/libs/storage/fastshard/client/client_stub.cpp:11:37: error: return type of out-of-line definition of 'NCloud::NFileStore::NStorage::NFastShard::TClient::Connect' differs from that in the declaration
   11 | std::unique_ptr<IEndpoint> TClient::Connect(const TString& host, ui16 port)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~          ^
$(SOURCE_ROOT)/cloud/filestore/libs/storage/fastshard/client/client.h:25:32: note: previous declaration is here
   25 |     std::shared_ptr<IEndpoint> Connect(const TString& host, ui16 port);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
1 error generated.

```
