### PR TITLE
fix asan error in partition2 describeblob

### DIFF
--- a/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_describe.cpp
@@ -339,7 +339,7 @@ void TPartitionActor::HandleDescribeBlob(
 
     ExecuteTx<TDescribeBlob>(
         ctx,
-        std::move(requestInfo),
+        requestInfo,
         MakePartialBlobId(blobId),
         false  // httpInfo
     );


### PR DESCRIPTION
### Notes
Do not move request info to transaction as it is used by scope timer

### Issue
Put links to the related issues here

Same as https://github.com/ydb-platform/nbs/pull/6247/changes
