### PR TITLE
Filestore: use request label for tablet metrics instead of compound sensor names: `ListNodes.Count -> Count{request="ListNodes"}`

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -1489,7 +1489,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         UNIT_ASSERT(subgroup);
         UNIT_ASSERT_VALUES_EQUAL(
             4,
-            subgroup->GetCounter("Compaction.Count")->GetAtomic());
+            subgroup->FindSubgroup("request", "Compaction")
+                ->GetCounter("Count")->GetAtomic());
     }
 
     Y_UNIT_TEST(ShouldMarkNodeRefsExhaustive)

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -3111,7 +3111,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             ->FindSubgroup("component", "storage")
             ->FindSubgroup("type", "hdd");
         UNIT_ASSERT_LT(
-            tabletCounters->GetCounter("GetStorageStats.TimeSumUs")
+            tabletCounters->FindSubgroup("request", "GetStorageStats")
+                ->GetCounter("TimeSumUs")
                 ->GetAtomic(),
             10'000'000);
     }
@@ -5328,28 +5329,44 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // counters->OutputPlainText(Cerr);
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            counters->GetCounter("CreateHandle.Count")->GetAtomic());
+            counters->FindSubgroup("request", "CreateHandle")
+                ->GetCounter("Count")
+                ->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            counters->GetCounter("CreateHandleInShard.Count")->GetAtomic());
+            counters->FindSubgroup("request", "CreateHandleInShard")
+                ->GetCounter("Count")
+                ->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            counters->GetCounter("CreateNode.Count")->GetAtomic());
+            counters->FindSubgroup("request", "CreateNode")
+                ->GetCounter("Count")
+                ->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
             6,
-            counters->GetCounter("CreateNodeInShard.Count")->GetAtomic());
+            counters->FindSubgroup("request", "CreateNodeInShard")
+                ->GetCounter("Count")
+                ->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            counters->GetCounter("GetNodeAttr.Count")->GetAtomic());
+            counters->FindSubgroup("request", "GetNodeAttr")
+                ->GetCounter("Count")
+                ->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            counters->GetCounter("GetNodeAttrInShard.Count")->GetAtomic());
+            counters->FindSubgroup("request", "GetNodeAttrInShard")
+                ->GetCounter("Count")
+                ->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            counters->GetCounter("UnlinkNode.Count")->GetAtomic());
+            counters->FindSubgroup("request", "UnlinkNode")
+                ->GetCounter("Count")
+                ->GetAtomic());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            counters->GetCounter("UnlinkNodeInShard.Count")->GetAtomic());
+            counters->FindSubgroup("request", "UnlinkNodeInShard")
+                ->GetCounter("Count")
+                ->GetAtomic());
     }
 
     SERVICE_TEST(ShouldCreateFilesInFileShards)

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -347,16 +347,22 @@ void TTabletMetrics::Register(
         EMetricType::MT_DERIVATIVE);
 
 #define FILESTORE_TABLET_METRICS_REGISTER_REQUEST(name, ...)                   \
-    REGISTER_AGGREGATABLE_SUM(                                                 \
+    AggregatableFsRegistry->Register(                                          \
+        {CreateLabel("request", #name), CreateSensor("Count")},                \
         name.Count,                                                            \
+        EAggregationType::AT_SUM,                                              \
         EMetricType::MT_DERIVATIVE);                                           \
                                                                                \
-    REGISTER_AGGREGATABLE_SUM(                                                 \
+    AggregatableFsRegistry->Register(                                          \
+        {CreateLabel("request", #name), CreateSensor("RequestBytes")},         \
         name.RequestBytes,                                                     \
+        EAggregationType::AT_SUM,                                              \
         EMetricType::MT_DERIVATIVE);                                           \
                                                                                \
-    REGISTER_AGGREGATABLE_SUM(                                                 \
+    AggregatableFsRegistry->Register(                                          \
+        {CreateLabel("request", #name), CreateSensor("TimeSumUs")},            \
         name.TimeSumUs,                                                        \
+        EAggregationType::AT_SUM,                                              \
         EMetricType::MT_DERIVATIVE);                                           \
                                                                                \
     name.Time.Register(                                                        \
@@ -368,32 +374,38 @@ void TTabletMetrics::Register(
 
 #undef FILESTORE_TABLET_METRICS_REGISTER_REQUEST
 
-    REGISTER_AGGREGATABLE_SUM_EXT(
+    AggregatableFsRegistry->Register(
+        {CreateLabel("request", "ListNodes"), CreateSensor("RequestedBytesPrecharge")},
         ListNodesExtra.RequestedBytesPrecharge,
-        "ListNodes.RequestedBytesPrecharge",
+        EAggregationType::AT_SUM,
         EMetricType::MT_DERIVATIVE);
-    REGISTER_AGGREGATABLE_SUM_EXT(
+    AggregatableFsRegistry->Register(
+        {CreateLabel("request", "ListNodes"), CreateSensor("PrepareAttempts")},
         ListNodesExtra.PrepareAttempts,
-        "ListNodes.PrepareAttempts",
+        EAggregationType::AT_SUM,
         EMetricType::MT_DERIVATIVE);
-    REGISTER_AGGREGATABLE_SUM_EXT(
+    AggregatableFsRegistry->Register(
+        {CreateLabel("request", "ListNodes"), CreateSensor("ResponseNodeRefs")},
         ListNodesExtra.ResponseNodeRefs,
-        "ListNodes.ResponseNodeRefs",
+        EAggregationType::AT_SUM,
         EMetricType::MT_DERIVATIVE);
 
-    REGISTER_AGGREGATABLE_SUM_EXT(
+    AggregatableFsRegistry->Register(
+        {CreateLabel("request", "CreateHandle"), CreateSensor("GuestKeepCacheSet")},
         CreateHandleExtra.GuestKeepCacheSet,
-        "CreateHandle.GuestKeepCacheSet",
+        EAggregationType::AT_SUM,
         EMetricType::MT_DERIVATIVE);
 
-    REGISTER_AGGREGATABLE_SUM_EXT(
+    AggregatableFsRegistry->Register(
+        {CreateLabel("request", "Compaction"), CreateSensor("DudCount")},
         CompactionExtra.DudCount,
-        "Compaction.DudCount",
+        EAggregationType::AT_SUM,
         EMetricType::MT_DERIVATIVE);
 
-    REGISTER_AGGREGATABLE_SUM_EXT(
+    AggregatableFsRegistry->Register(
+        {CreateLabel("request", "ConfirmAddData"), CreateSensor("DeferredCount")},
         ConfirmAddDataExtra.DeferredCount,
-        "ConfirmAddData.DeferredCount",
+        EAggregationType::AT_SUM,
         EMetricType::MT_DERIVATIVE);
 
     REGISTER_LOCAL(MaxBlobsInRange, EMetricType::MT_ABSOLUTE);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
@@ -265,34 +265,44 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
         registry->Visit(TInstant::Zero(), visitor);
         visitor.ValidateExpectedCounters({
             {{
-                {"sensor", "ReadData.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "ReadData"},
                 {"filesystem", "test"}}, 13_KB},
             {{
-                {"sensor", "ReadData.Count"},
+                {"sensor", "Count"},
+                {"request", "ReadData"},
                 {"filesystem", "test"}}, 2},
             {{
-                {"sensor", "WriteData.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "WriteData"},
                 {"filesystem", "test"}}, 3_KB},
             {{
-                {"sensor", "WriteData.Count"},
+                {"sensor", "Count"},
+                {"request", "WriteData"},
                 {"filesystem", "test"}}, 2},
             {{
-                {"sensor", "GetNodeAttr.Count"},
+                {"sensor", "Count"},
+                {"request", "GetNodeAttr"},
                 {"filesystem", "test"}}, 5},
             {{
-                {"sensor", "CreateHandle.Count"},
+                {"sensor", "Count"},
+                {"request", "CreateHandle"},
                 {"filesystem", "test"}}, 3},
             {{
-                {"sensor", "DestroyHandle.Count"},
+                {"sensor", "Count"},
+                {"request", "DestroyHandle"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "CreateNode.Count"},
+                {"sensor", "Count"},
+                {"request", "CreateNode"},
                 {"filesystem", "test"}}, 2},
             {{
-                {"sensor", "UnlinkNode.Count"},
+                {"sensor", "Count"},
+                {"request", "UnlinkNode"},
                 {"filesystem", "test"}}, 2},
             {{
-                {"sensor", "GetNodeXAttr.Count"},
+                {"sensor", "Count"},
+                {"request", "GetNodeXAttr"},
                 {"filesystem", "test"}}, 0},
         });
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_cache.cpp
@@ -150,21 +150,24 @@ TListNodesTxStats GetListNodesTxStats(
 
     visitor.ValidateExpectedCountersWithPredicate({
         {{{"filesystem", "test"},
-          {"sensor", "ListNodes.RequestedBytesPrecharge"}},
+          {"sensor", "RequestedBytesPrecharge"},
+          {"request", "ListNodes"}},
          [&stats](i64 value)
          {
              stats.BytesPrecharge = value;
              return true;
          }},
         {{{"filesystem", "test"},
-          {"sensor", "ListNodes.PrepareAttempts"}},
+          {"sensor", "PrepareAttempts"},
+          {"request", "ListNodes"}},
          [&stats](i64 value)
          {
             stats.PrepareAttempts = value;
             return true;
          }},
         {{{"filesystem", "test"},
-          {"sensor", "ListNodes.ResponseNodeRefs"}},
+          {"sensor", "ResponseNodeRefs"},
+          {"request", "ListNodes"}},
          [&stats](i64 value)
          {
             stats.ResponseNodeRefs = value;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -454,54 +454,70 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         }, true);
         Visitor.ValidateExpectedCounters({
             {{
-                {"sensor", "WriteBlob.Count"},
+                {"sensor", "Count"},
+                {"request", "WriteBlob"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "ReadBlob.Count"},
+                {"sensor", "Count"},
+                {"request", "ReadBlob"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "PatchBlob.Count"},
+                {"sensor", "Count"},
+                {"request", "PatchBlob"},
                 {"filesystem", "test"}}, 0},
             {{
-                {"sensor", "WriteData.Count"},
+                {"sensor", "Count"},
+                {"request", "WriteData"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "ReadData.Count"},
+                {"sensor", "Count"},
+                {"request", "ReadData"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "DescribeData.Count"},
+                {"sensor", "Count"},
+                {"request", "DescribeData"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "GenerateBlobIds.Count"},
+                {"sensor", "Count"},
+                {"request", "GenerateBlobIds"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "AddData.Count"},
+                {"sensor", "Count"},
+                {"request", "AddData"},
                 {"filesystem", "test"}}, 1},
         });
         Visitor.ValidateExpectedCounters({
             {{
-                {"sensor", "WriteBlob.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "WriteBlob"},
                 {"filesystem", "test"}}, sz},
             {{
-                {"sensor", "ReadBlob.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "ReadBlob"},
                 {"filesystem", "test"}}, sz},
             {{
-                {"sensor", "PatchBlob.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "PatchBlob"},
                 {"filesystem", "test"}}, 0},
             {{
-                {"sensor", "WriteData.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "WriteData"},
                 {"filesystem", "test"}}, sz},
             {{
-                {"sensor", "ReadData.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "ReadData"},
                 {"filesystem", "test"}}, sz},
             {{
-                {"sensor", "DescribeData.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "DescribeData"},
                 {"filesystem", "test"}}, sz},
             {{
-                {"sensor", "GenerateBlobIds.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "GenerateBlobIds"},
                 {"filesystem", "test"}}, sz},
             {{
-                {"sensor", "AddData.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "AddData"},
                 {"filesystem", "test"}}, sz},
             {{
                 {"sensor", "CurrentLoad"},
@@ -589,7 +605,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         for (const auto& requestName: requestNames) {
             expectedCounters.push_back(std::make_pair(
                 TVector<TTestRegistryVisitor::TLabel>({
-                    {"sensor", Sprintf("%s.TimeSumUs", requestName)},
+                    {"sensor", "TimeSumUs"},
+                    {"request", requestName},
                     {"filesystem", "test"}
                 }),
                 latencySensorPredicate

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -6061,7 +6061,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         using TLabel = TTestRegistryVisitor::TLabel;
         auto makeLabels = [] (const TString& request, const TString& sensor) {
             return TVector<TLabel>({
-                {"sensor", request + "." + sensor},
+                {"sensor", sensor},
+                {"request", request},
                 {"filesystem", "test"},
             });
         };
@@ -6361,16 +6362,20 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             registry->Visit(TInstant::Zero(), visitor);
             visitor.ValidateExpectedCounters({
                 {{
-                    {"sensor", "FlushBytes.RequestBytes"},
+                    {"sensor", "RequestBytes"},
+                    {"request", "FlushBytes"},
                     {"filesystem", "test"}}, 1_KB},
                 {{
-                    {"sensor", "FlushBytes.Count"},
+                    {"sensor", "Count"},
+                    {"request", "FlushBytes"},
                     {"filesystem", "test"}}, 1},
                 {{
-                    {"sensor", "TrimBytes.RequestBytes"},
+                    {"sensor", "RequestBytes"},
+                    {"request", "TrimBytes"},
                     {"filesystem", "test"}}, static_cast<i64>(block + 1_KB)},
                 {{
-                    {"sensor", "TrimBytes.Count"},
+                    {"sensor", "Count"},
+                    {"request", "TrimBytes"},
                     {"filesystem", "test"}}, 2},
             });
         }
@@ -6433,16 +6438,20 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             registry->Visit(TInstant::Zero(), visitor);
             visitor.ValidateExpectedCounters({
                 {{
-                    {"sensor", "FlushBytes.RequestBytes"},
+                    {"sensor", "RequestBytes"},
+                    {"request", "FlushBytes"},
                     {"filesystem", "test"}}, 0_KB},
                 {{
-                    {"sensor", "FlushBytes.Count"},
+                    {"sensor", "Count"},
+                    {"request", "FlushBytes"},
                     {"filesystem", "test"}}, 0},
                 {{
-                    {"sensor", "TrimBytes.RequestBytes"},
+                    {"sensor", "RequestBytes"},
+                    {"request", "TrimBytes"},
                     {"filesystem", "test"}}, 100_GB},
                 {{
-                    {"sensor", "TrimBytes.Count"},
+                    {"sensor", "Count"},
+                    {"request", "TrimBytes"},
                     {"filesystem", "test"}}, 1},
             });
         }
@@ -6483,13 +6492,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         registry->Visit(TInstant::Zero(), visitor);
         visitor.ValidateExpectedCounters({
             {{
-                {"sensor", "Compaction.RequestBytes"},
+                {"sensor", "RequestBytes"},
+                {"request", "Compaction"},
                 {"filesystem", "test"}}, 0},
             {{
-                {"sensor", "Compaction.Count"},
+                {"sensor", "Count"},
+                {"request", "Compaction"},
                 {"filesystem", "test"}}, 1},
             {{
-                {"sensor", "Compaction.DudCount"},
+                {"sensor", "DudCount"},
+                {"request", "Compaction"},
                 {"filesystem", "test"}}, 1},
         });
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_handles.cpp
@@ -65,7 +65,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
         registry->Visit(TInstant::Zero(), visitor);
         visitor.ValidateExpectedCounters({
             {{{"filesystem", "test"},
-              {"sensor", "CreateHandle.GuestKeepCacheSet"}},
+              {"sensor", "GuestKeepCacheSet"},
+              {"request", "CreateHandle"}},
              2},
         });
     }
@@ -144,7 +145,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Handles)
               {"sensor", "HandleStatsByNodeSumTotalSize"}},                    \
              sumTotalSize},                                                    \
             {{{"filesystem", "test"},                                          \
-              {"sensor", "CreateHandle.GuestKeepCacheSet"}},                   \
+              {"sensor", "GuestKeepCacheSet"},                                 \
+              {"request", "CreateHandle"}},                                    \
              keepCacheSet},                                                    \
         });                                                                    \
     }


### PR DESCRIPTION
### Notes
This is needed becaus calculating Time / Count with request in labels is much simpler than parsing request from the sensor name itself

### Issue
Simple change, no issue