### PR TITLE
issue-6326: RenameNode->Reboot->UnlinkNodeInShard replay ut + ListOpLogEntries local private api

### DIFF
--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -59,6 +59,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CompleteUnlinkNode,                     __VA_ARGS__)                   \
     xxx(DeleteOpLogEntry,                       __VA_ARGS__)                   \
     xxx(GetOpLogEntry,                          __VA_ARGS__)                   \
+    xxx(ListOpLogEntries,                       __VA_ARGS__)                   \
     xxx(WriteOpLogEntry,                        __VA_ARGS__)                   \
 // FILESTORE_TABLET_REQUESTS_PRIVATE
 
@@ -950,6 +951,21 @@ struct TEvIndexTabletPrivate
     struct TGetOpLogEntryResponse
     {
         TMaybe<NProto::TOpLogEntry> OpLogEntry;
+    };
+
+    //
+    // ListOpLogEntries
+    //
+    // NOTE: This event is not supposed to be sent outside of unit tests.
+    //
+
+    struct TListOpLogEntriesRequest
+    {
+    };
+
+    struct TListOpLogEntriesResponse
+    {
+        TVector<NProto::TOpLogEntry> OpLogEntries;
     };
 
     //

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -85,12 +85,16 @@ void TIndexTabletActor::ReplayOpLog(
                 false   // shouldUnlockUponCompletion
             );
         } else if (op.HasUnlinkNodeInShardRequest()) {
-            bool shouldUnlockUponCompletion =
-                GetFileSystem().GetDirectoryCreationInShardsEnabled();
+            const auto& request = op.GetUnlinkNodeInShardRequest();
+            // UnlinkNodeInShardRequests originating from
+            // RenameNode[InDestination] ops don't have OriginalRequest and
+            // don't require any post-unlink NodeRef deletion.
+            bool hasOriginalRequest = request.HasOriginalRequest();
+            bool shouldUnlockUponCompletion = hasOriginalRequest
+                && GetFileSystem().GetDirectoryCreationInShardsEnabled();
             if (shouldUnlockUponCompletion) {
                 // There is a need to unlock the node ref after the operation is
                 // completed, because the node ref should have been locked
-                const auto& request = op.GetUnlinkNodeInShardRequest();
                 const auto& originalRequest = request.GetOriginalRequest();
                 const bool locked = TryLockNodeRef(
                     {originalRequest.GetNodeId(), originalRequest.GetName()});
@@ -307,6 +311,65 @@ void TIndexTabletActor::CompleteTx_GetOpLogEntry(
     auto response =
         std::make_unique<TEvIndexTabletPrivate::TEvGetOpLogEntryResponse>();
     response->OpLogEntry = std::move(args.Entry);
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleListOpLogEntries(
+    const TEvIndexTabletPrivate::TEvListOpLogEntriesRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        msg->CallContext);
+
+    AddInFlightRequest<TEvIndexTabletPrivate::TListOpLogEntriesMethod>(
+        *requestInfo);
+
+    ExecuteTx<TListOpLogEntries>(ctx, std::move(requestInfo));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TIndexTabletActor::PrepareTx_ListOpLogEntries(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TListOpLogEntries& args)
+{
+    Y_UNUSED(ctx);
+
+    TIndexTabletDatabase db(tx.DB);
+    return db.ReadOpLog(args.Entries);
+}
+
+void TIndexTabletActor::ExecuteTx_ListOpLogEntries(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TListOpLogEntries& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+}
+
+void TIndexTabletActor::CompleteTx_ListOpLogEntries(
+    const TActorContext& ctx,
+    TTxIndexTablet::TListOpLogEntries& args)
+{
+    RemoveInFlightRequest(*args.RequestInfo);
+
+    LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        "%s ListOpLogEntries completed: %lu",
+        LogTag.c_str(),
+        args.Entries.size());
+
+    auto response =
+        std::make_unique<TEvIndexTabletPrivate::TEvListOpLogEntriesResponse>();
+    response->OpLogEntries = std::move(args.Entries);
     NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -155,6 +155,7 @@ namespace NCloud::NFileStore::NStorage {
                                                                                \
     xxx(DeleteOpLogEntry,                   __VA_ARGS__)                       \
     xxx(GetOpLogEntry,                      __VA_ARGS__)                       \
+    xxx(ListOpLogEntries,                   __VA_ARGS__)                       \
     xxx(WriteOpLogEntry,                    __VA_ARGS__)                       \
     xxx(CommitNodeCreationInShard,          __VA_ARGS__)                       \
                                                                                \
@@ -2855,7 +2856,7 @@ struct TTxIndexTablet
         const ui64 EntryId;
         TMaybe<NProto::TOpLogEntry> Entry;
 
-        explicit TGetOpLogEntry(TRequestInfoPtr requestInfo, ui64 entryId)
+        TGetOpLogEntry(TRequestInfoPtr requestInfo, ui64 entryId)
             : RequestInfo(std::move(requestInfo))
             , EntryId(entryId)
         {}
@@ -2863,6 +2864,25 @@ struct TTxIndexTablet
         void Clear() override
         {
             Entry.Clear();
+        }
+    };
+
+    //
+    // ListOpLogEntries
+    //
+
+    struct TListOpLogEntries: TTxIndexTabletBase
+    {
+        const TRequestInfoPtr RequestInfo;
+        TVector<NProto::TOpLogEntry> Entries;
+
+        explicit TListOpLogEntries(TRequestInfoPtr requestInfo)
+            : RequestInfo(std::move(requestInfo))
+        {}
+
+        void Clear() override
+        {
+            Entries.clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -2337,6 +2337,171 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
         UNIT_ASSERT_VALUES_EQUAL(0, nodeOpErrorFromShardCounter->Val());
     }
+
+    void DoTestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNode(
+        const TFileSystemConfig& tabletConfig,
+        bool useRenameInDestination)
+    {
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetDirectoryCreationInShardsEnabled(true);
+        TTestEnv env({}, storageConfig);
+
+        const ui32 nodeIdx = env.AddDynamicNode();
+        const ui64 tabletId = env.BootIndexTablet(nodeIdx);
+        bool intercepted = false;
+        bool shouldIntercept = true;
+        auto interceptor = [&] (auto& runtime, auto& event) {
+            Y_UNUSED(runtime);
+
+            switch (event->GetTypeRewrite()) {
+                case TEvService::EvUnlinkNodeRequest: {
+                    if (shouldIntercept) {
+                        intercepted = true;
+                        return true;
+                    }
+                    break;
+                }
+            }
+
+            return false;
+        };
+        OverrideDescribeFileStore(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            interceptor);
+
+        NMonitoring::TDynamicCountersPtr counters =
+            new NMonitoring::TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+
+        auto critEventCounter = counters->GetCounter(
+            "AppCriticalEvents/InvalidNodeRefUponCompleteUnlinkNode",
+            true);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+        tablet.ConfigureShards(true);
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        tablet.InitSession("client", "session");
+
+        //
+        //  Scenario:
+        //
+        //  uuid1 -> id1 (file)
+        //  name1 -> uuid1
+        //
+        //  uuid2 -> id2 (file)
+        //  name2 -> uuid2
+        //
+        //  move name1 to name2
+        //  intercept UnlinkNodeRequest
+        //  reboot
+        //  check that unlinking completes successfully
+        //
+
+        const TString shardId1 = "shard1";
+        const TString name1 = "name1";
+        const TString uuid1 = CreateGuidAsString();
+
+        // NodeRefs should be managed by the same shard for the RenameNode test
+        const TString shardId2 = useRenameInDestination ? "shard2" : shardId1;
+        const TString name2 = "name2";
+        const TString uuid2 = CreateGuidAsString();
+
+        CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, uuid1));
+        CreateExternalRef(tablet, RootNodeId, name1, shardId1, uuid1);
+
+        CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, uuid2));
+        CreateExternalRef(tablet, RootNodeId, name2, shardId2, uuid2);
+
+        if (useRenameInDestination) {
+            tablet.SendRenameNodeInDestinationRequest(
+                RootNodeId,
+                name2,
+                shardId1,
+                uuid1);
+        } else {
+            tablet.SendRenameNodeRequest(RootNodeId, name1, RootNodeId, name2);
+        }
+
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(1));
+        UNIT_ASSERT(intercepted);
+
+        //
+        // OpLogEntry should be present.
+        //
+
+        {
+            auto response = tablet.ListOpLogEntries();
+            UNIT_ASSERT_VALUES_EQUAL(1, response->OpLogEntries.size());
+            const auto& e = response->OpLogEntries[0];
+            UNIT_ASSERT_C(e.HasUnlinkNodeInShardRequest(), e.Utf8DebugString());
+            UNIT_ASSERT_C(
+                !e.GetUnlinkNodeInShardRequest().HasOriginalRequest(),
+                e.GetUnlinkNodeInShardRequest().GetOriginalRequest()
+                    .Utf8DebugString());
+        }
+
+        //
+        // Rebooting - Abort request should be re-sent upon tablet start.
+        //
+
+        shouldIntercept = false;
+        tablet.RebootTablet();
+        tablet.ReconnectPipe();
+        tablet.WaitReady();
+        tablet.RecoverSession();
+
+        //
+        // E_REJECTED is expected because tablet actor died.
+        //
+
+        if (useRenameInDestination) {
+            auto response = tablet.RecvRenameNodeInDestinationResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+        } else {
+            auto response = tablet.RecvRenameNodeResponse();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                response->GetStatus(),
+                FormatError(response->GetError()));
+        }
+
+        //
+        // OpLogEntry should be deleted.
+        //
+
+        {
+            auto response = tablet.ListOpLogEntries();
+            UNIT_ASSERT_VALUES_EQUAL(0, response->OpLogEntries.size());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, critEventCounter->Val());
+    }
+
+    TABLET_TEST_4K_ONLY(
+        TestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNodeInDestination)
+    {
+        DoTestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNode(
+            tabletConfig,
+            true /* useRenameInDestination */);
+    }
+
+    TABLET_TEST_4K_ONLY(
+        TestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNode)
+    {
+        DoTestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNode(
+            tabletConfig,
+            false /* useRenameInDestination */);
+    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -683,6 +683,12 @@ public:
         return std::make_unique<TRequestEvent>(entryId);
     }
 
+    auto CreateListOpLogEntriesRequest()
+    {
+        using TRequestEvent = TEvIndexTabletPrivate::TEvListOpLogEntriesRequest;
+        return std::make_unique<TRequestEvent>();
+    }
+
     auto CreateWriteOpLogEntryRequest(NProto::TOpLogEntry entry)
     {
         using TRequestEvent = TEvIndexTabletPrivate::TEvWriteOpLogEntryRequest;


### PR DESCRIPTION
### Notes
* fixing the bug described here https://github.com/ydb-platform/nbs/issues/6326
* ut for the same thing
* `ListOpLogEntries` local private API (needed for the ut)

**PS** This is the first PR developed, built and tested using a filestore-backed filesystem to store the code and build artifacts

### Issue
https://github.com/ydb-platform/nbs/issues/6326