### PR TITLE
[Disk Manager] issue-6257: fix overcommit for base disks created from small images

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
@@ -32,4 +32,8 @@ message PoolsConfig {
     optional string MinOptimizedPoolAge = 20 [default = "24h"];
     optional bool RegularBaseDiskOptimizationEnabled = 21 [default = true];
     optional string BaseDiskIdPrefix = 22 [default = "base-"];
+    // Makes base disks created from small images (for example, 32 GiB) larger,
+    // so that they are large enough to achieve the performance corresponding to
+    // `minBaseDiskUnits`.
+    optional bool AdjustBaseDiskSizeToMinBaseDiskUnits = 23 [default = false];
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
@@ -34,6 +34,6 @@ message PoolsConfig {
     optional string BaseDiskIdPrefix = 22 [default = "base-"];
     // Makes base disks created from small images (for example, 32 GiB) larger,
     // so that they are large enough to achieve the performance corresponding to
-    // `minBaseDiskUnits`.
+    // `minBaseDiskUnits`. See #6257 for details
     optional bool AdjustBaseDiskSizeToMinBaseDiskUnits = 23 [default = false];
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -675,9 +675,10 @@ const (
 	baseDiskUnitSize            = uint64(32 << 30)
 	minBaseDiskUnits            = 30
 	baseDiskOverSubscription    = 2
-	overlayDiskOversubscription = 30
-	// SSD units should be more valuable than HDD.
-	ssdUnitMultiplier = 5
+	overlayDiskOverSubscription = 30
+	// Represents how many regular (HDD-equivalent) performance units one SSD
+	// allocation unit is worth.
+	regularUnitsPerSSDUnit = 5
 )
 
 func (s *storageYDB) generateBaseDisk(
@@ -694,18 +695,28 @@ func (s *storageYDB) generateBaseDisk(
 		units = s.maxBaseDiskUnits
 		maxActiveSlots = s.maxActiveSlots
 	} else {
-		// Base disks are using SSD.
-		ssdUnits := divideWithRoundingUp(
-			imageSize,
-			baseDiskUnitSize,
-		)
+		// Base disks use SSD. Compute the number of SSD allocation units
+		// needed to hold the image.
+		ssdUnits := divideWithRoundingUp(imageSize, baseDiskUnitSize)
 		size = ssdUnits * baseDiskUnitSize
 
-		units = ssdUnitMultiplier * ssdUnits
-		units = baseDiskOverSubscription * units
-		units = max(units, minBaseDiskUnits)
+		// Regular (HDD-equivalent) units with oversubscription.
+		units = baseDiskOverSubscription * regularUnitsPerSSDUnit * ssdUnits
+		// A base disk must provide at least minBaseDiskUnits of performance,
+		// otherwise the overlay disks sharing it get underperformed (#6257).
+		if units < minBaseDiskUnits {
+			units = minBaseDiskUnits
+			// Grow the disk so it physically holds enough SSD units to back
+			// that performance.
+			ssdUnits = units / regularUnitsPerSSDUnit
+			// Never shrink the base disk below the image size (for safety).
+			size = max(size, ssdUnits*baseDiskUnitSize)
+		}
+
 		units = min(units, s.maxBaseDiskUnits)
 
+		// There cannot be more slots than units because each unit represents
+		// the smallest possible disk.
 		maxActiveSlots = min(units, s.maxActiveSlots)
 	}
 
@@ -743,13 +754,13 @@ func computeAllottedUnits(s *slot) uint64 {
 	switch s.overlayDiskKind {
 	case types.DiskKind_DISK_KIND_SSD:
 		res = divideWithRoundingUp(
-			ssdUnitMultiplier*overlayDiskUnits,
-			overlayDiskOversubscription,
+			regularUnitsPerSSDUnit*overlayDiskUnits,
+			overlayDiskOverSubscription,
 		)
 	case types.DiskKind_DISK_KIND_HDD:
 		res = divideWithRoundingUp(
 			overlayDiskUnits,
-			overlayDiskOversubscription,
+			overlayDiskOverSubscription,
 		)
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -706,17 +706,21 @@ func (s *storageYDB) generateBaseDisk(
 		// otherwise the overlay disks sharing it get underperformed (#6257).
 		if units < minBaseDiskUnits {
 			units = minBaseDiskUnits
-			// Grow the disk so it physically holds enough SSD units to back
-			// that performance.
-			ssdUnits = units / regularUnitsPerSSDUnit
-			// Never shrink the base disk below the image size (for safety).
-			size = max(size, ssdUnits*baseDiskUnitSize)
+
+			if s.adjustBaseDiskSizeToMinBaseDiskUnits {
+				// Grow the disk so that it physically contains enough SSD units
+				// to provide the required performance. The larger the disk, the
+				// higher the performance.
+				ssdUnits = units / regularUnitsPerSSDUnit
+				// Never shrink the base disk below the image size (for safety).
+				size = max(size, ssdUnits*baseDiskUnitSize)
+			}
 		}
 
 		units = min(units, s.maxBaseDiskUnits)
 
-		// There cannot be more slots than units because each unit represents
-		// the smallest possible disk.
+		// There cannot be more slots than units because each overlay disk
+		// consumes at least one unit.
 		maxActiveSlots = min(units, s.maxActiveSlots)
 	}
 

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
@@ -36,13 +36,12 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 		}
 	}
 
-	generate := func(requiredSize uint64) baseDisk {
+	generate := func(imageSize uint64) baseDisk {
 		storage := &storageYDB{
 			maxActiveSlots:   maxActiveSlots,
 			maxBaseDiskUnits: maxBaseDiskUnits,
 		}
 
-		imageSize := requiredSize
 		var srcDisk *types.Disk
 
 		baseDisk := storage.generateBaseDisk(
@@ -70,17 +69,17 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 	require.Equal(t, uint64(640), baseDisk.units)
 
 	baseDisk = generate(1)
-	require.Equal(t, uint64(32<<30), baseDisk.size)
+	require.Equal(t, uint64(192<<30), baseDisk.size)
 	require.Equal(t, uint64(30), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(30), baseDisk.units)
 
 	baseDisk = generate(32 << 30)
-	require.Equal(t, uint64(32<<30), baseDisk.size)
+	require.Equal(t, uint64(192<<30), baseDisk.size)
 	require.Equal(t, uint64(30), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(30), baseDisk.units)
 
 	baseDisk = generate((32 << 30) + 1)
-	require.Equal(t, uint64(64<<30), baseDisk.size)
+	require.Equal(t, uint64(192<<30), baseDisk.size)
 	require.Equal(t, uint64(30), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(30), baseDisk.units)
 
@@ -178,8 +177,8 @@ func TestCommonAcquireAndReleaseUnitsAndSlots(t *testing.T) {
 	require.Equal(t, uint64(1), slot1.allottedSlots)
 	require.Equal(t, uint64(1), slot1.allottedUnits)
 
-	hddUnit := overlayDiskOversubscription * baseDiskUnitSize
-	ssdUnit := hddUnit / ssdUnitMultiplier
+	hddUnit := overlayDiskOverSubscription * baseDiskUnitSize
+	ssdUnit := hddUnit / regularUnitsPerSSDUnit
 
 	slot2 := &slot{}
 	slot2.overlayDiskKind = types.DiskKind_DISK_KIND_SSD

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
@@ -9,7 +9,11 @@ import (
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func TestCommonGenerateBaseDiskForPool(t *testing.T) {
+func testCommonGenerateBaseDiskForPool(
+	t *testing.T,
+	adjustBaseDiskSizeToMinBaseDiskUnits bool,
+) {
+
 	maxActiveSlots := uint64(640)
 	maxBaseDiskUnits := uint64(640)
 
@@ -40,6 +44,8 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 		storage := &storageYDB{
 			maxActiveSlots:   maxActiveSlots,
 			maxBaseDiskUnits: maxBaseDiskUnits,
+
+			adjustBaseDiskSizeToMinBaseDiskUnits: adjustBaseDiskSizeToMinBaseDiskUnits,
 		}
 
 		var srcDisk *types.Disk
@@ -69,17 +75,29 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 	require.Equal(t, uint64(640), baseDisk.units)
 
 	baseDisk = generate(1)
-	require.Equal(t, uint64(192<<30), baseDisk.size)
+	if adjustBaseDiskSizeToMinBaseDiskUnits {
+		require.Equal(t, uint64(192<<30), baseDisk.size)
+	} else {
+		require.Equal(t, uint64(32<<30), baseDisk.size)
+	}
 	require.Equal(t, uint64(30), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(30), baseDisk.units)
 
 	baseDisk = generate(32 << 30)
-	require.Equal(t, uint64(192<<30), baseDisk.size)
+	if adjustBaseDiskSizeToMinBaseDiskUnits {
+		require.Equal(t, uint64(192<<30), baseDisk.size)
+	} else {
+		require.Equal(t, uint64(32<<30), baseDisk.size)
+	}
 	require.Equal(t, uint64(30), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(30), baseDisk.units)
 
 	baseDisk = generate((32 << 30) + 1)
-	require.Equal(t, uint64(192<<30), baseDisk.size)
+	if adjustBaseDiskSizeToMinBaseDiskUnits {
+		require.Equal(t, uint64(192<<30), baseDisk.size)
+	} else {
+		require.Equal(t, uint64(64<<30), baseDisk.size)
+	}
 	require.Equal(t, uint64(30), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(30), baseDisk.units)
 
@@ -119,6 +137,11 @@ func TestCommonGenerateBaseDiskForPool(t *testing.T) {
 	require.Equal(t, uint64(4096<<30), baseDisk.size)
 	require.Equal(t, uint64(1), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(1), baseDisk.units)
+}
+
+func TestCommonGenerateBaseDiskForPool(t *testing.T) {
+	testCommonGenerateBaseDiskForPool(t, false)
+	testCommonGenerateBaseDiskForPool(t, true)
 }
 
 func TestCommonFreeSlots(t *testing.T) {

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
@@ -23,6 +23,8 @@ type storageYDB struct {
 	maxBaseDiskUnits                   uint64
 	takeBaseDisksToScheduleParallelism int
 	baseDiskIDPrefix                   string
+
+	adjustBaseDiskSizeToMinBaseDiskUnits bool
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -510,5 +512,7 @@ func NewStorage(
 		maxBaseDiskUnits:                   uint64(config.GetMaxBaseDiskUnits()),
 		takeBaseDisksToScheduleParallelism: takeBaseDisksToScheduleParallelism,
 		baseDiskIDPrefix:                   config.GetBaseDiskIdPrefix(),
+
+		adjustBaseDiskSizeToMinBaseDiskUnits: config.GetAdjustBaseDiskSizeToMinBaseDiskUnits(),
 	}, nil
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -2110,13 +2110,13 @@ func TestStorageYDBCreatePoolWithImageSize(t *testing.T) {
 	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
 
 	// Check idempotency.
 	baseDisks, err = storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
 
 	baseDisks[0].CreateTaskID = "create"
 	err = storage.BaseDisksScheduled(ctx, baseDisks)
@@ -2176,7 +2176,7 @@ func TestStorageYDBRetireBaseDiskForPoolWithImageSize(t *testing.T) {
 	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
 
 	baseDisks[0].CreateTaskID = "create"
 	err = storage.BaseDisksScheduled(ctx, baseDisks)
@@ -2347,7 +2347,7 @@ func TestStorageYDBRetireBaseDiskForDeletedPoolUsingImageSize(t *testing.T) {
 	baseDisks, err = storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
 
 	err = storage.CheckConsistency(ctx)
 	require.NoError(t, err)

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -86,7 +86,13 @@ func newStorage(
 	db *persistence.YDBClient,
 ) Storage {
 
-	return newStorageWithConfig(t, ctx, db, makeDefaultConfig(), metrics.NewEmptyRegistry())
+	return newStorageWithConfig(
+		t,
+		ctx,
+		db,
+		makeDefaultConfig(),
+		metrics.NewEmptyRegistry(),
+	)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2110,13 +2116,13 @@ func TestStorageYDBCreatePoolWithImageSize(t *testing.T) {
 	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
 
 	// Check idempotency.
 	baseDisks, err = storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
 
 	baseDisks[0].CreateTaskID = "create"
 	err = storage.BaseDisksScheduled(ctx, baseDisks)
@@ -2157,6 +2163,51 @@ func TestStorageYDBCreatePoolWithImageSize(t *testing.T) {
 
 	err = storage.CheckConsistency(ctx)
 	require.NoError(t, err)
+
+}
+
+func TestStorageYDBCreatePoolWithImageSizeAndAdjustBaseDiskSizeToMinBaseDiskUnits(
+	t *testing.T,
+) {
+
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	maxActiveSlots := uint32(640)
+	maxBaseDisksInflight := uint32(1)
+	maxBaseDiskUnits := uint32(640)
+	adjustBaseDiskSizeToMinBaseDiskUnits := true
+	config := &pools_config.PoolsConfig{
+		MaxActiveSlots:       &maxActiveSlots,
+		MaxBaseDisksInflight: &maxBaseDisksInflight,
+		MaxBaseDiskUnits:     &maxBaseDiskUnits,
+
+		AdjustBaseDiskSizeToMinBaseDiskUnits: &adjustBaseDiskSizeToMinBaseDiskUnits,
+	}
+	storage := newStorageWithConfig(
+		t,
+		ctx,
+		db,
+		config,
+		metrics.NewEmptyRegistry(),
+	)
+
+	imageSize := uint64(10)
+
+	err = storage.ConfigurePool(ctx, "image", "zone", 1, imageSize)
+	require.NoError(t, err)
+
+	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(baseDisks))
+	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
+
+	err = storage.CheckConsistency(ctx)
+	require.NoError(t, err)
 }
 
 func TestStorageYDBRetireBaseDiskForPoolWithImageSize(t *testing.T) {
@@ -2176,7 +2227,7 @@ func TestStorageYDBRetireBaseDiskForPoolWithImageSize(t *testing.T) {
 	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
 
 	baseDisks[0].CreateTaskID = "create"
 	err = storage.BaseDisksScheduled(ctx, baseDisks)
@@ -2347,7 +2398,7 @@ func TestStorageYDBRetireBaseDiskForDeletedPoolUsingImageSize(t *testing.T) {
 	baseDisks, err = storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
-	require.Equal(t, 6*baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, baseDiskUnitSize, baseDisks[0].Size)
 
 	err = storage.CheckConsistency(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
### Notes
Base disks should have at least a size that corresponds to minBaseDiskUnits (30) to achieve the same performance. 

Right now, if an image is small, we can create a base disk with only 1 allocation unit (AU) which is 32 GiB for SSD. Such a base disk has performance limits of only 1000 IOPS and 15 MiB/s.
These limits are shared across 30 overlay disks. Due to overlay disk [oversubscription](https://github.com/ydb-platform/nbs/blob/3a5c4f51eb14c98a63a651176caef9f74b9ba573/cloud/disk_manager/internal/pkg/services/pools/storage/common.go#L746), each overlay disk can have 6 AUs (192 GiB) while still consuming only 1 AU from the base disk.
This seems to create an insufficient performance bottleneck.


### Issue
#6257 
