### PR TITLE
[Blockstore] remove vefify on UsedBlocksCount <= BlockCount; add comment; add unit test

### DIFF
--- a/cloud/blockstore/libs/storage/core/compaction_policy.h
+++ b/cloud/blockstore/libs/storage/core/compaction_policy.h
@@ -67,7 +67,11 @@ struct TRangeStat
     ui16 GarbageBlockCount() const
     {
         if (UsedBlockCount > BlockCount) {
-            // it means that some of these used blocks are still in fresh index
+            // UsedBlockCount can temporarily exceed BlockCount. For example, we
+            // may write a mixed/merged blob and then add a zero blob covering
+            // the same blocks to fresh. After compaction, BlockCount drops but
+            // UsedBlockCount stays the same. This mismatch is corrected on the
+            // next flush.
             return 0;
         }
 

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1337,12 +1337,6 @@ private:
         ui64 rangeGarbage = 0;
 
         if (isIgnoringZeroedCompaction) {
-            Y_DEBUG_ABORT_UNLESS(
-                State.GetUsedBlocksIgnoringZeroed() <= GetBlockCount());
-            Y_DEBUG_ABORT_UNLESS(
-                TopByGarbageIgnoringZeroed.UsedBlocksIgnoringZeroed() <=
-                TopByGarbageIgnoringZeroed.BlockCount);
-
             diskGarbage = GetExcessPercentage(
                 GetBlockCount(),
                 State.GetUsedBlocksIgnoringZeroed());

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -15095,6 +15095,144 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
             UNIT_ASSERT_VALUES_EQUAL(i, response->Record.GetBlocks(i).GetBlobOffset());
         }
     }
+
+    void DoShouldRunCompactionWhenUsedBlocksCountGreaterThanBlockCount(
+        bool ignoringZeroedCompactionEnabled)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshChannelWriteRequestsEnabled(true);
+        config.SetFreshChannelZeroRequestsEnabled(true);
+        config.SetWriteBlobThresholdSSD(1_MB);
+        config.SetCleanupThreshold(1000);
+        config.SetSSDMaxBlobsPerRange(1000);
+        config.SetFlushThreshold(1000_MB);
+        config.SetV1GarbageCompactionEnabled(true);
+        config.SetIgnoringZeroedCompactionEnabled(ignoringZeroedCompactionEnabled);
+        config.SetCompactionGarbageThreshold(999999);
+        config.SetCompactionRangeGarbageThreshold(20);
+
+        auto runtime = PrepareTestActorRuntime(
+            config,
+            2048,
+            {},
+            {.MediaKind = NCloud::NProto::STORAGE_MEDIA_SSD});
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        const auto expectedCompactionMode = ignoringZeroedCompactionEnabled
+            ? TEvPartitionPrivate::IgnoringZeroedCompaction
+            : TEvPartitionPrivate::GarbageCompaction;
+
+        TAutoPtr<IEventHandle> compactionRequest;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvPartitionPrivate::EvCompactionRequest)
+                {
+                    auto* msg = event->Get<
+                        TEvPartitionPrivate::TEvCompactionRequest>();
+                    if (msg->Mode == expectedCompactionMode &&
+                        !compactionRequest)
+                    {
+                        compactionRequest = event.Release();
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+        const auto assertUsedBlocksCountGreaterThanBlockCount = [&]
+        {
+            const auto& stats = partition.StatPartition()->Record.GetStats();
+            const ui64 blockCount =
+                stats.GetMixedBlocksCount() + stats.GetMergedBlocksCount();
+            UNIT_ASSERT_C(
+                stats.GetUsedBlocksCount() > blockCount,
+                "UsedBlocksCount=" << stats.GetUsedBlocksCount()
+                    << ", blockCount=" << blockCount);
+        };
+
+        partition.WriteBlocks(TBlockRange32::WithLength(0, 512));
+        // Zero blocks should be written to fresh. They will not unset used
+        // blocks until flush.
+        partition.ZeroBlocks(TBlockRange32::WithLength(0, 128));
+        partition.ZeroBlocks(TBlockRange32::WithLength(128, 128));
+        partition.ZeroBlocks(TBlockRange32::WithLength(256, 128));
+
+        TCompactionOptions options;
+        options.set(ToBit(ECompactionOption::Full));
+        options.set(ToBit(ECompactionOption::Forced));
+        partition.Compaction(0, options);
+        partition.Cleanup();
+
+        assertUsedBlocksCountGreaterThanBlockCount();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512);
+        }
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 512));
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        UNIT_ASSERT(!compactionRequest);
+        assertUsedBlocksCountGreaterThanBlockCount();
+
+        partition.WriteBlocks(TBlockRange32::WithLength(1024, 256));
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        // Too many garbage in the range [1024, 2048), compaction should be
+        // triggered.
+        UNIT_ASSERT(compactionRequest);
+
+        assertUsedBlocksCountGreaterThanBlockCount();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128 + 768);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512 + 512);
+        }
+
+        runtime->Send(compactionRequest.Release());
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        partition.Cleanup();
+
+        assertUsedBlocksCountGreaterThanBlockCount();
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128 + 512);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512 + 512);
+        }
+
+        partition.Flush();
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128 + 512);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 128 + 512);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRunGarbageCompactionWhenUsedBlocksCountGreaterThanBlockCount)
+    {
+        DoShouldRunCompactionWhenUsedBlocksCountGreaterThanBlockCount(false);
+    }
+
+    Y_UNIT_TEST(
+        ShouldRunIgnoringZeroedCompactionWhenUsedBlocksCountGreaterThanBlockCount)
+    {
+        DoShouldRunCompactionWhenUsedBlocksCountGreaterThanBlockCount(true);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -15146,7 +15146,8 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
 
         const auto assertUsedBlocksCountGreaterThanBlockCount = [&]
         {
-            const auto& stats = partition.StatPartition()->Record.GetStats();
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
             const ui64 blockCount =
                 stats.GetMixedBlocksCount() + stats.GetMergedBlocksCount();
             UNIT_ASSERT_C(

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -15173,9 +15173,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512);
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(512, stats.GetUsedBlocksCount());
         }
 
         partition.WriteBlocks(TBlockRange32::WithLength(1024, 512));
@@ -15193,9 +15193,9 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128 + 768);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512 + 512);
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128 + 768, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(512 + 512, stats.GetUsedBlocksCount());
         }
 
         runtime->Send(compactionRequest.Release());
@@ -15206,21 +15206,20 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128 + 512);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 512 + 512);
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(512 + 512, stats.GetUsedBlocksCount());
         }
 
         partition.Flush();
-        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
         runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
         {
             auto response = partition.StatPartition();
             const auto& stats = response->Record.GetStats();
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMixedBlocksCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetMergedBlocksCount(), 128 + 512);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetUsedBlocksCount(), 128 + 512);
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMixedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetMergedBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(128 + 512, stats.GetUsedBlocksCount());
         }
     }
 


### PR DESCRIPTION
Remove the verify previosly added in https://github.com/ydb-platform/nbs/pull/6027. The reason is that UsedBlocksCount might be greater then BlocksCount.

For example, we may write a mixed/merged blob and then add a zero blob covering the same blocks to fresh. After compaction, BlockCount drops but UsedBlockCount stays the same. This mismatch is corrected only on the next flush.

This problem does not seem to be easily solvable. We can not just set/unset used blocks on compaction because WriteBlocks request with greater commit id could set its blocks earlier.

But this problem does not seem to be a blocker. So we remove the verify and add unit test instead. The test ensures that compaction goes normally even if `UsedBlocksCount > BlocksCount`.

#5815