### PR TITLE
issue-5894: fixed a race in TTCPSideChannel related to concurrent TFuture cb runs

### DIFF
--- a/cloud/filestore/libs/service_kikimr/side_channel.cpp
+++ b/cloud/filestore/libs/service_kikimr/side_channel.cpp
@@ -194,7 +194,13 @@ public:
                 ep = EndpointPool,
                 generation
             ] (const TFuture<IAsyncEndpointPtr>& f) {
-                ep->Push(UnsafeExtractValue(f), generation);
+                // Copy instead of UnsafeExtractValue: this is a secondary
+                // subscriber (TryConnect already attached a logging
+                // subscriber to the same future). Moving the value out
+                // races with the logging callback when SetValue is still
+                // iterating callbacks on another thread while Subscribe
+                // runs us synchronously here.
+                ep->Push(f.GetValue(), generation);
             });
     }
 
@@ -279,7 +285,12 @@ public:
             ep = EndpointPool,
             generation
         ] (const TFuture<IAsyncEndpointPtr>& f) mutable {
-            auto e = UnsafeExtractValue(f);
+            // Copy instead of UnsafeExtractValue: this is a secondary
+            // subscriber (TryConnect attached a logging subscriber to the
+            // same future). Moving the value out races with the logging
+            // callback when SetValue is still iterating callbacks on
+            // another thread while Subscribe runs us synchronously here.
+            IAsyncEndpointPtr e = f.GetValue();
 
             if (!e) {
                 TResponse errorResponse;


### PR DESCRIPTION
### Notes
Fixing the following race:
  1. T1 (FUSE) calls `TryConnect()`, which subscribes the logging callback. Queued.
  2. `TryConnect()` returns. Before T1 reaches the next Subscribe.
  3. T2 (the connect fiber) calls `Promise.SetValue(...)`. Inside `TrySetValue()`, it flips state to `ValueSet`, swaps callbacks out, releases the lock, and starts iterating — runs the logging callback on T2. That callback does `if (f.GetValue())`,
  reading `__ptr_` of the `shared_ptr<IAsyncEndpoint>` stored in the future state.
  4. Meanwhile T1 reaches `connection.Subscribe(cb2)`. `Subscribe()` sees `state == ValueSet`, skips the queue, runs cb2 synchronously on T1. cb2 did `auto e = UnsafeExtractValue(f);` — `std::move(const_cast<T&>(f.GetValue()))` — a
  move-construct that writes `__ptr_` to null on that same `shared_ptr`.

### Issue
https://github.com/ydb-platform/nbs/issues/5894