### PR TITLE
[Filestore] TFileRingBuffer: Remove default constructor values

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -4106,7 +4106,12 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                     sessionId / "write_back_cache";
 
         {
-            TFileRingBuffer ringBuffer(path, WriteBackCacheCapacity);
+            TFileRingBuffer ringBuffer(
+                path,
+                WriteBackCacheCapacity,
+                0,
+                EFileRingBufferVersion::V6);
+
             UNIT_ASSERT(!ringBuffer.Empty());
         }
 
@@ -4147,7 +4152,12 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         }
 
         {
-            TFileRingBuffer ringBuffer(path, WriteBackCacheCapacity);
+            TFileRingBuffer ringBuffer(
+                path,
+                WriteBackCacheCapacity,
+                0,
+                EFileRingBufferVersion::V6);
+
             UNIT_ASSERT(ringBuffer.Empty());
         }
 

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
@@ -5,7 +5,7 @@ namespace NCloud::NFileStore::NFuse {
 ////////////////////////////////////////////////////////////////////////////////
 
 THandleOpsQueue::THandleOpsQueue(const TString& filePath, ui32 size)
-    : RequestsToProcess(filePath, size)
+    : RequestsToProcess(filePath, size, 0, EFileRingBufferVersion::V5)
 {}
 
 THandleOpsQueue::EResult THandleOpsQueue::AddDestroyRequest(

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -43,12 +43,16 @@ public:
     * metadata. If the size of the existing metadata is greater than the
     * specified capacity, the metadata area is shrunk to fit the existing
     * metadata.
+    *
+    * Argument version specifies the version of the file ring buffer format.
+    * It affects capabilities (like storing tags, enforcing checksum calculation
+    * for headers etc).
     */
     TFileRingBuffer(
         const TString& filePath,
         ui64 dataCapacity,
-        ui64 metadataCapacity = 0,
-        EFileRingBufferVersion version = EFileRingBufferVersion::V5);
+        ui64 metadataCapacity,
+        EFileRingBufferVersion version);
 
     ~TFileRingBuffer();
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -9,11 +9,29 @@
 #include <util/system/filemap.h>
 #include <util/system/tempfile.h>
 
-namespace NCloud {
+namespace NCloud::NTesting {
 
 using EVersion = EFileRingBufferVersion;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBuffer: public NCloud::TFileRingBuffer
+{
+public:
+    TFileRingBuffer(
+        const TString& filePath,
+        ui64 dataCapacity,
+        ui64 metadataCapacity = 0,
+        EVersion version = EVersion::V5)
+        : NCloud::TFileRingBuffer(
+              filePath,
+              dataCapacity,
+              metadataCapacity,
+              version)
+    {}
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
### Notes

Force users of `TFileRingBuffer` to explicitly specify version instead of relating on the default parameter.
