### PR TITLE
Fix HandlePollEvent / StopEndpoint race; resolves issue-6233

### DIFF
--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -894,10 +894,6 @@ bool TClientEndpoint::HandleInputRequests() noexcept
         RequestEvent.Clear();
     }
 
-    if (!CheckState(EEndpointState::Connected)) {
-        return false;
-    }
-
     auto requests = InputRequests.DequeueAll();
     if (!requests) {
         return false;
@@ -967,12 +963,6 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
         CancelRequestEvent.Clear();
     }
 
-    if (!CheckState(EEndpointState::Connected) &&
-        !CheckState(EEndpointState::Disconnecting))
-    {
-        return false;
-    }
-
     THashSet<ui64> clientRequestIdToCancel;
     for (auto req: CancelRequests.DequeueAll()) {
         clientRequestIdToCancel.emplace(req.ClientRequestId);
@@ -1017,10 +1007,6 @@ void TClientEndpoint::AbortRequests() noexcept
         AbortRequestsEvent.Clear();
     }
 
-    if (!CheckState(EEndpointState::Disconnecting)) {
-        return;
-    }
-
     auto requests = InputRequests.DequeueAll();
     if (requests) {
         QueuedRequests.Append(std::move(requests));
@@ -1057,12 +1043,6 @@ void TClientEndpoint::AbortRequest(
 
 bool TClientEndpoint::HandleCompletionEvents() noexcept
 {
-    if (!CheckState(EEndpointState::Connected) &&
-        !CheckState(EEndpointState::Disconnecting))
-    {
-        return false;
-    }
-
     try {
         ibv_cq* cq = CompletionQueue.get();
 
@@ -1761,10 +1741,16 @@ private:
         auto hasWork = false;
 
         for (const auto& endpoint: *endpoints) {
-            hasWork |= endpoint->HandleCancelRequests();
-            hasWork |= endpoint->HandleInputRequests();
-            hasWork |= endpoint->HandleCompletionEvents();
-            endpoint->AbortRequests();
+            if (endpoint->CheckState(EEndpointState::Connected)) {
+                hasWork |= endpoint->HandleCancelRequests();
+                hasWork |= endpoint->HandleInputRequests();
+                hasWork |= endpoint->HandleCompletionEvents();
+            }
+            if (endpoint->CheckState(EEndpointState::Disconnecting)) {
+                hasWork |= endpoint->HandleCancelRequests();
+                hasWork |= endpoint->HandleCompletionEvents();
+                endpoint->AbortRequests();
+            }
         }
 
         return hasWork;
@@ -1813,6 +1799,8 @@ private:
                     << "[send_queue.size=" << endpoint->SendQueue.Size()
                     << " recv_queue.size=" << endpoint->RecvQueue.Size() << "]");
             }
+
+            Detach(endpoint.get());
 
             endpoint->ChangeState(
                 EEndpointState::Disconnecting,
@@ -2068,9 +2056,6 @@ void TClient::StopEndpoint(TClientEndpoint* endpoint) noexcept
 {
     RDMA_INFO(endpoint->Log, "release resources");
     ConnectionPoller->Detach(endpoint);
-    if (endpoint->CompletionChannel) {
-        endpoint->Poller->Detach(endpoint);
-    }
     endpoint->DestroyQP();
     endpoint->Connection.reset();
     endpoint->StopResult.SetValue();
@@ -2137,7 +2122,6 @@ void TClient::Reconnect(TClientEndpoint* endpoint) noexcept
             // fallthrough
 
         case EEndpointState::Disconnected:
-            endpoint->Poller->Detach(endpoint);
             endpoint->DestroyQP();
             endpoint->SetConnection(
                 ConnectionPoller->CreateConnection(Config->IpTypeOfService));

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -548,7 +548,8 @@ public:
     bool HandleCancelRequests() noexcept;
     bool HandleCompletionEvents() noexcept;
     void AbortRequests() noexcept;
-    bool Flushed() const;
+    bool ClientRequestsFlushed() const;
+    bool WorkRequestsFlushed() const;
     bool FlushHanging() const;
 
     void SetNegotiatedProtocolVersion(int negotiatedProtocolVersion);
@@ -1357,14 +1358,18 @@ void TClientEndpoint::Disconnect() noexcept
     }
 }
 
-bool TClientEndpoint::Flushed() const
+bool TClientEndpoint::ClientRequestsFlushed() const
 {
-    return SendQueue.Size() == Config.SendQueueSize
-        && RecvQueue.Size() == Config.RecvQueueSize
-        && ActiveRequests.Empty()
+    return ActiveRequests.Empty()
         && !InputRequests
         && !QueuedRequests
         && !CancelRequests;
+}
+
+bool TClientEndpoint::WorkRequestsFlushed() const
+{
+    return SendQueue.Size() == Config.SendQueueSize
+        && RecvQueue.Size() == Config.RecvQueueSize;
 }
 
 bool TClientEndpoint::FlushHanging() const
@@ -1791,15 +1796,22 @@ private:
                 continue;
             }
 
-            if (!endpoint->Flushed()) {
+            if (!endpoint->ClientRequestsFlushed()) {
+                continue;
+            }
+
+            if (!endpoint->WorkRequestsFlushed()) {
                 if (!endpoint->FlushHanging()) {
                     continue;
                 }
+                // either we have a bug or underlying layer didn't flush WRs in time
                 RDMA_ERROR(endpoint->Log, "flush timeout "
                     << "[send_queue.size=" << endpoint->SendQueue.Size()
                     << " recv_queue.size=" << endpoint->RecvQueue.Size() << "]");
             }
 
+            // detach immediately to prevent completions from arriving during
+            // destruction sequence
             Detach(endpoint.get());
 
             endpoint->ChangeState(
@@ -2116,6 +2128,7 @@ void TClient::Reconnect(TClientEndpoint* endpoint) noexcept
 
         // create new connection and try again
         case EEndpointState::Connecting:
+            endpoint->Poller->Detach(endpoint);
             endpoint->ChangeState(
                 EEndpointState::Connecting,
                 EEndpointState::Disconnected);

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -464,6 +464,10 @@ TEST(TRdmaClientTest, ShouldProcessRequests)
 
         auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        }
+
         struct TResponse
         {
             bool Received = false;
@@ -873,6 +877,10 @@ TEST(TRdmaClientTest, ShouldReconnect)
         }
 
         auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+            PostSend<TRequestMessage>(context, qp, wr);
+        }
 
         Disconnect(testContext);
 

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -270,6 +270,92 @@ TEST(TRdmaClientTest, ShouldDetachFromPoller)
         ASSERT_EQ(1u, shared.use_count());
     }
 
+TEST(TRdmaClientTest, ShouldNotTriggerCompletionAfterFlushTimeout)
+{
+        auto context = MakeIntrusive<NVerbs::TTestContext>();
+        context->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(context);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->WaitMode = EWaitMode::Poll;
+        clientConfig->MaxReconnectDelay = 5s;
+
+        // even though it can technically be less than POLL_TIMEOUT, actual
+        // reaction time is still bound by it, because DisconnectFlushed runs
+        // only after Wait times out
+        clientConfig->FlushTimeout = 1s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        struct TClientHandler: IClientHandler
+        {
+            void HandleResponse(
+                TClientRequestPtr req,
+                ui32 status,
+                size_t responseBytes) override
+            {
+                Y_UNUSED(req);
+                Y_UNUSED(status);
+                Y_UNUSED(responseBytes);
+            }
+        };
+
+        std::vector<std::unique_ptr<ibv_send_wr>> sends;
+        context->PostSend = [&](auto* qp, auto* wr) {
+            Y_UNUSED(qp);
+            // hold send to complete it later
+            with_lock (context->CompletionLock) {
+                sends.push_back(std::make_unique<ibv_send_wr>(*wr));
+            }
+
+            // stall completion poller long enough for flush to time out
+            sleep(clientConfig->FlushTimeout.Seconds());
+
+            with_lock (context->CompletionLock) {
+                while (sends.size()) {
+                    context->SendEvents.push_back(sends.back().release());
+                    sends.pop_back();
+                }
+                context->CompletionHandle.Set();
+            }
+        };
+
+        // stall completion poller again to let connection poller destroy
+        // endpoint and trigger use-after-free
+        context->HandleCompletionEvent = [&](ibv_wc* wc) {
+            Y_UNUSED(wc);
+            sleep(1);
+        };
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::make_unique<TNullContext>(),
+            1024,
+            1024);
+
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        endpoint->Stop().Wait();
+}
+
 TEST(TRdmaClientTest, ShouldReturnErrorUponStartEndpointTimeout)
 {
         auto verbs =
@@ -377,13 +463,6 @@ TEST(TRdmaClientTest, ShouldProcessRequests)
         };
 
         auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
-
-        testContext->PostSend = [&](auto* qp, auto* wr) {
-            Y_UNUSED(qp);
-            const auto* msg =
-                reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr);
-            testContext->ReqIds.push_back(msg->ReqId);
-        };
 
         struct TResponse
         {
@@ -608,10 +687,7 @@ TEST(TRdmaClientTest, ShouldAbortRequests)
         TManualEvent sent;
         testContext->PostSend = [&](auto* qp, auto* wr) {
             Y_UNUSED(qp);
-            const auto* msg =
-                reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr);
-            testContext->ReqIds.push_back(msg->ReqId);
-            testContext->CompletionHandle.Set();
+            Y_UNUSED(wr);
             sent.Signal();
         };
 
@@ -797,13 +873,6 @@ TEST(TRdmaClientTest, ShouldReconnect)
         }
 
         auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
-
-        testContext->PostSend = [&](auto* qp, auto* wr) {
-            Y_UNUSED(qp);
-            const auto* msg =
-                reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr);
-            testContext->ReqIds.push_back(msg->ReqId);
-        };
 
         Disconnect(testContext);
 
@@ -1062,9 +1131,11 @@ TEST(TRdmaClientTest, ShouldNegotiateProtocolVersionFromAcceptMessage)
     testContext->PostSend = [&](auto* qp, auto* wr)
     {
         Y_UNUSED(qp);
-        const auto* msg =
-            reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr);
-        sentVersion = ParseMessageHeader(msg);
+        with_lock (testContext->CompletionLock) {
+            const auto* msg =
+                reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr);
+            sentVersion = ParseMessageHeader(msg);
+        }
         sent.Signal();
     };
 

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -338,10 +338,12 @@ TEST(TRdmaClientTest, ShouldNotTriggerCompletionAfterFlushTimeout)
 
         // stall completion poller again to let connection poller destroy
         // endpoint and trigger use-after-free
-        context->HandleCompletionEvent = [&](ibv_wc* wc) {
-            Y_UNUSED(wc);
-            sleep(1);
-        };
+        with_lock (context->CompletionLock) {
+            context->HandleCompletionEvent = [&](ibv_wc* wc) {
+                Y_UNUSED(wc);
+                sleep(1);
+            };
+        }
 
         auto request = endpoint->AllocateRequest(
             std::make_shared<TClientHandler>(),
@@ -466,7 +468,7 @@ TEST(TRdmaClientTest, ShouldProcessRequests)
 
         testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
             PostSend<TRequestMessage>(testContext, qp, wr);
-        }
+        };
 
         struct TResponse
         {
@@ -879,8 +881,8 @@ TEST(TRdmaClientTest, ShouldReconnect)
         auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
 
         testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
-            PostSend<TRequestMessage>(context, qp, wr);
-        }
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
 
         Disconnect(testContext);
 

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -403,6 +403,10 @@ TEST(TRdmaServerTest, ShouldHandleErrors)
             10020,
             std::make_shared<TServerHandler>());
 
+    context->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+        PostSend<TResponseMessage>(context, qp, wr);
+    }
+
     // emulate client connection
 
     NVerbs::CreateConnection(context);

--- a/cloud/storage/core/libs/rdma/impl/server_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server_ut.cpp
@@ -405,7 +405,7 @@ TEST(TRdmaServerTest, ShouldHandleErrors)
 
     context->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
         PostSend<TResponseMessage>(context, qp, wr);
-    }
+    };
 
     // emulate client connection
 
@@ -586,6 +586,10 @@ TEST(TRdmaServerTest, ShouldKeepSessionAliveUntilHandlerCompletes)
         }
     };
 
+    context->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+        PostSend<TResponseMessage>(context, qp, wr);
+    };
+
     std::atomic<rdma_cm_id*> sessionId{nullptr};
     NThreading::TPromise<void> sessionDestroyed =
         NThreading::NewPromise<void>();
@@ -693,6 +697,10 @@ TEST(TRdmaServerTest, ShouldKeepSessionAliveUntilHandlerCompletesOnDisconnect)
             return;
         }
         NVerbs::Flush(context);
+    };
+
+    context->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr) {
+        PostSend<TResponseMessage>(context, qp, wr);
     };
 
     std::atomic<rdma_cm_id*> sessionId{nullptr};

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -286,19 +286,9 @@ struct TTestVerbs
 
     void PostSend(ibv_qp* qp, ibv_send_wr* wr) override
     {
-        Y_UNUSED(qp);
-
         if (TestContext->PostSend) {
             TestContext->PostSend(qp, wr);
             return;
-        }
-
-        with_lock (TestContext->CompletionLock) {
-            const auto* msg =
-                reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr);
-            TestContext->ReqIds.push_back(msg->ReqId);
-            TestContext->SendEvents.push_back(new ibv_send_wr(*wr));
-            TestContext->CompletionHandle.Set();
         }
     }
 

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -288,14 +288,18 @@ struct TTestVerbs
     {
         Y_UNUSED(qp);
 
-        auto g = Guard(TestContext->CompletionLock);
-
         if (TestContext->PostSend) {
             TestContext->PostSend(qp, wr);
+            return;
         }
 
-        TestContext->SendEvents.push_back(new ibv_send_wr(*wr));
-        TestContext->CompletionHandle.Set();
+        with_lock (TestContext->CompletionLock) {
+            const auto* msg =
+                reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr);
+            TestContext->ReqIds.push_back(msg->ReqId);
+            TestContext->SendEvents.push_back(new ibv_send_wr(*wr));
+            TestContext->CompletionHandle.Set();
+        }
     }
 
     void PostRecv(ibv_qp* qp, ibv_recv_wr* wr) override

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -15,6 +15,13 @@ namespace NCloud::NStorage::NRdma::NVerbs {
 
 struct TTestContext: TAtomicRefCount<TTestContext>
 {
+    ~TTestContext()
+    {
+        for (auto* send: SendEvents) {
+            delete send;
+        }
+    }
+
     rdma_cm_id* Connection = nullptr;
     TEventHandle ConnectionHandle;
     TVector<std::unique_ptr<rdma_cm_id>> ClientConnections;

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -74,6 +74,18 @@ using TTestContextPtr = TIntrusivePtr<TTestContext>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+template <M>
+void PostSend(TTestContextPtr context, ibv_qp* qp, ibv_send_wr* wr)
+{
+    Y_UNUSED(qp);
+    const auto* msg = reinterpret_cast<M*>(wr->sg_list[0].addr);
+    context->ReqIds.push_back(msg->ReqId);
+    context->SendEvents.push_back(new ibv_send_wr(*wr));
+    context->CompletionHandle.Set();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 IVerbsPtr CreateTestVerbs(TTestContextPtr context);
 
 void CreateConnection(TTestContextPtr context);

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -74,14 +74,16 @@ using TTestContextPtr = TIntrusivePtr<TTestContext>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template <M>
+template <typename M>
 void PostSend(TTestContextPtr context, ibv_qp* qp, ibv_send_wr* wr)
 {
     Y_UNUSED(qp);
-    const auto* msg = reinterpret_cast<M*>(wr->sg_list[0].addr);
-    context->ReqIds.push_back(msg->ReqId);
-    context->SendEvents.push_back(new ibv_send_wr(*wr));
-    context->CompletionHandle.Set();
+    with_lock (context->CompletionLock) {
+        const auto* msg = reinterpret_cast<M*>(wr->sg_list[0].addr);
+        context->ReqIds.push_back(msg->ReqId);
+        context->SendEvents.push_back(new ibv_send_wr(*wr));
+        context->CompletionHandle.Set();
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reproduction steps
1. Disconnect gets triggered and proceeds to dismantle endpoint
2. Flush times out
3. Completion gets triggered, but CQ stalls for any reason
3. Endpoint gets destroyed by CM
4. CQ continues and dereferences raw endpoint pointer

It's quite hard to reproduce – I actually had to modify handlers to be less restrictive about the state in a poll mode and also insert a lot of manual waiting. Resulting test is somewhat convoluted, but reliably triggers the bug under asan
