### PR TITLE
[Filestore] issue-4547: replace `TVector<TBlockDataRef> Blocks` with TBlockRanges in tablet_actor_readdata.cpp

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/block_ranges.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/block_ranges.cpp
@@ -1,0 +1,1 @@
+#include "block_ranges.h"

--- a/cloud/filestore/libs/storage/tablet/model/block_ranges.h
+++ b/cloud/filestore/libs/storage/tablet/model/block_ranges.h
@@ -78,20 +78,12 @@ public:
         return false;
     }
 
-    // True if data produced by the given commit supersedes the block's
-    // currently visible data: the block has no visible data (Empty or
-    // Deleted) or its data comes from an older commit.
-    bool IsCommitNewerThanVisibleData(ui32 blockIndex, ui64 commitId) const
+    // Commit id of the source which currently wins the block: visible data
+    // (Blob/Fresh) or a deletion. Zero for a block nothing was recorded for.
+    ui64 GetCommitIdByBlockOffset(ui32 blockOffset) const
     {
-        const auto& source = GetSource(blockIndex);
-
-        if (source.Kind == ESourceKind::Empty
-                || source.Kind == ESourceKind::Deleted)
-        {
-            return true;
-        }
-
-        return source.CommitId < commitId;
+        Y_DEBUG_ABORT_UNLESS(blockOffset < Blocks.size());
+        return Blocks[blockOffset].CommitId;
     }
 
     bool IsFreshBlock(ui32 blockIndex) const

--- a/cloud/filestore/libs/storage/tablet/model/block_ranges.h
+++ b/cloud/filestore/libs/storage/tablet/model/block_ranges.h
@@ -28,8 +28,6 @@ public:
 
     struct TSource
     {
-        ESourceKind Kind = ESourceKind::Empty;
-
         // Commit which produced this visible source.
         // The source with the greatest CommitId wins.
         ui64 CommitId = 0;
@@ -40,7 +38,18 @@ public:
         // Valid only for Kind == Blob.
         // Offset in blob corresponding to this block.
         ui32 BlobOffset = 0;
+
+        // Deliberately declared last. TPartialBlobId and CommitId are 8 byte
+        // aligned, so a leading ui8 field would occupy a whole 8 byte slot,
+        // making TSource 40 bytes. At the end it fits into the padding that
+        // already follows BlobOffset, so TSource stays 32 bytes. We keep one
+        // TSource per block, so this is a 20% cut of the Blocks vector.
+        ESourceKind Kind = ESourceKind::Empty;
     };
+
+    static_assert(
+        32 == sizeof(TSource),
+        "TSource is stored per block, keep it compact");
 
     struct TBlobRange
     {

--- a/cloud/filestore/libs/storage/tablet/model/block_ranges.h
+++ b/cloud/filestore/libs/storage/tablet/model/block_ranges.h
@@ -86,11 +86,6 @@ public:
         return Blocks[blockOffset].CommitId;
     }
 
-    bool IsFreshBlock(ui32 blockIndex) const
-    {
-        return GetSource(blockIndex).Kind == ESourceKind::Fresh;
-    }
-
     bool AddBlobRange(
         ui32 blockIndex,
         ui32 blocksCount,
@@ -127,6 +122,16 @@ public:
         return UpdateRange(blockIndex, blocksCount, source);
     }
 
+    // Visits every block in order, passing the block's offset within the
+    // range and its source (which may be Empty).
+    template <typename TVisitor>
+    void VisitBlocks(TVisitor&& visitor) const
+    {
+        for (ui32 i = 0; i < Blocks.size(); ++i) {
+            visitor(i, Blocks[i]);
+        }
+    }
+
     // Visits maximal blob runs (same blob, same commit, contiguous offset).
     template <typename TVisitor>
     void VisitBlobRanges(TVisitor&& visitor) const
@@ -158,13 +163,6 @@ public:
     }
 
 private:
-    const TSource& GetSource(ui32 blockIndex) const
-    {
-        const ui32 i = blockIndex - BeginBlockIndex;
-        Y_DEBUG_ABORT_UNLESS(i < Blocks.size());
-        return Blocks[i];
-    }
-
     // prev is known to be a Blob.
     static bool SameBlobConsecutiveBlocks(
         const TSource& prev,

--- a/cloud/filestore/libs/storage/tablet/model/block_ranges.h
+++ b/cloud/filestore/libs/storage/tablet/model/block_ranges.h
@@ -1,0 +1,217 @@
+#pragma once
+
+#include "block.h"
+
+#include <util/generic/vector.h>
+#include <util/system/yassert.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Resolves the visible source for every block in a [begin, begin + blocksCount)
+// range. For each block the source with the greatest CommitId wins.
+//
+// Stored as a flat per-block array, so updates are O(blocks touched) with no
+// allocations. All block indices passed by the caller must lie within the
+// range.
+class TBlockRanges
+{
+public:
+    enum class ESourceKind : ui8
+    {
+        Empty,
+        Blob,
+        Fresh,
+        Deleted,
+    };
+
+    struct TSource
+    {
+        ESourceKind Kind = ESourceKind::Empty;
+
+        // Commit which produced this visible source.
+        // The source with the greatest CommitId wins.
+        ui64 CommitId = 0;
+
+        // Valid only for Kind == Blob.
+        TPartialBlobId BlobId;
+
+        // Valid only for Kind == Blob.
+        // Offset in blob corresponding to this block.
+        ui32 BlobOffset = 0;
+    };
+
+    struct TBlobRange
+    {
+        ui32 BlockIndex = 0;
+        ui32 BlocksCount = 0;
+
+        ui64 CommitId = 0;
+        TPartialBlobId BlobId;
+        ui32 BlobOffset = 0;
+    };
+
+private:
+    // Not const: TReadData reassigns its TBlockRanges member in place.
+    ui32 BeginBlockIndex = 0;
+
+    // One entry per block, Blocks[i] describes block BeginBlockIndex + i.
+    TVector<TSource> Blocks;
+
+public:
+    TBlockRanges(ui32 beginBlockIndex, ui32 blocksCount)
+        : BeginBlockIndex(beginBlockIndex)
+        , Blocks(blocksCount)
+    {
+        Y_ABORT_UNLESS(blocksCount);
+    }
+
+    bool HasBlobs() const
+    {
+        for (const auto& source: Blocks) {
+            if (source.Kind == ESourceKind::Blob) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // True if data produced by the given commit supersedes the block's
+    // currently visible data: the block has no visible data (Empty or
+    // Deleted) or its data comes from an older commit.
+    bool IsCommitNewerThanVisibleData(ui32 blockIndex, ui64 commitId) const
+    {
+        const auto& source = GetSource(blockIndex);
+
+        if (source.Kind == ESourceKind::Empty
+                || source.Kind == ESourceKind::Deleted)
+        {
+            return true;
+        }
+
+        return source.CommitId < commitId;
+    }
+
+    bool IsFreshBlock(ui32 blockIndex) const
+    {
+        return GetSource(blockIndex).Kind == ESourceKind::Fresh;
+    }
+
+    bool AddBlobRange(
+        ui32 blockIndex,
+        ui32 blocksCount,
+        ui64 commitId,
+        const TPartialBlobId& blobId,
+        ui32 blobOffset)
+    {
+        Y_ABORT_UNLESS(blobId);
+
+        TSource source;
+        source.Kind = ESourceKind::Blob;
+        source.CommitId = commitId;
+        source.BlobId = blobId;
+        source.BlobOffset = blobOffset;
+
+        return UpdateRange(blockIndex, blocksCount, source);
+    }
+
+    bool AddFreshRange(ui32 blockIndex, ui32 blocksCount, ui64 commitId)
+    {
+        TSource source;
+        source.Kind = ESourceKind::Fresh;
+        source.CommitId = commitId;
+
+        return UpdateRange(blockIndex, blocksCount, source);
+    }
+
+    bool AddDeletionRange(ui32 blockIndex, ui32 blocksCount, ui64 commitId)
+    {
+        TSource source;
+        source.Kind = ESourceKind::Deleted;
+        source.CommitId = commitId;
+
+        return UpdateRange(blockIndex, blocksCount, source);
+    }
+
+    // Visits maximal blob runs (same blob, same commit, contiguous offset).
+    template <typename TVisitor>
+    void VisitBlobRanges(TVisitor&& visitor) const
+    {
+        ui32 i = 0;
+        while (i < Blocks.size()) {
+            if (Blocks[i].Kind != ESourceKind::Blob) {
+                ++i;
+                continue;
+            }
+
+            const ui32 runStart = i;
+            while (++i < Blocks.size()
+                    && SameBlobConsecutiveBlocks(Blocks[i - 1], Blocks[i]))
+            {
+            }
+
+            const auto& source = Blocks[runStart];
+
+            TBlobRange range;
+            range.BlockIndex = BeginBlockIndex + runStart;
+            range.BlocksCount = i - runStart;
+            range.CommitId = source.CommitId;
+            range.BlobId = source.BlobId;
+            range.BlobOffset = source.BlobOffset;
+
+            visitor(range);
+        }
+    }
+
+private:
+    const TSource& GetSource(ui32 blockIndex) const
+    {
+        const ui32 i = blockIndex - BeginBlockIndex;
+        Y_DEBUG_ABORT_UNLESS(i < Blocks.size());
+        return Blocks[i];
+    }
+
+    // prev is known to be a Blob.
+    static bool SameBlobConsecutiveBlocks(
+        const TSource& prev,
+        const TSource& next)
+    {
+        return next.Kind == ESourceKind::Blob
+            && next.CommitId == prev.CommitId
+            && next.BlobId == prev.BlobId
+            && next.BlobOffset == prev.BlobOffset + 1;
+    }
+
+    bool UpdateRange(ui32 blockIndex, ui32 blocksCount, const TSource& source)
+    {
+        const ui32 first = blockIndex - BeginBlockIndex;
+        Y_DEBUG_ABORT_UNLESS(blocksCount);
+        Y_DEBUG_ABORT_UNLESS(first < Blocks.size());
+        Y_DEBUG_ABORT_UNLESS(blocksCount <= Blocks.size() - first);
+
+        bool changed = false;
+
+        for (ui32 i = 0; i < blocksCount; ++i) {
+            auto& prev = Blocks[first + i];
+
+            if (prev.CommitId < source.CommitId) {
+                prev = source;
+
+                if (source.Kind == ESourceKind::Blob) {
+                    // Blob offset advances together with the block index.
+                    prev.BlobOffset = source.BlobOffset + i;
+                }
+
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -16,6 +16,7 @@ SRCS(
     block_list_decode.cpp
     block_list_encode.cpp
     block_list_spec.cpp
+    block_ranges.cpp
     channels.cpp
     compaction_map.cpp
     deletion_markers.cpp

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -97,17 +97,17 @@ void FillDescribeDataResponse(
         }
     }
 
-    const ui64 actualFirstBlock = args.ActualRange().FirstBlock();
-    const ui32 actualBlockCount = args.ActualRange().BlockCount();
-
     NProtoPrivate::TFreshDataRange freshRange;
-    for (ui32 i = 0; i < actualBlockCount; ++i) {
-        const ui64 curOffset =
-            args.ActualRange().Offset + static_cast<ui64>(i) * blockSize;
+    args.BlockRanges.VisitBlocks([&] (
+        ui32 blockOffset,
+        const TBlockRanges::TSource& source)
+    {
+        const ui64 curOffset = args.ActualRange().Offset
+            + static_cast<ui64>(blockOffset) * blockSize;
 
-        const auto& bytes = args.Bytes[i];
+        const auto& bytes = args.Bytes[blockOffset];
 
-        if (args.BlockRanges.IsFreshBlock(actualFirstBlock + i)) {
+        if (source.Kind == TBlockRanges::ESourceKind::Fresh) {
             // it's a fresh block: accumulate it (with any newer fresh bytes
             // applied on top) into a contiguous fresh data range
             if (freshRange.GetContent()) {
@@ -123,11 +123,11 @@ void FillDescribeDataResponse(
                 freshRange.SetOffset(curOffset);
             }
 
-            auto target = args.Buffer->GetBlock(i);
+            auto target = args.Buffer->GetBlock(blockOffset);
             ApplyBytes(bytes, target);
             freshRange.MutableContent()->append(target);
 
-            continue;
+            return;
         }
 
         if (freshRange.GetContent()) {
@@ -145,7 +145,7 @@ void FillDescribeDataResponse(
             byteRange.SetOffset(curOffset + interval.OffsetInBlock);
             byteRange.SetContent(interval.Data);
         }
-    }
+    });
 
     if (freshRange.GetContent()) {
         *record->AddFreshDataRanges() = std::move(freshRange);
@@ -424,16 +424,12 @@ void TReadDataActor::ReadBlob(const TActorContext& ctx)
 
     TBlocksByBlob blocksByBlob;
 
-    const ui64 actualFirstBlock = ActualRange.FirstBlock();
-
-    BlockRanges.VisitBlobRanges(
-        [&] (const TBlockRanges::TBlobRange& range) {
-            auto& blocks = blocksByBlob[range.BlobId];
-            for (ui32 i = 0; i < range.BlocksCount; ++i) {
-                const ui32 blockOffset = IntegerCast<ui32>(
-                    static_cast<ui64>(range.BlockIndex) + i
-                    - actualFirstBlock);
-                blocks.emplace_back(range.BlobOffset + i, blockOffset);
+    BlockRanges.VisitBlocks(
+        [&] (ui32 blockOffset, const TBlockRanges::TSource& source) {
+            if (source.Kind == TBlockRanges::ESourceKind::Blob) {
+                blocksByBlob[source.BlobId].emplace_back(
+                    source.BlobOffset,
+                    blockOffset);
             }
         });
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -88,9 +88,12 @@ void FillDescribeDataResponse(
 
         for (const auto& range: ranges) {
             auto& rangeInBlob = *piece.AddRanges();
-            rangeInBlob.SetOffset(ui64(range.BlockIndex) * blockSize);
-            rangeInBlob.SetLength(ui64(range.BlocksCount) * blockSize);
-            rangeInBlob.SetBlobOffset(ui64(range.BlobOffset) * blockSize);
+            rangeInBlob.SetOffset(
+                static_cast<ui64>(range.BlockIndex) * blockSize);
+            rangeInBlob.SetLength(
+                static_cast<ui64>(range.BlocksCount) * blockSize);
+            rangeInBlob.SetBlobOffset(
+                static_cast<ui64>(range.BlobOffset) * blockSize);
         }
     }
 
@@ -99,7 +102,8 @@ void FillDescribeDataResponse(
 
     NProtoPrivate::TFreshDataRange freshRange;
     for (ui32 i = 0; i < actualBlockCount; ++i) {
-        const ui64 curOffset = args.ActualRange().Offset + ui64(i) * blockSize;
+        const ui64 curOffset =
+            args.ActualRange().Offset + static_cast<ui64>(i) * blockSize;
 
         const auto& bytes = args.Bytes[i];
 
@@ -273,10 +277,8 @@ public:
                 (blockOffset + 1) * Args.ActualRange().BlockSize
             );
 
-            if (Args.BlockRanges.IsCommitNewerThanVisibleData(
-                    IntegerCast<ui32>(
-                        Args.ActualRange().FirstBlock() + blockOffset),
-                    bytes.MinCommitId))
+            if (Args.BlockRanges.GetCommitIdByBlockOffset(
+                    IntegerCast<ui32>(blockOffset)) < bytes.MinCommitId)
             {
                 Args.Bytes[blockOffset].Intervals.push_back({
                     IntegerCast<ui32>(offsetInBlock),
@@ -429,7 +431,8 @@ void TReadDataActor::ReadBlob(const TActorContext& ctx)
             auto& blocks = blocksByBlob[range.BlobId];
             for (ui32 i = 0; i < range.BlocksCount; ++i) {
                 const ui32 blockOffset = IntegerCast<ui32>(
-                    ui64(range.BlockIndex) + i - actualFirstBlock);
+                    static_cast<ui64>(range.BlockIndex) + i
+                    - actualFirstBlock);
                 blocks.emplace_back(range.BlobOffset + i, blockOffset);
             }
         });

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -3,7 +3,9 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/throttler_info_serializer.h>
 #include <cloud/filestore/libs/diagnostics/trace_serializer.h>
+#include <cloud/filestore/libs/storage/tablet/model/block_ranges.h>
 #include <cloud/filestore/libs/storage/tablet/model/profile_log_events.h>
+#include <cloud/filestore/libs/storage/tablet/model/read_ahead.h>
 #include <cloud/filestore/libs/storage/tablet/model/split_range.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
@@ -25,18 +27,6 @@ using namespace NKikimr;
 using namespace NKikimr::NTabletFlatExecutor;
 
 namespace {
-
-////////////////////////////////////////////////////////////////////////////////
-
-bool ShouldReadBlobs(const TVector<TBlockDataRef>& blocks)
-{
-    for (const auto& block: blocks) {
-        if (block.BlobId) {
-            return true;
-        }
-    }
-    return false;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -68,34 +58,56 @@ void FillDescribeDataResponse(
     const TTabletStorageInfo& info,
     const ui64 tabletId,
     const ui32 blockSize,
-    const TByteRange& responseRange,
     const TTxIndexTablet::TReadData& args,
     NProtoPrivate::TDescribeDataResponse* record)
 {
     // metadata
-
     record->SetFileSize(args.Node->Attrs.GetSize());
 
-    // data
+    using TBlobRange = TBlockRanges::TBlobRange;
+    using TBlobRanges = TVector<TBlobRange>;
 
-    using TBlocks = TVector<TBlockDataRef>;
     // using TMap to make responses more stable and, thus, easier to test
-    TMap<TPartialBlobId, TBlocks> blobBlocks;
-    NProtoPrivate::TFreshDataRange freshRange;
-    for (ui64 i = 0; i < args.Blocks.size(); ++i) {
-        const auto& block = args.Blocks[i];
-        const ui64 curOffset = args.ActualRange().Offset + i * blockSize;
-        const TByteRange blockByteRange(curOffset, blockSize, blockSize);
-        if (!responseRange.Overlaps(blockByteRange)) {
-            continue;
+    TMap<TPartialBlobId, TBlobRanges> blobRanges;
+
+    args.BlockRanges.VisitBlobRanges(
+        [&] (const TBlockRanges::TBlobRange& range) {
+            blobRanges[range.BlobId].push_back(range);
+        });
+
+    for (const auto& [blobId, ranges]: blobRanges) {
+        auto& piece = *record->AddBlobPieces();
+
+        LogoBlobIDFromLogoBlobID(
+            MakeBlobId(tabletId, blobId),
+            piece.MutableBlobId());
+
+        piece.SetBSGroupId(info.GroupFor(
+            blobId.Channel(),
+            blobId.Generation()));
+
+        for (const auto& range: ranges) {
+            auto& rangeInBlob = *piece.AddRanges();
+            rangeInBlob.SetOffset(ui64(range.BlockIndex) * blockSize);
+            rangeInBlob.SetLength(ui64(range.BlocksCount) * blockSize);
+            rangeInBlob.SetBlobOffset(ui64(range.BlobOffset) * blockSize);
         }
+    }
+
+    const ui64 actualFirstBlock = args.ActualRange().FirstBlock();
+    const ui32 actualBlockCount = args.ActualRange().BlockCount();
+
+    NProtoPrivate::TFreshDataRange freshRange;
+    for (ui32 i = 0; i < actualBlockCount; ++i) {
+        const ui64 curOffset = args.ActualRange().Offset + ui64(i) * blockSize;
 
         const auto& bytes = args.Bytes[i];
 
-        if (!block.BlobId && block.MinCommitId) {
-            // it's a fresh block
+        if (args.BlockRanges.IsFreshBlock(actualFirstBlock + i)) {
+            // it's a fresh block: accumulate it (with any newer fresh bytes
+            // applied on top) into a contiguous fresh data range
             if (freshRange.GetContent()) {
-                ui64 endOffset =
+                const ui64 endOffset =
                     freshRange.GetOffset() + freshRange.GetContent().size();
                 if (endOffset < curOffset) {
                     *record->AddFreshDataRanges() = std::move(freshRange);
@@ -107,8 +119,6 @@ void FillDescribeDataResponse(
                 freshRange.SetOffset(curOffset);
             }
 
-            // applying fresh byte ranges that intersect with our current
-            // block
             auto target = args.Buffer->GetBlock(i);
             ApplyBytes(bytes, target);
             freshRange.MutableContent()->append(target);
@@ -117,18 +127,15 @@ void FillDescribeDataResponse(
         }
 
         if (freshRange.GetContent()) {
-            // adding our current fresh range to the response
+            // the current block is not a fresh block, so flush whatever fresh
+            // block range we were accumulating
             *record->AddFreshDataRanges() = std::move(freshRange);
             freshRange.Clear();
         }
 
-        if (block.BlobId) {
-            // it's a block that should be read from a blob
-            blobBlocks[block.BlobId].push_back(block);
-        }
-
-        // adding all fresh byte ranges that intersect with our current
-        // block to the response
+        // blob-backed and empty blocks: emit each fresh byte interval that
+        // intersects this block as its own fresh data range. Blob data itself
+        // is reported via BlobPieces above.
         for (const auto& interval: bytes.Intervals) {
             auto& byteRange = *record->AddFreshDataRanges();
             byteRange.SetOffset(curOffset + interval.OffsetInBlock);
@@ -139,51 +146,6 @@ void FillDescribeDataResponse(
     if (freshRange.GetContent()) {
         *record->AddFreshDataRanges() = std::move(freshRange);
         freshRange.Clear();
-    }
-
-    for (const auto& x: blobBlocks) {
-        auto& piece = *record->AddBlobPieces();
-        LogoBlobIDFromLogoBlobID(
-            MakeBlobId(tabletId, x.first),
-            piece.MutableBlobId());
-
-        piece.SetBSGroupId(info.GroupFor(
-            x.first.Channel(),
-            x.first.Generation()));
-
-        // joining adjacent ranges from this blob
-        NProtoPrivate::TRangeInBlob rangeInBlob;
-        ui32 prevBlobOffset = 0;
-        for (const auto& b: x.second) {
-            const auto curOffset =
-                static_cast<ui64>(b.BlockIndex) * blockSize;
-            if (rangeInBlob.GetLength()) {
-                const ui64 endOffset =
-                    rangeInBlob.GetOffset() + rangeInBlob.GetLength();
-
-                // if either Offsets are not adjacent or BlobOffsets are
-                // not adjacent, we should start a new range
-                if (endOffset < curOffset
-                        || prevBlobOffset + 1 != b.BlobOffset)
-                {
-                    *piece.AddRanges() = std::move(rangeInBlob);
-                    rangeInBlob.Clear();
-                }
-            }
-
-            if (!rangeInBlob.GetLength()) {
-                rangeInBlob.SetOffset(curOffset);
-                rangeInBlob.SetBlobOffset(b.BlobOffset * blockSize);
-            }
-
-            rangeInBlob.SetLength(rangeInBlob.GetLength() + blockSize);
-            prevBlobOffset = b.BlobOffset;
-        }
-
-        if (rangeInBlob.GetLength()) {
-            *piece.AddRanges() = std::move(rangeInBlob);
-            rangeInBlob.Clear();
-        }
     }
 }
 
@@ -207,6 +169,7 @@ class TReadDataVisitor final
 private:
     const TString& LogTag;
     TTxIndexTablet::TReadData& Args;
+
     bool ApplyingByteLayer = false;
 
 public:
@@ -221,11 +184,15 @@ public:
     {
         TABLET_VERIFY(!ApplyingByteLayer);
 
-        ui32 blockOffset = block.BlockIndex - Args.ActualRange().FirstBlock();
+        const ui32 blockOffset =
+            block.BlockIndex - Args.ActualRange().FirstBlock();
         TABLET_VERIFY(blockOffset < Args.ActualRange().BlockCount());
 
-        auto& prev = Args.Blocks[blockOffset];
-        if (Update(prev, block, {}, 0)) {
+        if (Args.BlockRanges.AddFreshRange(
+                block.BlockIndex,
+                1,
+                block.MinCommitId))
+        {
             Args.Buffer->SetBlock(blockOffset, blockData);
         }
     }
@@ -235,16 +202,7 @@ public:
         const TPartialBlobId& blobId,
         ui32 blobOffset)
     {
-        TABLET_VERIFY(!ApplyingByteLayer);
-        TABLET_VERIFY(blobId);
-
-        ui32 blockOffset = block.BlockIndex - Args.ActualRange().FirstBlock();
-        TABLET_VERIFY(blockOffset < Args.ActualRange().BlockCount());
-
-        auto& prev = Args.Blocks[blockOffset];
-        if (Update(prev, block, blobId, blobOffset)) {
-            Args.Buffer->ClearBlock(blockOffset);
-        }
+        Accept(block, blobId, blobOffset, 1);
     }
 
     void Accept(
@@ -253,29 +211,41 @@ public:
         ui32 blobOffset,
         ui32 blocksCount) override
     {
-        Accept(block, blobId, blobOffset);
+        TABLET_VERIFY(!ApplyingByteLayer);
+        TABLET_VERIFY(blobId);
+        TABLET_VERIFY(blocksCount);
 
-        if (blocksCount > 1) {
-            auto b = block;
-            while (--blocksCount > 0) {
-                b.BlockIndex++;
-                blobOffset++;
+        const ui64 actualBeginBlock = Args.ActualRange().FirstBlock();
+        const ui64 actualEndBlock =
+            actualBeginBlock + Args.ActualRange().BlockCount();
 
-                Accept(b, blobId, blobOffset);
-            }
-        }
+        const ui64 beginBlock = block.BlockIndex;
+        const ui64 endBlock = beginBlock + blocksCount;
+
+        TABLET_VERIFY(beginBlock >= actualBeginBlock);
+        TABLET_VERIFY(endBlock <= actualEndBlock);
+
+        Args.BlockRanges.AddBlobRange(
+            block.BlockIndex,
+            blocksCount,
+            block.MinCommitId,
+            blobId,
+            blobOffset);
     }
 
     void Accept(const TBlockDeletion& deletion) override
     {
         TABLET_VERIFY(!ApplyingByteLayer);
 
-        ui32 blockOffset = deletion.BlockIndex - Args.ActualRange().FirstBlock();
+        const ui32 blockOffset =
+            deletion.BlockIndex - Args.ActualRange().FirstBlock();
         TABLET_VERIFY(blockOffset < Args.ActualRange().BlockCount());
 
-        auto& prev = Args.Blocks[blockOffset];
-        if (prev.MinCommitId < deletion.CommitId) {
-            prev = {};
+        if (Args.BlockRanges.AddDeletionRange(
+                deletion.BlockIndex,
+                1,
+                deletion.CommitId))
+        {
             Args.Buffer->ClearBlock(blockOffset);
         }
     }
@@ -291,19 +261,24 @@ public:
         while (i < bytes.Length) {
             auto offset = bytes.Offset + i;
             auto relOffset = offset - firstBlockOffset;
-            auto blockIndex = relOffset / Args.ActualRange().BlockSize;
+            // Offset in blocks (not bytes)
+            auto blockOffset = relOffset / Args.ActualRange().BlockSize;
             auto offsetInBlock =
-                relOffset - blockIndex * Args.ActualRange().BlockSize;
+                relOffset - blockOffset * Args.ActualRange().BlockSize;
             // FreshBytes should be organized in such a way that newer commits
             // for the same bytes will be visited later than older commits, so
             // tracking individual byte commit ids is not needed
-            auto& prev = Args.Blocks[blockIndex];
             auto next = Min<ui32>(
                 bytes.Length,
-                (blockIndex + 1) * Args.ActualRange().BlockSize
+                (blockOffset + 1) * Args.ActualRange().BlockSize
             );
-            if (prev.MinCommitId < bytes.MinCommitId) {
-                Args.Bytes[blockIndex].Intervals.push_back({
+
+            if (Args.BlockRanges.IsCommitNewerThanVisibleData(
+                    IntegerCast<ui32>(
+                        Args.ActualRange().FirstBlock() + blockOffset),
+                    bytes.MinCommitId))
+            {
+                Args.Bytes[blockOffset].Intervals.push_back({
                     IntegerCast<ui32>(offsetInBlock),
                     TString(data.data() + i, next - i)
                 });
@@ -311,22 +286,6 @@ public:
 
             i = next;
         }
-    }
-
-private:
-    bool Update(
-        TBlockDataRef& prev,
-        const TBlock& block,
-        const TPartialBlobId& blobId,
-        ui32 blobOffset)
-    {
-        if (prev.MinCommitId < block.MinCommitId) {
-            memcpy(&prev, &block, sizeof(TBlock));
-            prev.BlobId = blobId;
-            prev.BlobOffset = blobOffset;
-            return true;
-        }
-        return false;
     }
 };
 
@@ -347,7 +306,7 @@ private:
     const TByteRange OriginByteRange;
     const TByteRange ActualRange;
     const ui64 TotalSize;
-    const TVector<TBlockDataRef> Blocks;
+    const TBlockRanges BlockRanges;
     TVector<TBlockBytes> Bytes;
     const IBlockBufferPtr Buffer;
     /*const*/ TSet<ui32> MixedBlocksRanges;
@@ -369,7 +328,7 @@ public:
         TByteRange originByteRange,
         TByteRange actualRange,
         ui64 totalSize,
-        TVector<TBlockDataRef> blocks,
+        TBlockRanges blockRanges,
         TVector<TBlockBytes> bytes,
         IBlockBufferPtr buffer,
         TSet<ui32> mixedBlocksRanges,
@@ -411,7 +370,7 @@ TReadDataActor::TReadDataActor(
         TByteRange originByteRange,
         TByteRange actualRange,
         ui64 totalSize,
-        TVector<TBlockDataRef> blocks,
+        TBlockRanges blockRanges,
         TVector<TBlockBytes> bytes,
         IBlockBufferPtr buffer,
         TSet<ui32> mixedBlocksRanges,
@@ -430,7 +389,7 @@ TReadDataActor::TReadDataActor(
     , OriginByteRange(originByteRange)
     , ActualRange(actualRange)
     , TotalSize(totalSize)
-    , Blocks(std::move(blocks))
+    , BlockRanges(std::move(blockRanges))
     , Bytes(std::move(bytes))
     , Buffer(std::move(buffer))
     , MixedBlocksRanges(std::move(mixedBlocksRanges))
@@ -463,16 +422,17 @@ void TReadDataActor::ReadBlob(const TActorContext& ctx)
 
     TBlocksByBlob blocksByBlob;
 
-    ui32 blockOffset = 0;
-    for (const auto& block: Blocks) {
-        ++blockOffset;
+    const ui64 actualFirstBlock = ActualRange.FirstBlock();
 
-        if (!block.BlobId) {
-            continue;
-        }
-
-        blocksByBlob[block.BlobId].emplace_back(block.BlobOffset, blockOffset - 1);
-    }
+    BlockRanges.VisitBlobRanges(
+        [&] (const TBlockRanges::TBlobRange& range) {
+            auto& blocks = blocksByBlob[range.BlobId];
+            for (ui32 i = 0; i < range.BlocksCount; ++i) {
+                const ui32 blockOffset = IntegerCast<ui32>(
+                    ui64(range.BlockIndex) + i - actualFirstBlock);
+                blocks.emplace_back(range.BlobOffset + i, blockOffset);
+            }
+        });
 
     auto request = std::make_unique<TEvIndexTabletPrivate::TEvReadBlobRequest>(
         RequestInfo->CallContext);
@@ -893,7 +853,11 @@ bool TIndexTabletActor::ValidateTx_ReadData(
             args.AlignedByteRange);
         if (readAheadRange.Defined()) {
             args.ReadAheadRange.ConstructInPlace(*readAheadRange);
-            args.Blocks.resize(args.ActualRange().BlockCount());
+
+            args.BlockRanges = TBlockRanges(
+                IntegerCast<ui32>(args.ActualRange().FirstBlock()),
+                IntegerCast<ui32>(args.ActualRange().BlockCount()));
+
             args.Bytes.resize(args.ActualRange().BlockCount());
             args.Buffer = CreateLazyBlockBuffer(args.ActualRange());
         }
@@ -1021,32 +985,36 @@ void TIndexTabletActor::CompleteTx_ReadData(
     };
 
     if (args.DescribeOnly && !HasError(args.Error)) {
-        if (args.ReadAheadRange) {
-            NProtoPrivate::TDescribeDataResponse record;
-            FillDescribeDataResponse(
-                *Info(),
-                TabletID(),
-                GetBlockSize(),
-                *args.ReadAheadRange,
-                args,
-                &record);
-            RegisterReadAheadResult(
-                args.NodeId,
-                args.Handle,
-                *args.ReadAheadRange,
-                record);
-        }
-
-        auto response =
-            std::make_unique<TEvIndexTablet::TEvDescribeDataResponse>();
-        auto& record = response->Record;
+        // Describes the whole ActualRange(). When read ahead kicked in,
+        // ActualRange() is the expanded read ahead range, so the full record
+        // goes to the read ahead cache and the response is clipped to the
+        // requested range via FilterResult - the same way cache hits are
+        // served in TryFillResult.
+        NProtoPrivate::TDescribeDataResponse fullRecord;
         FillDescribeDataResponse(
             *Info(),
             TabletID(),
             GetBlockSize(),
-            args.AlignedByteRange,
             args,
-            &record);
+            &fullRecord);
+
+        auto response =
+            std::make_unique<TEvIndexTablet::TEvDescribeDataResponse>();
+
+        if (args.ReadAheadRange) {
+            RegisterReadAheadResult(
+                args.NodeId,
+                args.Handle,
+                *args.ReadAheadRange,
+                fullRecord);
+
+            FilterResult(
+                args.AlignedByteRange,
+                fullRecord,
+                &response->Record);
+        } else {
+            response->Record = std::move(fullRecord);
+        }
 
         CompleteResponse<TEvIndexTablet::TDescribeDataMethod>(
             response->Record,
@@ -1101,7 +1069,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
         return;
     }
 
-    if (!ShouldReadBlobs(args.Blocks)) {
+    if (!args.BlockRanges.HasBlobs()) {
         ApplyBytes(
             LogTag,
             args.ActualRange(),
@@ -1169,7 +1137,7 @@ void TIndexTabletActor::CompleteTx_ReadData(
         args.OriginByteRange,
         args.ActualRange(),
         args.Node->Attrs.GetSize(),
-        std::move(args.Blocks),
+        std::move(args.BlockRanges),
         std::move(args.Bytes),
         std::move(args.Buffer),
         std::move(args.MixedBlocksRanges),

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -13,6 +13,7 @@
 #include <cloud/filestore/libs/storage/model/public.h>
 #include <cloud/filestore/libs/storage/tablet/events/tablet_private.h>
 #include <cloud/filestore/libs/storage/tablet/model/block.h>
+#include <cloud/filestore/libs/storage/tablet/model/block_ranges.h>
 #include <cloud/filestore/libs/storage/tablet/model/internal_request_id.h>
 #include <cloud/filestore/libs/storage/tablet/model/profile_log_events.h>
 #include <cloud/filestore/libs/storage/tablet/model/range_locks.h>
@@ -2055,7 +2056,7 @@ struct TTxIndexTablet
         ui64 NodeId = InvalidNodeId;
         TMaybe<TByteRange> ReadAheadRange;
         TMaybe<INodeIndexTabletDatabase::TNode> Node;
-        TVector<TBlockDataRef> Blocks;
+        TBlockRanges BlockRanges;
         TVector<TBlockBytes> Bytes;
 
         // NOTE: should persist state across tx restarts
@@ -2079,7 +2080,9 @@ struct TTxIndexTablet
             , Buffer(std::move(buffer))
             , DescribeOnly(describeOnly)
             , ExplicitNodeId(request.GetNodeId())
-            , Blocks(AlignedByteRange.BlockCount())
+            , BlockRanges(
+                IntegerCast<ui32>(AlignedByteRange.FirstBlock()),
+                IntegerCast<ui32>(AlignedByteRange.BlockCount()))
             , Bytes(AlignedByteRange.BlockCount())
         {
             Y_DEBUG_ABORT_UNLESS(AlignedByteRange.IsAligned());
@@ -2095,7 +2098,10 @@ struct TTxIndexTablet
             ReadAheadRange.Clear();
             Node.Clear();
 
-            std::fill(Blocks.begin(), Blocks.end(), TBlockDataRef());
+            BlockRanges = TBlockRanges(
+                IntegerCast<ui32>(AlignedByteRange.FirstBlock()),
+                IntegerCast<ui32>(AlignedByteRange.BlockCount()));
+
             std::fill(Bytes.begin(), Bytes.end(), TBlockBytes());
 
             // deliberately not calling TProfileAware::Clear()


### PR DESCRIPTION
### Notes
`TBlockRanges` will be optimized later.
Another goal is to make `tablet_actor_readdata.cpp` lighter and more readable.

### Issue
#4547
