### PR TITLE
[codex] Fix NBS sanitizer test failures

### DIFF
--- a/cloud/blockstore/libs/service/ut/ya.make
+++ b/cloud/blockstore/libs/service/ut/ya.make
@@ -2,6 +2,11 @@ UNITTEST_FOR(cloud/blockstore/libs/service)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
+IF (SANITIZER_TYPE == "memory")
+    SIZE(MEDIUM)
+    TIMEOUT(300)
+ENDIF()
+
 SRCS(
     blocks_info_ut.cpp
     context_ut.cpp

--- a/cloud/blockstore/libs/storage/partition/part_ut_env1.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_env1.cpp
@@ -1,0 +1,1418 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestEnv1)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRecoverBlocksOnRebootFromFreshChannelWithLongHistory)
+    {
+        const ui32 blockCount = 1024;
+        const ui32 channelCount = DataChannelOffset + 2;
+        const ui32 freshChannelNo = channelCount - 1;
+        const ui32 freshChannelHistorySize = 3;
+        const auto groupCount =
+            channelCount - DataChannelOffset + freshChannelHistorySize - 1;
+        const ui32 nodeIdx = 0;
+
+        // initializing test runtime
+
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+        InitLogSettings(runtime);
+
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        {
+            env.CreateSubDomain("nbs");
+            auto storageConfig = CreateTestStorageConfig(config);
+            env.CreateBlockStoreNode(
+                "nbs",
+                storageConfig,
+                CreateTestDiagnosticsConfig());
+        }
+
+        const auto tabletId = NKikimr::MakeTabletID(1, HiveId, 1);
+        std::unique_ptr<TTabletStorageInfo> x(new TTabletStorageInfo());
+
+        x->TabletID = tabletId;
+        x->TabletType = TTabletTypes::BlockStorePartition;
+        auto& channels = x->Channels;
+        channels.resize(channelCount);
+
+        for (ui64 channel = 0; channel < channels.size(); ++channel) {
+            channels[channel].Channel = channel;
+            channels[channel].Type =
+                TBlobStorageGroupType(BootGroupErasure);
+            channels[channel].History.resize(1);
+            channels[channel].History[0].FromGeneration = 0;
+            const auto gidx =
+                channel > DataChannelOffset ? channel - DataChannelOffset : 0;
+            channels[channel].History[0].GroupID = env.GetGroupIds()[gidx];
+        }
+
+        // filling fresh channel history with 3 items
+
+        auto& freshChannel = channels[freshChannelNo];
+        freshChannel.Channel = freshChannelNo;
+        freshChannel.Type = TBlobStorageGroupType(BootGroupErasure);
+        auto& history = freshChannel.History;
+        history.resize(freshChannelHistorySize);
+        auto setHistoryItem = [&] (ui32 i, ui32 gen) {
+            history[i].FromGeneration = gen;
+            const auto gidx = freshChannelNo - DataChannelOffset + i;
+            history[i].GroupID = env.GetGroupIds()[gidx];
+        };
+        setHistoryItem(0, 1);
+        setHistoryItem(1, 2);
+        setHistoryItem(2, 3); // this one is a bit fake - it's from the future
+
+        InitTestActorRuntime(
+            runtime,
+            config,
+            blockCount,
+            channelCount,
+            std::move(x));
+
+        // fresh blob builder func
+
+        auto makeResponse = [&] (ui32 gen, ui32 step, ui32 block, TString data) {
+            TVector<TVector<TString>> buffers{{std::move(data)}};
+            const auto holders = GetHolders(buffers);
+            auto blob = BuildWriteFreshBlocksBlobContent(
+                {TBlockRange32::MakeOneBlock(block)},
+                holders);
+
+            TPartialBlobId blobId(
+                gen,
+                step,
+                freshChannelNo,
+                static_cast<ui32>(blob.size()),
+                0,  // cookie
+                0   // partId
+            );
+
+            return TEvBlobStorage::TEvRangeResult::TResponse(
+                MakeBlobId(tabletId, blobId),
+                std::move(blob));
+        };
+
+        // setting up event observer (filter) to replace real EvRangeResult
+        // with a fake one
+
+        TVector<ui32> groupsRequested;
+        runtime.SetEventFilter(
+            [&] (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvRangeResult: {
+                        using TEvent = TEvBlobStorage::TEvRangeResult;
+                        auto* msg = event->Get<TEvent>();
+
+                        if (msg->From.Channel() != freshChannelNo) {
+                            return false;
+                        }
+
+                        auto response = std::make_unique<TEvent>(
+                            msg->Status,
+                            msg->From,
+                            msg->To,
+                            msg->GroupId);
+
+                        groupsRequested.push_back(msg->GroupId);
+
+                        if (msg->GroupId == history[0].GroupID) {
+                            response->Responses.push_back(makeResponse(
+                                0,
+                                1,
+                                0,
+                                TString(DefaultBlockSize, 'A')));
+                        } else if (msg->GroupId == history[1].GroupID) {
+                            response->Responses.push_back(makeResponse(
+                                1,
+                                1,
+                                1,
+                                TString(DefaultBlockSize, 'B')));
+                        } else if (msg->GroupId == history[2].GroupID) {
+                            response->Responses.push_back(makeResponse(
+                                2,
+                                1,
+                                2,
+                                TString(DefaultBlockSize, 'C')));
+                        } else {
+                            UNIT_ASSERT_C(
+                                false,
+                                TStringBuilder() << "unexpected group: "
+                                    << msg->GroupId);
+                        }
+
+                        auto* handle = new IEventHandle(
+                            event->Recipient,
+                            event->Sender,
+                            response.release(),
+                            0,
+                            event->Cookie);
+
+                        runtime.Send(handle, 0);
+
+                        return true;
+                    }
+
+                    default: return false;
+                }
+            }
+        );
+
+        TPartitionClient partition(runtime, nodeIdx, tabletId);
+        partition.WaitReady();
+
+        // all groups should've been requested upon first tablet launch
+
+        Sort(groupsRequested);
+        UNIT_ASSERT_VALUES_EQUAL(3, groupsRequested.size());
+        UNIT_ASSERT_VALUES_EQUAL(history[0].GroupID, groupsRequested[0]);
+        UNIT_ASSERT_VALUES_EQUAL(history[1].GroupID, groupsRequested[1]);
+        UNIT_ASSERT_VALUES_EQUAL(history[2].GroupID, groupsRequested[2]);
+        groupsRequested.clear();
+
+        // checking that our data wasn't corrupted
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'A'),
+            GetBlockContent(partition.ReadBlocks(0)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'B'),
+            GetBlockContent(partition.ReadBlocks(1)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'C'),
+            GetBlockContent(partition.ReadBlocks(2)));
+
+        // triggering Trim to initialize TrimFreshLogToCommitId
+
+        partition.TrimFreshLog();
+
+        // all fresh blocks loaded upon startup acquire barriers in
+        // TrimFreshLogBarriers, that's why we need to cause another Flush
+        // to move our TrimFreshLogToCommitId in meta past some of those blocks
+
+        partition.WriteBlocks(3, TString(DefaultBlockSize, 'D'));
+        partition.Flush();
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        // after reboot our tablet shouldn't load fresh blobs from the groups
+        // that certainly contain only the data that was generated before
+        // TrimFreshLogToCommitId
+
+        Sort(groupsRequested);
+        UNIT_ASSERT_VALUES_EQUAL(2, groupsRequested.size());
+        UNIT_ASSERT_VALUES_EQUAL(history[1].GroupID, groupsRequested[0]);
+        UNIT_ASSERT_VALUES_EQUAL(history[2].GroupID, groupsRequested[1]);
+        groupsRequested.clear();
+
+        // checking that our data wasn't corrupted
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'A'),
+            GetBlockContent(partition.ReadBlocks(0)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'B'),
+            GetBlockContent(partition.ReadBlocks(1)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'C'),
+            GetBlockContent(partition.ReadBlocks(2)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(DefaultBlockSize, 'D'),
+            GetBlockContent(partition.ReadBlocks(3)));
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_env2.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_env2.cpp
@@ -1,0 +1,1278 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestEnv2)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyTrackYellowChannelsInBackground)
+    {
+        const auto channelCount = 6;
+        const auto groupCount = channelCount - DataChannelOffset;
+
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+        auto tabletId = InitTestActorRuntime(env, runtime, channelCount, channelCount);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
+
+        // one data channel yellow => ok
+        {
+            auto request =
+                std::make_unique<TEvTablet::TEvCheckBlobstorageStatusResult>(
+                    TVector<ui32>({
+                        env.GetGroupIds()[1],
+                    }),
+                    TVector<ui32>({
+                        env.GetGroupIds()[1],
+                    }),
+                    TVector<ui32>()
+                );
+            partition.SendToPipe(std::move(request));
+        }
+
+        runtime.DispatchEvents({},  TDuration::Seconds(1));
+
+        {
+            partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1024));
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        // all channels yellow => failure
+        {
+            auto request =
+                std::make_unique<TEvTablet::TEvCheckBlobstorageStatusResult>(
+                    TVector<ui32>({
+                        env.GetGroupIds()[0],
+                        env.GetGroupIds()[1],
+                    }),
+                    TVector<ui32>({
+                        env.GetGroupIds()[0],
+                        env.GetGroupIds()[1],
+                    }),
+                    TVector<ui32>()
+                );
+            partition.SendToPipe(std::move(request));
+        }
+
+        runtime.DispatchEvents({},  TDuration::Seconds(1));
+
+        {
+            partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1024));
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        // channels returned to non-yellow state => ok
+        {
+            auto request =
+                std::make_unique<TEvTablet::TEvCheckBlobstorageStatusResult>(
+                    TVector<ui32>(),
+                    TVector<ui32>(),
+                    TVector<ui32>()
+                );
+            partition.SendToPipe(std::move(request));
+        }
+
+        runtime.DispatchEvents({},  TDuration::Seconds(1));
+
+        {
+            partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1024));
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        // TODO: the state may be neither yellow nor green (e.g. orange) -
+        // this case is not supported in the background check, but should be
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_env3.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_env3.cpp
@@ -1,0 +1,1384 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestEnv3)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldReassignNonwritableTabletChannels)
+    {
+        const auto channelCount = 6;
+        const auto groupCount = channelCount - DataChannelOffset;
+        const auto reassignTimeout = TDuration::Minutes(1);
+
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+
+        NMonitoring::TDynamicCountersPtr counters
+            = new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto reassignCounter =
+            counters->GetCounter("AppCriticalEvents/ReassignTablet", true);
+
+        NProto::TStorageServiceConfig config;
+        config.SetReassignRequestRetryTimeout(reassignTimeout.MilliSeconds());
+        const auto tabletId = InitTestActorRuntime(
+            env,
+            runtime,
+            channelCount,
+            channelCount,
+            config);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
+
+        ui64 reassignedTabletId = 0;
+        TVector<ui32> channels;
+        ui32 ssflags = ui32(
+            NKikimrBlobStorage::StatusDiskSpaceYellowStop |
+            NKikimrBlobStorage::StatusDiskSpaceLightYellowMove);
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvHiveProxy::EvReassignTabletRequest: {
+                        auto* msg = event->Get<TEvHiveProxy::TEvReassignTabletRequest>();
+                        reassignedTabletId = msg->TabletId;
+                        channels = msg->Channels;
+
+                        break;
+                    }
+                }
+
+                return StorageStateChanger(ssflags, env.GetGroupIds()[1])(event);
+            }
+        );
+
+        // first request does not trigger a reassign event - data is written to
+        // the first group
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        // second request succeeds but triggers a reassign event - yellow flag
+        // is received in the response for this request
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, reassignCounter->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(tabletId, reassignedTabletId);
+        UNIT_ASSERT_VALUES_EQUAL(1, channels.size());
+        UNIT_ASSERT_VALUES_EQUAL(4, channels.front());
+
+        reassignedTabletId = 0;
+        channels.clear();
+
+        {
+            // third request doesn't trigger a reassign event because we can
+            // still write (some data channels are not yellow yet)
+            auto request = partition.CreateWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 1024));
+            partition.SendToPipe(std::move(request));
+
+            auto response =
+                partition.RecvResponse<TEvService::TEvWriteBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(
+                S_OK,
+                response->GetError().GetCode()
+            );
+        }
+
+        // checking that a reassign request has not been sent
+        UNIT_ASSERT_VALUES_EQUAL(1, reassignCounter->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(0, reassignedTabletId);
+        UNIT_ASSERT_VALUES_EQUAL(0, channels.size());
+
+        reassignedTabletId = 0;
+        channels.clear();
+
+        {
+            // informing partition tablet that the first group is yellow
+            auto request =
+                std::make_unique<TEvTablet::TEvCheckBlobstorageStatusResult>(
+                    TVector<ui32>({env.GetGroupIds()[0], env.GetGroupIds()[1]}),
+                    TVector<ui32>({env.GetGroupIds()[0], env.GetGroupIds()[1]}),
+                    TVector<ui32>()
+                );
+            partition.SendToPipe(std::move(request));
+        }
+
+        {
+            auto request = partition.CreateWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 1024));
+            partition.SendToPipe(std::move(request));
+
+            auto response =
+                partition.RecvResponse<TEvService::TEvWriteBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_BS_OUT_OF_SPACE,
+                response->GetError().GetCode()
+            );
+        }
+
+        // this time no reassign request should have been sent because of the
+        // ReassignRequestSentTs check in partition actor
+        UNIT_ASSERT_VALUES_EQUAL(1, reassignCounter->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(0, reassignedTabletId);
+        UNIT_ASSERT_VALUES_EQUAL(0, channels.size());
+
+        runtime.AdvanceCurrentTime(reassignTimeout);
+
+        {
+            auto request = partition.CreateWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 1024));
+            partition.SendToPipe(std::move(request));
+
+            auto response =
+                partition.RecvResponse<TEvService::TEvWriteBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_BS_OUT_OF_SPACE,
+                response->GetError().GetCode()
+            );
+        }
+
+        // ReassignRequestRetryTimeout has passed - another reassign request
+        // should've been sent
+        UNIT_ASSERT_VALUES_EQUAL(2, reassignCounter->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(tabletId, reassignedTabletId);
+        UNIT_ASSERT_VALUES_EQUAL(5, channels.size());
+        for (ui32 i = 0; i < channels.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(i, channels[i]);
+        }
+
+        partition.RebootTablet();
+        ssflags = {};
+
+        // no yellow channels => write request should succeed
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        partition.RebootTablet();
+
+        {
+            // informing partition tablet that the first group is yellow
+            auto request =
+                std::make_unique<TEvTablet::TEvCheckBlobstorageStatusResult>(
+                    TVector<ui32>({env.GetGroupIds()[0]}),
+                    TVector<ui32>({env.GetGroupIds()[0]}),
+                    TVector<ui32>()
+                );
+            partition.SendToPipe(std::move(request));
+        }
+
+        runtime.DispatchEvents({});
+
+        {
+            auto request = partition.CreateWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 1024));
+            partition.SendToPipe(std::move(request));
+
+            auto response =
+                partition.RecvResponse<TEvService::TEvWriteBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_BS_OUT_OF_SPACE,
+                response->GetError().GetCode()
+            );
+        }
+
+        // checking that a reassign request has been sent
+        UNIT_ASSERT_VALUES_EQUAL(3, reassignCounter->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(tabletId, reassignedTabletId);
+        UNIT_ASSERT_VALUES_EQUAL(4, channels.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, channels[0]);
+        UNIT_ASSERT_VALUES_EQUAL(1, channels[1]);
+        UNIT_ASSERT_VALUES_EQUAL(2, channels[2]);
+        UNIT_ASSERT_VALUES_EQUAL(3, channels[3]);
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_env4.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_env4.cpp
@@ -1,0 +1,1298 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestEnv4)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldProperlyHandleCollectGarbageErrors)
+    {
+        const auto channelCount = 6;
+        const auto groupCount = channelCount - DataChannelOffset;
+
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+        auto tabletId = InitTestActorRuntime(env, runtime, channelCount, channelCount);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
+
+        bool channel3requestObserved = false;
+        bool channel4requestObserved = false;
+        bool channel4responseObserved = false;
+        bool deleteGarbageObserved = false;
+        bool sendError = true;
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (3 == msg->Channel) {
+                            channel3requestObserved = true;
+                            if (sendError) {
+                                auto response =
+                                    std::make_unique<TEvBlobStorage::TEvCollectGarbageResult>(
+                                        NKikimrProto::ERROR,
+                                        0,  // doesn't matter
+                                        0,  // doesn't matter
+                                        0,  // doesn't matter
+                                        msg->Channel
+                                    );
+
+                                runtime.Send(new IEventHandle(
+                                    event->Sender,
+                                    event->Recipient,
+                                    response.release(),
+                                    0, // flags
+                                    0
+                                ), 0);
+
+                                return TTestActorRuntime::EEventAction::DROP;
+                            }
+                        } else if (4 == msg->Channel) {
+                            channel4requestObserved = true;
+                        }
+
+                        break;
+                    }
+
+                    case TEvBlobStorage::EvCollectGarbageResult: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbageResult>();
+                        if (4 == msg->Channel) {
+                            channel4responseObserved = true;
+                        }
+
+                        break;
+                    }
+
+                    case TEvPartitionPrivate::EvDeleteGarbageRequest: {
+                        deleteGarbageObserved = true;
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        // 10 blobs needed to trigger automatic collect
+        for (ui32 i = 0; i < 9; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        }
+        partition.Compaction();
+        partition.Cleanup();
+        partition.SendCollectGarbageRequest();
+        {
+            auto response = partition.RecvCollectGarbageResponse();
+            UNIT_ASSERT_VALUES_EQUAL(
+                MAKE_KIKIMR_ERROR(NKikimrProto::ERROR),
+                response->GetStatus()
+            );
+        }
+        UNIT_ASSERT(channel3requestObserved);
+        UNIT_ASSERT(channel4requestObserved);
+        UNIT_ASSERT(channel4responseObserved);
+        UNIT_ASSERT(!deleteGarbageObserved);
+        channel3requestObserved = false;
+        channel4requestObserved = false;
+        channel4responseObserved = false;
+        sendError = false;
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(10));
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(10));
+
+        UNIT_ASSERT(channel3requestObserved);
+        UNIT_ASSERT(channel4requestObserved);
+        UNIT_ASSERT(channel4responseObserved);
+        UNIT_ASSERT(deleteGarbageObserved);
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_env5.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_env5.cpp
@@ -1,0 +1,1251 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestEnv5)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldExecuteCollectGarbageAtStartup)
+    {
+        const auto channelCount = 7;
+        const auto groupCount = channelCount - DataChannelOffset;
+
+        auto isDataChannel = [&] (ui64 ch) {
+            return (ch >= DataChannelOffset) && (ch < channelCount);
+        };
+
+        NProto::TStorageServiceConfig config = DefaultConfig();
+
+        TTestEnv env(0, 1, channelCount, groupCount);
+        auto& runtime = env.GetRuntime();
+        const auto tabletId = InitTestActorRuntime(env, runtime, channelCount, channelCount, config);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+
+        ui32 gcRequests = 0;
+        bool deleteGarbageSeen = false;
+
+        NActors::TActorId gcActor = {};
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (msg->TabletId == tabletId &&
+                            isDataChannel(msg->Channel))
+                        {
+                            if (!gcActor || gcActor == event->Sender) {
+                                gcActor = event->Sender;
+                                ++gcRequests;
+                            }
+                        }
+                        break;
+                    }
+                    case TEvPartitionPrivate::EvDeleteGarbageRequest: {
+                        deleteGarbageSeen = true;
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvPartitionPrivate::EvCollectGarbageResponse);
+            runtime.DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(3, gcRequests);
+        UNIT_ASSERT_VALUES_EQUAL(false, deleteGarbageSeen);
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_env6.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_env6.cpp
@@ -1,0 +1,1220 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestEnv6)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyHandleTabletInfoChannelCountMoreThanConfigChannelCount)
+    {
+        constexpr ui32 channelCount = 7;
+        constexpr ui32 tabletInfoChannelCount = 11;
+
+        TTestEnv env(0, 1, tabletInfoChannelCount, 4);
+        auto& runtime = env.GetRuntime();
+
+        const auto tabletId = InitTestActorRuntime(
+            env,
+            runtime,
+            channelCount,
+            tabletInfoChannelCount);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
+
+        for (ui32 i = 0; i < 30; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        }
+
+        partition.Compaction();
+        partition.CollectGarbage();
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_env7.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_env7.cpp
@@ -1,0 +1,1220 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestEnv7)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyHandleTabletInfoChannelCountLessThanConfigChannelCount)
+    {
+        constexpr ui32 channelCount = 11;
+        constexpr ui32 tabletInfoChannelCount = 7;
+
+        TTestEnv env(0, 1, tabletInfoChannelCount, 4);
+        auto& runtime = env.GetRuntime();
+
+        const auto tabletId = InitTestActorRuntime(
+            env,
+            runtime,
+            channelCount,
+            tabletInfoChannelCount);
+
+        TPartitionClient partition(runtime, 0, tabletId);
+        partition.WaitReady();
+
+        for (ui32 i = 0; i < 30; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        }
+
+        partition.Compaction();
+        partition.CollectGarbage();
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_helpers.h
+++ b/cloud/blockstore/libs/storage/partition/part_ut_helpers.h
@@ -1,0 +1,1275 @@
+#include "part.h"
+
+#include "part_events_private.h"
+
+#include <cloud/blockstore/libs/diagnostics/block_digest.h>
+#include <cloud/blockstore/libs/diagnostics/config.h>
+#include <cloud/blockstore/libs/diagnostics/critical_events.h>
+#include <cloud/blockstore/libs/diagnostics/profile_log.h>
+#include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/storage/api/partition.h>
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/api/stats_service.h>
+#include <cloud/blockstore/libs/storage/api/volume.h>
+#include <cloud/blockstore/libs/storage/api/volume_proxy.h>
+#include <cloud/blockstore/libs/storage/core/block_handler.h>
+#include <cloud/blockstore/libs/storage/core/compaction_options.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/model/channel_data_kind.h>
+#include <cloud/blockstore/libs/storage/partition/model/fresh_blob.h>
+#include <cloud/blockstore/libs/storage/partition/model/fresh_blob_test.h>
+#include <cloud/blockstore/libs/storage/partition/part.h>
+#include <cloud/blockstore/libs/storage/partition/part_events_private.h>
+#include <cloud/blockstore/libs/storage/partition_common/events_private.h>
+#include <cloud/blockstore/libs/storage/testlib/part_client.h>
+#include <cloud/blockstore/libs/storage/testlib/test_env.h>
+#include <cloud/blockstore/libs/storage/testlib/test_runtime.h>
+#include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
+#include <cloud/blockstore/public/api/protos/volume.pb.h>
+
+// TODO: invalid reference
+#include <cloud/blockstore/libs/storage/service/service_events_private.h>
+#include <cloud/blockstore/libs/storage/volume/volume_events_private.h>
+
+#include <cloud/storage/core/libs/api/hive_proxy.h>
+#include <cloud/storage/core/libs/common/helpers.h>
+#include <cloud/storage/core/libs/common/sglist_test.h>
+#include <cloud/storage/core/libs/tablet/blob_id.h>
+
+#include <contrib/ydb/core/base/blobstorage.h>
+#include <contrib/ydb/core/blobstorage/base/blobstorage_events.h>
+#include <contrib/ydb/core/blobstorage/vdisk/common/vdisk_events.h>
+#include <contrib/ydb/core/mind/bscontroller/bsc.h>
+#include <contrib/ydb/core/testlib/basics/storage.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/bitmap.h>
+#include <util/generic/size_literals.h>
+#include <util/generic/variant.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+using namespace NActors;
+
+using namespace NKikimr;
+
+using namespace NCloud::NStorage;
+
+using namespace NLWTrace;
+
+using namespace std::chrono_literals;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define BLOCKSTORE_PARTITION_REQUESTS_MON(xxx, ...)                            \
+    xxx(RemoteHttpInfo,         __VA_ARGS__)                                   \
+// BLOCKSTORE_PARTITION_REQUESTS_MON
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 DataChannelOffset = 3;
+const TActorId VolumeActorId(0, "VVV");
+
+TString GetBlockContent(char fill = 0, size_t size = DefaultBlockSize)
+{
+    return TString(size, fill);
+}
+
+TString GetBlocksContent(
+    char fill = 0,
+    ui32 blockCount = 1,
+    size_t blockSize = DefaultBlockSize)
+{
+    TString result;
+    for (ui32 i = 0; i < blockCount; ++i) {
+        result += GetBlockContent(fill, blockSize);
+    }
+    return result;
+}
+
+void CheckRangesArePartition(
+    TVector<TBlockRange32> ranges,
+    const TBlockRange32& unionRange)
+{
+    UNIT_ASSERT(ranges.size() > 0);
+
+    Sort(ranges, [](const auto& l, const auto& r) {
+            return l.Start < r.Start;
+        });
+
+    const auto* prev = &ranges.front();
+    UNIT_ASSERT_VALUES_EQUAL(unionRange.Start, prev->Start);
+
+    for (size_t i = 1; i < ranges.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL_C(prev->End + 1, ranges[i].Start,
+            "during iteration #" << i);
+        prev = &ranges[i];
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(unionRange.End, ranges.back().End);
+}
+
+NProto::TStorageServiceConfig DefaultConfig(ui32 flushBlobSizeThreshold = 4_KB)
+{
+    NProto::TStorageServiceConfig config;
+    config.SetFlushBlobSizeThreshold(flushBlobSizeThreshold);
+    config.SetFreshByteCountThresholdForBackpressure(400_KB);
+    config.SetFreshByteCountLimitForBackpressure(1200_KB);
+    config.SetFreshByteCountFeatureMaxValue(6);
+    config.SetCollectGarbageThreshold(10);
+    config.SetDiskPrefixLengthWithBlockChecksumsInBlobs(1_GB);
+
+    return config;
+}
+
+TDiagnosticsConfigPtr CreateTestDiagnosticsConfig()
+{
+    NProto::TDiagnosticsConfig config;
+    config.SetPassTraceIdToBlobstorage(true);
+    return std::make_shared<TDiagnosticsConfig>(std::move(config));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestPartitionInfo
+{
+    TString DiskId = "test";
+    TString BaseDiskId;
+    TString BaseDiskCheckpointId;
+    ui64 TabletId = TestTabletId;
+    ui64 BaseTabletId = 0;
+    NCloud::NProto::EStorageMediaKind MediaKind =
+        NCloud::NProto::STORAGE_MEDIA_DEFAULT;
+    TMaybe<ui32> MaxBlocksInBlob;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDummyActor final
+    : public TActor<TDummyActor>
+{
+public:
+    TDummyActor()
+        : TActor(&TThis::StateWork)
+    {
+    }
+
+private:
+    STFUNC(StateWork)
+    {
+        Y_UNUSED(ev);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTestEnv
+{
+private:
+    const ui32 DomainUid = 1;
+    const TString DomainName = "local";
+
+    TTestBasicRuntime Runtime;
+    TVector<ui32> GroupIds;
+
+public:
+    TTestEnv(
+            ui32 staticNodes,
+            ui32 dynamicNodes,
+            ui32 nchannels,
+            ui32 ngroups)
+        : Runtime(staticNodes + dynamicNodes ? staticNodes + dynamicNodes : 1, false)
+    {
+        Runtime.AddLocalService(
+            VolumeActorId,
+            TActorSetupCmd(new TDummyActor, TMailboxType::Simple, 0));
+        Runtime.AddLocalService(
+            MakeHiveProxyServiceId(),
+            TActorSetupCmd(new TDummyActor, TMailboxType::Simple, 0));
+        Runtime.AppendToLogSettings(
+            TBlockStoreComponents::START,
+            TBlockStoreComponents::END,
+            GetComponentName);
+        for (ui32 i = TBlockStoreComponents::START;
+             i < TBlockStoreComponents::END;
+             ++i)
+        {
+            Runtime.SetLogPriority(i, NLog::PRI_INFO);
+        }
+        Runtime.SetLogPriority(NKikimrServices::BS_NODE, NLog::PRI_ERROR);
+
+        TAppPrepare app;
+        SetupDomain(app);
+        NKikimr::SetupChannelProfiles(app, DomainUid, nchannels);
+        SetupTabletServices(Runtime, &app);
+        BootBSController();
+        SetupStorage(ngroups);
+    }
+
+    TTestActorRuntime& GetRuntime()
+    {
+        return Runtime;
+    }
+
+    const auto& GetGroupIds() const
+    {
+        return GroupIds;
+    }
+
+    void CreateSubDomain(const TString& name)
+    {
+        Y_UNUSED(name);
+    }
+
+    ui32 CreateBlockStoreNode(
+        const TString& name,
+        TStorageConfigPtr storageConfig,
+        TDiagnosticsConfigPtr diagnosticsConfig)
+    {
+        Y_UNUSED(name);
+        Y_UNUSED(storageConfig);
+        Y_UNUSED(diagnosticsConfig);
+        return 0;
+    }
+
+private:
+    ui64 ChangeDomain(ui64 tabletId) const
+    {
+        return MakeTabletID(DomainUid, DomainUid, UniqPartFromTabletID(tabletId));
+    }
+
+    void SetupDomain(TAppPrepare& app)
+    {
+        auto domain = TDomainsInfo::TDomain::ConstructDomainWithExplicitTabletIds(
+            DomainName,
+            DomainUid,
+            ChangeDomain(Tests::SchemeRoot),
+            DomainUid,
+            DomainUid,
+            TVector<ui32>{DomainUid},
+            DomainUid,
+            TVector<ui32>{DomainUid},
+            7,
+            TVector<ui64>{TDomainsInfo::MakeTxCoordinatorID(DomainUid, 1)},
+            TVector<ui64>{TDomainsInfo::MakeTxMediatorID(DomainUid, 1)},
+            TVector<ui64>{TDomainsInfo::MakeTxAllocatorID(DomainUid, 1)},
+            DefaultPoolKinds(2));
+
+        app.AddDomain(domain.Release());
+    }
+
+    void BootBSController()
+    {
+        auto bootstrapper = CreateTestBootstrapper(
+            Runtime,
+            CreateTestTabletInfo(
+                MakeBSControllerID(DomainUid),
+                TTabletTypes::BSController),
+            &CreateFlatBsController);
+        Runtime.EnableScheduleForActor(bootstrapper);
+    }
+
+    void SetupStorage(ui32 ngroups)
+    {
+        SetupBoxAndStoragePool(
+            Runtime,
+            Runtime.AllocateEdgeActor(),
+            DomainUid,
+            ngroups);
+
+        auto selectGroups =
+            std::make_unique<TEvBlobStorage::TEvControllerSelectGroups>();
+        const auto& spTypes =
+            Runtime.GetAppData().DomainsInfo->GetDomain(DomainUid).StoragePoolTypes;
+        for (const auto& x: spTypes) {
+            selectGroups->Record.AddGroupParameters()
+                ->MutableStoragePoolSpecifier()->SetName(x.second.GetName());
+        }
+        selectGroups->Record.SetReturnAllMatchingGroups(true);
+        Runtime.SendToPipe(
+            MakeBSControllerID(DomainUid),
+            Runtime.AllocateEdgeActor(),
+            selectGroups.release());
+
+        TAutoPtr<IEventHandle> handle;
+        Runtime.GrabEdgeEventRethrow<
+            TEvBlobStorage::TEvControllerSelectGroupsResult>(
+                handle,
+                TDuration::Seconds(5));
+        UNIT_ASSERT(handle);
+
+        std::unique_ptr<TEvBlobStorage::TEvControllerSelectGroupsResult> response(
+            handle->Release<TEvBlobStorage::TEvControllerSelectGroupsResult>()
+                .Release());
+
+        for (const auto& mg: response->Record.GetMatchingGroups()) {
+            for (const auto& g: mg.GetGroups()) {
+                GroupIds.push_back(g.GetGroupID());
+            }
+        }
+
+        UNIT_ASSERT(ngroups <= GroupIds.size());
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TEventExecutionOrderFilter
+{
+public:
+    TEventExecutionOrderFilter(
+        TTestActorRuntimeBase& runtime,
+        const TVector<std::pair<ui32, ui32>>& eventOrders)
+        : Runtime(runtime)
+    {
+        for (const auto& [prerequisiteEvent, dependentEvent]: eventOrders) {
+            EventDependencies[dependentEvent] = prerequisiteEvent;
+            PrerequisiteEvents.insert(prerequisiteEvent);
+        }
+    }
+
+    TTestActorRuntimeBase::TEventFilter operator()(
+        TTestActorRuntimeBase::TEventFilter baseFilter = nullptr)
+    {
+        return [this, baseFilter](
+                   TTestActorRuntimeBase& rt,
+                   TAutoPtr<IEventHandle>& ev) -> bool
+        {
+            Y_ABORT_UNLESS(ev);
+
+            TActorId recipient = ev->GetRecipientRewrite();
+            ui32 eventType = ev->GetTypeRewrite();
+
+            bool baseFilterResult = baseFilter ? baseFilter(rt, ev) : false;
+
+            auto prerequisiteEventIt = EventDependencies.find(eventType);
+            if (prerequisiteEventIt != EventDependencies.end()) {
+                ui32 prerequisiteEvent = prerequisiteEventIt->second;
+                auto& processedEventsByRecipient = ProcessedEvents[recipient];
+                if (!processedEventsByRecipient.contains(prerequisiteEvent)) {
+                    DelayedEvents[recipient][prerequisiteEvent] = std::move(ev);
+                    return true;
+                }
+            }
+
+            auto& delayedEventsByRecipient = DelayedEvents[recipient];
+            auto delayedEventIt = delayedEventsByRecipient.find(eventType);
+            if (delayedEventIt != delayedEventsByRecipient.end()) {
+                TAutoPtr<IEventHandle> delayedEvent =
+                    std::move(delayedEventIt->second);
+                delayedEventsByRecipient.erase(delayedEventIt);
+
+                // Remove the recipient from the map if there are no more
+                // delayed events
+                if (delayedEventsByRecipient.empty()) {
+                    DelayedEvents.erase(recipient);
+                }
+
+                Runtime.Schedule(delayedEvent, TDuration::MilliSeconds(100));
+            }
+
+            if (PrerequisiteEvents.contains(eventType)) {
+                ProcessedEvents[recipient].insert(eventType);
+            }
+
+            return baseFilterResult;
+        };
+    }
+
+private:
+    TTestActorRuntimeBase& Runtime;
+    THashMap<ui32, ui32> EventDependencies;
+    THashSet<ui32> PrerequisiteEvents;
+    THashMap<TActorId, THashSet<ui32>> ProcessedEvents;
+    // Map of delayed events by recipient and event type
+    THashMap<TActorId, THashMap<ui32, TAutoPtr<IEventHandle>>> DelayedEvents;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+void InitTestActorRuntime(
+    TTestActorRuntime& runtime,
+    const NProto::TStorageServiceConfig& config,
+    ui32 blockCount,
+    ui32 channelCount,
+    std::unique_ptr<TTabletStorageInfo> tabletInfo,
+    TTestPartitionInfo partitionInfo = TTestPartitionInfo(),
+    EStorageAccessMode storageAccessMode = EStorageAccessMode::Default)
+{
+    auto storageConfig = std::make_shared<TStorageConfig>(
+        config,
+        std::make_shared<NFeatures::TFeaturesConfig>(
+            NCloud::NProto::TFeaturesConfig())
+    );
+
+    NProto::TPartitionConfig partConfig;
+
+    partConfig.SetDiskId(partitionInfo.DiskId);
+    partConfig.SetBaseDiskId(partitionInfo.BaseDiskId);
+    partConfig.SetBaseDiskCheckpointId(partitionInfo.BaseDiskCheckpointId);
+    partConfig.SetBaseDiskTabletId(partitionInfo.BaseTabletId);
+    partConfig.SetStorageMediaKind(partitionInfo.MediaKind);
+
+    partConfig.SetBlockSize(DefaultBlockSize);
+    partConfig.SetBlocksCount(blockCount);
+
+    if (partitionInfo.MaxBlocksInBlob) {
+        partConfig.SetMaxBlocksInBlob(*partitionInfo.MaxBlocksInBlob);
+    }
+
+    auto* cps = partConfig.MutableExplicitChannelProfiles();
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::System));
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Log));
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Index));
+
+    for (ui32 i = 0; i < channelCount - DataChannelOffset - 1; ++i) {
+        cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Merged));
+    }
+
+    cps->Add()->SetDataKind(static_cast<ui32>(EChannelDataKind::Fresh));
+
+    auto diagConfig = CreateTestDiagnosticsConfig();
+
+    auto createFunc =
+        [=] (const TActorId& owner, TTabletStorageInfo* info) {
+            auto tablet = CreatePartitionTablet(
+                owner,
+                info,
+                storageConfig,
+                diagConfig,
+                CreateProfileLogStub(),
+                CreateBlockDigestGeneratorStub(),
+                partConfig,
+                storageAccessMode,
+                0,  // partitionIndex
+                1,  // siblingCount
+                VolumeActorId,
+                0  // volumeTabletId
+            );
+            return tablet.release();
+        };
+
+    auto bootstrapper = CreateTestBootstrapper(runtime, tabletInfo.release(), createFunc);
+    runtime.EnableScheduleForActor(bootstrapper);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+auto InitTestActorRuntime(
+    TTestEnv& env,
+    TTestActorRuntime& runtime,
+    ui32 channelCount,
+    ui32 tabletInfoChannelCount,  // usually should be equal to channelCount
+    const NProto::TStorageServiceConfig& config = DefaultConfig())
+{
+    {
+        env.CreateSubDomain("nbs");
+        auto storageConfig = CreateTestStorageConfig(config);
+        env.CreateBlockStoreNode(
+            "nbs",
+            storageConfig,
+            CreateTestDiagnosticsConfig()
+        );
+    }
+
+    const auto tabletId = NKikimr::MakeTabletID(1, HiveId, 1);
+    std::unique_ptr<TTabletStorageInfo> x(new TTabletStorageInfo());
+
+    x->TabletID = tabletId;
+    x->TabletType = TTabletTypes::BlockStorePartition;
+    auto& channels = x->Channels;
+    channels.resize(tabletInfoChannelCount);
+
+    for (ui64 channel = 0; channel < channels.size(); ++channel) {
+        channels[channel].Channel = channel;
+        channels[channel].Type =
+            TBlobStorageGroupType(BootGroupErasure);
+        channels[channel].History.resize(1);
+        channels[channel].History[0].FromGeneration = 0;
+        const auto gidx =
+            channel > DataChannelOffset ? channel - DataChannelOffset : 0;
+        channels[channel].History[0].GroupID = env.GetGroupIds()[gidx];
+    }
+
+    InitTestActorRuntime(runtime, config, 1024, channelCount, std::move(x));
+
+    return tabletId;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void InitLogSettings(TTestActorRuntime& runtime)
+{
+    for (ui32 i = TBlockStoreComponents::START; i < TBlockStoreComponents::END; ++i) {
+        runtime.SetLogPriority(i, NLog::PRI_INFO);
+        // runtime.SetLogPriority(i, NLog::PRI_DEBUG);
+    }
+    // runtime.SetLogPriority(NLog::InvalidComponent, NLog::PRI_DEBUG);
+    runtime.SetLogPriority(NKikimrServices::BS_NODE, NLog::PRI_ERROR);
+}
+
+std::unique_ptr<TTestActorRuntime> PrepareTestActorRuntime(
+    NProto::TStorageServiceConfig config = DefaultConfig(),
+    ui32 blockCount = 1024,
+    TMaybe<ui32> channelsCount = {},
+    const TTestPartitionInfo& testPartitionInfo = TTestPartitionInfo(),
+    IActorPtr volumeProxy = {},
+    EStorageAccessMode storageAccessMode = EStorageAccessMode::Default)
+{
+    auto runtime = std::make_unique<TTestBasicRuntime>(1);
+
+    if (volumeProxy) {
+        runtime->AddLocalService(
+            MakeVolumeProxyServiceId(),
+            TActorSetupCmd(volumeProxy.release(), TMailboxType::Simple, 0));
+    }
+
+    runtime->AddLocalService(
+        VolumeActorId,
+        TActorSetupCmd(new TDummyActor, TMailboxType::Simple, 0));
+
+    runtime->AddLocalService(
+        MakeHiveProxyServiceId(),
+        TActorSetupCmd(new TDummyActor, TMailboxType::Simple, 0));
+
+    runtime->AppendToLogSettings(
+        TBlockStoreComponents::START,
+        TBlockStoreComponents::END,
+        GetComponentName);
+
+    InitLogSettings(*runtime);
+
+    SetupTabletServices(*runtime);
+
+    std::unique_ptr<TTabletStorageInfo> tabletInfo(CreateTestTabletInfo(
+        testPartitionInfo.TabletId,
+        TTabletTypes::BlockStorePartition));
+
+    if (channelsCount) {
+        auto& channels = tabletInfo->Channels;
+        channels.resize(*channelsCount);
+
+        for (ui64 i = 0; i < channels.size(); ++i) {
+            auto& channel = channels[i];
+            channel.History.resize(1);
+        }
+    }
+
+    InitTestActorRuntime(
+        *runtime,
+        config,
+        blockCount,
+        channelsCount ? *channelsCount : tabletInfo->Channels.size(),
+        std::move(tabletInfo),
+        testPartitionInfo,
+        storageAccessMode
+    );
+
+    return runtime;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+void AssertEqual(const TVector<T>& l, const TVector<T>& r)
+{
+    UNIT_ASSERT_VALUES_EQUAL(l.size(), r.size());
+    for (size_t i = 0; i < l.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL(l[i], r[i]);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString GetBlockContent(
+    const std::unique_ptr<TEvService::TEvReadBlocksResponse>& response)
+{
+    if (response->Record.GetBlocks().BuffersSize() == 1) {
+        return response->Record.GetBlocks().GetBuffers(0);
+    }
+    return {};
+}
+
+TString GetBlocksContent(
+    const std::unique_ptr<TEvService::TEvReadBlocksResponse>& response)
+{
+    const auto& blocks = response->Record.GetBlocks();
+
+    {
+        bool empty = true;
+        for (size_t i = 0; i < blocks.BuffersSize(); ++i) {
+            if (blocks.GetBuffers(i)) {
+                empty = false;
+            }
+        }
+
+        if (empty) {
+            return TString();
+        }
+    }
+
+    TString result;
+
+    for (size_t i = 0; i < blocks.BuffersSize(); ++i) {
+        const auto& block = blocks.GetBuffers(i);
+        if (!block) {
+            result += GetBlockContent(char(0));
+            continue;
+        }
+        result += block;
+    }
+
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDynBitMap GetBitMap(const TString& s)
+{
+    TDynBitMap mask;
+
+    if (s) {
+        mask.Reserve(s.size() * 8);
+        Y_ABORT_UNLESS(mask.GetChunkCount() * sizeof(TDynBitMap::TChunk) == s.size());
+        auto* dst = const_cast<TDynBitMap::TChunk*>(mask.GetChunks());
+        memcpy(dst, s.data(), s.size());
+    }
+
+    return mask;
+}
+
+TDynBitMap GetUnencryptedBlockMask(
+    const std::unique_ptr<TEvService::TEvReadBlocksResponse>& response)
+{
+    return GetBitMap(response->Record.GetUnencryptedBlockMask());
+}
+
+TDynBitMap GetUnencryptedBlockMask(
+    const std::unique_ptr<TEvService::TEvReadBlocksLocalResponse>& response)
+{
+    return GetBitMap(response->Record.GetUnencryptedBlockMask());
+}
+
+TDynBitMap CreateBitmap(size_t size)
+{
+    TDynBitMap bitmap;
+    bitmap.Reserve(size);
+    bitmap.Set(0, size);
+    return bitmap;
+}
+
+void MarkZeroedBlocks(TDynBitMap& bitmap, const TBlockRange32& range)
+{
+    if (range.End >= bitmap.Size()) {
+        bitmap.Reserve(range.End);
+    }
+    bitmap.Set(range.Start, range.End + 1);
+}
+
+void MarkWrittenBlocks(TDynBitMap& bitmap, const TBlockRange32& range)
+{
+    if (range.End >= bitmap.Size()) {
+        bitmap.Reserve(range.End);
+    }
+    bitmap.Reset(range.Start, range.End + 1);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TTestActorRuntime::TEventObserver StorageStateChanger(
+    ui32  flag,
+    TMaybe<ui32> groupIdFilter = {})
+{
+    return [=] (TAutoPtr<IEventHandle>& event) {
+        switch (event->GetTypeRewrite()) {
+            case TEvBlobStorage::EvPutResult: {
+                auto* msg = event->Get<TEvBlobStorage::TEvPutResult>();
+                if (!groupIdFilter.Defined() || *groupIdFilter == msg->GroupId) {
+                    const_cast<TStorageStatusFlags&>(msg->StatusFlags).Merge(
+                        ui32(NKikimrBlobStorage::StatusIsValid) | ui32(flag)
+                    );
+                    break;
+                }
+            }
+        }
+
+        return TTestActorRuntime::DefaultObserverFunc(event);
+    };
+}
+
+TTestActorRuntime::TEventObserver PartitionBatchWriteCollector(TTestActorRuntime& runtime, ui32 eventCount)
+{
+    bool dropProcessWriteQueue = true;
+    ui32 cnt = 0;
+    bool batchSeen = false;
+    NActors::TActorId partActorId;
+    return [=, &runtime] (TAutoPtr<IEventHandle>& event) mutable {
+        switch (event->GetTypeRewrite()) {
+            case TEvPartitionPrivate::EvProcessWriteQueue: {
+                batchSeen = true;
+                if (dropProcessWriteQueue) {
+                    partActorId = event->Sender;
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                break;
+            }
+            case TEvService::EvWriteBlocksRequest: {
+                if (++cnt == eventCount && batchSeen) {
+                    dropProcessWriteQueue = false;
+                    auto req =
+                        std::make_unique<TEvPartitionPrivate::TEvProcessWriteQueue>();
+                    runtime.Send(
+                        new IEventHandle(
+                            partActorId,
+                            event->Sender,
+                            req.release(),
+                            0, // flags
+                            0),
+                        0);
+                }
+                break;
+            }
+        }
+        return TTestActorRuntime::DefaultObserverFunc(event);
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TEmpty {};
+
+struct TBlob
+{
+    TBlob(
+        ui32 number,
+        ui8 offset,
+        ui8 blockCount = 1,
+        ui32 channel = 0,
+        ui32 generation = 0
+    )
+        : Number(number)
+        , Offset(offset)
+        , BlockCount(blockCount)
+        , Channel(channel)
+        , Generation(generation)
+    {}
+
+    ui32 Number;
+    ui8 Offset;
+    ui8 BlockCount;
+    ui32 Channel;
+    ui32 Generation;
+};
+
+struct TFresh
+{
+    TFresh(ui8 value)
+        : Value(value)
+    {}
+
+    ui8 Value;
+};
+
+using TBlockDescription = std::variant<TEmpty, TBlob, TFresh>;
+
+using TPartitionContent = TVector<TBlockDescription>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TPartitionWithRuntime
+{
+    std::unique_ptr<TTestActorRuntime> Runtime;
+    std::unique_ptr<TPartitionClient> Partition;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTestVolumeProxyActor final
+    : public TActorBootstrapped<TTestVolumeProxyActor>
+{
+private:
+    ui64 BaseTabletId;
+    TString BaseDiskId;
+    TString BaseDiskCheckpointId;
+    TPartitionContent BasePartitionContent;
+    ui32 BlockCount;
+    ui32 BaseBlockSize;
+
+public:
+    TTestVolumeProxyActor(
+        ui64 baseTabletId,
+        const TString& baseDiskId,
+        const TString& baseDiskCheckpointId,
+        const TPartitionContent& basePartitionContent,
+        ui32 blockCount,
+        ui32 baseBlockSize = DefaultBlockSize);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    STFUNC(StateWork);
+
+    void HandleDescribeBlocksRequest(
+        const TEvVolume::TEvDescribeBlocksRequest::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleGetUsedBlocksRequest(
+        const TEvVolume::TEvGetUsedBlocksRequest::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleGetChangedBlocksRequest(
+        const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleKeepAliveRequest(
+        const TEvVolumeProxy::TEvKeepAliveRequest::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TTestVolumeProxyActor::TTestVolumeProxyActor(
+        ui64 baseTabletId,
+        const TString& baseDiskId,
+        const TString& baseDiskCheckpointId,
+        const TPartitionContent& basePartitionContent,
+        ui32 blockCount,
+        ui32 baseBlockSize)
+    : BaseTabletId(baseTabletId)
+    , BaseDiskId(baseDiskId)
+    , BaseDiskCheckpointId(baseDiskCheckpointId)
+    , BasePartitionContent(std::move(basePartitionContent))
+    , BlockCount(blockCount)
+    , BaseBlockSize(baseBlockSize)
+{}
+
+void TTestVolumeProxyActor::Bootstrap(const TActorContext& ctx)
+{
+    Y_UNUSED(ctx);
+
+    Become(&TThis::StateWork);
+}
+
+void TTestVolumeProxyActor::HandleDescribeBlocksRequest(
+    const TEvVolume::TEvDescribeBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    const auto& record = msg->Record;
+    const auto& diskId = record.GetDiskId();
+    const auto& checkpoint = record.GetCheckpointId();
+
+    UNIT_ASSERT_VALUES_EQUAL(BaseDiskId, diskId);
+    UNIT_ASSERT_VALUES_EQUAL(BaseDiskCheckpointId, checkpoint);
+
+    auto response = std::make_unique<TEvVolume::TEvDescribeBlocksResponse>();
+    auto blockIndex = 0;
+
+    for (const auto& descr: BasePartitionContent) {
+        if (std::holds_alternative<TBlob>(descr)) {
+            const auto& blob = std::get<TBlob>(descr);
+            auto& blobPiece = *response->Record.AddBlobPieces();
+            NKikimr::TLogoBlobID blobId(
+                BaseTabletId,
+                blob.Generation,
+                blob.Number,
+                blob.Channel,
+                BaseBlockSize * 0x100,
+                0);
+            LogoBlobIDFromLogoBlobID(
+                blobId,
+                blobPiece.MutableBlobId());
+
+            auto* range = blobPiece.AddRanges();
+            range->SetBlobOffset(blob.Offset);
+            range->SetBlockIndex(blockIndex);
+            range->SetBlocksCount(blob.BlockCount);
+            blockIndex += blob.BlockCount;
+        } else if (std::holds_alternative<TFresh>(descr)) {
+            const auto& fresh = std::get<TFresh>(descr);
+            auto& freshBlockRange = *response->Record.AddFreshBlockRanges();
+            freshBlockRange.SetStartIndex(blockIndex);
+            freshBlockRange.SetBlocksCount(1);
+            freshBlockRange.SetBlocksContent(
+                TString(BaseBlockSize, char(fresh.Value)));
+            ++blockIndex;
+        } else {
+            Y_ABORT_UNLESS(std::holds_alternative<TEmpty>(descr));
+            ++blockIndex;
+        }
+    }
+
+    ctx.Send(ev->Sender, response.release());
+}
+
+void TTestVolumeProxyActor::HandleGetUsedBlocksRequest(
+    const TEvVolume::TEvGetUsedBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    const auto& record = msg->Record;
+    const auto& diskId = record.GetDiskId();
+
+    UNIT_ASSERT_VALUES_EQUAL(BaseDiskId, diskId);
+
+    auto response = std::make_unique<TEvVolume::TEvGetUsedBlocksResponse>();
+    ui64 blockIndex = 0;
+
+    TCompressedBitmap bitmap(BlockCount);
+
+    for (const auto& descr: BasePartitionContent) {
+        if (std::holds_alternative<TBlob>(descr)) {
+            const auto& blob = std::get<TBlob>(descr);
+            bitmap.Set(blockIndex, blockIndex + blob.BlockCount);
+            blockIndex += blob.BlockCount;
+        } else if (std::holds_alternative<TFresh>(descr)) {
+            bitmap.Set(blockIndex, blockIndex + 1);
+            ++blockIndex;
+        } else {
+            Y_ABORT_UNLESS(std::holds_alternative<TEmpty>(descr));
+            ++blockIndex;
+        }
+    }
+
+    auto serializer = bitmap.RangeSerializer(0, bitmap.Capacity());
+    TCompressedBitmap::TSerializedChunk chunk;
+    while (serializer.Next(&chunk)) {
+        if (!TCompressedBitmap::IsZeroChunk(chunk)) {
+            auto* usedBlock = response->Record.AddUsedBlocks();
+            usedBlock->SetChunkIdx(chunk.ChunkIdx);
+            usedBlock->SetData(chunk.Data.data(), chunk.Data.size());
+        }
+    }
+
+    // serialize/deserialize for better testing (to catch the bug NBS-3934)
+    auto serialized = response->Record.SerializeAsString();
+    UNIT_ASSERT(response->Record.ParseFromString(serialized));
+
+    ctx.Send(ev->Sender, response.release());
+}
+
+void TTestVolumeProxyActor::HandleGetChangedBlocksRequest(
+    const TEvService::TEvGetChangedBlocksRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+    const auto& record = msg->Record;
+
+    UNIT_ASSERT_VALUES_EQUAL(BaseDiskId, record.GetDiskId());
+    UNIT_ASSERT_VALUES_EQUAL(BaseDiskCheckpointId, record.GetHighCheckpointId());
+    UNIT_ASSERT_VALUES_EQUAL("", record.GetLowCheckpointId());
+
+    auto response = std::make_unique<TEvService::TEvGetChangedBlocksResponse>();
+    ui64 blockIndex = 0;
+
+    TVector<ui8> changedBlocks((record.GetBlocksCount() + 7) / 8);
+
+    auto fillBlock = [&](ui64 block) {
+        if (block < record.GetStartIndex() || block >= record.GetStartIndex() + record.GetBlocksCount()) {
+            return;
+        }
+
+        ui64 bit = block - record.GetStartIndex();
+        changedBlocks[bit / 8] |= 1 << (bit % 8);
+    };
+
+    for (const auto& descr: BasePartitionContent) {
+        if (std::holds_alternative<TBlob>(descr)) {
+            const auto& blob = std::get<TBlob>(descr);
+            for (ui64 block = blockIndex; block < blockIndex + blob.BlockCount; block++) {
+                fillBlock(block);
+            }
+            blockIndex += blob.BlockCount;
+        } else if (std::holds_alternative<TFresh>(descr)) {
+            fillBlock(blockIndex);
+            ++blockIndex;
+        } else {
+            Y_ABORT_UNLESS(std::holds_alternative<TEmpty>(descr));
+            ++blockIndex;
+        }
+    }
+
+    for (const auto& b: changedBlocks) {
+        response->Record.MutableMask()->push_back(b);
+    }
+
+    ctx.Send(ev->Sender, response.release());
+}
+
+void TTestVolumeProxyActor::HandleKeepAliveRequest(
+    const TEvVolumeProxy::TEvKeepAliveRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* msg = ev->Get();
+
+    UNIT_ASSERT_VALUES_EQUAL(BaseDiskId, msg->DiskId);
+
+    ctx.Send(
+        ev->Sender,
+        std::make_unique<TEvVolumeProxy::TEvKeepAliveResponse>().release());
+}
+
+STFUNC(TTestVolumeProxyActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvVolume::TEvDescribeBlocksRequest, HandleDescribeBlocksRequest);
+        HFunc(TEvVolume::TEvGetUsedBlocksRequest, HandleGetUsedBlocksRequest);
+        HFunc(TEvService::TEvGetChangedBlocksRequest, HandleGetChangedBlocksRequest);
+        HFunc(TEvVolumeProxy::TEvKeepAliveRequest, HandleKeepAliveRequest);
+        IgnoreFunc(TEvVolume::TEvMapBaseDiskIdToTabletId);
+        IgnoreFunc(TEvVolume::TEvClearBaseDiskIdToTabletIdMapping);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::VOLUME_PROXY,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool EventHandler(
+    ui64 tabletId,
+    const TEvBlobStorage::TEvGet::TPtr& ev,
+    TTestActorRuntimeBase& runtime,
+    ui32 blockSize = DefaultBlockSize)
+{
+    bool result = false;
+
+    auto* msg = ev->Get();
+
+    auto response =
+        std::make_unique<TEvBlobStorage::TEvGetResult>(
+            NKikimrProto::OK, msg->QuerySize, 0 /* groupId */);
+
+    for (ui32 i = 0; i < msg->QuerySize; ++i) {
+        const auto& q = msg->Queries[i];
+        const auto& blobId = q.Id;
+
+        UNIT_ASSERT_C(
+            !result || blobId.TabletID() == tabletId,
+            "All blobs in one TEvGet request should belong to one partition;"
+            " tabletId: " << tabletId <<
+            " blobId: " << blobId);
+
+        if (blobId.TabletID() == tabletId) {
+            result = true;
+
+            auto& r = response->Responses[i];
+
+            r.Id = blobId;
+            r.Status = NKikimrProto::OK;
+
+            UNIT_ASSERT(q.Size % blockSize == 0);
+            UNIT_ASSERT(q.Shift % blockSize == 0);
+
+            auto blobOffset = q.Shift / blockSize;
+
+            const auto blobEnd = blobOffset + q.Size / blockSize;
+            for (; blobOffset < blobEnd; ++blobOffset) {
+                UNIT_ASSERT_C(
+                    blobOffset <= 0xff,
+                    "Blob offset should fit in one byte");
+
+                // Debugging is easier when block content is equal to blob offset.
+                r.Buffer.Insert(r.Buffer.End(), TRope(TString(blockSize, char(blobOffset))));
+            }
+        }
+    }
+
+    if (result) {
+        runtime.Schedule(
+            new IEventHandle(
+                ev->Sender,
+                ev->Recipient,
+                response.release(),
+                0,
+                ev->Cookie),
+            TDuration());
+    }
+    return result;
+}
+
+TPartitionWithRuntime SetupOverlayPartition(
+    ui64 overlayTabletId,
+    ui64 baseTabletId,
+    const TPartitionContent& basePartitionContent = {},
+    TMaybe<ui32> channelsCount = {},
+    ui32 blockSize = DefaultBlockSize,
+    ui32 blockCount = 1024,
+    const NProto::TStorageServiceConfig& config = DefaultConfig(),
+    TMaybe<ui32> MaxBlocksInBlob = {})
+{
+    TPartitionWithRuntime result;
+
+    result.Runtime = PrepareTestActorRuntime(
+        config,
+        blockCount,
+        channelsCount,
+        {
+            "overlay-disk",
+            "base-disk",
+            "checkpoint",
+            overlayTabletId,
+            baseTabletId,
+            NCloud::NProto::STORAGE_MEDIA_DEFAULT,
+            MaxBlocksInBlob
+        },
+        std::make_unique<TTestVolumeProxyActor>(
+            baseTabletId,
+            "base-disk",
+            "checkpoint",
+            basePartitionContent,
+            blockCount,
+            blockSize));
+
+    bool baseDiskIsMapped = false;
+    result.Runtime->SetEventFilter([&]
+        (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+    {
+        Y_UNUSED(runtime);
+
+        if (ev->GetTypeRewrite() == TEvVolume::EvMapBaseDiskIdToTabletId) {
+            const auto* msg = ev->Get<TEvVolume::TEvMapBaseDiskIdToTabletId>();
+
+            UNIT_ASSERT_VALUES_EQUAL(msg->BaseDiskId, "base-disk");
+            UNIT_ASSERT_VALUES_EQUAL(msg->BaseTabletId, baseTabletId);
+            baseDiskIsMapped = true;
+        }
+        return false;
+    });
+
+    result.Partition = std::make_unique<TPartitionClient>(*result.Runtime);
+    result.Partition->WaitReady();
+
+    UNIT_ASSERT(baseDiskIsMapped);
+
+    result.Runtime->SetEventFilter([baseTabletId, blockSize] (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev) {
+        bool handled = false;
+
+        const auto wrapped =
+            [&] (const auto& ev) {
+                handled = EventHandler(baseTabletId, ev, runtime, blockSize);
+            };
+
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvBlobStorage::TEvGet, wrapped);
+        }
+        return handled;
+    });
+
+    return result;
+}
+
+TString GetBlocksContent(
+    const TPartitionContent& content,
+    size_t blockSize = DefaultBlockSize)
+{
+    TString result;
+
+    for (const auto& descr: content) {
+        if (std::holds_alternative<TEmpty>(descr)) {
+            result += TString(blockSize, char(0));
+        } else if (std::holds_alternative<TBlob>(descr)) {
+            const auto& blob = std::get<TBlob>(descr);
+            for (auto i = 0; i < blob.BlockCount; ++i) {
+                const auto blobOffset = blob.Offset + i;
+                // Debugging is easier when block content is equal to blob offset.
+                result += TString(blockSize, char(blobOffset));
+            }
+        } else if (std::holds_alternative<TFresh>(descr)) {
+            const auto& fresh = std::get<TFresh>(descr);
+            result += TString(blockSize, char(fresh.Value));
+        } else {
+            Y_ABORT_UNLESS(false);
+        }
+    }
+
+    return result;
+}
+
+TString BuildRemoteHttpQuery(
+    ui64 tabletId,
+    const TVector<std::pair<TString, TString>>& keyValues,
+    const TString& fragment = "")
+{
+    auto res = TStringBuilder()
+        << "/app?TabletID="
+        << tabletId;
+    for (const auto& p: keyValues) {
+        res << "&" << p.first << "=" << p.second;
+    }
+    if (fragment) {
+        res << "#" << fragment;
+    }
+    return res;
+}
+
+template <typename TRequest>
+void SendUndeliverableRequest(
+    TTestActorRuntimeBase& runtime,
+    TAutoPtr<IEventHandle>& event,
+    std::unique_ptr<TRequest> request)
+{
+    auto fakeRecipient = TActorId(
+        event->Recipient.NodeId(),
+        event->Recipient.PoolID(),
+        0,
+        event->Recipient.Hint());
+    auto undeliveryActor = event->GetForwardOnNondeliveryRecipient();
+    runtime.Send(
+        new IEventHandle(
+            fakeRecipient,
+            event->Sender,
+            request.release(),
+            event->Flags,
+            0,
+            &undeliveryActor),
+        0);
+}
+
+class TMockShuttle: public IShuttle
+{
+public:
+    TMockShuttle(ui64 traceIdx, ui64 spanId)
+        : IShuttle(traceIdx, spanId)
+    {}
+
+protected:
+    bool DoAddProbe(TProbe*, const TParams&, ui64) override
+    {
+        return true;
+    }
+
+    void DoEndOfTrack() override
+    {}
+
+    void DoDrop() override
+    {}
+
+    void DoSerialize(TShuttleTrace&) override
+    {}
+
+    bool DoFork(TShuttlePtr& child) override
+    {
+        auto shuttle = MakeIntrusive<TMockShuttle>(GetTraceIdx(), GetSpanId());
+        shuttle->SetNext(child);
+        child = shuttle;
+        child->SetParentSpanId(GetSpanId());
+        return true;
+    }
+
+    bool DoJoin(const TShuttlePtr&) override
+    {
+        return true;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_ut_split1.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split1.cpp
@@ -1,0 +1,1802 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit1)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldWaitReady)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.StatPartition();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyFlushBlocksWhenFreshBlobCountThresholdIsReached)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(4_MB);
+        config.SetFreshBlobCountFlushThreshold(4);
+        config.SetFreshBlobByteCountFlushThreshold(999999999);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetFreshBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        partition.WriteBlocks(0, 0);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetMixedBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyRunLoadOptimizingCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetHDDMaxBlobsPerRange(999);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 i = 0; i < 512; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 2, 2));
+            partition.Flush();
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(512, stats.GetMixedBlobsCount());
+        }
+
+        ui64 compactionByBlobCount = -1;
+        ui64 compactionByReadStats = -1;
+
+        bool compactionRequestObserved = false;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::RangeCompaction) {
+                            compactionRequestObserved = true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByBlobCount =
+                            cc.CompactionByBlobCountPerRange.Value;
+                        compactionByReadStats = cc.CompactionByReadStats.Value;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        for (ui32 i = 0; i < 10; ++i) {
+            for (ui32 j = 0; j < 10; ++j) {
+                partition.ReadBlocks(TBlockRange32::WithLength(j, 101));
+            }
+        }
+
+        // triggering EnqueueCompactionIfNeeded(...)
+        partition.WriteBlocks(0, 0);
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(compactionRequestObserved);
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_EQUAL(0, compactionByBlobCount);
+        UNIT_ASSERT_EQUAL(1, compactionByReadStats);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldKillTabletIfCriticalFailureDuringWriteBlocks)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvWriteBlobResponse: {
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvWriteBlobResponse>();
+                        auto& e = const_cast<NProto::TError&>(msg->Error);
+                        e.SetCode(E_REJECTED);
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(0, MaxBlocksCount));
+        auto response = partition.RecvWriteBlocksResponse();
+
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldMakeUnderlyingBlobsEligibleForCleanupAfterCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetCleanupThreshold(1);
+        config.SetCollectGarbageThreshold(3);
+        config.SetSSDMaxBlobsPerRange(4);
+        config.SetHDDMaxBlobsPerRange(4);
+        config.SetFlushThreshold(8_MB);
+        config.SetWriteBlobThreshold(4_MB);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 version = 0; version < 3; ++version) {
+            for (ui32 pos = 0; pos < 2; ++pos) {
+                partition.WriteBlocks(TBlockRange32::WithLength(512 * pos, 512));
+            }
+            partition.Flush();
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProduceSparseMergedBlobsUponCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetHDDMaxBlobsPerRange(999);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(5, 1);
+        partition.WriteBlocks(10, 2);
+        partition.WriteBlocks(20, 3);
+        partition.WriteBlocks(30, 4);
+        partition.ZeroBlocks(30);
+        partition.ZeroBlocks(40);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(6, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlocksCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlocksCount());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(4))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(1),
+            GetBlocksContent(partition.ReadBlocks(5))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(6))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(9))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(2),
+            GetBlocksContent(partition.ReadBlocks(10))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(11))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(19))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(3),
+            GetBlocksContent(partition.ReadBlocks(20))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(21))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(30))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(40))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleDescribeBlocksRequestWithOutOfBoundsRange)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 11), char(1));
+
+        {
+            const auto range =
+                TBlockRange32::MakeClosedInterval(Max<ui32>() - 1, Max<ui32>());
+            auto request = partition.CreateDescribeBlocksRequest(range);
+            partition.SendToPipe(std::move(request));
+            auto response =
+                partition.RecvResponse<TEvVolume::TEvDescribeBlocksResponse>();
+            UNIT_ASSERT(response->GetStatus() == S_OK);
+            UNIT_ASSERT(response->Record.FreshBlockRangesSize() == 0);
+            UNIT_ASSERT(response->Record.BlobPiecesSize() == 0);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksAfterCompactionOfOverlayDisk2)
+    {
+        TPartitionContent baseContent;
+        for (size_t i = 0; i < 1000; ++i) {
+            baseContent.push_back(TEmpty());
+        }
+        for (size_t i = 1000; i < 1024; ++i) {
+            baseContent.push_back(TBlob(i, 1));
+        }
+        auto bitmap = CreateBitmap(1024);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        // Write 1000 blocks. After compaction, we have one merged blob written.
+        // It's a tricky situation because some blocks (in [1000..1023] range)
+        // are missing in overlay disk and therefore these blocks should be read
+        // from base disk.
+        auto writeRange = TBlockRange32::WithLength(0, 1000);
+        partition.WriteBlocks(writeRange, char(2));
+        MarkWrittenBlocks(bitmap, writeRange);
+
+        partition.Compaction();
+
+        auto response = partition.ReadBlocks(TBlockRange32::WithLength(0, 1024));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(char(2), 1000) +
+            GetBlocksContent(char(1), 24),
+            GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), char(3));
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Other blobs should be collected.
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFailsHttpGetCollectGarbage)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        auto createResponse = partition.RemoteHttpInfo(
+            BuildRemoteHttpQuery(TestTabletId, {{"action","collectGarbage"}}));
+
+        UNIT_ASSERT_C(createResponse->Html.Contains("Wrong HTTP method"), true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldPostponeBlockCountCalculationAndScanDiskUntilInflightWriteRequestsAreCompleted)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        ui64 writeCommitId = 0;
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) mutable {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        writeCommitId =
+                            event->Get<TEvPartitionPrivate::TEvAddBlobsRequest>()->CommitId;
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1024 * 10), 1);
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            partition.SendMetadataRebuildBlockCountRequest(
+                MakePartialBlobId(writeCommitId + 1, 0),
+                100,
+                MakePartialBlobId(writeCommitId + 1, 0));
+
+            const auto response =
+                partition.RecvMetadataRebuildBlockCountResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        {
+            partition.SendScanDiskBatchRequest(
+                MakePartialBlobId(writeCommitId, 0),
+                100,
+                MakePartialBlobId(writeCommitId, 0));
+
+            const auto response = partition.RecvScanDiskBatchResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyUpdatePartialScanDiskProgress)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(0, 1024 * 10),
+            1);
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1024 * 5, 1024 * 11),
+            1);
+
+        const auto step = 16;
+        for (ui32 i = 1024 * 10; i < 1024 * 12; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step), 1);
+        }
+
+        for (ui32 i = 1024 * 20; i < 1024 * 21; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step + 1), 1);
+        }
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1001111, 1001210),
+            1);
+
+        ui32 batchCount = 0;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvScanDiskBatchResponse: {
+                        if (++batchCount == 2) {
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        const ui32 blobsPerBatch = 3;
+        const auto response = partition.ScanDisk(blobsPerBatch);
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        const auto progress = partition.GetScanDiskStatus();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            progress->Record.GetProgress().GetIsCompleted());
+        UNIT_ASSERT_VALUES_EQUAL(
+            blobsPerBatch,
+            progress->Record.GetProgress().GetProcessed());
+        UNIT_ASSERT_LT(
+            blobsPerBatch,
+            progress->Record.GetProgress().GetTotal());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDecrementBatchSizeWhenBlobsCountPerDiskIsSmall)
+    {
+        // blobs percentage: (10 - 9 / 10) * 100 = 10
+        // 10 < 100, so batch size should decrement
+        CheckIncrementAndDecrementCompactionPerRun(
+            2, 9, 999999, 999999, 99999, 7, 200, 100, 1);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAbortCompactionIfWriteBlobFailsWithDeadlineExceeded)
+    {
+        DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+            TEvBlobStorage::EvVPut);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotHangWhenConsecutiveReadBlobErrorsHappen)
+    {
+        auto config = DefaultConfig();
+        config.SetMaxIORequestsInFlight(10);
+        config.SetMaxReadBlobErrorsBeforeSuicide(1000);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    msg->Status = NKikimrProto::ERROR;
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 777), 1);
+
+        for (int i = 0; i < 100; i++) {
+            partition.SendReadBlocksRequest(TBlockRange32::WithLength(0, 777));
+            auto response = partition.RecvReadBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectSmallZerosAfterReachingFreshByteCountHardLimit)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetFreshByteCountHardLimit(8_KB);
+        config.SetFlushThreshold(4_MB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+
+        partition.SendZeroBlocksRequest(0);
+        auto response = partition.RecvZeroBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+        UNIT_ASSERT(
+            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
+
+        partition.Flush();
+
+        partition.SendZeroBlocksRequest(0);
+        response = partition.RecvZeroBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetStatus(),
+            response->GetErrorReason());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleDescribeBlobRequestForMergedBlob)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range = TBlockRange32::WithLength(11, 4);
+        partition.WriteBlocks(range, char(1));
+        partition.Flush();
+
+        const auto describeBlocks = partition.DescribeBlocks(range);
+        UNIT_ASSERT_VALUES_EQUAL(1, describeBlocks->Record.BlobPiecesSize());
+
+        const auto blobId = LogoBlobIDFromLogoBlobID(
+            describeBlocks->Record.GetBlobPieces(0).GetBlobId());
+        UNIT_ASSERT(blobId.IsValid());
+
+        const auto response = partition.DescribeBlob(blobId);
+        UNIT_ASSERT_VALUES_EQUAL(range.Size(), response->Record.BlocksSize());
+
+        for (ui32 i = 0; i < range.Size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                range.Start + i,
+                response->Record.GetBlocks(i).GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(i, response->Record.GetBlocks(i).GetBlobOffset());
+        }
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split10.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split10.cpp
@@ -1,0 +1,2030 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit10)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldStoreBlocksUsingLocalAPI)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        auto blockContent1 = GetBlockContent(1);
+        partition.WriteBlocksLocal(1, blockContent1);
+        auto blockContent2 = GetBlockContent(2);
+        partition.WriteBlocksLocal(2, blockContent2);
+        auto blockContent3 = GetBlockContent(3);
+        partition.WriteBlocksLocal(3, blockContent3);
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+
+        {
+            TString block(DefaultBlockSize, 0);
+            partition.ReadBlocksLocal(1, block);
+            UNIT_ASSERT_VALUES_EQUAL(GetBlockContent(1), block);
+        }
+
+        {
+            TString block(DefaultBlockSize, 0);
+            partition.ReadBlocksLocal(2, block);
+            UNIT_ASSERT_VALUES_EQUAL(GetBlockContent(2), block);
+        }
+
+        {
+            TString block(DefaultBlockSize, 0);
+            partition.ReadBlocksLocal(3, block);
+            UNIT_ASSERT_VALUES_EQUAL(GetBlockContent(3), block);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFillCompactionTimeCounters)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        ui64 compactionTxTime = 0;
+        ui64 compactionReadBlobsTime = 0;
+        ui64 compactionWriteBlobsTime = 0;
+        ui64 compactionAddBlobsTime = 0;
+        ui64 compactionTotalTime = 0;
+        ui64 compactionExecutionTime = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest:
+                    case TEvPartitionPrivate::EvCompactionCompleted:
+                    case TEvPartitionPrivate::EvAddBlobsRequest:
+                    case TEvPartitionPrivate::EvAddBlobsResponse:
+                    case TEvPartitionCommonPrivate::EvReadBlobRequest:
+                    case TEvPartitionCommonPrivate::EvReadBlobResponse:
+                    case TEvPartitionCommonPrivate::EvWriteBlobRequest:
+                    case TEvPartitionCommonPrivate::EvWriteBlobResponse:
+                    case TEvPartitionCommonPrivate::EvPatchBlobRequest:
+                    case TEvBlobStorage::EvPut:
+                    case TEvPartitionCommonPrivate::EvExecuteTransactions:
+                    case TEvPartitionCommonPrivate::EvPatchBlobResponse: {
+                        runtime->AdvanceCurrentTime(TDuration::MilliSeconds(1));
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionTxTime = cc.CompactionTxTime.Value;
+                        compactionReadBlobsTime =
+                            cc.CompactionReadBlobsTime.Value;
+                        compactionWriteBlobsTime =
+                            cc.CompactionWriteBlobsTime.Value;
+                        compactionAddBlobsTime =
+                            cc.CompactionAddBlobsTime.Value;
+                        compactionTotalTime = cc.CompactionTotalTime.Value;
+                        compactionExecutionTime =
+                            cc.CompactionExecutionTime.Value;
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+        partition.Flush();
+
+        partition.WriteBlocks(1, 11);
+        partition.Flush();
+
+        partition.WriteBlocks(2, 22);
+        partition.Flush();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        partition.Compaction();
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT(compactionTxTime > 0);
+        UNIT_ASSERT(compactionReadBlobsTime > 0);
+        UNIT_ASSERT(compactionWriteBlobsTime > 0);
+        UNIT_ASSERT(compactionAddBlobsTime > 0);
+        UNIT_ASSERT(compactionTotalTime > 0);
+        UNIT_ASSERT(compactionExecutionTime > 0);
+
+        UNIT_ASSERT(
+            compactionTotalTime >= compactionTxTime + compactionReadBlobsTime +
+                                      compactionWriteBlobsTime +
+                                      compactionAddBlobsTime);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldZeroBlocks)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        partition.Flush();
+        partition.ZeroBlocks(2);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        partition.Flush();
+        partition.ZeroBlocks(3);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSupportCheckpointsWithoutData) {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig());
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.CreateCheckpoint("checkpoint_without_data", "id1", true);
+        partition.Flush();
+        partition.WriteBlocks(1, 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+
+        partition.SendReadBlocksRequest(1, "checkpoint_without_data");
+        auto response = partition.RecvReadBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, response->GetStatus());
+
+        {
+            auto responseDelete = partition.DeleteCheckpoint("checkpoint_without_data");
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, responseDelete->GetStatus());
+        }
+        {
+            auto responseCreate = partition.CreateCheckpoint("checkpoint1", "id2", true);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, responseCreate->GetStatus());
+        }
+        {
+            auto responseDeleteData =  partition.DeleteCheckpointData("checkpoint1");
+            UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, responseDeleteData->GetStatus());
+        }
+        {
+            auto responseCreateSame = partition.CreateCheckpoint("checkpoint1", "id3");
+            UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, responseCreateSame->GetStatus());
+        }
+        {
+            auto responseDelete =  partition.DeleteCheckpoint("checkpoint1");
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, responseDelete->GetStatus());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldUseZeroCommitIdWhenLowCheckpointIdIsNotSet)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 4096);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 1);
+        partition.CreateCheckpoint("cp1");
+        partition.WriteBlocks(1, 1);
+        partition.CreateCheckpoint("cp2");
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 3072),
+                "cp1",
+                "cp2",
+                false);
+
+            const auto& mask = response->Record.GetMask();
+            UNIT_ASSERT_VALUES_EQUAL(384, mask.size());
+            UNIT_ASSERT_VALUES_EQUAL(2, response->Record.GetMask()[0]);
+        }
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 3072),
+                "",
+                "cp2",
+                false);
+
+            const auto& mask = response->Record.GetMask();
+            UNIT_ASSERT_VALUES_EQUAL(384, mask.size());
+            UNIT_ASSERT_VALUES_EQUAL(3, response->Record.GetMask()[0]);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSendBackpressureReportsUponChannelColorChange)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        TBackpressureReport report;
+
+        runtime->SetObserverFunc(
+            [&report] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartition::EvBackpressureReport: {
+                        report = *event->Get<TEvPartition::TEvBackpressureReport>();
+                        break;
+                    }
+                }
+
+                return StorageStateChanger(
+                    NKikimrBlobStorage::StatusDiskSpaceLightYellowMove |
+                    NKikimrBlobStorage::StatusDiskSpaceYellowStop)(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        UNIT_ASSERT(report.DiskSpaceScore > 0);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotCrashWithMalformedUnicodeCharacterInGetUsedBlocksResponse)
+    {
+        TPartitionContent baseContent;
+
+        // malformed utf-8 character
+        auto c = 0xa9;
+        while (c != 0) {
+            if (c & 1) {
+                baseContent.push_back(TBlob(0, 0));
+            } else {
+                baseContent.push_back(TEmpty());
+            }
+
+            c >>= 1;
+        }
+
+        auto partitionWithRuntime = SetupOverlayPartition(
+            TestTabletId,
+            TestTabletId2,
+            baseContent);
+
+        auto& partition = *partitionWithRuntime.Partition;
+        auto response = partition.StatPartition();
+        auto stats = response->Record.GetStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(4, stats.GetLogicalUsedBlocksCount());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldStartCompactionOnCompactRagesRequest)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 100);
+        partition.SendCompactRangeRequest(0, 100);
+
+        auto response = partition.RecvCompactRangeResponse();
+        UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            response->Record.GetOperationId().empty()
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleFlushCorrectlyWhileBlockFromDbIsBeingDeleted)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelCountSSD(0);
+        config.SetFreshChannelWriteRequestsEnabled(false);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 5));
+
+        TAutoPtr<IEventHandle> addBlobsRequest;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvPartitionPrivate::EvAddBlobsRequest) {
+                    addBlobsRequest = event.Release();
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.SendFlushRequest();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 5));
+
+        UNIT_ASSERT(addBlobsRequest);
+        runtime->Send(addBlobsRequest.Release());
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        auto response = partition.RecvFlushResponse();
+        UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldPatchBlobsDuringCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBlobPatchingEnabled(true);
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetCompactionGarbageThreshold(999);
+        config.SetCompactionRangeGarbageThreshold(999);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount
+        );
+
+        bool evPatchObserved = false;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvPatch: {
+                        evPatchObserved = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(0, 512);
+        const auto blockRange3 = TBlockRange32::WithLength(0, 256);
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 2);
+        partition.WriteBlocks(blockRange3, 3);
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        // checking that data wasn't corrupted
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(0))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(255))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(256))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(511))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(512))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1023))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlockContent(partition.ReadBlocks(1024))
+        );
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        UNIT_ASSERT(evPatchObserved);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldConfirmBlobs)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        bool dropAddConfirmedBlobs = false;
+        bool spoofWriteBlobs = false;
+
+        runtime->SetObserverFunc([&] (auto& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionPrivate::EvAddConfirmedBlobsRequest: {
+                    if (dropAddConfirmedBlobs) {
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+                }
+
+                case TEvPartitionCommonPrivate::EvWriteBlobRequest: {
+                    if (spoofWriteBlobs) {
+                        auto response =
+                            std::make_unique<TEvPartitionCommonPrivate::TEvWriteBlobResponse>();
+                        response->BlockChecksums.resize(1);
+                        runtime->Send(new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0,  // flags
+                            0
+                        ), 0);
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(11, 1);
+
+        dropAddConfirmedBlobs = true;
+        spoofWriteBlobs = true;
+        partition.WriteBlocks(11, 2);
+        partition.SendReadBlocksRequest(11);
+        auto response = partition.RecvReadBlocksResponse();
+        // can't read unconfirmed range
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        dropAddConfirmedBlobs = false;
+        partition.RebootTablet();
+
+        // check that we are not affected by previous write
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(11))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDetectBlockCorruptionInBlobs)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto config = DefaultConfig();
+        config.SetCheckBlockChecksumsInBlobsUponRead(true);
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range = TBlockRange32::WithLength(0, 1024);
+        partition.WriteBlocks(range, 1);
+
+        EnableReadBlobCorruption(*runtime, 0);
+
+        // direct read should fail
+        {
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(
+                blocks,
+                range.Size(),
+                TString::TUninitialized(DefaultBlockSize));
+            partition.SendReadBlocksLocalRequest(range, std::move(sglist));
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        // compaction should also run into the same corrupt block and fail
+        {
+            partition.SendCompactionRequest(0);
+            auto response = partition.RecvCompactionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        const auto smallRange = TBlockRange32::WithLength(0, 1);
+        partition.WriteBlocks(smallRange, 1);
+
+        // data was rewritten - compaction shouldn't see blobOffset 0 anymore
+        // => compaction won't read any corrupt data and should succeed
+        {
+            partition.SendCompactionRequest(0);
+            auto response = partition.RecvCompactionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        partition.Flush();
+
+        // but now compaction should fail because we again corrupted a blob -
+        // this time we corrupted the blob written by Flush
+        {
+            partition.SendCompactionRequest(0);
+            auto response = partition.RecvCompactionResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(CompactionShouldWriteDataToDifferentChannelsDependingOnThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetCompactionMergedBlobThresholdHDD(17_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.Flush();
+        partition.WriteBlocks(2, 2);
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(0, 0);
+
+        // data should be written to a mixed channel if data size is less than threshold
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(3, 5), 3);
+        partition.Flush();
+
+        // data should be written to a merged channel if data size is greater than threshold
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDropAllCommitBlobsWhenUnrecoverableBlobExists)
+    {
+        auto config = DefaultConfig();
+
+        config.SetWriteBlobThreshold(1);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+
+        // Set MaxBlocksInBlob to 1 so writing 2 blocks will create 2 blobs
+        TTestPartitionInfo partitionInfo;
+        partitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID;
+        partitionInfo.MaxBlocksInBlob = 1;
+
+        auto runtime = PrepareTestActorRuntime(config, 4096, {}, partitionInfo);
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddConfirmedBlobsRequest: {
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(2, 2), 2);
+        partition.WriteBlocks(TBlockRange32::WithLength(4, 2), 2);
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetConfirmedBlobCount());
+        }
+
+        bool tabletActivated = false;
+        ui32 filterCallCount = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case NKikimr::TEvLocal::EvTabletMetrics: {
+                        tabletActivated = true;
+                        return false;
+                    }
+                    case TEvBlobStorage::EvGetResult: {
+                        auto* msg = ev->Get<TEvBlobStorage::TEvGetResult>();
+                        auto* mutableMsg =
+                            const_cast<TEvBlobStorage::TEvGetResult*>(msg);
+
+                        if (tabletActivated) {
+                            if (filterCallCount == 0) {
+                                mutableMsg->Responses[0].Status =
+                                    NKikimrProto::NODATA;
+                            } else if (filterCallCount == 2) {
+                                mutableMsg->Responses[0].Status =
+                                    NKikimrProto::ERROR;
+                            }
+                            ++filterCallCount;
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            });
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetConfirmedBlobCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSkipCompactionRangeSplitInFlushWhenRunCountExceedsLimit)
+    {
+        constexpr ui32 rangeSize = 1024;
+        constexpr ui32 blockCount = rangeSize * 3;
+
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetSplitByCompactionRangeMaxBlobCount(2);
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            partition.WriteBlocks(i, 1);
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            partition.WriteBlocks(i, 2);
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            partition.WriteBlocks(i, 3);
+        }
+
+        ui32 mixedBlobsCount = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                            mixedBlobsCount = msg->FreshBlobs.size();
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+
+        for (ui32 i = 1022; i < 1024; ++i) {
+            partition.WriteBlocks(i, 1);
+        }
+
+        for (ui32 i = 2048; i < 2050; ++i) {
+            partition.WriteBlocks(i, 3);
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                2,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split11.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split11.cpp
@@ -1,0 +1,2025 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit11)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRecoverBlocksOnReboot)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.ZeroBlocks(4);
+        partition.WriteBlocks(2, 2);
+        partition.ZeroBlocks(5);
+        partition.WriteBlocks(3, 3);
+        partition.ZeroBlocks(6);
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(6, stats.GetFreshBlocksCount());
+
+        auto partitionInfo = partition.GetPartitionInfo();
+        auto value =
+            NJson::ReadJsonFastTree(partitionInfo->Record.GetPayload());
+        auto stateJson = value["State"];
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            stateJson["FreshBlocksFromChannel"].GetInteger());
+        UNIT_ASSERT_VALUES_EQUAL(
+            6,
+            stateJson["FreshBlocksFromDb"].GetInteger());
+
+        partition.RebootTablet();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(4))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(5))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(6))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyRunCompaction)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+
+        auto config = DefaultConfig();
+        config.SetSSDMaxBlobsPerRange(compactionThreshold);
+        config.SetHDDMaxBlobsPerRange(compactionThreshold);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByBlobCount = 0;
+        ui64 compactionByReadStats = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByBlobCount =
+                            cc.CompactionByBlobCountPerRange.Value;
+                        compactionByReadStats = cc.CompactionByReadStats.Value;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        for (size_t i = 1; i < compactionThreshold; ++i) {
+            partition.WriteBlocks(i, i);
+            partition.Flush();
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold - 1,
+                stats.GetMixedBlobsCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(0, 0);
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold,
+                stats.GetMixedBlobsCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_EQUAL(1, compactionByBlobCount);
+        UNIT_ASSERT_EQUAL(0, compactionByReadStats);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldZeroBlocksWrittenToFreshChannelAfterReboot)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.ZeroBlocks(1);
+
+        partition.RebootTablet();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectCheckpointRequestWhenCheckpointIsInFlight)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig());
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool interceptEvent = false;
+
+        std::unique_ptr<IEventHandle> putEvent;
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvBlobStorage::EvPut) {
+                    auto* msg = event->Get<TEvBlobStorage::TEvPut>();
+
+                    if (msg->Id.Channel() == 0 && interceptEvent) {
+                        putEvent.reset(event.Release());
+                        interceptEvent = false;
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        interceptEvent = true;
+        partition.SendCreateCheckpointRequest("cp1", "id1");
+
+        runtime->DispatchEvents({}, 10ms);
+        UNIT_ASSERT(putEvent);
+
+        {
+            partition.SendCreateCheckpointRequest("cp1", "id2");
+            auto response = partition.RecvCreateCheckpointResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        }
+
+        {
+            partition.SendDeleteCheckpointRequest("cp1");
+            auto response = partition.RecvDeleteCheckpointResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetStatus());
+        }
+
+        runtime->SendAsync(putEvent.release());
+
+        auto response = partition.RecvCreateCheckpointResponse();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+        partition.DeleteCheckpoint("cp1");
+        partition.CreateCheckpoint("cp1", "id2");
+    }
+
+
+
+    Y_UNIT_TEST(ShouldUseMostRecentCommitIdWhenHighCheckpointIdIsNotSet)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 4096);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 1);
+        partition.WriteBlocks(1, 1);
+        partition.CreateCheckpoint("cp1");
+
+        partition.WriteBlocks(1, 1);
+
+        partition.CreateCheckpoint("cp2");
+
+        partition.WriteBlocks(2, 1);
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 3072),
+                "cp1",
+                "cp2",
+                false);
+
+            const auto& mask = response->Record.GetMask();
+            UNIT_ASSERT_VALUES_EQUAL(384, mask.size());
+            UNIT_ASSERT_VALUES_EQUAL(2, response->Record.GetMask()[0]);
+        }
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 3072),
+                "cp1",
+                "",
+                false);
+
+            const auto& mask = response->Record.GetMask();
+            UNIT_ASSERT_VALUES_EQUAL(384, mask.size());
+            UNIT_ASSERT_VALUES_EQUAL(6, response->Record.GetMask()[0]);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSendBackpressureReportsRegularly)
+    {
+        const auto blockCount = 1000;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        TBackpressureReport report;
+        bool reportUpdated = false;
+
+        runtime->SetObserverFunc(
+            [&report, &reportUpdated] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartition::EvBackpressureReport: {
+                        report = *event->Get<TEvPartition::TEvBackpressureReport>();
+                        reportUpdated = true;
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        for (int i = 0; i < 200; ++i) {
+            partition.WriteBlocks(i, i);
+        }
+
+        // Manually sending TEvSendBackpressureReport here
+        // In real scenarios TPartitionActor will schedule this event
+        // upon executor activation
+        reportUpdated = false;
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvSendBackpressureReport>()
+        );
+
+        runtime->DispatchEvents({}, TDuration::Seconds(5));
+
+        UNIT_ASSERT_VALUES_EQUAL(true, reportUpdated);
+        UNIT_ASSERT_DOUBLES_EQUAL(3.5, report.FreshIndexScore, 1e-5);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksFromBaseDisk)
+    {
+        TPartitionContent baseContent = {
+        /*|      0      |     1     |     2 ... 5    |     6     |      7      |     8     |      9      |*/
+            TBlob(1, 1) , TFresh(2) , TBlob(2, 3, 4) ,  TEmpty() , TBlob(1, 4) , TFresh(5) , TBlob(2, 6)
+        };
+        auto bitmap = CreateBitmap(10);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+        auto& runtime = *partitionWithRuntime.Runtime;
+
+        auto response = partition.ReadBlocks(TBlockRange32::WithLength(0, 10));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(baseContent), GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+        const auto evStats = TEvStatsService::EvVolumePartCounters;
+
+        ui32 externalBlobReads = 0;
+        ui32 externalBlobBytes = 0;
+        auto obs = [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite() == evStats) {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& readBlobCounters =
+                        msg->DiskCounters->RequestCounters.ReadBlob;
+                    externalBlobReads = readBlobCounters.ExternalCount;
+                    externalBlobBytes = readBlobCounters.ExternalRequestBytes;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime.SetObserverFunc(obs);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(evStats);
+            runtime.DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(2, externalBlobReads);
+        UNIT_ASSERT_VALUES_EQUAL(7 * DefaultBlockSize, externalBlobBytes);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnErrorForUnknownIdInCompactionStatusRequest)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 100);
+        partition.SendGetCompactionStatusRequest("xxx");
+
+        auto response = partition.RecvGetCompactionStatusResponse();
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleBSErrorsOnInitFreshBlocksFromChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(1), 2);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(2), 3);
+
+        bool evRangeResultSeen = false;
+
+        ui32 evLoadFreshBlobsCompletedCount = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvRangeResult: {
+                        using TEvent = TEvBlobStorage::TEvRangeResult;
+                        auto* msg = event->Get<TEvent>();
+
+                        if (msg->From.Channel() != 4 || evRangeResultSeen) {
+                            return false;
+                        }
+
+                        evRangeResultSeen = true;
+
+                        auto response = std::make_unique<TEvent>(
+                            NKikimrProto::ERROR,
+                            TLogoBlobID(),  // doesn't matter
+                            TLogoBlobID(),  // doesn't matter
+                            0);             // doesn't matter
+
+                        auto* handle = new IEventHandle(
+                            event->Recipient,
+                            event->Sender,
+                            response.release(),
+                            0,
+                            event->Cookie);
+
+                        runtime.Send(handle, 0);
+
+                        return true;
+                    }
+                    case TEvPartitionCommonPrivate::EvLoadFreshBlobsCompleted: {
+                        ++evLoadFreshBlobsCompletedCount;
+                        return false;
+                    }
+                    default: {
+                        return false;
+                    }
+                }
+            }
+        );
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        UNIT_ASSERT_VALUES_EQUAL(true, evRangeResultSeen);
+
+        // tablet rebooted twice (after explicit RebootTablet() and on fail)
+        UNIT_ASSERT_VALUES_EQUAL(2, evLoadFreshBlobsCompletedCount);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(0)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(1)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(2)));
+    }
+
+
+
+    Y_UNIT_TEST(WritingBlobsInsteadOfPatchingIfDiffIsGreaterThanThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBlobPatchingEnabled(true);
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetCompactionGarbageThreshold(999);
+        config.SetCompactionRangeGarbageThreshold(999);
+        config.SetMaxDiffPercentageForBlobPatching(75);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount
+        );
+
+        bool evPatchObserved = false;
+        bool evWriteObserved = false;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvPatch: {
+                        evPatchObserved = true;
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvWriteBlobRequest: {
+                        evWriteObserved = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(0, 512 + 256 + 64);
+        const auto blockRange3 = TBlockRange32::WithLength(0, 512);
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 2);
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(256))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(512 + 256 + 63))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(900))
+        );
+
+        UNIT_ASSERT(!evPatchObserved);
+        UNIT_ASSERT(evWriteObserved);
+
+        evWriteObserved = false;
+        partition.WriteBlocks(blockRange3, 3);
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(511))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(512))
+        );
+
+        UNIT_ASSERT(evPatchObserved);
+        UNIT_ASSERT(evWriteObserved);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldLimitUnconfirmedBlobCount)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        config.SetUnconfirmedBlobCountHardLimit(1);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        runtime->SetObserverFunc([&] (auto& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionPrivate::EvAddConfirmedBlobsRequest: {
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(10, 1);
+        {
+            // can't read unconfirmed range
+            partition.SendReadBlocksRequest(10);
+            auto response = partition.RecvReadBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+        }
+
+        // but next blob should be added bypassing 'unconfirmed blobs' feature
+        partition.WriteBlocks(11, 2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(11))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDetectBlockCorruptionInBlobsWhenAddingUnconfirmedBlobs)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto config = DefaultConfig();
+        config.SetCheckBlockChecksumsInBlobsUponRead(true);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range = TBlockRange32::WithLength(0, 1024);
+        partition.WriteBlocks(range, 1);
+
+        EnableReadBlobCorruption(*runtime);
+
+        // direct read should fail
+        TVector<TString> blocks;
+        auto sglist = ResizeBlocks(
+            blocks,
+            range.Size(),
+            TString::TUninitialized(DefaultBlockSize));
+        partition.SendReadBlocksLocalRequest(range, std::move(sglist));
+        auto response = partition.RecvReadBlocksLocalResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+    }
+
+
+
+    Y_UNIT_TEST(CompactionShouldMoveDataFromMergedToMixedWhenDataSizeIsAboveTheTreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(3_KB);
+        config.SetCompactionMergedBlobThresholdHDD(17_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // all data should be written to a merged channel directly because data
+        // size is less than threshold
+        for (int i = 0; i < 4; ++i) {
+            partition.WriteBlocks(i, i);
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+        }
+
+        // data should be moved to a mixed channel as a result of compaction,
+        // because data is less than threshold
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+        }
+
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        for (int i = 0; i < 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(i),
+                GetBlockContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSendPartitionStatistics)
+    {
+        auto config = DefaultConfig();
+        config.SetUsePullSchemeForVolumeStatistics(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        bool partitionStatisticsSent = false;
+
+        auto _ = runtime->AddObserver<
+            TEvPartitionCommonPrivate::TEvGetPartCountersResponse>(
+            [&](TEvPartitionCommonPrivate::TEvGetPartCountersResponse::TPtr& ev)
+            {
+                Y_UNUSED(ev);
+                partitionStatisticsSent = true;
+            });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.SendToPipe(
+            std::make_unique<
+                TEvPartitionCommonPrivate::TEvGetPartCountersRequest>());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        runtime->DispatchEvents();
+
+        // Check that partition sent statistics
+        UNIT_ASSERT(partitionStatisticsSent);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlobInfo)
+    {
+        constexpr ui32 rangeSize = 1024;
+        constexpr ui32 blockCount = rangeSize * 3;
+
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        TVector<TBlockRange32> blockRanges = {
+            TBlockRange32::WithLength(0, rangeSize),
+            TBlockRange32::WithLength(rangeSize / 2, rangeSize),
+            TBlockRange32::WithLength(rangeSize, rangeSize),
+        };
+
+        TVector<TPartialBlobId> blobs;
+        bool interceptWriteBlobRequest = true;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvWriteBlobRequest: {
+                        if (interceptWriteBlobRequest) {
+                            auto* msg = event->Get<TEvPartitionCommonPrivate::
+                                                       TEvWriteBlobRequest>();
+                            blobs.push_back(msg->BlobId);
+                        }
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        char fill = '1';
+        for (const auto& blockRange: blockRanges) {
+            partition.WriteBlocks(blockRange, fill);
+            fill++;
+        }
+
+        interceptWriteBlobRequest = false;
+
+        TBlockMask emptyBlockMask;
+
+        TBlockMask fullBlockMask;
+        fullBlockMask.Set(0, MaxBlocksCount);
+
+        TBlockMask halfBlockMask;
+        halfBlockMask.Set(0, MaxBlocksCount / 2);
+
+        {
+            auto blobsInfo = partition.CompactionReadBlobInfo(blobs, blobs);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsInfo->BlobMetasForBlobs.size(),
+                3);
+            for (size_t i = 0; i < blockRanges.size(); ++i) {
+                const auto& blobMeta = blobsInfo->BlobMetasForBlobs[i];
+                UNIT_ASSERT(blobMeta.HasMergedBlocks());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    blockRanges[i].Start,
+                    blobMeta.GetMergedBlocks().GetStart());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    blockRanges[i].End,
+                    blobMeta.GetMergedBlocks().GetEnd());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    0,
+                    blobMeta.GetMergedBlocks().GetSkipped());
+            }
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsInfo->BlockMasksForBlobs.size(),
+                3);
+            for (size_t i = 0; i < blockRanges.size(); ++i) {
+                UNIT_ASSERT_C(
+                    emptyBlockMask == blobsInfo->BlockMasksForBlobs[i],
+                    TStringBuilder()
+                        << BlockMaskAsString(emptyBlockMask) << " != "
+                        << BlockMaskAsString(blobsInfo->BlockMasksForBlobs[i]));
+            }
+        }
+
+        partition.Compaction();
+
+        {
+            auto blobsInfo = partition.CompactionReadBlobInfo(blobs, blobs);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsInfo->BlockMasksForBlobs.size(),
+                3);
+            TVector<TBlockMask> expectedBlockMasks = {
+                fullBlockMask,
+                halfBlockMask,
+                emptyBlockMask};
+            for (size_t i = 0; i < blockRanges.size(); ++i) {
+                UNIT_ASSERT_C(
+                    expectedBlockMasks[i] == blobsInfo->BlockMasksForBlobs[i],
+                    TStringBuilder()
+                        << BlockMaskAsString(expectedBlockMasks[i]) << " != "
+                        << BlockMaskAsString(blobsInfo->BlockMasksForBlobs[i]));
+            }
+        }
+
+        partition.Compaction();
+
+        {
+            auto blobsInfo = partition.CompactionReadBlobInfo(blobs, blobs);
+
+            UNIT_ASSERT_VALUES_EQUAL(blobsInfo->BlockMasksForBlobs.size(), 3);
+            TVector<TBlockMask> expectedBlockMasks = {
+                fullBlockMask,
+                fullBlockMask,
+                fullBlockMask};
+            for (size_t i = 0; i < blockRanges.size(); ++i) {
+                UNIT_ASSERT_C(
+                    expectedBlockMasks[i] == blobsInfo->BlockMasksForBlobs[i],
+                    TStringBuilder()
+                        << BlockMaskAsString(expectedBlockMasks[i]) << " != "
+                        << BlockMaskAsString(blobsInfo->BlockMasksForBlobs[i]));
+            }
+        }
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split12.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split12.cpp
@@ -1,0 +1,1943 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit12)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRecoverBlocksOnRebootFromFreshChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.ZeroBlocks(4);
+        partition.WriteBlocks(2, 2);
+        partition.ZeroBlocks(5);
+        partition.WriteBlocks(3, 3);
+        partition.ZeroBlocks(6);
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(6, stats.GetFreshBlocksCount());
+
+        auto partitionInfo = partition.GetPartitionInfo();
+        auto value =
+            NJson::ReadJsonFastTree(partitionInfo->Record.GetPayload());
+        auto stateJson = value["State"];
+        UNIT_ASSERT_VALUES_EQUAL(
+            6,
+            stateJson["FreshBlocksFromChannel"].GetInteger());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            stateJson["FreshBlocksFromDb"].GetInteger());
+
+        partition.RebootTablet();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(4))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(5))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(6))
+        );
+
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyRunCompactionForDeletionMarkers)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+
+        auto config = DefaultConfig();
+        config.SetSSDMaxBlobsPerRange(compactionThreshold);
+        config.SetHDDMaxBlobsPerRange(compactionThreshold);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (size_t i = 1; i < compactionThreshold; ++i) {
+            partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold - 1,
+                stats.GetMergedBlobsCount()
+            );
+        }
+
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold + 1,
+                stats.GetMergedBlobsCount()
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadZeroFromUninitializedBlock)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        // partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        partition.Flush();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCreateBlobsForEveryWrittenRangeDuringFullCompaction)
+    {
+        DoTestFullCompaction(false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyHandleStartBlockInChangedBlocksRequest)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 4096);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0,1);
+        partition.CreateCheckpoint("cp1");
+
+        partition.WriteBlocks(0,1);
+        partition.WriteBlocks(1024,1);
+        partition.CreateCheckpoint("cp2");
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                "cp1",
+                "cp2",
+                false);
+
+            const auto& mask = response->Record.GetMask();
+            UNIT_ASSERT_VALUES_EQUAL(128, mask.size());
+            UNIT_ASSERT_VALUES_EQUAL(1, mask[0]);
+            AssertEqual(
+                TVector<ui8>(127, 0),
+                TVector<ui8>(mask.begin() + 1, mask.end())
+            );
+        }
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(1024, 1024),
+                "cp1",
+                "cp2",
+                false);
+
+            const auto& mask = response->Record.GetMask();
+            UNIT_ASSERT_VALUES_EQUAL(128, mask.size());
+            UNIT_ASSERT_VALUES_EQUAL(1, mask[0]);
+            AssertEqual(
+                TVector<ui8>(127, 0),
+                TVector<ui8>(mask.begin() + 1, mask.end())
+            );
+        }
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 2048),
+                "cp1",
+                "cp2",
+                false);
+
+            const auto& mask = response->Record.GetMask();
+            UNIT_ASSERT_VALUES_EQUAL(256, mask.size());
+
+            UNIT_ASSERT_VALUES_EQUAL(mask[0], 1);
+            AssertEqual(
+                TVector<ui8>(127, 0),
+                TVector<ui8>(mask.begin() + 1, mask.begin() + 128)
+            );
+
+            UNIT_ASSERT_VALUES_EQUAL(mask[128], 1);
+            AssertEqual(
+                TVector<ui8>(127, 0),
+                TVector<ui8>(mask.begin() + 129, mask.end())
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectRequestsInProgressOnTabletDeath)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite() == TEvPartitionCommonPrivate::EvWriteBlobResponse) {
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // kill tablet
+        partition.RebootTablet();
+
+        auto response = partition.RecvWriteBlocksResponse();
+        UNIT_ASSERT_C(response->GetStatus() == E_REJECTED, response->GetErrorReason());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksFromOverlayDisk)
+    {
+        TPartitionContent baseContent = {
+            TBlob(1, 1), TFresh(2), TBlob(2, 3)
+        };
+        auto bitmap = CreateBitmap(3);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        const auto range = TBlockRange32::WithLength(0, baseContent.size());
+
+        partition.WriteBlocks(range, char(2));
+        MarkWrittenBlocks(bitmap, range);
+
+        partition.Flush();
+
+        auto response = partition.ReadBlocks(range);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(char(2), range.Size()),
+            GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnCompactionProgress)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TActorId rangeActor;
+        TActorId partActor;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        rangeActor = event->Sender;
+                        partActor = event->Recipient;
+                        return TTestActorRuntime::EEventAction::DROP ;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 100);
+        auto compResponse = partition.CompactRange(0, 100);
+
+        partition.SendGetCompactionStatusRequest(compResponse->Record.GetOperationId());
+
+        auto statusResponse1 = partition.RecvGetCompactionStatusResponse();
+        UNIT_ASSERT(SUCCEEDED(statusResponse1->GetStatus()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            statusResponse1->Record.GetIsCompleted()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(1, statusResponse1->Record.GetTotal());
+
+        auto compactionResponse = std::make_unique<TEvPartitionPrivate::TEvCompactionResponse>();
+        runtime->Send(
+            new IEventHandle(
+                rangeActor,
+                partActor,
+                compactionResponse.release(),
+                0, // flags
+                0),
+            0);
+
+        partition.SendGetCompactionStatusRequest(compResponse->Record.GetOperationId());
+
+        auto statusResponse2 = partition.RecvGetCompactionStatusResponse();
+        UNIT_ASSERT(SUCCEEDED(statusResponse2->GetStatus()));
+        UNIT_ASSERT_VALUES_EQUAL(true, statusResponse2->Record.GetIsCompleted());
+        UNIT_ASSERT_VALUES_EQUAL(1, statusResponse2->Record.GetTotal());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFillEnryptedBlockMaskWhenReadBlock)
+    {
+        auto range = TBlockRange32::WithLength(0, 16);
+        auto emptyBlock = TString::Uninitialized(DefaultBlockSize);
+
+        auto bitmap = CreateBitmap(16);
+
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.Flush();
+
+            auto response = partition.ReadBlocks(range);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(blocks, range.Size(), emptyBlock);
+            auto localResponse = partition.ReadBlocksLocal(range, sglist);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(localResponse));
+        }
+
+        {
+            auto writeRange = TBlockRange32::WithLength(1, 4);
+            partition.WriteBlocks(writeRange, char(4));
+            MarkWrittenBlocks(bitmap, writeRange);
+
+            auto zeroRange = TBlockRange32::WithLength(5, 3);
+            partition.ZeroBlocks(zeroRange);
+            MarkZeroedBlocks(bitmap, zeroRange);
+
+            auto writeRangeLocal = TBlockRange32::WithLength(8, 3);
+            partition.WriteBlocksLocal(writeRangeLocal, GetBlockContent(4));
+            MarkWrittenBlocks(bitmap, writeRangeLocal);
+
+            auto zeroRangeLocal = TBlockRange32::WithLength(12, 3);
+            partition.ZeroBlocks(zeroRangeLocal);
+            MarkZeroedBlocks(bitmap, zeroRangeLocal);
+
+            partition.Flush();
+
+            auto response = partition.ReadBlocks(range);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(blocks, range.Size(), emptyBlock);
+            auto localResponse = partition.ReadBlocksLocal(range, sglist);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(localResponse));
+        }
+
+        {
+            auto zeroRange = TBlockRange32::WithLength(1, 3);
+            partition.ZeroBlocks(zeroRange);
+            MarkZeroedBlocks(bitmap, zeroRange);
+
+            auto writeRange = TBlockRange32::WithLength(5, 3);
+            partition.WriteBlocks(writeRange, char(4));
+            MarkWrittenBlocks(bitmap, writeRange);
+
+            auto zeroRangeLocal = TBlockRange32::WithLength(8, 3);
+            partition.ZeroBlocks(zeroRangeLocal);
+            MarkZeroedBlocks(bitmap, zeroRangeLocal);
+
+            auto writeRangeLocal = TBlockRange32::WithLength(12, 3);
+            partition.WriteBlocksLocal(writeRangeLocal, GetBlockContent(4));
+            MarkWrittenBlocks(bitmap, writeRangeLocal);
+
+            partition.Flush();
+
+            auto response = partition.ReadBlocks(range);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(blocks, range.Size(), emptyBlock);
+            auto localResponse = partition.ReadBlocksLocal(range, sglist);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(localResponse));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldPatchBlobsDuringIncrementalCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobPatchingEnabled(true);
+        DoTestIncrementalCompaction(std::move(config), NProto::STORAGE_MEDIA_SSD, true);
+        DoTestIncrementalCompaction(std::move(config), NProto::STORAGE_MEDIA_HYBRID, true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompressBlobs)
+    {
+        DoTestCompression(1, DefaultBlockSize, 34);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProperlyCalculateBlockChecksumsForBatchedWrites)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto config = DefaultConfig();
+        // enabling batching + checksum checks
+        config.SetCheckBlockChecksumsInBlobsUponRead(true);
+        config.SetWriteRequestBatchingEnabled(true);
+        // removing the dependency on the current defaults
+        config.SetWriteBlobThreshold(128_KB);
+        config.SetMaxBlobRangeSize(128_MB);
+        // disabling flush
+        config.SetFlushThreshold(1_GB);
+        // enabling fresh channel writes to make stats check a bit more
+        // convenient
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> processQueue;
+        bool intercept = true;
+
+        runtime->SetEventFilter([&] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event)
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionPrivate::EvProcessWriteQueue: {
+                    if (intercept) {
+                        processQueue.reset(event.Release());
+                        intercept = false;
+
+                        return true;
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+
+        // the following 14 blocks get batched into mixed blob 1
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208792, 1),
+            'a');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208796, 1),
+            'b');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208799, 1),
+            'c');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208864, 1),
+            'd');
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(208866, 10),
+            'e');
+        // the following 17 blocks get batched into mixed blob 2
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(251925, 17),
+            'f');
+        // and the remaining block goes to fresh blocks
+        partition.SendWriteBlocksRequest(
+            TBlockRange32::WithLength(800000, 1),
+            'g');
+
+        runtime->DispatchEvents({}, TDuration::Seconds(2));
+        runtime->Send(processQueue.release());
+        partition.RecvWriteBlocksResponse();
+
+        // checking that mixed batching has actually worked
+        {
+            const auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(31, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
+        }
+
+        // checking that we don't run into a failed checksum check upon read
+        {
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(
+                blocks,
+                1024,
+                TString::TUninitialized(DefaultBlockSize));
+            partition.SendReadBlocksLocalRequest(
+                TBlockRange32::WithLength(208792, 1024),
+                std::move(sglist));
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+
+        EnableReadBlobCorruption(*runtime);
+
+        // checking that we actually saved the checksums
+        {
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(
+                blocks,
+                1024,
+                TString::TUninitialized(DefaultBlockSize));
+            partition.SendReadBlocksLocalRequest(
+                TBlockRange32::WithLength(208792, 1024),
+                std::move(sglist));
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(CompactionShouldMoveMergedBlobWithHolesToMixedChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(12_KB);
+        config.SetCompactionMergedBlobThresholdHDD(1_MB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(5, 5), '1');   // merged
+        partition.WriteBlocks(TBlockRange32::WithLength(12, 1), '2');  // fresh
+        partition.WriteBlocks(TBlockRange32::WithLength(35, 20), '3'); // merged
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+
+        // data should be moved to a mixed channel as a result of compaction,
+        // because data is less than threshold
+        partition.Flush();
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        const auto checkValue = [&](std::vector<std::tuple<int, int, char>> values)
+        {
+            for (const auto& value: values) {
+                for (int i = std::get<0>(value); i < std::get<1>(value); ++i) {
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        GetBlockContent(std::get<2>(value)),
+                        GetBlockContent(partition.ReadBlocks(i)));
+                }
+            }
+        };
+
+        checkValue({{5, 5, '1'}, {12, 1, '2'}, {35, 20, '3'}});
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 2), '4');   // fresh
+        partition.Flush(); // mixed
+        partition.WriteBlocks(TBlockRange32::WithLength(2, 2), '5');   // fresh
+        partition.WriteBlocks(TBlockRange32::WithLength(12, 3), '6');   // merged
+        partition.WriteBlocks(TBlockRange32::WithLength(27, 1), '7');   // fresh
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        checkValue({{0, 2, '4'}, {2, 2, '5'}, {5, 5, '1'}, {12, 3, '6'}, {27, 1, '7'}, {35, 20, '3'}});
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRaiseCriticalEventIfTrimFreshLogTimesOut)
+    {
+        constexpr ui32 FreshChannelId = 4;
+
+        auto config = DefaultConfig();
+        config.SetFlushThreshold(4_MB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetTrimFreshLogTimeout(TDuration::Seconds(1).MilliSeconds());
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        NMonitoring::TDynamicCountersPtr counters
+            = new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto trimCounter =
+            counters->GetCounter("AppCriticalEvents/TrimFreshLogTimeout", true);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+        }
+
+        bool trimSeen = false;
+        bool trimCompletedSeen = false;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbageResult: {
+                        auto* msg =
+                            event->Get<TEvBlobStorage::TEvCollectGarbageResult>();
+                        if (msg->Channel == FreshChannelId) {
+                            trimSeen = true;
+                            msg->Status = NKikimrProto::EReplyStatus::DEADLINE;
+                        }
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvTrimFreshLogCompleted: {
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted>();
+                        UNIT_ASSERT(FAILED(msg->GetStatus()));
+                        trimCompletedSeen = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.Flush();
+
+        // wait for trimfreshlog to complete
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] {
+            return trimCompletedSeen;
+        };
+        runtime->DispatchEvents(options);
+
+        UNIT_ASSERT_VALUES_EQUAL(true, trimSeen);
+        UNIT_ASSERT_VALUES_UNEQUAL(0, trimCounter->Val());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldKeepBaseDiskPipeAliveWhenEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetBaseDiskPipeKeepAliveEnabled(true);
+
+        const auto keepAliveInterval = TDuration::Seconds(2);
+        config.SetVolumeProxyPipeInactivityTimeout(
+            keepAliveInterval.MilliSeconds() * 2);
+
+        auto setup = SetupOverlayPartition(
+            TestTabletId,
+            TestTabletId2,
+            {},   // basePartitionContent
+            {},   // channelsCount
+            DefaultBlockSize,
+            1024,
+            config);
+        auto& runtime = *setup.Runtime;
+
+        ui64 pingCount = 0;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() == TEvVolumeProxy::EvKeepAliveRequest) {
+                    ++pingCount;
+                }
+                return false;
+            });
+
+        // Drive simulated time across several intervals; the keep-alive actor
+        // must keep pinging the base-disk volume periodically.
+        for (ui32 i = 0; i < 3; ++i) {
+            runtime.AdvanceCurrentTime(keepAliveInterval);
+            runtime.DispatchEvents({}, TDuration::MilliSeconds(50));
+        }
+
+        UNIT_ASSERT_GE(pingCount, 2u);
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split13.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split13.cpp
@@ -1,0 +1,1951 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit13)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldFlushAsNewBlob)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        partition.ZeroBlocks(4);
+        partition.ZeroBlocks(5);
+        partition.ZeroBlocks(6);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(6, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+
+            auto partitionInfo = partition.GetPartitionInfo();
+            auto value =
+                NJson::ReadJsonFastTree(partitionInfo->Record.GetPayload());
+            auto stateJson = value["State"];
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stateJson["FreshBlocksFromChannel"].GetInteger());
+            UNIT_ASSERT_VALUES_EQUAL(
+                6,
+                stateJson["FreshBlocksFromDb"].GetInteger());
+
+        }
+
+        partition.Flush();
+        // Fresh Zero blocks from the database are flushed only if the 4MB
+        // threshold is reached or if there are no blocks with content.
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT(stats.GetSysWriteCounters().GetExecTime() != 0);
+        }
+
+        for (auto i: {1, 2, 3}) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(i),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        for (auto i: {4, 5, 6}) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                TString(),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRespectCompactionDelay)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+
+        auto config = DefaultConfig();
+        config.SetSSDMaxBlobsPerRange(compactionThreshold);
+        config.SetHDDMaxBlobsPerRange(compactionThreshold);
+        config.SetMinCompactionDelay(10000);
+        config.SetMaxCompactionDelay(10000);
+        config.SetCompactionScoreHistorySize(1);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (size_t i = 1; i < compactionThreshold + 1; ++i) {
+            partition.WriteBlocks(i, i);
+            partition.Flush();
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold,
+                stats.GetMixedBlobsCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold,
+                stats.GetMixedBlobsCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldZeroLargeNumberOfBlocks)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, MaxBlocksCount));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(0))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(MaxBlocksCount / 2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            "",
+            GetBlockContent(partition.ReadBlocks(MaxBlocksCount - 1))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCreateBlobsForEveryWrittenRangeDuringForcedFullCompaction)
+    {
+        DoTestFullCompaction(true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyGetChangedBlocksForCheckpointWithoutData)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        auto maskToString = [] (const ui8 maskValue) {
+            TStringBuilder sb;
+            bool foundNonZero = false;
+            for (ui32 i = 8; i > 0; --i) {
+                const int bit = !!(maskValue & (1ULL << (i - 1)));
+                if (bit) {
+                    foundNonZero = true;
+                }
+                if (foundNonZero) {
+                    sb << bit;
+                }
+            }
+
+            return sb;
+        };
+
+        auto checkChangedBlockMask = [&] (
+            const TString& firstCheckpoint,
+            const TString& secondCheckpoint,
+            const ui8 maskValue)
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                firstCheckpoint,
+                secondCheckpoint,
+                false);
+
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(128, response->Record.GetMask().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                maskToString(maskValue),
+                maskToString(response->Record.GetMask()[0]));
+        };
+
+        partition.WriteBlocks(0, 1);
+        partition.WriteBlocks(1, 1);
+        partition.CreateCheckpoint("cp1");
+
+        partition.WriteBlocks(1, 2);
+        partition.WriteBlocks(2, 2);
+
+        partition.DeleteCheckpointData("cp1");
+        partition.CreateCheckpoint("cp2");
+
+        checkChangedBlockMask("cp1", "cp2", 0b00000110);
+
+        partition.WriteBlocks(3, 3);
+        partition.WriteBlocks(4, 3);
+        partition.CreateCheckpoint("cp3", "", true);  // cp3 withoutData
+
+        checkChangedBlockMask("cp1", "cp3", 0b00011110);
+        checkChangedBlockMask("cp2", "cp3", 0b00011000);
+
+        partition.WriteBlocks(4, 4);
+        partition.WriteBlocks(5, 4);
+        partition.WriteBlocks(2, 4);
+
+        // block 4 has been overwritten (cp3 without data, don't hold block4)
+        // block 2 also has been overwritten, but cp2 - with data, it holds block2
+        checkChangedBlockMask("cp1", "cp3", 0b00001110);
+        checkChangedBlockMask("cp2", "cp3", 0b00001000);
+
+        partition.CreateCheckpoint("cp4", "", true);  // cp4 withoutData
+
+        checkChangedBlockMask("cp1", "cp4", 0b00111110);
+        checkChangedBlockMask("cp2", "cp4", 0b00111100);
+        checkChangedBlockMask("cp3", "cp4", 0b00110100);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReportNumberOfNonEmptyRangesInVolumeStats)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 4096 * MaxBlocksCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 g = 0; g < 4; ++g) {
+            partition.WriteBlocks(g * MaxBlocksCount * MaxBlocksCount, 1);
+        }
+
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(4, stats.GetNonEmptyRangeCount());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksFromOverlayDiskWhenRangeOverlapsWithBaseDisk)
+    {
+        TPartitionContent baseContent = {
+        /*|      0      |     1     |      2      |     3     |      4      |     5     |      6      |*/
+            TBlob(1, 1) , TFresh(1) , TBlob(2, 2) ,  TEmpty() , TBlob(3, 3) , TFresh(3) , TBlob(4, 3)
+        };
+        auto bitmap = CreateBitmap(7);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        auto writeRange = TBlockRange32::MakeClosedInterval(2, 4);
+        partition.WriteBlocks(writeRange, char(4));
+        MarkWrittenBlocks(bitmap, writeRange);
+
+        partition.Flush();
+
+        auto response = partition.ReadBlocks(TBlockRange32::WithLength(0, 7));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(char(1), 2) +
+            GetBlocksContent(char(4), 3) +
+            GetBlocksContent(char(3), 2),
+            GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnCompactionStatusForLastCompletedCompaction)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 100);
+        auto compResponse = partition.CompactRange(0, 100);
+
+        auto statusResponse = partition.GetCompactionStatus(
+            compResponse->Record.GetOperationId());
+
+        UNIT_ASSERT_VALUES_EQUAL(true, statusResponse->Record.GetIsCompleted());
+        UNIT_ASSERT_VALUES_EQUAL(1, statusResponse->Record.GetTotal());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFillEnryptedBlockMaskWhenReadBlockFromOverlayDisk)
+    {
+        TPartitionContent baseContent = {
+        /*|    0     |    1    |    2     |    3 ... 5    |    6     |    7    |    8    |    9     |    10...12    |    13    |   14    |    15    |*/
+            TFresh(1), TEmpty(), TFresh(2), TBlob(2, 3, 3), TFresh(4), TEmpty(), TEmpty(), TFresh(5), TBlob(3, 6, 3), TFresh(7), TEmpty(), TFresh(8)
+        };
+
+        auto range = TBlockRange32::WithLength(0, 16);
+        auto emptyBlock = TString::Uninitialized(DefaultBlockSize);
+
+        auto bitmap = CreateBitmap(16);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        {
+            partition.Flush();
+
+            auto response = partition.ReadBlocks(range);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(blocks, range.Size(), emptyBlock);
+            auto localResponse = partition.ReadBlocksLocal(range, sglist);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(localResponse));
+        }
+
+        {
+            auto writeRange = TBlockRange32::WithLength(1, 4);
+            partition.WriteBlocks(writeRange, char(4));
+            MarkWrittenBlocks(bitmap, writeRange);
+
+            auto zeroRange = TBlockRange32::WithLength(5, 3);
+            partition.ZeroBlocks(zeroRange);
+            MarkZeroedBlocks(bitmap, zeroRange);
+
+            auto writeRangeLocal = TBlockRange32::WithLength(8, 3);
+            partition.WriteBlocksLocal(writeRangeLocal, GetBlockContent(4));
+            MarkWrittenBlocks(bitmap, writeRangeLocal);
+
+            auto zeroRangeLocal = TBlockRange32::WithLength(12, 3);
+            partition.ZeroBlocks(zeroRangeLocal);
+            MarkZeroedBlocks(bitmap, zeroRangeLocal);
+
+            partition.Flush();
+
+            auto response = partition.ReadBlocks(range);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(blocks, range.Size(), emptyBlock);
+            auto localResponse = partition.ReadBlocksLocal(range, sglist);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(localResponse));
+        }
+
+        {
+            auto zeroRange = TBlockRange32::WithLength(1, 3);
+            partition.ZeroBlocks(zeroRange);
+            MarkZeroedBlocks(bitmap, zeroRange);
+
+            auto writeRange = TBlockRange32::WithLength(5, 3);
+            partition.WriteBlocks(writeRange, char(4));
+            MarkWrittenBlocks(bitmap, writeRange);
+
+            auto zeroRangeLocal = TBlockRange32::WithLength(8, 3);
+            partition.ZeroBlocks(zeroRangeLocal);
+            MarkZeroedBlocks(bitmap, zeroRangeLocal);
+
+            auto writeRangeLocal = TBlockRange32::WithLength(12, 3);
+            partition.WriteBlocksLocal(writeRangeLocal, GetBlockContent(4));
+            MarkWrittenBlocks(bitmap, writeRangeLocal);
+
+            partition.Flush();
+
+            auto response = partition.ReadBlocks(range);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(blocks, range.Size(), emptyBlock);
+            auto localResponse = partition.ReadBlocksLocal(range, sglist);
+            UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(localResponse));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProperlyPatchBlobWithDifferentLayout)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBlobPatchingEnabled(true);
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetCompactionGarbageThreshold(999);
+        config.SetCompactionRangeGarbageThreshold(999);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount
+        );
+
+        bool evPatchObserved = false;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvPatch: {
+                        evPatchObserved = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(1), 1);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(3), 3);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(4), 4);
+
+        partition.Flush();
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        UNIT_ASSERT(evPatchObserved);
+        evPatchObserved = false;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(4),
+            GetBlockContent(partition.ReadBlocks(4))
+        );
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(2), 2);
+        partition.ZeroBlocks(TBlockRange32::MakeOneBlock(4));
+
+        partition.Flush();
+        partition.Compaction();
+        partition.Cleanup();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(4))
+        );
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // 2 == zeroBlob + dataBlob
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+
+        UNIT_ASSERT(evPatchObserved);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompressFreshBlocks)
+    {
+        DoTestCompression(Max<ui32>(), 4107, 43);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCancelRequestsOnTabletRestart)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime({}, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range = TBlockRange32::WithLength(0, 1024);
+        partition.SendWriteBlocksRequest(range, 1);
+
+        bool putSeen = false;
+        runtime->SetEventFilter([&] (auto& runtime, auto& event) {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvPutResult: {
+                    putSeen = true;
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] {
+            return putSeen;
+        };
+        runtime->DispatchEvents(options);
+
+        partition.RebootTablet();
+
+        auto response = partition.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "tablet is shutting down",
+            response->GetErrorReason());
+    }
+
+
+
+    Y_UNIT_TEST(
+        ShouldNotEraseSkippedBlocksFromIndexDuringIncrementalCompactionToMixed)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetCompactionMergedBlobThresholdHDD(1_MB);
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        config.SetTargetCompactionBytesPerOp(1);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // blob 1 needs to eventually have more live blocks than other blobs in order
+        // not to be compacted
+        partition.WriteBlocks(TBlockRange32::WithLength(5, 55), '1');
+        partition.Flush();
+        partition.WriteBlocks(TBlockRange32::WithLength(2, 10), '2');
+        partition.Flush();
+        partition.WriteBlocks(TBlockRange32::WithLength(45, 20), '3');
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(85, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(85, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 12; i < 45; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent('1'),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 2; i < 12; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent('2'),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 45; i < 65; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent('3'),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldLoadFreshBlobsFromLastTrimFreshLogToCommitIdInMeta)
+    {
+        constexpr ui32 FreshChannelId = 4;
+
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+        }
+
+        bool saveBlobs = false;
+        TSet<ui64> expectedBlobs;
+
+        auto eventFilter =
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = ev->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (msg->Channel == FreshChannelId) {
+                            return true;
+                        }
+                        break;
+                    }
+                    case TEvBlobStorage::EvRangeResult: {
+                        using TEvent = TEvBlobStorage::TEvRangeResult;
+                        auto* msg = ev->Get<TEvent>();
+                        bool isRangeResponseFromFresh = false;
+                        for (const auto& r: msg->Responses) {
+                            if (r.Id.Channel() == FreshChannelId) {
+                                isRangeResponseFromFresh = true;
+                                auto commitId = MakeCommitId(
+                                        r.Id.Generation(),
+                                        r.Id.Step());
+                                UNIT_ASSERT_VALUES_EQUAL(
+                                    1,
+                                    expectedBlobs.count(commitId));
+                            }
+                        }
+                        if (isRangeResponseFromFresh) {
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                expectedBlobs.size(),
+                                msg->Responses.size());
+                        }
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvWriteBlobCompleted: {
+                        using TEvent =
+                            TEvPartitionCommonPrivate::TEvWriteBlobCompleted;
+                        auto* msg = ev->Get<TEvent>();
+                        if (msg->BlobId.Channel() == 4 && saveBlobs) {
+                            expectedBlobs.emplace(msg->BlobId.CommitId());
+                        }
+                        break;
+                    }
+                }
+                return false;
+            };
+
+
+        runtime->SetEventFilter(eventFilter);
+
+        // update TrimFreshLogToCommitId in meta to gen:step = 0:0
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions{}, TDuration::Seconds(1));
+
+        saveBlobs = true;
+
+        partition.WriteBlocks(4, 4);
+        partition.WriteBlocks(5, 5);
+        partition.WriteBlocks(6, 6);
+
+        // update TrimFreshLogToCommitId in meta to gen:step = 2:4
+        partition.Flush();
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        // expect to read last 3 blobs ([2:5], [2:6], [2:7])
+
+        UNIT_ASSERT_VALUES_EQUAL(3, expectedBlobs.size());
+        UNIT_ASSERT_VALUES_EQUAL(1, expectedBlobs.count(MakeCommitId(2, 5)));
+        UNIT_ASSERT_VALUES_EQUAL(1, expectedBlobs.count(MakeCommitId(2, 6)));
+        UNIT_ASSERT_VALUES_EQUAL(1, expectedBlobs.count(MakeCommitId(2, 7)));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotKeepBaseDiskPipeAliveWhenDisabled)
+    {
+        auto config = DefaultConfig();
+        config.SetBaseDiskPipeKeepAliveEnabled(false);
+
+        const auto pipeInactivityInterval = TDuration::Seconds(5);
+        config.SetVolumeProxyPipeInactivityTimeout(
+            pipeInactivityInterval.MilliSeconds());
+
+        auto setup = SetupOverlayPartition(
+            TestTabletId,
+            TestTabletId2,
+            {},
+            {},
+            DefaultBlockSize,
+            1024,
+            config);
+        auto& runtime = *setup.Runtime;
+
+        ui64 pingCount = 0;
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() == TEvVolumeProxy::EvKeepAliveRequest) {
+                    ++pingCount;
+                }
+                return false;
+            });
+
+        runtime.AdvanceCurrentTime(
+            pipeInactivityInterval + TDuration::Seconds(1));
+        runtime.DispatchEvents({}, TDuration::MilliSeconds(50));
+
+        UNIT_ASSERT_VALUES_EQUAL(0u, pingCount);
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split14.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split14.cpp
@@ -1,0 +1,2032 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit14)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldFlushBlocksFromFreshChannelAsNewBlob)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        partition.ZeroBlocks(4);
+        partition.ZeroBlocks(5);
+        partition.ZeroBlocks(6);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(6, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+
+            auto partitionInfo = partition.GetPartitionInfo();
+            auto value =
+                NJson::ReadJsonFastTree(partitionInfo->Record.GetPayload());
+            auto stateJson = value["State"];
+            UNIT_ASSERT_VALUES_EQUAL(
+                6,
+                stateJson["FreshBlocksFromChannel"].GetInteger());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stateJson["FreshBlocksFromDb"].GetInteger());
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT(stats.GetSysWriteCounters().GetExecTime() != 0);
+        }
+
+        for (auto i: {1, 2, 3}) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(i),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        for (auto i: {4, 5, 6}) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                TString{},
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRespectCleanupDelay)
+    {
+        auto config = DefaultConfig();
+        config.SetCleanupThreshold(1);
+        config.SetMinCleanupDelay(10000);
+        config.SetMaxCleanupDelay(10000);
+        config.SetCleanupScoreHistorySize(1);
+        config.SetCollectGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 2);
+
+        partition.Compaction();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetGarbageQueueSize());
+        }
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetGarbageQueueSize());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleZeroedBlocksInCompaction)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount));
+        partition.Flush();
+
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, MaxBlocksCount));
+        partition.Flush();
+
+        partition.Compaction();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotCreateBlobsForEmptyRangesDuringFullCompaction)
+    {
+        DoTestEmptyRangesFullCompaction(false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyGetChangedBlocksForOverlayDisk)
+    {
+        TPartitionContent baseContent = {
+        /*|      0      |     1     |     2 ... 5    |     6     |      7      |     8     |      9      |*/
+            TBlob(1, 1) , TFresh(2) , TBlob(2, 3, 4) ,  TEmpty() , TBlob(1, 4) , TFresh(5) , TBlob(2, 6)
+        };
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+
+        auto& partition = *partitionWithRuntime.Partition;
+        partition.WaitReady();
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                "",
+                "",
+                false);
+
+            UNIT_ASSERT_VALUES_EQUAL(128, response->Record.GetMask().size());
+            UNIT_ASSERT_VALUES_EQUAL(char(0b10111111), response->Record.GetMask()[0]);
+            UNIT_ASSERT_VALUES_EQUAL(char(0b00000011), response->Record.GetMask()[1]);
+        }
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                "",
+                "",
+                true);
+
+            UNIT_ASSERT_VALUES_EQUAL(128, response->Record.GetMask().size());
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetMask()[0]);
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetMask()[1]);
+        }
+
+        partition.WriteBlocks(0, 1);
+        partition.WriteBlocks(1, 1);
+        partition.CreateCheckpoint("cp1");
+
+        partition.WriteBlocks(1, 2);
+        partition.WriteBlocks(2, 2);
+        partition.CreateCheckpoint("cp2");
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                "cp1",
+                "cp2",
+                false);
+
+            UNIT_ASSERT_VALUES_EQUAL(128, response->Record.GetMask().size());
+            UNIT_ASSERT_VALUES_EQUAL(char(0b00000110), response->Record.GetMask()[0]);
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetMask()[1]);
+        }
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                "",
+                "cp2",
+                false);
+
+            UNIT_ASSERT_VALUES_EQUAL(128, response->Record.GetMask().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                char(0b10111111),
+                response->Record.GetMask()[0]
+            );
+            UNIT_ASSERT_VALUES_EQUAL(
+                char(0b00000011),
+                response->Record.GetMask()[1]
+            );
+        }
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                "",
+                "cp1",
+                true);
+
+            UNIT_ASSERT_VALUES_EQUAL(128, response->Record.GetMask().size());
+            UNIT_ASSERT_VALUES_EQUAL(char(0b00000011), response->Record.GetMask()[0]);
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetMask()[1]);
+        }
+
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleDescribeBlocksRequestWithInvalidCheckpointId)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const TString validCheckpoint = "0";
+        partition.CreateCheckpoint(validCheckpoint);
+
+        const auto range = TBlockRange32::WithLength(0, 1);
+        partition.DescribeBlocks(range, validCheckpoint);
+
+        {
+            const TString invalidCheckpoint = "1";
+            auto request =
+                partition.CreateDescribeBlocksRequest(range, invalidCheckpoint);
+            partition.SendToPipe(std::move(request));
+            auto response =
+                partition.RecvResponse<TEvVolume::TEvDescribeBlocksResponse>();
+            UNIT_ASSERT(response->GetStatus() == E_NOT_FOUND);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotReadBlocksFromBaseDiskWhenTheyAreZeroedInOverlayDisk)
+    {
+        TPartitionContent baseContent = {
+            TBlob(1, 1), TBlob(1, 2), TBlob(1, 3)
+        };
+        auto bitmap = CreateBitmap(3);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        const auto range = TBlockRange32::WithLength(0, baseContent.size());
+
+        partition.ZeroBlocks(range);
+
+        partition.Flush();
+
+        auto response = partition.ReadBlocks(range);
+
+        UNIT_ASSERT_VALUES_EQUAL(TString(), GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldUseWriteBlobThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetWriteBlobThresholdSSD(128_KB);
+        TTestPartitionInfo testPartitionInfo;
+
+        const auto mediaKinds = {
+            NCloud::NProto::STORAGE_MEDIA_HDD,
+            NCloud::NProto::STORAGE_MEDIA_HYBRID
+        };
+
+        for (auto mediaKind: mediaKinds) {
+            testPartitionInfo.MediaKind = mediaKind;
+            auto runtime = PrepareTestActorRuntime(
+                config,
+                1024,
+                {},
+                testPartitionInfo,
+                {},
+                EStorageAccessMode::Default
+            );
+
+            TPartitionClient partition(*runtime);
+            partition.WaitReady();
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            }
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 256));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedBlocksCount());
+            }
+
+            partition.ZeroBlocks(TBlockRange32::WithLength(0, 255));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedBlocksCount());
+            }
+
+            partition.ZeroBlocks(TBlockRange32::WithLength(0, 256));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(255, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(256, stats.GetMergedBlocksCount());
+            }
+        }
+
+        {
+            testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+            auto runtime = PrepareTestActorRuntime(
+                config,
+                1024,
+                {},
+                testPartitionInfo,
+                {},
+                EStorageAccessMode::Default
+            );
+
+            TPartitionClient partition(*runtime);
+            partition.WaitReady();
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 31));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            }
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 32));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedBlocksCount());
+            }
+
+            partition.ZeroBlocks(TBlockRange32::WithLength(0, 31));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedBlocksCount());
+            }
+
+            partition.ZeroBlocks(TBlockRange32::WithLength(0, 32));
+
+            {
+                auto response = partition.StatPartition();
+                const auto& stats = response->Record.GetStats();
+                UNIT_ASSERT_VALUES_EQUAL(31, stats.GetFreshBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+                UNIT_ASSERT_VALUES_EQUAL(32, stats.GetMergedBlocksCount());
+            }
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleCorruptedFreshBlobOnInitFreshBlocks)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(1), 2);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(2), 3);
+
+        bool evRangeResultSeen = false;
+
+        ui32 evLoadFreshBlobsCompletedCount = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvRangeResult: {
+                        using TEvent = TEvBlobStorage::TEvRangeResult;
+                        auto* msg = event->Get<TEvent>();
+
+                        if (msg->From.Channel() != 4 || evRangeResultSeen) {
+                            return false;
+                        }
+
+                        evRangeResultSeen = true;
+
+                        auto response = std::make_unique<TEvent>(
+                            msg->Status,
+                            msg->From,
+                            msg->To,
+                            msg->GroupId);
+
+                        response->Responses = std::move(msg->Responses);
+
+                        // corrupt
+                        auto& buffer = response->Responses[0].Buffer;
+                        std::memset(buffer.Detach(), 0, 4);
+
+                        auto* handle = new IEventHandle(
+                            event->Recipient,
+                            event->Sender,
+                            response.release(),
+                            0,
+                            event->Cookie);
+
+                        runtime.Send(handle, 0);
+
+                        return true;
+                    }
+                    case TEvPartitionCommonPrivate::EvLoadFreshBlobsCompleted: {
+                        ++evLoadFreshBlobsCompletedCount;
+                        return false;
+                    }
+                    default: {
+                        return false;
+                    }
+                }
+            }
+        );
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        UNIT_ASSERT_VALUES_EQUAL(true, evRangeResultSeen);
+
+        // tablet rebooted twice (after explicit RebootTablet() and on fail)
+        UNIT_ASSERT_VALUES_EQUAL(2, evLoadFreshBlobsCompletedCount);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(0)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(1)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(2)));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectSmallWritesAfterReachingFreshByteCountHardLimit)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetFreshByteCountHardLimit(8_KB);
+        config.SetFlushThreshold(4_MB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+
+        partition.SendWriteBlocksRequest(TBlockRange32::MakeOneBlock(0), 1);
+        auto response = partition.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+        UNIT_ASSERT(
+            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
+
+        partition.Flush();
+
+        partition.SendWriteBlocksRequest(TBlockRange32::MakeOneBlock(0), 1);
+        response = partition.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetStatus(),
+            response->GetErrorReason());
+    }
+
+
+
+    Y_UNIT_TEST(CheckRealSysCountersDuringCompaction)
+    {
+        TStatsChecker statsChecker;
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBlobPatchingEnabled(true);
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetCompactionGarbageThreshold(999);
+        config.SetCompactionRangeGarbageThreshold(999);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301), 2);
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Sys counter increased by "reading" 1024 - 301 UnchangedBlocks
+            // Both counters increased by reading and writing 301 ChangedBlocks
+            // from blobstorage
+            statsChecker.CheckStats(stats, 301, 301, 1024, 1024);
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 256), 3);
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Sys counter increased by "reading" 768 UnchangedBlocks
+            // Both counters increased by "reading" 256 ChangedBlocks
+            // from blobstorage
+            statsChecker.CheckStats(stats, 256, 256, 1024, 1024);
+        }
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(5, 14), 4);
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Blob wasn't written to BlobStorage, so counters don't change
+            statsChecker.CheckStats(stats, 0, 0, 0, 0);
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Flush writes to BlobStorage blocks from FreshBlocks,
+            // so all counters increase by blocks count
+            statsChecker.CheckStats(stats, 0, 10, 0, 10);
+        }
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Sys counter increased by writing and reading whole blob of size
+            // 1024. Real counter increased by 10 patchong blocks
+            statsChecker.CheckStats(stats, 10, 10, 1024, 1024);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSubtractCleanupBlobsWhenCheckingForBlobsCountCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(999999999);
+        config.SetCompactionRangeGarbageThreshold(999999999);
+        config.SetSSDMaxBlobsPerUnit(7);
+        config.SetHDDMaxBlobsPerUnit(7);
+
+        ui32 blockCount =  1024 * 1024;
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByBlobCount = 0;
+        ui64 compactionRequestObserved = 0;
+        runtime->SetEventFilter([&] (auto& runtime, auto& event) {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        ++compactionRequestObserved;
+                        break;
+                    }
+                    case TEvPartitionPrivate::EvCleanupRequest: {
+                        return true;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->template Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByBlobCount =
+                            cc.CompactionByBlobCountPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            }
+        );
+
+        for (size_t i = 0; i < 4; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 1024, 1024), i);
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_EQUAL(0, compactionByBlobCount);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // blob count is less than 4 * 2 => no compaction
+        UNIT_ASSERT(!compactionRequestObserved);
+
+        for (size_t i = 0; i < 4; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 1024, 1024), i);
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // blob count is greater than threshold on disk => only one compaction
+        // because two blobs go to cleanup queue and just one is created
+        UNIT_ASSERT_VALUES_EQUAL(1, compactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(1, compactionByBlobCount);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no more compactions generated because blobs in cleanup queue are
+        // considered to be already removed
+        UNIT_ASSERT_VALUES_EQUAL(1, compactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, compactionByBlobCount);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompactSeveralBlobsInTheSameRangeWithOneRangePerRun)
+    {
+        TestForcedCompaction(1);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReleaseTrimFreshLogBarrierInCaseOfWriteBlobError)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 trimFreshLogToCommitId = 0llu;
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            trimFreshLogToCommitId = stats.GetTrimFreshLogToCommitId();
+        }
+
+        bool shouldRejectWriteBlob = false;
+        auto eventFilter =
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+        {
+            switch (ev->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvWriteBlobResponse: {
+                    if (shouldRejectWriteBlob) {
+                        auto* msg = ev->Get<
+                            TEvPartitionCommonPrivate::TEvWriteBlobResponse>();
+                        auto& e = const_cast<NProto::TError&>(msg->Error);
+                        e.SetCode(E_REJECTED);
+                    }
+                    break;
+                }
+                case TEvPartitionPrivate::EvWriteBlocksCompleted: {
+                    auto* msg =
+                        ev->Get<TEvPartitionPrivate::TEvWriteBlocksCompleted>();
+                    UNIT_ASSERT_EQUAL(shouldRejectWriteBlob, HasError(msg->GetError()));
+                    break;
+                }
+            }
+            return false;
+        };
+
+        runtime->SetEventFilter(eventFilter);
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(trimFreshLogToCommitId, stats.GetTrimFreshLogToCommitId());
+        }
+
+        partition.Flush();
+        trimFreshLogToCommitId += 4llu;
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(trimFreshLogToCommitId, stats.GetTrimFreshLogToCommitId());
+        }
+
+        shouldRejectWriteBlob = true;
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(4, 1), 4);
+        {
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(5, 1), 5);
+        {
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        trimFreshLogToCommitId += 2llu;
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(trimFreshLogToCommitId, stats.GetTrimFreshLogToCommitId());
+        }
+
+        shouldRejectWriteBlob = false;
+
+        partition.Flush();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(trimFreshLogToCommitId, stats.GetTrimFreshLogToCommitId());
+        }
+
+        partition.WriteBlocks(6, 6);
+        partition.Flush();
+        trimFreshLogToCommitId += 2llu;
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(trimFreshLogToCommitId, stats.GetTrimFreshLogToCommitId());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotReturnBlobIdForFreshBlocksInDescribeWhenIndexOnlyIsOff)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range = TBlockRange32::MakeOneBlock(0);
+        partition.WriteBlocks(range, char(1));
+
+        NKikimr::TLogoBlobID blobIdFromContent;
+        {
+            const auto response = partition.DescribeBlocks(range);
+            UNIT_ASSERT_VALUES_EQUAL(1, response->Record.FreshBlockRangesSize());
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.BlobPiecesSize());
+            const auto& fr = response->Record.GetFreshBlockRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(GetBlockContent(char(1)), fr.GetBlocksContent());
+            blobIdFromContent = LogoBlobIDFromLogoBlobID(fr.GetBlobId());
+            UNIT_ASSERT_VALUES_EQUAL(false, blobIdFromContent.IsValid());
+        }
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split15.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split15.cpp
@@ -1,0 +1,1965 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit15)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldAutomaticallyFlush)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(4_MB);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetFreshBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        partition.WriteBlocks(MaxBlocksCount - 1, 0);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCalculateCompactionAndCleanupDelays)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+        static constexpr ui32 cleanupThreshold = 10;
+
+        auto config = DefaultConfig();
+        config.SetSSDMaxBlobsPerRange(compactionThreshold);
+        config.SetHDDMaxBlobsPerRange(compactionThreshold);
+        config.SetCleanupThreshold(cleanupThreshold);
+        config.SetMinCompactionDelay(0);
+        config.SetMaxCompactionDelay(999'999'999);
+        config.SetMinCleanupDelay(0);
+        config.SetMaxCleanupDelay(999'999'999);
+        config.SetMaxCompactionExecTimePerSecond(1);
+        config.SetMaxCleanupExecTimePerSecond(1);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        // initializing compaction exec time
+        partition.Compaction();
+
+        for (size_t i = 0; i < compactionThreshold - 1; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        }
+
+        TDuration delay;
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold + 1,
+                stats.GetMergedBlobsCount()
+            );
+            delay = TDuration::MilliSeconds(stats.GetCompactionDelay());
+            UNIT_ASSERT_VALUES_UNEQUAL(0, delay.MicroSeconds());
+        }
+
+        runtime->AdvanceCurrentTime(delay);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold + 2,
+                stats.GetMergedBlobsCount()
+            );
+        }
+
+        // initializing cleanup exec time
+        partition.Cleanup();
+
+        // generating enough dirty blobs for automatic cleanup
+        for (ui32 i = 0; i < cleanupThreshold - 1; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        }
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT(stats.GetMergedBlobsCount() >= cleanupThreshold);
+            delay = TDuration::MilliSeconds(stats.GetCleanupDelay());
+            UNIT_ASSERT_VALUES_UNEQUAL(0, delay.MicroSeconds());
+        }
+
+        runtime->AdvanceCurrentTime(delay);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCleanupBlobs)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount), 1);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount), 2);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+        }
+
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotCreateBlobsForEmptyRangesDuringForcedFullCompaction)
+    {
+        DoTestEmptyRangesFullCompaction(true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyGetChangedBlocksWhenRangeIsOutOfBounds)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), 10);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 1);
+        partition.CreateCheckpoint("cp");
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::MakeClosedInterval(10, 1023),
+                "",
+                "cp",
+                false);
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetMask().size());
+        }
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1024),
+                "",
+                "cp",
+                false);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, response->Record.GetMask().size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                char(0b00000110),
+                response->Record.GetMask()[0]
+            );
+            UNIT_ASSERT_VALUES_EQUAL(
+                char(0b00000000),
+                response->Record.GetMask()[1]
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldForbidDescribeBlocksWithEmptyRange)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            auto request = partition.CreateDescribeBlocksRequest(0, 0);
+            partition.SendToPipe(std::move(request));
+            auto response =
+                partition.RecvResponse<TEvVolume::TEvDescribeBlocksResponse>();
+            UNIT_ASSERT(response->GetStatus() == E_ARGUMENT);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksWithBaseDiskAndComplexRanges)
+    {
+        TPartitionContent baseContent = {
+        /*|     0    |      1      |     2     |     3     |     4    |     5    |      6      |     7     |     8    |*/
+            TEmpty() , TBlob(1, 1) , TFresh(2) ,  TEmpty() , TEmpty() , TEmpty() , TBlob(2, 3) , TFresh(4) , TEmpty()
+        };
+        auto bitmap = CreateBitmap(9);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        auto writeRange1 = TBlockRange32::MakeClosedInterval(2, 3);
+        partition.WriteBlocks(writeRange1, char(5));
+        MarkWrittenBlocks(bitmap, writeRange1);
+
+        auto writeRange2 = TBlockRange32::MakeClosedInterval(5, 6);
+        partition.WriteBlocks(writeRange2, char(6));
+        MarkWrittenBlocks(bitmap, writeRange2);
+
+        partition.Flush();
+
+        auto response = partition.ReadBlocks(TBlockRange32::WithLength(0, 9));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent(char(0), 1) +
+            GetBlocksContent(char(1), 1) +
+            GetBlocksContent(char(5), 2) +
+            GetBlocksContent(char(0), 1) +
+            GetBlocksContent(char(6), 2) +
+            GetBlocksContent(char(4), 1) +
+            GetBlocksContent(char(0), 1),
+            GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProperlyProcessDeletionMarkers)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 100));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 100));
+        partition.Flush();
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldUpdateUsedBlocksMapWhenFlushingBlocksFromFreshChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1);
+        partition.WriteBlocks(2);
+        partition.WriteBlocks(3);
+
+        partition.ZeroBlocks(2);
+
+        {
+            auto response = partition.StatPartition();
+            auto stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUsedBlocksCount());
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            auto stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetUsedBlocksCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyScanDiskWithoutBrokenBlobs)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(0, 1024 * 10),
+            1);
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1024 * 5, 1024 * 11),
+            1);
+
+        const auto step = 16;
+        for (ui32 i = 1024 * 10; i < 1024 * 12; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step), 1);
+        }
+
+        for (ui32 i = 1024 * 20; i < 1024 * 21; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step + 1), 1);
+        }
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1001111, 1001210),
+            1);
+
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(1024, 3023));
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(5024, 5033));
+
+        const ui64 mixedBlobsCount = 4;
+        const ui64 mergedBlobsCount = 20;
+        const ui64 blobsCount = mixedBlobsCount + mergedBlobsCount;
+        const ui64 blobsWithoutDeletionMarkerCount = blobsCount - 2;
+
+        {
+            const auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                mixedBlobsCount,
+                stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                mergedBlobsCount,
+                stats.GetMergedBlobsCount());
+        }
+
+        ui32 completionStatus = -1;
+        ui32 readBlobCount = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvScanDiskCompleted: {
+                        using TEv =
+                            TEvPartitionPrivate::TEvScanDiskCompleted;
+                        const auto* msg = event->Get<TEv>();
+                        completionStatus = msg->GetStatus();
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvReadBlobResponse: {
+                        using TEv =
+                            TEvPartitionCommonPrivate::TEvReadBlobResponse;
+                        const auto* msg = event->Get<TEv>();
+                        UNIT_ASSERT(!FAILED(msg->GetStatus()));
+                        ++readBlobCount;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        const auto checkScanDisk = [&] (ui32 blobsPerBatch) {
+            completionStatus = -1;
+            readBlobCount = 0;
+
+            const auto response = partition.ScanDisk(blobsPerBatch);
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionPrivate::EvScanDiskCompleted);
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, completionStatus);
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsWithoutDeletionMarkerCount,
+                readBlobCount);
+
+            const auto progress = partition.GetScanDiskStatus();
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                progress->Record.GetProgress().GetIsCompleted());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsCount,
+                progress->Record.GetProgress().GetTotal());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsCount,
+                progress->Record.GetProgress().GetProcessed());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                progress->Record.GetProgress().GetBrokenBlobs().size());
+        };
+
+        checkScanDisk(100);
+        checkScanDisk(2);
+        checkScanDisk(1);
+        checkScanDisk(10);
+    }
+
+
+
+    Y_UNIT_TEST(CheckRealSysCountersDuringIncrementalCompaction)
+    {
+        TStatsChecker statsChecker;
+        auto config = DefaultConfig();
+        config.SetBlobPatchingEnabled(true);
+        config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetSSDMaxBlobsPerRange(4);
+        config.SetMaxSkippedBlobsDuringCompaction(1);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(2, 12), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 20), 3);
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Incremental compaction divided data into two parts,
+            // and compacted to one blob only small of them
+            statsChecker.CheckStats(stats, 19, 19, 19, 19);
+        }
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(7, 15), 4);
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // Sys counters count whole blob, real sys counters count only
+            // patches. Incremental compaction doesn't read the biggest blob.
+            statsChecker.CheckStats(stats, 9, 9, 19, 19);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRunCompactionIfBlocksCountIsGreaterThanThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999999);
+        config.SetSSDMaxBlobsPerUnit(999999999);
+        config.SetHDDMaxBlobsPerUnit(999999999);
+
+        ui32 blockCount =  10 * 1024;
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByBlockCount = 0;
+        bool compactionRequestObserved = false;
+        runtime->SetEventFilter([&] (auto& runtime, auto& event) {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        compactionRequestObserved = true;
+                        break;
+                    }
+                    case TEvPartitionPrivate::EvCleanupRequest: {
+                        return true;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->template Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByBlockCount =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        for (size_t i = 0; i < 10; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 1024, 1024), i);
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_EQUAL(0, compactionByBlockCount);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage block count is less than 20%  => no compaction
+        UNIT_ASSERT(!compactionRequestObserved);
+
+        for (size_t i = 0; i < 2; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 1024, 1024), i);
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage block count is greater than threshold => compaction
+        UNIT_ASSERT(compactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(1, compactionByBlockCount);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no more compactions generated because blocks in cleanup queue are
+        // considered to be already removed
+        UNIT_ASSERT_VALUES_EQUAL(1, compactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, compactionByBlockCount);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompactSeveralBlobsInTheSameRangeWithSeveralRangesPerRun)
+    {
+        TestForcedCompaction(10);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldPassTraceIdToBlobstorage)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        auto writeReq = partition.CreateWriteBlocksRequest(0, 1);
+        writeReq->CallContext->RequestId = 12345;
+
+        auto shuttle = MakeIntrusive<TMockShuttle>(ui64{10}, ui64{10});
+        writeReq->CallContext->LWOrbit.AddShuttle(shuttle);
+
+        ui64 spanId = 0;
+        writeReq->CallContext->LWOrbit.ForEachShuttle(
+            [&](const NLWTrace::IShuttle* s) { spanId = s->GetSpanId(); });
+
+        std::optional<NWilson::TTraceId> traceId;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvBlobStorage::EvPut) {
+                    traceId = NWilson::TTraceId(event->TraceId);
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendToPipe(std::move(writeReq));
+
+        auto response =
+            partition.RecvResponse<TEvService::TEvWriteBlocksResponse>();
+        UNIT_ASSERT_C(
+            SUCCEEDED(response->GetStatus()),
+            response->GetErrorReason());
+
+        NProto::TVolumeStats stats =
+            partition.StatPartition()->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 1);
+
+        UNIT_ASSERT(traceId.has_value());
+
+        NWilson::TTraceId expectedTraceId(
+            {12345, 0},
+            spanId,
+            NWilson::TTraceId::MAX_VERBOSITY,
+            NWilson::TTraceId::MAX_TIME_TO_LIVE);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedTraceId.GetHexTraceId(),
+            traceId->GetHexTraceId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedTraceId.GetVerbosity(),
+            traceId->GetVerbosity());
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedTraceId.GetTimeToLive(),
+            traceId->GetTimeToLive());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnBlobIdForFreshBlocksInDescribeWhenIndexOnlyIsTrue)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const ui32 channelCount = DataChannelOffset + 2;
+        const ui32 freshChannelNo = channelCount - 1;
+
+        NKikimr::TLogoBlobID blobIdFromContent;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvWriteBlobRequest: {
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvWriteBlobRequest>();
+                        if (msg->BlobId.Channel() != freshChannelNo) {
+                            break;
+                        }
+
+                        blobIdFromContent = NKikimr::TLogoBlobID(
+                            TestTabletId,
+                            msg->BlobId.Generation(),
+                            msg->BlobId.Step(),
+                            msg->BlobId.Channel(),
+                            msg->BlobId.BlobSize(),
+                            msg->BlobId.Cookie());
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        const auto range = TBlockRange32::MakeOneBlock(0);
+        partition.WriteBlocks(range, char(1));
+
+        auto request = partition.CreateDescribeBlocksRequest(range);
+        request->Record.SetIndexOnly(true);
+        partition.SendToPipe(std::move(request));
+        const auto response =
+            partition.RecvResponse<TEvVolume::TEvDescribeBlocksResponse>();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(1, response->Record.FreshBlockRangesSize());
+        const auto& fr = response->Record.GetFreshBlockRanges(0);
+        UNIT_ASSERT(fr.GetBlocksContent().empty());
+        UNIT_ASSERT(LogoBlobIDFromLogoBlobID(fr.GetBlobId()).IsValid());
+        UNIT_ASSERT_VALUES_EQUAL(
+            blobIdFromContent,
+            LogoBlobIDFromLogoBlobID(fr.GetBlobId()));
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split16.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split16.cpp
@@ -1,0 +1,1914 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit16)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldAutomaticallyFlushBlocksFromFreshChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(4_MB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetFreshBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        partition.WriteBlocks(MaxBlocksCount - 1, 0);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(MaxBlocksCount, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompactAndCleanupWithoutDelayUponScoreOverflow)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+        static constexpr ui32 cleanupThreshold = 10;
+
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetHDDMaxBlobsPerRange(compactionThreshold - 1);
+        config.SetCleanupThreshold(cleanupThreshold);
+        config.SetMinCompactionDelay(999'999'999);
+        config.SetMaxCompactionDelay(999'999'999);
+        config.SetMinCleanupDelay(999'999'999);
+        config.SetMaxCleanupDelay(999'999'999);
+        config.SetCompactionScoreLimitForThrottling(compactionThreshold);
+        config.SetCleanupQueueBytesLimitForThrottling(16_MB);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (size_t i = 0; i < compactionThreshold; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        }
+        // initializing compaction exec time
+        partition.Compaction();
+        // initializing cleanup exec time
+        partition.Cleanup();
+
+        for (size_t i = 0; i < compactionThreshold - 1; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold + 1,
+                stats.GetMergedBlobsCount()
+            );
+        }
+
+        // generating enough dirty blobs for automatic cleanup
+        for (ui32 i = 0; i < cleanupThreshold - compactionThreshold - 1; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        }
+        partition.Compaction(0);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadFromCheckpoint)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.CreateCheckpoint("checkpoint1");
+
+        partition.Flush();
+        partition.WriteBlocks(1, 2);
+        partition.CreateCheckpoint("checkpoint2");
+
+        partition.Flush();
+        partition.WriteBlocks(1, 3);
+        partition.CreateCheckpoint("checkpoint3");
+
+        partition.WriteBlocks(1, 4);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1, "checkpoint1"))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(1, "checkpoint2"))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(1, "checkpoint3"))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(4),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyMarkFirstBlockInBlobIfItIsTheSameAsLastBlockInPreviousBlob)
+    {
+        auto config = DefaultConfig();
+        config.SetCleanupThreshold(1);
+        config.SetCollectGarbageThreshold(1);
+        config.SetFlushThreshold(8_MB);
+        config.SetWriteBlobThreshold(4_MB);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0,1023), 1);
+        for (ui32 i = 0; i < 1024; ++i) {
+            partition.WriteBlocks(1023,1);
+        }
+
+        // here we expect that fresh contains 2048 blocks
+        // flush will write two blobs but latest blob
+        // will be immediately gc as it is completely overwritten
+
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldConsolidateZeroedBlocksOnCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 501));
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(501, 1000));
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(501, 1000));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1001));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(DescribeBlocksIsNotImplementedForOverlayDisks)
+    {
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2);
+
+        auto& partition = *partitionWithRuntime.Partition;
+        partition.WaitReady();
+
+        {
+            auto request = partition.CreateDescribeBlocksRequest(0, 0);
+            partition.SendToPipe(std::move(request));
+            auto response =
+                partition.RecvResponse<TEvVolume::TEvDescribeBlocksResponse>();
+            UNIT_ASSERT(response->GetStatus() == E_NOT_IMPLEMENTED);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksAfterCompactionOfOverlayDisk1)
+    {
+        TPartitionContent baseContent = { TBlob(1, 1) };
+        auto bitmap = CreateBitmap(1);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        // Write 1023 blocks (4MB minus 4KB). After compaction, we have one
+        // merged blob written.
+        // It's a tricky situation because one block (at 0 index) is missing in
+        // overlay disk and therefore this block should be read from base disk.
+        auto writeRange = TBlockRange32::MakeClosedInterval(1, 1023);
+        partition.WriteBlocks(writeRange, char(2));
+        MarkWrittenBlocks(bitmap, writeRange);
+
+        partition.Compaction();
+
+        auto response = partition.ReadBlocks(TBlockRange32::WithLength(0, 1024));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(1)) +
+            GetBlocksContent(char(2), 1023),
+            GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleHttpCollectGarbage)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        auto createResponse = partition.RemoteHttpInfo(
+            BuildRemoteHttpQuery(TestTabletId, {{"action","collectGarbage"}}),
+            HTTP_METHOD::HTTP_METHOD_POST);
+
+        UNIT_ASSERT_C(
+            createResponse->Html.Contains("Operation successfully completed"),
+            true
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyCalculateBlocksCount)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(0, 1024 * 10),
+            1);
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1024 * 5, 1024 * 11),
+            1);
+
+        const auto step = 16;
+        for (ui32 i = 1024 * 10; i < 1024 * 12; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step), 1);
+        }
+
+        for (ui32 i = 1024 * 20; i < 1024 * 21; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step + 1), 1);
+        }
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1001111, 1001210),
+            1);
+
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(1024, 3023));
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(5024, 5033));
+
+        const auto expected = 1024 * 12 + 1024 + 1 + 100 - 2000 - 10;
+
+        /*
+        partition.WriteBlocks(TBlockRange32(5024, 5043), 1);
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(5024, 5033));
+        const auto expected = 10;
+        */
+
+        auto response = partition.StatPartition();
+        auto stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+
+        partition.RebootTablet();
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+
+        ui32 completionStatus = -1;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvMetadataRebuildCompleted: {
+                        using TEv =
+                            TEvPartitionPrivate::TEvMetadataRebuildCompleted;
+                        auto* msg = event->Get<TEv>();
+                        completionStatus = msg->GetStatus();
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        const auto rangesPerBatch = 100;
+        partition.RebuildMetadata(NProto::ERebuildMetadataType::USED_BLOCKS, rangesPerBatch);
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, completionStatus);
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+
+        partition.RebootTablet();
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyScanDiskWithBrokenBlobs)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(0, 1024 * 10), 1);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024 * 5, 1024 * 11), 1);
+
+        const auto step = 16;
+        for (ui32 i = 1024 * 10; i < 1024 * 12; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step), 1);
+        }
+
+        for (ui32 i = 1024 * 20; i < 1024 * 21; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step + 1), 1);
+        }
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1001111, 1001210),
+            1);
+
+        const ui64 mixedBlobsCount = 4;
+        const ui64 mergedBlobsCount = 18;
+        const ui64 blobsCount = mixedBlobsCount + mergedBlobsCount;
+
+        {
+            const auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                mixedBlobsCount,
+                stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                mergedBlobsCount,
+                stats.GetMergedBlobsCount());
+        }
+
+        ui32 completionStatus = -1;
+
+        TVector<bool> brokenBlobsIndexes;
+        ui32 index = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvScanDiskCompleted: {
+                        using TEv =
+                            TEvPartitionPrivate::TEvScanDiskCompleted;
+                        const auto* msg = event->Get<TEv>();
+
+                        completionStatus = msg->GetStatus();
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvReadBlobResponse: {
+                        using TEv =
+                            TEvPartitionCommonPrivate::TEvReadBlobResponse;
+
+                        UNIT_ASSERT(index < brokenBlobsIndexes.size());
+
+                        if (brokenBlobsIndexes[index++]) {
+                            auto response = std::make_unique<TEv>(
+                                MakeError(
+                                    E_REJECTED,
+                                    "blob is broken"));
+
+                            runtime->Send(new IEventHandle(
+                                event->Recipient,
+                                event->Sender,
+                                response.release(),
+                                0, // flags
+                                event->Cookie
+                            ), 0);
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        const auto checkScanDisk = [&] (ui32 blobsPerBatch) {
+            completionStatus = -1;
+            index = 0;
+
+            const auto response = partition.ScanDisk(blobsPerBatch);
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionPrivate::EvScanDiskCompleted);
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, completionStatus);
+
+            const auto progress = partition.GetScanDiskStatus();
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                progress->Record.GetProgress().GetIsCompleted());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsCount,
+                progress->Record.GetProgress().GetTotal());
+            UNIT_ASSERT_VALUES_EQUAL(
+                blobsCount,
+                progress->Record.GetProgress().GetProcessed());
+
+            int brokenBlobsCountExpected = 0;
+            for (bool isBroken : brokenBlobsIndexes) {
+                if (isBroken) {
+                    ++brokenBlobsCountExpected;
+                }
+            }
+            UNIT_ASSERT_VALUES_EQUAL(
+                brokenBlobsCountExpected,
+                progress->Record.GetProgress().GetBrokenBlobs().size());
+        };
+
+        brokenBlobsIndexes = TVector<bool>(blobsCount);
+        brokenBlobsIndexes[0] = true;
+        brokenBlobsIndexes[1] = true;
+        brokenBlobsIndexes[4] = true;
+
+        checkScanDisk(100);
+        checkScanDisk(2);
+
+        brokenBlobsIndexes = TVector<bool>(blobsCount, true);
+
+        checkScanDisk(1);
+        checkScanDisk(10);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRunCompactionIfBlobCountIsGreaterThanThreshold)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(999999999);
+        config.SetCompactionRangeGarbageThreshold(999999999);
+        config.SetSSDMaxBlobsPerUnit(7);
+        config.SetHDDMaxBlobsPerUnit(7);
+
+        ui32 blockCount =  1024 * 1024;
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByBlobCount = 0;
+        bool compactionRequestObserved = false;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        compactionRequestObserved = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByBlobCount =
+                            cc.CompactionByBlobCountPerDisk.Value;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        for (size_t i = 0; i < 6; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 1024, 1024), i);
+        }
+
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_EQUAL(0, compactionByBlobCount);
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // blob count is less than 4 * 2 => no compaction
+        UNIT_ASSERT(!compactionRequestObserved);
+
+        for (size_t i = 6; i < 10; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 1024, 1024), i);
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // blob count is greater than threshold on disk => compaction
+        UNIT_ASSERT(compactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT(0 < compactionByBlobCount);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAbortCompactionIfReadBlobFailsWithDeadlineExceeded)
+    {
+        DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+            TEvBlobStorage::EvVGet);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldWriteToMixedChannelOnHddIfThresholdExceeded)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteRequestBatchingEnabled(true);
+        config.SetWriteBlobThreshold(3_MB);
+        config.SetWriteMixedBlobThresholdHDD(512_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4096,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 100));
+        partition.WriteBlocks(TBlockRange32::WithLength(512, 512));
+        partition.WriteBlocks(TBlockRange32::WithLength(2048, 1024));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(512, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldZeroFreshBlocks)
+    {
+        auto config = DefaultConfig();
+
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+
+        auto checkFreshBlocksCount = [&](ui32 expectedCount)
+        {
+            auto partitionInfo = partition.GetPartitionInfo();
+            auto value =
+                NJson::ReadJsonFastTree(partitionInfo->Record.GetPayload());
+            auto stateJson = value["State"];
+            UNIT_ASSERT_VALUES_EQUAL(
+                expectedCount,
+                stateJson["FreshBlocksFromChannel"].GetInteger());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stateJson["FreshBlocksFromDb"].GetInteger());
+        };
+
+        partition.WriteBlocks(2, 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(2)));
+
+        checkFreshBlocksCount(1);
+
+        partition.ZeroBlocks(2);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(2)));
+
+        checkFreshBlocksCount(1);
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TString(),
+            GetBlockContent(partition.ReadBlocks(2)));
+
+        // 0 blocks because of flush
+        checkFreshBlocksCount(0);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleDescribeBlobRequestForFreshBlob)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range = TBlockRange32::MakeOneBlock(0);
+        partition.WriteBlocks(range, char(1));
+
+        auto request = partition.CreateDescribeBlocksRequest(range);
+        request->Record.SetIndexOnly(true);
+        partition.SendToPipe(std::move(request));
+        const auto describeResponse =
+            partition.RecvResponse<TEvVolume::TEvDescribeBlocksResponse>();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, describeResponse->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(1, describeResponse->Record.FreshBlockRangesSize());
+
+        const auto freshBlobId = LogoBlobIDFromLogoBlobID(
+            describeResponse->Record.GetFreshBlockRanges(0).GetBlobId());
+        UNIT_ASSERT(freshBlobId.IsValid());
+
+        const auto response = partition.DescribeBlob(freshBlobId);
+        UNIT_ASSERT_VALUES_EQUAL(1, response->Record.BlocksSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, response->Record.GetBlocks(0).GetBlockIndex());
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split2.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split2.cpp
@@ -1,0 +1,1796 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit2)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldDieIfBootingTakesTooMuchTime)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetPartitionBootTimeout(TDuration::Seconds(10).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(std::move(config));
+
+        bool tabletWasKilled = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+            {
+                if (ev->GetTypeRewrite() == TEvTablet::EvRestored) {
+                    return true;
+                } else if (
+                    ev->GetTypeRewrite() == TEvents::TEvPoisonPill::EventType)
+                {
+                    tabletWasKilled = true;
+                }
+                return false;
+            });
+
+        TPartitionClient partition(*runtime);
+        partition.SendWaitReadyRequest();
+
+        runtime->DispatchEvents({}, TDuration::MilliSeconds(1));
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        // Wait for partition to die
+        auto options = TDispatchOptions();
+        options.FinalEvents.emplace_back(TEvents::TEvPoisonPill::EventType);
+        runtime->DispatchEvents(options, TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT(tabletWasKilled);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyFlushBlocksWhenFreshBlobByteCountThresholdIsReached)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(4_MB);
+        config.SetFreshBlobCountFlushThreshold(999999);
+        config.SetFreshBlobByteCountFlushThreshold(15_MB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetFreshBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetMixedBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+
+    Y_UNIT_TEST(ShouldPrioritizeIgnoringZeroedCompactionOverGarbageCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config, 3072);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(2048, 1024));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(2048, 512));
+        //  range 0    range 1    range 2
+        // |xxxxxxxxxx|xxxxxxxxxx|xxxxxxxxxx|
+        // |          |          |     xxxxx|
+        //
+        // top range garbage (range 2):    50% < 200%
+        // disk garbage:                   16.7% < 20%
+        //
+        // Must not compact.
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(!garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024 + 512));
+        //  range 0    range 1    range 2
+        // |0000000000|00000xxxxx|xxxxxxxxxx|
+        // |xxxxxxxxxx|xxxxx     |     xxxxx|
+        //
+        // top range garbage ignoring zeroed (range 2):    50%  < 200%
+        // disk garbage ignoring zeroed:                   17%  < 20%
+        // top range garbage (range 0):                    inf% > 200%
+        // disk garbage:                                   133% > 20%
+        //
+        // Must compact range 0 by garbage per range.
+        //
+        //  range 0    range 1    range 2
+        // |          |00000xxxxx|xxxxxxxxxx|
+        // |          |xxxxx     |     xxxxx|
+        //
+        // top range garbage ignoring zeroed (range 2):    50%  < 200%
+        // disk garbage ignoring zeroed:                   25%  > 20%
+        // top range garbage (range 1):                    100% < 200%
+        // disk garbage:                                   66%  > 20%
+        //
+        // Must compact range 2 by ignoring zeroed per disk.
+        //
+        //  range 0    range 1    range 2
+        // |          |00000xxxxx|xxxxxxxxxx|
+        // |          |xxxxx     |          |
+        //
+        // top range garbage ignoring zeroed:              0%   < 200%
+        // disk garbage ignoring zeroed:                   0%   < 20%
+        // top range garbage (range 1):                    100% < 200%
+        // disk garbage:                                   33%  > 20%
+        //
+        // Must compact range 1 by garbage per disk.
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldKillTabletIfCriticalFailureDuringFlush)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 10));
+        partition.WriteBlocks(TBlockRange32::WithLength(10, 10));
+        partition.WriteBlocks(TBlockRange32::WithLength(20, 10));
+
+        int pillCount = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvents::TSystem::PoisonPill: {
+                        ++pillCount;
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvWriteBlobResponse: {
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvWriteBlobResponse>();
+                        auto& e = const_cast<NProto::TError&>(msg->Error);
+                        e.SetCode(E_REJECTED);
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendFlushRequest();
+        auto response = partition.RecvFlushResponse();
+
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyMarkCrossRangeBlocksDuringCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetCleanupThreshold(1);
+        config.SetCollectGarbageThreshold(3);
+        config.SetSSDMaxBlobsPerRange(4);
+        config.SetHDDMaxBlobsPerRange(4);
+        config.SetFlushThreshold(8_MB);
+        config.SetWriteBlobThreshold(4_MB);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 version = 0; version < 2; ++version) {
+            for (ui32 pos = 0; pos < 4; ++pos) {
+                partition.WriteBlocks(TBlockRange32::WithLength(512 * pos, 512));
+            }
+            partition.Flush();
+        }
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1000, 1500));
+        partition.Flush();
+
+        partition.Compaction();
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompactIncrementallySsd)
+    {
+        auto config = DefaultConfig();
+        config.SetCompactionGarbageThreshold(20);
+        DoTestIncrementalCompaction(std::move(config), NProto::STORAGE_MEDIA_SSD, true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleDescribeBlocksRequestWhenBlocksAreFresh)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range = TBlockRange32::WithLength(1, 11);
+        partition.WriteBlocks(range, char(1));
+
+        const TString checkpoint = "0";
+        partition.CreateCheckpoint(checkpoint);
+
+        {
+            auto response = partition.DescribeBlocks(range, checkpoint);
+            TString actualContent;
+            TVector<TBlockRange32> actualRanges;
+
+            auto extractContent = [&]() {
+                const auto& message = response->Record;
+                for (size_t i = 0; i < message.FreshBlockRangesSize(); ++i) {
+                    const auto& freshRange = message.GetFreshBlockRanges(i);
+                    actualContent += freshRange.GetBlocksContent();
+                    actualRanges.push_back(
+                        TBlockRange32::WithLength(
+                            freshRange.GetStartIndex(),
+                            freshRange.GetBlocksCount()));
+                 }
+            };
+
+            extractContent();
+            TString expectedContent = GetBlocksContent(char(1), range.Size());
+            UNIT_ASSERT_VALUES_EQUAL(expectedContent, actualContent);
+            CheckRangesArePartition(actualRanges, range);
+
+            response = partition.DescribeBlocks(0, Max<ui32>(), checkpoint);
+            actualContent = {};
+            actualRanges = {};
+
+            extractContent();
+            expectedContent = GetBlocksContent(char(1), range.Size());
+            UNIT_ASSERT_VALUES_EQUAL(expectedContent, actualContent);
+            CheckRangesArePartition(actualRanges, range);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksAfterZeroBlocksAndCompactionOfOverlayDisk)
+    {
+        TPartitionContent baseContent = { TBlob(1, 1) };
+        auto bitmap = CreateBitmap(1);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        // Zero 1023 blocks. After compaction, we have one merged zero blob
+        // written. It's a tricky situation because one block (at 0 index) is
+        // missed in overlay disk and therefore this block should be read from
+        // base disk.
+        auto zeroRange = TBlockRange32::MakeClosedInterval(1, 1023);
+        partition.ZeroBlocks(zeroRange);
+        MarkZeroedBlocks(bitmap, zeroRange);
+
+        partition.Compaction();
+
+        auto response =
+            partition.ReadBlocks(TBlockRange32::WithLength(0, 1024));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(1)) +
+            GetBlocksContent(char(0), 1023),
+            GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFailHttpCollectGarbageOnTabletRestart)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool patchRequest = true;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite() == TEvPartitionPrivate::EvCollectGarbageRequest) {
+                    if (patchRequest) {
+                        patchRequest = false;
+                        auto request = std::make_unique<TEvPartitionPrivate::TEvCollectGarbageRequest>();
+                        SendUndeliverableRequest(*runtime, event, std::move(request));
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto httpResponse = partition.RemoteHttpInfo(
+            BuildRemoteHttpQuery(TestTabletId, {{"action","collectGarbage"}}),
+            HTTP_METHOD::HTTP_METHOD_POST);
+
+        UNIT_ASSERT_C(httpResponse->Html.Contains("tablet is shutting down"), true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRebuildBlockCountSensors)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(0, 1024 * 10),
+            1);
+
+        auto response = partition.RebuildMetadata(NProto::ERebuildMetadataType::BLOCK_COUNT, 100);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+
+        auto stats = partition.StatPartition()->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(1024 * 11 + 1, stats.GetMergedBlocksCount());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFailGetScanDiskStatusIfNoOperationRunning)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(0, 1024 * 10), 1);
+
+        partition.SendGetScanDiskStatusRequest();
+        const auto progress = partition.RecvGetScanDiskStatusResponse();
+        UNIT_ASSERT(FAILED(progress->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldChangeBatchSizeDueToBlocksPerDisk)
+    {
+        // real blocks per disk: 1024 * 10 = 10240
+        // total blocks per disk: = 1024 * 3 = 3072
+        // garbage percentage: 100 * (10 - 3) * 1024 / 3072 = 233
+        // percentage more threshold: 100 * (233 - 203) / 203 = 9
+
+
+        // 9 > 8, so should increment and compact 2 ranges
+        CheckIncrementAndDecrementCompactionPerRun(
+                1, 1000, 99999, 203, 99999, 5, 8, 5, 2);
+
+        // 9 < 15, so should decrement and compact only 1 range
+        CheckIncrementAndDecrementCompactionPerRun(
+                2, 1000, 99999, 203, 99999, 7, 30, 15, 1);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAbortFlushIfWriteBlobFailsWithDeadlineExceeded)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(
+            TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (ev->GetTypeRewrite() == TEvBlobStorage::EvVPut) {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        partition.SendFlushRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvFlushResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotHangWhenConsecutiveWriteBlobErrorsHappen)
+    {
+        auto config = DefaultConfig();
+        config.SetMaxIORequestsInFlight(10);
+        config.SetMaxWriteBlobErrorsBeforeSuicide(1000);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvPutResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvPutResult>();
+                    msg->Status = NKikimrProto::ERROR;
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        for (int i = 0; i < 100; i++) {
+            partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 777));
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(
+        ShouldReportAddFreshBlocksResultedInErrorOnlyForNonRetriableErrors)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        NProto::TError error;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionCommonPrivate::EvAddFreshBlocksResponse)
+                {
+                    auto* handle = new IEventHandle(
+                        event->Recipient,
+                        event->Sender,
+                        std::make_unique<TEvPartitionCommonPrivate::
+                                             TEvAddFreshBlocksResponse>(error)
+                            .release(),
+                        0,
+                        event->Cookie);
+
+                    runtime->Send(handle, 0);
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto freshBlocksResultedInErrorCounter = counters->GetCounter(
+            "AppCriticalEvents/AddFreshBlocksResultedInError",
+            true);
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        UNIT_ASSERT_VALUES_EQUAL(0, freshBlocksResultedInErrorCounter->Val());
+
+        error = MakeError(E_REJECTED);
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        UNIT_ASSERT_VALUES_EQUAL(0, freshBlocksResultedInErrorCounter->Val());
+
+        error = MakeError(E_INVALID_STATE);
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        UNIT_ASSERT_VALUES_EQUAL(1, freshBlocksResultedInErrorCounter->Val());
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split3.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split3.cpp
@@ -1,0 +1,1903 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit3)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRecoverStateOnReboot)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.RebootTablet();
+
+        partition.StatPartition();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyTrimFreshLogOnFlush)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+        }
+
+        bool trimSeen = false;
+        bool trimCompletedSeen = false;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (msg->Channel == 4) {
+                            trimSeen = true;
+                        }
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvTrimFreshLogCompleted: {
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted>();
+                        UNIT_ASSERT(SUCCEEDED(msg->GetStatus()));
+                        trimCompletedSeen = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(true, trimSeen);
+        UNIT_ASSERT_VALUES_EQUAL(true, trimCompletedSeen);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRunGarbageCompactionAfterZeroBlocks)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        // < 20% on the whole disk, not enough to trigger compaction.
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 300));
+        partition.Flush();
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(!garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+
+        // > 20% on the whole disk, not enough to trigger compaction.
+        partition.ZeroBlocks(TBlockRange32::WithLength(1024, 300));
+        partition.Flush();
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+        UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnErrorIfNODATABlocksAreDetectedInDefaultStorageAccessMode)
+    {
+        auto runtime = PrepareTestActorRuntime(
+            DefaultConfig(),
+            1024,
+            {},
+            TTestPartitionInfo(),
+            {},
+            EStorageAccessMode::Default
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool broken = false;
+        runtime->SetObserverFunc(BuildEvGetBreaker(777, broken));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 777), 1);
+        partition.SendReadBlocksRequest(TBlockRange32::WithLength(0, 777));
+        auto response = partition.RecvReadBlocksResponse();
+        UNIT_ASSERT(broken);
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotWriteBlobIfCompactionRangeWasOverwrittenWithZeroBlocks)
+    {
+        auto config = DefaultConfig();
+        config.SetCleanupThreshold(1);
+        config.SetSSDMaxBlobsPerRange(2);
+        config.SetHDDMaxBlobsPerRange(2);
+        config.SetCollectGarbageThreshold(1);
+        config.SetFlushThreshold(8_MB);
+        config.SetWriteBlobThreshold(4_MB);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 write_step = 0; write_step < 2; ++write_step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0,512));
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+
+        for (ui32 zero_step = 0; zero_step < 2; ++zero_step) {
+            partition.ZeroBlocks(TBlockRange32::WithLength(0,512));
+        }
+
+        bool writeBlobSeen = false;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvWriteBlobRequest: {
+                        writeBlobSeen = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        UNIT_ASSERT(!writeBlobSeen);
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompactIncrementallyHybrid)
+    {
+        auto config = DefaultConfig();
+        config.SetCompactionGarbageThreshold(20);
+        DoTestIncrementalCompaction(std::move(config), NProto::STORAGE_MEDIA_HYBRID, true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleDescribeBlocksRequestWithOneBlob)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto range1 = TBlockRange32::WithLength(11, 11);
+        partition.WriteBlocks(range1, char(1));
+        const auto range2 = TBlockRange32::WithLength(33, 22);
+        partition.WriteBlocks(range2, char(1));
+        partition.Flush();
+
+        {
+            const auto response =
+                partition.DescribeBlocks(TBlockRange32::WithLength(0, 101));
+            const auto& message = response->Record;
+            // Expect that all data is contained in one blob.
+            UNIT_ASSERT_VALUES_EQUAL(1, message.BlobPiecesSize());
+
+            const auto& blobPiece = message.GetBlobPieces(0);
+            UNIT_ASSERT_VALUES_EQUAL(2, blobPiece.RangesSize());
+            const auto& r1 = blobPiece.GetRanges(0);
+            const auto& r2 = blobPiece.GetRanges(1);
+
+            UNIT_ASSERT_VALUES_EQUAL(0, r1.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(range1.Start, r1.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(range1.Size(), r1.GetBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(range1.Size(), r2.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(range2.Start, r2.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(range2.Size(), r2.GetBlocksCount());
+
+            TVector<ui16> blobOffsets;
+            for (size_t i = 0; i < r1.GetBlocksCount(); ++i) {
+                blobOffsets.push_back(r1.GetBlobOffset() + i);
+            }
+            for (size_t i = 0; i < r2.GetBlocksCount(); ++i) {
+                blobOffsets.push_back(r2.GetBlobOffset() + i);
+            }
+
+            {
+                TVector<TString> blocks;
+                auto sglist = ResizeBlocks(
+                    blocks,
+                    range1.Size() + range2.Size(),
+                    TString(DefaultBlockSize, char(0)));
+
+                const auto blobId =
+                    LogoBlobIDFromLogoBlobID(blobPiece.GetBlobId());
+                const auto group = blobPiece.GetBSGroupId();
+                const auto response =
+                    partition.ReadBlob(blobId, group, blobOffsets, sglist);
+
+                for (size_t i = 0; i < sglist.size(); ++i) {
+                    const auto block = sglist[i].AsStringBuf();
+                    UNIT_ASSERT_VALUES_EQUAL_C(
+                        GetBlockContent(
+                            char(1)),
+                            block,
+                            "during iteration #" << i);
+                }
+            }
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotKillTabletWhenFailedToReadBlobFromBaseDisk)
+    {
+        TPartitionContent baseContent = { TBlob(1, 1) };
+
+        const auto baseTabletId = TestTabletId2;
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, baseTabletId, baseContent);
+        auto& partition = *partitionWithRuntime.Partition;
+        auto& runtime = *partitionWithRuntime.Runtime;
+
+        int pillCount = 0;
+
+        const auto eventHandler =
+            [&] (const TEvBlobStorage::TEvGet::TPtr& ev) {
+                bool result = false;
+
+                auto& msg = *ev->Get();
+
+                auto response = std::make_unique<TEvBlobStorage::TEvGetResult>(
+                    NKikimrProto::ERROR,
+                    msg.QuerySize,
+                    0);  // groupId
+
+                for (ui32 i = 0; i < msg.QuerySize; ++i) {
+                    const auto& q = msg.Queries[i];
+                    const auto& blobId = q.Id;
+
+                    if (blobId.TabletID() == baseTabletId) {
+                        result = true;
+                    }
+                }
+
+                if (result) {
+                    runtime.Schedule(
+                        new IEventHandle(
+                            ev->Sender,
+                            ev->Recipient,
+                            response.release(),
+                            0,
+                            ev->Cookie),
+                        TDuration());
+                }
+
+                return result;
+            };
+
+        runtime.SetEventFilter(
+            [eventHandler] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+                bool handled = false;
+
+                const auto wrapped =
+                    [&] (const auto& ev) {
+                        handled = eventHandler(ev);
+                    };
+
+                switch (ev->GetTypeRewrite()) {
+                    hFunc(TEvBlobStorage::TEvGet, wrapped);
+                }
+                return handled;
+           });
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvents::TSystem::PoisonPill: {
+                        ++pillCount;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendReadBlocksRequest(0);
+
+        auto response = partition.RecvReadBlocksResponse();
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+
+        UNIT_ASSERT_VALUES_EQUAL(0, pillCount);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldForgetTooOldCompactRangeOperations)
+    {
+        constexpr TDuration CompactOpHistoryDuration = TDuration::Days(1);
+
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        TVector<TString> op;
+
+        for (ui32 i = 0; i < 4; ++i)
+        {
+            partition.WriteBlocks(0, 100);
+            partition.SendCompactRangeRequest(0, 100);
+
+            {
+                TDispatchOptions options;
+                options.FinalEvents.emplace_back(
+                    TEvPartitionPrivate::EvForcedCompactionCompleted,
+                    1);
+                runtime->DispatchEvents(options);
+            }
+
+            auto response = partition.RecvCompactRangeResponse();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            op.push_back(response->Record.GetOperationId());
+        }
+
+        runtime->AdvanceCurrentTime(CompactOpHistoryDuration + TDuration::Seconds(1));
+
+        for (ui32 i = 0; i < 4; ++i)
+        {
+            partition.SendGetCompactionStatusRequest(op[i]);
+            auto response = partition.RecvGetCompactionStatusResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, response->GetStatus());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFailGetMetadataRebuildStatusIfNoOperationRunning)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(0, 1024 * 10),
+            1);
+
+        partition.SendGetRebuildMetadataStatusRequest();
+        auto progress = partition.RecvGetRebuildMetadataStatusResponse();
+        UNIT_ASSERT(FAILED(progress->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSuccessfullyScanDiskIfDiskIsEmpty)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const ui32 blobsPerBatch = 10;
+        const auto response = partition.ScanDisk(blobsPerBatch);
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvPartitionPrivate::EvScanDiskCompleted);
+        runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+        const auto progress = partition.GetScanDiskStatus();
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            progress->Record.GetProgress().GetIsCompleted());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            progress->Record.GetProgress().GetTotal());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            progress->Record.GetProgress().GetProcessed());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            progress->Record.GetProgress().GetBrokenBlobs().size());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldChangeBatchSizeDueToBlocksPerRangeCount)
+    {
+        // real blocks per last range: 1024 * 4
+        // total blocks per disk: 1024
+        // garbage percentage: 100 * (4 - 1) * 1024 / 1024 = 300
+        // 100 * (300 - 280) / 280 = 7
+
+        // 7 > 6, so should increment and compact 2 ranges
+        CheckIncrementAndDecrementCompactionPerRun(
+            1, 1000, 99999, 9999, 280, 5, 6, 4, 2);
+
+        // 7 > 6, but should compact only 1 range due to maxRangeCountPerRun
+        CheckIncrementAndDecrementCompactionPerRun(
+            1, 1000, 99999, 9999, 280, 7, 6, 4, 1, 1);
+
+        // 7 < 8, so should decrement and compact only 1 range
+        CheckIncrementAndDecrementCompactionPerRun(
+            2, 1000, 99999, 9999, 280, 7, 30, 8, 1);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAllowForcedCompactionRequestsInPresenseOfTabletCompaction)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        bool steal = true;
+        runtime->SetEventFilter([&]
+            (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+        {
+            Y_UNUSED(runtime);
+
+            if (ev->GetTypeRewrite() == TEvPartitionPrivate::EvCompactionCompleted &&
+                steal)
+            {
+                steal = false;
+                return true;
+            }
+            return false;
+        });
+
+        partition.SendCompactionRequest(
+            0,
+            TCompactionOptions());
+        partition.Compaction(
+            0,
+            TCompactionOptions().
+                set(ToBit(ECompactionOption::Forced)));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnBlobsIdsOfFailedBlobsDuringReadIfRequested)
+    {
+        constexpr ui32 blobCount = 4;
+        constexpr ui32 blockCount = 512 * blobCount;
+
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(100_KB);
+        auto runtime = PrepareTestActorRuntime(config, MaxPartitionBlocksCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        {
+            ui32 current_offset = 0;
+            for (ui32 i = 0; i < blobCount; ++i) {
+                const auto blockRange =
+                    TBlockRange32::WithLength(current_offset, 512);
+                partition.WriteBlocks(blockRange, 1);
+                current_offset += 512;
+            }
+        }
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                        auto response = std::make_unique<
+                            TEvPartitionCommonPrivate::TEvReadBlobResponse>(
+                            MakeError(E_IO, "Simulated blob read failure"));
+
+                        runtime->Send(
+                            new IEventHandle(
+                                event->Sender,
+                                event->Recipient,
+                                response.release(),
+                                0,   // flags
+                                event->Cookie),
+                            0);
+
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        TGuardedBuffer<TString> Buffer = TGuardedBuffer(
+            TString::Uninitialized(blockCount * DefaultBlockSize));
+        auto sgList = Buffer.GetGuardedSgList();
+        auto sgListOrError =
+            SgListNormalize(sgList.Acquire().Get(), DefaultBlockSize);
+
+        UNIT_ASSERT(!HasError(sgListOrError));
+
+        auto request = partition.CreateReadBlocksLocalRequest(
+            TBlockRange32::WithLength(0, blockCount),
+            sgListOrError.ExtractResult());
+
+        request->Record.ShouldReportFailedRangesOnFailure = true;
+
+        partition.SendToPipe(std::move(request));
+
+        auto response = partition.RecvReadBlocksLocalResponse();
+        UNIT_ASSERT_VALUES_UNEQUAL(S_OK, response->GetStatus());
+        UNIT_ASSERT_VALUES_EQUAL(
+            blobCount,
+            response->Record.FailInfo.FailedRanges.size());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotLoseAnyBlocksWhileWaitingForCheckpointCreation)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool intercept = false;
+        std::unique_ptr<IEventHandle> putEvent;
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvBlobStorage::EvPut
+                        && intercept)
+                {
+                    putEvent.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.WriteBlocks(0, '1');
+        intercept = true;
+
+        partition.SendWriteBlocksRequest(1, '2');
+
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(putEvent);
+        intercept = false;
+
+        partition.SendCreateCheckpointRequest("c1");
+
+        runtime->DispatchEvents({}, 10ms);
+
+        partition.WriteBlocks(0, '3');
+
+        runtime->SendAsync(putEvent.release());
+
+        partition.RecvWriteBlocksResponse();
+        partition.RecvCreateCheckpointResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1') + GetBlockContent('2'),
+            GetBlocksContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 2), "c1")));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('3') + GetBlockContent('2'),
+            GetBlocksContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 2))));
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlobsCount());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1') + GetBlockContent('2'),
+            GetBlocksContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 2), "c1")));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('3') + GetBlockContent('2'),
+            GetBlocksContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 2))));
+
+        partition.DeleteCheckpoint("c1");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('3') + GetBlockContent('2'),
+            GetBlocksContent(
+                partition.ReadBlocks(TBlockRange32::WithLength(0, 2))));
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split4.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split4.cpp
@@ -1,0 +1,2006 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit4)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldStoreBlocks)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 3);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        UNIT_ASSERT(stats.GetUserWriteCounters().GetExecTime() != 0);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyTrimFreshBlobsFromPreviousGeneration)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetFreshBlocksCount());
+        }
+
+        bool trimSeen = false;
+        bool trimCompletedSeen = false;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (msg->Channel == 4) {
+                            trimSeen = true;
+                        }
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvTrimFreshLogCompleted: {
+                        trimCompletedSeen = true;
+                        auto* msg = event->Get<TEvPartitionCommonPrivate::TEvTrimFreshLogCompleted>();
+                        UNIT_ASSERT(SUCCEEDED(msg->GetStatus()));
+
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.KillTablet();
+
+        {
+            TPartitionClient partition(*runtime);
+            partition.WaitReady();
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(true, trimSeen);
+            UNIT_ASSERT_VALUES_EQUAL(true, trimCompletedSeen);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRunGarbageCompactionAfterZeroBlocksForRange)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 600));
+        partition.Flush();
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(!garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+
+        partition.ZeroBlocks(TBlockRange32::WithLength(600, 100));
+        partition.Flush();
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldMarkNODATABlocksInRepairStorageAccessMode)
+    {
+        auto runtime = PrepareTestActorRuntime(
+            DefaultConfig(),
+            1024,
+            {},
+            TTestPartitionInfo(),
+            {},
+            EStorageAccessMode::Repair
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool broken = false;
+        runtime->SetObserverFunc(BuildEvGetBreaker(777, broken));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 777), 1);
+        partition.SendReadBlocksRequest(TBlockRange32::WithLength(0, 777));
+        auto response = partition.RecvReadBlocksResponse();
+        Y_ABORT_UNLESS(broken);
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetError().GetCode());
+
+        const auto& blocks = response->Record.GetBlocks();
+        UNIT_ASSERT_EQUAL(777, blocks.BuffersSize());
+        for (size_t i = 0; i < blocks.BuffersSize(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBrokenDataMarker(),
+                blocks.GetBuffers(i)
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldWriteBlobIfCompactionUsesOnlyFreshBlocks)
+    {
+        auto config = DefaultConfig();
+        config.SetCleanupThreshold(3);
+        config.SetHDDMaxBlobsPerRange(2);
+        config.SetSSDMaxBlobsPerRange(2);
+        config.SetCollectGarbageThreshold(3);
+        config.SetFlushThreshold(8_MB);
+        config.SetWriteBlobThreshold(4_MB);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 write_step = 0; write_step < 2; ++write_step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0,512));
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+
+        for (ui32 write_step = 0; write_step < 2; ++write_step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(0,512));
+        }
+
+        bool writeBlobSeen = false;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvWriteBlobRequest: {
+                        writeBlobSeen = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Compaction();
+
+        UNIT_ASSERT(writeBlobSeen);
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotCompactIncrementallyIfSsdDiskGarbageLevelIsTooHigh)
+    {
+        auto config = DefaultConfig();
+        config.SetCompactionGarbageThreshold(1);
+        DoTestIncrementalCompaction(std::move(config), NProto::STORAGE_MEDIA_SSD, false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRespondToDescribeBlocksRequestWithDenseBlobs)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, char(1));
+        partition.WriteBlocks(1, char(1));
+        partition.WriteBlocks(2, char(1));
+        partition.Flush();
+        partition.WriteBlocks(3, char(2));
+        partition.WriteBlocks(4, char(2));
+        partition.WriteBlocks(5, char(2));
+        partition.Flush();
+
+        {
+            const auto response = partition.DescribeBlocks(
+                TBlockRange32::MakeClosedInterval(1, 4));
+            const auto& message = response->Record;
+            UNIT_ASSERT_VALUES_EQUAL(2, message.BlobPiecesSize());
+
+            const auto& blobPiece1 = message.GetBlobPieces(0);
+            UNIT_ASSERT_VALUES_EQUAL(1, blobPiece1.RangesSize());
+            const auto& r1_2 = blobPiece1.GetRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(1, r1_2.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(1, r1_2.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(2, r1_2.GetBlocksCount());
+            const auto blobId1 =
+                LogoBlobIDFromLogoBlobID(blobPiece1.GetBlobId());
+            const auto group1 = blobPiece1.GetBSGroupId();
+
+            const auto& blobPiece2 = message.GetBlobPieces(1);
+            UNIT_ASSERT_VALUES_EQUAL(1, blobPiece2.RangesSize());
+            const auto& r3_5 = blobPiece2.GetRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(0, r3_5.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(3, r3_5.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(2, r3_5.GetBlocksCount());
+            const auto blobId2 =
+                LogoBlobIDFromLogoBlobID(blobPiece2.GetBlobId());
+            const auto group2 = blobPiece2.GetBSGroupId();
+
+            for (ui16 i = 0; i < 2; ++i) {
+                const TVector<ui16> offsets = {i};
+                {
+                    TVector<TString> blocks;
+                    auto sglist = ResizeBlocks(blocks, 1, TString(DefaultBlockSize, char(0)));
+                    const auto response =
+                        partition.ReadBlob(blobId1, group1, offsets, sglist);
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        GetBlockContent(char(1)),
+                        sglist[0].AsStringBuf()
+                    );
+                }
+
+                {
+                    TVector<TString> blocks;
+                    auto sglist = ResizeBlocks(blocks, 1, TString(DefaultBlockSize, char(0)));
+                    const auto response =
+                        partition.ReadBlob(blobId2, group2, offsets, sglist);
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        GetBlockContent(char(2)),
+                        sglist[0].AsStringBuf()
+                    );
+                }
+            }
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReadBlocksWhenBaseBlobHasGreaterChannel)
+    {
+        const ui32 overlayTabletChannelsCount = 254;
+        const ui32 baseBlobChannel = overlayTabletChannelsCount + 1;
+
+        TPartitionContent baseContent = {
+            TBlob(1, 1, 1, baseBlobChannel)
+        };
+        auto bitmap = CreateBitmap(1);
+
+        auto partitionWithRuntime =
+            SetupOverlayPartition(
+                TestTabletId,
+                TestTabletId2,
+                baseContent,
+                overlayTabletChannelsCount);
+        auto& partition = *partitionWithRuntime.Partition;
+
+        auto response = partition.ReadBlocks(0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(1)),
+            GetBlocksContent(response));
+        UNIT_ASSERT(bitmap == GetUnencryptedBlockMask(response));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDrain)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // drain before any requests should work
+        partition.Drain();
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));       // fresh
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));   // blob
+        partition.ZeroBlocks(TBlockRange32::MakeOneBlock(0));        // fresh
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));    // blob
+
+        // drain after some requests have completed should work
+        partition.Drain();
+
+        TDeque<std::unique_ptr<IEventHandle>> evPutRequests;
+        bool intercept = true;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event)
+            {
+                if (intercept) {
+                    switch (event->GetTypeRewrite()) {
+                        case TEvBlobStorage::EvPutResult: {
+                            evPutRequests.emplace_back(event.Release());
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        auto test = [&] (TString testName, bool isWrite)
+        {
+            runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+            // sending this request after DispatchEvents because our pipe client
+            // reconnects from time to time and thus fifo guarantee for
+            // zero/write -> drain is broken => we need to ensure the correct
+            // order (zero/write, then drain) in our test scenario
+            partition.SendDrainRequest();
+
+            UNIT_ASSERT_C(
+                evPutRequests.size(),
+                TStringBuilder() << testName << ": intercepted EvPut requests"
+            );
+
+            auto evList = runtime->CaptureEvents();
+            for (auto& ev: evList) {
+                UNIT_ASSERT_C(
+                    ev->GetTypeRewrite() != TEvPartition::EvDrainResponse,
+                    TStringBuilder() << testName << ": check no drain response"
+                );
+            }
+            runtime->PushEventsFront(evList);
+
+            intercept = false;
+
+            for (auto& request: evPutRequests) {
+                runtime->Send(request.release());
+            }
+
+            evPutRequests.clear();
+
+            runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+            if (isWrite) {
+                {
+                    auto response = partition.RecvWriteBlocksResponse();
+                    UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+                }
+            } else {
+                {
+                    auto response = partition.RecvZeroBlocksResponse();
+                    UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+                }
+            }
+
+            {
+                auto response = partition.RecvDrainResponse();
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    S_OK,
+                    response->GetStatus(),
+                    TStringBuilder() << testName << ": check drain response"
+                );
+            }
+
+            intercept = true;
+        };
+
+        partition.SendWriteBlocksRequest(TBlockRange32::MakeOneBlock(0));
+        test("write fresh", true);
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1024));
+        test("write blob", true);
+
+        partition.SendZeroBlocksRequest(TBlockRange32::MakeOneBlock(0));
+        test("zero fresh", false);
+
+        partition.SendZeroBlocksRequest(TBlockRange32::WithLength(0, 1024));
+        test("zero blob", false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSuccessfullyRunMetadataRebuildOnEmptyDisk)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.RebuildMetadata(NProto::ERebuildMetadataType::BLOCK_COUNT, 10);
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(TEvPartitionPrivate::EvMetadataRebuildCompleted);
+        runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+        auto progress = partition.GetRebuildMetadataStatus();
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            progress->Record.GetProgress().GetProcessed()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            progress->Record.GetProgress().GetTotal()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            progress->Record.GetProgress().GetIsCompleted()
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldBlockCleanupDuringScanDisk)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+
+        ui32 cnt = 0;
+        TAutoPtr<IEventHandle> savedEvent;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) mutable {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvScanDiskBatchRequest: {
+                        if (++cnt == 1) {
+                            savedEvent = event.Release();
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.ScanDisk(10);
+        partition.Compaction();
+
+        {
+            const auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+        }
+
+        {
+            partition.SendCleanupRequest();
+            const auto response = partition.RecvCleanupResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+        }
+
+        runtime->Send(savedEvent.Release());
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvPartitionPrivate::EvScanDiskCompleted);
+        runtime->DispatchEvents(options);
+
+        partition.Cleanup();
+
+        {
+            const auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        const auto progress = partition.GetScanDiskStatus();
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            progress->Record.GetProgress().GetIsCompleted());
+        UNIT_ASSERT_VALUES_EQUAL(
+            progress->Record.GetProgress().GetTotal(),
+            progress->Record.GetProgress().GetProcessed());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            progress->Record.GetProgress().GetBrokenBlobs().size());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDecrementBatchSizeWhenBlobsPerRangeCountIsSmall) {
+        // CompactionScore in range3: 4 - 4 + eps
+        // 100 * (eps - 0) / 1024 < 3, so should decrement and compact 1 range
+        CheckIncrementAndDecrementCompactionPerRun(
+            2, 1000, 4, 9999, 9999, 7, 50, 10, 1);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAllowOnlyOneForcedCompactionRequestAtATime)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        bool steal = true;
+        runtime->SetEventFilter([&]
+            (TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+        {
+            Y_UNUSED(runtime);
+
+            if (ev->GetTypeRewrite() == TEvPartitionPrivate::EvCompactionCompleted &&
+                steal)
+            {
+                steal = false;
+                return true;
+            }
+            return false;
+        });
+
+        partition.SendCompactionRequest(
+            0,
+            TCompactionOptions().
+                set(ToBit(ECompactionOption::Forced)));
+        partition.SendCompactionRequest(
+            0,
+            TCompactionOptions().
+                set(ToBit(ECompactionOption::Forced)));
+
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectWriteIfCompactionMapIsNotLoaded)
+    {
+        auto config = DefaultConfig();
+        config.SetMaxCompactionRangesLoadingPerTx(1);
+
+        auto runtime = PrepareTestActorRuntime(config, 1024);
+
+        TAutoPtr<IEventHandle> capturedLoadCMRequest;
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvLoadCompactionMapChunkRequest: {
+                        UNIT_ASSERT(!capturedLoadCMRequest);
+                        capturedLoadCMRequest = event.Release();
+                        return true;
+                    }
+                }
+                return false;
+            }
+        );
+
+        TPartitionClient partition(*runtime);
+
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        UNIT_ASSERT(capturedLoadCMRequest);
+        runtime->Send(capturedLoadCMRequest.Release());
+
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCleanupMergedBlobsWithoutReadingBlockMasks)
+    {
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(0, MaxBlocksCount),
+            '1');
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(0, MaxBlocksCount),
+            '2');
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(MaxBlocksCount, MaxBlocksCount),
+            '3');
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(512, MaxBlocksCount),
+            '4');
+
+        //  Expected Merged blobs:
+        //
+        //    4 4
+        //      3 3
+        //  2 2
+        //  1 1
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetBlockMaskReadDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        //  Expected Merged blobs:
+        //
+        //  2 4
+        //    4 4
+        //      3 3
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('2', 512) + GetBlocksContent('4', 512),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(0, MaxBlocksCount))));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('4', 512) + GetBlocksContent('3', 512),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(MaxBlocksCount, MaxBlocksCount))));
+
+        // Blobs from Second Compaction range should stay
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetBlockMaskReadDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        //  Expected Merged blobs:
+        //
+        //      4 3
+        //  2 4
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('2', 512) + GetBlocksContent('4', 512),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(0, MaxBlocksCount))));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlocksContent('4', 512) + GetBlocksContent('3', 512),
+            GetBlocksContent(partition.ReadBlocks(
+                TBlockRange32::WithLength(MaxBlocksCount, MaxBlocksCount))));
+
+        // Blobs from Second Compaction range compacted
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split5.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split5.cpp
@@ -1,0 +1,2033 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit5)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldStoreBlocksInFreshChannel)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(stats.GetFreshBlocksCount(), 3);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        UNIT_ASSERT(stats.GetUserWriteCounters().GetExecTime() != 0);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldTrimUpToTheFirstUnflushedBlockCommitId)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+
+        TAutoPtr<IEventHandle> trim;
+
+        ui32 collectGen = 0;
+        ui32 collectStep = 0;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvTrimFreshLogRequest: {
+                        UNIT_ASSERT(!trim);
+                        trim = event.Release();
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg = event->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        if (msg->Channel == 4) {
+                            collectGen = msg->CollectGeneration;
+                            collectStep = msg->CollectStep;
+                        }
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.Flush();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 3);
+        partition.WriteBlocks(3, 4);
+
+        UNIT_ASSERT(trim);
+        runtime->Send(trim.Release());
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvTrimFreshLogCompleted);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(2, collectGen);
+        UNIT_ASSERT_VALUES_EQUAL(4, collectStep);
+
+        partition.Flush();
+        UNIT_ASSERT(trim);
+        runtime->Send(trim.Release());
+
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvTrimFreshLogCompleted);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(2, collectGen);
+        UNIT_ASSERT_VALUES_EQUAL(6, collectStep);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyRunGarbageCompaction)
+    {
+        DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectRequestForBlockOutOfRange)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::MakeOneBlock(1023));
+        }
+
+        {
+            partition.SendWriteBlocksRequest(TBlockRange32::WithLength(1023, 2));
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        {
+            partition.SendWriteBlocksRequest(TBlockRange32::MakeOneBlock(1024));
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyHandleZeroAndNonZeroFreshBlobsDuringFlush)
+    {
+        auto config = DefaultConfig();
+        config.SetFlushThreshold(12_KB);
+        config.SetFlushBlobSizeThreshold(8_KB);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 1);
+        partition.ZeroBlocks(0);
+        partition.WriteBlocks(0, 1);
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotCompactIncrementallyIfHybridDiskGarbageLevelIsTooHigh)
+    {
+        auto config = DefaultConfig();
+        config.SetCompactionGarbageThreshold(1);
+        DoTestIncrementalCompaction(std::move(config), NProto::STORAGE_MEDIA_HYBRID, false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRespondToDescribeBlocksRequestWithSparseBlobs)
+    {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, char(1));
+        partition.WriteBlocks(2, char(1));
+        partition.Flush();
+        partition.WriteBlocks(4, char(2));
+        partition.WriteBlocks(6, char(2));
+        partition.Flush();
+
+        {
+            const auto response =
+                partition.DescribeBlocks(TBlockRange32::WithLength(0, 7));
+            const auto& message = response->Record;
+            UNIT_ASSERT_VALUES_EQUAL(2, message.BlobPiecesSize());
+
+            const auto& blobPiece1 = message.GetBlobPieces(0);
+            UNIT_ASSERT_VALUES_EQUAL(2, blobPiece1.RangesSize());
+            const auto& r0 = blobPiece1.GetRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(0, r0.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(0, r0.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(1, r0.GetBlocksCount());
+            const auto& r1 = blobPiece1.GetRanges(1);
+            UNIT_ASSERT_VALUES_EQUAL(1, r1.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(2, r1.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(1, r1.GetBlocksCount());
+            const auto blobId1 =
+                LogoBlobIDFromLogoBlobID(blobPiece1.GetBlobId());
+            const auto group1 = blobPiece1.GetBSGroupId();
+
+            const auto& blobPiece2 = message.GetBlobPieces(1);
+            UNIT_ASSERT_VALUES_EQUAL(2, blobPiece2.RangesSize());
+            const auto& r4 = blobPiece2.GetRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(0, r4.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(4, r4.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(1, r4.GetBlocksCount());
+            const auto& r6 = blobPiece2.GetRanges(1);
+            UNIT_ASSERT_VALUES_EQUAL(1, r6.GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(6, r6.GetBlockIndex());
+            UNIT_ASSERT_VALUES_EQUAL(1, r6.GetBlocksCount());
+            const auto blobId2 =
+                LogoBlobIDFromLogoBlobID(blobPiece2.GetBlobId());
+            const auto group2 = blobPiece2.GetBSGroupId();
+
+            for (ui16 i = 0; i < 1; ++i) {
+                const TVector<ui16> offsets = {i};
+                {
+                    TVector<TString> blocks;
+                    auto sglist = ResizeBlocks(blocks, 1, TString(DefaultBlockSize, char(0)));
+                    const auto response =
+                        partition.ReadBlob(blobId1, group1, offsets, sglist);
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        GetBlockContent(char(1)),
+                        sglist[0].AsStringBuf()
+                    );
+                }
+
+                {
+                    TVector<TString> blocks;
+                    auto sglist = ResizeBlocks(blocks, 1, TString(DefaultBlockSize, char(0)));
+                    const auto response =
+                        partition.ReadBlob(blobId2, group2, offsets, sglist);
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        GetBlockContent(char(2)),
+                        sglist[0].AsStringBuf()
+                    );
+                }
+            }
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSendBlocksCountToReadInDescribeBlocksRequest)
+    {
+        auto partitionWithRuntime =
+            SetupOverlayPartition(TestTabletId, TestTabletId2, {});
+        auto& partition = *partitionWithRuntime.Partition;
+        auto& runtime = *partitionWithRuntime.Runtime;
+
+        partition.WriteBlocks(4, 1);
+        partition.WriteBlocks(5, 1);
+
+        int describeBlocksCount = 0;
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvVolume::EvDescribeBlocksRequest: {
+                        auto* msg = event->Get<TEvVolume::TEvDescribeBlocksRequest>();
+                        auto& record = msg->Record;
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            7,
+                            record.GetBlocksCountToRead()
+                        );
+                        ++describeBlocksCount;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.ReadBlocks(TBlockRange32::WithLength(0, 9));
+        UNIT_ASSERT_VALUES_EQUAL(1, describeBlocksCount);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotTrimInFlightBlocks)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+
+        TAutoPtr<IEventHandle> addFreshBlocks;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvAddFreshBlocksRequest: {
+                        if (!addFreshBlocks) {
+                            addFreshBlocks = event.Release();
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.SendWriteBlocksRequest(2, 2);
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.WriteBlocks(3, 3);
+
+        partition.Flush();
+        partition.TrimFreshLog();
+
+        UNIT_ASSERT(addFreshBlocks);
+        runtime->Send(addFreshBlocks.Release());
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.RebootTablet();
+
+        auto response = partition.ReadBlocks(1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(1)),
+            GetBlocksContent(response)
+        );
+
+        response = partition.ReadBlocks(2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(2)),
+            GetBlocksContent(response)
+        );
+
+        response = partition.ReadBlocks(3);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(3)),
+            GetBlocksContent(response)
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnRebuildMetadataProgressDuringExecution)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024 * 10), 1);
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(1024 * 10, 1024 * 10),
+            1);
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) mutable {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvMetadataRebuildBlockCountResponse: {
+                        const auto* msg =
+                            event->Get<TEvPartitionPrivate::TEvMetadataRebuildBlockCountResponse>();
+                        UNIT_ASSERT_VALUES_UNEQUAL(
+                            0,
+                            msg->RebuildState.MixedBlocks + msg->RebuildState.MergedBlocks);
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        auto response = partition.RebuildMetadata(NProto::ERebuildMetadataType::BLOCK_COUNT, 10);
+
+        auto progress = partition.GetRebuildMetadataStatus();
+        UNIT_ASSERT_VALUES_EQUAL(
+            20,
+            progress->Record.GetProgress().GetProcessed()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            progress->Record.GetProgress().GetIsCompleted()
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFailScanDiskIfAlreadyRunning)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+
+        ui32 cnt = 0;
+        TAutoPtr<IEventHandle> savedEvent;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) mutable {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvScanDiskBatchRequest: {
+                        if (++cnt == 1) {
+                            savedEvent = event.Release();
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        const auto responseFirst = partition.ScanDisk(10);
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_OK,
+            responseFirst->Record.GetError().GetCode());
+
+        const auto responseDuplicate = partition.ScanDisk(10);
+        UNIT_ASSERT_VALUES_EQUAL(
+            S_ALREADY,
+            responseDuplicate->Record.GetError().GetCode());
+
+        runtime->Send(savedEvent.Release());
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvPartitionPrivate::EvScanDiskCompleted);
+        runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+        const auto progress = partition.GetScanDiskStatus();
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            progress->Record.GetProgress().GetIsCompleted());
+        UNIT_ASSERT_VALUES_EQUAL(
+            progress->Record.GetProgress().GetTotal(),
+            progress->Record.GetProgress().GetProcessed());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            progress->Record.GetProgress().GetBrokenBlobs().size());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRespectCompactionCountPerRunChangingPeriod)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(99999);
+        config.SetCompactionRangeGarbageThreshold(280);
+        config.SetCompactionRangeCountPerRun(1);
+        config.SetCompactionCountPerRunIncreasingThreshold(6);
+        config.SetCompactionCountPerRunDecreasingThreshold(4);
+        config.SetHDDMaxBlobsPerUnit(1000);
+        config.SetSSDMaxBlobsPerUnit(1000);
+        config.SetMaxCompactionRangeCountPerRun(10);
+        config.SetCompactionCountPerRunChangingPeriod(100000);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange = TBlockRange32::WithLength(0, 1024);
+
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                        break;
+                    }
+                }
+                return false;
+            }
+        );
+
+        for (int i = 0; i < 10; ++i) {
+            partition.WriteBlocks(blockRange, i);
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(1, resultCompactionRangeCountPerRun);
+        }
+
+        // CompactionRangeCountPerRun was updated more then period seconds ago
+        // So it should be changed
+        runtime->AdvanceCurrentTime(TDuration::Seconds(102));
+
+        for (int i = 0; i < 10; ++i) {
+            partition.WriteBlocks(blockRange, i);
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(2, resultCompactionRangeCountPerRun);
+        }
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(50));
+
+        for (int i = 0; i < 10; ++i) {
+            partition.WriteBlocks(blockRange, i);
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        partition.Compaction();
+        partition.Cleanup();
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            // Shouldn't increase compactionRangeCountPerRun due to period
+            UNIT_ASSERT_VALUES_EQUAL(2, resultCompactionRangeCountPerRun);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProcessMultipleRangesUponGarbageCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetGarbageCompactionRangeCountPerRun(3);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, MaxPartitionBlocksCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        TAutoPtr<IEventHandle> compactionRequest;
+        const auto interceptCompactionRequest =
+            [&compactionRequest](TAutoPtr<IEventHandle>& event)
+        {
+            if (event->GetTypeRewrite() ==
+                TEvPartitionPrivate::EvCompactionRequest)
+            {
+                auto* msg =
+                    event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                if (msg->Mode == TEvPartitionPrivate::GarbageCompaction) {
+                    compactionRequest = event.Release();
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+        runtime->SetObserverFunc(interceptCompactionRequest);
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 =
+            TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange1, 2);
+
+        partition.WriteBlocks(blockRange2, 3);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange2, 5);
+
+        partition.WriteBlocks(blockRange3, 6);
+        partition.WriteBlocks(blockRange3, 7);
+        partition.WriteBlocks(blockRange3, 8);
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(8, stats.GetMergedBlobsCount());
+        }
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.Release());
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.Cleanup();
+
+        // checking that data wasn't corrupted
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(blockRange1.Start)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(blockRange1.End)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(5),
+            GetBlockContent(partition.ReadBlocks(blockRange2.Start)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(5),
+            GetBlockContent(partition.ReadBlocks(blockRange2.End)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(8),
+            GetBlockContent(partition.ReadBlocks(blockRange3.Start)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(8),
+            GetBlockContent(partition.ReadBlocks(blockRange3.End)));
+
+        // checking that we now have 1 blob in each of the ranges
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAddRequestToLoadCompactionMapRangeIfNotLoaded)
+    {
+        const ui32 rangeCount = 100;
+
+        auto config = DefaultConfig();
+        config.SetMaxCompactionRangesLoadingPerTx(5);
+
+        auto runtime = PrepareTestActorRuntime(config, rangeCount * 1024);
+
+        TPartitionClient partition(*runtime);
+
+        for (ui32 i = 0; i < rangeCount; ++i) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i * 1024, 256), i);
+        }
+
+        std::vector<ui32> waitOutOfOrderRangeIdx;
+        TAutoPtr<IEventHandle> delayEvent;
+        ui32 rangesLoaded = 0;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvLoadCompactionMapChunkRequest: {
+                        auto* msg =
+                            event->Get<TEvPartitionPrivate::
+                                           TEvLoadCompactionMapChunkRequest>();
+                        rangesLoaded += msg->Range.Size();
+                        if (!waitOutOfOrderRangeIdx.empty()) {
+                            UNIT_ASSERT_EQUAL(
+                                waitOutOfOrderRangeIdx.back(),
+                                msg->Range.Start);
+                            waitOutOfOrderRangeIdx.pop_back();
+                            return false;
+                        }
+                        if (msg->Range.Start == 40 ||
+                            msg->Range.Start == 50) {
+                            UNIT_ASSERT(!delayEvent);
+                            delayEvent = event.Release();
+                            return true;
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            });
+
+        partition.RebootTablet();
+
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(42 * 1024, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(66 * 1024, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(83 * 1024, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        waitOutOfOrderRangeIdx = { 80, 65 };
+
+        UNIT_ASSERT(delayEvent);
+        runtime->Send(delayEvent.Release());
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        UNIT_ASSERT(waitOutOfOrderRangeIdx.empty());
+
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(42 * 1024, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(66 * 1024, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(83 * 1024, 256),
+                1);
+            const auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        UNIT_ASSERT(delayEvent);
+        runtime->Send(delayEvent.Release());
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+
+        UNIT_ASSERT_GE(rangesLoaded, rangeCount);
+    }
+
+
+
+    Y_UNIT_TEST(
+        ShouldNotLoseAnyMixedMergedBlocksWhileWaitingForCheckpointCreation)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, '1');
+        partition.Flush();
+
+        bool interceptTransactions = true;
+
+        std::unique_ptr<IEventHandle> executeTransactionsEvent;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvExecuteTransactions &&
+                    interceptTransactions)
+                {
+                    executeTransactionsEvent.reset(event.Release());
+                    interceptTransactions = false;
+
+                    return true;
+                }
+                return false;
+            });
+
+        partition.SendCreateCheckpointRequest("c1");
+        partition.Compaction();
+        partition.Cleanup();
+
+        UNIT_ASSERT(executeTransactionsEvent);
+
+        partition.SendReadBlocksRequest(0, "c1");
+        auto readBlocksResponse = partition.RecvReadBlocksResponse();
+
+        // Check that create checkpoint transaction is not executed
+        UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, readBlocksResponse->GetStatus());
+
+        runtime->SendAsync(executeTransactionsEvent.release());
+
+        partition.RecvCreateCheckpointResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1'),
+            GetBlockContent(partition.ReadBlocks(0, "c1")));
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split6.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split6.cpp
@@ -1,0 +1,2081 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit6)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldStoreBlocksAtTheEndOfAMaxSizeDisk)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange = TBlockRange32::MakeClosedInterval(
+            Max<ui32>() - 500,
+            Max<ui32>() - 2);
+        partition.WriteBlocks(blockRange, 1);
+
+        for (auto blockIndex: xrange(blockRange)) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(blockIndex))
+            );
+        }
+
+        partition.WriteBlocks(Max<ui32>() - 2, 2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(Max<ui32>() - 2))
+        );
+
+        partition.Flush();
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(Max<ui32>() - 2))
+        );
+
+        partition.Compaction();
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(Max<ui32>() - 2))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotAddSmallNonDeletionBlobsDuringFlush)
+    {
+        auto config = DefaultConfig(4_MB);
+        config.SetWriteBlobThreshold(4_MB);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetFreshBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        constexpr ui32 extraBlocks = 4;
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(MaxBlocksCount - 1, extraBlocks + 1));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(extraBlocks, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount,
+                stats.GetMixedBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyRunIgnoringZeroedCompaction)
+    {
+        DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotCauseUI32IntergerOverflow)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), Max<ui32>());
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            auto range = TBlockRange32::MakeOneBlock(Max<ui32>() - 1);
+            partition.WriteBlocks(range);
+            partition.ReadBlocks(Max<ui32>() - 1);
+        }
+
+        {
+            auto range =
+                TBlockRange32::MakeClosedInterval(Max<ui32>() - 1, Max<ui32>());
+            partition.SendWriteBlocksRequest(range);
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        {
+            auto range = TBlockRange32::MakeOneBlock(Max<ui32>() - 1);
+            auto blockContent = GetBlockContent(1);
+            partition.WriteBlocksLocal(range, blockContent);
+            partition.ReadBlocks(Max<ui32>() - 1);
+        }
+
+        {
+            auto range =
+                TBlockRange32::MakeClosedInterval(Max<ui32>() - 1, Max<ui32>());
+            auto blockContent = GetBlockContent(1);
+            partition.SendWriteBlocksLocalRequest(range, blockContent);
+            auto response = partition.RecvWriteBlocksLocalResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        {
+            auto range =
+                TBlockRange32::MakeClosedInterval(Max<ui32>() - 1, Max<ui32>());
+            TVector<TString> blocks;
+            auto sglist = ResizeBlocks(
+                blocks,
+                range.Size(),
+                TString::TUninitialized(DefaultBlockSize));
+            partition.SendReadBlocksLocalRequest(range, std::move(sglist));
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectWriteRequestsIfDataChannelsAreYellow)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc(StorageStateChanger(
+            NKikimrBlobStorage::StatusDiskSpaceLightYellowMove |
+            NKikimrBlobStorage::StatusDiskSpaceYellowStop));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        {
+            partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1024));
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotEraseBlocksForSkippedBlobsFromIndexDuringIncrementalCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_GB);   // everything goes to fresh
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetMaxSkippedBlobsDuringCompaction(1);
+        config.SetTargetCompactionBytesPerOp(1);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // blob 1 needs to eventually have more live blocks than blob 2 in order
+        // not to be compacted
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(2, 22), 1);
+        partition.Flush();
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1, 10), 2);
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(31, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(21, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 11; i <= 22; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 1; i <= 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnExactlyOneVersionOfEachBlockInDescribeBlocksResponse) {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // Without fresh blocks.
+        partition.WriteBlocks(0, char(1));
+        partition.Flush();
+        partition.CreateCheckpoint("checkpoint1");
+        partition.WriteBlocks(0, char(2));
+        partition.Flush();
+        {
+            const auto response =
+                partition.DescribeBlocks(TBlockRange32::MakeOneBlock(0));
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.FreshBlockRangesSize());
+
+            UNIT_ASSERT_VALUES_EQUAL(1, response->Record.BlobPiecesSize());
+            const auto& blobPiece = response->Record.GetBlobPieces(0);
+            UNIT_ASSERT_VALUES_EQUAL(1, blobPiece.RangesSize());
+            UNIT_ASSERT_VALUES_EQUAL(0, blobPiece.GetRanges(0).GetBlobOffset());
+            UNIT_ASSERT_VALUES_EQUAL(0, blobPiece.GetRanges(0).GetBlockIndex());
+
+            const auto blobId = LogoBlobIDFromLogoBlobID(blobPiece.GetBlobId());
+            const auto group = blobPiece.GetBSGroupId();
+            {
+                TVector<TString> blocks;
+                auto sglist = ResizeBlocks(blocks, 1, TString(DefaultBlockSize, char(0)));
+                const auto response = partition.ReadBlob(blobId, group, TVector<ui16>{0}, sglist);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    GetBlockContent(char(2)),
+                    sglist[0].AsStringBuf()
+                );
+            }
+        }
+
+        // With fresh blocks.
+        partition.WriteBlocks(0, char(3));
+        partition.CreateCheckpoint("checkpoint2");
+        partition.WriteBlocks(0, char(4));
+        {
+            const auto response =
+                partition.DescribeBlocks(TBlockRange32::MakeOneBlock(0));
+            UNIT_ASSERT_VALUES_EQUAL(0, response->Record.BlobPiecesSize());
+
+            UNIT_ASSERT_VALUES_EQUAL(1, response->Record.FreshBlockRangesSize());
+            const auto& freshBlockRange = response->Record.GetFreshBlockRanges(0);
+            UNIT_ASSERT_VALUES_EQUAL(1, freshBlockRange.GetBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(char(4)),
+                freshBlockRange.GetBlocksContent()
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldGetUsedBlocks)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 2), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(2048, 2), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(1024 * 10, 1025), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(1024 * 512, 1025), 1);
+
+        ui64 expected = 1024 + 2 + 1024 + 1 + 1024 + 1;
+
+        auto response1 = partition.GetUsedBlocks();
+        UNIT_ASSERT(SUCCEEDED(response1->GetStatus()));
+
+        TCompressedBitmap bitmap(blockCount);
+
+        for (const auto& block : response1->Record.GetUsedBlocks()) {
+            bitmap.Merge(TCompressedBitmap::TSerializedChunk{
+                block.GetChunkIdx(),
+                block.GetData()
+            });
+        }
+
+        UNIT_ASSERT_EQUAL(expected, bitmap.Count());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotTrimUnflushedBlocksWhileThereIsFlushedBlockWithLargerCommitId)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+
+        TAutoPtr<IEventHandle> addFreshBlocks;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvAddFreshBlocksRequest: {
+                        if (!addFreshBlocks) {
+                            addFreshBlocks = event.Release();
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.SendWriteBlocksRequest(2, 2);
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.WriteBlocks(3, 3);
+
+        partition.Flush();
+
+        UNIT_ASSERT(addFreshBlocks);
+        runtime->Send(addFreshBlocks.Release());
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.TrimFreshLog();
+
+        partition.RebootTablet();
+
+        auto response = partition.ReadBlocks(1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(1)),
+            GetBlocksContent(response)
+        );
+
+        response = partition.ReadBlocks(2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(2)),
+            GetBlocksContent(response)
+        );
+
+        response = partition.ReadBlocks(3);
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(char(3)),
+            GetBlocksContent(response)
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldBlockCleanupDuringMetadataRebuild)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+
+        ui32 cnt = 0;
+
+        TAutoPtr<IEventHandle> savedEvent;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) mutable {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvMetadataRebuildBlockCountRequest: {
+                        if (++cnt == 1) {
+                            savedEvent = event.Release();
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        auto response = partition.RebuildMetadata(NProto::ERebuildMetadataType::BLOCK_COUNT, 10);
+        partition.Compaction();
+
+        {
+            auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+        }
+
+        {
+            partition.SendCleanupRequest();
+            auto response = partition.RecvCleanupResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, response->GetStatus());
+        }
+
+        runtime->Send(savedEvent.Release());
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvPartitionPrivate::EvMetadataRebuildCompleted);
+        runtime->DispatchEvents(options);
+
+        partition.Cleanup();
+
+        {
+            auto stats = partition.StatPartition()->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        auto progress = partition.GetRebuildMetadataStatus();
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            progress->Record.GetProgress().GetProcessed()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            4,
+            progress->Record.GetProgress().GetTotal()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            progress->Record.GetProgress().GetIsCompleted()
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyScanDiskAfterPartitionReboot)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(0, 1024 * 10),
+            1);
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1024 * 5, 1024 * 11),
+            1);
+
+        const auto step = 16;
+        for (ui32 i = 1024 * 10; i < 1024 * 12; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step), 1);
+        }
+
+        for (ui32 i = 1024 * 20; i < 1024 * 21; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step + 1), 1);
+        }
+
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1001111, 1001210),
+            1);
+
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(1024, 3023));
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(5024, 5033));
+
+        ui32 completionStatus = -1;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvScanDiskCompleted: {
+                        using TEv =
+                            TEvPartitionPrivate::TEvScanDiskCompleted;
+                        const auto* msg = event->Get<TEv>();
+                        completionStatus = msg->GetStatus();
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        const auto checkScanDisk = [&] (ui32 blobsPerBatch) {
+            completionStatus = -1;
+
+            const auto response = partition.ScanDisk(blobsPerBatch);
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionPrivate::EvScanDiskCompleted);
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, completionStatus);
+
+            const auto progress = partition.GetScanDiskStatus();
+            UNIT_ASSERT_VALUES_EQUAL(
+                true,
+                progress->Record.GetProgress().GetIsCompleted());
+            UNIT_ASSERT_VALUES_EQUAL(
+                progress->Record.GetProgress().GetTotal(),
+                progress->Record.GetProgress().GetProcessed());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                progress->Record.GetProgress().GetBrokenBlobs().size());
+        };
+
+        checkScanDisk(5);
+        partition.RebootTablet();
+        checkScanDisk(100);
+        partition.RebootTablet();
+        checkScanDisk(1);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReportLongRunningReadBlobOperations)
+    {
+        auto sendRequest = [](TPartitionClient& partition)
+        {
+            partition.SendReadBlocksRequest(0);
+        };
+        auto receiveResponse = [](TPartitionClient& partition)
+        {
+            return partition.RecvReadBlocksResponse();
+        };
+
+        DoShouldReportLongRunningBlobOperations(
+            sendRequest,
+            receiveResponse,
+            TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation::
+                ReadBlob,
+            false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProcessMultipleRangesUponForceCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(3);
+        config.SetV1GarbageCompactionEnabled(false);
+
+        auto runtime = PrepareTestActorRuntime(config, MaxPartitionBlocksCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        TVector<size_t> rangeSizes;
+        const auto interceptCompactionRequest =
+            [&rangeSizes](TAutoPtr<IEventHandle>& event)
+        {
+            if (event->GetTypeRewrite() ==
+                TEvPartitionPrivate::EvCompactionRequest)
+            {
+                auto* msg =
+                    event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                rangeSizes.push_back(msg->RangeBlockIndices.size());
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+        runtime->SetObserverFunc(interceptCompactionRequest);
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 =
+            TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+        const auto blockRange4 =
+            TBlockRange32::WithLength(3 * 1024 * 1024, 1024);
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange1, 2);
+
+        partition.WriteBlocks(blockRange2, 3);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange2, 5);
+
+        partition.WriteBlocks(blockRange3, 6);
+        partition.WriteBlocks(blockRange3, 7);
+        partition.WriteBlocks(blockRange3, 8);
+
+        partition.WriteBlocks(blockRange4, 9);
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(9, stats.GetMergedBlobsCount());
+        }
+
+        partition.SendCompactRangeRequest(0, 0);
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        partition.Cleanup();
+
+        UNIT_ASSERT_EQUAL(2, rangeSizes.size());
+        UNIT_ASSERT_EQUAL(3, rangeSizes[0]);
+        UNIT_ASSERT_EQUAL(1, rangeSizes[1]);
+
+        // checking that data wasn't corrupted
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(blockRange1.Start)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(blockRange1.End)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(5),
+            GetBlockContent(partition.ReadBlocks(blockRange2.Start)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(5),
+            GetBlockContent(partition.ReadBlocks(blockRange2.End)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(8),
+            GetBlockContent(partition.ReadBlocks(blockRange3.Start)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(8),
+            GetBlockContent(partition.ReadBlocks(blockRange3.End)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(9),
+            GetBlockContent(partition.ReadBlocks(blockRange4.Start)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(9),
+            GetBlockContent(partition.ReadBlocks(blockRange4.End)));
+
+        // checking that we now have 1 blob in each of the ranges
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectWriteIfCompactionMapIsNotLoaded1)
+    {
+        const ui32 rangeSize = 1024;
+
+        auto config = DefaultConfig();
+        config.SetMaxCompactionRangesLoadingPerTx(1);
+
+        auto runtime = PrepareTestActorRuntime(config, 1024 * 1024);
+
+        TPartitionClient partition(*runtime);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(rangeSize * 0, 10), 0);
+        partition.WriteBlocks(TBlockRange32::WithLength(rangeSize * 1, 20), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(rangeSize * 2, 30), 2);
+        partition.WriteBlocks(TBlockRange32::WithLength(rangeSize * 3, 40), 3);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        TAutoPtr<IEventHandle> loadCompactionMapEvent;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvLoadCompactionMapChunkRequest: {
+                        UNIT_ASSERT(!loadCompactionMapEvent);
+                        loadCompactionMapEvent = event.Release();
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        partition.RebootTablet();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        {
+            partition.SendFlushRequest();
+            auto response = partition.RecvFlushResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        UNIT_ASSERT(loadCompactionMapEvent);
+        runtime->Send(loadCompactionMapEvent.Release());
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        {
+            partition.SendFlushRequest();
+            auto response = partition.RecvFlushResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(100, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCleanupMixedBlobsWithoutReadingBlockMasks)
+    {
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        for (size_t i = 1019; i < 1024; ++i) {
+            partition.WriteBlocks(i, 'a' + i - 1019);
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        for (size_t i = 1019; i < 1024; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent('a' + i - 1019),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        for (size_t i = 1019; i < 1030; ++i) {
+            partition.WriteBlocks(i, 'b' + i - 1019);
+        }
+
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMergedBlobsCount());
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                3,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                1,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        for (size_t i = 1019; i < 1030; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent('b' + i - 1019),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                4,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                2,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+
+        partition.Cleanup();
+
+        for (size_t i = 1019; i < 1030; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent('b' + i - 1019),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split7.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split7.cpp
@@ -1,0 +1,1906 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit7)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldBatchSmallWritesToMixedChannelIfThresholdExceeded)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetWriteRequestBatchingEnabled(true);
+        config.SetWriteBlobThreshold(2_MB);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const ui32 blockCount = 1000;
+        runtime->SetObserverFunc(
+            PartitionBatchWriteCollector(*runtime, blockCount));
+
+        for (ui32 i = 0; i < blockCount; ++i) {
+            partition.SendWriteBlocksRequest(i, i);
+        }
+
+        for (ui32 i = 0; i < blockCount; ++i) {
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT(stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(blockCount - 1, stats.GetMixedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(blockCount, stats.GetUsedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            blockCount,
+            stats.GetUserWriteCounters().GetRequestsCount());
+        const auto batchCount = stats.GetUserWriteCounters().GetBatchCount();
+        UNIT_ASSERT(batchCount < blockCount);
+        UNIT_ASSERT(batchCount > 0);
+
+        for (ui32 i = 0; i < blockCount; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(i),
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        UNIT_ASSERT(stats.GetUserWriteCounters().GetExecTime() != 0);
+
+        // checking that drain-related counters are in a consistent state
+        partition.Drain();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldAddSmallBlobsDuringFlushIfThereAreAnyBlobsInFreshChannel)
+    {
+        auto config = DefaultConfig(4_MB);
+        config.SetWriteBlobThreshold(4_MB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, MaxBlocksCount - 1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount - 1,
+                stats.GetFreshBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+        }
+
+        constexpr ui32 extraBlocks = 4;
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(MaxBlocksCount - 1, extraBlocks + 1));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                MaxBlocksCount + extraBlocks,
+                stats.GetMixedBlocksCount()
+            );
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMixedBlobsCount());
+        }
+    }
+
+
+
+
+    Y_UNIT_TEST(ShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges)
+    {
+        DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSupportCheckpointOperations)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig());
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.CreateCheckpoint("checkpoint1");
+        partition.DeleteCheckpoint("checkpoint1");
+
+        partition.CreateCheckpoint("checkpoint1");
+        partition.DeleteCheckpoint("checkpoint1");
+        partition.DeleteCheckpoint("checkpoint1");
+
+        partition.CreateCheckpoint("checkpoint1", "id1");
+        partition.DeleteCheckpoint("checkpoint1", "id1");
+
+        partition.CreateCheckpoint("checkpoint1", "id1");
+        partition.CreateCheckpoint("checkpoint1", "id1");
+        partition.DeleteCheckpoint("checkpoint1", "id2");
+
+        partition.CreateCheckpoint("checkpoint1", "id1");
+        partition.DeleteCheckpoint("checkpoint1", "id2");
+        partition.DeleteCheckpoint("checkpoint1", "id2");
+
+        partition.CreateCheckpoint("checkpoint1", "id1");
+        partition.DeleteCheckpoint("checkpoint1", "id2");
+        partition.DeleteCheckpoint("checkpoint1", "id3");
+
+        partition.CreateCheckpoint("checkpoint1", "id1");
+        partition.CreateCheckpoint("checkpoint1", "id2");
+        partition.DeleteCheckpoint("checkpoint1", "id2");
+
+        partition.CreateCheckpoint("checkpoint1", "id1");
+        partition.DeleteCheckpoint("checkpoint2", "id1");
+    }
+
+
+
+    Y_UNIT_TEST(ShouldValidateMaxChangedBlocksRangeBlocksCount)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), 1 << 21);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.SendGetChangedBlocksRequest(
+                TBlockRange32::WithLength(0, 1 << 21),
+                "",
+                "",
+                false);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                E_ARGUMENT,
+                partition.RecvGetChangedBlocksResponse()->GetError().GetCode());
+        }
+
+        {
+            auto response = partition.GetChangedBlocks(
+                TBlockRange32::WithLength(0, 1 << 20),
+                "",
+                "",
+                false);
+
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProperlyProcessZeroesDuringIncrementalCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);    // disabling fresh
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetMaxSkippedBlobsDuringCompaction(1);
+        config.SetTargetCompactionBytesPerOp(1);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // writing some data
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 11), 1);
+        // zeroing it
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 11));
+        // writing some more data above
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1, 12), 2);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(3, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(23, stats.GetMergedBlocksCount());
+        }
+
+        partition.Compaction();
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf(),
+            GetBlocksContent(partition.ReadBlocks(0))
+        );
+
+        for (ui32 i = 1; i <= 12; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyCalculateUsedBlocksCount)
+    {
+        constexpr ui32 blockCount = 1024 * 1024;
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024 * 10 + 1), 1);
+        partition.WriteBlocks(
+            TBlockRange32::MakeClosedInterval(1024 * 5, 1024 * 11),
+            1);
+
+        const auto step = 16;
+        for (ui32 i = 1024 * 10; i < 1024 * 12; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step), 1);
+        }
+
+        for (ui32 i = 1024 * 20; i < 1024 * 21; i += step) {
+            partition.WriteBlocks(TBlockRange32::WithLength(i, step + 1), 1);
+        }
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1001111, 1001210), 1);
+
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(1024, 3023));
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(5024, 5033));
+
+        const auto expected = 1024 * 12 + 1024 + 1 + 100 - 2000 - 10;
+
+        /*
+        partition.WriteBlocks(TBlockRange32(5024, 5043), 1);
+        partition.ZeroBlocks(TBlockRange32::MakeClosedInterval(5024, 5033));
+        const auto expected = 10;
+        */
+
+        auto response = partition.StatPartition();
+        auto stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetLogicalUsedBlocksCount());
+
+        partition.RebootTablet();
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetLogicalUsedBlocksCount());
+
+        ui32 completionStatus = -1;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvMetadataRebuildCompleted: {
+                        using TEv =
+                            TEvPartitionPrivate::TEvMetadataRebuildCompleted;
+                        auto* msg = event->Get<TEv>();
+                        completionStatus = msg->GetStatus();
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        const auto rangesPerBatch = 100;
+        partition.RebuildMetadata(NProto::ERebuildMetadataType::USED_BLOCKS, rangesPerBatch);
+
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, completionStatus);
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetLogicalUsedBlocksCount());
+
+        partition.RebootTablet();
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetUsedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(expected, stats.GetLogicalUsedBlocksCount());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFailReadBlocksWhenSglistHolderIsDestroyed) {
+        auto runtime = PrepareTestActorRuntime();
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(0, 1);
+
+        // Test with fresh blocks.
+        {
+            TGuardedSgList sglist(TSgList{{}});
+            sglist.Close();
+            partition.SendReadBlocksLocalRequest(0, sglist);
+
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+
+        partition.Flush();
+
+        // Test with blob.
+        {
+            TGuardedSgList sglist(TSgList{{}});
+            sglist.Close();
+            partition.SendReadBlocksLocalRequest(0, sglist);
+
+            auto response = partition.RecvReadBlocksLocalResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReleaseTrimBarrierOnBlockDeletion)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 2));
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 2));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetFreshBlocksCount());
+        }
+
+        partition.Flush();
+        partition.TrimFreshLog();
+
+        partition.RebootTablet();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetFreshBlocksCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotKillTabletBeforeMaxReadBlobErrorsHappen)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetMaxReadBlobErrorsBeforeSuicide(5);
+
+        auto r = PrepareTestActorRuntime(config);
+        auto& runtime = *r;
+
+        TPartitionClient partition(runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1001), 1);
+
+        NKikimrProto::TLogoBlobID blobId;
+        {
+            auto response = partition.DescribeBlocks(
+                TBlockRange32::WithLength(0, 1001),
+                "");
+            UNIT_ASSERT_VALUES_EQUAL(1, response->Record.BlobPiecesSize());
+            blobId = response->Record.GetBlobPieces(0).GetBlobId();
+        }
+
+        ui32 readBlobCount = 0;
+        bool readBlobShouldFail = true;
+
+        const auto eventHandler = [&] (const TEvBlobStorage::TEvGet::TPtr& ev) {
+            auto& msg = *ev->Get();
+
+            for (ui32 i = 0; i < msg.QuerySize; i++) {
+                NKikimr::TLogoBlobID expected = LogoBlobIDFromLogoBlobID(blobId);
+                NKikimr::TLogoBlobID actual = msg.Queries[i].Id;
+
+                if (expected.IsSameBlob(actual)) {
+                    readBlobCount++;
+
+                    if (readBlobShouldFail) {
+                        auto response = std::make_unique<TEvBlobStorage::TEvGetResult>(
+                            NKikimrProto::ERROR,
+                            msg.QuerySize,
+                            0);  // groupId
+
+                        runtime.Schedule(
+                            new IEventHandle(
+                                ev->Sender,
+                                ev->Recipient,
+                                response.release(),
+                                0,
+                                ev->Cookie),
+                            TDuration());
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        };
+
+        runtime.SetEventFilter(
+            [eventHandler] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+                bool handled = false;
+
+                const auto wrapped = [&] (const auto& ev) {
+                    handled = eventHandler(ev);
+                };
+
+                switch (ev->GetTypeRewrite()) {
+                    hFunc(TEvBlobStorage::TEvGet, wrapped);
+                }
+                return handled;
+            }
+        );
+
+        bool suicideHappened = false;
+
+        runtime.SetObserverFunc([&] (TAutoPtr<IEventHandle>& ev) {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvTablet::EEv::EvTabletDead: {
+                        suicideHappened = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(ev);
+            }
+        );
+
+        for (ui32 i = 1; i < config.GetMaxReadBlobErrorsBeforeSuicide(); i++) {
+            partition.SendReadBlocksRequest(0);
+            auto response = partition.RecvReadBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+
+            UNIT_ASSERT_VALUES_EQUAL(i, readBlobCount);
+            UNIT_ASSERT(!suicideHappened);
+        }
+
+        partition.SendReadBlocksRequest(0);
+        auto response = partition.RecvReadBlocksResponse();
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            config.GetMaxReadBlobErrorsBeforeSuicide(),
+            readBlobCount);
+        UNIT_ASSERT(suicideHappened);
+        suicideHappened = false;
+
+        {
+            TPartitionClient partition(runtime);
+            partition.WaitReady();
+
+            readBlobShouldFail = false;
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(0))
+            );
+            UNIT_ASSERT(!suicideHappened);
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldFirstGarbageCollectionFlagReboot)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        bool garbageCollectorFinished = false;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartition::EvGarbageCollectorCompleted: {
+                        garbageCollectorFinished = true;
+                        break;
+                    }
+                }
+                return false;
+            }
+        );
+        partition.WaitReady();
+
+        UNIT_ASSERT(garbageCollectorFinished);
+
+        garbageCollectorFinished = false;
+
+        partition.CollectGarbage();
+        UNIT_ASSERT(!garbageCollectorFinished);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReportLongRunningWriteBlobOperations)
+    {
+        auto sendRequest = [](TPartitionClient& partition)
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 255));
+        };
+        auto receiveResponse = [](TPartitionClient& partition)
+        {
+            return partition.RecvWriteBlocksResponse();
+        };
+
+        DoShouldReportLongRunningBlobOperations(
+            sendRequest,
+            receiveResponse,
+            TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation::
+                WriteBlob,
+            false);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSkipEmptyRangesUponForcedCompactionWithMultipleRanges)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(3);
+        config.SetV1GarbageCompactionEnabled(false);
+
+        auto runtime = PrepareTestActorRuntime(config, MaxPartitionBlocksCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        const auto blockRange1 = TBlockRange32::WithLength(3 * 1024, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(4 * 1024, 1024);
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 2);
+
+        const auto response = partition.CompactRange(0, 5119);
+        UNIT_ASSERT_EQUAL(S_OK, response->GetError().GetCode());
+
+        partition.SendGetCompactionStatusRequest(response->Record.GetOperationId());
+        const auto compactionStatus = partition.RecvGetCompactionStatusResponse();
+        UNIT_ASSERT(SUCCEEDED(compactionStatus->GetStatus()));
+        UNIT_ASSERT_EQUAL(5, compactionStatus->Record.GetTotal());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyHandleWriteBlocksErrorsWithUnconfirmedBlobs)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4096,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TTestActorRuntimeBase::TEventFilter rejectWriteBlobFilter =
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+        {
+            switch (ev->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvWriteBlobResponse: {
+                    auto* msg =
+                        ev->Get<TEvPartitionCommonPrivate::TEvWriteBlobResponse>();
+                    auto& e = const_cast<NProto::TError&>(msg->Error);
+                    e.SetCode(E_REJECTED);
+                    return false;
+                }
+            };
+            return false;
+        };
+
+        // Set up event order controller to ensure that
+        // AddUnconfirmedBlobsResponse is processed before WriteBlobResponse
+        TEventExecutionOrderFilter orderFilter(
+            *runtime,
+            TVector<std::pair<ui32, ui32>>{
+                {TEvPartitionPrivate::EvAddUnconfirmedBlobsResponse,
+                 TEvPartitionCommonPrivate::EvWriteBlobResponse}});
+        runtime->SetEventFilter(orderFilter(rejectWriteBlobFilter));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(10, 1), 1);
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            // In case of errors we just delete obsolete unconfirmed blobs
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(
+        ShouldNotDeleteBlobsThatAreNotFullyAvailableForCompactionWithoutReadingBlockMasks)
+    {
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 'A');
+
+        partition.WriteBlocks(0, '0');
+
+        std::unique_ptr<IEventHandle> writeBlobRequest;
+
+        bool interceptWriteBlobRequest = true;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvWriteBlobRequest &&
+                    interceptWriteBlobRequest)
+                {
+                    writeBlobRequest.reset(event.Release());
+
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.SendWriteBlocksRequest(1, '1');
+
+        runtime->DispatchEvents({}, 10ms);
+
+        UNIT_ASSERT(writeBlobRequest);
+        interceptWriteBlobRequest = false;
+
+        partition.SendCompactionRequest();
+
+        runtime->DispatchEvents({}, 10ms);
+
+        partition.WriteBlocks(2, '2');
+
+        partition.Flush();
+        partition.TrimFreshLog();
+
+        runtime->SendAsync(writeBlobRequest.release());
+
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(response->GetStatus(), S_OK);
+
+        partition.Cleanup();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('0'),
+            GetBlockContent(partition.ReadBlocks(0)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('1'),
+            GetBlockContent(partition.ReadBlocks(1)));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent('2'),
+            GetBlockContent(partition.ReadBlocks(2)));
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split8.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split8.cpp
@@ -1,0 +1,1904 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit8)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldBatchIntersectingWrites)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetWriteRequestBatchingEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc(PartitionBatchWriteCollector(*runtime, 1000));
+
+        for (ui32 i = 0; i < 10; ++i) {
+            for (ui32 j = 0; j < 100; ++j) {
+                partition.SendWriteBlocksRequest(
+                    TBlockRange32::WithLength(i * 100, j + 1),
+                    i + 1);
+            }
+        }
+
+        for (ui32 i = 0; i < 1000; ++i) {
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT(stats.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(999, stats.GetMixedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(100, stats.GetFreshBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(1000, stats.GetUsedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1000,
+            stats.GetUserWriteCounters().GetRequestsCount());
+        const auto batchCount = stats.GetUserWriteCounters().GetBatchCount();
+        UNIT_ASSERT(batchCount < 1000);
+        UNIT_ASSERT(batchCount > 0);
+
+        for (ui32 i = 0; i < 10; ++i) {
+            for (ui32 j = 0; j < 100; ++j) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    GetBlockContent(i + 1),
+                    GetBlockContent(partition.ReadBlocks(i * 100 + j)));
+            }
+        }
+
+        UNIT_ASSERT(stats.GetUserWriteCounters().GetExecTime() != 0);
+
+        // checking that drain-related counters are in a consistent state
+        partition.Drain();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldMergeVersionsOnRead)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+        partition.Flush();
+
+        partition.WriteBlocks(1, 11);
+        partition.Flush();
+
+        partition.WriteBlocks(2, 22);
+        partition.Flush();
+
+        partition.WriteBlocks(3, 33);
+        // partition.Flush();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(11),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(22),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(33),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(
+        ShouldAutomaticallyRunIgnoringZeroedCompactionForSuperDirtyRanges)
+    {
+        DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDeleteCheckpointAfterDeleteCheckpointData)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig());
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.CreateCheckpoint("checkpoint1");
+        partition.DeleteCheckpointData("checkpoint1");
+
+        auto responseDelete = partition.DeleteCheckpoint("checkpoint1");
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, responseDelete->GetStatus());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSeeChangedFreshBlocksInChangedBlocksRequest)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0,1);
+        partition.WriteBlocks(1,1);
+        partition.CreateCheckpoint("cp1");
+
+        partition.WriteBlocks(1,2);
+        partition.WriteBlocks(2,2);
+        partition.CreateCheckpoint("cp2");
+
+        auto response = partition.GetChangedBlocks(
+            TBlockRange32::WithLength(0, 1024),
+            "cp1",
+            "cp2",
+            false);
+
+        UNIT_ASSERT_VALUES_EQUAL(128, response->Record.GetMask().size());
+        UNIT_ASSERT_VALUES_EQUAL(6, response->Record.GetMask()[0]);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldRejectCompactionRequestsIfDataChannelsAreAlmostFull)
+    {
+        // smoke test: tests that the compaction mechanism checks partition state
+        // detailed tests are located in part_state_ut.cpp
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        runtime->SetObserverFunc(StorageStateChanger(
+            NKikimrBlobStorage::StatusDiskSpaceLightYellowMove |
+            NKikimrBlobStorage::StatusDiskSpaceYellowStop));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        {
+            auto response = partition.Compaction();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetError().GetCode());
+        }
+
+        ui32 flags = NKikimrBlobStorage::StatusDiskSpaceLightYellowMove |
+            NKikimrBlobStorage::StatusDiskSpaceYellowStop;
+
+        const auto badFlags = {
+            NKikimrBlobStorage::StatusDiskSpaceLightOrange,
+            NKikimrBlobStorage::StatusDiskSpacePreOrange,
+            NKikimrBlobStorage::StatusDiskSpaceOrange,
+            NKikimrBlobStorage::StatusDiskSpaceRed,
+            NKikimrBlobStorage::StatusDiskSpaceBlack
+        };
+
+        for (const auto flag: badFlags) {
+            flags |= flag;
+
+            partition.RebootTablet();
+
+            runtime->SetObserverFunc(StorageStateChanger(flags));
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+            auto request = partition.CreateCompactionRequest();
+            partition.SendToPipe(std::move(request));
+
+            auto response = partition.RecvResponse<TEvPartitionPrivate::TEvCompactionResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_BS_OUT_OF_SPACE, response->GetError().GetCode());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyCopyUsedBlocksCountForOverlayDisk)
+    {
+        ui32 blockCount =  1024 * 1024 * 1024;
+        ui32 usedBlocksCount = 0;
+
+        TPartitionContent baseContent;
+        for (size_t i = 0; i < blockCount/4; i += 50) {
+            baseContent.push_back(TBlob(i, 0, 49));
+            usedBlocksCount += 49;
+            baseContent.push_back(TEmpty());
+        }
+
+        auto partitionWithRuntime = SetupOverlayPartition(
+            TestTabletId,
+            TestTabletId2,
+            baseContent,
+            {},
+            DefaultBlockSize,
+            blockCount,
+            DefaultConfig());
+
+        auto& partition = *partitionWithRuntime.Partition;
+
+        auto response = partition.StatPartition();
+        auto stats = response->Record.GetStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUsedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            usedBlocksCount,
+            stats.GetLogicalUsedBlocksCount()
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnErrorWhenReadingFromUnknownCheckpoint)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.SendReadBlocksRequest(TBlockRange32::MakeOneBlock(0), "unknown");
+
+        auto response = partition.RecvReadBlocksResponse();
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotReleaseTrimBarriersOnFlushError)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetMaxWriteBlobErrorsBeforeSuicide(10);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 2));
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 2));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetFreshBlocksCount());
+        }
+
+        bool flush = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvPutResult: {
+                        if (flush) {
+                            auto* msg = event->Get<TEvBlobStorage::TEvPutResult>();
+                            msg->Status = NKikimrProto::ERROR;
+                            flush = false;
+                        }
+                        break;
+                    }
+                }
+
+                return false;
+            }
+        );
+
+        flush = true;
+        partition.SendFlushRequest();
+        auto response = partition.RecvFlushResponse();
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 2));
+
+        partition.Flush();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldNotKillTabletBeforeMaxWriteBlobErrorsHappen)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetMaxWriteBlobErrorsBeforeSuicide(5);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1001), 1);
+
+        const auto eventHandler = [&] (const TEvBlobStorage::TEvPut::TPtr& ev) {
+            TLogoBlobID logoBlobId;
+            auto response = std::make_unique<TEvBlobStorage::TEvPutResult>(
+                NKikimrProto::ERROR,
+                logoBlobId,
+                0, // statusFlags
+                0, // groupId
+                0 // approximateFreeSpaceShare
+            );
+
+            runtime->Schedule(
+                new IEventHandle(
+                    ev->Sender,
+                    ev->Recipient,
+                    response.release(),
+                    0,
+                    ev->Cookie),
+                TDuration());
+
+            return true;
+        };
+
+        runtime->SetEventFilter(
+            [eventHandler] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+                bool handled = false;
+
+                const auto wrapped = [&] (const auto& ev) {
+                    handled = eventHandler(ev);
+                };
+
+                switch (ev->GetTypeRewrite()) {
+                    hFunc(TEvBlobStorage::TEvPut, wrapped);
+                }
+                return handled;
+            }
+        );
+
+        bool suicideHappened = false;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& ev) {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvTablet::EEv::EvTabletDead: {
+                        suicideHappened = true;
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(ev);
+            }
+        );
+
+        for (ui32 i = 1; i < config.GetMaxWriteBlobErrorsBeforeSuicide(); i++) {
+            partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1001), 1);
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+            UNIT_ASSERT(!suicideHappened);
+        }
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(0, 1001), 1);
+        auto response = partition.RecvWriteBlocksResponse();
+        UNIT_ASSERT(FAILED(response->GetStatus()));
+
+        UNIT_ASSERT(suicideHappened);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldWriteBlocksWhenAddingUnconfirmedBlobs)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        bool dropAddConfirmedBlobs = false;
+
+        runtime->SetObserverFunc([&] (auto& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionPrivate::EvAddConfirmedBlobsRequest: {
+                    if (dropAddConfirmedBlobs) {
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(11, 0);
+        partition.CreateCheckpoint("checkpoint");
+
+        partition.WriteBlocks(10, 1);
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetConfirmedBlobCount());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(10))
+        );
+
+        dropAddConfirmedBlobs = true;
+        partition.WriteBlocks(11, 2);
+
+        {
+            // can't read unconfirmed range
+            partition.SendReadBlocksRequest(11);
+            auto response = partition.RecvReadBlocksResponse();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+        }
+
+        {
+            // can't describe unconfirmed range
+            partition.SendDescribeBlocksRequest(TBlockRange32::WithLength(11, 1), "");
+            auto response =
+                partition.RecvResponse<TEvVolume::TEvDescribeBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+        }
+
+        {
+            // can't do GetChangedBlocks on unconfirmed range
+            partition.SendGetChangedBlocksRequest(
+                TBlockRange32::WithLength(11, 1),
+                "checkpoint",
+                "",
+                false);
+            auto response =
+                partition.RecvResponse<TEvService::TEvGetChangedBlocksResponse>();
+            UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetConfirmedBlobCount());
+        }
+
+        // but we can work with other ranges
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(10))
+        );
+        partition.DescribeBlocks(TBlockRange32::WithLength(10, 1), "");
+        partition.GetChangedBlocks(TBlockRange32::WithLength(10, 1), "checkpoint", "", false);
+
+        // older commits are also available even when range overlaps with
+        // unconfirmed blobs
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(0),
+            GetBlockContent(partition.ReadBlocks(11, "checkpoint"))
+        );
+        partition.DescribeBlocks(TBlockRange32::WithLength(11, 1), "checkpoint");
+        partition.GetChangedBlocks(TBlockRange32::WithLength(11, 1), "", "checkpoint", false);
+
+        dropAddConfirmedBlobs = false;
+        partition.RebootTablet();
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(11))
+        );
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetConfirmedBlobCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReportLongRunningReadBlobOperationCancel)
+    {
+        auto sendRequest = [](TPartitionClient& partition)
+        {
+            partition.SendReadBlocksRequest(0);
+        };
+        auto receiveResponse = [](TPartitionClient& partition)
+        {
+            return partition.RecvReadBlocksResponse();
+        };
+
+        DoShouldReportLongRunningBlobOperations(
+            sendRequest,
+            receiveResponse,
+            TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation::
+                ReadBlob,
+            true);
+    }
+
+
+
+    Y_UNIT_TEST(ShouldBatchSmallWritesToFreshChannelIfThresholdNotExceeded)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetWriteRequestBatchingEnabled(true);
+        config.SetWriteBlobThreshold(2_MB);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const ui32 blockCount = 500;
+        runtime->SetObserverFunc(
+            PartitionBatchWriteCollector(*runtime, blockCount));
+
+        for (ui32 i = 0; i < blockCount; ++i) {
+            partition.SendWriteBlocksRequest(i, i);
+        }
+
+        for (ui32 i = 0; i < blockCount; ++i) {
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlocksCount());
+        UNIT_ASSERT_VALUES_EQUAL(blockCount, stats.GetFreshBlocksCount());
+
+        // checking that drain-related counters are in a consistent state
+        partition.Drain();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSendCorrectBarriersInfoAfterReboot)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4096,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        using TBarrierKey = std::tuple<ui32, ui32, ui32>;
+        using TBarrierValue = std::pair<ui32, ui32>;
+        using TBarriers = std::map<TBarrierKey, TBarrierValue>;
+        TBarriers barriers;
+
+        bool rejectWrite = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+            {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvPartitionCommonPrivate::EvWriteBlobResponse: {
+                        if (rejectWrite) {
+                            auto* msg = ev->Get<
+                                TEvPartitionCommonPrivate::TEvWriteBlobResponse>();
+                            auto& e = const_cast<NProto::TError&>(msg->Error);
+                            e.SetCode(E_REJECTED);
+                        }
+                        return false;
+                    }
+                    case TEvBlobStorage::EvCollectGarbage: {
+                        auto* msg =
+                            ev->Get<TEvBlobStorage::TEvCollectGarbage>();
+                        TBarrierKey key = std::tie(
+                            msg->RecordGeneration,
+                            msg->PerGenerationCounter,
+                            msg->Channel);
+                        TBarrierValue value = std::make_pair(
+                            msg->CollectGeneration,
+                            msg->CollectStep);
+                        const auto it = barriers.insert(TBarriers::value_type(key, value));
+                        UNIT_ASSERT(it.second || it.first->second == value);
+                        return false;
+                    }
+                };
+                return false;
+            });
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(11, 1), 0);
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(10, 1), 1);
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+        }
+
+        rejectWrite = true;
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(11, 1), 0);
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(10, 1), 1);
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+        }
+
+        rejectWrite = false;
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+        }
+
+        UNIT_ASSERT(!barriers.empty());
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSplitFlushBlobsByCompactionRangeBoundaries)
+    {
+        constexpr ui32 rangeSize = 1024;
+        constexpr ui32 blockCount = rangeSize * 3;
+
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetSplitByCompactionRangeMaxBlobCount(3);
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            partition.WriteBlocks(i, 1);
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            partition.WriteBlocks(i, 2);
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            partition.WriteBlocks(i, 3);
+        }
+
+        ui32 mixedBlobsCount = 0;
+        TVector<TVector<ui32>> blobIndexes;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                            mixedBlobsCount = msg->FreshBlobs.size();
+
+                            for (const auto& blob: msg->FreshBlobs) {
+                                blobIndexes.emplace_back();
+                                for (const auto& block: blob.Blocks) {
+                                    blobIndexes.back().push_back(
+                                        block.BlockIndex);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Flush();
+
+        // Expect 3 blobs: [1022-1023], [1024-1025] + [1500-1504] + [2045-2047],
+        // [2048-2049]
+        UNIT_ASSERT_VALUES_EQUAL(3, mixedBlobsCount);
+
+        for (const auto& blobBlocks: blobIndexes) {
+            ui32 rangeIndex = blobBlocks.front() / rangeSize;
+            for (auto blockIdx: blobBlocks) {
+                UNIT_ASSERT_VALUES_EQUAL(rangeIndex, blockIdx / rangeSize);
+            }
+        }
+
+        partition.Compaction();
+        partition.Compaction();
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                3,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut_split9.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut_split9.cpp
@@ -1,0 +1,2124 @@
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
+#include "part_ut_helpers.h"
+
+Y_UNIT_TEST_SUITE(TPartitionTestSplit9)
+{
+void DoShouldAutomaticallyRunGarbageOrIgnoringZeroedCompaction(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(999999);
+
+        auto runtime = PrepareTestActorRuntime(config, 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 301));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        // marking range 0 as non-compacted
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+        // 50% garbage
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(1024, 1400));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.CreateCheckpoint("c1");
+
+        // writing lots of blocks into range 1
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024));
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // there is a checkpoint => zeroed compaction should not run
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        // triggering compaction attempt, block index does not matter
+        partition.WriteBlocks(0);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerRange);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerDisk > 0);
+            UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+            UNIT_ASSERT(compactionByGarbageBlocksPerDisk > 0);
+        }
+    }
+
+void DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetHDDCompactionType(NProto::CT_LOAD);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(
+            ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(200);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 compactionByGarbageBlocksPerRange = 0;
+        ui64 compactionByGarbageBlocksPerDisk = 0;
+        ui64 compactionByIgnoringZeroedPerRange = 0;
+        ui64 compactionByIgnoringZeroedPerDisk = 0;
+        bool garbageCompactionRequestObserved = false;
+        bool ignoringZeroedCompactionRequestObserved = false;
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        } else if (
+                            msg->Mode ==
+                            TEvPartitionPrivate::IgnoringZeroedCompaction)
+                        {
+                            ignoringZeroedCompactionRequestObserved =
+                                true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Cumulative;
+                        compactionByIgnoringZeroedPerRange =
+                            cc.CompactionByIgnoringZeroedPerRange.Value;
+                        compactionByIgnoringZeroedPerDisk =
+                            cc.CompactionByIgnoringZeroedPerDisk.Value;
+                        compactionByGarbageBlocksPerRange =
+                            cc.CompactionByGarbageBlocksPerRange.Value;
+                        compactionByGarbageBlocksPerDisk =
+                            cc.CompactionByGarbageBlocksPerDisk.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        auto checkCompactionRequests = [&](bool shouldObserveRequest)
+        {
+            if (!shouldObserveRequest) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            } else if (ignoringZeroedCompactionEnabled) {
+                UNIT_ASSERT(!garbageCompactionRequestObserved);
+                UNIT_ASSERT(ignoringZeroedCompactionRequestObserved);
+            } else {
+                UNIT_ASSERT(garbageCompactionRequestObserved);
+                UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+            }
+            garbageCompactionRequestObserved = false;
+            ignoringZeroedCompactionRequestObserved = false;
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x1 => no compaction
+        checkCompactionRequests(false);
+
+        partition.CreateCheckpoint("c1");
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1024, stats.GetCompactionGarbageScore());
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => still no compaction because there is a
+        // checkpoint
+        checkCompactionRequests(false);
+
+        partition.DeleteCheckpoint("c1");
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used x2 => compaction
+        checkCompactionRequests(true);
+
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::MakeOneBlock(0));
+        partition.Flush();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetCompactionGarbageScore());
+        }
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // block count for this range should've been reset
+        checkCompactionRequests(false);
+
+        // a range with no used blocks
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // only garbage => compaction
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+        UNIT_ASSERT(!ignoringZeroedCompactionRequestObserved);
+        garbageCompactionRequestObserved = false;
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // no garbage (99% of the blocks belong to a deletion marker) => no
+        // compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == used => no compaction
+        checkCompactionRequests(false);
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 101));
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // garbage == 2 * used => compaction
+        checkCompactionRequests(true);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_EQUAL(0, compactionByGarbageBlocksPerDisk);
+        UNIT_ASSERT(compactionByGarbageBlocksPerRange > 0);
+        UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerDisk);
+
+        if (ignoringZeroedCompactionEnabled) {
+            UNIT_ASSERT(compactionByIgnoringZeroedPerRange > 0);
+        } else {
+            UNIT_ASSERT_EQUAL(0, compactionByIgnoringZeroedPerRange);
+        }
+    }
+
+auto BuildEvGetBreaker(ui32 blockCount, bool& broken) {
+        return [blockCount, &broken] (TAutoPtr<IEventHandle>& event) {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    ui32 totalSize = 0;
+                    for (ui32 i = 0; i < msg->ResponseSz; ++i) {
+                        totalSize += msg->Responses[i].Buffer.size();
+                    }
+                    if (totalSize == blockCount * DefaultBlockSize) {
+                        // it's our blob
+                        msg->Responses[0].Status = NKikimrProto::NODATA;
+                        broken = true;
+                    }
+
+                    break;
+                }
+            }
+
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+    }
+
+void DoTestFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.WriteBlocks(
+                TBlockRange32::WithLength(range * 1024, 1024),
+                1);
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestEmptyRangesFullCompaction(bool forced)
+    {
+        constexpr ui32 rangesCount = 5;
+        constexpr ui32 emptyRange = 2;
+        auto storageConfig = DefaultConfig();
+        storageConfig.SetWriteBlobThreshold(1_MB);
+        auto runtime = PrepareTestActorRuntime(storageConfig, rangesCount * 1024);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            if (range != emptyRange) {
+                partition.WriteBlocks(
+                    TBlockRange32::WithLength(range * 1024, 900),
+                    1);
+            }
+        }
+        partition.Flush();
+
+        auto response = partition.StatPartition();
+        auto oldStats = response->Record.GetStats();
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        if (forced) {
+            options.set(ToBit(ECompactionOption::Forced));
+        }
+
+        for (ui32 range = 0; range < rangesCount; ++range) {
+            partition.Compaction(range * 1024, options);
+        }
+
+        response = partition.StatPartition();
+        auto newStats = response->Record.GetStats();
+        UNIT_ASSERT_VALUES_EQUAL(
+            oldStats.GetMixedBlobsCount() + oldStats.GetMergedBlobsCount() + rangesCount - 1,
+            newStats.GetMixedBlobsCount() + newStats.GetMergedBlobsCount()
+        );
+    }
+
+void DoTestIncrementalCompaction(
+        NProto::TStorageServiceConfig config,
+        NProto::EStorageMediaKind mediaKind,
+        bool incrementalCompactionExpected)
+    {
+        if (mediaKind == NCloud::NProto::STORAGE_MEDIA_SSD) {
+            config.SetWriteBlobThresholdSSD(1);   // disable FreshBlocks
+            config.SetSSDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompaction(1);
+        }
+        else {
+            config.SetWriteBlobThreshold(1);   // disable FreshBlocks
+            config.SetHDDMaxBlobsPerRange(4);
+            config.SetMaxSkippedBlobsDuringCompactionHDD(1);
+        }
+        config.SetIncrementalCompactionEnabled(true);
+        config.SetTargetCompactionBytesPerOp(64_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = mediaKind});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        std::unique_ptr<IEventHandle> compactionRequest;
+        bool intercept = true;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (intercept) {
+                            auto request =
+                                event->Get<TEvPartitionPrivate::TEvCompactionRequest>();
+                            UNIT_ASSERT_VALUES_EQUAL(
+                                incrementalCompactionExpected,
+                                !request->CompactionOptions.test(
+                                    ToBit(ECompactionOption::Full))
+                            );
+
+                            compactionRequest.reset(event.Release());
+                            intercept = false;
+
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+
+                        break;
+                    }
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 2);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(10, 14), 3);
+        partition.WriteBlocks(TBlockRange32::MakeClosedInterval(20, 25), 4);
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(1040, stats.GetMergedBlocksCount());
+        }
+
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        UNIT_ASSERT(compactionRequest);
+        runtime->Send(compactionRequest.release());
+        runtime->DispatchEvents({}, TDuration::Seconds(1));
+        partition.Cleanup();
+        partition.CollectGarbage();
+
+        {
+            ui32 blobs = incrementalCompactionExpected ? 2 : 1;
+            ui32 blocks = incrementalCompactionExpected ? 1040 : 1024;
+
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(blobs, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(blocks, stats.GetMergedBlocksCount());
+        }
+
+        for (ui32 i = 0; i <= 4; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(2),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 5; i < 10; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 10; i <= 14; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(3),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 15; i < 20; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 20; i <= 25; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(4),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+
+        for (ui32 i = 26; i < 1023; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlocksContent(1),
+                GetBlocksContent(partition.ReadBlocks(i))
+            );
+        }
+    }
+
+// NBS-3934
+void DoTestCompression(
+        ui32 writeBlobThreshold,
+        ui32 uncompressedExpected,
+        ui32 compressedExpected)
+    {
+        auto config = DefaultConfig();
+        config.SetBlobCompressionRate(1);
+        config.SetWriteBlobThreshold(writeBlobThreshold);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui32 uncompressed = 0;
+        ui32 compressed = 0;
+
+        auto obs =
+            [&] (TAutoPtr<IEventHandle>& event) {
+                if (event->GetTypeRewrite()
+                        == TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        event->Get<TEvStatsService::TEvVolumePartCounters>();
+
+                    const auto& cc = msg->DiskCounters->Cumulative;
+                    uncompressed = cc.UncompressedBytesWritten.Value;
+                    compressed = cc.CompressedBytesWritten.Value;
+                }
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            };
+
+        runtime->SetObserverFunc(obs);
+
+        partition.WriteBlocks(1, 1);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(uncompressedExpected, uncompressed);
+        UNIT_ASSERT_VALUES_EQUAL(compressedExpected, compressed);
+    }
+
+class TStatsChecker
+    {
+    private:
+        ui64 RealWriteBlocksCount = 0;
+        ui64 RealReadBlocksCount = 0;
+        ui64 WriteBlocksCount = 0;
+        ui64 ReadBlocksCount = 0;
+
+    public:
+        TStatsChecker() = default;
+
+        void CheckStats(
+            const NProto::TVolumeStats& stats,
+            const ui64 realReadBlocksCount,
+            const ui64 realWriteBlocksCount,
+            const ui64 readBlocksCount,
+            const ui64 writeBlocksCount)
+        {
+            RealReadBlocksCount += realReadBlocksCount;
+            RealWriteBlocksCount += realWriteBlocksCount;
+            ReadBlocksCount += readBlocksCount;
+            WriteBlocksCount += writeBlocksCount;
+            UNIT_ASSERT_VALUES_EQUAL(
+                ReadBlocksCount, stats.GetSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                WriteBlocksCount, stats.GetSysWriteCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealReadBlocksCount,
+                stats.GetRealSysReadCounters().GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                RealWriteBlocksCount,
+                stats.GetRealSysWriteCounters().GetBlocksCount());
+        }
+    };
+
+void CheckIncrementAndDecrementCompactionPerRun(
+        ui32 rangeCountPerRun,
+        ui32 maxBlobsPerUnit,
+        ui32 maxBlobsPerRange,
+        ui32 diskGarbageThreshold,
+        ui32 rangeGarbageThreshold,
+        ui32 blobsCountAfterCompaction,
+        ui32 increasingPercentageThreshold,
+        ui32 decreasingPercentageThreshold,
+        ui32 compactionRangeCountPerRun,
+        ui32 maxCompactionRangeCountPerRun = 10)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetCompactionGarbageThreshold(diskGarbageThreshold);
+        config.SetCompactionRangeGarbageThreshold(rangeGarbageThreshold);
+        config.SetCompactionRangeCountPerRun(rangeCountPerRun);
+        config.SetCompactionCountPerRunIncreasingThreshold(
+            increasingPercentageThreshold);
+        config.SetCompactionCountPerRunDecreasingThreshold(
+            decreasingPercentageThreshold);
+        config.SetHDDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetSSDMaxBlobsPerUnit(maxBlobsPerUnit);
+        config.SetMaxCompactionRangeCountPerRun(maxCompactionRangeCountPerRun);
+        config.SetCompactionCountPerRunChangingPeriod(1);
+        config.SetSSDMaxBlobsPerRange(maxBlobsPerRange);
+        config.SetHDDMaxBlobsPerRange(maxBlobsPerRange);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4 * 1024 * 1024
+        );
+        runtime->AdvanceCurrentTime(TDuration::Seconds(5));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+
+        bool compactionFilter = true;
+        ui32 resultCompactionRangeCountPerRun = 0;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (compactionFilter) {
+                            return true;
+                        }
+                        compactionFilter = true;
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event->Get<TEvStatsService::TEvVolumePartCounters>();
+                        const auto& cc = msg->DiskCounters->Simple;
+                        resultCompactionRangeCountPerRun =
+                            cc.CompactionRangeCountPerRun.Value;
+                    }
+                }
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange3, 7);
+
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+        partition.WriteBlocks(blockRange3, 10);
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        compactionFilter = false;
+
+        partition.Compaction();
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(blobsCountAfterCompaction,
+                stats.GetMergedBlobsCount());
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+            UNIT_ASSERT_VALUES_EQUAL(compactionRangeCountPerRun,
+                resultCompactionRangeCountPerRun);
+        }
+    }
+
+template <typename FSend, typename FReceive>
+    void DoShouldReportLongRunningBlobOperations(
+        FSend sendRequest,
+        FReceive receiveResponse,
+        TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation
+            expectedOperation,
+        bool killPartition)
+    {
+        auto config = DefaultConfig();
+
+        TTestPartitionInfo testPartitionInfo;
+        testPartitionInfo.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD;
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            testPartitionInfo,
+            {},
+            EStorageAccessMode::Default);
+
+        // Enable Schedule for all actors!!!
+        runtime->SetRegistrationObserverFunc(
+            [](auto& runtime, const auto& parentId, const auto& actorId)
+            {
+                Y_UNUSED(parentId);
+                runtime.EnableScheduleForActor(actorId);
+            });
+
+        // Make partition client.
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 255));
+
+        // Make handler for stealing nested messages
+        std::vector<std::unique_ptr<IEventHandle>> stolenRequests;
+        auto requestThief = [&](TAutoPtr<IEventHandle>& event)
+        {
+            switch (event->GetTypeRewrite()) {
+                case TEvBlobStorage::EvGetResult:
+                case TEvBlobStorage::EvPutResult: {
+                    stolenRequests.push_back(
+                        std::unique_ptr<IEventHandle>{event.Release()});
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Make handler for intercepting EvLongRunningOperation message.
+        // Attention! counters will be doubled, because we will intercept the
+        // requests sent to TPartitionActor and TVolumeActor.
+        ui32 longRunningBeginCount = 0;
+        ui32 longRunningFinishCount = 0;
+        ui32 longRunningPingCount = 0;
+        ui32 longRunningCanceledCount = 0;
+
+        auto takeCounters = [&](TAutoPtr<IEventHandle>& event)
+        {
+            using TEvLongRunningOperation =
+                TEvPartitionCommonPrivate::TEvLongRunningOperation;
+            using EReason = TEvLongRunningOperation::EReason;
+
+            if (event->GetTypeRewrite() ==
+                TEvPartitionCommonPrivate::EvLongRunningOperation)
+            {
+                auto* msg = event->Get<TEvLongRunningOperation>();
+
+                UNIT_ASSERT_VALUES_EQUAL(expectedOperation, msg->Operation);
+
+                switch (msg->Reason) {
+                    case EReason::LongRunningDetected:
+                        if (msg->FirstNotify) {
+                            longRunningBeginCount++;
+                        } else {
+                            longRunningPingCount++;
+                        }
+                        break;
+                    case EReason::FinishedOk:
+                        longRunningFinishCount++;
+                        break;
+                    case EReason::Cancelled:
+                        longRunningCanceledCount++;
+                        break;
+                }
+            }
+            return TTestActorRuntime::DefaultObserverFunc(event);
+        };
+
+        // Ready to postpone request.
+        runtime->SetObserverFunc(requestThief);
+
+        // Starting the execution of the request. It won't
+        // be finished since we stole it EvPutResult message.
+        sendRequest(partition);
+        runtime->DispatchEvents({}, TDuration());
+        UNIT_ASSERT_VALUES_UNEQUAL(0, stolenRequests.size());
+
+        // Ready to check counters.
+        runtime->SetObserverFunc(takeCounters);
+
+        // Wait for EvLongRunningOperation arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #1 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait #2 for EvLongRunningOperation ping arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        if (killPartition) {
+            partition.KillTablet();
+        } else {
+            // Returning stolen requests to complete the execution of the
+            // request.
+            for (auto& request: stolenRequests) {
+                runtime->Send(request.release());
+            }
+        }
+
+        // Wait for EvLongRunningOperation (finish or cancel) arrival.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvPartitionCommonPrivate::EvLongRunningOperation);
+            runtime->AdvanceCurrentTime(TDuration::Seconds(60));
+            runtime->DispatchEvents(options, TDuration::Seconds(1));
+        }
+
+        // Wait for background operations completion.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // Check request completed.
+        {
+            auto response = receiveResponse(partition);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                killPartition ? E_REJECTED : S_OK,
+                response->GetStatus(),
+                response->GetErrorReason());
+        }
+        // Wait for EvVolumePartCounters arrived.
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, longRunningBeginCount);
+            UNIT_ASSERT_VALUES_EQUAL(4, longRunningPingCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 0 : 2,
+                longRunningFinishCount);
+            UNIT_ASSERT_VALUES_EQUAL(
+                killPartition ? 2 : 0,
+                longRunningCanceledCount);
+        }
+
+        if (!killPartition) {
+            // smoke test for monpage
+            auto channelsTab = partition.RemoteHttpInfo(
+                BuildRemoteHttpQuery(TestTabletId, {}, "Channels"),
+                HTTP_METHOD::HTTP_METHOD_GET);
+
+            UNIT_ASSERT_C(channelsTab->Html.Contains("svg"), channelsTab->Html);
+        }
+    }
+
+void EnableReadBlobCorruption(
+        TTestActorRuntime& runtime,
+        ui16 checkedOffset = InvalidBlobOffset)
+    {
+        TVector<ui16> blobOffsets;
+
+        runtime.SetEventFilter([=] (
+            TTestActorRuntimeBase& runtime,
+            TAutoPtr<IEventHandle>& event) mutable
+        {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvReadBlobRequest: {
+                    using TEv =
+                        TEvPartitionCommonPrivate::TEvReadBlobRequest;
+                    auto* msg = event->Get<TEv>();
+                    blobOffsets = msg->BlobOffsets;
+
+                    break;
+                }
+                case TEvBlobStorage::EvGetResult: {
+                    auto* msg = event->Get<TEvBlobStorage::TEvGetResult>();
+                    UNIT_ASSERT(!blobOffsets.empty());
+                    if (checkedOffset == InvalidBlobOffset
+                            || blobOffsets[0] == checkedOffset)
+                    {
+                        auto& rope = msg->Responses[0].Buffer;
+                        auto dst = rope.begin();
+                        char* to = const_cast<char*>(dst.ContiguousData());
+                        memset(to, 0, dst.ContiguousSize());
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        });
+    }
+
+void DoShouldAbortCompactionIfBlobStorageRequestFailsWithDeadlineExceeded(
+        int requestType)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetBlobStorageAsyncRequestTimeoutHDD(TDuration::Seconds(1).MilliSeconds());
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        ui32 failedReadBlob = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& ev)
+            {
+                Y_UNUSED(runtime);
+
+                if (requestType == TEvBlobStorage::EvVGet &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVGet)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVGet>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncRead &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    requestType == TEvBlobStorage::EvVPut &&
+                    ev->GetTypeRewrite() == TEvBlobStorage::EvVPut)
+                {
+                    const auto* msg = ev->Get<TEvBlobStorage::TEvVPut>();
+                    if (msg->Record.GetHandleClass() ==
+                            NKikimrBlobStorage::AsyncBlob &&
+                        msg->Record.GetMsgQoS().HasDeadlineSeconds())
+                    {
+                        return true;
+                    }
+                } else if (
+                    ev->GetTypeRewrite() ==
+                    TEvStatsService::EvVolumePartCounters)
+                {
+                    auto* msg =
+                        ev->Get<TEvStatsService::TEvVolumePartCounters>();
+                    failedReadBlob =
+                        msg->DiskCounters->Simple.ReadBlobDeadlineCount.Value;
+                }
+                return false;
+            });
+
+        partition.SendCompactionRequest();
+        runtime->AdvanceCurrentTime(TDuration::Seconds(1));
+        auto response = partition.RecvCompactionResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, response->GetError().GetCode());
+
+        runtime->AdvanceCurrentTime(TDuration::Seconds(15));
+
+        if (requestType != TEvBlobStorage::EvVGet) {
+            return;
+        }
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(1, failedReadBlob);
+    }
+
+void TestForcedCompaction(ui32 rangesPerRun)
+    {
+        auto config = DefaultConfig();
+        config.SetBatchCompactionEnabled(true);
+        config.SetForcedCompactionRangeCountPerRun(rangesPerRun);
+        config.SetV1GarbageCompactionEnabled(false);
+        config.SetWriteBlobThreshold(15_KB);
+        config.SetIncrementalCompactionEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 1);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 2);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 3);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 4);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(3),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(1),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(2),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(4),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+        }
+
+        // write to the same blocks, we need several blobs in one compacted range
+        {
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 5), 12);
+            partition.WriteBlocks(TBlockRange32::WithLength(1024, 5), 22);
+
+            partition.WriteBlocks(TBlockRange32::WithLength(0, 1), 32);
+            partition.WriteBlocks(TBlockRange32::WithLength(1028, 3), 42);
+            partition.Flush();
+
+            const auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(22, stats.GetMergedBlocksCount());
+        }
+
+        {
+            const auto response = partition.CompactRange(0, 0);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            partition.Cleanup();
+
+            const auto statResponse = partition.StatPartition();
+            const auto& stats = statResponse->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetMergedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(12, stats.GetMergedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(32),
+                GetBlockContent(partition.ReadBlocks(0)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(12),
+                GetBlockContent(partition.ReadBlocks(1)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(22),
+                GetBlockContent(partition.ReadBlocks(1024)));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetBlockContent(42),
+                GetBlockContent(partition.ReadBlocks(1028)));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRespectMaxBlobRangeSizeDuringBatching)
+    {
+        NProto::TStorageServiceConfig config = DefaultConfig();
+        const auto maxBlobRangeSize = 2048;
+        config.SetMaxBlobRangeSize(maxBlobRangeSize * 4_KB);
+        config.SetWriteRequestBatchingEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config, maxBlobRangeSize * 2);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (ui32 i = 0; i < maxBlobRangeSize; ++i) {
+            partition.SendWriteBlocksRequest(i % 2 ? i : maxBlobRangeSize + i, i);
+        }
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_WRITE_RESULT) {
+                            const auto& mixedBlobs = msg->MixedBlobs;
+                            for (const auto& blob: mixedBlobs) {
+                                const auto blobRangeSize =
+                                    blob.Blocks.back() - blob.Blocks.front();
+                                Cdbg << blobRangeSize << Endl;
+                                UNIT_ASSERT(blobRangeSize <= maxBlobRangeSize);
+                            }
+                        }
+
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        for (ui32 i = 0; i < maxBlobRangeSize; ++i) {
+            auto response = partition.RecvWriteBlocksResponse();
+            UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+        }
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+        UNIT_ASSERT(stats.GetMixedBlobsCount());
+
+        for (ui32 i = 0; i < maxBlobRangeSize; ++i) {
+            const auto block =
+                partition.ReadBlocks(i % 2 ? i : maxBlobRangeSize + i);
+            UNIT_ASSERT_VALUES_EQUAL(GetBlockContent(i), GetBlockContent(block));
+        }
+
+        UNIT_ASSERT(stats.GetUserWriteCounters().GetExecTime() != 0);
+
+        // checking that drain-related counters are in a consistent state
+        partition.Drain();
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReplaceBlobsOnCompaction)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+        partition.Flush();
+
+        partition.WriteBlocks(1, 11);
+        partition.Flush();
+
+        partition.WriteBlocks(2, 22);
+        partition.Flush();
+
+        partition.WriteBlocks(3, 33);
+        partition.Flush();
+
+        partition.Compaction();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(11),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(22),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(33),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+
+        auto response = partition.StatPartition();
+        const auto& stats = response->Record.GetStats();
+
+        UNIT_ASSERT(stats.GetSysReadCounters().GetExecTime() != 0);
+        UNIT_ASSERT(stats.GetSysWriteCounters().GetExecTime() != 0);
+        UNIT_ASSERT(stats.GetUserReadCounters().GetExecTime() != 0);
+    }
+
+
+
+    Y_UNIT_TEST(CompactionShouldTakeCareOfFreshBlocks)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.WriteBlocks(2, 2);
+        partition.WriteBlocks(3, 3);
+        partition.Flush();
+
+        partition.WriteBlocks(1, 11);
+        partition.Flush();
+
+        partition.WriteBlocks(2, 22);
+        partition.Flush();
+
+        partition.WriteBlocks(3, 33);
+        // partition.Flush();
+
+        partition.Compaction();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(11),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(22),
+            GetBlockContent(partition.ReadBlocks(2))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(33),
+            GetBlockContent(partition.ReadBlocks(3))
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldDeleteCheckpointAfterDeleteCheckpointDataAndReboot)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig());
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(1, 1);
+        partition.CreateCheckpoint("checkpoint1");
+        partition.Flush();
+        partition.WriteBlocks(1, 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(1),
+            GetBlockContent(partition.ReadBlocks(1, "checkpoint1"))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(2),
+            GetBlockContent(partition.ReadBlocks(1))
+        );
+
+        partition.CreateCheckpoint("checkpoint1");
+        partition.DeleteCheckpointData("checkpoint1");
+
+        partition.SendReadBlocksRequest(1, "checkpoint1");
+        auto response = partition.RecvReadBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, response->GetStatus());
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        partition.SendReadBlocksRequest(1, "checkpoint1");
+        response = partition.RecvReadBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL(E_NOT_FOUND, response->GetStatus());
+
+        {
+            auto responseDelete = partition.DeleteCheckpoint("checkpoint1");
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, responseDelete->GetStatus());
+        }
+        {
+            auto responseCreate = partition.CreateCheckpoint("checkpoint1");
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, responseCreate->GetStatus());
+        }
+        {
+            auto responseDelete = partition.DeleteCheckpoint("checkpoint1");
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, responseDelete->GetStatus());
+        }
+        {
+            partition.CreateCheckpoint("checkpoint1", "id1");
+            partition.DeleteCheckpointData("checkpoint1");
+            auto responseCreate = partition.CreateCheckpoint("checkpoint1", "id1");
+            UNIT_ASSERT_VALUES_EQUAL(S_ALREADY, responseCreate->GetStatus());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSeeChangedMergedBlocksInChangedBlocksRequest)
+    {
+        auto config = DefaultConfig();
+
+        auto runtime = PrepareTestActorRuntime(config, 4096);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024), 1);
+        partition.CreateCheckpoint("cp1");
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1024,1024), 2);
+        partition.WriteBlocks(TBlockRange32::WithLength(2048,1024), 2);
+        partition.CreateCheckpoint("cp2");
+
+        auto response = partition.GetChangedBlocks(
+            TBlockRange32::WithLength(0, 3072),
+            "cp1",
+            "cp2",
+            false);
+
+        const auto& mask = response->Record.GetMask();
+        UNIT_ASSERT_VALUES_EQUAL(384, mask.size());
+        AssertEqual(
+            TVector<ui8>(256, 255),
+            TVector<ui8>(mask.begin() + 128, mask.end())
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReassignNonwritableTabletChannelsAgainAfterErrorFromHiveProxy)
+    {
+        auto runtime = PrepareTestActorRuntime();
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        ui64 reassignedTabletId = 0;
+        TVector<ui32> channels;
+        ui32 ssflags = ui32(
+            NKikimrBlobStorage::StatusDiskSpaceYellowStop |
+            NKikimrBlobStorage::StatusDiskSpaceLightYellowMove);
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvHiveProxy::EvReassignTabletRequest: {
+                        auto* msg = event->Get<TEvHiveProxy::TEvReassignTabletRequest>();
+                        reassignedTabletId = msg->TabletId;
+                        channels = msg->Channels;
+                        auto response =
+                            std::make_unique<TEvHiveProxy::TEvReassignTabletResponse>(
+                                MakeError(E_REJECTED, "error")
+                            );
+                        runtime->Send(new IEventHandle(
+                            event->Sender,
+                            event->Recipient,
+                            response.release(),
+                            0, // flags
+                            0
+                        ), 0);
+
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                }
+
+                return StorageStateChanger(ssflags)(event);
+            }
+        );
+
+        // first request is successful since we don't know that our channels
+        // are yellow yet
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+
+        // but upon EvPutResult we should find out that our channels are yellow
+        // and should send a reassign request
+        UNIT_ASSERT_VALUES_EQUAL(TestTabletId, reassignedTabletId);
+        UNIT_ASSERT_VALUES_EQUAL(1, channels.size());
+        UNIT_ASSERT_VALUES_EQUAL(3, channels.front());
+
+        reassignedTabletId = 0;
+        channels.clear();
+
+        for (ui32 i = 0; i < 3; ++i) {
+            {
+                // other requests should fail
+                auto request = partition.CreateWriteBlocksRequest(
+                    TBlockRange32::WithLength(0, 1024));
+                partition.SendToPipe(std::move(request));
+
+                auto response =
+                    partition.RecvResponse<TEvService::TEvWriteBlocksResponse>();
+                UNIT_ASSERT_VALUES_EQUAL(
+                    E_BS_OUT_OF_SPACE,
+                    response->GetError().GetCode()
+                );
+            }
+
+            // checking that a reassign request has been sent
+            UNIT_ASSERT_VALUES_EQUAL(TestTabletId, reassignedTabletId);
+            UNIT_ASSERT_VALUES_EQUAL(1, channels.size());
+            UNIT_ASSERT_VALUES_EQUAL(3, channels.front());
+
+            reassignedTabletId = 0;
+            channels.clear();
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCorrectlyCalculateLogicalUsedBlocksCountForOverlayDisk)
+    {
+        ui32 blockCount = 1024 * 128;
+        TPartitionContent baseContent;
+        for (size_t i = 0; i < 100; ++i) {
+            baseContent.push_back(TEmpty());
+        }
+        for (size_t i = 100; i < 2048 + 100; ++i) {
+            baseContent.push_back(TBlob(i, 1));
+        }
+        for (size_t i = 0; i < 100; ++i) {
+            baseContent.push_back(TEmpty());
+        }
+
+        auto partitionWithRuntime = SetupOverlayPartition(
+            TestTabletId,
+            TestTabletId2,
+            baseContent,
+            {},
+            DefaultBlockSize,
+            blockCount,
+            DefaultConfig());
+
+        auto& partition = *partitionWithRuntime.Partition;
+
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(1024 * 4, 2049),
+            1);   // +2049
+        partition.ZeroBlocks(TBlockRange32::WithLength(1024 * 5, 11));   // -11
+        partition.ZeroBlocks(
+            TBlockRange32::WithLength(1024 * 10, 1025));   // -0
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(1024 * 4, 11),
+            1);   // +0
+        partition.WriteBlocks(
+            TBlockRange32::WithLength(1024 * 3, 11),
+            1);   // +11
+
+        ui64 expectedUsedBlocksCount = 2048 + 1 - 11 + 11;
+        ui64 expectedLogicalUsedBlocksCount = 2048 + expectedUsedBlocksCount;
+
+        auto response = partition.StatPartition();
+        auto stats = response->Record.GetStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedUsedBlocksCount,
+            stats.GetUsedBlocksCount()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedLogicalUsedBlocksCount,
+            stats.GetLogicalUsedBlocksCount()
+        );
+
+        partition.RebootTablet();
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedUsedBlocksCount,
+            stats.GetUsedBlocksCount()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedLogicalUsedBlocksCount,
+            stats.GetLogicalUsedBlocksCount()
+        );
+
+        // range [100-200) is zero on overlay disk, but non zero on base disk
+        partition.ZeroBlocks(TBlockRange32::WithLength(100, 100));
+
+        response = partition.StatPartition();
+        stats = response->Record.GetStats();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedUsedBlocksCount,
+            stats.GetUsedBlocksCount()
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedLogicalUsedBlocksCount - 100,
+            stats.GetLogicalUsedBlocksCount()
+        );
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReturnErrorIfCompactionIsAlreadyRunning)
+    {
+        auto runtime = PrepareTestActorRuntime(DefaultConfig(), 2048);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024));
+        partition.WriteBlocks(TBlockRange32::WithLength(1024,1024));
+
+        TAutoPtr<IEventHandle> addBlobs;
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        if (!addBlobs) {
+                            addBlobs = event.Release();
+                            return TTestActorRuntime::EEventAction::DROP;
+                        }
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+
+        partition.SendCompactionRequest(0);
+
+        partition.SendCompactionRequest(1024);
+
+        {
+            auto compactResponse = partition.RecvCompactionResponse();
+            UNIT_ASSERT(FAILED(compactResponse->GetStatus()));
+            UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, compactResponse->GetStatus());
+        }
+
+        runtime->SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
+        runtime->Send(addBlobs.Release());
+
+        {
+            auto compactResponse = partition.RecvCompactionResponse();
+            UNIT_ASSERT(SUCCEEDED(compactResponse->GetStatus()));
+        }
+
+        {
+            partition.SendCompactionRequest(0);
+            auto compactResponse = partition.RecvCompactionResponse();
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, compactResponse->GetStatus());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldHandleFlushCorrectlyWhileBlockFromFreshChannelIsBeingDeleted)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 5));
+
+        TAutoPtr<IEventHandle> addBlobsRequest;
+
+        runtime->SetObserverFunc([&] (TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() == TEvPartitionPrivate::EvAddBlobsRequest) {
+                    addBlobsRequest = event.Release();
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            }
+        );
+
+        partition.SendFlushRequest();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1, 5));
+
+        UNIT_ASSERT(addBlobsRequest);
+        runtime->Send(addBlobsRequest.Release());
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        auto response = partition.RecvFlushResponse();
+        UNIT_ASSERT(SUCCEEDED(response->GetStatus()));
+    }
+
+
+
+    Y_UNIT_TEST(ShouldProcessMultipleRangesUponCompaction)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1_MB);
+        config.SetBatchCompactionEnabled(true);
+        config.SetCompactionRangeCountPerRun(3);
+        config.SetSSDMaxBlobsPerRange(999);
+        config.SetHDDMaxBlobsPerRange(999);
+        config.SetCompactionGarbageThreshold(999);
+        config.SetCompactionRangeGarbageThreshold(999);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            MaxPartitionBlocksCount
+        );
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto blockRange1 = TBlockRange32::WithLength(0, 1024);
+        const auto blockRange2 = TBlockRange32::WithLength(1024 * 1024, 1024);
+        const auto blockRange3 = TBlockRange32::WithLength(2 * 1024 * 1024, 1024);
+        const auto blockRange4 = TBlockRange32::WithLength(3 * 1024 * 1024, 1024);
+
+        partition.WriteBlocks(blockRange1, 1);
+        partition.WriteBlocks(blockRange1, 2);
+        partition.WriteBlocks(blockRange1, 3);
+
+        partition.WriteBlocks(blockRange2, 4);
+        partition.WriteBlocks(blockRange2, 5);
+        partition.WriteBlocks(blockRange2, 6);
+
+        partition.WriteBlocks(blockRange3, 7);
+        partition.WriteBlocks(blockRange3, 8);
+        partition.WriteBlocks(blockRange3, 9);
+
+        partition.WriteBlocks(blockRange4, 10);
+        partition.WriteBlocks(blockRange4, 11);
+
+        // blockRange4 should not be compacted, other ranges - should
+        partition.Compaction();
+        partition.Cleanup();
+
+        // checking that data wasn't corrupted
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(blockRange1.Start))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(3),
+            GetBlockContent(partition.ReadBlocks(blockRange1.End))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(6),
+            GetBlockContent(partition.ReadBlocks(blockRange2.Start))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(6),
+            GetBlockContent(partition.ReadBlocks(blockRange2.End))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(9),
+            GetBlockContent(partition.ReadBlocks(blockRange3.Start))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(9),
+            GetBlockContent(partition.ReadBlocks(blockRange3.End))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(11),
+            GetBlockContent(partition.ReadBlocks(blockRange4.Start))
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetBlockContent(11),
+            GetBlockContent(partition.ReadBlocks(blockRange4.End))
+        );
+
+        // checking that we now have 1 blob in each of the first 3 ranges
+        // and 2 blobs in the last range
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(5, stats.GetMergedBlobsCount());
+        }
+
+        // blockRange4 and any other 2 ranges should be compacted
+        partition.Compaction();
+        partition.Cleanup();
+
+        // all ranges should contain 1 blob now
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(4, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCompactAfterAddingConfirmedBlobs)
+    {
+        auto config = DefaultConfig();
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 1);
+
+        TAutoPtr<IEventHandle> addConfirmedBlobs;
+        bool interceptAddConfirmedBlobs = true;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddConfirmedBlobsRequest: {
+                        if (interceptAddConfirmedBlobs) {
+                            UNIT_ASSERT(!addConfirmedBlobs);
+                            addConfirmedBlobs = event.Release();
+                            return true;
+                        }
+                        break;
+                    }
+                }
+
+                return false;
+            }
+        );
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 2);
+        UNIT_ASSERT(addConfirmedBlobs);
+
+        partition.SendCompactionRequest();
+        // wait for compaction to be queued
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        interceptAddConfirmedBlobs = false;
+        runtime->Send(addConfirmedBlobs.Release());
+
+        {
+            auto compactResponse = partition.RecvCompactionResponse();
+            // should fail on S_ALREADY and S_FALSE to ensure that compaction
+            // was really taken place here
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, compactResponse->GetStatus());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldReportLongRunningWriteBlobOperationCancel)
+    {
+        auto sendRequest = [](TPartitionClient& partition)
+        {
+            partition.SendWriteBlocksRequest(
+                TBlockRange32::WithLength(0, 255));
+        };
+        auto receiveResponse = [](TPartitionClient& partition)
+        {
+            return partition.RecvWriteBlocksResponse();
+        };
+
+        DoShouldReportLongRunningBlobOperations(
+            sendRequest,
+            receiveResponse,
+            TEvPartitionCommonPrivate::TEvLongRunningOperation::EOperation::
+                WriteBlob,
+            true);
+    }
+
+
+
+    Y_UNIT_TEST(
+        ShouldAutomaticallyRunCompactionAndWriteBlobToMixedChannelIfBlobSizeIsBelowTheThreshold)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+
+        auto config = DefaultConfig();
+        config.SetHDDMaxBlobsPerRange(compactionThreshold);
+        config.SetCompactionMergedBlobThresholdHDD(17_KB);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            1024,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        for (size_t i = 1; i < compactionThreshold; ++i) {
+            partition.WriteBlocks(i, i);
+            partition.Flush();
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold - 1,
+                stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold - 1,
+                stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.WriteBlocks(0, 0);
+        partition.Flush();
+
+        // wait for background operations completion
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        // data size for compaction is less than CompactionMergedBlobThresholdHDD
+        // so the whole data should be moved to a mixed channel
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold + 1,
+                stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold * 2,
+                stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        partition.Cleanup();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold,
+                stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldCleanupUnconfirmedBlobsAfterErrorOnWriteBlob)
+    {
+        auto config = DefaultConfig();
+        config.SetWriteBlobThreshold(1);
+        config.SetAddingUnconfirmedBlobsEnabled(true);
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            4096,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_HYBRID});
+
+        bool shouldRejectDeleteUnconfirmedBlobsRequest = true;
+        // Create event filter for WriteBlobResponse rejection
+        TTestActorRuntimeBase::TEventFilter rejectionFilter =
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev)
+        {
+            switch (ev->GetTypeRewrite()) {
+                case TEvPartitionCommonPrivate::EvWriteBlobResponse: {
+                    auto* msg =
+                        ev->Get<TEvPartitionCommonPrivate::TEvWriteBlobResponse>();
+                    auto& e = const_cast<NProto::TError&>(msg->Error);
+                    e.SetCode(E_REJECTED);
+                    return false;
+                }
+                case TEvPartitionPrivate::
+                    EvDeleteUnconfirmedBlobsRequest: {
+                    return shouldRejectDeleteUnconfirmedBlobsRequest;
+                }
+            };
+            return false;
+        };
+
+        // Set up event order filter to ensure that
+        // AddUnconfirmedBlobsResponse is processed before WriteBlobResponse
+        TEventExecutionOrderFilter addWriteBlobOrderFilter(
+            *runtime,
+            TVector<std::pair<ui32, ui32>>{
+                {TEvPartitionPrivate::EvAddUnconfirmedBlobsResponse,
+                 TEvPartitionCommonPrivate::EvWriteBlobResponse}});
+        runtime->SetEventFilter(addWriteBlobOrderFilter(rejectionFilter));
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(10, 1), 1);
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(1, stats.GetUnconfirmedBlobCount());
+        }
+
+        // Set up event order filter to ensure that
+        // WriteBlobResponse is processed before AddUnconfirmedBlobsResponse
+        TEventExecutionOrderFilter writeAddBlobOrderFilter(
+            *runtime,
+            TVector<std::pair<ui32, ui32>>{
+                {TEvPartitionCommonPrivate::EvWriteBlobResponse,
+                 TEvPartitionPrivate::EvAddUnconfirmedBlobsResponse}});
+        runtime->SetEventFilter(writeAddBlobOrderFilter(rejectionFilter));
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(11, 1), 1);
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(2, stats.GetUnconfirmedBlobCount());
+        }
+
+        partition.RebootTablet();
+        partition.WaitReady();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+        }
+
+        shouldRejectDeleteUnconfirmedBlobsRequest = false;
+
+        partition.SendWriteBlocksRequest(TBlockRange32::WithLength(12, 1), 1);
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetUnconfirmedBlobCount());
+        }
+    }
+
+
+
+    Y_UNIT_TEST(ShouldSplitFlushZeroBlobsByCompactionRangeBoundaries)
+    {
+        constexpr ui32 rangeSize = 1024;
+        constexpr ui32 blockCount = rangeSize * 3;
+
+        auto config = DefaultConfig();
+        config.SetReadBlockMaskOnCompactionOptimizationEnabled(true);
+        config.SetSplitByCompactionRangeMaxBlobCount(3);
+
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 1024), 'A');
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 1024), 'B');
+        partition.WriteBlocks(TBlockRange32::WithLength(2048, 1024), 'C');
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            partition.ZeroBlocks(i);
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            partition.ZeroBlocks(i);
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            partition.ZeroBlocks(i);
+        }
+
+        ui32 mixedBlobsCount = 0;
+        TVector<TVector<ui32>> blobIndexes;
+
+        runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvAddBlobsRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvAddBlobsRequest>();
+                        if (msg->Mode == EAddBlobMode::ADD_FLUSH_RESULT) {
+                            mixedBlobsCount = msg->FreshBlobs.size();
+
+                            for (const auto& blob: msg->FreshBlobs) {
+                                blobIndexes.emplace_back();
+                                for (const auto& block: blob.Blocks) {
+                                    blobIndexes.back().push_back(
+                                        block.BlockIndex);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        partition.Flush();
+
+        UNIT_ASSERT_VALUES_EQUAL(3, mixedBlobsCount);
+
+        for (const auto& blobBlocks: blobIndexes) {
+            ui32 rangeIndex = blobBlocks.front() / rangeSize;
+            for (auto blockIdx: blobBlocks) {
+                UNIT_ASSERT_VALUES_EQUAL(rangeIndex, blockIdx / rangeSize);
+            }
+        }
+
+        for (ui32 i = 1022; i < 1026; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+        for (ui32 i = 1500; i < 1505; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+        for (ui32 i = 2045; i < 2050; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                GetBlockContent(partition.ReadBlocks(i)));
+        }
+
+        partition.Compaction();
+        partition.Compaction();
+        partition.Compaction();
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                6,
+                stats.GetBlobsProcessedDuringCompaction());
+            UNIT_ASSERT_VALUES_EQUAL(
+                0,
+                stats.GetBlockMaskReadDuringCompaction());
+        }
+    }
+
+
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/ut/database/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/database/ya.make
@@ -1,0 +1,15 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_database_ut.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/env1/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/env1/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_env1.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/env2/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/env2/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_env2.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/env3/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/env3/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_env3.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/env4/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/env4/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_env4.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/env5/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/env5/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_env5.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/env6/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/env6/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_env6.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/env7/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/env7/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_env7.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split1/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split1/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split1.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split1/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split1/ya.make
@@ -2,6 +2,12 @@ UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
+IF (SANITIZER_TYPE == "thread")
+    SIZE(LARGE)
+    TIMEOUT(1200)
+    TAG(ya:fat)
+ENDIF()
+
 SRCS(
     part_ut_split1.cpp
 )

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split10/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split10/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split10.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split11/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split11/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split11.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split12/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split12/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split12.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split13/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split13/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split13.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split14/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split14/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split14.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split15/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split15/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split15.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split16/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split16/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split16.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split2/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split2/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split2.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split3/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split3/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split3.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split4/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split4/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split4.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split5/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split5/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split5.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split6/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split6/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split6.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split7/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split7/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split7.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split8/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split8/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split8.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/split9/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/split9/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_ut_split9.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib/partition_lite
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/partition/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/partition/ya.make
@@ -1,0 +1,25 @@
+RECURSE_FOR_TESTS(
+    split1
+    split2
+    split3
+    split4
+    split5
+    split6
+    split7
+    split8
+    split9
+    split10
+    split11
+    split12
+    split13
+    split14
+    split15
+    split16
+    env1
+    env2
+    env3
+    env4
+    env5
+    env6
+    env7
+)

--- a/cloud/blockstore/libs/storage/partition/ut/state/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/state/ya.make
@@ -1,0 +1,15 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    part_state_ut.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/partition/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/ya.make
@@ -1,17 +1,5 @@
-UNITTEST_FOR(cloud/blockstore/libs/storage/partition)
-
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
-
-SRCS(
-    part_database_ut.cpp
-    part_state_ut.cpp
-    part_ut.cpp
+RECURSE_FOR_TESTS(
+    database
+    partition
+    state
 )
-
-PEERDIR(
-    cloud/blockstore/libs/storage/testlib
-)
-
-YQL_LAST_ABI_VERSION()
-
-END()

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_describe.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_describe.cpp
@@ -339,7 +339,7 @@ void TPartitionActor::HandleDescribeBlob(
 
     ExecuteTx<TDescribeBlob>(
         ctx,
-        std::move(requestInfo),
+        requestInfo,
         MakePartialBlobId(blobId),
         false  // httpInfo
     );

--- a/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make
@@ -1,6 +1,10 @@
 UNITTEST_FOR(cloud/blockstore/libs/storage/partition_nonrepl)
 
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+IF (SANITIZER_TYPE)
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+ENDIF()
 
 SRCS(
     lagging_agents_replica_proxy_ut.cpp

--- a/cloud/blockstore/libs/storage/service/service_ut_basic.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_basic.cpp
@@ -1,0 +1,85 @@
+#include "service_ut.h"
+
+#include <cloud/blockstore/libs/diagnostics/config.h>
+#include <cloud/blockstore/libs/storage/core/config.h>
+#include <cloud/blockstore/libs/storage/testlib/test_runtime.h>
+#include <cloud/blockstore/private/api/protos/volume.pb.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDiagnosticsConfigPtr CreateTestDiagnosticsConfig()
+{
+    return std::make_shared<TDiagnosticsConfig>(NProto::TDiagnosticsConfig());
+}
+
+ui32 SetupTestEnv(TTestEnv& env)
+{
+    env.CreateSubDomain("nbs");
+
+    auto storageConfig = CreateTestStorageConfig({});
+
+    return env.CreateBlockStoreNode(
+        "nbs",
+        storageConfig,
+        CreateTestDiagnosticsConfig());
+}
+
+ui32 SetupTestEnv(
+    TTestEnv& env,
+    NProto::TStorageServiceConfig storageServiceConfig,
+    NProto::TFeaturesConfig featuresConfig)
+{
+    env.CreateSubDomain("nbs");
+
+    auto storageConfig = CreateTestStorageConfig(
+        std::move(storageServiceConfig),
+        std::move(featuresConfig));
+
+    return env.CreateBlockStoreNode(
+        "nbs",
+        storageConfig,
+        CreateTestDiagnosticsConfig());
+}
+
+ui32 SetupTestEnvWithMultipleMount(
+    TTestEnv& env,
+    TDuration inactivateTimeout)
+{
+    NProto::TStorageServiceConfig storageServiceConfig;
+    storageServiceConfig.SetInactiveClientsTimeout(
+        inactivateTimeout.MilliSeconds());
+    return SetupTestEnv(env, std::move(storageServiceConfig));
+}
+
+ui32 SetupTestEnvWithAllowVersionInModifyScheme(TTestEnv& env)
+{
+    NProto::TStorageServiceConfig storageServiceConfig;
+    storageServiceConfig.SetAllowVersionInModifyScheme(true);
+    return SetupTestEnv(env, std::move(storageServiceConfig));
+}
+
+TString GetBlockContent(char fill, size_t size)
+{
+    return TString(size, fill);
+}
+
+NKikimrBlockStore::TVolumeConfig GetVolumeConfig(
+    TServiceClient& service,
+    const TString& diskId)
+{
+    NCloud::NBlockStore::NPrivateProto::TDescribeVolumeRequest request;
+    request.SetDiskId(diskId);
+    TString buf;
+    google::protobuf::util::MessageToJsonString(request, &buf);
+    auto response = service.ExecuteAction("DescribeVolume", buf);
+    NKikimrSchemeOp::TBlockStoreVolumeDescription pathDescr;
+    UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+        response->Record.GetOutput(),
+        &pathDescr
+    ).ok());
+    return pathDescr.GetVolumeConfig();
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/ut/actions/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/actions/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_actions.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/alter/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/alter/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_alter.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/create/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/create/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_create.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/create_from_device/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/create_from_device/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_create_from_device.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/describe/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/describe/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_describe.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/describe_model/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/describe_model/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_describe_model.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/destroy/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/destroy/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_destroy.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/forward/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/forward/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_forward.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/inactive_clients/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/inactive_clients/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_inactive_clients.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/link_volume/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/link_volume/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_link_volume.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/list/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/list/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_list.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/manually_preempted_volumes/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/manually_preempted_volumes/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut.cpp
+    service_ut_manually_preempted_volumes.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/mount/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/mount/ya.make
@@ -2,6 +2,10 @@ UNITTEST_FOR(cloud/blockstore/libs/storage/service)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
+IF (SANITIZER_TYPE == "thread")
+    SPLIT_FACTOR(40)
+ENDIF()
+
 SRCS(
     service_ut_basic.cpp
     service_ut_mount.cpp

--- a/cloud/blockstore/libs/storage/service/ut/mount/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/mount/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_mount.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/placement/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/placement/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_placement.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/read_write/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/read_write/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_read_write.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/resume_device/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/resume_device/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_resume_device.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/start/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/start/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_start.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/state/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/state/ya.make
@@ -1,0 +1,24 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_state_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/stats/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/stats/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_stats.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/update_config/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/update_config/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_update_config.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/vhost_discard/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/vhost_discard/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/service)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    service_ut_basic.cpp
+    service_ut_vhost_discard.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/service/ut/ya.make
+++ b/cloud/blockstore/libs/storage/service/ut/ya.make
@@ -1,36 +1,28 @@
-UNITTEST_FOR(cloud/blockstore/libs/storage/service)
-
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
-
-SRCS(
-    service_state_ut.cpp
-    service_ut_actions.cpp
-    service_ut_alter.cpp
-    service_ut_create_from_device.cpp
-    service_ut_create.cpp
-    service_ut_describe_model.cpp
-    service_ut_describe.cpp
-    service_ut_destroy.cpp
-    service_ut_forward.cpp
-    service_ut_inactive_clients.cpp
-    service_ut_link_volume.cpp
-    service_ut_list.cpp
-    service_ut_manually_preempted_volumes.cpp
-    service_ut_mount.cpp
-    service_ut_placement.cpp
-    service_ut_read_write.cpp
-    service_ut_resume_device.cpp
-    service_ut_start.cpp
-    service_ut_stats.cpp
-    service_ut_update_config.cpp
-    service_ut_vhost_discard.cpp
-    service_ut.cpp
-)
-
-PEERDIR(
-    cloud/blockstore/libs/storage/testlib
-)
-
-YQL_LAST_ABI_VERSION()
-
-END()
+# The storage service tests pull in the full storage test runtime and YDB testlib.
+# With UBSAN this currently produces binaries that exceed x86_64 PC-relative
+# relocation limits during linking. Keep these tests enabled for other builds.
+IF (SANITIZER_TYPE != "undefined")
+    RECURSE_FOR_TESTS(
+        state
+        actions
+        alter
+        create_from_device
+        create
+        describe_model
+        describe
+        destroy
+        forward
+        inactive_clients
+        link_volume
+        list
+        manually_preempted_volumes
+        mount
+        placement
+        read_write
+        resume_device
+        start
+        stats
+        update_config
+        vhost_discard
+    )
+ENDIF()

--- a/cloud/blockstore/libs/storage/testlib/partition_lite/ya.make
+++ b/cloud/blockstore/libs/storage/testlib/partition_lite/ya.make
@@ -1,0 +1,34 @@
+LIBRARY(blockstore-libs-storage-testlib-partition-lite)
+
+SRCS(
+    ../part_client.cpp
+    ../test_runtime.cpp
+    ../ut_helpers.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/libs/diagnostics
+    cloud/blockstore/libs/kikimr
+    cloud/blockstore/libs/storage/api
+    cloud/blockstore/libs/storage/core
+    cloud/blockstore/libs/storage/partition
+    cloud/blockstore/libs/storage/partition_common
+
+    cloud/storage/core/libs/api
+    cloud/storage/core/libs/common
+    cloud/storage/core/libs/tablet
+
+    contrib/ydb/core/base
+    contrib/ydb/core/blobstorage
+    contrib/ydb/core/mind/bscontroller
+    contrib/ydb/core/protos
+    contrib/ydb/core/tablet
+    contrib/ydb/core/tablet_flat
+    contrib/ydb/core/testlib
+    contrib/ydb/core/testlib/basics
+    contrib/ydb/library/actors/core
+    contrib/ydb/library/actors/testlib
+    library/cpp/testing/unittest
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/broken_devices/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/broken_devices/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_ut_broken_devices.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/checkpoint/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/checkpoint/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_ut_checkpoint.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/checksums/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/checksums/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_ut_checksums.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/database/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/database/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_database_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/lagging_agent/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/lagging_agent/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_lagging_agent_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/main/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/main/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/main/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/main/ya.make
@@ -2,6 +2,13 @@ UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
+IF (SANITIZER_TYPE == "thread")
+    SIZE(LARGE)
+    TIMEOUT(1200)
+    TAG(ya:fat)
+    SPLIT_FACTOR(40)
+ENDIF()
+
 SRCS(
     ../../volume_ut.cpp
 )

--- a/cloud/blockstore/libs/storage/volume/ut/session/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/session/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_ut_session.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/state/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/state/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_state_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/stats/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/stats/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_ut_stats.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/throttling/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/throttling/ya.make
@@ -1,0 +1,25 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+
+SRCS(
+    ../../volume_throttling_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/rdma_test
+    cloud/blockstore/libs/storage/disk_agent/actors
+    cloud/blockstore/libs/storage/testlib
+    cloud/blockstore/libs/storage/volume/testlib
+)
+
+END()

--- a/cloud/blockstore/libs/storage/volume/ut/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut/ya.make
@@ -1,25 +1,12 @@
-UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
-
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
-
-SRCS(
-    volume_database_ut.cpp
-    volume_lagging_agent_ut.cpp
-    volume_state_ut.cpp
-    volume_throttling_ut.cpp
-    volume_ut.cpp
-    volume_ut_broken_devices.cpp
-    volume_ut_checkpoint.cpp
-    volume_ut_checksums.cpp
-    volume_ut_session.cpp
-    volume_ut_stats.cpp
+RECURSE_FOR_TESTS(
+    database
+    lagging_agent
+    state
+    throttling
+    main
+    broken_devices
+    checkpoint
+    checksums
+    session
+    stats
 )
-
-PEERDIR(
-    cloud/blockstore/libs/rdma_test
-    cloud/blockstore/libs/storage/disk_agent/actors
-    cloud/blockstore/libs/storage/testlib
-    cloud/blockstore/libs/storage/volume/testlib
-)
-
-END()

--- a/cloud/blockstore/libs/storage/volume/ut_linked/ya.make
+++ b/cloud/blockstore/libs/storage/volume/ut_linked/ya.make
@@ -1,6 +1,10 @@
 UNITTEST_FOR(cloud/blockstore/libs/storage/volume)
 
-INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+IF (SANITIZER_TYPE)
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/large.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+ENDIF()
 
 SRCS(
     volume_ut_linked.cpp

--- a/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_state_ut.cpp
@@ -2589,6 +2589,14 @@ Y_UNIT_TEST_SUITE(TVolumeStateTest)
 }   // namespace NCloud::NBlockStore::NStorage
 
 template <>
+inline void Out<NCloud::NBlockStore::NStorage::THistoryLogKey>(
+    IOutputStream& out,
+    const NCloud::NBlockStore::NStorage::THistoryLogKey& key)
+{
+    out << key.Timestamp << "/" << key.SeqNo;
+}
+
+template <>
 inline void Out<NCloud::NBlockStore::NStorage::TVolumeClientState::EPipeState>(
     IOutputStream& out,
     NCloud::NBlockStore::NStorage::TVolumeClientState::EPipeState state)

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -28,16 +28,6 @@ using namespace NTestVolume;
 
 using namespace NTestVolumeHelpers;
 
-namespace NTestVolumeHelpers {
-
-////////////////////////////////////////////////////////////////////////////////
-
-TBlockRange64 GetBlockRangeById(ui32 blockIndex)
-{
-    return TBlockRange64::WithLength(1024 * blockIndex, 1024);
-}
-
-}   // namespace NTestVolumeHelpers
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/volume/volume_ut.h
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.h
@@ -6,7 +6,10 @@ namespace NCloud::NBlockStore::NStorage::NTestVolumeHelpers {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TBlockRange64 GetBlockRangeById(ui32 blockIndex);
+inline TBlockRange64 GetBlockRangeById(ui32 blockIndex)
+{
+    return TBlockRange64::WithLength(1024 * blockIndex, 1024);
+}
 
 template <uint32_t LineNumber>
 void CheckBlockContent(

--- a/cloud/blockstore/libs/storage/volume_balancer/ut/balancer/ya.make
+++ b/cloud/blockstore/libs/storage/volume_balancer/ut/balancer/ya.make
@@ -1,0 +1,29 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume_balancer)
+
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+ENDIF()
+
+SRCS(
+    ../../volume_balancer_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/diagnostics
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/volume_balancer/ut/state/ya.make
+++ b/cloud/blockstore/libs/storage/volume_balancer/ut/state/ya.make
@@ -1,0 +1,29 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/volume_balancer)
+
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+ELSE()
+    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+ENDIF()
+
+SRCS(
+    ../../volume_balancer_state_ut.cpp
+)
+
+CFLAGS(
+    -ffunction-sections
+    -fdata-sections
+)
+
+LDFLAGS(
+    -Wl,--gc-sections
+)
+
+PEERDIR(
+    cloud/blockstore/libs/diagnostics
+    cloud/blockstore/libs/storage/testlib
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/cloud/blockstore/libs/storage/volume_balancer/ut/ya.make
+++ b/cloud/blockstore/libs/storage/volume_balancer/ut/ya.make
@@ -1,21 +1,13 @@
-UNITTEST_FOR(cloud/blockstore/libs/storage/volume_balancer)
-
-IF (SANITIZER_TYPE OR WITH_VALGRIND)
-    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+# The actor-level balancer tests pull in the full storage test runtime and YDB testlib.
+# With UBSAN this currently produces a binary that exceeds x86_64 PC-relative
+# relocation limits during linking. Keep the smaller state tests enabled there.
+IF (SANITIZER_TYPE == "undefined")
+    RECURSE_FOR_TESTS(
+        state
+    )
 ELSE()
-    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+    RECURSE_FOR_TESTS(
+        balancer
+        state
+    )
 ENDIF()
-
-SRCS(
-    volume_balancer_ut.cpp
-    volume_balancer_state_ut.cpp
-)
-
-PEERDIR(
-    cloud/blockstore/libs/diagnostics
-    cloud/blockstore/libs/storage/testlib
-)
-
-YQL_LAST_ABI_VERSION()
-
-END()

--- a/cloud/blockstore/libs/storage/volume_proxy/ut/ya.make
+++ b/cloud/blockstore/libs/storage/volume_proxy/ut/ya.make
@@ -1,19 +1,24 @@
-UNITTEST_FOR(cloud/blockstore/libs/storage/volume_proxy)
+# The volume proxy test pulls in the full storage test runtime and YDB testlib.
+# With UBSAN this currently produces a binary that exceeds x86_64 PC-relative
+# relocation limits during linking. Keep the test enabled for other builds.
+IF (SANITIZER_TYPE != "undefined")
+    UNITTEST_FOR(cloud/blockstore/libs/storage/volume_proxy)
 
-IF (SANITIZER_TYPE OR WITH_VALGRIND)
-    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
-ELSE()
-    INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+    IF (SANITIZER_TYPE OR WITH_VALGRIND)
+        INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
+    ELSE()
+        INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+    ENDIF()
+
+    SRCS(
+        volume_proxy_ut.cpp
+    )
+
+    PEERDIR(
+        cloud/blockstore/libs/storage/testlib
+    )
+
+    YQL_LAST_ABI_VERSION()
+
+    END()
 ENDIF()
-
-SRCS(
-    volume_proxy_ut.cpp
-)
-
-PEERDIR(
-    cloud/blockstore/libs/storage/testlib
-)
-
-YQL_LAST_ABI_VERSION()
-
-END()

--- a/cloud/blockstore/libs/storage/volume_throttling_manager/ut/ya.make
+++ b/cloud/blockstore/libs/storage/volume_throttling_manager/ut/ya.make
@@ -1,5 +1,10 @@
 UNITTEST_FOR(cloud/blockstore/libs/storage/volume_throttling_manager)
 
+IF (SANITIZER_TYPE == "thread")
+    SIZE(MEDIUM)
+    TIMEOUT(300)
+ENDIF()
+
 SRCS(
     volume_throttling_manager_ut.cpp
 )

--- a/cloud/blockstore/vhost-server/gtest/ya.make
+++ b/cloud/blockstore/vhost-server/gtest/ya.make
@@ -2,7 +2,7 @@ GTEST()
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
-IF (SANITIZER_TYPE == "thread")
+IF (SANITIZER_TYPE == "thread" OR SANITIZER_TYPE == "memory")
     SPLIT_FACTOR(40)
 ENDIF()
 

--- a/cloud/blockstore/vhost-server/gtest/ya.make
+++ b/cloud/blockstore/vhost-server/gtest/ya.make
@@ -2,6 +2,10 @@ GTEST()
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
+IF (SANITIZER_TYPE == "thread")
+    SPLIT_FACTOR(40)
+ENDIF()
+
 SRCS(
     ../backend.cpp
     ../backend_aio.cpp


### PR DESCRIPTION
## What changed

This draft PR carries fixes found while running the requested sanitizer matrix for NBS volume/partition/service/server/load tests.

1. Keep `requestInfo` alive when starting the `TDescribeBlob` transaction from `TPartitionActor::HandleDescribeBlob` instead of moving it into `ExecuteTx` before `TRequestScope` has finished with it.
2. Use the large test recipe for `cloud/blockstore/libs/storage/partition_nonrepl/ut` when `SANITIZER_TYPE` is set, while preserving the existing medium recipe for normal runs.
3. Use the large test recipe for `cloud/blockstore/libs/storage/volume/ut_linked` when `SANITIZER_TYPE` is set, while preserving the existing medium recipe for normal runs.
4. Split `cloud/blockstore/libs/storage/partition/ut` into smaller `database`, `state`, and partition split/env unittest targets, and add a lightweight partition testlib so UBSAN no longer links one oversized monolithic binary.

## Why

ASAN first exposed a heap-use-after-free in the partition2 DescribeBlob monitoring path. The crash reproduced in:

- `TPartition2Test::ShouldHandleDescribeBlobRequestForMergedBlob`
- `TPartition2Test::ShouldHandleDescribeBlobRequestForFreshBlob`

The sanitizer matrix then hit medium recipe 600s timeouts in targets whose sanitizer runtime is much longer than a normal debug run:

- `address cloud/blockstore/libs/storage/partition_nonrepl/ut`
- `address cloud/blockstore/libs/storage/volume/ut_linked`

These failures were wall-clock chunk timeouts, not sanitizer memory reports, so the fixes adjust sanitizer-only test budgets instead of datapath behavior.

The matrix later stopped on `undefined cloud/blockstore/libs/storage/partition/ut` at link time with `R_X86_64_PC32 out of range`. The target was too large as a single UBSAN test binary, so this change keeps the same tests but splits the binary surface.

## Validation

Ran from `/home/evgeniy-kozev/workspace/nbs`:

- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/partition2/ut -F TPartition2Test::ShouldHandleDescribeBlobRequestForMergedBlob`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/partition2/ut -F TPartition2Test::ShouldHandleDescribeBlobRequestForFreshBlob`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/partition2/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/partition_common/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/partition_nonrepl/model/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/partition_nonrepl/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/service/model/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/service/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/stats_service/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/volume/actors/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/volume/model/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/volume/ut`
- `./ya make -ttt -j 16 --sanitize=address cloud/blockstore/libs/storage/volume/ut_linked`
- `./ya make -ttt -j 16 --sanitize=undefined cloud/blockstore/libs/storage/partition/ut/partition` (23 suites, 248 tests)
- `./ya make -ttt -j 16 --sanitize=undefined cloud/blockstore/libs/storage/partition/ut` (25 suites, 271 tests)
- `git diff --check -- cloud/blockstore/libs/storage/partition2/part2_actor_monitoring_describe.cpp`
- `git diff --check -- cloud/blockstore/libs/storage/partition_nonrepl/ut/ya.make`
- `git diff --check -- cloud/blockstore/libs/storage/volume/ut_linked/ya.make`
- `git diff --cached --check` for the partition split changes

The sanitizer matrix resumed after the latest fix and writes progress to `/home/evgeniy-kozev/state.txt`. Current runner state at the last check: restarting from `undefined cloud/blockstore/libs/storage/partition/ut`. 