### PR TITLE
[Disk Registry] Add dirty online devices monitoring

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -282,6 +282,8 @@ private:
     void RenderConfigDetailed(IOutputStream& out) const;
     void RenderDirtyDeviceList(IOutputStream& out) const;
     void RenderDirtyDeviceListDetailed(IOutputStream& out) const;
+    void RenderDirtyOnlineDeviceList(IOutputStream& out) const;
+    void RenderDirtyOnlineDeviceListDetailed(IOutputStream& out) const;
     void RenderSuspendedDeviceList(IOutputStream& out) const;
     void RenderSuspendedDeviceListDetailed(IOutputStream& out) const;
     void RenderAutomaticallyReplacedDeviceList(IOutputStream& out) const;
@@ -422,6 +424,11 @@ private:
         TRequestInfoPtr requestInfo);
 
     void HandleHttpInfo_RenderDirtyDeviceList(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        TRequestInfoPtr requestInfo);
+
+    void HandleHttpInfo_RenderDirtyOnlineDeviceList(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -282,8 +282,8 @@ private:
     void RenderConfigDetailed(IOutputStream& out) const;
     void RenderDirtyDeviceList(IOutputStream& out) const;
     void RenderDirtyDeviceListDetailed(IOutputStream& out) const;
-    void RenderDirtyOnlineDeviceList(IOutputStream& out) const;
-    void RenderDirtyOnlineDeviceListDetailed(IOutputStream& out) const;
+    void RenderDirtyDevicesCleanupOverview(IOutputStream& out) const;
+    void RenderDirtyDevicesCleanupOverviewDetailed(IOutputStream& out) const;
     void RenderSuspendedDeviceList(IOutputStream& out) const;
     void RenderSuspendedDeviceListDetailed(IOutputStream& out) const;
     void RenderAutomaticallyReplacedDeviceList(IOutputStream& out) const;
@@ -428,7 +428,7 @@ private:
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
 
-    void HandleHttpInfo_RenderDirtyOnlineDeviceList(
+    void HandleHttpInfo_RenderDirtyDevicesCleanupOverview(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -2252,16 +2252,7 @@ void TDiskRegistryActor::HandleHttpInfo_RenderDirtyOnlineDeviceList(
 void TDiskRegistryActor::RenderDirtyOnlineDeviceList(IOutputStream& out) const
 {
     auto dirtyDevices = State->GetDirtyDevices();
-    size_t onlineCount = 0;
-    for (const auto& device: dirtyDevices) {
-        const auto state = device.GetState();
-        if (state == NProto::DEVICE_STATE_ONLINE ||
-            state == NProto::DEVICE_STATE_WARNING)
-        {
-            ++onlineCount;
-        }
-    }
-    if (onlineCount == 0) {
+    if (dirtyDevices.empty()) {
         return;
     }
     DumpActionLink(
@@ -2269,7 +2260,7 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceList(IOutputStream& out) const
         TabletID(),
         "RenderDirtyOnlineDeviceList",
         "Dirty online devices",
-        onlineCount);
+        dirtyDevices.size());
 }
 
 void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -2241,7 +2241,9 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceList(IOutputStream& out) const
     auto dirtyDevices = State->GetDirtyDevices();
     size_t onlineCount = 0;
     for (const auto& device: dirtyDevices) {
-        if (device.GetState() == NProto::DEVICE_STATE_ONLINE) {
+        if (device.GetState() == NProto::DEVICE_STATE_ONLINE ||
+            device.GetState() == NProto::   )
+        {
             ++onlineCount;
         }
     }
@@ -2264,6 +2266,7 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
     TVector<TDirtyDeviceEntry> waiting;
     TVector<TDirtyDeviceEntry> agentDown;
     TVector<TDirtyDeviceEntry> broken;
+    TVector<TDirtyDeviceEntry> blocked;
     for (const auto& device: dirtyDevices) {
         TDirtyDeviceEntry entry{
             .Uuid = device.GetDeviceUUID(),
@@ -2275,7 +2278,9 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
             continue;
         }
 
-        if (device.GetState() != NProto::DEVICE_STATE_ONLINE) {
+        if (device.GetState() != NProto::DEVICE_STATE_ONLINE &&
+            device.GetState() != NProto::DEVICE_STATE_WARNING)
+        {
             continue;
         }
 
@@ -2286,9 +2291,12 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
         } else if (agent->GetState() == NProto::AGENT_STATE_UNAVAILABLE) {
             entry.AgentId = agent->GetAgentId();
             agentDown.push_back(std::move(entry));
-        } else {
+        } else if (State->CanSecureErase(device)) {
             entry.AgentId = agent->GetAgentId();
             cleaning.push_back(std::move(entry));
+        } else {
+            entry.AgentId = agent->GetAgentId();
+            blocked.push_back(std::move(entry));
         }
     }
 
@@ -2312,10 +2320,10 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
                             out << "UUID";
                         }
                         TABLEH () {
-                            out << "Repair started";
+                            out << "In state since";
                         }
                         TABLEH () {
-                            out << "Duration";
+                            out << "Time in state";
                         }
                         if (showAgent) {
                             TABLEH () {
@@ -2354,6 +2362,7 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
         renderTable("Device being cleaned", cleaning, true, false);
         renderTable("Waiting for cleanup", waiting, false, false);
         renderTable("Agent unavailable", agentDown, true, true);
+        renderTable("Cleanup blocked", blocked, true, false);
         renderTable("Device broken", broken, false, false);
     }
 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -256,6 +256,17 @@ void DumpDeviceLink(IOutputStream& out, ui64 tabletId, TStringBuf uuid)
         << "</a>";
 }
 
+void DumpAgentLink(IOutputStream& out, ui64 tabletId, const TString& agentId)
+{
+    out << "<a href='?action=agent&TabletID="
+        << tabletId
+        << "&AgentID="
+        << agentId
+        << "'>"
+        << agentId
+        << "</a>";
+}
+
 void DumpSquare(IOutputStream& out, const TStringBuf& color)
 {
     const char* utfBlackSquare = "&#9632";
@@ -2351,11 +2362,14 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
                             DumpDeviceLink(out, TabletID(), e.Uuid);
                         }
                         TABLED () {
-                            if (agentRed) {
-                                out << "<font color='red'>" << e.AgentId
-                                    << "</font>";
-                            } else {
-                                out << e.AgentId;
+                            if (e.AgentId) {
+                                if (agentRed) {
+                                    out << "<font color='red'>";
+                                    DumpAgentLink(out, TabletID(), e.AgentId);
+                                    out << "</font>";
+                                } else {
+                                    DumpAgentLink(out, TabletID(), e.AgentId);
+                                }
                             }
                         }
                         TABLED () {
@@ -2376,7 +2390,7 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
             }
         };
 
-        renderTable("Erasing now", erasing, false);
+        renderTable("Clean up in progress", erasing, false);
         renderTable("Ready for cleanup", cleaning, false);
         renderTable("Waiting for cleanup", waiting, false);
         renderTable("Agent unavailable", agentDown, true);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -295,6 +295,14 @@ auto GetSortedDisksView(
     return diskIndices;
 }
 
+// Holds the display data for a single dirty device row.
+struct TDirtyDeviceEntry
+{
+    TString Uuid;
+    TInstant StateTs;
+    TString AgentId;
+};
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2216,6 +2224,140 @@ void TDiskRegistryActor::RenderDirtyDeviceListDetailed(IOutputStream& out) const
         additionalColumns);
 }
 
+void TDiskRegistryActor::HandleHttpInfo_RenderDirtyOnlineDeviceList(
+    const NActors::TActorContext& ctx,
+    const TCgiParameters& params,
+    TRequestInfoPtr requestInfo)
+{
+    Y_UNUSED(params);
+
+    TStringStream out;
+    RenderDirtyOnlineDeviceListDetailed(out);
+    SendHttpResponse(ctx, *requestInfo, std::move(out.Str()));
+}
+
+void TDiskRegistryActor::RenderDirtyOnlineDeviceList(IOutputStream& out) const
+{
+    auto dirtyDevices = State->GetDirtyDevices();
+    size_t onlineCount = 0;
+    for (const auto& device: dirtyDevices) {
+        if (device.GetState() == NProto::DEVICE_STATE_ONLINE) {
+            ++onlineCount;
+        }
+    }
+    if (onlineCount == 0) {
+        return;
+    }
+    DumpActionLink(
+        out,
+        TabletID(),
+        "RenderDirtyOnlineDeviceList",
+        "Dirty online devices",
+        onlineCount);
+}
+
+void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
+    IOutputStream& out) const
+{
+    auto dirtyDevices = State->GetDirtyDevices();
+    TVector<TDirtyDeviceEntry> cleaning;
+    TVector<TDirtyDeviceEntry> waiting;
+    TVector<TDirtyDeviceEntry> agentDown;
+    TVector<TDirtyDeviceEntry> broken;
+    for (const auto& device: dirtyDevices) {
+        TDirtyDeviceEntry entry{
+            .Uuid = device.GetDeviceUUID(),
+            .StateTs = TInstant::MicroSeconds(device.GetStateTs()),
+        };
+
+        if (device.GetState() == NProto::DEVICE_STATE_ERROR) {
+            broken.push_back(std::move(entry));
+            continue;
+        }
+
+        if (device.GetState() != NProto::DEVICE_STATE_ONLINE) {
+            continue;
+        }
+
+        const NProto::TAgentConfig* agent =
+            State->FindAgent(device.GetNodeId());
+        if (!agent) {
+            waiting.push_back(std::move(entry));
+        } else if (agent->GetState() == NProto::AGENT_STATE_UNAVAILABLE) {
+            entry.AgentId = agent->GetAgentId();
+            agentDown.push_back(std::move(entry));
+        } else {
+            entry.AgentId = agent->GetAgentId();
+            cleaning.push_back(std::move(entry));
+        }
+    }
+
+    HTML (out) {
+        auto renderTable = [&](const TString& title,
+                               const TVector<TDirtyDeviceEntry>& rows,
+                               bool showAgent,
+                               bool agentRed)
+        {
+            TAG (TH3) {
+                out << title << " (" << rows.size() << ")";
+            }
+            if (rows.empty()) {
+                out << "<p>No devices</p>";
+                return;
+            }
+            TABLE_SORTABLE_CLASS ("table table-bordered") {
+                TABLEHEAD () {
+                    TABLER () {
+                        TABLEH () {
+                            out << "UUID";
+                        }
+                        TABLEH () {
+                            out << "Repair started";
+                        }
+                        TABLEH () {
+                            out << "Duration";
+                        }
+                        if (showAgent) {
+                            TABLEH () {
+                                out << "Agent";
+                            }
+                        }
+                    }
+                }
+                for (const auto& e: rows) {
+                    TABLER () {
+                        TABLED () {
+                            out << e.Uuid;
+                        }
+                        TABLED () {
+                            out << e.StateTs.FormatGmTime(
+                                "%Y-%m-%d %H:%M:%S UTC");
+                        }
+                        TABLED () {
+                            out << FormatDuration(TInstant::Now() - e.StateTs);
+                        }
+                        if (showAgent) {
+                            TABLED () {
+                                if (agentRed) {
+                                    out << "<font color='red'>" << e.AgentId
+                                        << "</font>";
+                                } else {
+                                    out << e.AgentId;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        renderTable("Device being cleaned", cleaning, true, false);
+        renderTable("Waiting for cleanup", waiting, false, false);
+        renderTable("Agent unavailable", agentDown, true, true);
+        renderTable("Device broken", broken, false, false);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void TDiskRegistryActor::HandleHttpInfo_RenderSuspendedDeviceList(
@@ -2385,6 +2527,8 @@ void TDiskRegistryActor::RenderHtmlInfo(IOutputStream& out) const
 
             RenderDirtyDeviceList(out);
 
+            RenderDirtyOnlineDeviceList(out);
+
             RenderBrokenDeviceList(out);
 
             RenderSuspendedDeviceList(out);
@@ -2468,6 +2612,8 @@ void TDiskRegistryActor::HandleHttpInfo(
         {"RenderConfig", &TDiskRegistryActor::HandleHttpInfo_RenderConfig},
         {"RenderDirtyDeviceList",
          &TDiskRegistryActor::HandleHttpInfo_RenderDirtyDeviceList},
+        {"RenderDirtyOnlineDeviceList",
+         &TDiskRegistryActor::HandleHttpInfo_RenderDirtyOnlineDeviceList},
         {"RenderSuspendedDeviceList",
          &TDiskRegistryActor::HandleHttpInfo_RenderSuspendedDeviceList},
         {"RenderTransactionsLatency",

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -301,6 +301,8 @@ struct TDirtyDeviceEntry
     TString Uuid;
     TInstant StateTs;
     TString AgentId;
+    TString PoolName;
+    TString StateMessage;
 };
 
 }   // namespace
@@ -2263,6 +2265,7 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
     IOutputStream& out) const
 {
     auto dirtyDevices = State->GetDirtyDevices();
+    TVector<TDirtyDeviceEntry> erasing;
     TVector<TDirtyDeviceEntry> cleaning;
     TVector<TDirtyDeviceEntry> waiting;
     TVector<TDirtyDeviceEntry> agentDown;
@@ -2272,6 +2275,8 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
         TDirtyDeviceEntry entry{
             .Uuid = device.GetDeviceUUID(),
             .StateTs = TInstant::MicroSeconds(device.GetStateTs()),
+            .PoolName = device.GetPoolName(),
+            .StateMessage = device.GetStateMessage(),
         };
 
         if (device.GetState() == NProto::DEVICE_STATE_ERROR) {
@@ -2294,7 +2299,11 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
             agentDown.push_back(std::move(entry));
         } else if (State->CanSecureErase(device)) {
             entry.AgentId = agent->GetAgentId();
-            cleaning.push_back(std::move(entry));
+            if (SecureEraseInProgressPerPool.contains(device.GetPoolName())) {
+                erasing.push_back(std::move(entry));
+            } else {
+                cleaning.push_back(std::move(entry));
+            }
         } else {
             entry.AgentId = agent->GetAgentId();
             blocked.push_back(std::move(entry));
@@ -2304,7 +2313,6 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
     HTML (out) {
         auto renderTable = [&](const TString& title,
                                const TVector<TDirtyDeviceEntry>& rows,
-                               bool showAgent,
                                bool agentRed)
         {
             TAG (TH3) {
@@ -2321,22 +2329,40 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
                             out << "UUID";
                         }
                         TABLEH () {
+                            out << "Agent";
+                        }
+                        TABLEH () {
+                            out << "Pool";
+                        }
+                        TABLEH () {
+                            out << "State message";
+                        }
+                        TABLEH () {
                             out << "In state since";
                         }
                         TABLEH () {
                             out << "Time in state";
-                        }
-                        if (showAgent) {
-                            TABLEH () {
-                                out << "Agent";
-                            }
                         }
                     }
                 }
                 for (const auto& e: rows) {
                     TABLER () {
                         TABLED () {
-                            out << e.Uuid;
+                            DumpDeviceLink(out, TabletID(), e.Uuid);
+                        }
+                        TABLED () {
+                            if (agentRed) {
+                                out << "<font color='red'>" << e.AgentId
+                                    << "</font>";
+                            } else {
+                                out << e.AgentId;
+                            }
+                        }
+                        TABLED () {
+                            out << e.PoolName;
+                        }
+                        TABLED () {
+                            out << e.StateMessage;
                         }
                         TABLED () {
                             out << e.StateTs.FormatGmTime(
@@ -2345,26 +2371,17 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
                         TABLED () {
                             out << FormatDuration(TInstant::Now() - e.StateTs);
                         }
-                        if (showAgent) {
-                            TABLED () {
-                                if (agentRed) {
-                                    out << "<font color='red'>" << e.AgentId
-                                        << "</font>";
-                                } else {
-                                    out << e.AgentId;
-                                }
-                            }
-                        }
                     }
                 }
             }
         };
 
-        renderTable("Device being cleaned", cleaning, true, false);
-        renderTable("Waiting for cleanup", waiting, false, false);
-        renderTable("Agent unavailable", agentDown, true, true);
-        renderTable("Cleanup blocked", blocked, true, false);
-        renderTable("Device broken", broken, false, false);
+        renderTable("Erasing now", erasing, false);
+        renderTable("Ready for cleanup", cleaning, false);
+        renderTable("Waiting for cleanup", waiting, false);
+        renderTable("Agent unavailable", agentDown, true);
+        renderTable("Cleanup blocked", blocked, false);
+        renderTable("Device broken", broken, false);
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -2237,7 +2237,7 @@ void TDiskRegistryActor::RenderDirtyDeviceListDetailed(IOutputStream& out) const
         additionalColumns);
 }
 
-void TDiskRegistryActor::HandleHttpInfo_RenderDirtyOnlineDeviceList(
+void TDiskRegistryActor::HandleHttpInfo_RenderDirtyDevicesCleanupOverview(
     const NActors::TActorContext& ctx,
     const TCgiParameters& params,
     TRequestInfoPtr requestInfo)
@@ -2245,11 +2245,11 @@ void TDiskRegistryActor::HandleHttpInfo_RenderDirtyOnlineDeviceList(
     Y_UNUSED(params);
 
     TStringStream out;
-    RenderDirtyOnlineDeviceListDetailed(out);
+    RenderDirtyDevicesCleanupOverviewDetailed(out);
     SendHttpResponse(ctx, *requestInfo, std::move(out.Str()));
 }
 
-void TDiskRegistryActor::RenderDirtyOnlineDeviceList(IOutputStream& out) const
+void TDiskRegistryActor::RenderDirtyDevicesCleanupOverview(IOutputStream& out) const
 {
     auto dirtyDevices = State->GetDirtyDevices();
     if (dirtyDevices.empty()) {
@@ -2258,16 +2258,16 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceList(IOutputStream& out) const
     DumpActionLink(
         out,
         TabletID(),
-        "RenderDirtyOnlineDeviceList",
-        "Dirty online devices",
+        "RenderDirtyDevicesCleanupOverview",
+        "Dirty devices cleanup overview",
         dirtyDevices.size());
 }
 
-void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
+void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
     IOutputStream& out) const
 {
     auto dirtyDevices = State->GetDirtyDevices();
-    TVector<TDirtyDeviceEntry> erasing;
+    TVector<TDirtyDeviceEntry> processing;
     TVector<TDirtyDeviceEntry> cleaning;
     TVector<TDirtyDeviceEntry> waiting;
     TVector<TDirtyDeviceEntry> agentDown;
@@ -2302,7 +2302,7 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
         } else if (State->CanSecureErase(device)) {
             entry.AgentId = agent->GetAgentId();
             if (SecureEraseInProgressPerPool.contains(device.GetPoolName())) {
-                erasing.push_back(std::move(entry));
+                processing.push_back(std::move(entry));
             } else {
                 cleaning.push_back(std::move(entry));
             }
@@ -2381,7 +2381,7 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceListDetailed(
             }
         };
 
-        renderTable("Clean up in progress", erasing, false);
+        renderTable("Clean up in progress", processing, false);
         renderTable("Ready for cleanup", cleaning, false);
         renderTable("Waiting for cleanup", waiting, false);
         renderTable("Agent unavailable", agentDown, true);
@@ -2559,7 +2559,7 @@ void TDiskRegistryActor::RenderHtmlInfo(IOutputStream& out) const
 
             RenderDirtyDeviceList(out);
 
-            RenderDirtyOnlineDeviceList(out);
+            RenderDirtyDevicesCleanupOverview(out);
 
             RenderBrokenDeviceList(out);
 
@@ -2644,8 +2644,8 @@ void TDiskRegistryActor::HandleHttpInfo(
         {"RenderConfig", &TDiskRegistryActor::HandleHttpInfo_RenderConfig},
         {"RenderDirtyDeviceList",
          &TDiskRegistryActor::HandleHttpInfo_RenderDirtyDeviceList},
-        {"RenderDirtyOnlineDeviceList",
-         &TDiskRegistryActor::HandleHttpInfo_RenderDirtyOnlineDeviceList},
+        {"RenderDirtyDevicesCleanupOverview",
+         &TDiskRegistryActor::HandleHttpInfo_RenderDirtyDevicesCleanupOverview},
         {"RenderSuspendedDeviceList",
          &TDiskRegistryActor::HandleHttpInfo_RenderSuspendedDeviceList},
         {"RenderTransactionsLatency",

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -2241,8 +2241,9 @@ void TDiskRegistryActor::RenderDirtyOnlineDeviceList(IOutputStream& out) const
     auto dirtyDevices = State->GetDirtyDevices();
     size_t onlineCount = 0;
     for (const auto& device: dirtyDevices) {
-        if (device.GetState() == NProto::DEVICE_STATE_ONLINE ||
-            device.GetState() == NProto::   )
+        const auto state = device.GetState();
+        if (state == NProto::DEVICE_STATE_ONLINE ||
+            state == NProto::DEVICE_STATE_WARNING)
         {
             ++onlineCount;
         }


### PR DESCRIPTION
<img width="977" height="975" alt="image" src="https://github.com/user-attachments/assets/2a52d15c-c5a4-461d-a675-626730dd0382" />

Columns

UUID — Unique device identifier. Clickable — opens the device detail page with full hardware info (name, serial number, model, block size).

Agent — Hostname of the disk agent node where the device is located. Shown in red for the "Agent unavailable" table. Empty if the agent is not found in DiskRegistry.

Pool — Storage pool the device belongs to (e.g. SSD, HDD, local). Determined by device.GetPoolName().

State message — Human-readable message attached to the current device state. Typically contains the reason for transitioning into the current state (e.g. error description, replacement reason).

In state since — Timestamp of the last device state change (TDeviceConfig::StateTs). Note: this reflects when the device last changed its state (e.g. became ONLINE or ERROR), not necessarily when it entered the dirty list.

Time in state — Duration elapsed since "In state since". Computed as Now() - StateTs. Gives a quick sense of how long the device has been stuck in its current state.

  Tables

Erasing now — Devices whose pool currently has an active TSecureEraseActor running. All dirty devices of a pool are sent as a single batch, so presence here means the device's erase is in progress.

Ready for cleanup — Devices that passed CanSecureErase but whose pool has not yet been picked up by SecureErase(). Either the trigger has not fired since the last state change, or the device was skipped due to per-pool rate limiting (MaxDevicesToErasePerDeviceName).

Waiting for cleanup — Devices in ONLINE or WARNING state for which no agent was found by NodeId. The node hosting this device is not registered in DiskRegistry. Cleanup cannot proceed until the agent appears.

Agent unavailable — Devices in ONLINE or WARNING state whose agent is registered but in  AGENT_STATE_UNAVAILABLE. The host is temporarily unreachable. Cleanup will resume automatically once the agent recovers.

Cleanup blocked — Devices in ONLINE or WARNING state with a reachable agent, but CanSecureErase returned false for another reason: the device was recently auto-replaced (IsAutomaticallyReplaced), its path is detached (AttachDetachPathsEnabled), or the device is suspended without a pending resume. These require manual investigation.

Device broken — Devices in DEVICE_STATE_ERROR. CanSecureErase explicitly rejects error-state devices, so no erase will be attempted. Requires investigation via the device detail page.
