### PR TITLE
[Blockstore] Add smooth throttling of garbage compaction according to blockCount / diskSize ratio

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1636,17 +1636,18 @@ message TStorageServiceConfig
     optional bool EnableDynamicGarbageCompactionThrottling = 516;
 
     // Disk fill percentage below which garbage compaction throttling is fully
-    // enabled. Measured in percents of the disk size. Applies when
-    // EnableDynamicGarbageCompactionThrottling is on.
-    optional uint32 GarbageCompactionThrottlingSoftLimit = 517;
+    // enabled. Measured in percents of the disk size.
+    // Applies when EnableDynamicGarbageCompactionThrottling is on.
+    optional uint32 GarbageCompactionThrottlingSoftLimit = 516;
 
     // Disk fill percentage above which garbage compaction throttling is
-    // disabled. Measured in percents of the disk size. Applies when
-    // EnableDynamicGarbageCompactionThrottling is on.
-    optional uint32 GarbageCompactionThrottlingHardLimit = 518;
+    // disabled. Measured in percents of the disk size.
+    // Applies when EnableDynamicGarbageCompactionThrottling is on.
+    optional uint32 GarbageCompactionThrottlingHardLimit = 517;
 
-    // Max garbage compaction exec time per second (in ms). Applies when
-    // EnableDynamicGarbageCompactionThrottling is on and disk fill is below
-    // GarbageCompactionThrottlingSoftLimit.
-    optional uint32 MaxGarbageCompactionExecTimePerSecond = 519;
+    // Max garbage compaction exec time per second (in ms) when garbage
+    // compaction throttling is as strong as possible.
+    // Applies when EnableDynamicGarbageCompactionThrottling is on and disk fill
+    // is below GarbageCompactionThrottlingSoftLimit.
+    optional uint32 MinGarbageCompactionExecTimePerSecondLimit = 518;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1638,16 +1638,16 @@ message TStorageServiceConfig
     // Disk fill percentage below which garbage compaction throttling is fully
     // enabled. Measured in percents of the disk size.
     // Applies when EnableDynamicGarbageCompactionThrottling is on.
-    optional uint32 GarbageCompactionThrottlingSoftLimit = 516;
+    optional uint32 ThrottleGarbageCompactionBelowFillPercentage = 516;
 
     // Disk fill percentage above which garbage compaction throttling is
     // disabled. Measured in percents of the disk size.
     // Applies when EnableDynamicGarbageCompactionThrottling is on.
-    optional uint32 GarbageCompactionThrottlingHardLimit = 517;
+    optional uint32 StopGarbageCompactionThrottlingAboveFillPercentage = 517;
 
     // Max garbage compaction exec time per second (in ms) when garbage
     // compaction throttling is as strong as possible.
     // Applies when EnableDynamicGarbageCompactionThrottling is on and disk fill
-    // is below GarbageCompactionThrottlingSoftLimit.
-    optional uint32 MinGarbageCompactionExecTimePerSecondLimit = 518;
+    // is below ThrottleGarbageCompactionBelowFillPercentage.
+    optional uint32 MinGarbageCompactionExecTimePerSecond = 518;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1638,17 +1638,17 @@ message TStorageServiceConfig
     // Disk fill percentage below which garbage compaction throttling is fully
     // enabled. Measured in percents of the disk size.
     // Applies when EnableDynamicGarbageCompactionThrottling is on.
-    optional uint32 ThrottleGarbageCompactionBelowFillPercentage = 516;
+    optional uint32 ThrottleGarbageCompactionBelowFillPercentage = 517;
 
     // Disk fill percentage above which garbage compaction throttling is
     // disabled. Measured in percents of the disk size.
     // Applies when EnableDynamicGarbageCompactionThrottling is on.
-    optional uint32 StopGarbageCompactionThrottlingAboveFillPercentage = 517;
+    optional uint32 StopGarbageCompactionThrottlingAboveFillPercentage = 518;
 
     // Minimal value of the limit on garbage compaction execution time (in ms).
     // That is, when garbage compaction throttling is at its strongest, the
     // garbage compaction execution time per second does not exceed this value.
     // Applies when EnableDynamicGarbageCompactionThrottling is enabled and disk
     // usage is below ThrottleGarbageCompactionBelowFillPercentage.
-    optional uint32 MinGarbageCompactionExecTimePerSecond = 518;
+    optional uint32 MinGarbageCompactionExecTimePerSecond = 519;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1645,9 +1645,10 @@ message TStorageServiceConfig
     // Applies when EnableDynamicGarbageCompactionThrottling is on.
     optional uint32 StopGarbageCompactionThrottlingAboveFillPercentage = 517;
 
-    // Max garbage compaction exec time per second (in ms) when garbage
-    // compaction throttling is as strong as possible.
-    // Applies when EnableDynamicGarbageCompactionThrottling is on and disk fill
-    // is below ThrottleGarbageCompactionBelowFillPercentage.
+    // Minimal value of the limit on garbage compaction execution time (in ms).
+    // That is, when garbage compaction throttling is at its strongest, the
+    // garbage compaction execution time per second does not exceed this value.
+    // Applies when EnableDynamicGarbageCompactionThrottling is enabled and disk
+    // usage is below ThrottleGarbageCompactionBelowFillPercentage.
     optional uint32 MinGarbageCompactionExecTimePerSecond = 518;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1629,4 +1629,24 @@ message TStorageServiceConfig
     // Maximum number of concurrent DescribeScheme requests during ListVolumes
     // traversal. 0 means use this default.
     optional uint32 ListVolumesConcurrency = 515;
+
+    // Enables dynamic garbage compaction throttling based on disk fill
+    // percentage. Should not be used together with
+    // IgnoringZeroedCompactionEnabled.
+    optional bool EnableDynamicGarbageCompactionThrottling = 516;
+
+    // Disk fill percentage below which garbage compaction throttling is fully
+    // enabled. Measured in percents of the disk size. Applies when
+    // EnableDynamicGarbageCompactionThrottling is on.
+    optional uint32 GarbageCompactionThrottlingSoftLimit = 517;
+
+    // Disk fill percentage above which garbage compaction throttling is
+    // disabled. Measured in percents of the disk size. Applies when
+    // EnableDynamicGarbageCompactionThrottling is on.
+    optional uint32 GarbageCompactionThrottlingHardLimit = 518;
+
+    // Max garbage compaction exec time per second (in ms). Applies when
+    // EnableDynamicGarbageCompactionThrottling is on and disk fill is below
+    // GarbageCompactionThrottlingSoftLimit.
+    optional uint32 MaxGarbageCompactionExecTimePerSecond = 519;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -207,19 +207,19 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MaxCompactionDelay,                 TDuration, TDuration::Zero()      )\
     xxx(MinCompactionDelay,                 TDuration, TDuration::Zero()      )\
     xxx(MaxCompactionExecTimePerSecond,     TDuration, TDuration::Zero()      )\
-    xxx(MinGarbageCompactionExecTimePerSecondLimit,                            \
+    xxx(MinGarbageCompactionExecTimePerSecond,                                 \
             TDuration,                                                         \
             TDuration::Seconds(1)                                             )\
     xxx(MaxCompactionExecTimePerSecondForZeroed, TDuration, TDuration::Zero() )\
-    xxx(CompactionScoreHistorySize,               ui32, 10                    )\
-    xxx(CompactionScoreLimitForThrottling,        ui32, 300                   )\
-    xxx(EnableDynamicGarbageCompactionThrottling, bool, false                 )\
-    xxx(GarbageCompactionThrottlingSoftLimit,     ui32, 120                   )\
-    xxx(GarbageCompactionThrottlingHardLimit,     ui32, 200                   )\
-    xxx(TargetCompactionBytesPerOp,               ui64, 64_KB                 )\
-    xxx(MaxSkippedBlobsDuringCompaction,          ui32, 3                     )\
-    xxx(MaxSkippedBlobsDuringCompactionHDD,       ui32, 3                     )\
-    xxx(IncrementalCompactionEnabled,             bool, false                 )\
+    xxx(CompactionScoreHistorySize,             ui32, 10                      )\
+    xxx(CompactionScoreLimitForThrottling,      ui32, 300                     )\
+    xxx(EnableDynamicGarbageCompactionThrottling,           bool, false       )\
+    xxx(ThrottleGarbageCompactionBelowFillPercentage,       ui32, 120         )\
+    xxx(StopGarbageCompactionThrottlingAboveFillPercentage, ui32, 200         )\
+    xxx(TargetCompactionBytesPerOp,             ui64, 64_KB                   )\
+    xxx(MaxSkippedBlobsDuringCompaction,        ui32, 3                       )\
+    xxx(MaxSkippedBlobsDuringCompactionHDD,     ui32, 3                       )\
+    xxx(IncrementalCompactionEnabled,           bool, false                   )\
     xxx(CompactionCountPerRunIncreasingThreshold, ui32, 0                     )\
     xxx(CompactionCountPerRunDecreasingThreshold, ui32, 0                     )\
     xxx(CompactionRangeCountPerRun,             ui32,   3                     )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -206,14 +206,18 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(OptimizeForShortRanges,             bool,      false                  )\
     xxx(MaxCompactionDelay,                 TDuration, TDuration::Zero()      )\
     xxx(MinCompactionDelay,                 TDuration, TDuration::Zero()      )\
-    xxx(MaxCompactionExecTimePerSecond,          TDuration, TDuration::Zero() )\
+    xxx(MaxCompactionExecTimePerSecond,     TDuration, TDuration::Zero()      )\
+    xxx(MaxGarbageCompactionExecTimePerSecond,   TDuration, TDuration::Zero() )\
     xxx(MaxCompactionExecTimePerSecondForZeroed, TDuration, TDuration::Zero() )\
-    xxx(CompactionScoreHistorySize,             ui32,   10                    )\
-    xxx(CompactionScoreLimitForThrottling,      ui32,   300                   )\
-    xxx(TargetCompactionBytesPerOp,             ui64,   64_KB                 )\
-    xxx(MaxSkippedBlobsDuringCompaction,        ui32,   3                     )\
-    xxx(MaxSkippedBlobsDuringCompactionHDD,     ui32,   3                     )\
-    xxx(IncrementalCompactionEnabled,           bool,   false                 )\
+    xxx(CompactionScoreHistorySize,               ui32, 10                    )\
+    xxx(CompactionScoreLimitForThrottling,        ui32, 300                   )\
+    xxx(EnableDynamicGarbageCompactionThrottling, bool, false                 )\
+    xxx(GarbageCompactionThrottlingSoftLimit,     ui32, 120                   )\
+    xxx(GarbageCompactionThrottlingHardLimit,     ui32, 200                   )\
+    xxx(TargetCompactionBytesPerOp,               ui64, 64_KB                 )\
+    xxx(MaxSkippedBlobsDuringCompaction,          ui32, 3                     )\
+    xxx(MaxSkippedBlobsDuringCompactionHDD,       ui32, 3                     )\
+    xxx(IncrementalCompactionEnabled,             bool, false                 )\
     xxx(CompactionCountPerRunIncreasingThreshold, ui32, 0                     )\
     xxx(CompactionCountPerRunDecreasingThreshold, ui32, 0                     )\
     xxx(CompactionRangeCountPerRun,             ui32,   3                     )\
@@ -759,6 +763,7 @@ BLOCKSTORE_STORAGE_CONFIG(BLOCKSTORE_STORAGE_DECLARE_CONFIG)
     xxx(SplitCompactionTx)                                                     \
     xxx(VerifyRecreatedBlobMetasOnCleanup)                                     \
     xxx(UseRecreatedBlobMetasOnCleanup)                                       \
+    xxx(DynamicGarbageCompactionThrottling)                                    \
 
 // BLOCKSTORE_BINARY_FEATURES
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -211,15 +211,15 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
             TDuration,                                                         \
             TDuration::Seconds(1)                                             )\
     xxx(MaxCompactionExecTimePerSecondForZeroed, TDuration, TDuration::Zero() )\
-    xxx(CompactionScoreHistorySize,             ui32, 10                      )\
-    xxx(CompactionScoreLimitForThrottling,      ui32, 300                     )\
+    xxx(CompactionScoreHistorySize,             ui32,   10                    )\
+    xxx(CompactionScoreLimitForThrottling,      ui32,   300                   )\
     xxx(EnableDynamicGarbageCompactionThrottling,           bool, false       )\
     xxx(ThrottleGarbageCompactionBelowFillPercentage,       ui32, 120         )\
     xxx(StopGarbageCompactionThrottlingAboveFillPercentage, ui32, 200         )\
-    xxx(TargetCompactionBytesPerOp,             ui64, 64_KB                   )\
-    xxx(MaxSkippedBlobsDuringCompaction,        ui32, 3                       )\
-    xxx(MaxSkippedBlobsDuringCompactionHDD,     ui32, 3                       )\
-    xxx(IncrementalCompactionEnabled,           bool, false                   )\
+    xxx(TargetCompactionBytesPerOp,             ui64,   64_KB                 )\
+    xxx(MaxSkippedBlobsDuringCompaction,        ui32,   3                     )\
+    xxx(MaxSkippedBlobsDuringCompactionHDD,     ui32,   3                     )\
+    xxx(IncrementalCompactionEnabled,           bool,   false                 )\
     xxx(CompactionCountPerRunIncreasingThreshold, ui32, 0                     )\
     xxx(CompactionCountPerRunDecreasingThreshold, ui32, 0                     )\
     xxx(CompactionRangeCountPerRun,             ui32,   3                     )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -207,7 +207,9 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(MaxCompactionDelay,                 TDuration, TDuration::Zero()      )\
     xxx(MinCompactionDelay,                 TDuration, TDuration::Zero()      )\
     xxx(MaxCompactionExecTimePerSecond,     TDuration, TDuration::Zero()      )\
-    xxx(MaxGarbageCompactionExecTimePerSecond,   TDuration, TDuration::Zero() )\
+    xxx(MinGarbageCompactionExecTimePerSecondLimit,                            \
+            TDuration,                                                         \
+            TDuration::Seconds(1)                                             )\
     xxx(MaxCompactionExecTimePerSecondForZeroed, TDuration, TDuration::Zero() )\
     xxx(CompactionScoreHistorySize,               ui32, 10                    )\
     xxx(CompactionScoreLimitForThrottling,        ui32, 300                   )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -102,7 +102,7 @@ public:
     TDuration GetMinCompactionDelay() const;
     TDuration GetMaxCompactionExecTimePerSecond() const;
     TDuration GetMaxCompactionExecTimePerSecondForZeroed() const;
-    TDuration GetMaxGarbageCompactionExecTimePerSecond() const;
+    TDuration GetMinGarbageCompactionExecTimePerSecondLimit() const;
     ui32 GetCompactionScoreHistorySize() const;
     ui32 GetCompactionScoreLimitForThrottling() const;
     bool GetEnableDynamicGarbageCompactionThrottling() const;

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -102,8 +102,12 @@ public:
     TDuration GetMinCompactionDelay() const;
     TDuration GetMaxCompactionExecTimePerSecond() const;
     TDuration GetMaxCompactionExecTimePerSecondForZeroed() const;
+    TDuration GetMaxGarbageCompactionExecTimePerSecond() const;
     ui32 GetCompactionScoreHistorySize() const;
     ui32 GetCompactionScoreLimitForThrottling() const;
+    bool GetEnableDynamicGarbageCompactionThrottling() const;
+    ui32 GetGarbageCompactionThrottlingSoftLimit() const;
+    ui32 GetGarbageCompactionThrottlingHardLimit() const;
     ui64 GetTargetCompactionBytesPerOp() const;
     [[nodiscard]] ui32 GetMaxSkippedBlobsDuringCompaction() const;
     [[nodiscard]] ui32 GetMaxSkippedBlobsDuringCompactionHDD() const;
@@ -434,6 +438,11 @@ public:
         const TString& diskId) const;
 
     [[nodiscard]] bool IsUseRecreatedBlobMetasOnCleanupFeatureEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& diskId) const;
+
+    [[nodiscard]] bool IsDynamicGarbageCompactionThrottlingFeatureEnabled(
         const TString& cloudId,
         const TString& folderId,
         const TString& diskId) const;

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -102,12 +102,12 @@ public:
     TDuration GetMinCompactionDelay() const;
     TDuration GetMaxCompactionExecTimePerSecond() const;
     TDuration GetMaxCompactionExecTimePerSecondForZeroed() const;
-    TDuration GetMinGarbageCompactionExecTimePerSecondLimit() const;
+    TDuration GetMinGarbageCompactionExecTimePerSecond() const;
     ui32 GetCompactionScoreHistorySize() const;
     ui32 GetCompactionScoreLimitForThrottling() const;
     bool GetEnableDynamicGarbageCompactionThrottling() const;
-    ui32 GetGarbageCompactionThrottlingSoftLimit() const;
-    ui32 GetGarbageCompactionThrottlingHardLimit() const;
+    ui32 GetThrottleGarbageCompactionBelowFillPercentage() const;
+    ui32 GetStopGarbageCompactionThrottlingAboveFillPercentage() const;
     ui64 GetTargetCompactionBytesPerOp() const;
     [[nodiscard]] ui32 GetMaxSkippedBlobsDuringCompaction() const;
     [[nodiscard]] ui32 GetMaxSkippedBlobsDuringCompactionHDD() const;

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -213,6 +213,10 @@ struct TSimpleDiskCounters
         EPublishingPolicy::Repl,
         TSimpleCounter::ECounterType::Max,
         ECounterExpirationPolicy::Permanent};
+    TCounter GarbageCompactionMaxExecTimePerSecond{
+        EPublishingPolicy::Repl,
+        TSimpleCounter::ECounterType::Generic,
+        ECounterExpirationPolicy::Permanent};
     TCounter UnconfirmedBlobCount{
         EPublishingPolicy::Repl,
         TSimpleCounter::ECounterType::Generic,
@@ -276,6 +280,7 @@ struct TSimpleDiskCounters
         MakeMeta<&TSimpleDiskCounters::CompactionIgnoringZeroedScore>(),
         MakeMeta<&TSimpleDiskCounters::ChannelHistorySize>(),
         MakeMeta<&TSimpleDiskCounters::CompactionRangeCountPerRun>(),
+        MakeMeta<&TSimpleDiskCounters::GarbageCompactionMaxExecTimePerSecond>(),
         MakeMeta<&TSimpleDiskCounters::UnconfirmedBlobCount>(),
         MakeMeta<&TSimpleDiskCounters::ConfirmedBlobCount>(),
         MakeMeta<&TSimpleDiskCounters::ReadBlobDeadlineCount>(),

--- a/cloud/blockstore/libs/storage/core/disk_counters.h
+++ b/cloud/blockstore/libs/storage/core/disk_counters.h
@@ -213,7 +213,7 @@ struct TSimpleDiskCounters
         EPublishingPolicy::Repl,
         TSimpleCounter::ECounterType::Max,
         ECounterExpirationPolicy::Permanent};
-    TCounter GarbageCompactionMaxExecTimePerSecond{
+    TCounter GarbageCompactionExecTimePerSecondLimit{
         EPublishingPolicy::Repl,
         TSimpleCounter::ECounterType::Generic,
         ECounterExpirationPolicy::Permanent};
@@ -280,7 +280,7 @@ struct TSimpleDiskCounters
         MakeMeta<&TSimpleDiskCounters::CompactionIgnoringZeroedScore>(),
         MakeMeta<&TSimpleDiskCounters::ChannelHistorySize>(),
         MakeMeta<&TSimpleDiskCounters::CompactionRangeCountPerRun>(),
-        MakeMeta<&TSimpleDiskCounters::GarbageCompactionMaxExecTimePerSecond>(),
+        MakeMeta<&TSimpleDiskCounters::GarbageCompactionExecTimePerSecondLimit>(),
         MakeMeta<&TSimpleDiskCounters::UnconfirmedBlobCount>(),
         MakeMeta<&TSimpleDiskCounters::ConfirmedBlobCount>(),
         MakeMeta<&TSimpleDiskCounters::ReadBlobDeadlineCount>(),

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1077,6 +1077,23 @@ bool TPartitionActor::IsUseRecreatedBlobMetasOnCleanupEnabled() const
                PartitionConfig.GetDiskId());
 }
 
+bool TPartitionActor::IsDynamicGarbageCompactionThrottlingEnabled() const
+{
+    return Config->GetEnableDynamicGarbageCompactionThrottling() ||
+           Config->IsDynamicGarbageCompactionThrottlingFeatureEnabled(
+               PartitionConfig.GetCloudId(),
+               PartitionConfig.GetFolderId(),
+               PartitionConfig.GetDiskId());
+}
+
+bool TPartitionActor::IsIgnoringZeroedCompactionEnabled() const
+{
+    if (IsDynamicGarbageCompactionThrottlingEnabled()) {
+        return false;
+    }
+
+    return Config->GetIgnoringZeroedCompactionEnabled();
+}
 ////////////////////////////////////////////////////////////////////////////////
 
 STFUNC(TPartitionActor::StateBoot)

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1086,14 +1086,6 @@ bool TPartitionActor::IsDynamicGarbageCompactionThrottlingEnabled() const
                PartitionConfig.GetDiskId());
 }
 
-bool TPartitionActor::IsIgnoringZeroedCompactionEnabled() const
-{
-    if (IsDynamicGarbageCompactionThrottlingEnabled()) {
-        return false;
-    }
-
-    return Config->GetIgnoringZeroedCompactionEnabled();
-}
 ////////////////////////////////////////////////////////////////////////////////
 
 STFUNC(TPartitionActor::StateBoot)

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -451,6 +451,10 @@ private:
         ui64 diskThreshold,
         const NActors::TActorContext& ctx);
 
+    TDuration ComputeGarbageCompactionExecTime(
+        const NActors::TActorContext& ctx,
+        bool throttlingAllowed);
+
     bool IsCompactRangePending(
         const TString& operationId,
         ui32& ranges) const;

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -488,6 +488,8 @@ private:
     [[nodiscard]] bool IsReadBlockMaskOnCompactionOptimizationEnabled() const;
     [[nodiscard]] bool IsVerifyRecreatedBlobMetasOnCleanupEnabled() const;
     [[nodiscard]] bool IsUseRecreatedBlobMetasOnCleanupEnabled() const;
+    [[nodiscard]] bool IsDynamicGarbageCompactionThrottlingEnabled() const;
+    [[nodiscard]] bool IsIgnoringZeroedCompactionEnabled() const;
 
     void ProcessStorageStatusFlags(
         const NActors::TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -489,7 +489,6 @@ private:
     [[nodiscard]] bool IsVerifyRecreatedBlobMetasOnCleanupEnabled() const;
     [[nodiscard]] bool IsUseRecreatedBlobMetasOnCleanupEnabled() const;
     [[nodiscard]] bool IsDynamicGarbageCompactionThrottlingEnabled() const;
-    [[nodiscard]] bool IsIgnoringZeroedCompactionEnabled() const;
 
     void ProcessStorageStatusFlags(
         const NActors::TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -164,6 +164,7 @@ private:
     NBlobMetrics::TBlobLoadMetrics OverlayMetrics;
 
     bool FirstGarbageCollectionCompleted = false;
+    bool IsGarbageCompactionThrottlingMisconfigured = false;
 
     TTransactionTimeTracker TransactionTimeTracker;
     TBSGroupOperationTimeTracker BSGroupOperationTimeTracker;

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1591,13 +1591,13 @@ void TPartitionActor::ChangeRangeCountPerRunIfNeeded(
     const auto compactionRangeCountPerRun =
         State->GetCompactionRangeCountPerRun();
 
-    if (thresholdPercentage > countPerRunIncreasingThreshold
-        && compactionRangeCountPerRun <
-        Config->GetMaxCompactionRangeCountPerRun())
+    if (thresholdPercentage > countPerRunIncreasingThreshold &&
+        compactionRangeCountPerRun < Config->GetMaxCompactionRangeCountPerRun())
     {
         State->IncrementCompactionRangeCountPerRun();
         State->SetLastCompactionRangeCountPerRunTime(ctx.Now());
-    } else if (thresholdPercentage < countPerRunDecreasingThreshold &&
+    } else if (
+        thresholdPercentage < countPerRunDecreasingThreshold &&
         compactionRangeCountPerRun > 1)
     {
         State->DecrementCompactionRangeCountPerRun();
@@ -1627,7 +1627,8 @@ TDuration TPartitionActor::ComputeGarbageCompactionExecTime(
             "ThrottleGarbageCompactionBelowFillPercentage > "
             "StopGarbageCompactionThrottlingAboveFillPercentage";
     } else if (stopThrottlingAboveFillPercentage > MaxPercentage) {
-        configError = TStringBuilder()
+        configError =
+            TStringBuilder()
             << "StopGarbageCompactionThrottlingAboveFillPercentage is greater "
                "than "
             << MaxPercentage;
@@ -1739,9 +1740,8 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
     if (IsDynamicGarbageCompactionThrottlingEnabled() &&
         info->Mode == TEvPartitionPrivate::GarbageCompaction)
     {
-        maxCompactionExecTimePerSecond = ComputeGarbageCompactionExecTime(
-            ctx,
-            info->ThrottlingAllowed);
+        maxCompactionExecTimePerSecond =
+            ComputeGarbageCompactionExecTime(ctx, info->ThrottlingAllowed);
     }
 
     if (info->ThrottlingAllowed) {

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1192,23 +1192,23 @@ STFUNC(TCompactionActor::StateWork)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ui32 GetPercentage(ui64 enumerator, ui64 denominator)
+ui32 GetPercentage(ui64 numerator, ui64 denominator)
 {
-    const double p = enumerator * 100. / Max(denominator, 1UL);
+    const double p = numerator * 100. / Max(denominator, 1UL);
     const double MAX_P = 1'000;
     return Min(p, MAX_P);
 }
 
-ui32 GetExcessPercentage(ui64 enumerator, ui64 denominator)
+ui32 GetExcessPercentage(ui64 numerator, ui64 denominator)
 {
-    const double p = GetPercentage(enumerator, denominator);
-    return p < 100? 0 : p - 100;
+    const double p = GetPercentage(numerator, denominator);
+    return p < 100 ? 0 : p - 100;
 }
 
 ui64 GetDiskBlockCount(const TPartitionState& state)
 {
     return state.GetMixedBlocksCount() + state.GetMergedBlocksCount() -
-        state.GetCleanupQueue().GetQueueBlocks();
+           state.GetCleanupQueue().GetQueueBlocks();
 }
 
 ui32 GetDiskFillPercentage(const TPartitionState& state)
@@ -1217,33 +1217,33 @@ ui32 GetDiskFillPercentage(const TPartitionState& state)
     return GetPercentage(GetDiskBlockCount(state), diskSizeInBlocks);
 }
 
-TDuration GetGarbageCompactionMaxExecTimePerSecond(
-    const TStorageConfig& config,
+TDuration GetGarbageCompactionExecTimePerSecondLimit(
+    ui32 softLimit,
+    ui32 hardLimit,
+    TDuration minGarbageCompactionExecTimePerSecondLimit,
     ui32 diskFillPercentage)
 {
-    const ui32 softLimit = config.GetGarbageCompactionThrottlingSoftLimit();
-    const ui32 hardLimit = config.GetGarbageCompactionThrottlingHardLimit();
-    const TDuration maxExec = config.GetMaxGarbageCompactionExecTimePerSecond();
+    Y_DEBUG_ABORT_UNLESS(softLimit <= hardLimit);
+    Y_DEBUG_ABORT_UNLESS(
+        minGarbageCompactionExecTimePerSecondLimit.GetValue() > 0);
 
     if (diskFillPercentage <= softLimit) {
-        return maxExec;
+        return minGarbageCompactionExecTimePerSecondLimit;
     }
 
     if (diskFillPercentage >= hardLimit) {
         // No throttling.
-        return TDuration::MilliSeconds(1000);
+        return TDuration::Seconds(1);
     }
 
-    const i64 maxMs = maxExec.MilliSeconds();
-    if (maxMs == 0) {
-        // Zero value also means no throttling.
-        return TDuration::Zero();
-    }
-
-    const i64 execTimeMs = maxMs +
-        (1000 - maxMs) * static_cast<i64>(diskFillPercentage - softLimit) /
-        (hardLimit - softLimit);
-    return TDuration::MilliSeconds(Max<i64>(execTimeMs, 1));
+    // Linear interpolation on [softLimit, hardLimit] range.
+    return minGarbageCompactionExecTimePerSecondLimit +
+           (TDuration::Seconds(1) -
+            minGarbageCompactionExecTimePerSecondLimit) *
+               (static_cast<double>(diskFillPercentage) -
+                static_cast<double>(softLimit)) /
+               (static_cast<double>(hardLimit) -
+                static_cast<double>(softLimit));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1657,7 +1657,7 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
     auto maxCompactionExecTimePerSecond =
         Config->GetMaxCompactionExecTimePerSecond();
 
-    if (IsIgnoringZeroedCompactionEnabled() &&
+    if (Config->GetIgnoringZeroedCompactionEnabled() &&
         info->Mode == TEvPartitionPrivate::GarbageCompaction &&
         Config->GetMaxCompactionExecTimePerSecondForZeroed())
     {
@@ -1673,31 +1673,50 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
         }
     }
 
-    auto throttlingAllowed = info->ThrottlingAllowed;
-
     if (IsDynamicGarbageCompactionThrottlingEnabled() &&
-        !IsIgnoringZeroedCompactionEnabled() &&
+        !Config->GetIgnoringZeroedCompactionEnabled() &&
         info->Mode == TEvPartitionPrivate::GarbageCompaction)
     {
         const ui32 softLimit =
             Config->GetGarbageCompactionThrottlingSoftLimit();
         const ui32 hardLimit =
             Config->GetGarbageCompactionThrottlingHardLimit();
+        const auto minGarbageCompactionExecTimePerSecondLimit =
+            Config->GetMinGarbageCompactionExecTimePerSecondLimit();
 
-        if (softLimit && hardLimit && softLimit < hardLimit) {
+        if (softLimit > hardLimit) {
+            LOG_WARN(
+                ctx,
+                TBlockStoreComponents::PARTITION,
+                "%s Invalid garbage compaction throttling config: "
+                "GarbageCompactionThrottlingSoftLimit (%u) > "
+                "GarbageCompactionThrottlingHardLimit (%u)",
+                LogTitle.GetWithTime().c_str(),
+                softLimit,
+                hardLimit);
+        } else if (minGarbageCompactionExecTimePerSecondLimit.GetValue() == 0) {
+            LOG_WARN(
+                ctx,
+                TBlockStoreComponents::PARTITION,
+                "%s Invalid garbage compaction throttling config: "
+                "MinGarbageCompactionExecTimePerSecondLimit is zero",
+                LogTitle.GetWithTime().c_str());
+        } else {
             maxCompactionExecTimePerSecond =
-                GetGarbageCompactionMaxExecTimePerSecond(
-                    *Config,
+                GetGarbageCompactionExecTimePerSecondLimit(
+                    softLimit,
+                    hardLimit,
+                    minGarbageCompactionExecTimePerSecondLimit,
                     GetDiskFillPercentage(*State));
         }
 
-        PartCounters->Simple.GarbageCompactionMaxExecTimePerSecond.Set(
-            throttlingAllowed
+        PartCounters->Simple.GarbageCompactionExecTimePerSecondLimit.Set(
+            info->ThrottlingAllowed
                 ? maxCompactionExecTimePerSecond.MilliSeconds()
                 : 0);
     }
 
-    if (throttlingAllowed) {
+    if (info->ThrottlingAllowed) {
         State->SetCompactionDelay(CalculateBackgroundOpThrottleDelay(
             State->GetCompactionExecTimeForLastSecond(ctx.Now()),
             maxCompactionExecTimePerSecond,

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1196,7 +1196,7 @@ ui32 GetPercentage(ui64 numerator, ui64 denominator)
 {
     const double p = numerator * 100. / Max(denominator, 1UL);
     const double MAX_P = 1'000;
-    return Min(p, MAX_P);
+    return Min(std::round(p), MAX_P);
 }
 
 ui32 GetExcessPercentage(ui64 numerator, ui64 denominator)
@@ -1240,10 +1240,8 @@ TDuration GetGarbageCompactionExecTimePerSecondLimit(
     return minGarbageCompactionExecTimePerSecondLimit +
            (TDuration::Seconds(1) -
             minGarbageCompactionExecTimePerSecondLimit) *
-               (static_cast<double>(diskFillPercentage) -
-                static_cast<double>(softLimit)) /
-               (static_cast<double>(hardLimit) -
-                static_cast<double>(softLimit));
+               (static_cast<double>(diskFillPercentage) - softLimit) /
+               (hardLimit - softLimit);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1192,15 +1192,58 @@ STFUNC(TCompactionActor::StateWork)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ui32 GetExcessPercentage(ui64 enumerator, ui64 denominator)
+ui32 GetPercentage(ui64 enumerator, ui64 denominator)
 {
-    if (enumerator < denominator) {
-        return 0;
-    }
-
-    const double p = (enumerator - denominator) * 100. / Max(denominator, 1UL);
+    const double p = enumerator * 100. / Max(denominator, 1UL);
     const double MAX_P = 1'000;
     return Min(p, MAX_P);
+}
+
+ui32 GetExcessPercentage(ui64 enumerator, ui64 denominator)
+{
+    const double p = GetPercentage(enumerator, denominator);
+    return p < 100? 0 : p - 100;
+}
+
+ui64 GetDiskBlockCount(const TPartitionState& state)
+{
+    return state.GetMixedBlocksCount() + state.GetMergedBlocksCount() -
+        state.GetCleanupQueue().GetQueueBlocks();
+}
+
+ui32 GetDiskFillPercentage(const TPartitionState& state)
+{
+    const ui64 diskSizeInBlocks = state.GetBlocksCount();
+    return GetPercentage(GetDiskBlockCount(state), diskSizeInBlocks);
+}
+
+TDuration GetGarbageCompactionMaxExecTimePerSecond(
+    const TStorageConfig& config,
+    ui32 diskFillPercentage)
+{
+    const ui32 softLimit = config.GetGarbageCompactionThrottlingSoftLimit();
+    const ui32 hardLimit = config.GetGarbageCompactionThrottlingHardLimit();
+    const TDuration maxExec = config.GetMaxGarbageCompactionExecTimePerSecond();
+
+    if (diskFillPercentage <= softLimit) {
+        return maxExec;
+    }
+
+    if (diskFillPercentage >= hardLimit) {
+        // No throttling.
+        return TDuration::MilliSeconds(1000);
+    }
+
+    const i64 maxMs = maxExec.MilliSeconds();
+    if (maxMs == 0) {
+        // Zero value also means no throttling.
+        return TDuration::Zero();
+    }
+
+    const i64 execTimeMs = maxMs +
+        (1000 - maxMs) * static_cast<i64>(diskFillPercentage - softLimit) /
+        (hardLimit - softLimit);
+    return TDuration::MilliSeconds(Max<i64>(execTimeMs, 1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1304,8 +1347,7 @@ public:
 private:
     [[nodiscard]] ui64 GetBlockCount() const
     {
-        return State.GetMixedBlocksCount() + State.GetMergedBlocksCount() -
-               State.GetCleanupQueue().GetQueueBlocks();
+        return GetDiskBlockCount(State);
     }
 
     [[nodiscard]] ui64 GetGarbagePercentage() const
@@ -1614,7 +1656,8 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
 
     auto maxCompactionExecTimePerSecond =
         Config->GetMaxCompactionExecTimePerSecond();
-    if (Config->GetIgnoringZeroedCompactionEnabled() &&
+
+    if (IsIgnoringZeroedCompactionEnabled() &&
         info->Mode == TEvPartitionPrivate::GarbageCompaction &&
         Config->GetMaxCompactionExecTimePerSecondForZeroed())
     {
@@ -1630,7 +1673,31 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
         }
     }
 
-    if (info->ThrottlingAllowed) {
+    auto throttlingAllowed = info->ThrottlingAllowed;
+
+    if (IsDynamicGarbageCompactionThrottlingEnabled() &&
+        !IsIgnoringZeroedCompactionEnabled() &&
+        info->Mode == TEvPartitionPrivate::GarbageCompaction)
+    {
+        const ui32 softLimit =
+            Config->GetGarbageCompactionThrottlingSoftLimit();
+        const ui32 hardLimit =
+            Config->GetGarbageCompactionThrottlingHardLimit();
+
+        if (softLimit && hardLimit && softLimit < hardLimit) {
+            maxCompactionExecTimePerSecond =
+                GetGarbageCompactionMaxExecTimePerSecond(
+                    *Config,
+                    GetDiskFillPercentage(*State));
+        }
+
+        PartCounters->Simple.GarbageCompactionMaxExecTimePerSecond.Set(
+            throttlingAllowed
+                ? maxCompactionExecTimePerSecond.MilliSeconds()
+                : 0);
+    }
+
+    if (throttlingAllowed) {
         State->SetCompactionDelay(CalculateBackgroundOpThrottleDelay(
             State->GetCompactionExecTimeForLastSecond(ctx.Now()),
             maxCompactionExecTimePerSecond,

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1611,15 +1611,19 @@ TDuration TPartitionActor::ComputeGarbageCompactionExecTime(
     const TActorContext& ctx,
     bool throttlingAllowed)
 {
+    // Fall back to the static budget unless the dynamic config is valid.
+    TDuration execTimePerSecond = Config->GetMaxCompactionExecTimePerSecond();
+
+    if (IsGarbageCompactionThrottlingMisconfigured) {
+        return execTimePerSecond;
+    }
+
     const ui32 throttleBelowFillPercentage =
         Config->GetThrottleGarbageCompactionBelowFillPercentage();
     const ui32 stopThrottlingAboveFillPercentage =
         Config->GetStopGarbageCompactionThrottlingAboveFillPercentage();
     const TDuration minExecTimePerSecond =
         Config->GetMinGarbageCompactionExecTimePerSecond();
-
-    // Fall back to the static budget unless the dynamic config is valid.
-    TDuration execTimePerSecond = Config->GetMaxCompactionExecTimePerSecond();
 
     TString configError;
     if (throttleBelowFillPercentage > stopThrottlingAboveFillPercentage) {
@@ -1650,6 +1654,7 @@ TDuration TPartitionActor::ComputeGarbageCompactionExecTime(
             "%s Invalid garbage compaction throttling config: %s",
             LogTitle.GetWithTime().c_str(),
             configError.c_str());
+        IsGarbageCompactionThrottlingMisconfigured = true;
     } else {
         execTimePerSecond = InterpolateCompactionExecTime(
             throttleBelowFillPercentage,

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1192,11 +1192,13 @@ STFUNC(TCompactionActor::StateWork)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static constexpr double MaxPercentage = 1'000;
+static constexpr TDuration NoThrottleExecTimePerSecond = TDuration::Seconds(1);
+
 ui32 GetPercentage(ui64 numerator, ui64 denominator)
 {
     const double p = numerator * 100. / Max(denominator, 1UL);
-    const double MAX_P = 1'000;
-    return Min(std::round(p), MAX_P);
+    return static_cast<ui32>(Min(p, MaxPercentage));
 }
 
 ui32 GetExcessPercentage(ui64 numerator, ui64 denominator)
@@ -1207,8 +1209,14 @@ ui32 GetExcessPercentage(ui64 numerator, ui64 denominator)
 
 ui64 GetDiskBlockCount(const TPartitionState& state)
 {
-    return state.GetMixedBlocksCount() + state.GetMergedBlocksCount() -
-           state.GetCleanupQueue().GetQueueBlocks();
+    const ui64 mixedAndMergedBlocks =
+        state.GetMixedBlocksCount() + state.GetMergedBlocksCount();
+    const ui64 queueBlocks = state.GetCleanupQueue().GetQueueBlocks();
+    Y_DEBUG_ABORT_UNLESS(mixedAndMergedBlocks >= queueBlocks);
+
+    return mixedAndMergedBlocks < queueBlocks
+               ? 0
+               : mixedAndMergedBlocks - queueBlocks;
 }
 
 ui32 GetDiskFillPercentage(const TPartitionState& state)
@@ -1217,31 +1225,30 @@ ui32 GetDiskFillPercentage(const TPartitionState& state)
     return GetPercentage(GetDiskBlockCount(state), diskSizeInBlocks);
 }
 
-TDuration GetGarbageCompactionExecTimePerSecondLimit(
-    ui32 softLimit,
-    ui32 hardLimit,
-    TDuration minGarbageCompactionExecTimePerSecondLimit,
+TDuration InterpolateCompactionExecTime(
+    ui32 throttleBelowFillPercentage,
+    ui32 stopThrottlingAboveFillPercentage,
+    TDuration minExecTimePerSecond,
     ui32 diskFillPercentage)
 {
-    Y_DEBUG_ABORT_UNLESS(softLimit <= hardLimit);
     Y_DEBUG_ABORT_UNLESS(
-        minGarbageCompactionExecTimePerSecondLimit.GetValue() > 0);
+        throttleBelowFillPercentage <= stopThrottlingAboveFillPercentage);
+    Y_DEBUG_ABORT_UNLESS(minExecTimePerSecond.GetValue() > 0);
+    Y_DEBUG_ABORT_UNLESS(minExecTimePerSecond <= NoThrottleExecTimePerSecond);
 
-    if (diskFillPercentage <= softLimit) {
-        return minGarbageCompactionExecTimePerSecondLimit;
+    if (diskFillPercentage <= throttleBelowFillPercentage) {
+        return minExecTimePerSecond;
+    }
+    if (diskFillPercentage >= stopThrottlingAboveFillPercentage) {
+        return NoThrottleExecTimePerSecond;
     }
 
-    if (diskFillPercentage >= hardLimit) {
-        // No throttling.
-        return TDuration::Seconds(1);
-    }
-
-    // Linear interpolation on [softLimit, hardLimit] range.
-    return minGarbageCompactionExecTimePerSecondLimit +
-           (TDuration::Seconds(1) -
-            minGarbageCompactionExecTimePerSecondLimit) *
-               (static_cast<double>(diskFillPercentage) - softLimit) /
-               (hardLimit - softLimit);
+    // Position of diskFillPercentage within the throttling band, in [0, 1].
+    const double t =
+        static_cast<double>(diskFillPercentage - throttleBelowFillPercentage) /
+        (stopThrottlingAboveFillPercentage - throttleBelowFillPercentage);
+    return minExecTimePerSecond +
+           (NoThrottleExecTimePerSecond - minExecTimePerSecond) * t;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1600,6 +1607,64 @@ void TPartitionActor::ChangeRangeCountPerRunIfNeeded(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TDuration TPartitionActor::ComputeGarbageCompactionExecTime(
+    const TActorContext& ctx,
+    bool throttlingAllowed)
+{
+    const ui32 throttleBelowFillPercentage =
+        Config->GetThrottleGarbageCompactionBelowFillPercentage();
+    const ui32 stopThrottlingAboveFillPercentage =
+        Config->GetStopGarbageCompactionThrottlingAboveFillPercentage();
+    const TDuration minExecTimePerSecond =
+        Config->GetMinGarbageCompactionExecTimePerSecond();
+
+    // Fall back to the static budget unless the dynamic config is valid.
+    TDuration execTimePerSecond = Config->GetMaxCompactionExecTimePerSecond();
+
+    TString configError;
+    if (throttleBelowFillPercentage > stopThrottlingAboveFillPercentage) {
+        configError =
+            "ThrottleGarbageCompactionBelowFillPercentage > "
+            "StopGarbageCompactionThrottlingAboveFillPercentage";
+    } else if (stopThrottlingAboveFillPercentage > MaxPercentage) {
+        configError = TStringBuilder()
+            << "StopGarbageCompactionThrottlingAboveFillPercentage is greater "
+               "than "
+            << MaxPercentage;
+    } else if (minExecTimePerSecond.GetValue() == 0) {
+        configError = "MinGarbageCompactionExecTimePerSecond is zero";
+    } else if (minExecTimePerSecond > NoThrottleExecTimePerSecond) {
+        configError =
+            "MinGarbageCompactionExecTimePerSecond exceeds one second";
+    } else if (Config->GetIgnoringZeroedCompactionEnabled()) {
+        configError =
+            "Ignoring zeroed compaction and dynamic garbage compaction are "
+            "enabled simultaneously";
+    }
+
+    if (configError) {
+        LOG_WARN(
+            ctx,
+            TBlockStoreComponents::PARTITION,
+            "%s Invalid garbage compaction throttling config: %s",
+            LogTitle.GetWithTime().c_str(),
+            configError.c_str());
+    } else {
+        execTimePerSecond = InterpolateCompactionExecTime(
+            throttleBelowFillPercentage,
+            stopThrottlingAboveFillPercentage,
+            minExecTimePerSecond,
+            GetDiskFillPercentage(*State));
+    }
+
+    PartCounters->Simple.GarbageCompactionExecTimePerSecondLimit.Set(
+        throttlingAllowed ? execTimePerSecond.MilliSeconds() : 0);
+
+    return execTimePerSecond;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
 {
     if (CompactionMapLoadState) {
@@ -1672,46 +1737,11 @@ void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
     }
 
     if (IsDynamicGarbageCompactionThrottlingEnabled() &&
-        !Config->GetIgnoringZeroedCompactionEnabled() &&
         info->Mode == TEvPartitionPrivate::GarbageCompaction)
     {
-        const ui32 softLimit =
-            Config->GetGarbageCompactionThrottlingSoftLimit();
-        const ui32 hardLimit =
-            Config->GetGarbageCompactionThrottlingHardLimit();
-        const auto minGarbageCompactionExecTimePerSecondLimit =
-            Config->GetMinGarbageCompactionExecTimePerSecondLimit();
-
-        if (softLimit > hardLimit) {
-            LOG_WARN(
-                ctx,
-                TBlockStoreComponents::PARTITION,
-                "%s Invalid garbage compaction throttling config: "
-                "GarbageCompactionThrottlingSoftLimit (%u) > "
-                "GarbageCompactionThrottlingHardLimit (%u)",
-                LogTitle.GetWithTime().c_str(),
-                softLimit,
-                hardLimit);
-        } else if (minGarbageCompactionExecTimePerSecondLimit.GetValue() == 0) {
-            LOG_WARN(
-                ctx,
-                TBlockStoreComponents::PARTITION,
-                "%s Invalid garbage compaction throttling config: "
-                "MinGarbageCompactionExecTimePerSecondLimit is zero",
-                LogTitle.GetWithTime().c_str());
-        } else {
-            maxCompactionExecTimePerSecond =
-                GetGarbageCompactionExecTimePerSecondLimit(
-                    softLimit,
-                    hardLimit,
-                    minGarbageCompactionExecTimePerSecondLimit,
-                    GetDiskFillPercentage(*State));
-        }
-
-        PartCounters->Simple.GarbageCompactionExecTimePerSecondLimit.Set(
-            info->ThrottlingAllowed
-                ? maxCompactionExecTimePerSecond.MilliSeconds()
-                : 0);
+        maxCompactionExecTimePerSecond = ComputeGarbageCompactionExecTime(
+            ctx,
+            info->ThrottlingAllowed);
     }
 
     if (info->ThrottlingAllowed) {

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -3690,6 +3690,94 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(true);
     }
 
+    void CheckGarbageCompactionExecTimePerSecondLimit(
+        ui32 softLimit,
+        ui32 hardLimit,
+        ui32 fillPercentage,
+        ui32 expectedExecTimeLimit)
+    {
+        auto config = DefaultConfig();
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetEnableDynamicGarbageCompactionThrottling(true);
+        config.SetGarbageCompactionThrottlingSoftLimit(softLimit);
+        config.SetGarbageCompactionThrottlingHardLimit(hardLimit);
+        config.SetMinGarbageCompactionExecTimePerSecondLimit(200);
+        config.SetCompactionGarbageThreshold(20);
+        config.SetCompactionRangeGarbageThreshold(20);
+        config.SetMinCompactionDelay(0);
+        config.SetMaxCompactionDelay(999'999'999);
+
+        constexpr ui32 blockCount = 1000;
+        auto runtime = PrepareTestActorRuntime(config, blockCount);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        bool garbageCompactionRequestObserved = false;
+        ui64 garbageCompactionExecTimePerSecondLimit = 0;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        auto* msg = event->Get<
+                            TEvPartitionPrivate::TEvCompactionRequest>();
+                        if (msg->Mode == TEvPartitionPrivate::GarbageCompaction)
+                        {
+                            garbageCompactionRequestObserved = true;
+                        }
+                        break;
+                    }
+                    case TEvStatsService::EvVolumePartCounters: {
+                        auto* msg =
+                            event
+                                ->Get<TEvStatsService::TEvVolumePartCounters>();
+                        garbageCompactionExecTimePerSecondLimit =
+                            msg->DiskCounters->Simple
+                                .GarbageCompactionExecTimePerSecondLimit.Value;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        // Writing blocks in such a way that
+        // `BlockCount / DiskSize` is exactly `fillPercentage` percent.
+        const ui32 writeBlockCount = blockCount * fillPercentage / 200;
+        UNIT_ASSERT(writeBlockCount < blockCount);
+        const auto blockRange = TBlockRange32::WithLength(0, writeBlockCount);
+        partition.WriteBlocks(blockRange);
+        partition.WriteBlocks(blockRange);
+        partition.Flush();
+
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        UNIT_ASSERT(garbageCompactionRequestObserved);
+
+        partition.SendToPipe(
+            std::make_unique<TEvPartitionPrivate::TEvUpdateCounters>());
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(
+                TEvStatsService::EvVolumePartCounters);
+            runtime->DispatchEvents(options);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            expectedExecTimeLimit,
+            garbageCompactionExecTimePerSecondLimit);
+    }
+
+    Y_UNIT_TEST(ShouldCalculateGarbageCompactionExecTimePerSecondLimit)
+    {
+        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 70, 200);
+        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 90, 300);
+        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 120, 600);
+        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 180, 1000);
+        CheckGarbageCompactionExecTimePerSecondLimit(120, 120, 120, 200);
+    }
+
     Y_UNIT_TEST(CompactionShouldTakeCareOfFreshBlocks)
     {
         auto runtime = PrepareTestActorRuntime();

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -10857,17 +10857,17 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
     {
         // real blocks per disk: 1024 * 10 = 10240
         // total blocks per disk: = 1024 * 3 = 3072
-        // garbage percentage: 100 * (10 - 3) * 1024 / 3072 = 233
-        // percentage more threshold: 100 * (233 - 203) / 203 = 9
+        // garbage percentage: 100 * (10 - 3) * 1024 / 3072 ~ 233
+        // percentage more threshold: 100 * (233 - 203) / 203 ~ 15
 
 
-        // 9 > 8, so should increment and compact 2 ranges
+        // 15 > 14, so should increment and compact 2 ranges
         CheckIncrementAndDecrementCompactionPerRun(
-                1, 1000, 99999, 203, 99999, 5, 8, 5, 2);
+                1, 1000, 99999, 203, 99999, 5, 14, 5, 2);
 
-        // 9 < 15, so should decrement and compact only 1 range
+        // 15 < 16, so should decrement and compact only 1 range
         CheckIncrementAndDecrementCompactionPerRun(
-                2, 1000, 99999, 203, 99999, 7, 30, 15, 1);
+                2, 1000, 99999, 203, 99999, 7, 30, 16, 1);
     }
 
     Y_UNIT_TEST(ShouldChangeBatchSizeDueToBlocksPerRangeCount)

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -3690,18 +3690,20 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         DoShouldAutomaticallyRunGarbageCompactionForSuperDirtyRanges(true);
     }
 
-    void CheckGarbageCompactionExecTimePerSecondLimit(
-        ui32 softLimit,
-        ui32 hardLimit,
+    void CheckInterpolatedGarbageCompactionExecTimePerSecond(
+        ui32 throttleBelowFillPercentage,
+        ui32 stopThrottlingAboveFillPercentage,
         ui32 fillPercentage,
-        ui32 expectedExecTimeLimit)
+        ui32 expectedExecTime)
     {
         auto config = DefaultConfig();
         config.SetV1GarbageCompactionEnabled(true);
         config.SetEnableDynamicGarbageCompactionThrottling(true);
-        config.SetGarbageCompactionThrottlingSoftLimit(softLimit);
-        config.SetGarbageCompactionThrottlingHardLimit(hardLimit);
-        config.SetMinGarbageCompactionExecTimePerSecondLimit(200);
+        config.SetThrottleGarbageCompactionBelowFillPercentage(
+            throttleBelowFillPercentage);
+        config.SetStopGarbageCompactionThrottlingAboveFillPercentage(
+            stopThrottlingAboveFillPercentage);
+        config.SetMinGarbageCompactionExecTimePerSecond(200);
         config.SetCompactionGarbageThreshold(20);
         config.SetCompactionRangeGarbageThreshold(20);
         config.SetMinCompactionDelay(0);
@@ -3765,17 +3767,17 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
 
         UNIT_ASSERT_VALUES_EQUAL(
-            expectedExecTimeLimit,
+            expectedExecTime,
             garbageCompactionExecTimePerSecondLimit);
     }
 
     Y_UNIT_TEST(ShouldCalculateGarbageCompactionExecTimePerSecondLimit)
     {
-        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 70, 200);
-        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 90, 300);
-        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 120, 600);
-        CheckGarbageCompactionExecTimePerSecondLimit(80, 160, 180, 1000);
-        CheckGarbageCompactionExecTimePerSecondLimit(120, 120, 120, 200);
+        CheckInterpolatedGarbageCompactionExecTimePerSecond(80, 160, 70, 200);
+        CheckInterpolatedGarbageCompactionExecTimePerSecond(80, 160, 90, 300);
+        CheckInterpolatedGarbageCompactionExecTimePerSecond(80, 160, 120, 600);
+        CheckInterpolatedGarbageCompactionExecTimePerSecond(80, 160, 180, 1000);
+        CheckInterpolatedGarbageCompactionExecTimePerSecond(120, 120, 120, 200);
     }
 
     Y_UNIT_TEST(CompactionShouldTakeCareOfFreshBlocks)
@@ -10858,14 +10860,14 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         // real blocks per disk: 1024 * 10 = 10240
         // total blocks per disk: = 1024 * 3 = 3072
         // garbage percentage: 100 * (10 - 3) * 1024 / 3072 ~ 233
-        // percentage more threshold: 100 * (233 - 203) / 203 ~ 15
+        // percentage more threshold: 100 * (233 - 203) / 203 ~ 14.8
 
 
-        // 15 > 14, so should increment and compact 2 ranges
+        // 14.8 > 13, so should increment and compact 2 ranges
         CheckIncrementAndDecrementCompactionPerRun(
-                1, 1000, 99999, 203, 99999, 5, 14, 5, 2);
+                1, 1000, 99999, 203, 99999, 5, 13, 5, 2);
 
-        // 15 < 16, so should decrement and compact only 1 range
+        // 14.8 < 16, so should decrement and compact only 1 range
         CheckIncrementAndDecrementCompactionPerRun(
                 2, 1000, 99999, 203, 99999, 7, 30, 16, 1);
     }

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -10867,9 +10867,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         CheckIncrementAndDecrementCompactionPerRun(
                 1, 1000, 99999, 203, 99999, 5, 13, 5, 2);
 
-        // 14.8 < 16, so should decrement and compact only 1 range
+        // 14.8 < 15, so should decrement and compact only 1 range
         CheckIncrementAndDecrementCompactionPerRun(
-                2, 1000, 99999, 203, 99999, 7, 30, 16, 1);
+                2, 1000, 99999, 203, 99999, 7, 30, 15, 1);
     }
 
     Y_UNIT_TEST(ShouldChangeBatchSizeDueToBlocksPerRangeCount)


### PR DESCRIPTION
### Notes
More generic solution instead of https://github.com/ydb-platform/nbs/pull/6027.

Proposed solution:
- We make throttling more or less active dynamically depending on the amount of space used by the disk.
- Namely, we look on the percentage of mixed+merged blocks according to the disk size.
- If the presentage high, we do not throttle (maxCompactionExecTimePerSecond=1000ms); if it is low, we apply maximal throttling (the value of maxCompactionExecTimePerSecond is taken from config); otherwize we use linear interpolation of maxCompactionExecTimePerSecond.

### Issue
#5815
