### PR TITLE
fix TAsyncClient declaration in async_client_stub.cpp

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/client/async_client_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/client/async_client_stub.cpp
@@ -4,6 +4,8 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TAsyncClient::TAsyncClient() = default;
+
 NThreading::TFuture<IAsyncEndpointPtr> TAsyncClient::Connect(
     const TString& host,
     ui16 port)


### PR DESCRIPTION
### Notes
Fix a linker error when building filestore vhost with the FastShard IPC stub (`FORCE_FASTSHARD_IPC_STUB=yes`).

`TAsyncClient` declares a default constructor in `async_client.h`, and `bootstrap.cpp` instantiates it in `TBootstrapVhost::InitEndpoints()`. The real implementation in `async_client.cpp` defines that constructor, but `async_client_stub.cpp` only stubbed `Connect`, leaving `TAsyncClient::TAsyncClient()` undefined in stub builds.

Add `TAsyncClient::TAsyncClient() = default;` to the stub so stub and non-stub builds expose the same symbol set.

### Issue

```
ld.lld: error: undefined symbol: NCloud::NFileStore::NStorage::NFastShard::TAsyncClient::TAsyncClient()
>>> referenced by bootstrap.cpp
>>>               bootstrap.cpp.pic.o:(NCloud::NFileStore::NDaemon::TBootstrapVhost::InitEndpoints()) in archive cloud/filestore/libs/daemon/vhost/liblibs-daemon-vhost.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
