### PR TITLE
fix: coredumps in qemu tests with sanitizers

### DIFF
--- a/.github/packer/scripts/github-runner.sh
+++ b/.github/packer/scripts/github-runner.sh
@@ -182,7 +182,7 @@ chmod 1777 /coredumps
 {
     echo "fs.aio-max-nr=1048576"
     echo "vm.swappiness=1"
-    echo "kernel.core_pattern=/coredumps/core.%e.%u.%b.%p.%t"
+    echo "kernel.core_pattern=/coredumps/%e.%p.%s"
     echo "kernel.core_uses_pid=1"
     echo "fs.suid_dumpable=0"
 } >> /etc/sysctl.conf

--- a/.github/scripts/nebius_manage_vm_test.py
+++ b/.github/scripts/nebius_manage_vm_test.py
@@ -365,7 +365,7 @@ def test_generate_cloud_init_script_renders_repo_template(monkeypatch):
     assert "RUNNER_ALLOW_RUNASROOT" not in script
     assert 'runuser -u "$RUNNER_USER" -- ./config.sh' in script
     assert './svc.sh install "$RUNNER_USER"' in script
-    assert "kernel.core_pattern=/coredumps/core.%e.%u.%b.%p.%t" in script
+    assert "kernel.core_pattern=/coredumps/%e.%p.%s" in script
     assert "LimitMEMLOCK=infinity" in script
     assert "kernel.dmesg_restrict=0" not in script
     assert "NOPASSWD:ALL" not in script

--- a/.github/scripts/templates/nebius_runner_cloud_init.sh
+++ b/.github/scripts/templates/nebius_runner_cloud_init.sh
@@ -18,7 +18,7 @@ grep localhost /etc/hosts
 
 mkdir -p /coredumps
 chmod 1777 /coredumps
-grep -qF "kernel.core_pattern=/coredumps/core.%e.%u.%b.%p.%t" /etc/sysctl.conf || echo "kernel.core_pattern=/coredumps/core.%e.%u.%b.%p.%t" >> /etc/sysctl.conf
+grep -qF "kernel.core_pattern=/coredumps/%e.%p.%s" /etc/sysctl.conf || echo "kernel.core_pattern=/coredumps/%e.%p.%s" >> /etc/sysctl.conf
 grep -qF "kernel.core_uses_pid=1" /etc/sysctl.conf || echo "kernel.core_uses_pid=1" >> /etc/sysctl.conf
 grep -qF "fs.suid_dumpable=0" /etc/sysctl.conf || echo "fs.suid_dumpable=0" >> /etc/sysctl.conf
 grep -qF "* soft memlock unlimited" /etc/security/limits.conf || echo "* soft memlock unlimited" >> /etc/security/limits.conf

--- a/cloud/storage/core/tools/common/python/core_pattern.py
+++ b/cloud/storage/core/tools/common/python/core_pattern.py
@@ -1,23 +1,152 @@
 # -*- coding: utf-8 -*-
-import logging
+"""Helpers for predicting Linux core dump filenames."""
 
-from os.path import basename
+import logging
+import re
+
+from os.path import abspath, basename, isabs, join
 
 
 logger = logging.getLogger(__name__)
 
+CORE_FILENAME_MAX_BYTES = 128
 
+CORE_PATTERN_WILDCARD_SPECIFIERS = (
+    '%P',
+    '%i',
+    '%I',
+    '%u',
+    '%g',
+    '%d',
+    '%s',
+    '%t',
+    '%h',
+    '%b',
+    '%c',
+    '%F',
+)
+
+TRUNCATION_WILDCARD_SPECIFIER_MAX_BYTES = {
+    # yatest expands %p to the real PID after core_pattern() returns.
+    # If %p is before a long %E expansion, Linux truncates the real filename
+    # after writing the expanded PID, not the two-byte "%p" token. Reserve
+    # enough bytes for the largest Linux pid_t decimal value while truncating
+    # our recovery glob.
+    '%p': 10,
+}
+
+
+def _full_binary_path(binary_path, cwd):
+    if isabs(binary_path):
+        return binary_path
+
+    if cwd:
+        return abspath(join(cwd, binary_path))
+
+    return abspath(binary_path)
+
+
+def _core_comm(binary_path):
+    # Linux truncates %e to the first 15 bytes of task comm.
+    return basename(binary_path)[:15] + '*'
+
+
+def _escape_recover_core_pattern_literal_percent(text):
+    return text.replace('%', '%%')
+
+
+def _wildcard_variable_width_specifiers_for_truncation(pattern):
+    # Some specifiers that remain in the returned glob are expanded later by
+    # yatest's recover_core_dump_file(). Replace those before truncating long
+    # patterns, otherwise the later expansion can make the glob longer than
+    # the actual filename Linux wrote under core(5)'s 128-byte limit.
+    wildcard_expansion_extra_bytes = 0
+    parts = []
+    offset = 0
+    for part in re.split(r'(%.)', pattern):
+        max_bytes = TRUNCATION_WILDCARD_SPECIFIER_MAX_BYTES.get(part)
+        part_bytes = len(part.encode())
+        # Specifiers past the kernel truncation boundary cannot affect the
+        # actual filename prefix, so leave them alone. They will usually be
+        # removed by the final truncation below.
+        if max_bytes is None or offset >= CORE_FILENAME_MAX_BYTES:
+            parts.append(part)
+            offset += part_bytes
+            continue
+
+        parts.append('*')
+        # Account for the bytes hidden by replacing a variable-width specifier
+        # with a one-byte glob. This keeps our truncated glob shorter by the
+        # same amount Linux may spend on the real expansion.
+        wildcard_expansion_extra_bytes += max_bytes - len('*')
+        offset += part_bytes
+
+    return ''.join(parts), wildcard_expansion_extra_bytes
+
+
+def _truncate_core_pattern(pattern):
+    if len(pattern.encode()) <= CORE_FILENAME_MAX_BYTES:
+        return pattern
+
+    # First make the visible prefix conservative for later-expanded tokens
+    # such as %p, then cut it to the same byte budget Linux applies to the
+    # fully expanded core filename.
+    pattern, wildcard_expansion_extra_bytes = (
+        _wildcard_variable_width_specifiers_for_truncation(pattern)
+    )
+
+    # core(5): the resulting core filename is limited to 128 bytes on Linux.
+    # Keep the returned value a glob because truncation can remove suffix
+    # specifiers such as %p after the kernel expands the pattern.
+    max_pattern_bytes = max(
+        1,
+        CORE_FILENAME_MAX_BYTES - wildcard_expansion_extra_bytes,
+    )
+    truncated = pattern.encode()[:max_pattern_bytes - 1]
+    while True:
+        try:
+            return truncated.decode() + '*'
+        except UnicodeDecodeError:
+            truncated = truncated[:-1]
+
+
+# Technically we do not need this function, because it is used in Daemon class
+# and it itself calls common.execute with core_pattern argument, which, if set
+# to None will automatically use yatool builtin pattern discovery inside
+# `recover_core_dump_file`
+# https://github.com/yandex/yatool/blob/main/library/python/cores/__init__.py#L24
+# but we have few special cases like
+# cloud/storage/core/tools/testing/unstable-process/
+# which launch process, but we want to actually track different process
 def core_pattern(binary_path, cwd=None):
-    with open("/proc/sys/kernel/core_pattern") as f:
-        p = f.read().strip("\n")
+    """Return a yatest-compatible glob for the current Linux core pattern."""
+    with open('/proc/sys/kernel/core_pattern') as f:
+        p = f.read().strip('\n')
 
-        logger.info("System core pattern: %s", p)
+        logger.info('System core pattern: %s', p)
 
         if not p.startswith('|'):
-            mask = basename(binary_path)[:8] + '*'
-            return p.replace('%e', mask)
+            full_binary_path = _full_binary_path(binary_path, cwd)
+            literal_percent = '__CORE_PATTERN_LITERAL_PERCENT__'
+            p = p.replace('%%', literal_percent)
+            p = p.replace(
+                '%E',
+                _escape_recover_core_pattern_literal_percent(
+                    full_binary_path.replace('/', '!')
+                ),
+            )
+            p = p.replace(
+                '%e',
+                _escape_recover_core_pattern_literal_percent(
+                    _core_comm(binary_path)
+                ),
+            )
+            for specifier in CORE_PATTERN_WILDCARD_SPECIFIERS:
+                p = p.replace(specifier, '*')
+            p = p.replace(literal_percent, '%%')
+            return _truncate_core_pattern(p)
 
-    name = binary_path.replace("/", "_")
-    name = name.replace(".", "_")
+    name = binary_path.replace('/', '_')
+    name = name.replace('.', '_')
 
     return f'/var/lib/apport/coredump/core.{name}.*'

--- a/cloud/storage/core/tools/common/python/ut/core_pattern_ut.py
+++ b/cloud/storage/core/tools/common/python/ut/core_pattern_ut.py
@@ -1,0 +1,156 @@
+"""Tests for core dump filename recovery patterns."""
+
+import builtins
+import fnmatch
+import re
+from io import StringIO
+from unittest import mock
+
+from cloud.storage.core.tools.common.python.core_pattern import (
+    CORE_FILENAME_MAX_BYTES,
+    core_pattern,
+)
+
+
+def core_pattern_with_system_pattern(pattern, binary_path, cwd=None):
+    """Run core_pattern() with a mocked Linux system core pattern."""
+    real_open = builtins.open
+
+    def open_mock(path, *args, **kwargs):
+        if path == '/proc/sys/kernel/core_pattern':
+            return StringIO(pattern)
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch('builtins.open', open_mock):
+        return core_pattern(binary_path, cwd)
+
+
+def recover_core_mask_like_yatest(core_mask, pid):
+    """Resolve the subset of yatest core-mask tokens used by these tests."""
+    def resolve(text):
+        if text == '%p':
+            return str(pid)
+        if text == '%%':
+            return '%'
+        if text.startswith('%'):
+            return '*'
+        return text
+
+    return ''.join(
+        resolve(p)
+        for p in filter(None, re.split(r'(%.)', core_mask))
+    )
+
+
+def test_short_pattern_is_rendered_without_truncation():
+    """Short patterns should render known specifiers without truncation."""
+    assert (
+        core_pattern_with_system_pattern(
+            '/coredumps/%e.%p.%s',
+            '/build/bin/storage-service',
+        )
+        == '/coredumps/storage-service*.%p.*'
+    )
+
+
+def test_literal_percent_is_preserved():
+    """Literal percent signs in system patterns should survive recovery."""
+    assert (
+        core_pattern_with_system_pattern(
+            '/cores/%%.%e.%p',
+            '/build/bin/nbs',
+        )
+        == '/cores/%%.nbs*.%p'
+    )
+
+
+def test_literal_percent_in_executable_path_is_preserved():
+    """Literal percent signs in executable paths should be escaped."""
+    assert (
+        core_pattern_with_system_pattern(
+            '/cores/%E.%p',
+            '/build/foo%p/nbs',
+        )
+        == '/cores/!build!foo%%p!nbs.%p'
+    )
+
+
+def test_percent_p_in_executable_path_is_not_treated_as_pid_specifier():
+    """A path-local %p should not be resolved as the crashing PID."""
+    binary_path = '/build/foo%p/nbs'
+    pid = 12345
+    core_filename = '/cores/!build!foo%p!nbs.12345'
+
+    pattern = core_pattern_with_system_pattern('/cores/%E.%p', binary_path)
+    resolved_pattern = recover_core_mask_like_yatest(pattern, pid)
+
+    naive_pattern = '/cores/!build!foo%p!nbs.%p'
+    resolved_naive_pattern = recover_core_mask_like_yatest(naive_pattern, pid)
+
+    assert resolved_naive_pattern == '/cores/!build!foo12345!nbs.12345'
+    assert not fnmatch.fnmatch(core_filename, resolved_naive_pattern)
+    assert resolved_pattern == core_filename
+
+
+def test_long_expanded_pattern_is_truncated_to_kernel_limit():
+    """Long expanded paths should be limited to Linux core filename size."""
+    binary_path = (
+        '/build/' + '/'.join(['long-directory-name'] * 12) + '/nbs'
+    )
+
+    pattern = core_pattern_with_system_pattern('/cores/%E.%p', binary_path)
+
+    assert len(pattern.encode()) == CORE_FILENAME_MAX_BYTES
+    assert pattern.endswith('*')
+    assert pattern.startswith('/cores/!build!long-directory-name')
+    assert '%p' not in pattern
+
+
+def test_variable_width_pid_before_long_expanded_pattern_matches_kernel_truncation():
+    """A PID before a long %E should match the kernel-truncated filename."""
+    binary_path = (
+        '/build/' + '/'.join(['long-directory-name'] * 12) + '/nbs'
+    )
+    pid = '1234567'
+
+    pattern = core_pattern_with_system_pattern('/cores/%p.%E', binary_path)
+    core_filename = f"/cores/{pid}.{binary_path.replace('/', '!')}"
+    core_filename = core_filename.encode()[:CORE_FILENAME_MAX_BYTES].decode()
+
+    assert len(pattern.encode()) <= CORE_FILENAME_MAX_BYTES
+    assert pattern.startswith('/cores/*.')
+    assert '%p' not in pattern
+    assert fnmatch.fnmatch(core_filename, pattern)
+
+
+def test_naive_truncation_before_pid_expansion_would_miss_core():
+    """Naive truncation before resolving %p would miss real core files."""
+    binary_path = (
+        '/build/' + '/'.join(['long-directory-name'] * 12) + '/nbs'
+    )
+    pid = '1234567890'
+    encoded_binary_path = binary_path.replace('/', '!')
+
+    core_filename = f"/cores/{pid}.{encoded_binary_path}"
+    core_filename = core_filename.encode()[:CORE_FILENAME_MAX_BYTES].decode()
+
+    naive_pattern = f"/cores/%p.{encoded_binary_path}"
+    naive_pattern = (
+        naive_pattern.encode()[:CORE_FILENAME_MAX_BYTES - 1].decode() + '*'
+    )
+    naive_pattern = naive_pattern.replace('%p', pid)
+
+    pattern = core_pattern_with_system_pattern('/cores/%p.%E', binary_path)
+
+    assert not fnmatch.fnmatch(core_filename, naive_pattern)
+    assert fnmatch.fnmatch(core_filename, pattern)
+
+
+def test_truncation_does_not_split_utf8_sequence():
+    """Truncation should not split a multibyte UTF-8 character."""
+    binary_path = '/build/' + 'x' * 116 + '/\N{SNOWMAN}'
+
+    pattern = core_pattern_with_system_pattern('/cores/%E.%p', binary_path)
+
+    assert len(pattern.encode()) <= CORE_FILENAME_MAX_BYTES
+    assert pattern.endswith('*')

--- a/cloud/storage/core/tools/common/python/ut/ya.make
+++ b/cloud/storage/core/tools/common/python/ut/ya.make
@@ -1,0 +1,13 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+TEST_SRCS(
+    core_pattern_ut.py
+)
+
+PEERDIR(
+    cloud/storage/core/tools/common/python
+)
+
+END()

--- a/cloud/storage/core/tools/common/ya.make
+++ b/cloud/storage/core/tools/common/ya.make
@@ -1,4 +1,5 @@
 RECURSE(
     go
     python
+    python/ut
 )

--- a/cloud/storage/core/tools/testing/qemu/lib/backtrace.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/backtrace.py
@@ -1,30 +1,185 @@
+"""Guest-side core dump setup and backtrace collection for QEMU tests."""
+
+import shlex
+import textwrap
+
 import yatest.common as common
 
 
+def _process_coredumps_script(gdb, backtrace_dir):
+    return textwrap.dedent(f"""\
+        #!/bin/bash
+        set -x
+
+        gdb={shlex.quote(gdb)}
+        backtrace_dir={shlex.quote(backtrace_dir)}
+        gdb_args=( \\
+            --batch \\
+            -iex 'set print thread-events off' \\
+            -iex 'set auto-load safe-path /' \\
+            -ex bt \\
+        )
+
+        sudo mkdir -p "$backtrace_dir"
+        sudo sysctl \\
+            kernel.core_pattern \\
+            kernel.core_uses_pid \\
+            fs.suid_dumpable \\
+            | sudo tee "$backtrace_dir/guest-coredump-sysctl.txt"
+        for f in \\
+            /tmp/run_test.command.txt \\
+            /tmp/run_test.ulimit.soft.txt \\
+            /tmp/run_test.ulimit.hard.txt \\
+            /tmp/run_test.limits.txt
+        do
+            sudo test -f "$f" && sudo cp -f "$f" "$backtrace_dir"
+        done
+        sudo find /coredumps \\
+            -maxdepth 1 \\
+            -type f \\
+            ! -name '*.txt' \\
+            -printf '%f\\n' \\
+            | sort \\
+            | sudo tee "$backtrace_dir/guest-cores.txt"
+        sudo find /coredumps \\
+            -maxdepth 1 \\
+            -type f \\
+            -name '*.txt' \\
+            -exec cp -f {{}} "$backtrace_dir" \\;
+        sudo dmesg \\
+            | tail -n 200 \\
+            | sudo tee "$backtrace_dir/guest-dmesg.txt"
+
+        run_test_command=''
+        if sudo test -f /tmp/run_test.command.txt; then
+            run_test_command=$(sudo cat /tmp/run_test.command.txt)
+        fi
+
+        core_executable_name() {{
+            local core="$1"
+            printf '%s\\n' "$core" | sed -E 's/\\.[^.]*\\.[^.]*$//'
+        }}
+
+        while IFS= read -r core; do
+            [ -n "$core" ] || continue
+            backtrace="$backtrace_dir/$core.backtrace"
+            executable_name=$(core_executable_name "$core")
+            run_test_basename="${{run_test_command##*/}}"
+            executable=''
+            if sudo test -s "/coredumps/$core.exe.txt"; then
+                executable=$(sudo cat "/coredumps/$core.exe.txt" | tr '!' '/')
+            fi
+            if [ -n "$executable" ] && sudo test -x "$executable"; then
+                sudo "$gdb" \\
+                    "$executable" \\
+                    "/coredumps/$core" \\
+                    "${{gdb_args[@]}}" \\
+                    | sudo tee "$backtrace"
+            elif \\
+                [ -n "$run_test_command" ] && \\
+                sudo test -x "$run_test_command" && \\
+                [ "${{run_test_basename:0:15}}" = "$executable_name" ]
+            then
+                sudo "$gdb" \\
+                    "$run_test_command" \\
+                    "/coredumps/$core" \\
+                    "${{gdb_args[@]}}" \\
+                    | sudo tee "$backtrace"
+            else
+                sudo "$gdb" \\
+                    -c "/coredumps/$core" \\
+                    "${{gdb_args[@]}}" \\
+                    | sudo tee "$backtrace"
+            fi
+        done < "$backtrace_dir/guest-cores.txt"
+    """)
+
+
 def setup_coredumps(ssh):
-    ssh("sudo mkdir -p /cores")
-    ssh("sudo sysctl -w 'kernel.core_pattern=/cores/%E.%p'")
+    """Install guest core dump collection helpers."""
+    ssh('sudo mkdir -p /coredumps')
+    ssh('sudo chmod 1777 /coredumps')
+    # this wrapper is needed because we want to use %E in the pattern
+    # and not %e, because %E expands to the executable filename, but
+    # with slashes replaced by '!' to avoid directory creation.
+    # If the resulting core filename is too long, it is truncated
+    # to 128 bytes, including the trailing '*', and the '*' is
+    # appended to the truncated filename. (since Linux 5.19)
+    # and to get backtraces with correct executable names,
+    # So we create "short" core name that can be matched to the executable
+    # name
+    # and use it in the backtrace script to find the right executable for gdb.
+    # it also alleviates issue with too long file names (and simply looks
+    # nicer)
+    core_helper = textwrap.dedent("""\
+        #!/bin/bash
+        set -eu
 
-    # Default core limit is 0, so it's essential to increase it. Unfortunately
-    # there seems to be no portable way to do this across all images used in
-    # our tests. What works every time, is setting them locally inside the
-    # /run_test.sh script
+        core_dir=/coredumps
+        comm="${1//\\//_}"
+        comm="${comm//[[:space:]]/_}"
+        pid="$2"
+        signal="$3"
+        encoded_executable="$4"
+        core_name="$comm.$pid.$signal"
 
-    gdb = common.runtime.gdb_path()
-    gdb_args = "--batch -iex 'set print thread-events off' -iex 'set auto-load safe-path /' -ex bt"
-    backtrace_dir = common.output_path()
-    script = "\n".join([
-        "#!/bin/bash",
-        "set -x",
-        "for core in $(ls /cores); do",
-        "    binary_path_pid=$(echo $core | sed 's/!/\\//g')",
-        "    binary_path=$(echo $binary_path_pid | sed 's/\\.[0-9]*$//')",
-        "    binary_pid=$(basename $binary_path_pid)",
-        f"    backtrace={backtrace_dir}/$binary_pid.backtrace",
-        f"    sudo {gdb} $binary_path /cores/$core {gdb_args} | sudo tee $backtrace",
-        "done"])
-    ssh(f"sudo tee /process_coredumps.sh <<'EOF' && sudo chmod +x /process_coredumps.sh\n{script}\nEOF")
+        mkdir -p "$core_dir"
+        chmod 1777 "$core_dir"
+
+        cat > "$core_dir/$core_name"
+        printf '%s\\n' "$encoded_executable" > "$core_dir/$core_name.exe.txt"
+    """)
+    ssh(
+        "sudo tee /usr/local/bin/qemu-core-helper <<'EOF' && "
+        'sudo chmod +x /usr/local/bin/qemu-core-helper\n'
+        f'{core_helper}\n'
+        'EOF'
+    )
+    ssh(
+        'sudo sysctl -w '
+        "'kernel.core_pattern=|/usr/local/bin/qemu-core-helper %e %p %s %E'"
+    )
+    ssh("sudo sysctl -w 'kernel.core_pipe_limit=4'")
+    ssh("sudo sysctl -w 'kernel.core_uses_pid=1'")
+    # Tests are launched via `sudo /run_test.sh`, so their dumpability is
+    # governed by fs.suid_dumpable. Keep dumps enabled for these guest-side
+    # privileged launches and store them in a root-owned absolute path.
+    ssh("sudo sysctl -w 'fs.suid_dumpable=2'")
+    ssh(
+        "sudo grep -q '^\\* soft core unlimited$' "
+        '/etc/security/limits.conf || '
+        "printf '%s\\n' "
+        "'* soft core unlimited' "
+        "'* hard core unlimited' | "
+        'sudo tee -a /etc/security/limits.conf >/dev/null'
+    )
+    ssh(
+        'if command -v visudo >/dev/null 2>&1; then '
+        'tmp=$(mktemp) && '
+        "printf '%s\\n' "
+        "'Defaults rlimit_core=default' "
+        "'Defaults env_keep += \"ASAN_OPTIONS MSAN_OPTIONS "
+        "TSAN_OPTIONS UBSAN_OPTIONS\"' "
+        '> "$tmp" && '
+        'if sudo visudo -c -f "$tmp" >/dev/null 2>&1; then '
+        'sudo install -m 0440 "$tmp" /etc/sudoers.d/98-rlimit; '
+        'fi; '
+        'rm -f "$tmp"; '
+        'fi'
+    )
+
+    script = _process_coredumps_script(
+        common.runtime.gdb_path(),
+        common.output_path(),
+    )
+    ssh(
+        "sudo tee /process_coredumps.sh <<'EOF' && "
+        'sudo chmod +x /process_coredumps.sh\n'
+        f'{script}\n'
+        'EOF'
+    )
 
 
 def process_coredumps(ssh):
-    ssh("sudo /process_coredumps.sh")
+    """Run guest-side core dump backtrace collection."""
+    ssh('sudo /process_coredumps.sh')

--- a/cloud/storage/core/tools/testing/qemu/lib/common.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/common.py
@@ -1,10 +1,25 @@
 import logging
 import os
 import platform
+import shlex
 import tarfile
 import yatest.common as common
 
 logger = logging.getLogger(__name__)
+
+SANITIZER_OPTIONS = (
+    "ASAN_OPTIONS",
+    "MSAN_OPTIONS",
+    "TSAN_OPTIONS",
+    "UBSAN_OPTIONS",
+)
+
+
+def sanitizer_core_options_exports():
+    return [
+        'export {name}="${{{name}:+${name}:}}disable_coredump=0"'.format(name=name)
+        for name in SANITIZER_OPTIONS
+    ]
 
 
 class SshToGuest(object):
@@ -13,11 +28,21 @@ class SshToGuest(object):
         self.port = port
         self.key = key
 
-    def get_command(self, command, timeout=None):
+    def get_command(self, command, timeout=None, wrap_test_env=True):
         cmd = []
 
         if timeout is not None:
             cmd = ["timeout", str(timeout)]
+
+        if command and wrap_test_env:
+            quoted_command = shlex.quote(command)
+            command = (
+                "if [ -x /test_env.sh ]; then "
+                "exec /test_env.sh {command}; "
+                "else "
+                "exec /bin/bash -lc {command}; "
+                "fi"
+            ).format(command=quoted_command)
 
         cmd += [
             "ssh",

--- a/cloud/storage/core/tools/testing/qemu/lib/recipe.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/recipe.py
@@ -19,6 +19,7 @@ from .common import (
     get_qemu_bios,
     get_qemu_firmware,
     get_qemu_kvm,
+    sanitizer_core_options_exports,
 )
 from cloud.storage.core.tests.common import (
     append_recipe_err_files,
@@ -141,7 +142,7 @@ def start_instance(args, inst_index):
 
     if args.invoke_test:
         recipe_set_env("TEST_COMMAND_WRAPPER",
-                       " ".join(ssh.get_command("sudo /run_test.sh")),
+                       " ".join(ssh.get_command("sudo /run_test.sh", wrap_test_env=False)),
                        inst_index)
 
     ready_flag_path = recipe_get_env("QEMU_SET_READY_FLAG", inst_index)
@@ -434,6 +435,17 @@ def _prepare_test_environment(ssh, virtio):
     library.python.testing.recipe.set_env(
         "TEST_ENV_WRAPPER", vm_env['TEST_ENV_WRAPPER'])
 
+    test_env_sh = '\n'.join(
+        [
+            "#!/bin/bash",
+            "ulimit -Hc unlimited || true",
+            "ulimit -Sc unlimited || true",
+        ] + sanitizer_core_options_exports() + [
+            'exec /bin/bash -lc "$1"',
+        ]
+    )
+    ssh("sudo tee /test_env.sh <<'TEST-ENV' && sudo chmod +x /test_env.sh\n{}\nTEST-ENV".format(test_env_sh))
+
     run_test_sh = '\n'.join(
         [
             "#!/bin/bash"
@@ -441,10 +453,15 @@ def _prepare_test_environment(ssh, virtio):
             "export {}={}".format(k, shlex.quote(v))
             for k, v in vm_env.items()
         ] + [
-            # this should be a part of `setup_coredumps`, but there seems to be
-            # no portable way to do this globally
-            "ulimit -c unlimited"
-        ] + [
+            # Keep this locally as well so the test wrapper records the
+            # effective limits in artifacts even when guest-wide limits are set.
+            "ulimit -Hc unlimited || true",
+            "ulimit -Sc unlimited || true",
+            "ulimit -Ha >/tmp/run_test.ulimit.hard.txt 2>&1",
+            "ulimit -Sa >/tmp/run_test.ulimit.soft.txt 2>&1",
+            "cat /proc/self/limits >/tmp/run_test.limits.txt 2>&1",
+            "printf '%s\\n' \"$1\" >/tmp/run_test.command.txt 2>&1",
+        ] + sanitizer_core_options_exports() + [
             '"$@"',
             "exit_code=$?",
             "sync",


### PR DESCRIPTION
Initial motivation was to make errors like this at least debuggable:
```
Warning: Permanently added '[127.0.0.1]:43535' (ED25519) to the list of known hosts.
Authenticated to 127.0.0.1 ([127.0.0.1]:43535) using "publickey".
/run_test.sh: line 155:  2016 Segmentation fault      "$@"
Transferred: sent 3844, received 2644 bytes, in 0.2 seconds
Bytes per second: sent 15828.5, received 10887.3
```

https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/Nightly-build-(msan)/27541425895/1/nebius-x86-64-msan/summary/1/ya-test.html

But during journey through all the shenanigans I discovered few things:
1. We didn't use "[yandex](https://github.com/yandex/yatool/blob/0a869b5b78177e6ebfe6718adad35efb329d4a77/library/python/cores/__init__.py#L77)" corepattern (which is preferred way for coredumping in my opinion due to how yatool is written)
2. Collecting of coredumps inside qemu tests was quite broken due to few incorrect assumptions that were made which lead to not being able to process cores produced by tests. Like cases where we launch some wrapper command but in reality we want traces from child process.
3. Cores on *san builds were not working at all due to clang configuration
4. Cores were not saved sometimes at all due to combination of ulimits/sudo config.

Ideally it would be better to incorporate some settings in builded images itself and build/upload them somewhat automatically and regularly, but this is a task for another day.

Test runs are available here https://github.com/ydb-platform/nbs/pull/6235