### PR TITLE
[Disk Manager]  Add hanging tasks timeouts by task type

### DIFF
--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -82,4 +82,7 @@ message TasksConfig {
 
     // Overrides MaxRetriableErrorCount.
     map<string, uint64> MaxRetriableErrorCountByTaskType = 40;
+
+    // Overrides HangingTaskTimeout by task type.
+    map<string, string> HangingTasksTimeoutByType = 41;
 }

--- a/cloud/tasks/config/config.proto
+++ b/cloud/tasks/config/config.proto
@@ -84,5 +84,5 @@ message TasksConfig {
     map<string, uint64> MaxRetriableErrorCountByTaskType = 40;
 
     // Overrides HangingTaskTimeout by task type.
-    map<string, string> HangingTasksTimeoutByType = 41;
+    map<string, string> HangingTaskTimeoutByType = 41;
 }

--- a/cloud/tasks/persistence/ydb.go
+++ b/cloud/tasks/persistence/ydb.go
@@ -30,6 +30,7 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 type Type = ydb_types.Type
+type StructOption = ydb_types.StructOption
 
 const (
 	TypeBool      = ydb_types.TypeBool
@@ -48,6 +49,10 @@ const (
 func Optional(t ydb_types.Type) ydb_types.Type { return ydb_types.Optional(t) }
 
 func List(t Type) ydb_types.Type { return ydb_types.List(t) }
+
+func Struct(opts ...StructOption) Type { return ydb_types.Struct(opts...) }
+
+func StructField(name string, t Type) StructOption { return ydb_types.StructField(name, t) }
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/tasks/storage/common.go
+++ b/cloud/tasks/storage/common.go
@@ -47,11 +47,11 @@ func strListValue(strings []string) persistence.Value {
 }
 
 func durationByTaskTypeListValue(
-	valuesByTaskType map[string]time.Duration,
+	valueByTaskType map[string]time.Duration,
 ) persistence.Value {
 
-	values := make([]persistence.Value, 0, len(valuesByTaskType))
-	for taskType, value := range valuesByTaskType {
+	values := make([]persistence.Value, 0, len(valueByTaskType))
+	for taskType, value := range valueByTaskType {
 		values = append(values, persistence.StructValue(
 			persistence.StructFieldValue("task_type", persistence.UTF8Value(taskType)),
 			persistence.StructFieldValue("timeout", persistence.IntervalValue(value)),

--- a/cloud/tasks/storage/common.go
+++ b/cloud/tasks/storage/common.go
@@ -46,6 +46,30 @@ func strListValue(strings []string) persistence.Value {
 	return result
 }
 
+func durationByTaskTypeListValue(
+	valuesByTaskType map[string]time.Duration,
+) persistence.Value {
+
+	values := make([]persistence.Value, 0, len(valuesByTaskType))
+	for taskType, value := range valuesByTaskType {
+		values = append(values, persistence.StructValue(
+			persistence.StructFieldValue("task_type", persistence.UTF8Value(taskType)),
+			persistence.StructFieldValue("timeout", persistence.IntervalValue(value)),
+		))
+	}
+
+	if len(values) == 0 {
+		return persistence.ZeroValue(persistence.List(
+			persistence.Struct(
+				persistence.StructField("task_type", persistence.TypeUTF8),
+				persistence.StructField("timeout", persistence.TypeInterval),
+			),
+		))
+	}
+
+	return persistence.ListValue(values...)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func unmarshalErrorDetails(bytes []byte) (*errors.ErrorDetails, error) {

--- a/cloud/tasks/storage/compound_storage.go
+++ b/cloud/tasks/storage/compound_storage.go
@@ -490,7 +490,7 @@ func NewStorage(
 	}
 
 	hangingTaskTimeoutByType, err := parseDurationByTaskType(
-		config.GetHangingTasksTimeoutByType(),
+		config.GetHangingTaskTimeoutByType(),
 	)
 	if err != nil {
 		return nil, err

--- a/cloud/tasks/storage/compound_storage.go
+++ b/cloud/tasks/storage/compound_storage.go
@@ -489,6 +489,13 @@ func NewStorage(
 		return nil, err
 	}
 
+	hangingTaskTimeoutByType, err := parseDurationByTaskType(
+		config.GetHangingTasksTimeoutByType(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	inflightHangingTaskTimeout, err := time.ParseDuration(
 		config.GetInflightHangingTaskTimeout(),
 	)
@@ -516,6 +523,7 @@ func NewStorage(
 
 			exceptHangingTaskTypes:            config.GetExceptHangingTaskTypes(),
 			hangingTaskTimeout:                hangingTaskTimeout,
+			hangingTaskTimeoutByType:          hangingTaskTimeoutByType,
 			inflightHangingTaskTimeout:        inflightHangingTaskTimeout,
 			stallingHangingTaskTimeout:        stallingHangingTaskTimeout,
 			missedEstimatesUntilTaskIsHanging: config.GetMissedEstimatesUntilTaskIsHanging(),
@@ -544,4 +552,21 @@ func NewStorage(
 		storageFolder: config.GetStorageFolder(),
 		storage:       storage,
 	}, nil
+}
+
+func parseDurationByTaskType(
+	values map[string]string,
+) (map[string]time.Duration, error) {
+
+	result := make(map[string]time.Duration, len(values))
+	for taskType, value := range values {
+		duration, err := time.ParseDuration(value)
+		if err != nil {
+			return nil, err
+		}
+
+		result[taskType] = duration
+	}
+
+	return result, nil
 }

--- a/cloud/tasks/storage/storage_ydb.go
+++ b/cloud/tasks/storage/storage_ydb.go
@@ -22,6 +22,7 @@ type storageYDB struct {
 
 	exceptHangingTaskTypes            []string
 	hangingTaskTimeout                time.Duration
+	hangingTaskTimeoutByType          map[string]time.Duration
 	inflightHangingTaskTimeout        time.Duration
 	stallingHangingTaskTimeout        time.Duration
 	missedEstimatesUntilTaskIsHanging uint64

--- a/cloud/tasks/storage/storage_ydb_impl.go
+++ b/cloud/tasks/storage/storage_ydb_impl.go
@@ -942,6 +942,10 @@ func (s *storageYDB) listHangingTasks(
 		declare $limit as Uint64;
 		declare $except_task_types as List<Utf8>;
 		declare $hanging_task_timeout as Interval;
+		declare $hanging_task_timeout_by_type as List<Struct<
+			task_type: Utf8,
+			timeout: Interval
+		>>;
 		declare $inflight_hanging_task_timeout as Interval;
 		declare $stalling_hanging_task_timeout as Interval;
 		declare $missed_estimates_until_task_is_hanging as Uint64;
@@ -953,19 +957,25 @@ func (s *storageYDB) listHangingTasks(
 			select id from ready_to_cancel UNION ALL
 			select id from cancelling
 		);
-		select *
+
+		select tasks.*
 		from tasks
+		left join AS_TABLE($hanging_task_timeout_by_type) as hanging_task_timeout_by_type
+		on tasks.task_type == hanging_task_timeout_by_type.task_type
 		where
-		 	(id in $task_ids) and
-			(task_type not in $except_task_types) and
+			(tasks.id in $task_ids) and
+			(tasks.task_type not in $except_task_types) and
 			(
-				($now - created_at >= $hanging_task_timeout) or
-			    inflight_duration >= MAX_OF(
-					estimated_inflight_duration * $missed_estimates_until_task_is_hanging,
+				($now - tasks.created_at >= COALESCE(
+					hanging_task_timeout_by_type.timeout,
+					$hanging_task_timeout
+				)) or
+				tasks.inflight_duration >= MAX_OF(
+					tasks.estimated_inflight_duration * $missed_estimates_until_task_is_hanging,
 					$inflight_hanging_task_timeout,
 				) or
-				stalling_duration >= MAX_OF(
-					estimated_stalling_duration * $missed_estimates_until_task_is_hanging,
+				tasks.stalling_duration >= MAX_OF(
+					tasks.estimated_stalling_duration * $missed_estimates_until_task_is_hanging,
 					$stalling_hanging_task_timeout,
 				)
 			)
@@ -979,6 +989,10 @@ func (s *storageYDB) listHangingTasks(
 		persistence.ValueParam(
 			"$hanging_task_timeout",
 			persistence.IntervalValue(s.hangingTaskTimeout),
+		),
+		persistence.ValueParam(
+			"$hanging_task_timeout_by_type",
+			durationByTaskTypeListValue(s.hangingTaskTimeoutByType),
 		),
 		persistence.ValueParam(
 			"$inflight_hanging_task_timeout",

--- a/cloud/tasks/storage/storage_ydb_test.go
+++ b/cloud/tasks/storage/storage_ydb_test.go
@@ -1344,7 +1344,7 @@ func TestStorageYDBListHangingTasksWithTimeoutByType(t *testing.T) {
 	fastHangingTaskTimeout := time.Hour
 	fixture := newHangingTaskTestFixture(t, &tasks_config.TasksConfig{
 		HangingTaskTimeout: &hangingTaskTimeoutString,
-		HangingTasksTimeoutByType: map[string]string{
+		HangingTaskTimeoutByType: map[string]string{
 			"fast": fastHangingTaskTimeout.String(),
 		},
 	})

--- a/cloud/tasks/storage/storage_ydb_test.go
+++ b/cloud/tasks/storage/storage_ydb_test.go
@@ -1338,6 +1338,52 @@ func TestStorageYDBListHangingTasksWithExceptions(t *testing.T) {
 	)
 }
 
+func TestStorageYDBListHangingTasksWithTimeoutByType(t *testing.T) {
+	hangingTaskTimeout := 24 * time.Hour
+	hangingTaskTimeoutString := hangingTaskTimeout.String()
+	fastHangingTaskTimeout := time.Hour
+	fixture := newHangingTaskTestFixture(t, &tasks_config.TasksConfig{
+		HangingTaskTimeout: &hangingTaskTimeoutString,
+		HangingTasksTimeoutByType: map[string]string{
+			"fast": fastHangingTaskTimeout.String(),
+		},
+	})
+	defer fixture.teardown()
+
+	expectedTaskIDs := []string{
+		fixture.createTask(
+			"fast",
+			TaskStatusReadyToRun,
+			time.Now().Add(-fastHangingTaskTimeout).Add(-time.Minute),
+			0, 0, 0, 0,
+		),
+		fixture.createTask(
+			"default",
+			TaskStatusRunning,
+			time.Now().Add(-hangingTaskTimeout).Add(-time.Minute),
+			0, 0, 0, 0,
+		),
+	}
+	fixture.createTask(
+		"fast",
+		TaskStatusReadyToRun,
+		time.Now().Add(-fastHangingTaskTimeout).Add(time.Minute),
+		0, 0, 0, 0,
+	)
+	fixture.createTask(
+		"default",
+		TaskStatusReadyToRun,
+		time.Now().Add(-fastHangingTaskTimeout).Add(-time.Minute),
+		0, 0, 0, 0,
+	)
+
+	require.ElementsMatch(
+		t,
+		expectedTaskIDs,
+		fixture.ListHangingTasksIDs(),
+	)
+}
+
 func TestStorageYDBListTasksRunning(t *testing.T) {
 	ctx, cancel := context.WithCancel(newContext())
 	defer cancel()


### PR DESCRIPTION
### Notes
For ready_to_run tasks, which are enqueued, we won't notice them being hanging until they are executed by the runner. If we want to enable estimates, we will have to set hanging tasks timeout to (max disk size / estimated transfer bandwidth), which would cap at days. 
This would prevent us from seing tasks expected to be executed quickly as hanging. 
