### PR TITLE
issue-5643: disabling multiple-stage IO for tablet adapter mode regardless of StorageConfig flags

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -202,7 +202,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                                                                               \
     TTestEnv env({}, config);                                                 \
                                                                               \
-    ui32 nodeIdx = env.AddDynamicNode();                                     \
+    ui32 nodeIdx = env.AddDynamicNode();                                      \
                                                                               \
     TServiceClient service(env.GetRuntime(), nodeIdx);                        \
     auto fsInfo = CreateFileSystem(service, fsConfig);                        \
@@ -373,6 +373,61 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto& sessions = response.GetSessions();
             UNIT_ASSERT_VALUES_EQUAL(0, sessions.size());
         }
+    }
+
+    SERVICE_TEST(ShouldCheckForShardsInAdapterModeUponSessionCreationInShards)
+    {
+        //
+        // Enabling some features which shouldn't work for adapter-mode shards.
+        //
+
+        TShardedFileSystemConfig fsConfig;
+        config.SetTwoStageReadEnabled(true);
+        config.SetThreeStageWriteEnabled(true);
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        //
+        // Configuring one of the shards to use the adapter mode.
+        //
+
+        {
+            NProtoPrivate::TConfigureAsShardRequest request;
+            request.SetFileSystemId(fsConfig.Shard1Id);
+            request.SetIsFastShard(true);
+            request.SetShardNo(1);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            auto jsonResponse = service.ExecuteAction("configureasshard", buf);
+            NProtoPrivate::TConfigureAsShardResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError().GetMessage());
+        }
+
+        THeaders headers = {
+            .FileSystemId = fsConfig.FsId,
+            .ClientId = "client",
+            .SessionId = "",
+            .SessionSeqNo = 0};
+
+        auto response = service.CreateSession(
+            headers,
+            "" /* checkpointId */,
+            false /* restoreClientSession */,
+            0 /* sessionSeqNo */,
+            false /* readOnly */);
+
+        //
+        // Checking that the unsupported features are disabled.
+        //
+
+        const auto& f = response->Record.GetFileStore().GetFeatures();
+        UNIT_ASSERT(!f.GetTwoStageReadEnabled());
+        UNIT_ASSERT(!f.GetThreeStageWriteEnabled());
     }
 
     SERVICE_TEST(ShouldRestoreSessionInShardAfterShardRestart)

--- a/cloud/filestore/libs/storage/tablet/shard_request_actor.h
+++ b/cloud/filestore/libs/storage/tablet/shard_request_actor.h
@@ -12,7 +12,7 @@ namespace NCloud::NFileStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename TRequest, typename TResponse>
-class TShardRequestActor final
+class TShardRequestActor
     : public NActors::TActorBootstrapped<TShardRequestActor<TRequest, TResponse>>
 {
 private:
@@ -21,7 +21,6 @@ private:
     const TRequestInfoPtr RequestInfo;
     const TRequest::ProtoRecordType Request;
     const TVector<TString> ShardIds;
-    std::unique_ptr<TResponse> Response;
     ui32 ProcessedShards = 0;
 
     NProto::TProfileLogRequestInfo ProfileLogRequest;
@@ -39,6 +38,11 @@ public:
         std::unique_ptr<TResponse> response);
 
     void Bootstrap(const NActors::TActorContext& ctx);
+
+protected:
+    std::unique_ptr<TResponse> Response;
+
+    virtual void OnResponse(const TResponse::ProtoRecordType& record);
 
 private:
     STFUNC(StateWork)
@@ -71,6 +75,15 @@ private:
         const NActors::TActorContext& ctx,
         const NProto::TError& error);
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TRequest, typename TResponse>
+void TShardRequestActor<TRequest, TResponse>::OnResponse(
+    const TResponse::ProtoRecordType& record)
+{
+    Y_UNUSED(record);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -144,6 +157,8 @@ void TShardRequestActor<TRequest, TResponse>::HandleResponse(
         ReplyAndDie(ctx, msg->GetError());
         return;
     }
+
+    OnResponse(msg->Record);
 
     LOG_DEBUG(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -214,7 +214,10 @@ protected:
     void OnResponse(const NProtoPrivate::TCreateSessionResponse& record)
         override
     {
-        if (record.GetAdapterModeEnabled() && Response->Record.HasFileStore()) {
+        if (record.GetAdapterModeEnabled()
+                && Response
+                && Response->Record.HasFileStore())
+        {
             auto* f = Response->Record.MutableFileStore()->MutableFeatures();
             ProcessAdapterModeFeatures(*f);
         }
@@ -508,8 +511,10 @@ void TIndexTabletActor::CompleteTx_CreateSession(
 
     if (FastShard) {
         response->Record.SetAdapterModeEnabled(true);
-        auto* f = response->Record.MutableFileStore()->MutableFeatures();
-        ProcessAdapterModeFeatures(*f);
+        if (!args.Request.GetNoFileStoreInfo()) {
+            auto* f = response->Record.MutableFileStore()->MutableFeatures();
+            ProcessAdapterModeFeatures(*f);
+        }
     }
 
     TVector<TString> shardIds;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -187,11 +187,39 @@ void Convert(
     fileStore.SetShardNo(fileSystem.GetShardNo());
 }
 
+void ProcessAdapterModeFeatures(NProto::TFileStoreFeatures& f)
+{
+    //
+    // Adapter mode doesn't support multiple-stage IO yet. Disabling
+    // multiple-stage IO for the whole FS for simplicity if at least one shard
+    // is configured in adapter mode.
+    //
+
+    f.SetTwoStageReadEnabled(false);
+    f.SetThreeStageWriteEnabled(false);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
-using TCreateShardSessionsActor = TShardRequestActor<
+using TCreateShardSessionsActorBase = TShardRequestActor<
     TEvIndexTablet::TEvCreateSessionRequest,
     TEvIndexTablet::TEvCreateSessionResponse>;
+
+class TCreateShardSessionsActor: public TCreateShardSessionsActorBase
+{
+public:
+    using TCreateShardSessionsActorBase::TCreateShardSessionsActorBase;
+
+protected:
+    void OnResponse(const NProtoPrivate::TCreateSessionResponse& record)
+        override
+    {
+        if (record.GetAdapterModeEnabled() && Response->Record.HasFileStore()) {
+            auto* f = Response->Record.MutableFileStore()->MutableFeatures();
+            ProcessAdapterModeFeatures(*f);
+        }
+    }
+};
 
 }   // namespace
 
@@ -476,6 +504,12 @@ void TIndexTabletActor::CompleteTx_CreateSession(
             "%s New session TFileStoreFeatures '%s'",
             LogTag.c_str(),
             fileStore.GetFeatures().ShortDebugString().c_str());
+    }
+
+    if (FastShard) {
+        response->Record.SetAdapterModeEnabled(true);
+        auto* f = response->Record.MutableFileStore()->MutableFeatures();
+        ProcessAdapterModeFeatures(*f);
     }
 
     TVector<TString> shardIds;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -245,6 +245,15 @@ void TIndexTabletActor::CompleteAdapterLoadState(
         WaitReadyRequests.pop_front();
     }
 
+    //
+    // Adapter mode doesn't support multiple-stage IO yet.
+    //
+
+    NProto::TStorageConfig adapterModeOverrides;
+    adapterModeOverrides.SetTwoStageReadEnabled(false);
+    adapterModeOverrides.SetThreeStageWriteEnabled(false);
+    Config->Merge(adapterModeOverrides);
+
     TThrottlerConfig config;
     Convert(args.FileSystem.GetPerformanceProfile(), config);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -245,15 +245,6 @@ void TIndexTabletActor::CompleteAdapterLoadState(
         WaitReadyRequests.pop_front();
     }
 
-    //
-    // Adapter mode doesn't support multiple-stage IO yet.
-    //
-
-    NProto::TStorageConfig adapterModeOverrides;
-    adapterModeOverrides.SetTwoStageReadEnabled(false);
-    adapterModeOverrides.SetThreeStageWriteEnabled(false);
-    Config->Merge(adapterModeOverrides);
-
     TThrottlerConfig config;
     Convert(args.FileSystem.GetPerformanceProfile(), config);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
@@ -46,15 +46,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
         tablet.WaitReady();
         {
             auto response = tablet.InitSession("client", "session");
-
-            //
-            // For adapter mode multiple-stage io should be disabled regardless
-            // of the flags in StorageConfig.
-            //
-
-            const auto& feat = response->Record.GetFileStore().GetFeatures();
-            UNIT_ASSERT(!feat.GetTwoStageReadEnabled());
-            UNIT_ASSERT(!feat.GetThreeStageWriteEnabled());
+            UNIT_ASSERT(response->Record.GetAdapterModeEnabled());
         }
 
         const TString shardId1 = "shard1";

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
@@ -20,6 +20,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
     TABLET_TEST_4K_ONLY(ShouldUseAdapter)
     {
         NProto::TStorageConfig storageConfig;
+        storageConfig.SetTwoStageReadEnabled(true);
+        storageConfig.SetThreeStageWriteEnabled(true);
         TTestEnv env({}, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
@@ -42,7 +44,18 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
 
         tablet.ReconnectPipe();
         tablet.WaitReady();
-        tablet.InitSession("client", "session");
+        {
+            auto response = tablet.InitSession("client", "session");
+
+            //
+            // For adapter mode multiple-stage io should be disabled regardless
+            // of the flags in StorageConfig.
+            //
+
+            const auto& feat = response->Record.GetFileStore().GetFeatures();
+            UNIT_ASSERT(!feat.GetTwoStageReadEnabled());
+            UNIT_ASSERT(!feat.GetThreeStageWriteEnabled());
+        }
 
         const TString shardId1 = "shard1";
         const TString uuid1 = CreateGuidAsString();

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -73,6 +73,9 @@ message TCreateSessionResponse
     // Tablet generation and owner generation
     // for the accepted subsession owner.
     uint64 OwnerGeneration = 5;
+
+    // True if this tablet is configured to run in adapter mode.
+    bool AdapterModeEnabled = 6;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
Whenever you configure some of the shards to run in "adapter" mode (aka fastshard) and forget to explicitly disable multiple-stage IO, you generate tons of critical events and IO hangs. This PR fixes this inconvenience by forcing multiple-stage IO to be disabled if at least one of the shards is configured to run in adapter mode.

### Issue
https://github.com/ydb-platform/nbs/issues/5643