### PR TITLE
[Filestore] increase vfs fsync queue benchmark timeout

### DIFF
--- a/cloud/filestore/libs/vfs/bench/ya.make
+++ b/cloud/filestore/libs/vfs/bench/ya.make
@@ -1,5 +1,8 @@
 Y_BENCHMARK()
 
+SIZE(medium)
+TIMEOUT(300)
+
 IF (SANITIZER_TYPE)
     TAG(ya:manual)
 ENDIF()


### PR DESCRIPTION
### Notes
Prevent benchmark chunks from being killed by the default 60s timeout when running the full benchmark set
- mark `cloud/filestore/libs/vfs/bench` as `SIZE(medium)` and set `TIMEOUT(300)`

The benchmark suite contains many subtests, each taking around ~5 seconds by design.  
With the default chunk timeout, the run is terminated before all tests start, causing `NOT_LAUNCHED` results.  
This change only adjusts test runner limits and does not affect benchmark measurement logic or reported performance metrics.

### Issue
- This is a **chunk timeout** issue, not a benchmark logic crash.
- The suite includes many subtests; total chunk runtime exceeds 60s, so remaining tests are not launched.
- The stack trace seen in timeout handling appears during forced termination, not as primary root cause.

```
30 tests: 11 - GOOD, 19 - NOT_LAUNCHED

benchmark was killed by timeout
Info: 

Chunk exceeded 60s timeout and was killed
List of the tests involved in the launch:
bench::TFSyncQueue_DataEnqDeq_8 (good) duration: 5.00s
bench::TFSyncQueue_MetaEnqDeq_4 (good) duration: 5.00s
bench::TFSyncQueue_MetaEnqDeq_2 (good) duration: 5.00s
bench::TFSyncQueue_DataEnqDeq_4 (good) duration: 5.00s
bench::TFSyncQueue_MetaEnqDeq_16 (good) duration: 5.00s
bench::TFSyncQueue_MetaEnqDeq_1 (good) duration: 5.00s
bench::TFSyncQueue_DataEnqDeq_1 (good) duration: 5.00s
bench::TFSyncQueue_DataMixedEnqDeqLocalWaitAfter64Iterations_1 (good) duration: 5.00s
bench::TFSyncQueue_DataEnqDeq_2 (good) duration: 5.00s
bench::TFSyncQueue_MetaEnqDeq_8 (good) duration: 5.00s
1 more tests with 5.00s total duration are not listed.
19 tests were not launched inside chunk.
Killed by timeout (60 s)
```
