### PR TITLE
[Filestore] Confirm recovered data, accounting for page faults

### DIFF
--- a/cloud/filestore/libs/storage/core/tablet.h
+++ b/cloud/filestore/libs/storage/core/tablet.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include "cpu_timer.h"
+#include "tablet_tx_rescheduler.h"
 
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/storage/core/probes.h>
@@ -95,12 +96,17 @@ class TTabletBase
     : public NKikimr::NTabletFlatExecutor::TTabletExecutedFlat
 {
 public:
-    TTabletBase(const NActors::TActorId& owner,
-                NKikimr::TTabletStorageInfoPtr storage)
+    TTabletBase(
+            const NActors::TActorId& owner,
+            NKikimr::TTabletStorageInfoPtr storage,
+            ITxReschedulerPtr txRescheduler)
         : TTabletExecutedFlat(storage.Get(), owner, NewMiniKQLFactory())
+        , TxRescheduler(std::move(txRescheduler))
     {}
 
 protected:
+    ITxReschedulerPtr TxRescheduler;
+
     template <typename TTx>
     class TTransaction final
         : public ITransactionBase
@@ -136,6 +142,26 @@ protected:
         {
             Generation = tx.Generation;
             Step = tx.Step;
+
+            // Reschedule (restart) the transaction from PrepareTx when the
+            // injected rescheduler asks for it. In production this is a no-op
+            // stub; tests inject an implementation to make the transaction
+            // restart/reorder path.
+            if (Self->TxRescheduler->ShouldReschedule()) {
+                LOG_INFO(
+                    ctx,
+                    T::LogComponent,
+                    "[%lu] Forced reschedule of %s (gen: %u, step: %u)",
+                    Self->TabletID(),
+                    TTx::Name,
+                    Generation,
+                    Step);
+
+                Args.Clear();
+                Args.OnRestart();
+                tx.Reschedule();
+                return false;
+            }
 
             TX_TRACK(TxPrepare);
             LOG_TRACE(ctx, T::LogComponent,

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
@@ -1,0 +1,28 @@
+#include "tablet_tx_rescheduler.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TNoOpTxRescheduler final
+    : public ITxRescheduler
+{
+public:
+    bool ShouldReschedule() override
+    {
+        return false;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITxReschedulerPtr CreateNoOpTxRescheduler()
+{
+    return std::make_shared<TNoOpTxRescheduler>();
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Decides whether a tablet transaction should be rescheduled (restarted) from
+// PrepareTx. Production uses a no-op stub; tests inject an implementation that
+// reschedules to make the transaction restart/reorder path.
+struct ITxRescheduler
+{
+    virtual ~ITxRescheduler() = default;
+
+    virtual bool ShouldReschedule() = 0;
+};
+
+using ITxReschedulerPtr = std::shared_ptr<ITxRescheduler>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Default rescheduler used in production: never reschedules.
+ITxReschedulerPtr CreateNoOpTxRescheduler();
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/ya.make
+++ b/cloud/filestore/libs/storage/core/ya.make
@@ -11,6 +11,7 @@ SRCS(
     tablet.cpp
     tablet_counters.cpp
     tablet_schema.cpp
+    tablet_tx_rescheduler.cpp
 )
 
 PEERDIR(

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -245,7 +245,8 @@ public:
                     traceSerializer,
                     systemCounters,
                     metricsRegistry,
-                    fastShardServer);
+                    fastShardServer,
+                    CreateNoOpTxRescheduler());
                 return actor.release();
             };
 

--- a/cloud/filestore/libs/storage/tablet/tablet.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet.cpp
@@ -21,7 +21,8 @@ IActorPtr CreateIndexTablet(
     ITraceSerializerPtr traceSerializer,
     TSystemCountersPtr systemCounters,
     NMetrics::IMetricsRegistryPtr metricsRegistry,
-    NFastShard::IServerPtr fastShardServer)
+    NFastShard::IServerPtr fastShardServer,
+    ITxReschedulerPtr txRescheduler)
 {
     return std::make_unique<TIndexTabletActor>(
         owner,
@@ -32,7 +33,8 @@ IActorPtr CreateIndexTablet(
         std::move(traceSerializer),
         std::move(systemCounters),
         std::move(metricsRegistry),
-        std::move(fastShardServer));
+        std::move(fastShardServer),
+        std::move(txRescheduler));
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet.h
+++ b/cloud/filestore/libs/storage/tablet/tablet.h
@@ -5,6 +5,7 @@
 #include <cloud/filestore/libs/diagnostics/metrics/public.h>
 #include <cloud/filestore/libs/diagnostics/public.h>
 #include <cloud/filestore/libs/storage/core/public.h>
+#include <cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h>
 #include <cloud/filestore/libs/storage/fastshard/server/server.h>
 
 #include <cloud/storage/core/libs/kikimr/public.h>
@@ -24,6 +25,7 @@ NActors::IActorPtr CreateIndexTablet(
     ITraceSerializerPtr traceSerializer,
     TSystemCountersPtr systemCounters,
     NMetrics::IMetricsRegistryPtr metricsRegistry,
-    NFastShard::IServerPtr fastShardServer);
+    NFastShard::IServerPtr fastShardServer,
+    ITxReschedulerPtr txRescheduler);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -68,9 +68,10 @@ TIndexTabletActor::TIndexTabletActor(
         ITraceSerializerPtr traceSerializer,
         TSystemCountersPtr systemCounters,
         NMetrics::IMetricsRegistryPtr metricsRegistry,
-        NFastShard::IServerPtr fastShardServer)
+        NFastShard::IServerPtr fastShardServer,
+        ITxReschedulerPtr txRescheduler)
     : TActor(&TThis::StateBoot)
-    , TTabletBase(owner, std::move(storage))
+    , TTabletBase(owner, std::move(storage), std::move(txRescheduler))
     , Metrics{std::move(metricsRegistry)}
     , ProfileLog(std::move(profileLog))
     , TraceSerializer(std::move(traceSerializer))

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -205,7 +205,8 @@ public:
         ITraceSerializerPtr traceSerializer,
         TSystemCountersPtr systemCounters,
         NMetrics::IMetricsRegistryPtr metricsRegistry,
-        NFastShard::IServerPtr fastShardServer);
+        NFastShard::IServerPtr fastShardServer,
+        ITxReschedulerPtr txRescheduler);
     ~TIndexTabletActor() override;
 
     static constexpr ui32 LogComponent = TFileStoreComponents::TABLET;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -790,6 +790,7 @@ private:
         ui64 commitId,
         const NProto::TUnconfirmedData& entry);
     void ConfirmData(ui64 commitId, const NActors::TActorContext& ctx);
+    void ConfirmNextRecoveredData(const NActors::TActorContext& ctx);
     void SendDeferredConfirmAddDataResponse(
         const NActors::TActorContext& ctx,
         TPendingConfirmAddData pending,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -86,8 +86,8 @@ void TIndexTabletActor::UnconfirmedAddBlobSafePointReached(
 
     if (UnconfirmedRecoveryReady) {
         SendPendingConfirmAddDataResponse(ctx, commitId, error);
-    } else if (ConfirmedData.empty()) {
-        BlobsConfirmed(ctx);
+    } else {
+        ConfirmNextRecoveredData(ctx);
     }
 }
 
@@ -400,9 +400,20 @@ void TIndexTabletActor::ConfirmData(ui64 commitId, const TActorContext& ctx)
 
     const auto& entry = pos->second;
 
-    // Submit AddBlob tx immediately to keep confirmation ordering in tx queue
-    // (assuming no page-fault/restart).
     AddBlobForUnconfirmedData(ctx, commitId, entry.Data);
+}
+
+void TIndexTabletActor::ConfirmNextRecoveredData(const TActorContext& ctx)
+{
+    if (RecoveredDataToConfirm.empty()) {
+        BlobsConfirmed(ctx);
+        return;
+    }
+
+    const ui64 commitId = RecoveredDataToConfirm.front();
+    RecoveredDataToConfirm.pop_front();
+
+    ConfirmData(commitId, ctx);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
@@ -317,14 +317,16 @@ void TIndexTabletActor::HandleConfirmBlobsCompleted(
     }
 
     // Recovery must replay confirmations in commitId order to preserve write
-    // order for overlapping ranges.
+    // order for overlapping ranges. Confirm them one at a time, advancing on
+    // each write's safe point. A single AddBlob is ever
+    // in flight, so page faults cannot reorder
     Sort(recoverableCommitIds);
 
-    for (ui64 commitId: recoverableCommitIds) {
-        // TODO(#5353) Support out of order insertion to unblock here
-        // immediately
-        ConfirmData(commitId, ctx);
-    }
+    RecoveredDataToConfirm.assign(
+        recoverableCommitIds.begin(),
+        recoverableCommitIds.end());
+
+    ConfirmNextRecoveredData(ctx);
 }
 
 void TIndexTabletActor::BlobsConfirmed(const TActorContext& ctx)

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -259,6 +259,11 @@ protected:
     // Data confirmed but not yet added to index
     THashMap<ui64, TTrackedUnconfirmedData> ConfirmedData;
 
+    // CommitIds of writes still to confirm during startup recovery, in commitId
+    // order. They are confirmed one at a time, so a single AddBlob
+    // is ever in flight up to SafePoint and page faults cannot reorder TXes
+    TDeque<ui64> RecoveredDataToConfirm;
+
     // CommitIds scheduled for unconfirmed-data deletion and waiting for
     // completion.
     THashSet<ui64> DeletionQueue;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -3,6 +3,7 @@
 
 #include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/service/request.h>
+#include <cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h>
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
 
@@ -14,6 +15,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/random/fast.h>
+#include <util/random/random.h>
 
 #include <algorithm>
 #include <initializer_list>
@@ -23,6 +25,27 @@ namespace NCloud::NFileStore::NStorage {
 using namespace NKikimr;
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Reschedules transactions with probability 1/Ratio, to exercise the recovery
+// confirmation path under transaction restarts/reorderings.
+class TRandomTxRescheduler final
+    : public ITxRescheduler
+{
+private:
+    const ui32 Ratio;
+
+public:
+    explicit TRandomTxRescheduler(ui32 ratio)
+        : Ratio(ratio)
+    {}
+
+    bool ShouldReschedule() override
+    {
+        return Ratio > 0 && RandomNumber<ui32>(Ratio) == 0;
+    }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1355,46 +1378,54 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
     Y_UNIT_TEST(ShouldConfirmOverlappingUnconfirmedWritesInOrderAfterRestart)
     {
         const ui32 block = 4_KB;
+        const ui32 cycleCount = 15;
 
-        NProto::TStorageConfig storageConfig;
-        storageConfig.SetWriteBlobThreshold(1);
-        storageConfig.SetAddingUnconfirmedDataEnabled(true);
-        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        for (ui32 cycle = 0; cycle < cycleCount; ++cycle) {
+            NProto::TStorageConfig storageConfig;
+            storageConfig.SetWriteBlobThreshold(1);
+            storageConfig.SetAddingUnconfirmedDataEnabled(true);
+            storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-        TTestEnv env({}, std::move(storageConfig));
-        ui32 nodeIdx = env.AddDynamicNode();
-        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+            TTestEnv env({}, std::move(storageConfig));
+            // Inject a rescheduler so recovery confirmation is exercised under
+            // transaction restarts/reorderings.
+            env.SetTxRescheduler(std::make_shared<TRandomTxRescheduler>(3));
+            ui32 nodeIdx = env.AddDynamicNode();
+            ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
-        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
-        tablet.InitSession("client", "session");
+            TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+            tablet.InitSession("client", "session");
 
-        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
-        ui64 handle = CreateHandle(tablet, id);
-        AssertStorageStats(tablet, 0, 0);
+            auto id =
+                CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+            ui64 handle = CreateHandle(tablet, id);
+            AssertStorageStats(tablet, 0, 0);
 
-        // Three overlapping writes to block 0 (oldest -> newest)
-        ui64 prevCommitId = 0;
-        for (char fill: {'a', 'b', 'c'}) {
-            const ui64 commitId = GenerateBlobIdsAndPutBlob(
-                env,
-                tablet,
-                id,
-                handle,
-                0,
-                block,
-                fill);
-            WaitForTabletCommit(env);
-            UNIT_ASSERT_GT(commitId, prevCommitId);
-            prevCommitId = commitId;
+            // Three overlapping writes to block 0 (oldest -> newest)
+            ui64 prevCommitId = 0;
+            for (char fill: {'a', 'b', 'c'}) {
+                const ui64 commitId = GenerateBlobIdsAndPutBlob(
+                    env,
+                    tablet,
+                    id,
+                    handle,
+                    0,
+                    block,
+                    fill);
+                WaitForTabletCommit(env);
+                UNIT_ASSERT_GT(commitId, prevCommitId);
+                prevCommitId = commitId;
+            }
+            AssertStorageStats(tablet, 3, 0);
+
+            handle = RebootTabletAndCreateHandle(tablet, id);
+            AssertStorageStats(tablet, 0, 0);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                BuildExpectedData({{block, 'c'}}),
+                ReadData(tablet, handle, block, 0),
+                "cycle=" << cycle);
         }
-        AssertStorageStats(tablet, 3, 0);
-
-        handle = RebootTabletAndCreateHandle(tablet, id);
-        AssertStorageStats(tablet, 0, 0);
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            BuildExpectedData({{block, 'c'}}),
-            ReadData(tablet, handle, block, 0));
     }
 
     Y_UNIT_TEST(ShouldHandleCommitIdOverflowInAddDataUnconfirmed)

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1352,6 +1352,51 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             ReadData(tablet, handle, expected.size(), 0));
     }
 
+    Y_UNIT_TEST(ShouldConfirmOverlappingUnconfirmedWritesInOrderAfterRestart)
+    {
+        const ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig));
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+        AssertStorageStats(tablet, 0, 0);
+
+        // Three overlapping writes to block 0 (oldest -> newest)
+        ui64 prevCommitId = 0;
+        for (char fill: {'a', 'b', 'c'}) {
+            const ui64 commitId = GenerateBlobIdsAndPutBlob(
+                env,
+                tablet,
+                id,
+                handle,
+                0,
+                block,
+                fill);
+            WaitForTabletCommit(env);
+            UNIT_ASSERT_GT(commitId, prevCommitId);
+            prevCommitId = commitId;
+        }
+        AssertStorageStats(tablet, 3, 0);
+
+        handle = RebootTabletAndCreateHandle(tablet, id);
+        AssertStorageStats(tablet, 0, 0);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            BuildExpectedData({{block, 'c'}}),
+            ReadData(tablet, handle, block, 0));
+    }
+
     Y_UNIT_TEST(ShouldHandleCommitIdOverflowInAddDataUnconfirmed)
     {
         const ui32 block = 4_KB;

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -474,7 +474,8 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
             TraceSerializer,
             SystemCounters,
             Registry,
-            nullptr /* fastShardServer */);
+            nullptr /* fastShardServer */,
+            TxRescheduler);
         return actor.release();
     };
 
@@ -606,7 +607,8 @@ void TTestEnv::SetupLocalServiceConfig(
             TraceSerializer,
             SystemCounters,
             Registry,
-            nullptr /* fastShardServer */);
+            nullptr /* fastShardServer */,
+            TxRescheduler);
         return actor.release();
     };
 

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -9,6 +9,7 @@
 #include <cloud/filestore/libs/storage/core/config.h>
 #include <cloud/filestore/libs/storage/core/public.h>
 #include <cloud/filestore/libs/storage/core/system_counters.h>
+#include <cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h>
 #include <cloud/filestore/private/api/protos/tablet.pb.h>
 
 #include <cloud/storage/core/libs/diagnostics/public.h>
@@ -89,6 +90,7 @@ private:
     IProfileLogPtr ProfileLog;
     ITraceSerializerPtr TraceSerializer;
     TSystemCountersPtr SystemCounters;
+    ITxReschedulerPtr TxRescheduler = CreateNoOpTxRescheduler();
 
     NKikimr::TTestBasicRuntime Runtime;
     TVector<ui32> GroupIds;
@@ -116,6 +118,14 @@ public:
     NActors::TTestActorRuntime& GetRuntime()
     {
         return Runtime;
+    }
+
+    // Inject a transaction rescheduler.
+    // Defaults to a no-op stub; tests set a custom one to exercise the
+    // transaction restart/reorder path. Must be set before BootIndexTablet.
+    void SetTxRescheduler(ITxReschedulerPtr txRescheduler)
+    {
+        TxRescheduler = std::move(txRescheduler);
     }
 
     TStorageConfigPtr GetStorageConfig() const


### PR DESCRIPTION
### Notes
Currently during recovery we ignore the fact, that page fault can occur and mix AddBlob TXes. So, this fix ensures that we will take page faults into account

### Issue
#2293
