### PR TITLE
[NBS] Local NVMe service: keep polling for local NVMe devices after empty startup discovery

### DIFF
--- a/cloud/blockstore/config/local_nvme.proto
+++ b/cloud/blockstore/config/local_nvme.proto
@@ -7,10 +7,13 @@ option go_package = "github.com/ydb-platform/nbs/cloud/blockstore/config";
 ////////////////////////////////////////////////////////////////////////////////
 
 message TLocalNVMeConfig {
-    // Source URI for retrieving the list of NVMe devices to use (e.g. file:///etc/nbs/devices.txt)
+    // Source URI for retrieving the list of NVMe devices to use (e.g. file:///etc/nbs/devices.txt).
     optional string DevicesSourceUri = 1;
 
     // Path to the file for persisting the service state.
     // Used to restore state after restart.
     optional string StateCacheFilePath = 2;
+
+    // How often to poll the device provider while no NVMe devices are available (in milliseconds).
+    optional uint32 UpdateDevicesInterval = 3;
 }

--- a/cloud/blockstore/libs/local_nvme/config.cpp
+++ b/cloud/blockstore/libs/local_nvme/config.cpp
@@ -4,7 +4,11 @@
 
 #include <util/generic/string.h>
 
+#include <chrono>
+
 namespace NCloud::NBlockStore {
+
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -13,6 +17,7 @@ namespace {
 #define BLOCKSTORE_LOCAL_NVME_CONFIG(xxx)                                      \
     xxx(DevicesSourceUri,                TString,          ""                 )\
     xxx(StateCacheFilePath,              TString,          ""                 )\
+    xxx(UpdateDevicesInterval,           TDuration,        1min               )\
 // BLOCKSTORE_LOCAL_NVME_CONFIG
 
 #define BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG(name, type, value)                \
@@ -29,6 +34,12 @@ template <typename TTarget, typename TSource>
 TTarget ConvertValue(const TSource& value)
 {
     return TTarget(value);
+}
+
+template <>
+TDuration ConvertValue<TDuration, ui32>(const ui32& value)
+{
+    return TDuration::MilliSeconds(value);
 }
 
 }   //  namespace

--- a/cloud/blockstore/libs/local_nvme/config.h
+++ b/cloud/blockstore/libs/local_nvme/config.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/config/local_nvme.pb.h>
 
+#include <util/datetime/base.h>
 #include <util/generic/fwd.h>
 
 #include <variant>
@@ -25,6 +26,7 @@ public:
 
     [[nodiscard]] TString GetDevicesSourceUri() const;
     [[nodiscard]] TString GetStateCacheFilePath() const;
+    [[nodiscard]] TDuration GetUpdateDevicesInterval() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -42,7 +42,7 @@ const NProto::TError ServiceStoppedError =
 const NProto::TError ServiceDestroyedError =
     MakeError(E_REJECTED, "Local NVMe service is destroyed");
 
-const TDuration FetchDevicesRetryTimeout = TDuration::Seconds(1);
+const TDuration UpdateDevicesRetryTimeout = TDuration::Seconds(1);
 const TDuration SanitizeStatusProbeTimeout = TDuration::MilliSeconds(100);
 const TDuration VfioDeviceRetryDelay = TDuration::MilliSeconds(100);
 const ui32 VfioDeviceMaxRetries = 100;
@@ -145,7 +145,7 @@ private:
     bool IsVfioDevSupported = false;
 
     TFuture<void> Ready;
-    TCont* InitializeCont = nullptr;
+    TCont* StartCont = nullptr;
 
     THashMap<TSerialNumber, NProto::TNVMeDevice> Devices;
     THashSet<TSerialNumber> AcquiredDevices;
@@ -195,27 +195,33 @@ private:
         const std::weak_ptr<TLocalNVMeService>& weakService)
         -> TResultOrError<std::shared_ptr<TLocalNVMeService>>;
 
-    void Initialize();
-    auto FetchDevices() -> NProto::TError;
+    void StartImpl();
+    auto Initialize() -> NProto::TError;
+    auto FetchDevices() const -> TResultOrError<TVector<NProto::TNVMeDevice>>;
+    auto PrepareDevice(
+        const TSerialNumber& serialNumber,
+        const TString& pciAddr) const -> TResultOrError<NProto::TNVMeDevice>;
+    auto UpdateDevices() -> NProto::TError;
     bool TryRestoreStateFromCache();
     void UpdateStateCache();
-    auto CreateStateSnapshot() -> NProto::TLocalNVMeServiceState;
+    auto CreateStateSnapshot() const -> NProto::TLocalNVMeServiceState;
     auto SanitizeNVMeDevice(const NProto::TNVMeDevice& device)
         -> NProto::TError;
     auto ResetToSingleNamespace(const NProto::TNVMeDevice& device)
         -> NProto::TError;
-    auto GetNVMeCtrlPath(const NProto::TNVMeDevice& device) -> TFsPath;
+    auto GetNVMeCtrlPath(const NProto::TNVMeDevice& device) const -> TFsPath;
     auto BindDeviceToDriver(
         const NProto::TNVMeDevice& device,
         const TString& driverName) -> NProto::TError;
-    auto GetVfioDevName(const TString& pciAddress) -> TResultOrError<TString>;
+    auto GetVfioDevName(const TString& pciAddress) const
+        -> TResultOrError<TString>;
 
     auto StopImpl() -> TFuture<void>;
 
     template <typename TOpResult>
     auto GetOperationResult(
         const TSerialNumber& serialNumber,
-        const TString& idempotenceId)
+        const TString& idempotenceId) const
         -> std::optional<TFuture<typename TOpResult::value_type>>;
 
     template <typename TOpResult, typename TFnResult, typename TFn>
@@ -242,42 +248,66 @@ TLocalNVMeService::TLocalNVMeService(
     , SysFs(std::move(sysFs))
 {}
 
-void TLocalNVMeService::Initialize()
+void TLocalNVMeService::StartImpl()
 {
-    // Store a pointer to the current continuation so Initialize can be stopped
-    // if Stop is called.
-    InitializeCont = RunningCont();
-    Y_DEBUG_ABORT_UNLESS(InitializeCont);
+    // Save the StartImpl continuation so Stop() can interrupt startup.
+    StartCont = RunningCont();
+    Y_DEBUG_ABORT_UNLESS(StartCont);
 
     Y_DEFER
     {
-        InitializeCont = nullptr;
+        StartCont = nullptr;
     };
 
-    if (!TryRestoreStateFromCache()) {
-        for (;;) {
-            STORAGE_INFO("Fetching NVMe devices from the provider");
-
-            auto error = FetchDevices();
-            if (!HasError(error)) {
-                break;
-            }
-
-            STORAGE_ERROR(
-                "Failed to fetch NVMe devices from the provider: "
-                << FormatError(error));
-
-            if (!SleepCont(FetchDevicesRetryTimeout)) {
-                STORAGE_INFO("Initialization has been cancelled");
-                return;
-            }
-        }
+    if (auto error = Initialize(); HasError(error)) {
+        STORAGE_ERROR(
+            "Failed to initialize Local NVMe service: " << FormatError(error));
+        return;
     }
 
+    // Initialization is complete; publish the Running state.
     EServiceState state = EServiceState::Initializing;
     if (!ServiceState.compare_exchange_strong(state, EServiceState::Running)) {
         Y_DEBUG_ABORT_UNLESS(state == EServiceState::Stopped);
+        return;
     }
+
+    // The service is already running, but devices may appear later. Keep
+    // polling the provider until at least one device becomes available.
+    while (Devices.empty()) {
+        if (!SleepCont(Config->GetUpdateDevicesInterval())) {
+            return;
+        }
+
+        const auto error = UpdateDevices();
+        if (HasError(error)) {
+            STORAGE_ERROR(
+                "Failed to update NVMe device list: " << FormatError(error));
+        }
+    }
+}
+
+auto TLocalNVMeService::Initialize() -> NProto::TError
+{
+    if (TryRestoreStateFromCache()) {
+        return {};
+    }
+
+    for (;;) {
+        const auto error = UpdateDevices();
+        if (!HasError(error)) {
+            break;
+        }
+
+        STORAGE_ERROR(
+            "Failed to update NVMe device list: " << FormatError(error));
+
+        if (!SleepCont(UpdateDevicesRetryTimeout)) {
+            return MakeError(E_CANCELLED, "Initialization has been cancelled");
+        }
+    }
+
+    return {};
 }
 
 void TLocalNVMeService::Start()
@@ -295,6 +325,8 @@ void TLocalNVMeService::Start()
 
     Log = Logging->CreateLog("BLOCKSTORE_LOCAL_NVME");
 
+    STORAGE_INFO("Starting Local NVMe service");
+
     auto [supported, error] = SafeExecute<TResultOrError<bool>>(
         [&] { return SysFs->IsVfioDevSupported(); });
     if (HasError(error)) {
@@ -308,7 +340,7 @@ void TLocalNVMeService::Start()
         [weakSelf = weak_from_this()]
         {
             if (auto self = weakSelf.lock()) {
-                self->Initialize();
+                self->StartImpl();
             }
         });
 }
@@ -321,8 +353,8 @@ auto TLocalNVMeService::StopImpl() -> TFuture<void>
     futures.reserve(Operations.size() + 1);
 
     futures.push_back(Ready);
-    if (InitializeCont) {
-        InitializeCont->Cancel();
+    if (StartCont) {
+        StartCont->Cancel();
     }
 
     for (const auto& [_, op]: Operations) {
@@ -349,6 +381,8 @@ void TLocalNVMeService::Stop()
         // Service is not running
         return;
     }
+
+    STORAGE_INFO("Stopping Local NVMe service");
 
     auto future = Executor->Execute([this] { return StopImpl(); });
     future.Wait();
@@ -442,52 +476,16 @@ auto TLocalNVMeService::EnsureIsReady(
     return service;
 }
 
-auto TLocalNVMeService::FetchDevices() -> NProto::TError
+auto TLocalNVMeService::UpdateDevices() -> NProto::TError
 {
-    auto future = DeviceProvider->ListNVMeDevices();
-    auto [devices, error] = Executor->ResultOrError(future);
-
+    auto [devices, error] = FetchDevices();
     if (HasError(error)) {
         return error;
     }
 
-    STORAGE_INFO(
-        "Fetched NVMe devices (" << devices.size()
-                                 << "): " << Join(", ", devices));
-
-    // We expect Device provider to provide serial numbers and PCI addresses
-
-    for (const auto& src: devices) {
-        if (src.GetPCIAddress().empty()) {
-            STORAGE_WARN("Ignore device with empty PCI address: " << src);
-            continue;
-        }
-
-        if (src.GetSerialNumber().empty()) {
-            STORAGE_WARN("Ignore device with empty serial number: " << src);
-            continue;
-        }
-
-        const auto pciAddr = NormalizePCIAddr(src.GetPCIAddress());
-
-        auto [device, deviceError] = SafeExecute<TAcquireResult>(
-            [&] { return SysFs->GetNVMeDeviceFromPCIAddr(pciAddr); });
-
-        if (HasError(deviceError)) {
-            STORAGE_ERROR(
-                "Failed to retrieve information about "
-                << src << ": " << FormatError(deviceError));
-            continue;
-        }
-
-        if (device.GetSerialNumber() != src.GetSerialNumber()) {
-            STORAGE_ERROR(
-                "Serial numbers don't match: " << src << " vs " << device
-                                               << ". Ignore device");
-            continue;
-        }
-
-        Devices[device.GetSerialNumber()] = std::move(device);
+    Devices.clear();
+    for (auto& d: devices) {
+        Devices[d.GetSerialNumber()] = std::move(d);
     }
 
     UpdateStateCache();
@@ -495,7 +493,84 @@ auto TLocalNVMeService::FetchDevices() -> NProto::TError
     return {};
 }
 
-auto TLocalNVMeService::CreateStateSnapshot() -> NProto::TLocalNVMeServiceState
+auto TLocalNVMeService::PrepareDevice(
+    const TSerialNumber& serialNumber,
+    const TString& pciAddr) const -> TResultOrError<NProto::TNVMeDevice>
+{
+    if (pciAddr.empty()) {
+        return MakeError(E_ARGUMENT, "empty PCI address");
+    }
+
+    if (serialNumber.empty()) {
+        return MakeError(E_ARGUMENT, "empty serial number");
+    }
+
+    const auto normalizedPCIAddr = NormalizePCIAddr(pciAddr);
+
+    auto [device, error] = SafeExecute<TResultOrError<NProto::TNVMeDevice>>(
+        [&] { return SysFs->GetNVMeDeviceFromPCIAddr(normalizedPCIAddr); });
+
+    if (HasError(error)) {
+        return MakeError(
+            error.GetCode(),
+            TStringBuilder() << "Failed to get NVMe device from sysfs"
+                             << " by PCI address " << normalizedPCIAddr << ": "
+                             << error.GetMessage());
+    }
+
+    if (device.GetSerialNumber() != serialNumber) {
+        return MakeError(
+            E_INVALID_STATE,
+            TStringBuilder()
+                << "NVMe serial number mismatch for PCI address "
+                << normalizedPCIAddr << ": expected " << serialNumber
+                << ", got " << device.GetSerialNumber());
+    }
+
+    return device;
+}
+
+auto TLocalNVMeService::FetchDevices() const
+    -> TResultOrError<TVector<NProto::TNVMeDevice>>
+{
+    STORAGE_INFO("Fetching NVMe devices from the provider");
+
+    auto future = DeviceProvider->ListNVMeDevices();
+    auto [devices, error] = Executor->ResultOrError(future);
+
+    if (HasError(error)) {
+        STORAGE_ERROR(
+            "Failed to fetch NVMe devices from the provider: "
+            << FormatError(error));
+        return error;
+    }
+
+    STORAGE_INFO(
+        "Fetched NVMe devices from the provider ("
+        << devices.size() << "): " << Join(", ", devices));
+
+    TVector<NProto::TNVMeDevice> result;
+    result.reserve(devices.size());
+
+    for (const auto& src: devices) {
+        auto [device, error] =
+            PrepareDevice(src.GetSerialNumber(), src.GetPCIAddress());
+
+        if (HasError(error)) {
+            STORAGE_WARN(
+                "Ignoring NVMe device reported by the provider"
+                << ": " << src << ": " << FormatError(error));
+            continue;
+        }
+
+        result.push_back(std::move(device));
+    }
+
+    return result;
+}
+
+auto TLocalNVMeService::CreateStateSnapshot() const
+    -> NProto::TLocalNVMeServiceState
 {
     NProto::TLocalNVMeServiceState proto;
     for (const auto& [_, device]: Devices) {
@@ -591,7 +666,7 @@ auto TLocalNVMeService::BindDeviceToDriver(
 template <typename TOpResult>
 auto TLocalNVMeService::GetOperationResult(
     const TSerialNumber& serialNumber,
-    const TString& idempotenceId)
+    const TString& idempotenceId) const
     -> std::optional<TFuture<typename TOpResult::value_type>>
 {
     auto makeErrorFuture = [](ui32 code, TString msg)
@@ -738,7 +813,7 @@ auto TLocalNVMeService::AcquireDeviceImpl(NProto::TNVMeDevice device)
     return device;
 }
 
-auto TLocalNVMeService::GetVfioDevName(const TString& pciAddress)
+auto TLocalNVMeService::GetVfioDevName(const TString& pciAddress) const
     -> TResultOrError<TString>
 {
     // Binding to vfio-pci completes before the vfio-dev sysfs entry may
@@ -774,7 +849,7 @@ auto TLocalNVMeService::GetVfioDevName(const TString& pciAddress)
                          << " retries");
 }
 
-auto TLocalNVMeService::GetNVMeCtrlPath(const NProto::TNVMeDevice& device)
+auto TLocalNVMeService::GetNVMeCtrlPath(const NProto::TNVMeDevice& device) const
     -> TFsPath
 {
     const TString& pciAddr = device.GetPCIAddress();

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -347,11 +347,12 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
 
         NProto::TLocalNVMeConfig proto;
         proto.SetStateCacheFilePath(StateCacheFile);
+        proto.SetUpdateDevicesInterval(TDuration::Seconds(1).MilliSeconds());
 
         Config = std::make_shared<TLocalNVMeConfig>(proto);
     }
 
-    auto ListNVMeDevices()
+    auto ListNVMeDevices() const
     {
         for (;;) {
             auto future = Service->ListNVMeDevices();
@@ -1470,6 +1471,94 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             E_REJECTED,
             error.GetCode(),
             FormatError(error));
+    }
+
+    Y_UNIT_TEST_F(ShouldStartWithoutNvmeDevicesAndDiscoverThemLater, TFixture)
+    {
+        const ui32 successfulAttempt = 3;
+
+        TAutoEvent lastRequest;
+        std::atomic<ui32> attempts = 0;
+
+        DeviceProvider->ListNVMeDevicesImpl.SetValue(
+            [&]
+            {
+                ++attempts;
+                if (attempts < successfulAttempt) {
+                    return MakeFuture(TVector<NProto::TNVMeDevice>());
+                }
+
+                lastRequest.Signal();
+
+                return MakeFuture(CreateDeviceList());
+            });
+
+        {
+            auto [devices, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_VALUES_EQUAL(0, devices.size());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(1, attempts.load());
+
+        lastRequest.WaitT(
+            Config->GetUpdateDevicesInterval() * successfulAttempt);
+
+        UNIT_ASSERT_VALUES_EQUAL(successfulAttempt, attempts.load());
+
+        {
+            auto [devices, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_VALUES_EQUAL(Devices.size(), devices.size());
+            for (size_t i = 0; i != Devices.size(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    Devices[i].DebugString(),
+                    devices[i].DebugString(),
+                    "#" << i);
+            }
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldStopWhilePollingForNvmeDevices, TFixture)
+    {
+        const ui32 lastAttempt = 2;
+
+        TAutoEvent lastRequest;
+        std::atomic<ui32> attempts = 0;
+
+        DeviceProvider->ListNVMeDevicesImpl.SetValue(
+            [&]
+            {
+                ++attempts;
+                if (attempts >= lastAttempt) {
+                    lastRequest.Signal();
+                }
+
+                return MakeFuture(TVector<NProto::TNVMeDevice>());
+            });
+
+        {
+            auto [devices, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_VALUES_EQUAL(0, devices.size());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(1, attempts.load());
+
+        lastRequest.WaitT(Config->GetUpdateDevicesInterval() * lastAttempt);
+
+        UNIT_ASSERT_VALUES_EQUAL(lastAttempt, attempts.load());
+
+        Service->Stop();
     }
 
     Y_UNIT_TEST_F(ShouldGetDevicesFromInfra, TFixtureInfra)


### PR DESCRIPTION
Previously, the local NVMe service fetched the device list from the provider only during startup. If the provider returned an empty list, the service stayed without devices until the process was restarted.

Now the service continues to update the device list after startup while no local NVMe devices are available. This allows it to pick up NVMe devices that appear on the host later, without requiring a process restart.
