### PR TITLE
[NBS] Local NVMe service: move long-running operations to background thread pool

### DIFF
--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -1006,6 +1006,7 @@ void TBootstrapBase::Start()
     START_COMMON_COMPONENT(RdmaRequestServer);
     START_COMMON_COMPONENT(RdmaTarget);
     START_COMMON_COMPONENT(CellManager);
+    START_COMMON_COMPONENT(LongRunningTaskExecutor);
     START_COMMON_COMPONENT(LocalNVMeDeviceProvider);
     START_COMMON_COMPONENT(LocalNVMeService);
 
@@ -1062,6 +1063,7 @@ void TBootstrapBase::Stop()
     STOP_COMMON_COMPONENT(Scheduler);
     STOP_COMMON_COMPONENT(LocalNVMeService);
     STOP_COMMON_COMPONENT(LocalNVMeDeviceProvider);
+    STOP_COMMON_COMPONENT(LongRunningTaskExecutor);
     STOP_COMMON_COMPONENT(CellManager);
     STOP_COMMON_COMPONENT(RdmaTarget);
     STOP_COMMON_COMPONENT(RdmaRequestServer);

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -85,6 +85,7 @@ protected:
     NBD::IErrorHandlerMapPtr NbdErrorHandlerMap;
     NCloud::NStorage::NRdma::IServerPtr RdmaRequestServer;
     IStartablePtr RdmaTarget;
+    ITaskQueuePtr LongRunningTaskExecutor;
     ILocalNVMeDeviceProviderPtr LocalNVMeDeviceProvider;
     ILocalNVMeServicePtr LocalNVMeService;
     ICertificateProviderPtr CertificateProvider;

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -816,7 +816,8 @@ void TBootstrapYdb::InitKikimrService()
             logging,
             LocalNVMeDeviceProvider,
             NvmeManager,
-            Executor);
+            Executor,
+            BackgroundThreadPool);
     } else {
         LocalNVMeDeviceProvider = CreateLocalNVMeDeviceProviderStub();
         LocalNVMeService = CreateLocalNVMeServiceStub();

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -806,6 +806,8 @@ void TBootstrapYdb::InitKikimrService()
     STORAGE_INFO("PartitionBudgetManager initialized")
 
     if (Configs->LocalNVMeConfig->GetDevicesSourceUri()) {
+        LongRunningTaskExecutor = CreateLongRunningTaskExecutor("LongRunning");
+
         LocalNVMeDeviceProvider =
             ServerModuleFactories->LocalNVMeDeviceProviderFactory(
                 logging,
@@ -817,7 +819,7 @@ void TBootstrapYdb::InitKikimrService()
             LocalNVMeDeviceProvider,
             NvmeManager,
             Executor,
-            BackgroundThreadPool);
+            LongRunningTaskExecutor);
     } else {
         LocalNVMeDeviceProvider = CreateLocalNVMeDeviceProviderStub();
         LocalNVMeService = CreateLocalNVMeServiceStub();

--- a/cloud/blockstore/libs/local_nvme/service.h
+++ b/cloud/blockstore/libs/local_nvme/service.h
@@ -43,6 +43,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     ILoggingServicePtr logging,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
-    TExecutorPtr executor);
+    TExecutorPtr executor,
+    ITaskQueuePtr backgroundExecutor);
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/service_generic.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_generic.cpp
@@ -9,9 +9,16 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     ILoggingServicePtr logging,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
-    TExecutorPtr executor)
+    TExecutorPtr executor,
+    ITaskQueuePtr backgroundExecutor)
 {
-    Y_UNUSED(config, logging, deviceProvider, nvmeManager, executor);
+    Y_UNUSED(
+        config,
+        logging,
+        deviceProvider,
+        nvmeManager,
+        executor,
+        backgroundExecutor);
 
     return CreateLocalNVMeServiceStub();
 }

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -897,7 +897,7 @@ auto TLocalNVMeService::SanitizeNVMeDevice(const NProto::TNVMeDevice& device)
 try {
     STORAGE_INFO("Sanitize " << device.GetSerialNumber().Quote());
 
-    const auto ctrlPath = GetNVMeCtrlPath(device);
+    const TFsPath ctrlPath = GetNVMeCtrlPath(device);
 
     CheckError(NVMeManager->StartSanitize(ctrlPath));
 

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -228,6 +228,7 @@ private:
 
     template <typename TOpResult, typename TFnResult, typename TFn>
     auto StartOperation(
+        TString opName,
         TFn fn,
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<TFnResult>;
@@ -717,6 +718,7 @@ auto TLocalNVMeService::GetOperationResult(
 
 template <typename TOpResult, typename TFnResult, typename TFn>
 auto TLocalNVMeService::StartOperation(
+    TString opName,
     TFn fn,
     const TSerialNumber& serialNumber,
     const TString& idempotenceId) -> TFuture<TFnResult>
@@ -733,11 +735,22 @@ auto TLocalNVMeService::StartOperation(
     if (auto opResult =
             GetOperationResult<TOpResult>(serialNumber, idempotenceId))
     {
+        STORAGE_INFO(
+            "Idempotent " << opName
+                          << " NVMe device operation already completed for "
+                          << serialNumber.Quote()
+                          << ", idempotenceId: " << idempotenceId);
+
         return *opResult;
     }
 
+    STORAGE_INFO(
+        "Starting " << opName << " NVMe device operation for "
+                    << serialNumber.Quote()
+                    << ", idempotenceId: " << idempotenceId);
+
     auto op = std::make_shared<TOperation>();
-    op->Name = TypeName<TOpResult>();
+    op->Name = std::move(opName);
     op->IdempotenceId = idempotenceId;
     op->StartTime = Now();
 
@@ -768,14 +781,27 @@ auto TLocalNVMeService::AcquireDevice(
     const TString& idempotenceId) -> TFuture<TAcquireResult>
 {
     auto future = StartOperation<TAcquireOperationResult, TAcquireResult>(
+        "Acquire",
         &TLocalNVMeService::AcquireDeviceImpl,
         serialNumber,
         idempotenceId);
 
-    // If idempotenceId isn't provided - wait operation synchronously
-    if (!idempotenceId || future.IsReady()) {
+    if (future.IsReady()) {
         return future;
     }
+
+    // If idempotenceId isn't provided, wait for the operation synchronously.
+    if (!idempotenceId) {
+        STORAGE_INFO(
+            "Waiting for Acquire NVMe device operation to complete "
+            "synchronously for "
+            << serialNumber.Quote() << ": idempotenceId is not provided");
+        return future;
+    }
+
+    STORAGE_DEBUG(
+        "Acquire NVMe device operation is still in progress for "
+        << serialNumber.Quote() << ", idempotenceId: " << idempotenceId);
 
     return MakeFuture<TAcquireResult>(
         MakeError(E_TRY_AGAIN, "Acquire in progress"));
@@ -933,14 +959,27 @@ auto TLocalNVMeService::ReleaseDevice(
     const TString& idempotenceId) -> TFuture<NProto::TError>
 {
     auto future = StartOperation<TReleaseOperationResult, NProto::TError>(
+        "Release",
         &TLocalNVMeService::ReleaseDeviceImpl,
         serialNumber,
         idempotenceId);
 
-    // If idempotenceId isn't provided - wait operation synchronously
-    if (!idempotenceId || future.IsReady()) {
+    if (future.IsReady()) {
         return future;
     }
+
+    // If idempotenceId isn't provided, wait for the operation synchronously.
+    if (!idempotenceId) {
+        STORAGE_INFO(
+            "Waiting for Release NVMe device operation to complete "
+            "synchronously for "
+            << serialNumber.Quote() << ": idempotenceId is not provided");
+        return future;
+    }
+
+    STORAGE_DEBUG(
+        "Release NVMe device operation is still in progress for "
+        << serialNumber.Quote() << ", idempotenceId: " << idempotenceId);
 
     return MakeFuture<NProto::TError>(
         MakeError(E_TRY_AGAIN, "Release in progress"));

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -137,6 +137,7 @@ private:
     const ILocalNVMeDeviceProviderPtr DeviceProvider;
     const NNvme::INvmeManagerPtr NVMeManager;
     const TExecutorPtr Executor;
+    const ITaskQueuePtr BackgroundExecutor;
     const ISysFsPtr SysFs;
 
     std::atomic<EServiceState> ServiceState = EServiceState::NotReady;
@@ -158,6 +159,7 @@ public:
         ILocalNVMeDeviceProviderPtr deviceProvider,
         NNvme::INvmeManagerPtr nvmeManager,
         TExecutorPtr executor,
+        ITaskQueuePtr backgroundExecutor,
         ISysFsPtr sysFs);
 
     // IStartable
@@ -239,12 +241,14 @@ TLocalNVMeService::TLocalNVMeService(
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,
+    ITaskQueuePtr backgroundExecutor,
     ISysFsPtr sysFs)
     : Config(std::move(config))
     , Logging(std::move(logging))
     , DeviceProvider(std::move(deviceProvider))
     , NVMeManager(std::move(nvmeManager))
     , Executor(std::move(executor))
+    , BackgroundExecutor(std::move(backgroundExecutor))
     , SysFs(std::move(sysFs))
 {}
 
@@ -655,12 +659,11 @@ auto TLocalNVMeService::BindDeviceToDriver(
         "Bind " << device.GetSerialNumber().Quote() << " to " << driverName
                 << " driver");
 
-    return SafeExecute<NProto::TError>(
-        [&]
-        {
-            SysFs->BindPCIDeviceToDriver(device.GetPCIAddress(), driverName);
-            return MakeError(S_OK);
-        });
+    auto future = BackgroundExecutor->Execute(
+        [sysfs = SysFs, pciAddr = device.GetPCIAddress(), driverName]
+        { sysfs->BindPCIDeviceToDriver(pciAddr, driverName); });
+
+    return Executor->ResultOrError(future).GetError();
 }
 
 template <typename TOpResult>
@@ -868,7 +871,7 @@ auto TLocalNVMeService::SanitizeNVMeDevice(const NProto::TNVMeDevice& device)
 try {
     STORAGE_INFO("Sanitize " << device.GetSerialNumber().Quote());
 
-    const TFsPath ctrlPath = GetNVMeCtrlPath(device);
+    const auto ctrlPath = GetNVMeCtrlPath(device);
 
     CheckError(NVMeManager->StartSanitize(ctrlPath));
 
@@ -899,6 +902,8 @@ try {
     }
 
     return {};
+} catch (const TServiceError& e) {
+    return MakeError(e.GetCode(), ToString(e.GetMessage()));
 } catch (...) {
     return MakeError(E_FAIL, CurrentExceptionMessage());
 }
@@ -910,13 +915,17 @@ auto TLocalNVMeService::ResetToSingleNamespace(
         "Reset NVMe " << device.GetSerialNumber().Quote()
                       << " to single namespace");
 
-    return SafeExecute<NProto::TError>(
-        [&]
-        {
-            const TFsPath ctrlPath = GetNVMeCtrlPath(device);
+    auto [ctrlPath, error] = SafeExecute<TResultOrError<TFsPath>>(
+        [&] { return GetNVMeCtrlPath(device); });
+    if (HasError(error)) {
+        return error;
+    }
 
-            return NVMeManager->ResetToSingleNamespace(ctrlPath);
-        });
+    auto future = BackgroundExecutor->Execute(
+        [nvme = NVMeManager, ctrlPath = std::move(ctrlPath)]
+        { return nvme->ResetToSingleNamespace(ctrlPath); });
+
+    return Executor->WaitFor(future);
 }
 
 auto TLocalNVMeService::ReleaseDevice(
@@ -983,6 +992,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,
+    ITaskQueuePtr backgroundExecutor,
     ISysFsPtr sysFs)
 {
     return std::make_shared<TLocalNVMeService>(
@@ -991,6 +1001,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
         std::move(deviceProvider),
         std::move(nvmeManager),
         std::move(executor),
+        std::move(backgroundExecutor),
         std::move(sysFs));
 }
 
@@ -999,7 +1010,8 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     ILoggingServicePtr logging,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
-    TExecutorPtr executor)
+    TExecutorPtr executor,
+    ITaskQueuePtr backgroundExecutor)
 {
     return CreateLocalNVMeService(
         std::move(config),
@@ -1007,6 +1019,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
         std::move(deviceProvider),
         std::move(nvmeManager),
         std::move(executor),
+        std::move(backgroundExecutor),
         CreateSysFs("/sys"));
 }
 

--- a/cloud/blockstore/libs/local_nvme/service_linux.h
+++ b/cloud/blockstore/libs/local_nvme/service_linux.h
@@ -15,6 +15,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,
+    ITaskQueuePtr backgroundExecutor,
     ISysFsPtr sysFs);
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -9,6 +9,7 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/proto_helpers.h>
+#include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
@@ -248,6 +249,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
     ILoggingServicePtr Logging;
     std::shared_ptr<TTestNVMeManager> NVMeManager;
     TExecutorPtr Executor;
+    ITaskQueuePtr BackgroundThreadPool;
     std::shared_ptr<TTestSysFs> SysFs;
 
     ILocalNVMeServicePtr Service;
@@ -265,6 +267,9 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
 
         NVMeManager = std::make_shared<TTestNVMeManager>();
 
+        BackgroundThreadPool = CreateLongRunningTaskExecutor("BG");
+        BackgroundThreadPool->Start();
+
         Executor = TExecutor::Create("TestExecutor");
         Executor->Start();
     }
@@ -273,6 +278,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
     {
         Service->Stop();
         Executor->Stop();
+        BackgroundThreadPool->Stop();
         Logging->Stop();
 
         if (StateCacheFile) {
@@ -280,7 +286,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
         }
     }
 
-    auto CreateService(ILocalNVMeDeviceProviderPtr deviceProvider)
+    auto CreateService(ILocalNVMeDeviceProviderPtr deviceProvider) const
         -> ILocalNVMeServicePtr
     {
         return CreateLocalNVMeService(
@@ -289,6 +295,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
             std::move(deviceProvider),
             std::static_pointer_cast<INvmeManager>(NVMeManager),
             Executor,
+            BackgroundThreadPool,
             std::static_pointer_cast<ISysFs>(SysFs));
     }
 


### PR DESCRIPTION
Recreating an NVMe namespace and binding an NVMe device to a driver may take a significant amount of time.

This change offloads these operations to a background thread to avoid blocking the coroutine thread.