### PR TITLE
[Filestore] Send ReadData buffer as an external payload

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -769,7 +769,7 @@ message TStorageConfig
 
     // Use custom protobuf parser for TReadDataResponse
     // to optimize TReadDataActor performance.
-    optional bool UseCustomReadDataResponseParser = 498;
+    optional bool UseCustomReadDataResponseParser = 498 [deprecated = true];
 
     // If true, describes will be done using SchemeCache instead of TxProxy.
     optional bool UseSchemeCache = 499;
@@ -821,4 +821,7 @@ message TStorageConfig
 
     // Cache TTL that is used by TStorageServiceActor::HandleStatFileStore.
     optional uint32 StatFileStoreCacheTTL = 516; // in ms
+
+    // Pass data buffer from the tablet as a message payload
+    optional bool ExternalReadDataPayload = 517;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -371,6 +371,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(CollectGarbageThresholdForBackpressureSoft,    ui64,    256_GB        )\
                                                                                \
     xxx(StatFileStoreCacheTTL,              TDuration,  TDuration::Zero()     )\
+                                                                               \
+    xxx(ExternalReadDataPayload,                bool,   false                 )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -428,6 +428,8 @@ public:
     ui64 GetCollectGarbageThresholdForBackpressureSoft() const;
 
     [[nodiscard]] TDuration GetStatFileStoreCacheTTL() const;
+
+    [[nodiscard]] bool GetExternalReadDataPayload() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -137,6 +137,10 @@ private:
 
     void ReadData(const TActorContext& ctx, const TString& fallbackReason);
 
+    NProto::TError ProcessExternalPayload(
+        const TRope& payload,
+        NProto::TReadDataResponse& readDataResponse);
+
     void HandleReadDataResponse(
         const TEvService::TEvReadDataResponse::TPtr& ev,
         const TActorContext& ctx);
@@ -723,6 +727,59 @@ void TReadDataActor::ReadData(
     ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
 }
 
+NProto::TError TReadDataActor::ProcessExternalPayload(
+    const TRope& payload,
+    NProto::TReadDataResponse& readDataResponse)
+{
+    ui64 bufferSize = readDataResponse.GetLength();
+    if (payload.size() != bufferSize) {
+        return MakeError(
+            E_ARGUMENT,
+            TStringBuilder()
+                << "Payload has an incorrect size. Expected size: "
+                << bufferSize << " Actual size: " << payload.size());
+    }
+
+    ui64 remainingBufferSize = bufferSize;
+    auto it = payload.begin();
+    if (!ReadRequest.GetIovecs().empty()) {
+        for (auto& iovec: ReadRequest.GetIovecs()) {
+            ui64 currentOffset = 0;
+            while (iovec.GetLength() > currentOffset) {
+                ui64 dataToWrite =
+                    Min(iovec.GetLength() - currentOffset, remainingBufferSize);
+                if (dataToWrite == 0) {
+                    break;
+                }
+                TRopeUtils::Memcpy(
+                    reinterpret_cast<char*>(iovec.GetBase()),
+                    it,
+                    dataToWrite);
+                remainingBufferSize -= dataToWrite;
+                currentOffset += dataToWrite;
+                it += dataToWrite;
+            }
+        }
+    } else {
+        auto& buffer = *readDataResponse.MutableBuffer();
+        buffer.ReserveAndResize(bufferSize);
+        TRopeUtils::Memcpy(&buffer[0], it, payload.size());
+        remainingBufferSize -= payload.size();
+    }
+
+    if (remainingBufferSize != 0) {
+        return MakeError(
+            E_ARGUMENT,
+            TStringBuilder()
+                << "Failed to read buffer from payload. "
+                   " Expected buffer size: "
+                << bufferSize << " Actual bytes copied from payload: "
+                << bufferSize - remainingBufferSize);
+    }
+
+    return {};
+}
+
 void TReadDataActor::HandleReadDataResponse(
     const TEvService::TEvReadDataResponse::TPtr& ev,
     const TActorContext& ctx)
@@ -752,6 +809,27 @@ void TReadDataActor::HandleReadDataResponse(
     if (!isResponseParsed) {
         auto* msg = ev->Get();
         response->Record = std::move(msg->Record);
+
+        ui64 bufferSize = response->Record.GetLength();
+        if (response->Record.GetBuffer().empty() && bufferSize != 0) {
+            if (msg->GetPayloadCount() != 1 ||
+                msg->GetTotalPayloadSize() != bufferSize)
+            {
+                HandleError(
+                    ctx,
+                    MakeError(
+                        E_ARGUMENT,
+                        "Payload is unavailable or has an incorrect size"));
+                return;
+            }
+            auto err = ProcessExternalPayload(
+                msg->GetPayload(0),
+                response->Record);
+            if (HasError(err)) {
+                HandleError(ctx, err);
+                return;
+            }
+        }
     }
 
     auto& record = response->Record;
@@ -1062,7 +1140,10 @@ void TStorageServiceActor::HandleReadData(
         std::move(shardState),
         session->MediaKind,
         useTwoStageRead,
-        filestore.GetFeatures().GetUseCustomReadDataResponseParser(),
+        // UseCustomReadDataResponseParser is deprecated and not compatible with
+        // ExternalReadDataPayload
+        filestore.GetFeatures().GetUseCustomReadDataResponseParser() &&
+            !filestore.GetFeatures().GetExternalReadDataPayload(),
         filestore.GetFeatures().GetZeroCopyReadEnabled());
 
     NCloud::Register(ctx, std::move(actor));

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -734,7 +734,7 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
     ui64 bufferSize = readDataResponse.GetLength();
     if (payload.size() != bufferSize) {
         return MakeError(
-            E_ARGUMENT,
+            E_BADMSG,
             TStringBuilder()
                 << "Payload has an incorrect size. Expected size: "
                 << bufferSize << " Actual size: " << payload.size());
@@ -763,13 +763,13 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
     } else {
         auto& buffer = *readDataResponse.MutableBuffer();
         buffer.ReserveAndResize(bufferSize);
-        TRopeUtils::Memcpy(&buffer[0], it, payload.size());
+        TRopeUtils::Memcpy(buffer.begin(), it, payload.size());
         remainingBufferSize -= payload.size();
     }
 
     if (remainingBufferSize != 0) {
         return MakeError(
-            E_ARGUMENT,
+            E_BADMSG,
             TStringBuilder()
                 << "Failed to read buffer from payload. "
                    " Expected buffer size: "
@@ -818,7 +818,7 @@ void TReadDataActor::HandleReadDataResponse(
                 HandleError(
                     ctx,
                     MakeError(
-                        E_ARGUMENT,
+                        E_BADMSG,
                         "Payload is unavailable or has an incorrect size"));
                 return;
             }

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4928,6 +4928,14 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         testReadDataRequestWithIovecs(std::move(config));
     }
 
+
+    Y_UNIT_TEST(ShouldUseExternalPayloadForReadDataRequest)
+    {
+        NProto::TStorageConfig config;
+        config.SetExternalReadDataPayload(true);
+        testReadDataRequestWithIovecs(std::move(config));
+    }
+
     Y_UNIT_TEST(ShouldHandleToggleServiceState)
     {
         TTestEnv env;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -119,6 +119,8 @@ void FillFeatures(
 
     features->SetStatFileStoreCacheTTL(
         config.GetStatFileStoreCacheTTL().MilliSeconds());
+
+    features->SetExternalReadDataPayload(config.GetExternalReadDataPayload());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -189,6 +189,15 @@ void FillDescribeDataResponse(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void MoveBufferToPayload(TEvService::TEvReadDataResponse& response)
+{
+    response.Record.SetLength(response.Record.GetBuffer().size());
+    response.AddPayload(TRope(std::move(*response.Record.MutableBuffer())));
+    response.Record.MutableBuffer()->clear();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TReadDataVisitor final
     : public IFreshBlockVisitor
     , public IMixedBlockVisitor
@@ -544,9 +553,7 @@ void TReadDataActor::ReplyAndDie(
             }
 
             if (ExternalReadDataPayload) {
-                response->Record.SetLength(response->Record.GetBuffer().size());
-                response->AddPayload(
-                    TRope(std::move(*response->Record.MutableBuffer())));
+                MoveBufferToPayload(*response);
             }
         }
 
@@ -1120,9 +1127,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
         }
 
         if (Config->GetExternalReadDataPayload()) {
-            response->Record.SetLength(response->Record.GetBuffer().size());
-            response->AddPayload(
-                TRope(std::move(*response->Record.MutableBuffer())));
+            MoveBufferToPayload(*response);
         }
 
         CompleteResponse<TEvService::TReadDataMethod>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -345,6 +345,7 @@ private:
     IProfileLogPtr ProfileLog;
     NProto::TBackendInfo BackendInfo;
     NProto::TProfileLogRequestInfo ProfileLogRequest;
+    const bool ExternalReadDataPayload;
 
 public:
     TReadDataActor(
@@ -365,7 +366,8 @@ public:
         TSet<ui32> mixedBlocksRanges,
         IProfileLogPtr profileLog,
         NProto::TBackendInfo backendInfo,
-        NProto::TTProfileLogRequestInfo profileLogRequest);
+        NProto::TTProfileLogRequestInfo profileLogRequest,
+        bool externalReadDataPayload);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -406,7 +408,8 @@ TReadDataActor::TReadDataActor(
         TSet<ui32> mixedBlocksRanges,
         IProfileLogPtr profileLog,
         NProto::TBackendInfo backendInfo,
-        NProto::TTProfileLogRequestInfo profileLogRequest)
+        NProto::TTProfileLogRequestInfo profileLogRequest,
+        bool externalReadDataPayload)
     : TraceSerializer(std::move(traceSerializer))
     , LogTag(std::move(logTag))
     , FileSystemId(std::move(fileSystemId))
@@ -425,6 +428,7 @@ TReadDataActor::TReadDataActor(
     , ProfileLog(std::move(profileLog))
     , BackendInfo(std::move(backendInfo))
     , ProfileLogRequest(std::move(profileLogRequest))
+    , ExternalReadDataPayload(externalReadDataPayload)
 {
     TABLET_VERIFY(ActualRange.IsAligned());
 }
@@ -537,6 +541,12 @@ void TReadDataActor::ReplyAndDie(
                     true /* ignoreBufferOverflow */,
                     FileSystemId,
                     ProfileLogRequest);
+            }
+
+            if (ExternalReadDataPayload) {
+                response->Record.SetLength(response->Record.GetBuffer().size());
+                response->AddPayload(
+                    TRope(std::move(*response->Record.MutableBuffer())));
             }
         }
 
@@ -1109,6 +1119,12 @@ void TIndexTabletActor::CompleteTx_ReadData(
                 args.ProfileLogRequest);
         }
 
+        if (Config->GetExternalReadDataPayload()) {
+            response->Record.SetLength(response->Record.GetBuffer().size());
+            response->AddPayload(
+                TRope(std::move(*response->Record.MutableBuffer())));
+        }
+
         CompleteResponse<TEvService::TReadDataMethod>(
             response->Record,
             args.RequestInfo->CallContext,
@@ -1154,7 +1170,8 @@ void TIndexTabletActor::CompleteTx_ReadData(
         std::move(args.MixedBlocksRanges),
         ProfileLog,
         std::move(backendInfo),
-        std::move(args.ProfileLogRequest));
+        std::move(args.ProfileLogRequest),
+        Config->GetExternalReadDataPayload());
 
     auto actorId = NCloud::Register(ctx, std::move(actor));
     WorkerActors.insert(actorId);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -8617,6 +8617,41 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             "got "
                 << rebootTracker.GetGenerationCount());
     }
+
+    TABLET_TEST(ShouldPassReadDataAsPayload)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetExternalReadDataPayload(true);
+
+        TTestEnv env({} /* config */, std::move(storageConfig));
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto data = GenerateValidateData(1_KB);
+        tablet.WriteData(handle, 0, data.size(), data.c_str());
+        tablet.Flush();
+
+        auto response = tablet.ReadData(handle, 0, 1_KB);
+        const auto& buffer = response->Record.GetBuffer();
+        UNIT_ASSERT(buffer.empty());
+        UNIT_ASSERT_VALUES_EQUAL(data.size(), response->Record.GetLength());
+        UNIT_ASSERT_VALUES_EQUAL(1, response->GetPayloadCount());
+        UNIT_ASSERT_VALUES_EQUAL(data.size(), response->GetTotalPayloadSize());
+        auto& payload = response->GetPayload(0);
+        UNIT_ASSERT_VALUES_EQUAL(data.size(), payload.size());
+        UNIT_ASSERT_VALUES_EQUAL(data, payload.ConvertToString());
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -839,6 +839,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetReadBlobDisabled(true);
         config.SetWriteBlobDisabled(true);
         config.SetUseCustomReadDataResponseParser(true);
+        config.SetExternalReadDataPayload(true);
 
         features.SetTwoStageReadEnabled(true);
         features.SetTwoStageReadThreshold(64_KB);
@@ -868,6 +869,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetReadBlobDisabled(true);
         features.SetWriteBlobDisabled(true);
         features.SetUseCustomReadDataResponseParser(true);
+        features.SetExternalReadDataPayload(true);
 
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
     }

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -54,10 +54,11 @@ message TFileStoreFeatures
     bool UnconfirmedFlowEnabled = 39;
     bool GuestPosixAclEnabled = 40;
     bool UseListNodesInternal = 41;
-    bool UseCustomReadDataResponseParser = 42;
+    bool UseCustomReadDataResponseParser = 42 [deprecated = true];
     optional uint64 DirectoryHandlesPersistentHandleMaxSize = 43;
     bool ServerWriteBackCacheFlushWritesInParallelEnabled = 44;
     uint32 StatFileStoreCacheTTL = 45; // in ms
+    bool ExternalReadDataPayload = 46;
 }
 
 message TFileStore

--- a/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/nfs-patch.txt
@@ -1,0 +1,1 @@
+ExternalReadDataPayload: true

--- a/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/test.py
+++ b/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/test.py
@@ -1,0 +1,41 @@
+import pytest
+
+import cloud.storage.core.tools.testing.fio.lib as fio
+
+from cloud.filestore.tests.python.lib.common import get_filestore_mount_path
+
+SCENARIOS = ["randwrite", "randrw"]
+
+BLOCK_SIZE = 4096
+
+SIZES = [BLOCK_SIZE - 1, 4 * fio.KB, 1 * fio.MB]
+
+UNALIGNED_TESTS = fio.generate_tests(
+    offset=100,
+    sizes=SIZES,
+    iodepths=[1],
+    numjobs=[1],
+    scenarios=SCENARIOS)
+
+ALIGNED_TESTS = fio.generate_tests(
+    offset=0,
+    sizes=SIZES,
+    iodepths=[1],
+    numjobs=[4],
+    scenarios=SCENARIOS)
+
+
+@pytest.mark.parametrize("name", UNALIGNED_TESTS.keys())
+def test_fio_unaligned(name):
+    mount_dir = get_filestore_mount_path()
+    file_name = fio.get_file_name(mount_dir, name)
+
+    fio.run_test(file_name, UNALIGNED_TESTS[name], fail_on_errors=True)
+
+
+@pytest.mark.parametrize("name", ALIGNED_TESTS.keys())
+def test_fio_aligned(name):
+    mount_dir = get_filestore_mount_path()
+    file_name = fio.get_file_name(mount_dir, name)
+
+    fio.run_test(file_name, ALIGNED_TESTS[name], fail_on_errors=True)

--- a/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/ya.make
@@ -1,0 +1,34 @@
+PY3TEST()
+
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+ENDIF()
+
+DEPENDS(
+    cloud/storage/core/tools/testing/fio/bin
+)
+
+PEERDIR(
+    cloud/filestore/tests/python/lib
+    cloud/storage/core/tools/testing/fio/lib
+)
+
+TEST_SRCS(
+    test.py
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/nfs-patch.txt
+)
+
+SET(QEMU_VIRTIO fs)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-fallback-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-fallback-test/nfs-patch.txt
@@ -1,3 +1,4 @@
 ZeroCopyWriteEnabled: true
 ZeroCopyReadEnabled: true
 UseCustomReadDataResponseParser: true
+ExternalReadDataPayload: true


### PR DESCRIPTION
issue: #6334

The tablet currently sends ReadDataResponse with the data buffer embedded inside the protobuf message:
https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp#L1101

This approach causes several issues:

1. Parsing the buffer from the protobuf message on the filestore-vhost side is expensive.
2. The interconnect does not support transmitting protobuf messages over XDC/RDMA.

Instead, the data buffer can be sent as a message payload. This avoids the protobuf parsing overhead and enables XDC/RDMA transport support.

UseCustomReadDataResponseParser feature is deprecated.




