### PR TITLE
[Filestore] enable dynamic backpressure without throttler (#2512)

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -824,4 +824,10 @@ message TStorageConfig
 
     // Pass data buffer from the tablet as a message payload
     optional bool ExternalReadDataPayload = 517;
+
+    // Throttling configuration for backpressure usecase, when global throttler is disabled
+    optional uint32 SoftBackpressureMaxWriteBandwidth = 518;   // in MiB/s
+    optional uint32 SoftBackpressureMaxReadBandwidth = 519;    // in MiB/s
+    optional uint32 SoftBackpressureMaxWriteIops = 520;
+    optional uint32 SoftBackpressureMaxReadIops = 521;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -373,6 +373,10 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(StatFileStoreCacheTTL,              TDuration,  TDuration::Zero()     )\
                                                                                \
     xxx(ExternalReadDataPayload,                bool,   false                 )\
+    xxx(SoftBackpressureMaxWriteBandwidth,             ui32,    10'240        )\
+    xxx(SoftBackpressureMaxReadBandwidth,              ui32,    30'720        )\
+    xxx(SoftBackpressureMaxWriteIops,                  ui32,    10'000        )\
+    xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -373,8 +373,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(StatFileStoreCacheTTL,              TDuration,  TDuration::Zero()     )\
                                                                                \
     xxx(ExternalReadDataPayload,                bool,   false                 )\
-    xxx(SoftBackpressureMaxWriteBandwidth,             ui32,    10'240        )\
-    xxx(SoftBackpressureMaxReadBandwidth,              ui32,    30'720        )\
+    xxx(SoftBackpressureMaxWriteBandwidth,             ui32,    10 * 1024     )\
+    xxx(SoftBackpressureMaxReadBandwidth,              ui32,    30 * 1024     )\
     xxx(SoftBackpressureMaxWriteIops,                  ui32,    10'000        )\
     xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
 // FILESTORE_STORAGE_CONFIG

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -430,6 +430,10 @@ public:
     [[nodiscard]] TDuration GetStatFileStoreCacheTTL() const;
 
     [[nodiscard]] bool GetExternalReadDataPayload() const;
+    ui32 GetSoftBackpressureMaxWriteBandwidth() const;
+    ui32 GetSoftBackpressureMaxReadBandwidth() const;
+    ui32 GetSoftBackpressureMaxWriteIops() const;
+    ui32 GetSoftBackpressureMaxReadIops() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers.cpp
@@ -45,6 +45,18 @@ NProto::TNode CreateAttrs(NProto::ENodeType type, int mode, ui64 size, ui64 uid,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool IsValidPerformanceProfile(
+    const NProto::TFileStorePerformanceProfile& profile)
+{
+    return profile.GetMaxReadIops()
+        && profile.GetMaxReadBandwidth()
+        && profile.GetMaxPostponedWeight()
+        && profile.GetMaxPostponedTime()
+        && profile.GetDefaultPostponedRequestWeight();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 NProto::TNode CreateRegularAttrs(ui32 mode, ui32 uid, ui32 gid)
 {
     return CreateAttrs(NProto::E_REGULAR_NODE, mode, 0, uid, gid);
@@ -362,7 +374,9 @@ TThrottlerConfig BuildThrottlerConfig(
     const NProto::TFileStorePerformanceProfile& performanceProfile)
 {
     TThrottlerConfig config;
-    Convert(performanceProfile, config);
+    if (IsValidPerformanceProfile(performanceProfile)) {
+        Convert(performanceProfile, config);
+    }
 
     const bool throttlingEnabled =
         storageConfig.GetThrottlingEnabled() && config.ThrottlingEnabled;

--- a/cloud/filestore/libs/storage/tablet/helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers.cpp
@@ -332,18 +332,16 @@ void ApplySoftBackpressureParameters(
     const TStorageConfig& storageConfig,
     TDefaultParameters& parameters)
 {
-    const ui32 maxWriteBandwidth =
+    const ui64 maxWriteBandwidth =
         storageConfig.GetSoftBackpressureMaxWriteBandwidth();
     if (maxWriteBandwidth) {
-        parameters.MaxWriteBandwidth =
-            static_cast<ui64>(maxWriteBandwidth) * 1_MB;
+        parameters.MaxWriteBandwidth = maxWriteBandwidth * 1_MB;
     }
 
-    const ui32 maxReadBandwidth =
+    const ui64 maxReadBandwidth =
         storageConfig.GetSoftBackpressureMaxReadBandwidth();
     if (maxReadBandwidth) {
-        parameters.MaxReadBandwidth =
-            static_cast<ui64>(maxReadBandwidth) * 1_MB;
+        parameters.MaxReadBandwidth = maxReadBandwidth * 1_MB;
     }
 
     const ui32 maxWriteIops =
@@ -357,6 +355,22 @@ void ApplySoftBackpressureParameters(
     if (maxReadIops) {
         parameters.MaxReadIops = maxReadIops;
     }
+}
+
+TThrottlerConfig BuildThrottlerConfig(
+    const TStorageConfig& storageConfig,
+    const NProto::TFileStorePerformanceProfile& performanceProfile)
+{
+    TThrottlerConfig config;
+    Convert(performanceProfile, config);
+
+    const bool throttlingEnabled =
+        storageConfig.GetThrottlingEnabled() && config.ThrottlingEnabled;
+    if (storageConfig.GetSoftBackpressureEnabled() && !throttlingEnabled) {
+        ApplySoftBackpressureParameters(storageConfig, config.DefaultParameters);
+    }
+
+    return config;
 }
 
 bool IsLockingAllowed(

--- a/cloud/filestore/libs/storage/tablet/helpers.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers.cpp
@@ -1,6 +1,10 @@
 #include "helpers.h"
 
+#include <cloud/filestore/libs/storage/core/config.h>
+
 #include <contrib/ydb/core/protos/filestore_config.pb.h>
+
+#include <util/generic/size_literals.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -321,6 +325,37 @@ void Convert(
         l.MaxPostponedCount = src.GetMaxPostponedCount();
         l.MaxPostponedTime = TDuration::MilliSeconds(src.GetMaxPostponedTime());
         l.MaxWriteCostMultiplier = src.GetMaxWriteCostMultiplier();
+    }
+}
+
+void ApplySoftBackpressureParameters(
+    const TStorageConfig& storageConfig,
+    TDefaultParameters& parameters)
+{
+    const ui32 maxWriteBandwidth =
+        storageConfig.GetSoftBackpressureMaxWriteBandwidth();
+    if (maxWriteBandwidth) {
+        parameters.MaxWriteBandwidth =
+            static_cast<ui64>(maxWriteBandwidth) * 1_MB;
+    }
+
+    const ui32 maxReadBandwidth =
+        storageConfig.GetSoftBackpressureMaxReadBandwidth();
+    if (maxReadBandwidth) {
+        parameters.MaxReadBandwidth =
+            static_cast<ui64>(maxReadBandwidth) * 1_MB;
+    }
+
+    const ui32 maxWriteIops =
+        storageConfig.GetSoftBackpressureMaxWriteIops();
+    if (maxWriteIops) {
+        parameters.MaxWriteIops = maxWriteIops;
+    }
+
+    const ui32 maxReadIops =
+        storageConfig.GetSoftBackpressureMaxReadIops();
+    if (maxReadIops) {
+        parameters.MaxReadIops = maxReadIops;
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -160,6 +160,9 @@ void Convert(
     const NProto::TFileStorePerformanceProfile& src,
     TThrottlerConfig& dst);
 
+bool IsValidPerformanceProfile(
+    const NProto::TFileStorePerformanceProfile& profile);
+
 TThrottlerConfig BuildThrottlerConfig(
     const TStorageConfig& storageConfig,
     const NProto::TFileStorePerformanceProfile& performanceProfile);

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -160,6 +160,10 @@ void Convert(
     const NProto::TFileStorePerformanceProfile& src,
     TThrottlerConfig& dst);
 
+TThrottlerConfig BuildThrottlerConfig(
+    const TStorageConfig& storageConfig,
+    const NProto::TFileStorePerformanceProfile& performanceProfile);
+
 void ApplySoftBackpressureParameters(
     const TStorageConfig& storageConfig,
     TDefaultParameters& parameters);

--- a/cloud/filestore/libs/storage/tablet/helpers.h
+++ b/cloud/filestore/libs/storage/tablet/helpers.h
@@ -24,6 +24,10 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TStorageConfig;
+
+////////////////////////////////////////////////////////////////////////////////
+
 [[nodiscard]] inline ui64 SafeIncrement(ui64 value, size_t delta)
 {
     Y_ABORT_UNLESS(value <= Max<ui64>() - delta, "v: %lu, d: %lu", value, Max<ui64>() - delta);
@@ -155,6 +159,10 @@ void Convert(
 void Convert(
     const NProto::TFileStorePerformanceProfile& src,
     TThrottlerConfig& dst);
+
+void ApplySoftBackpressureParameters(
+    const TStorageConfig& storageConfig,
+    TDefaultParameters& parameters);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/filestore/libs/storage/tablet/helpers_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/helpers_ut.cpp
@@ -1,5 +1,6 @@
 #include "helpers.h"
 
+#include <cloud/filestore/libs/storage/core/config.h>
 #include <cloud/filestore/public/api/protos/fs.pb.h>
 
 #include <google/protobuf/util/message_differencer.h>
@@ -7,6 +8,8 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <contrib/ydb/core/protos/filestore_config.pb.h>
+
+#include <util/generic/size_literals.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -327,6 +330,45 @@ Y_UNIT_TEST_SUITE(THelpers)
         UNIT_ASSERT_VALUES_EQUAL(
             TargetThrottlerConfig.DefaultThresholds.MaxWriteCostMultiplier,
             config.DefaultThresholds.MaxWriteCostMultiplier);
+    }
+
+    Y_UNIT_TEST(ShouldApplySoftBackpressureParameters)
+    {
+        NProto::TStorageConfig protoConfig;
+        protoConfig.SetSoftBackpressureMaxWriteBandwidth(7);
+        protoConfig.SetSoftBackpressureMaxReadBandwidth(13);
+        protoConfig.SetSoftBackpressureMaxWriteIops(17);
+        protoConfig.SetSoftBackpressureMaxReadIops(19);
+
+        TDefaultParameters parameters;
+        ApplySoftBackpressureParameters(TStorageConfig(protoConfig), parameters);
+
+        UNIT_ASSERT_VALUES_EQUAL(7_MB, parameters.MaxWriteBandwidth);
+        UNIT_ASSERT_VALUES_EQUAL(13_MB, parameters.MaxReadBandwidth);
+        UNIT_ASSERT_VALUES_EQUAL(17, parameters.MaxWriteIops);
+        UNIT_ASSERT_VALUES_EQUAL(19, parameters.MaxReadIops);
+    }
+
+    Y_UNIT_TEST(ShouldNotApplyZeroSoftBackpressureParameters)
+    {
+        NProto::TStorageConfig protoConfig;
+        protoConfig.SetSoftBackpressureMaxWriteBandwidth(0);
+        protoConfig.SetSoftBackpressureMaxReadBandwidth(0);
+        protoConfig.SetSoftBackpressureMaxWriteIops(0);
+        protoConfig.SetSoftBackpressureMaxReadIops(0);
+
+        TDefaultParameters parameters;
+        parameters.MaxWriteBandwidth = 101;
+        parameters.MaxReadBandwidth = 102;
+        parameters.MaxWriteIops = 103;
+        parameters.MaxReadIops = 104;
+
+        ApplySoftBackpressureParameters(TStorageConfig(protoConfig), parameters);
+
+        UNIT_ASSERT_VALUES_EQUAL(101, parameters.MaxWriteBandwidth);
+        UNIT_ASSERT_VALUES_EQUAL(102, parameters.MaxReadBandwidth);
+        UNIT_ASSERT_VALUES_EQUAL(103, parameters.MaxWriteIops);
+        UNIT_ASSERT_VALUES_EQUAL(104, parameters.MaxReadIops);
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1,5 +1,7 @@
 #include "tablet_actor.h"
 
+#include "helpers.h"
+
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/registry.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttler_logger.h>
@@ -378,11 +380,10 @@ TIndexTabletActor::GetBackpressureValues() const
     };
 }
 
-void TIndexTabletActor::UpdateWriteCostMultiplierDueToBackpressure()
+double TIndexTabletActor::CalculateWriteCostMultiplierBackpressure() const
 {
     if (!Config->GetSoftBackpressureEnabled()) {
-        AccessThrottlingPolicy().UpdateWriteCostMultiplierDueToBackpressure(0.0);
-        return;
+        return 0.0;
     }
 
     const auto bpThresholds = BuildBackpressureThresholds();
@@ -427,11 +428,14 @@ void TIndexTabletActor::UpdateWriteCostMultiplierDueToBackpressure()
             bpThresholds.CollectGarbage,
             bpValues.CollectGarbage));
 
-    AccessThrottlingPolicy().UpdateWriteCostMultiplierDueToBackpressure(
-        backpressure);
+    return backpressure;
 }
 
-////////////////////////////////////////////////////////////////////////////////
+void TIndexTabletActor::UpdateWriteCostMultiplierDueToBackpressure()
+{
+    AccessThrottlingPolicy().UpdateWriteCostMultiplierDueToBackpressure(
+        CalculateWriteCostMultiplierBackpressure());
+}
 
 void TIndexTabletActor::ResetThrottlingPolicy()
 {
@@ -444,6 +448,29 @@ void TIndexTabletActor::ResetThrottlingPolicy()
     } else {
         Throttler->ResetPolicy(AccessThrottlingPolicy());
     }
+}
+
+void TIndexTabletActor::SetSoftBackpressureThrottlingActive(
+    bool active,
+    bool hasPostponedRequests)
+{
+    if (SoftBackpressureThrottlingActive == active) {
+        return;
+    }
+
+    if (hasPostponedRequests) {
+        return;
+    }
+
+    SoftBackpressureThrottlingActive = active;
+
+    TThrottlerConfig config;
+    Convert(GetPerformanceProfile(), config);
+    if (SoftBackpressureThrottlingActive) {
+        ApplySoftBackpressureParameters(*Config, config.DefaultParameters);
+    }
+    AccessThrottlingPolicy().Reset(config);
+    ResetThrottlingPolicy();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -450,31 +450,6 @@ void TIndexTabletActor::ResetThrottlingPolicy()
     }
 }
 
-void TIndexTabletActor::SetSoftBackpressureThrottlingActive(
-    bool active,
-    bool hasPostponedRequests)
-{
-    if (SoftBackpressureThrottlingActive == active) {
-        return;
-    }
-
-    if (hasPostponedRequests) {
-        return;
-    }
-
-    SoftBackpressureThrottlingActive = active;
-
-    TThrottlerConfig config;
-    Convert(GetPerformanceProfile(), config);
-    if (SoftBackpressureThrottlingActive) {
-        ApplySoftBackpressureParameters(*Config, config.DefaultParameters);
-    }
-    AccessThrottlingPolicy().Reset(config);
-    ResetThrottlingPolicy();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 template <typename TRequest>
 NProto::TError TIndexTabletActor::ValidateWriteRequest(
     const TActorContext& ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -167,7 +167,6 @@ private:
 
     TThrottlerLogger ThrottlerLogger;
     ITabletThrottlerPtr Throttler;
-    bool SoftBackpressureThrottlingActive = false;
 
     TStorageConfigPtr Config;
     TDiagnosticsConfigPtr DiagConfig;
@@ -448,9 +447,6 @@ private:
     TBackpressureValues GetBackpressureValues() const;
 
     void ResetThrottlingPolicy();
-    void SetSoftBackpressureThrottlingActive(
-        bool active,
-        bool hasPostponedRequests);
     double CalculateWriteCostMultiplierBackpressure() const;
     void UpdateWriteCostMultiplierDueToBackpressure();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -167,6 +167,7 @@ private:
 
     TThrottlerLogger ThrottlerLogger;
     ITabletThrottlerPtr Throttler;
+    bool SoftBackpressureThrottlingActive = false;
 
     TStorageConfigPtr Config;
     TDiagnosticsConfigPtr DiagConfig;
@@ -447,6 +448,10 @@ private:
     TBackpressureValues GetBackpressureValues() const;
 
     void ResetThrottlingPolicy();
+    void SetSoftBackpressureThrottlingActive(
+        bool active,
+        bool hasPostponedRequests);
+    double CalculateWriteCostMultiplierBackpressure() const;
     void UpdateWriteCostMultiplierDueToBackpressure();
 
     void ExecuteTx_AddBlob_Write(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -245,8 +245,9 @@ void TIndexTabletActor::CompleteAdapterLoadState(
         WaitReadyRequests.pop_front();
     }
 
-    TThrottlerConfig config;
-    Convert(args.FileSystem.GetPerformanceProfile(), config);
+    const auto config = BuildThrottlerConfig(
+        *Config,
+        args.FileSystem.GetPerformanceProfile());
 
     LoadState(
         Executor()->Generation(),
@@ -294,7 +295,6 @@ void TIndexTabletActor::CompleteAdapterLoadState(
 
     RegisterFileStore(ctx);
     RegisterStatCounters(ctx.Now());
-    SoftBackpressureThrottlingActive = false;
     ResetThrottlingPolicy();
 
     if (FastShardServer) {
@@ -366,8 +366,9 @@ void TIndexTabletActor::CompleteTx_LoadState(
         WaitReadyRequests.pop_front();
     }
 
-    TThrottlerConfig config;
-    Convert(args.FileSystem.GetPerformanceProfile(), config);
+    const auto config = BuildThrottlerConfig(
+        *Config,
+        args.FileSystem.GetPerformanceProfile());
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Initializing tablet state");
@@ -528,7 +529,6 @@ void TIndexTabletActor::CompleteTx_LoadState(
 
     RegisterFileStore(ctx);
     RegisterStatCounters(ctx.Now());
-    SoftBackpressureThrottlingActive = false;
     ResetThrottlingPolicy();
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -294,6 +294,7 @@ void TIndexTabletActor::CompleteAdapterLoadState(
 
     RegisterFileStore(ctx);
     RegisterStatCounters(ctx.Now());
+    SoftBackpressureThrottlingActive = false;
     ResetThrottlingPolicy();
 
     if (FastShardServer) {
@@ -527,6 +528,7 @@ void TIndexTabletActor::CompleteTx_LoadState(
 
     RegisterFileStore(ctx);
     RegisterStatCounters(ctx.Now());
+    SoftBackpressureThrottlingActive = false;
     ResetThrottlingPolicy();
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -80,13 +80,8 @@ void TIndexTabletActor::HandleUpdateLeakyBucketCounters(
     const TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters::TPtr& /*ev*/,
     const NActors::TActorContext& ctx)
 {
-    const bool throttlingEnabled =
-        Config->GetThrottlingEnabled() &&
-        GetPerformanceProfile().GetThrottlingEnabled();
-    if (throttlingEnabled || SoftBackpressureThrottlingActive) {
-        // update write cost multiplier for metrics
-        UpdateWriteCostMultiplierDueToBackpressure();
-    }
+    // update write cost multiplier for metrics
+    UpdateWriteCostMultiplierDueToBackpressure();
 
     const ui64 currentRate = std::ceil(
         GetThrottlingPolicy().CalculateCurrentSpentBudgetShare(ctx.Now()) * 100);
@@ -179,10 +174,6 @@ bool TIndexTabletActor::ThrottleIfNeeded(
     const bool softBackpressureThrottlingEnabled =
         !throttlingEnabled &&
         CalculateWriteCostMultiplierBackpressure() > 0.0;
-
-    SetSoftBackpressureThrottlingActive(
-        softBackpressureThrottlingEnabled,
-        hasPostponedRequests);
 
     if (!throttlingEnabled &&
         !softBackpressureThrottlingEnabled &&

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_throttling.cpp
@@ -80,8 +80,13 @@ void TIndexTabletActor::HandleUpdateLeakyBucketCounters(
     const TEvIndexTabletPrivate::TEvUpdateLeakyBucketCounters::TPtr& /*ev*/,
     const NActors::TActorContext& ctx)
 {
-    // update write cost multiplier for metrics
-    UpdateWriteCostMultiplierDueToBackpressure();
+    const bool throttlingEnabled =
+        Config->GetThrottlingEnabled() &&
+        GetPerformanceProfile().GetThrottlingEnabled();
+    if (throttlingEnabled || SoftBackpressureThrottlingActive) {
+        // update write cost multiplier for metrics
+        UpdateWriteCostMultiplierDueToBackpressure();
+    }
 
     const ui64 currentRate = std::ceil(
         GetThrottlingPolicy().CalculateCurrentSpentBudgetShare(ctx.Now()) * 100);
@@ -162,9 +167,26 @@ bool TIndexTabletActor::ThrottleIfNeeded(
     const typename TMethod::TRequest::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
-    if (!Config->GetThrottlingEnabled() ||
-        !GetPerformanceProfile().GetThrottlingEnabled() ||
-        ev->Get()->Record.GetHeaders().GetThrottlingDisabled())
+    if (ev->Get()->Record.GetHeaders().GetThrottlingDisabled()) {
+        return false;
+    }
+
+    const bool throttlingEnabled =
+        Config->GetThrottlingEnabled() &&
+        GetPerformanceProfile().GetThrottlingEnabled();
+    const bool hasPostponedRequests = Throttler &&
+        Throttler->GetPostponedRequestsCount();
+    const bool softBackpressureThrottlingEnabled =
+        !throttlingEnabled &&
+        CalculateWriteCostMultiplierBackpressure() > 0.0;
+
+    SetSoftBackpressureThrottlingActive(
+        softBackpressureThrottlingEnabled,
+        hasPostponedRequests);
+
+    if (!throttlingEnabled &&
+        !softBackpressureThrottlingEnabled &&
+        !hasPostponedRequests)
     {
         return false;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -285,9 +285,13 @@ void TIndexTabletActor::ExecuteTx_UpdateConfig(
     TTransactionContext& tx,
     TTxIndexTablet::TUpdateConfig& args)
 {
-    Y_UNUSED(ctx);
-
     TIndexTabletDatabase db(tx.DB);
+
+    ApplyStorageConfigOverrides(
+        ctx,
+        args.FileSystem.GetCloudId(),
+        args.FileSystem.GetFolderId(),
+        args.FileSystem.GetFileSystemId());
 
     const auto config = BuildThrottlerConfig(
         *Config,
@@ -305,12 +309,6 @@ void TIndexTabletActor::CompleteTx_UpdateConfig(
     RegisterFileStore(ctx);
     RegisterStatCounters(ctx.Now());
     ResetThrottlingPolicy();
-
-    ApplyStorageConfigOverrides(
-        ctx,
-        GetCloudId(),
-        GetFolderId(),
-        GetFileSystemId());
 
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
         "%s Sending OK response for UpdateConfig with version=%u",

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -301,6 +301,7 @@ void TIndexTabletActor::CompleteTx_UpdateConfig(
     UpdateLogTag();
     RegisterFileStore(ctx);
     RegisterStatCounters(ctx.Now());
+    SoftBackpressureThrottlingActive = false;
     ResetThrottlingPolicy();
 
     ApplyStorageConfigOverrides(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -1,5 +1,7 @@
 #include "tablet_actor.h"
 
+#include "helpers.h"
+
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 
 #include <util/string/join.h>
@@ -287,8 +289,9 @@ void TIndexTabletActor::ExecuteTx_UpdateConfig(
 
     TIndexTabletDatabase db(tx.DB);
 
-    TThrottlerConfig config;
-    Convert(args.FileSystem.GetPerformanceProfile(), config);
+    const auto config = BuildThrottlerConfig(
+        *Config,
+        args.FileSystem.GetPerformanceProfile());
 
     UpdateConfig(db, *Config, args.FileSystem, config);
 }
@@ -301,7 +304,6 @@ void TIndexTabletActor::CompleteTx_UpdateConfig(
     UpdateLogTag();
     RegisterFileStore(ctx);
     RegisterStatCounters(ctx.Now());
-    SoftBackpressureThrottlingActive = false;
     ResetThrottlingPolicy();
 
     ApplyStorageConfigOverrides(

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -1,5 +1,7 @@
 #include "tablet_state_impl.h"
 
+#include "helpers.h"
+
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
 #include <cloud/filestore/libs/storage/core/model.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
@@ -49,15 +51,6 @@ NProto::TFileStorePerformanceProfile GetDefaultPerformanceProfile()
     profile.SetDefaultPostponedRequestWeight(
         config.DefaultPostponedRequestWeight);
     return profile;
-}
-
-bool IsValid(const NProto::TFileStorePerformanceProfile& profile)
-{
-    return profile.GetMaxReadIops()
-        && profile.GetMaxReadBandwidth()
-        && profile.GetMaxPostponedWeight()
-        && profile.GetMaxPostponedTime()
-        && profile.GetDefaultPostponedRequestWeight();
 }
 
 ui64 CalculateInMemoryIndexCacheCapacity(
@@ -296,7 +289,7 @@ void TIndexTabletState::SetCompressNodeRef(
 const NProto::TFileStorePerformanceProfile& TIndexTabletState::GetPerformanceProfile() const
 {
     if (FileSystem.HasPerformanceProfile() &&
-        IsValid(FileSystem.GetPerformanceProfile()))
+        IsValidPerformanceProfile(FileSystem.GetPerformanceProfile()))
     {
         return FileSystem.GetPerformanceProfile();
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -2672,6 +2672,69 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.DestroyHandle(handle);
     }
 
+    void DoTestSoftBackpressureThrottlingDefaults(
+        const TFileSystemConfig& tabletConfig,
+        bool throttlingEnabled,
+        ui32 expectedError)
+    {
+        const ui32 block = tabletConfig.BlockSize;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetThrottlingEnabled(throttlingEnabled);
+        storageConfig.SetMultipleStageRequestThrottlingEnabled(true);
+        storageConfig.SetSoftBackpressureEnabled(true);
+        storageConfig.SetSoftBackpressureMaxWriteBandwidth(1);
+        storageConfig.SetSoftBackpressureMaxWriteIops(1);
+        storageConfig.SetFlushThresholdForBackpressureSoft(block);
+        storageConfig.SetFlushThresholdForBackpressure(3 * block);
+
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        TFileSystemConfig config = tabletConfig;
+        config.PerformanceProfile.ThrottlingEnabled = throttlingEnabled;
+        config.PerformanceProfile.MaxReadIops = 1'000;
+        config.PerformanceProfile.MaxWriteIops = 1'000;
+        config.PerformanceProfile.MaxReadBandwidth = 64_MB;
+        config.PerformanceProfile.MaxWriteBandwidth = 64_MB;
+        config.PerformanceProfile.MaxPostponedWeight = 1; // reject delayed writes
+        config.PerformanceProfile.MaxWriteCostMultiplier = 5;
+        config.PerformanceProfile.MaxPostponedTime =
+            TDuration::Seconds(25).MilliSeconds();
+        config.PerformanceProfile.MaxPostponedCount = 64;
+        config.PerformanceProfile.BurstPercentage = 300;
+        config.PerformanceProfile.DefaultPostponedRequestWeight = 1_KB;
+        tablet.UpdateConfig(config);
+
+        auto id = CreateNode(
+            tablet,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        tablet.SendWriteDataRequest(handle, 0, block, 'a');
+        tablet.AssertWriteDataQuickResponse(S_OK);
+
+        tablet.SendWriteDataRequest(handle, block, block, 'b');
+        tablet.AssertWriteDataQuickResponse(S_OK);
+
+        // soft limit: 1 block, hard limit: 3 blocks,
+        // we added 2 blocks
+        // with backpressure our multiplier will increase to 3
+        tablet.SendWriteDataRequest(handle, 2 * block, block, 'c');
+        tablet.AssertWriteDataQuickResponse(expectedError);
+
+        tablet.DestroyHandle(handle);
+    }
+
     TABLET_TEST_16K(ShouldNotThrottleWritesDueToSoftBackpressureIfDisabled)
     {
         DoTestSoftBackpressureWriteThrottling(tabletConfig, false);
@@ -2680,6 +2743,109 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     TABLET_TEST_16K(ShouldThrottleWritesDueToSoftBackpressureIfEnabled)
     {
         DoTestSoftBackpressureWriteThrottling(tabletConfig, true);
+    }
+
+    TABLET_TEST_16K(ShouldThrottleWritesDueToSoftBackpressureIfThrottlingDisabled)
+    {
+        DoTestSoftBackpressureThrottlingDefaults(
+            tabletConfig,
+            false,
+            E_FS_THROTTLED);
+    }
+
+    TABLET_TEST_16K(ShouldNotApplySoftBackpressureDefaultsToEnabledThrottling)
+    {
+        DoTestSoftBackpressureThrottlingDefaults(
+            tabletConfig,
+            true,
+            S_OK);
+    }
+
+    TABLET_TEST_16K(
+        ShouldPreserveSoftBackpressureAccountingUntilPostponedQueueIsDrained)
+    {
+        const ui32 block = tabletConfig.BlockSize;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetThrottlingEnabled(true);
+        storageConfig.SetMultipleStageRequestThrottlingEnabled(true);
+        storageConfig.SetSoftBackpressureEnabled(true);
+        storageConfig.SetWriteBlobThreshold(1_GB);
+        storageConfig.SetFlushThreshold(1_GB);
+        storageConfig.SetCompactionThreshold(999'999);
+        storageConfig.SetCleanupThreshold(999'999);
+        storageConfig.SetFlushBytesThreshold(1_GB);
+        storageConfig.SetFlushThresholdForBackpressureSoft(block);
+        storageConfig.SetFlushThresholdForBackpressure(4 * block);
+        storageConfig.SetSoftBackpressureMaxWriteBandwidth(1);
+        storageConfig.SetSoftBackpressureMaxWriteIops(1);
+
+        TTestEnv env({}, storageConfig);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.InitSession("client", "session");
+
+        TFileSystemConfig config = tabletConfig;
+        config.PerformanceProfile.ThrottlingEnabled = false;
+        config.PerformanceProfile.MaxReadIops = 1'000;
+        config.PerformanceProfile.MaxWriteIops = 1'000;
+        config.PerformanceProfile.MaxReadBandwidth = 64_MB;
+        config.PerformanceProfile.MaxWriteBandwidth = 64_MB;
+        config.PerformanceProfile.MaxPostponedWeight = block;
+        config.PerformanceProfile.MaxWriteCostMultiplier = 5;
+        config.PerformanceProfile.MaxPostponedTime =
+            TDuration::Seconds(25).MilliSeconds();
+        config.PerformanceProfile.MaxPostponedCount = 64;
+        config.PerformanceProfile.BurstPercentage = 100;
+        config.PerformanceProfile.DefaultPostponedRequestWeight = 1_KB;
+        tablet.UpdateConfig(config);
+
+        auto id = CreateNode(
+            tablet,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto writeDataThrottlingDisabled = [&](
+            ui64 offset,
+            ui32 len,
+            char fill)
+        {
+            auto request = tablet.CreateWriteDataRequest(
+                handle,
+                offset,
+                len,
+                fill);
+            request->Record.MutableHeaders()->SetThrottlingDisabled(true);
+            tablet.SendRequest(std::move(request));
+        };
+
+        writeDataThrottlingDisabled(0, block, 'a');
+        tablet.AssertWriteDataQuickResponse(S_OK);
+        writeDataThrottlingDisabled(block, block, 'b');
+        tablet.AssertWriteDataQuickResponse(S_OK);
+
+        tablet.SendWriteDataRequest(handle, 2 * block, block, 'c');
+        // postponed write fills the soft-mode queue budget
+        tablet.AssertWriteDataNoResponse();
+
+        tablet.Flush();
+
+        tablet.SendWriteDataRequest(handle, 3 * block, block, 'd');
+        // flushing backpressure must not reset queued weight
+        tablet.AssertWriteDataQuickResponse(E_FS_THROTTLED);
+
+        tablet.AdvanceTime(TDuration::Hours(1));
+        // the original postponed write still completes
+        tablet.AssertWriteDataResponse(S_OK);
+
+        tablet.DestroyHandle(handle);
     }
 
     TABLET_TEST_16K(ShouldRejectWritesDueToBackpressure)

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -8,6 +8,7 @@
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
 
 #include <cloud/storage/core/libs/api/hive_proxy.h>
+#include <cloud/storage/core/libs/features/features_config.h>
 
 #include <library/cpp/iterator/enumerate.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -2675,20 +2676,32 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     void DoTestSoftBackpressureThrottlingDefaults(
         const TFileSystemConfig& tabletConfig,
         bool throttlingEnabled,
-        ui32 expectedError)
+        ui32 expectedError,
+        bool enableSoftBackpressureViaFeaturesConfig)
     {
         const ui32 block = tabletConfig.BlockSize;
 
         NProto::TStorageConfig storageConfig;
         storageConfig.SetThrottlingEnabled(throttlingEnabled);
         storageConfig.SetMultipleStageRequestThrottlingEnabled(true);
-        storageConfig.SetSoftBackpressureEnabled(true);
+        if (!enableSoftBackpressureViaFeaturesConfig) {
+            storageConfig.SetSoftBackpressureEnabled(true);
+        }
         storageConfig.SetSoftBackpressureMaxWriteBandwidth(1);
         storageConfig.SetSoftBackpressureMaxWriteIops(1);
         storageConfig.SetFlushThresholdForBackpressureSoft(block);
         storageConfig.SetFlushThresholdForBackpressure(3 * block);
 
         TTestEnv env({}, storageConfig);
+
+        if (enableSoftBackpressureViaFeaturesConfig) {
+            NCloud::NProto::TFeaturesConfig featuresConfigProto;
+            auto* feature = featuresConfigProto.AddFeatures();
+            feature->SetName("SoftBackpressureEnabled");
+            feature->MutableWhitelist()->AddCloudIds("test_cloud");
+            env.GetStorageConfig()->SetFeaturesConfig(
+                NFeatures::TFeaturesConfig(featuresConfigProto));
+        }
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2697,7 +2710,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             env.GetRuntime(),
             nodeIdx,
             tabletId,
-            tabletConfig);
+            tabletConfig,
+            !enableSoftBackpressureViaFeaturesConfig);
         tablet.InitSession("client", "session");
 
         TFileSystemConfig config = tabletConfig;
@@ -2750,7 +2764,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         DoTestSoftBackpressureThrottlingDefaults(
             tabletConfig,
             false,
-            E_FS_THROTTLED);
+            E_FS_THROTTLED,
+            false);
     }
 
     TABLET_TEST_16K(ShouldNotApplySoftBackpressureDefaultsToEnabledThrottling)
@@ -2758,7 +2773,17 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         DoTestSoftBackpressureThrottlingDefaults(
             tabletConfig,
             true,
-            S_OK);
+            S_OK,
+            false);
+    }
+
+    TABLET_TEST_16K(ShouldRebuildSoftBackpressureThrottlingAfterUpdateConfig)
+    {
+        DoTestSoftBackpressureThrottlingDefaults(
+            tabletConfig,
+            false,
+            E_FS_THROTTLED,
+            true);
     }
 
     TABLET_TEST_16K(


### PR DESCRIPTION
### Notes
> Previous PR: https://github.com/ydb-platform/nbs/pull/6164
* Enable dynamic backpressure even if throttling is disabled (so enable throttling, but with new parameters)
* Introduce new limits, based on current observations (old limits are too low)
* Add unit and integration tests

### Issue
https://github.com/ydb-platform/nbs/issues/2512
