### PR TITLE
fix: added retries to unstable Github API in vm removal

### DIFF
--- a/.github/scripts/nebius_manage_vm.py
+++ b/.github/scripts/nebius_manage_vm.py
@@ -27,6 +27,7 @@ from .helpers import (
 )
 from github import Auth as GithubAuth
 from github import Github
+from github.GithubException import GithubException
 
 from nebius.sdk import SDK
 from nebius.aio.cli_config import Config
@@ -668,6 +669,24 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
         logger.error("Response: %s", request.status, exc_info=True)
 
 
+@retry(
+    attempts=GITHUB_API_RETRY_ATTEMPTS,
+    interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
+    retry_exceptions=(GithubException,),
+)
+def get_self_hosted_runner(client: Github, repo: str, runner_id: str):
+    return client.get_repo(repo).get_self_hosted_runner(runner_id)
+
+
+@retry(
+    attempts=GITHUB_API_RETRY_ATTEMPTS,
+    interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
+    retry_exceptions=(GithubException,),
+)
+def remove_self_hosted_runner(client: Github, repo: str, runner_id: str) -> bool:
+    return client.get_repo(repo).remove_self_hosted_runner(runner_id)
+
+
 def remove_runner_from_github(
     client: Github, github_repo_owner: str, github_repo: str, vm_id: str, apply: bool
 ) -> str:
@@ -680,7 +699,7 @@ def remove_runner_from_github(
         logger.info("Runner with name %s not found, skipping", vm_id)
         return "not_found"
 
-    runner = client.get_repo(repo).get_self_hosted_runner(runner_id)
+    runner = get_self_hosted_runner(client, repo, runner_id)
     if runner is None:
         logger.info("Runner with name %s not found, skipping", vm_id)
         return "not_found"
@@ -696,7 +715,7 @@ def remove_runner_from_github(
         return "busy"
 
     if apply:
-        result = client.get_repo(repo).remove_self_hosted_runner(runner_id)
+        result = remove_self_hosted_runner(client, repo, runner_id)
 
         if not result:
             # removed throwing exception here, because removing VM is more important

--- a/.github/scripts/nebius_manage_vm_test.py
+++ b/.github/scripts/nebius_manage_vm_test.py
@@ -476,6 +476,96 @@ def test_find_runner_by_name_does_not_retry_missing_runner(monkeypatch):
     assert sleeps == []
 
 
+def test_remove_runner_from_github_retries_github_lookup_errors(monkeypatch):
+    list_runner_attempts = []
+    get_runner_attempts = []
+    sleeps = []
+
+    class FakeRepo:
+        def get_self_hosted_runners(self):
+            list_runner_attempts.append(1)
+            return [SimpleNamespace(name="vm-id", id="runner-id")]
+
+        def get_self_hosted_runner(self, runner_id):
+            assert runner_id == "runner-id"
+            get_runner_attempts.append(1)
+            if len(get_runner_attempts) == 1:
+                raise m.GithubException(
+                    401,
+                    {"message": "Bad credentials", "status": "401"},
+                    {},
+                )
+            return SimpleNamespace(
+                name="vm-id",
+                id="runner-id",
+                status="offline",
+                busy=False,
+            )
+
+    class FakeGithub:
+        def get_repo(self, repo_name):
+            assert repo_name == "owner/repo"
+            return FakeRepo()
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setattr(m.time, "sleep", sleeps.append)
+
+    assert (
+        m.remove_runner_from_github(FakeGithub(), "owner", "repo", "vm-id", False)
+        == "would_remove"
+    )
+    assert len(list_runner_attempts) == 1
+    assert len(get_runner_attempts) == 2
+    assert sleeps == [m.GITHUB_API_RETRY_INTERVAL_SEC]
+
+
+def test_remove_runner_from_github_retries_github_remove_errors(monkeypatch):
+    list_runner_attempts = []
+    remove_runner_attempts = []
+    sleeps = []
+
+    class FakeRepo:
+        def get_self_hosted_runners(self):
+            list_runner_attempts.append(1)
+            return [SimpleNamespace(name="vm-id", id="runner-id")]
+
+        def get_self_hosted_runner(self, runner_id):
+            assert runner_id == "runner-id"
+            return SimpleNamespace(
+                name="vm-id",
+                id="runner-id",
+                status="offline",
+                busy=False,
+            )
+
+        def remove_self_hosted_runner(self, runner_id):
+            assert runner_id == "runner-id"
+            remove_runner_attempts.append(1)
+            if len(remove_runner_attempts) == 1:
+                raise m.GithubException(
+                    401,
+                    {"message": "Bad credentials", "status": "401"},
+                    {},
+                )
+            return True
+
+    class FakeGithub:
+        def get_repo(self, repo_name):
+            assert repo_name == "owner/repo"
+            return FakeRepo()
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setattr(m.time, "sleep", sleeps.append)
+
+    assert (
+        m.remove_runner_from_github(FakeGithub(), "owner", "repo", "vm-id", True)
+        == "removed"
+    )
+    assert len(list_runner_attempts) == 1
+    assert len(remove_runner_attempts) == 2
+    assert sleeps == [m.GITHUB_API_RETRY_INTERVAL_SEC]
+
+
 def test_retry_retries_async_function_and_passes_attempt(monkeypatch):
     attempts = []
     sleeps = []


### PR DESCRIPTION
Unjustified
```
github.GithubException.BadCredentialsException: 401 {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest", "status": "401"}
```
Here https://github.com/ydb-platform/nbs/actions/runs/28032529741/job/82987793229