### PR TITLE
[Disk Manager] issue-6257: allow to configure BaseDiskOverSubscription via PoolsConfig

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
@@ -34,6 +34,15 @@ message PoolsConfig {
     optional string BaseDiskIdPrefix = 22 [default = "base-"];
     // Makes base disks created from small images (for example, 32 GiB) larger,
     // so that they are large enough to achieve the performance corresponding to
-    // `minBaseDiskUnits`. See #6257 for details
+    // `minBaseDiskUnits`. See #6257 for details.
     optional bool AdjustBaseDiskSizeToMinBaseDiskUnits = 23 [default = false];
+    // Controls how many base disk allocation units are allocated for a given
+    // number of overlay disk allocation units.
+    // The lower this value, the higher the aggregated bandwidth that can be
+    // achieved when reading from base disks and lower overcommit.
+    // IMPORTANT NOTE:
+    //  * It can't be less than 1
+    //  * Reducing this number also increases the total size of the base disks
+    //    that need to be allocated.
+    optional uint32 BaseDiskOverSubscription = 24 [default = 2];
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -127,6 +127,7 @@ func (d *baseDisk) toBaseDisk() BaseDisk {
 		CheckpointID:        d.checkpointID,
 		CreateTaskID:        d.createTaskID,
 		Size:                d.size,
+		Units:               d.units,
 		Ready:               d.status == baseDiskStatusReady,
 	}
 }
@@ -674,7 +675,6 @@ const (
 	// 32 GB.
 	baseDiskUnitSize            = uint64(32 << 30)
 	minBaseDiskUnits            = 30
-	baseDiskOverSubscription    = 2
 	overlayDiskOverSubscription = 30
 	// Represents how many regular (HDD-equivalent) performance units one SSD
 	// allocation unit is worth.
@@ -701,7 +701,7 @@ func (s *storageYDB) generateBaseDisk(
 		size = ssdUnits * baseDiskUnitSize
 
 		// Regular (HDD-equivalent) units with oversubscription.
-		units = baseDiskOverSubscription * regularUnitsPerSSDUnit * ssdUnits
+		units = s.baseDiskOverSubscription * regularUnitsPerSSDUnit * ssdUnits
 		// A base disk must provide at least minBaseDiskUnits of performance,
 		// otherwise the overlay disks sharing it get underperformed (#6257).
 		if units < minBaseDiskUnits {

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
@@ -16,6 +16,7 @@ func testCommonGenerateBaseDiskForPool(
 
 	maxActiveSlots := uint64(640)
 	maxBaseDiskUnits := uint64(640)
+	baseDiskOverSubscription := uint64(2)
 
 	check := func(
 		actual baseDisk,
@@ -46,6 +47,8 @@ func testCommonGenerateBaseDiskForPool(
 			maxBaseDiskUnits: maxBaseDiskUnits,
 
 			adjustBaseDiskSizeToMinBaseDiskUnits: adjustBaseDiskSizeToMinBaseDiskUnits,
+
+			baseDiskOverSubscription: baseDiskOverSubscription,
 		}
 
 		var srcDisk *types.Disk
@@ -137,6 +140,36 @@ func testCommonGenerateBaseDiskForPool(
 	require.Equal(t, uint64(4096<<30), baseDisk.size)
 	require.Equal(t, uint64(1), baseDisk.maxActiveSlots)
 	require.Equal(t, uint64(1), baseDisk.units)
+
+	// Tests without base disk oversubscription.
+	maxActiveSlots = 640
+	maxBaseDiskUnits = 640
+	baseDiskOverSubscription = 1
+
+	baseDisk = generate(192 << 30)
+	require.Equal(t, uint64(192<<30), baseDisk.size)
+	require.Equal(t, uint64(30), baseDisk.maxActiveSlots)
+	require.Equal(t, uint64(30), baseDisk.units)
+
+	baseDisk = generate((192 << 30) + 1)
+	require.Equal(t, uint64(224<<30), baseDisk.size)
+	require.Equal(t, uint64(35), baseDisk.maxActiveSlots)
+	require.Equal(t, uint64(35), baseDisk.units)
+
+	baseDisk = generate(1024 << 30)
+	require.Equal(t, uint64(1024<<30), baseDisk.size)
+	require.Equal(t, uint64(160), baseDisk.maxActiveSlots)
+	require.Equal(t, uint64(160), baseDisk.units)
+
+	baseDisk = generate(2048 << 30)
+	require.Equal(t, uint64(2048<<30), baseDisk.size)
+	require.Equal(t, uint64(320), baseDisk.maxActiveSlots)
+	require.Equal(t, uint64(320), baseDisk.units)
+
+	baseDisk = generate(4096 << 30)
+	require.Equal(t, uint64(4096<<30), baseDisk.size)
+	require.Equal(t, uint64(640), baseDisk.maxActiveSlots)
+	require.Equal(t, uint64(640), baseDisk.units)
 }
 
 func TestCommonGenerateBaseDiskForPool(t *testing.T) {

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
@@ -22,6 +22,7 @@ type BaseDisk struct {
 	CheckpointID        string
 	CreateTaskID        string
 	Size                uint64
+	Units               uint64
 	Ready               bool
 }
 

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
@@ -25,6 +25,8 @@ type storageYDB struct {
 	baseDiskIDPrefix                   string
 
 	adjustBaseDiskSizeToMinBaseDiskUnits bool
+
+	baseDiskOverSubscription uint64
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -494,6 +496,10 @@ func NewStorage(
 		config.GetMaxBaseDiskUnits() != 0,
 		"MaxBaseDiskUnits should not be zero",
 	)
+	common.Assert(
+		config.GetBaseDiskOverSubscription() != 0,
+		"BaseDiskOverSubscription should not be zero",
+	)
 
 	// Default value.
 	takeBaseDisksToScheduleParallelism := 1
@@ -514,5 +520,7 @@ func NewStorage(
 		baseDiskIDPrefix:                   config.GetBaseDiskIdPrefix(),
 
 		adjustBaseDiskSizeToMinBaseDiskUnits: config.GetAdjustBaseDiskSizeToMinBaseDiskUnits(),
+
+		baseDiskOverSubscription: uint64(config.GetBaseDiskOverSubscription()),
 	}, nil
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -2210,6 +2210,48 @@ func TestStorageYDBCreatePoolWithImageSizeAndAdjustBaseDiskSizeToMinBaseDiskUnit
 	require.NoError(t, err)
 }
 
+func TestStorageYDBCreatePoolWithLargerImageSize(
+	t *testing.T,
+) {
+
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	maxActiveSlots := uint32(640)
+	maxBaseDisksInflight := uint32(1)
+	maxBaseDiskUnits := uint32(640)
+	config := &pools_config.PoolsConfig{
+		MaxActiveSlots:       &maxActiveSlots,
+		MaxBaseDisksInflight: &maxBaseDisksInflight,
+		MaxBaseDiskUnits:     &maxBaseDiskUnits,
+	}
+	storage := newStorageWithConfig(
+		t,
+		ctx,
+		db,
+		config,
+		metrics.NewEmptyRegistry(),
+	)
+
+	imageSize := uint64(7 * baseDiskUnitSize)
+
+	err = storage.ConfigurePool(ctx, "image", "zone", 1, imageSize)
+	require.NoError(t, err)
+
+	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(baseDisks))
+	require.Equal(t, 7*baseDiskUnitSize, baseDisks[0].Size)
+	require.Equal(t, uint64(70), baseDisks[0].Units)
+
+	err = storage.CheckConsistency(ctx)
+	require.NoError(t, err)
+}
+
 func TestStorageYDBRetireBaseDiskForPoolWithImageSize(t *testing.T) {
 	ctx, cancel := context.WithCancel(newContext())
 	defer cancel()


### PR DESCRIPTION
### Notes
Decreasing BaseDiskOverSubscription results in larger base disks, which provide higher aggregated bandwidth and IOPS

### Issue
#6257 
