### PR TITLE
Add agent ids filter to QueryAgentsInfo

### DIFF
--- a/cloud/blockstore/apps/client/lib/query_agents_info.cpp
+++ b/cloud/blockstore/apps/client/lib/query_agents_info.cpp
@@ -18,10 +18,22 @@ namespace {
 
 class TQueryAgentsInfoCommand final: public TCommand
 {
+private:
+    TVector<TString> AgentIds;
+    TVector<ui32> States;
+
 public:
     explicit TQueryAgentsInfoCommand(IBlockStorePtr client)
         : TCommand(std::move(client))
-    {}
+    {
+        Opts.AddLongOption("agent-id", "agent id (several agents can be added at a time)")
+            .RequiredArgument("STR")
+            .AppendTo(&AgentIds);
+
+        Opts.AddLongOption("state", "agent state (0=online, 1=warning, 2=unavailable)")
+            .RequiredArgument("NUM")
+            .AppendTo(&States);
+    }
 
 protected:
     bool DoExecute() override
@@ -33,6 +45,15 @@ protected:
         auto request = std::make_shared<NProto::TQueryAgentsInfoRequest>();
         if (Proto) {
             ParseFromTextFormat(input, *request);
+        } else {
+            auto* filter = request->MutableFilter();
+            filter->MutableAgentIds()->Assign(
+                AgentIds.begin(),
+                AgentIds.end());
+            for (auto state: States) {
+                filter->MutableStates()->Add(
+                    static_cast<NProto::EAgentState>(state));
+            }
         }
 
         STORAGE_DEBUG("Sending QueryAgentsInfo request");

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -8223,11 +8223,34 @@ NProto::EVolumeIOMode TDiskRegistryState::GetIoMode(
 TVector<NProto::TAgentInfo> TDiskRegistryState::QueryAgentsInfo(
     const NProto::TQueryAgentsInfoRequest::TAgentFilter& filter) const
 {
+    THashSet<TString> agentIds(
+        filter.GetAgentIds().begin(),
+        filter.GetAgentIds().end());
+    THashSet<int> states(
+        filter.GetStates().begin(),
+        filter.GetStates().end());
+
     auto shouldFilterAgent = [&](const NProto::TAgentConfig& agent)
     {
-        return !filter.GetStates().empty() &&
-               std::ranges::find(filter.GetStates(), agent.GetState()) ==
-                   filter.GetStates().end();
+        if (!agentIds.empty() && !agentIds.contains(agent.GetAgentId())) {
+            return true;
+        }
+
+        return !states.empty() && !states.contains(agent.GetState());
+    };
+
+    auto toStoragePoolKind = [](NProto::EDevicePoolKind kind)
+    {
+        switch (kind) {
+            case NProto::DEVICE_POOL_KIND_LOCAL:
+                return NProto::STORAGE_POOL_KIND_LOCAL;
+            case NProto::DEVICE_POOL_KIND_GLOBAL:
+                return NProto::STORAGE_POOL_KIND_GLOBAL;
+            case NProto::DEVICE_POOL_KIND_DEFAULT:
+                return NProto::STORAGE_POOL_KIND_DEFAULT;
+            default:
+                return NProto::STORAGE_POOL_KIND_DEFAULT;
+        }
     };
 
     TVector<NProto::TAgentInfo> ret;
@@ -8249,6 +8272,9 @@ TVector<NProto::TAgentInfo> TDiskRegistryState::QueryAgentsInfo(
             if (inserted) {
                 deviceInfo.SetDeviceName(device.GetDeviceName());
                 deviceInfo.SetDeviceSerialNumber(device.GetSerialNumber());
+                deviceInfo.SetStoragePoolName(device.GetPoolName());
+                deviceInfo.SetStoragePoolKind(
+                    toStoragePoolKind(device.GetPoolKind()));
             }
 
             deviceInfo.SetDeviceTotalSpaceInBytes(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_agents_info.cpp
@@ -110,6 +110,21 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 deviceSpaceInBytes,
                 deviceInfo.GetDeviceFreeSpaceInBytes());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                "",
+                deviceInfo.GetStoragePoolName());
+            UNIT_ASSERT_EQUAL(
+                NProto::STORAGE_POOL_KIND_DEFAULT,
+                deviceInfo.GetStoragePoolKind());
+
+            const auto& poolDeviceInfo = agentInfo.GetDevices(1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                "local-ssd",
+                poolDeviceInfo.GetStoragePoolName());
+            UNIT_ASSERT_EQUAL(
+                NProto::STORAGE_POOL_KIND_LOCAL,
+                poolDeviceInfo.GetStoragePoolKind());
         }
 
         {
@@ -578,6 +593,139 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateQueryAgentsInfoTest)
         UNIT_ASSERT_VALUES_EQUAL(online, 2);
         UNIT_ASSERT_VALUES_EQUAL(warning, 1);
         UNIT_ASSERT_VALUES_EQUAL(unavailable, 1);
+    }
+
+    Y_UNIT_TEST(ShouldFilterByAgentId)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        auto agentConfig1 = AgentConfig(
+            1,
+            {
+                Device("dev-1", "uuid-1", "rack-1"),
+                Device("dev-2", "uuid-2", "rack-1"),
+            });
+
+        auto agentConfig2 = AgentConfig(
+            2,
+            {
+                Device("dev-3", "uuid-3", "rack-2"),
+                Device("dev-4", "uuid-4", "rack-2"),
+            });
+
+        auto agentConfig3 = AgentConfig(
+            3,
+            {
+                Device("dev-5", "uuid-5", "rack-3"),
+            });
+
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithKnownAgents(
+                    {agentConfig1, agentConfig2, agentConfig3})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
+
+        {
+            auto agentsInfo = state.QueryAgentsInfo({});
+            UNIT_ASSERT_VALUES_EQUAL(3, agentsInfo.size());
+        }
+
+        {
+            NProto::TQueryAgentsInfoRequest::TAgentFilter filter;
+            filter.AddAgentIds(agentConfig2.GetAgentId());
+
+            auto agentsInfo = state.QueryAgentsInfo(filter);
+            UNIT_ASSERT_VALUES_EQUAL(1, agentsInfo.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig2.GetAgentId(),
+                agentsInfo[0].GetAgentId());
+            UNIT_ASSERT_VALUES_EQUAL(2, agentsInfo[0].DevicesSize());
+        }
+
+        {
+            NProto::TQueryAgentsInfoRequest::TAgentFilter filter;
+            filter.AddAgentIds(agentConfig1.GetAgentId());
+            filter.AddAgentIds(agentConfig3.GetAgentId());
+
+            auto agentsInfo = state.QueryAgentsInfo(filter);
+            UNIT_ASSERT_VALUES_EQUAL(2, agentsInfo.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig1.GetAgentId(),
+                agentsInfo[0].GetAgentId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig3.GetAgentId(),
+                agentsInfo[1].GetAgentId());
+        }
+
+        {
+            NProto::TQueryAgentsInfoRequest::TAgentFilter filter;
+            filter.AddAgentIds("nonexistent-agent");
+
+            auto agentsInfo = state.QueryAgentsInfo(filter);
+            UNIT_ASSERT_VALUES_EQUAL(0, agentsInfo.size());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldFilterByAgentIdAndState)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([&](TDiskRegistryDatabase db) { db.InitSchema(); });
+
+        auto agentConfig1 = AgentConfig(
+            1,
+            {
+                Device("dev-1", "uuid-1", "rack-1"),
+            });
+
+        auto agentConfig2 = AgentConfig(
+            2,
+            {
+                Device("dev-2", "uuid-2", "rack-2"),
+            });
+
+        auto statePtr =
+            TDiskRegistryStateBuilder()
+                .WithKnownAgents({agentConfig1, agentConfig2})
+                .Build();
+        TDiskRegistryState& state = *statePtr;
+
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                TVector<TString> affectedDisks;
+                state.UpdateAgentState(
+                    db,
+                    agentConfig1.GetAgentId(),
+                    NProto::EAgentState::AGENT_STATE_WARNING,
+                    TInstant::Now(),
+                    "test",
+                    affectedDisks);
+            });
+
+        {
+            NProto::TQueryAgentsInfoRequest::TAgentFilter filter;
+            filter.AddAgentIds(agentConfig1.GetAgentId());
+            filter.MutableStates()->Add(
+                NProto::EAgentState::AGENT_STATE_WARNING);
+
+            auto agentsInfo = state.QueryAgentsInfo(filter);
+            UNIT_ASSERT_VALUES_EQUAL(1, agentsInfo.size());
+            UNIT_ASSERT_VALUES_EQUAL(
+                agentConfig1.GetAgentId(),
+                agentsInfo[0].GetAgentId());
+        }
+
+        {
+            NProto::TQueryAgentsInfoRequest::TAgentFilter filter;
+            filter.AddAgentIds(agentConfig1.GetAgentId());
+            filter.MutableStates()->Add(
+                NProto::EAgentState::AGENT_STATE_ONLINE);
+
+            auto agentsInfo = state.QueryAgentsInfo(filter);
+            UNIT_ASSERT_VALUES_EQUAL(0, agentsInfo.size());
+        }
     }
 }
 

--- a/cloud/blockstore/public/api/protos/disk.proto
+++ b/cloud/blockstore/public/api/protos/disk.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "cloud/blockstore/public/api/protos/headers.proto";
+import "cloud/blockstore/public/api/protos/local_ssd.proto";
 import "cloud/storage/core/protos/error.proto";
 
 package NCloud.NBlockStore.NProto;
@@ -217,6 +218,12 @@ message TDeviceInfo
 
     // Decomissioned space in bytes.
     uint64 DeviceDecommissionedSpaceInBytes = 9;
+
+    // Storage pool name.
+    string StoragePoolName = 10;
+
+    // Storage pool kind.
+    EStoragePoolKind StoragePoolKind = 11;
 }
 
 message TAgentInfo {
@@ -246,6 +253,10 @@ message TQueryAgentsInfoRequest
         // Filter out agents whose states are not in this list.
         // An empty list means that there is no filter.
         repeated EAgentState States = 1;
+
+        // Filter by agent ids.
+        // An empty list means that there is no filter.
+        repeated string AgentIds = 2;
     }
 
     // Optional request headers.


### PR DESCRIPTION
### Notes

1) Extended `TQueryAgentsInfoRequest.TAgentFilter` with a repeated `AgentIds` field so that callers can request info for specific agents instead of fetching all of them. 
2) Enriched `TDeviceInfo` with `StoragePoolName` and `StoragePoolKind` fields. 

### Issue
https://github.com/ydb-platform/nbs/issues/4621
