### PR TITLE
[Filestore] Fix Alter requests throttling

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -479,7 +479,12 @@ void TAlterFileStoreActor::AlterShards(const TActorContext& ctx)
     }
 
     NextShardToAlter = 0;
-    for (ui32 i = 0; i < ShardsToAlter; ++i) {
+    const ui32 limit = StorageConfig->GetMaxShardManagementRequestsInFlight();
+    const ui32 endShardIndex =
+        (limit == 0) ? ShardsToAlter
+                     : std::min<ui32>(NextShardToAlter + limit, ShardsToAlter);
+
+    for (ui32 i = 0; i < endShardIndex; ++i) {
         AlterShard(ctx, i);
         NextShardToAlter = i + 1;
     }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -141,6 +141,10 @@ NProtoPrivate::TUnsafeChangeTabletStateResponse SetCompressNodeRef(
     return response;
 }
 
+// Helper class to count Describe/Create/Alter/Destroy/Configure
+// shard requests. We intentionally skip Main FS requests and requests
+// made by proxies. That's because we want to process only original shard
+// requests to check max in-flight and request/response counters.
 class TShardRequestCounter
 {
 private:
@@ -203,6 +207,7 @@ private:
             }
 
             case TEvIndexTablet::EvConfigureAsShardRequest: {
+                // Skipping calls made by Proxies.
                 if (ev->Recipient != MakeIndexTabletProxyServiceId()) {
                     return;
                 }
@@ -216,6 +221,7 @@ private:
             }
 
             case TEvIndexTablet::EvConfigureAsShardResponse: {
+                // We count only calls made by original actor.
                 auto it = ConfigureRequestSenders.find(ev->Cookie);
                 if (it == ConfigureRequestSenders.end() ||
                     ev->Recipient != it->second)
@@ -230,6 +236,12 @@ private:
             case TEvSSProxy::EvDescribeFileStoreRequest: {
                 using TRequest = TEvSSProxy::TEvDescribeFileStoreRequest;
                 const auto* msg = ev->Get<TRequest>();
+                // We need to count only DescribeShard operations, so excluding:
+                // 1. Cookie == Max<ui64>(): this is MainFileStoreCookie called
+                // from TAlterFileStoreActor::DescribeMainFileStore.
+                // 2. ShardIdPrefix we also need to check, as there is a call
+                // TIndexTabletProxyActor::DescribeFileStore with Cookie
+                // set to conn.Id.
                 if (ev->Cookie == Max<ui64>() ||
                     !msg->FileSystemId.StartsWith(ShardIdPrefix))
                 {
@@ -245,9 +257,12 @@ private:
             }
 
             case TEvSSProxy::EvDescribeFileStoreResponse: {
+                // Skipping this Cookie, it's MainFileStoreCookie called from
+                // TAlterFileStoreActor::DescribeMainFileStore.
                 if (ev->Cookie == Max<ui64>()) {
                     return;
                 }
+                // Skipping calls made by TIndexTabletProxyActor.
                 auto it = DescribeRequestSenders.find(ev->Cookie);
                 if (it == DescribeRequestSenders.end() ||
                     ev->Recipient != it->second)
@@ -259,6 +274,7 @@ private:
             }
 
             case TEvSSProxy::EvAlterFileStoreRequest: {
+                // Skipping MainFileStoreCookie.
                 if (ev->Cookie == Max<ui64>()) {
                     return;
                 }
@@ -271,6 +287,7 @@ private:
             }
 
             case TEvSSProxy::EvAlterFileStoreResponse: {
+                // Skipping MainFileStoreCookie.
                 if (ev->Cookie == Max<ui64>()) {
                     return;
                 }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -145,7 +145,9 @@ class TShardRequestCounter
 {
 private:
     TTestActorRuntimeBase& Runtime;
+    const TString ShardIdPrefix;
     TTestActorRuntimeBase::TEventFilter PrevFilter;
+    THashMap<ui64, TActorId> DescribeRequestSenders;
     THashMap<ui64, TActorId> ConfigureRequestSenders;
 
 public:
@@ -165,8 +167,9 @@ public:
     ui32 DestroyResponses = 0;
     ui32 DestroyMaxInFlight = 0;
 
-    TShardRequestCounter(TTestActorRuntimeBase& runtime)
+    TShardRequestCounter(TTestActorRuntimeBase& runtime, const TString& fsId)
         : Runtime(runtime)
+        , ShardIdPrefix(TStringBuilder() << fsId << ShardNumPrefix)
     {
         PrevFilter = Runtime.SetEventFilter(
             [this](auto& runtime, TAutoPtr<IEventHandle>& event)
@@ -225,6 +228,14 @@ private:
             }
 
             case TEvSSProxy::EvDescribeFileStoreRequest: {
+                using TRequest = TEvSSProxy::TEvDescribeFileStoreRequest;
+                const auto* msg = ev->Get<TRequest>();
+                if (ev->Cookie == Max<ui64>() ||
+                    !msg->FileSystemId.StartsWith(ShardIdPrefix))
+                {
+                    return;
+                }
+                DescribeRequestSenders[ev->Cookie] = ev->Sender;
                 if (++DescribeRequests > DescribeResponses) {
                     DescribeMaxInFlight = std::max(
                         DescribeMaxInFlight,
@@ -234,11 +245,23 @@ private:
             }
 
             case TEvSSProxy::EvDescribeFileStoreResponse: {
+                if (ev->Cookie == Max<ui64>()) {
+                    return;
+                }
+                auto it = DescribeRequestSenders.find(ev->Cookie);
+                if (it == DescribeRequestSenders.end() ||
+                    ev->Recipient != it->second)
+                {
+                    return;
+                }
                 ++DescribeResponses;
                 break;
             }
 
             case TEvSSProxy::EvAlterFileStoreRequest: {
+                if (ev->Cookie == Max<ui64>()) {
+                    return;
+                }
                 if (++AlterRequests > AlterResponses) {
                     AlterMaxInFlight = std::max(
                         AlterMaxInFlight,
@@ -248,6 +271,9 @@ private:
             }
 
             case TEvSSProxy::EvAlterFileStoreResponse: {
+                if (ev->Cookie == Max<ui64>()) {
+                    return;
+                }
                 ++AlterResponses;
                 break;
             }
@@ -3023,7 +3049,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const ui64 fsSize = 1000;
         const ui64 shardsCount = 2;
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId);
 
             service.CreateFileStore(fsId, fsSize);
 
@@ -3034,7 +3060,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
                     << counters.CreateResponses);
         }
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId);
 
             service.ResizeFileStore(fsId, fsSize, false /* force */, shardsCount);
 
@@ -4357,7 +4383,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
 
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId2);
             service.DestroyFileStore(fsId2);
             UNIT_ASSERT_VALUES_EQUAL(5, counters.DestroyRequests);
             UNIT_ASSERT_VALUES_EQUAL(5, counters.DestroyResponses);
@@ -4414,7 +4440,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
 
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId2);
             service.DestroyFileStore(fsId2);
             UNIT_ASSERT_VALUES_EQUAL(4, counters.DestroyMaxInFlight);
         }
@@ -4573,6 +4599,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(1);
+        config.SetStrictFileSystemSizeEnforcementEnabled(true);
         TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -4581,7 +4608,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         TServiceClient service(env.GetRuntime(), nodeIdx);
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId);
 
             service.CreateFileStore(fsId, 2_GB / 4_KB);
 
@@ -4592,6 +4619,8 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             UNIT_ASSERT_VALUES_EQUAL(2, counters.ConfigureRequests);
             UNIT_ASSERT_VALUES_EQUAL(2, counters.ConfigureResponses);
             UNIT_ASSERT_VALUES_EQUAL(1, counters.ConfigureMaxInFlight);
+
+            UNIT_ASSERT_VALUES_EQUAL(0, counters.AlterRequests);
         }
 
         TVector<TString> expected = {fsId, fsId + "_s1", fsId + "_s2"};
@@ -4602,7 +4631,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
 
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId);
 
             service.ResizeFileStore(fsId, 6_GB / 4_KB);
 
@@ -4617,6 +4646,10 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             UNIT_ASSERT_VALUES_EQUAL(6, counters.ConfigureRequests);
             UNIT_ASSERT_VALUES_EQUAL(6, counters.ConfigureResponses);
             UNIT_ASSERT_VALUES_EQUAL(1, counters.ConfigureMaxInFlight);
+
+            UNIT_ASSERT_VALUES_EQUAL(2, counters.AlterRequests);
+            UNIT_ASSERT_VALUES_EQUAL(2, counters.AlterResponses);
+            UNIT_ASSERT_VALUES_EQUAL(1, counters.AlterMaxInFlight);
         }
 
         expected = TVector<TString>{
@@ -8040,7 +8073,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         TServiceClient service(env.GetRuntime(), nodeIdx);
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId);
 
             service.CreateFileStore(fsId, fsSize);
 
@@ -8144,7 +8177,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         TServiceClient service(env.GetRuntime(), nodeIdx);
         {
-            TShardRequestCounter counters(env.GetRuntime());
+            TShardRequestCounter counters(env.GetRuntime(), fsId);
 
             service.CreateFileStore(fsId, fsSize);
 


### PR DESCRIPTION
### Notes
Closes #6310

Main functionality implemented in #6272.

Add missing AlterShards throttling.

### Testing
```
./ya test -F '*TStorageServiceShardingTest*' -- cloud/filestore/libs/storage/service/
...
Total 1 suite:
        1 - GOOD
Total 90 tests:
        90 - GOOD
Ok
```
