### PR TITLE
Fix flaky volume_perf tests

### DIFF
--- a/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_perf_ut.cpp
@@ -544,7 +544,7 @@ void TestSufferWithMetrics(NCloud::NProto::EStorageMediaKind diskKind)
     {
         TestSufferCount(
             calc,
-            TDuration::Seconds(15),
+            TDuration::Seconds(14),
             slow,
             expected,
             expectedSmooth,
@@ -734,13 +734,12 @@ Y_UNIT_TEST_SUITE(TVolumePerfTest)
         UNIT_ASSERT(expectedCost < TDuration::Seconds(15));
 
         const auto requestTime = expectedCost + TDuration::Seconds(1);
-
         // expectedCost > 1s => per-second Suffer must stay off,
         // but for the 15s window SmoothSuffer should still be set.
         TestSufferCount(
             calc,
             requestTime,
-            TDuration::Seconds(15),
+            TDuration::Seconds(1),
             0,      // expected Suffer
             1,      // expected SmoothSuffer
             0);     // expected CriticalSuffer
@@ -789,7 +788,7 @@ Y_UNIT_TEST_SUITE(TVolumePerfTest)
         TestSufferCount(
             calc,
             requestTime,
-            TDuration::Seconds(15),
+            TDuration::Seconds(1),
             0,  // expected Suffer
             1,  // expected SmoothSuffer
             1); // expected CriticalSuffer
@@ -1246,7 +1245,7 @@ Y_UNIT_TEST_SUITE(TVolumePerfTest)
 
         calc.Register(*volumeCounters, volume);
 
-        TestSufferCountPostponed(calc, TDuration::Seconds(15), 0, 0, 0);
+        TestSufferCountPostponed(calc, TDuration::Seconds(1), 0, 0, 0);
 
         UNIT_ASSERT_VALUES_EQUAL(false, calc.IsSuffering());
     }


### PR DESCRIPTION
### Notes
Reduced waiting time to keep checks inside the 15s smoothing window to avoid boundary-dependent sample rollover in rare runs.

