### PR TITLE
Add SkipTests config for Disk Manager remote tests

### DIFF
--- a/cloud/disk_manager/test/remote/cmd/config/config.proto
+++ b/cloud/disk_manager/test/remote/cmd/config/config.proto
@@ -11,4 +11,5 @@ message TestConfig {
     required string ImageURL = 2;
     required uint64 ImageSize = 3;
     required uint32 ImageCrc32 = 4;
+    repeated string SkipTests = 5;
 }

--- a/cloud/disk_manager/test/remote/cmd/main.go
+++ b/cloud/disk_manager/test/remote/cmd/main.go
@@ -1592,9 +1592,19 @@ func runTests(
 		},
 	}
 
+	skipTests := make(map[string]bool)
+	for _, name := range testConfig.GetSkipTests() {
+		skipTests[name] = true
+	}
+
 	log.Printf("Starting tests")
 
 	for _, test := range tests {
+		if skipTests[test.Name] {
+			log.Printf("Skipping test %v", test.Name)
+			continue
+		}
+
 		log.Printf("Starting test %v", test.Name)
 
 		se, err := test.Run(ctx, client, privateClient, testConfig, nbsConfig)


### PR DESCRIPTION
### Notes
Add `SkipTests` to the remote test TestConfig so tests can be skipped via config instead of changing the test runner

Changes:
- Add repeated string `SkipTests` to `cloud/disk_manager/test/remote/cmd/config/config.proto`
- In `runTests`, build a set from `testConfig.GetSkipTests()` and skip matching tests by `test.Name`, with a log line for each skipped test

### Issue
Some remote tests assume resources that are not available in every test environment. For example, certain tests require HDD disks, but not all labs provide them. In environments like `hw-nbs-stable-lab`, running the full test suite may fail because the required disk types or other resources are missing.

`SkipTests` lets us exclude incompatible tests per environment via config, without modifying the test runner code.
