### PR TITLE
Experiment: small files read ahead

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -821,4 +821,10 @@ message TStorageConfig
 
     // Cache TTL that is used by TStorageServiceActor::HandleStatFileStore.
     optional uint32 StatFileStoreCacheTTL = 516; // in ms
+
+    // Enables reading data when a small regular file is opened in read-only,
+    // non-direct mode. The service attaches the file contents to the
+    // create-handle response for clients that can consume it.
+    optional bool ReadDataOnReadOnlyCreateHandleEnabled = 517;
+    optional uint64 ReadDataOnReadOnlyCreateHandleMaxFileSize = 518;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -205,6 +205,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(ReadAheadCacheRangeSize,                ui32,       0                 )\
     xxx(ReadAheadMaxGapPercentage,              ui32,       20                )\
     xxx(ReadAheadCacheMaxHandlesPerNode,        ui32,      128                )\
+    xxx(ReadDataOnReadOnlyCreateHandleEnabled, bool,       false              )\
+    xxx(ReadDataOnReadOnlyCreateHandleMaxFileSize, ui64,   128_KB             )\
     xxx(EntryTimeout,                    TDuration, TDuration::Zero()         )\
     xxx(RegularFileEntryTimeout,         TDuration, TDuration::Zero()         )\
     xxx(NegativeEntryTimeout,            TDuration, TDuration::Zero()         )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -242,6 +242,8 @@ public:
     ui32 GetReadAheadCacheRangeSize() const;
     ui32 GetReadAheadMaxGapPercentage() const;
     ui32 GetReadAheadCacheMaxHandlesPerNode() const;
+    bool GetReadDataOnReadOnlyCreateHandleEnabled() const;
+    ui64 GetReadDataOnReadOnlyCreateHandleMaxFileSize() const;
 
     ui32 GetNodeIndexCacheMaxNodes() const;
 

--- a/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/actors/tablet_writedata.cpp
@@ -140,7 +140,9 @@ void TWriteDataActor::ReplyAndDie(
             1,
             BlobsSize,
             ctx.Now() - RequestInfo->StartedTs,
-            BackendInfo.GetIsOverloaded());
+            BackendInfo.GetIsOverloaded(),
+            TString() /* createHandleSessionId */,
+            0 /* createHandleRequestId */);
         NCloud::Send(ctx, Tablet, std::move(response));
     }
 

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -360,6 +360,8 @@ struct TEvIndexTabletPrivate
     struct TReadWriteCompleted: TOperationCompleted
     {
         const bool IsOverloaded;
+        const TString CreateHandleSessionId;
+        const ui64 CreateHandleRequestId;
 
         TReadWriteCompleted(
                 TSet<ui32> mixedBlocksRanges,
@@ -367,7 +369,9 @@ struct TEvIndexTabletPrivate
                 ui32 requestCount,
                 ui32 requestBytes,
                 TDuration d,
-                bool isOverloaded)
+                bool isOverloaded,
+                TString createHandleSessionId,
+                ui64 createHandleRequestId)
             : TOperationCompleted(
                 std::move(mixedBlocksRanges),
                 commitId,
@@ -375,6 +379,8 @@ struct TEvIndexTabletPrivate
                 requestBytes,
                 d)
             , IsOverloaded(isOverloaded)
+            , CreateHandleSessionId(std::move(createHandleSessionId))
+            , CreateHandleRequestId(createHandleRequestId)
         {
         }
     };

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -611,6 +611,10 @@ private:
         const NActors::TActorContext& ctx,
         TTxIndexTablet::TListNodes& args);
 
+    void StartReadDataForCreateHandle(
+        const NActors::TActorContext& ctx,
+        TTxIndexTablet::TCreateHandle& args);
+
     void CompleteCreateHandle(
         const NActors::TActorContext& ctx,
         TTxIndexTablet::TCreateHandle& args);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -4,6 +4,7 @@
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/storage/api/tablet_proxy.h>
+#include <cloud/filestore/libs/storage/model/block_buffer.h>
 
 #include <util/generic/guid.h>
 
@@ -39,6 +40,48 @@ NProto::TError ValidateRequest(const NProto::TCreateHandleRequest& request)
     }
 
     return {};
+}
+
+bool IsReadOnlyNonDirect(ui32 flags)
+{
+    constexpr ui32 incompatibleFlags =
+        ProtoFlag(NProto::TCreateHandleRequest::E_CREATE) |
+        ProtoFlag(NProto::TCreateHandleRequest::E_WRITE) |
+        ProtoFlag(NProto::TCreateHandleRequest::E_APPEND) |
+        ProtoFlag(NProto::TCreateHandleRequest::E_TRUNCATE) |
+        ProtoFlag(NProto::TCreateHandleRequest::E_DIRECT);
+
+    return HasFlag(flags, NProto::TCreateHandleRequest::E_READ) &&
+        (flags & incompatibleFlags) == 0;
+}
+
+bool ShouldReadDataOnCreateHandle(
+    const TStorageConfig& config,
+    const TTxIndexTablet::TCreateHandle& args)
+{
+    if (!config.GetReadDataOnReadOnlyCreateHandleEnabled() ||
+        config.GetTabletUnsafeAsyncReadOnlyCreateHandleEnabled() ||
+        config.GetFakeDescribeDataEnabled() ||
+        !IsReadOnlyNonDirect(args.Flags))
+    {
+        return false;
+    }
+
+    const ui64 handle = args.Response.GetHandle();
+    if (!handle) {
+        return false;
+    }
+
+    const auto& node = args.Response.GetNodeAttr();
+    if (node.GetType() != NProto::E_REGULAR_NODE) {
+        return false;
+    }
+
+    const ui64 fileSize = node.GetSize();
+    const ui64 maxFileSize =
+        config.GetReadDataOnReadOnlyCreateHandleMaxFileSize();
+
+    return fileSize && maxFileSize && fileSize <= maxFileSize;
 }
 
 }   // namespace
@@ -526,6 +569,42 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
     }
 }
 
+void TIndexTabletActor::StartReadDataForCreateHandle(
+    const TActorContext& ctx,
+    TTxIndexTablet::TCreateHandle& args)
+{
+    const auto& node = args.Response.GetNodeAttr();
+
+    NProto::TReadDataRequest request;
+    request.MutableHeaders()->CopyFrom(args.Request.GetHeaders());
+    request.SetFileSystemId(args.Request.GetFileSystemId());
+    request.SetNodeId(node.GetId());
+    request.SetHandle(args.Response.GetHandle());
+    request.SetOffset(0);
+    request.SetLength(node.GetSize());
+
+    const TByteRange byteRange(
+        request.GetOffset(),
+        request.GetLength(),
+        GetBlockSize());
+    const TByteRange alignedByteRange = byteRange.AlignedSuperRange();
+    auto blockBuffer = CreateBlockBuffer(alignedByteRange);
+
+    TMaybe<NProto::TCreateHandleResponse> response;
+    response.ConstructInPlace(std::move(args.Response));
+
+    ExecuteTx<TReadData>(
+        ctx,
+        args.RequestInfo,
+        request,
+        byteRange,
+        alignedByteRange,
+        std::move(blockBuffer),
+        false /* describeOnly */,
+        std::move(response),
+        std::move(args.ProfileLogRequest));
+}
+
 void TIndexTabletActor::CompleteCreateHandle(
     const TActorContext& ctx,
     TTxIndexTablet::TCreateHandle& args)
@@ -564,6 +643,11 @@ void TIndexTabletActor::CompleteCreateHandle(
             args.OpLogEntry.GetEntryId(),
             std::move(args.Response));
 
+        return;
+    }
+
+    if (ShouldReadDataOnCreateHandle(*Config, args)) {
+        StartReadDataForCreateHandle(ctx, args);
         return;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -345,6 +345,9 @@ private:
     IProfileLogPtr ProfileLog;
     NProto::TBackendInfo BackendInfo;
     NProto::TProfileLogRequestInfo ProfileLogRequest;
+    TMaybe<NProto::TCreateHandleResponse> CreateHandleResponse;
+    TString CreateHandleSessionId;
+    ui64 CreateHandleRequestId = 0;
 
 public:
     TReadDataActor(
@@ -365,7 +368,10 @@ public:
         TSet<ui32> mixedBlocksRanges,
         IProfileLogPtr profileLog,
         NProto::TBackendInfo backendInfo,
-        NProto::TTProfileLogRequestInfo profileLogRequest);
+        NProto::TProfileLogRequestInfo profileLogRequest,
+        TMaybe<NProto::TCreateHandleResponse> createHandleResponse,
+        TString createHandleSessionId,
+        ui64 createHandleRequestId);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -406,7 +412,10 @@ TReadDataActor::TReadDataActor(
         TSet<ui32> mixedBlocksRanges,
         IProfileLogPtr profileLog,
         NProto::TBackendInfo backendInfo,
-        NProto::TTProfileLogRequestInfo profileLogRequest)
+        NProto::TProfileLogRequestInfo profileLogRequest,
+        TMaybe<NProto::TCreateHandleResponse> createHandleResponse,
+        TString createHandleSessionId,
+        ui64 createHandleRequestId)
     : TraceSerializer(std::move(traceSerializer))
     , LogTag(std::move(logTag))
     , FileSystemId(std::move(fileSystemId))
@@ -425,6 +434,9 @@ TReadDataActor::TReadDataActor(
     , ProfileLog(std::move(profileLog))
     , BackendInfo(std::move(backendInfo))
     , ProfileLogRequest(std::move(profileLogRequest))
+    , CreateHandleResponse(std::move(createHandleResponse))
+    , CreateHandleSessionId(std::move(createHandleSessionId))
+    , CreateHandleRequestId(createHandleRequestId)
 {
     TABLET_VERIFY(ActualRange.IsAligned());
 }
@@ -508,7 +520,9 @@ void TReadDataActor::ReplyAndDie(
             1,
             OriginByteRange.Length,
             ctx.Now() - RequestInfo->StartedTs,
-            BackendInfo.GetIsOverloaded());
+            BackendInfo.GetIsOverloaded(),
+            CreateHandleSessionId,
+            CreateHandleRequestId);
 
         NCloud::Send(ctx, Tablet, std::move(response));
     }
@@ -519,18 +533,50 @@ void TReadDataActor::ReplyAndDie(
         "ReadData");
 
     if (RequestInfo->Sender != Tablet) {
-        // reply to caller
-        auto response = std::make_unique<TEvService::TEvReadDataResponse>(error);
-        if (SUCCEEDED(error.GetCode())) {
-            CopyFileData(
-                LogTag,
-                OriginByteRange,
-                ActualRange,
-                TotalSize,
-                *Buffer,
-                response->Record.MutableBuffer());
+        auto copyData = [&] (auto& record) {
+            if (SUCCEEDED(error.GetCode())) {
+                CopyFileData(
+                    LogTag,
+                    OriginByteRange,
+                    ActualRange,
+                    TotalSize,
+                    *Buffer,
+                    record.MutableBuffer());
+            }
+        };
 
-            if (ShouldCalculateChecksums) {
+        auto completeResponse = [&] (auto& record, const char* requestName) {
+            const bool builtTraceInfo = BuildTraceInfo(
+                TraceSerializer,
+                RequestInfo->CallContext,
+                record);
+            LOG_DEBUG(ctx, TFileStoreComponents::TABLET_WORKER,
+                "%s %s: #%lu completed (%s), trace-info: %d",
+                LogTag.c_str(),
+                requestName,
+                RequestInfo->CallContext->RequestId,
+                FormatError(record.GetError()).c_str(),
+                builtTraceInfo);
+            BuildThrottlerInfo(*RequestInfo->CallContext, record);
+            *record.MutableHeaders()->MutableBackendInfo() =
+                std::move(BackendInfo);
+        };
+
+        if (CreateHandleResponse) {
+            auto response =
+                std::make_unique<TEvService::TEvCreateHandleResponse>();
+            response->Record = std::move(CreateHandleResponse.GetRef());
+
+            copyData(response->Record);
+            completeResponse(response->Record, "CreateHandle read-ahead");
+
+            NCloud::Reply(ctx, *RequestInfo, std::move(response));
+        } else {
+            auto response =
+                std::make_unique<TEvService::TEvReadDataResponse>(error);
+            copyData(response->Record);
+
+            if (SUCCEEDED(error.GetCode()) && ShouldCalculateChecksums) {
                 CalculateChecksums(
                     response->Record.GetBuffer(),
                     BlockSize,
@@ -538,23 +584,11 @@ void TReadDataActor::ReplyAndDie(
                     FileSystemId,
                     ProfileLogRequest);
             }
+
+            completeResponse(response->Record, "ReadData");
+
+            NCloud::Reply(ctx, *RequestInfo, std::move(response));
         }
-
-        const bool builtTraceInfo = BuildTraceInfo(
-            TraceSerializer,
-            RequestInfo->CallContext,
-            response->Record);
-        LOG_DEBUG(ctx, TFileStoreComponents::TABLET_WORKER,
-            "%s ReadData: #%lu completed (%s), trace-info: %d",
-            LogTag.c_str(),
-            RequestInfo->CallContext->RequestId,
-            FormatError(response->Record.GetError()).c_str(),
-            builtTraceInfo);
-        BuildThrottlerInfo(*RequestInfo->CallContext, response->Record);
-        *response->Record.MutableHeaders()->MutableBackendInfo() =
-            std::move(BackendInfo);
-
-        NCloud::Reply(ctx, *RequestInfo, std::move(response));
     }
 
     FinalizeProfileLogRequestInfo(
@@ -675,6 +709,7 @@ void TIndexTabletActor::HandleReadData(
         alignedByteRange,
         std::move(blockBuffer),
         false /* describeOnly */,
+        TMaybe<NProto::TCreateHandleResponse>(),
         std::move(profileLogRequest));
 }
 
@@ -691,6 +726,12 @@ void TIndexTabletActor::HandleReadDataCompleted(
     Metrics.ReadData.Update(msg->Count, msg->Size, msg->Time);
     if (msg->IsOverloaded) {
         Metrics.OverloadedCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    if (msg->CreateHandleRequestId) {
+        CommitDupCacheEntry(
+            msg->CreateHandleSessionId,
+            msg->CreateHandleRequestId);
     }
 }
 
@@ -813,6 +854,7 @@ void TIndexTabletActor::HandleDescribeData(
         alignedByteRange,
         std::move(blockBuffer),
         true /* describeOnly */,
+        TMaybe<NProto::TCreateHandleResponse>(),
         std::move(profileLogRequest));
 }
 
@@ -1003,6 +1045,52 @@ void TIndexTabletActor::CompleteTx_ReadData(
         ReleaseMixedBlocks(args.MixedBlocksRanges);
     };
 
+    if (args.CreateHandleResponse &&
+        (HasError(args.Error) || !ShouldReadBlobs(args.Blocks)))
+    {
+        auto response = std::make_unique<TEvService::TEvCreateHandleResponse>();
+        response->Record = std::move(args.CreateHandleResponse.GetRef());
+
+        if (!HasError(args.Error)) {
+            ApplyBytes(
+                LogTag,
+                args.ActualRange(),
+                std::move(args.Bytes),
+                *args.Buffer);
+
+            CopyFileData(
+                LogTag,
+                args.OriginByteRange,
+                args.ActualRange(),
+                args.Node->Attrs.GetSize(),
+                *args.Buffer,
+                response->Record.MutableBuffer());
+        }
+
+        CommitDupCacheEntry(args.SessionId, args.RequestId);
+
+        auto& requestMetrics = args.ProfileLogRequest.GetBehaveAsShard()
+            ? Metrics.CreateHandleInShard
+            : Metrics.CreateHandle;
+        requestMetrics.Update(1, 0, ctx.Now() - args.RequestInfo->StartedTs);
+
+        CompleteResponse<TEvService::TCreateHandleMethod>(
+            response->Record,
+            args.RequestInfo->CallContext,
+            ctx);
+
+        NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+
+        FinalizeProfileLogRequestInfo(
+            std::move(args.ProfileLogRequest),
+            ctx.Now(),
+            GetFileSystemId(),
+            MakeError(S_OK),
+            ProfileLog);
+
+        return;
+    }
+
     if (args.DescribeOnly && !HasError(args.Error)) {
         if (args.ReadAheadRange) {
             NProtoPrivate::TDescribeDataResponse record;
@@ -1154,7 +1242,10 @@ void TIndexTabletActor::CompleteTx_ReadData(
         std::move(args.MixedBlocksRanges),
         ProfileLog,
         std::move(backendInfo),
-        std::move(args.ProfileLogRequest));
+        std::move(args.ProfileLogRequest),
+        std::move(args.CreateHandleResponse),
+        args.SessionId,
+        args.RequestId);
 
     auto actorId = NCloud::Register(ctx, std::move(actor));
     WorkerActors.insert(actorId);

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -2069,6 +2069,7 @@ struct TTxIndexTablet
         const TByteRange AlignedByteRange;
         /*const*/ IBlockBufferPtr Buffer;
         const bool DescribeOnly;
+        TMaybe<NProto::TCreateHandleResponse> CreateHandleResponse;
         // Used when we want to read data from a specific node, not the node
         // inferred from the handle.
         const ui64 ExplicitNodeId = InvalidNodeId;
@@ -2091,6 +2092,7 @@ struct TTxIndexTablet
                 TByteRange alignedByteRange,
                 IBlockBufferPtr buffer,
                 bool describeOnly,
+                TMaybe<NProto::TCreateHandleResponse> createHandleResponse,
                 NProto::TProfileLogRequestInfo profileLogRequest)
             : TSessionAware(request)
             , TProfileAware(std::move(profileLogRequest))
@@ -2100,6 +2102,7 @@ struct TTxIndexTablet
             , AlignedByteRange(alignedByteRange)
             , Buffer(std::move(buffer))
             , DescribeOnly(describeOnly)
+            , CreateHandleResponse(std::move(createHandleResponse))
             , ExplicitNodeId(request.GetNodeId())
             , Blocks(AlignedByteRange.BlockCount())
             , Bytes(AlignedByteRange.BlockCount())

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -85,6 +85,9 @@ void TFileSystem::Reset()
 {
     STORAGE_INFO("resetting filesystem cache");
     DirectoryHandleCache->Reset();
+    with_lock (ReadDataLock) {
+        ReadDataByHandle.clear();
+    }
 }
 
 void TFileSystem::ScheduleProcessHandleOpsQueue()

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.h
@@ -100,6 +100,9 @@ private:
     TQueue<TReleaseRequest> DelayedReleaseQueue;
     TMutex DelayedReleaseQueueLock;
 
+    THashMap<ui64, TString> ReadDataByHandle;
+    TMutex ReadDataLock;
+
     TWriteBackCache WriteBackCache;
 
     std::atomic<ui64> GlobalAttrVersion = 1;
@@ -465,6 +468,15 @@ private:
         fuse_ino_t ino,
         ui64 handle,
         const NCloud::NProto::TError& writeBackCacheError);
+    void StoreReadData(
+        ui64 handle,
+        TString data);
+    bool TryGetReadData(
+        ui64 handle,
+        ui64 offset,
+        ui32 length,
+        TString* data);
+    void DropReadData(ui64 handle);
     void CompleteAsyncDestroyHandle(
         TCallContext& callContext,
         const NProto::TDestroyHandleResponse& response);

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -119,6 +119,50 @@ void FillWriteDataIovecs(
 ////////////////////////////////////////////////////////////////////////////////
 // read & write files
 
+void TFileSystem::StoreReadData(
+    ui64 handle,
+    TString data)
+{
+    if (!handle || data.empty()) {
+        return;
+    }
+
+    with_lock (ReadDataLock) {
+        ReadDataByHandle[handle] = std::move(data);
+    }
+}
+
+bool TFileSystem::TryGetReadData(
+    ui64 handle,
+    ui64 offset,
+    ui32 length,
+    TString* data)
+{
+    with_lock (ReadDataLock) {
+        auto it = ReadDataByHandle.find(handle);
+        if (it == ReadDataByHandle.end()) {
+            return false;
+        }
+
+        const auto& buffer = it->second;
+        if (offset >= buffer.size()) {
+            data->clear();
+            return true;
+        }
+
+        const ui64 size = Min<ui64>(length, buffer.size() - offset);
+        *data = buffer.substr(offset, size);
+        return true;
+    }
+}
+
+void TFileSystem::DropReadData(ui64 handle)
+{
+    with_lock (ReadDataLock) {
+        ReadDataByHandle.erase(handle);
+    }
+}
+
 void TFileSystem::Create(
     TCallContextPtr callContext,
     fuse_req_t req,
@@ -170,6 +214,11 @@ void TFileSystem::Create(
             self->FSyncQueue->Dequeue(reqId, error, TNodeId {parent});
 
             if (CheckResponse(self, *callContext, req, response)) {
+                if (!response.GetBuffer().empty()) {
+                    self->StoreReadData(
+                        response.GetHandle(),
+                        response.GetBuffer());
+                }
                 self->ReplyCreateWithCache(
                     *callContext,
                     error,
@@ -222,7 +271,11 @@ void TFileSystem::Open(
                 {
                     fi.keep_cache = 1;
                 }
-
+                if (!response.GetBuffer().empty()) {
+                    self->StoreReadData(
+                        response.GetHandle(),
+                        response.GetBuffer());
+                }
                 self->ReplyOpen(*callContext, response.GetError(), req, &fi);
             }
         });
@@ -272,6 +325,8 @@ void TFileSystem::ReleaseImpl(
     ui64 handle,
     const NCloud::NProto::TError& writeBackCacheError)
 {
+    DropReadData(handle);
+
     // If WriteBackCache was used, Release() previously asked it to flush the
     // data related to this handle and release the references to it. It could
     // return an error if data has been lost due to flush failure.
@@ -387,6 +442,20 @@ void TFileSystem::Read(
     callContext->Unaligned = !IsAligned(offset, Config->GetBlockSize())
         || !IsAligned(size, Config->GetBlockSize());
 
+    const auto strategy = GetWriteBackCacheRequestStrategy(fi);
+    if (strategy == EWriteBackCacheRequestStrategy::DoNotUse) {
+        TString data;
+        if (TryGetReadData(fi->fh, offset, size, &data)) {
+            ReplyBuf(
+                *callContext,
+                {},
+                req,
+                data.empty() ? nullptr : data.data(),
+                data.size());
+            return;
+        }
+    }
+
     auto request = StartRequest<NProto::TReadDataRequest>(ino);
     request->SetHandle(fi->fh);
     request->SetOffset(offset);
@@ -435,8 +504,6 @@ void TFileSystem::Read(
             }
         }
     };
-
-    const auto strategy = GetWriteBackCacheRequestStrategy(fi);
 
     switch (strategy) {
         case EWriteBackCacheRequestStrategy::DoNotUse: {

--- a/cloud/filestore/public/api/protos/data.proto
+++ b/cloud/filestore/public/api/protos/data.proto
@@ -90,6 +90,9 @@ message TCreateHandleResponse
     // kernel this refers to the page cache
     bool GuestKeepCache = 6;
 
+    // Optional full file contents for small read-only non-direct opens.
+    bytes Buffer = 7;
+
     // Optional response headers.
     TResponseHeaders Headers = 1000;
 }

--- a/cloud/filestore/tests/read_ahead/grep_mount/disabled/nfs-storage.txt
+++ b/cloud/filestore/tests/read_ahead/grep_mount/disabled/nfs-storage.txt
@@ -1,0 +1,2 @@
+ReadDataOnReadOnlyCreateHandleEnabled: false
+ReadDataOnReadOnlyCreateHandleMaxFileSize: 4096

--- a/cloud/filestore/tests/read_ahead/grep_mount/disabled/test.py
+++ b/cloud/filestore/tests/read_ahead/grep_mount/disabled/test.py
@@ -1,0 +1,5 @@
+import cloud.filestore.tests.read_ahead.grep_mount.lib as grep_mount
+
+
+def test_grep_read_ahead_disabled():
+    grep_mount.run_grep_read_ahead_benchmark("disabled")

--- a/cloud/filestore/tests/read_ahead/grep_mount/disabled/ya.make
+++ b/cloud/filestore/tests/read_ahead/grep_mount/disabled/ya.make
@@ -1,0 +1,37 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+SRCDIR(${ARCADIA_ROOT}/cloud/filestore/tests/read_ahead/grep_mount)
+
+TAG(ya:manual)
+SPLIT_FACTOR(1)
+
+TEST_SRCS(
+    test.py
+)
+
+DEPENDS(
+    cloud/filestore/tools/analytics/profile_tool
+)
+
+PEERDIR(
+    cloud/filestore/tests/read_ahead/grep_mount/lib
+    cloud/filestore/tests/python/lib
+    cloud/filestore/tools/testing/profile_log
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/read_ahead/grep_mount/disabled/nfs-storage.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_INVOKE_TEST NO)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/read_ahead/grep_mount/enabled/nfs-storage.txt
+++ b/cloud/filestore/tests/read_ahead/grep_mount/enabled/nfs-storage.txt
@@ -1,0 +1,2 @@
+ReadDataOnReadOnlyCreateHandleEnabled: true
+ReadDataOnReadOnlyCreateHandleMaxFileSize: 4096

--- a/cloud/filestore/tests/read_ahead/grep_mount/enabled/test.py
+++ b/cloud/filestore/tests/read_ahead/grep_mount/enabled/test.py
@@ -1,0 +1,5 @@
+import cloud.filestore.tests.read_ahead.grep_mount.lib as grep_mount
+
+
+def test_grep_read_ahead_enabled():
+    grep_mount.run_grep_read_ahead_benchmark("enabled")

--- a/cloud/filestore/tests/read_ahead/grep_mount/enabled/ya.make
+++ b/cloud/filestore/tests/read_ahead/grep_mount/enabled/ya.make
@@ -1,0 +1,37 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/medium.inc)
+SRCDIR(${ARCADIA_ROOT}/cloud/filestore/tests/read_ahead/grep_mount)
+
+TAG(ya:manual)
+SPLIT_FACTOR(1)
+
+TEST_SRCS(
+    test.py
+)
+
+DEPENDS(
+    cloud/filestore/tools/analytics/profile_tool
+)
+
+PEERDIR(
+    cloud/filestore/tests/read_ahead/grep_mount/lib
+    cloud/filestore/tests/python/lib
+    cloud/filestore/tools/testing/profile_log
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+SET(
+    NFS_STORAGE_CONFIG_PATCH
+    cloud/filestore/tests/read_ahead/grep_mount/enabled/nfs-storage.txt
+)
+
+SET(QEMU_VIRTIO fs)
+SET(QEMU_INVOKE_TEST NO)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
+
+END()

--- a/cloud/filestore/tests/read_ahead/grep_mount/lib/__init__.py
+++ b/cloud/filestore/tests/read_ahead/grep_mount/lib/__init__.py
@@ -1,0 +1,175 @@
+import json
+import os
+import shlex
+
+import cloud.filestore.tools.testing.profile_log.common as profile
+import yatest.common as common
+
+from cloud.filestore.tests.python.lib.common import flush_logs
+from cloud.storage.core.tools.testing.qemu.lib.common import SshToGuest
+
+
+FILE_SYSTEM_ID = "nfs_test"
+FILE_COUNT = 1024
+FILES_PER_DIR = 32
+PATTERN = "READ_AHEAD_GREP_PATTERN"
+PROFILE_REQUESTS = ("CreateHandle", "DescribeData", "ReadData", "ReadBlob")
+
+
+def _make_payload(index):
+    prefix = f"{PATTERN} file={index:04d}\n"
+    body = "abcdefghijklmnopqrstuvwxyz0123456789\n" * 24
+    return (prefix + body).encode("utf-8")
+
+
+def _ssh():
+    port = int(os.getenv("QEMU_FORWARDING_PORT"))
+    ssh_key = os.getenv("QEMU_SSH_KEY")
+    return SshToGuest(user="qemu", port=port, key=ssh_key)
+
+
+def _run_root_script(ssh, script, timeout=120):
+    return ssh(f"sudo bash -s <<'BASH'\n{script}\nBASH", timeout=timeout)
+
+
+def _populate_files(ssh, root):
+    script = f"""
+set -euo pipefail
+root={shlex.quote(root)}
+pattern={shlex.quote(PATTERN)}
+files={FILE_COUNT}
+files_per_dir={FILES_PER_DIR}
+
+rm -rf "$root"
+mkdir -p "$root"
+
+for i in $(seq 0 $((files - 1))); do
+    dir=$(printf "%s/dir-%03d" "$root" $((i / files_per_dir)))
+    mkdir -p "$dir"
+
+    file=$(printf "%s/file-%04d.txt" "$dir" "$i")
+    {{
+        printf "%s file=%04d\\n" "$pattern" "$i"
+        for _ in $(seq 1 24); do
+            printf "abcdefghijklmnopqrstuvwxyz0123456789\\n"
+        done
+    }} > "$file"
+done
+
+sync
+"""
+    _run_root_script(ssh, script)
+    return len(_make_payload(0))
+
+
+def _drop_guest_caches(ssh):
+    _run_root_script(ssh, "sync\necho 3 > /proc/sys/vm/drop_caches")
+
+
+def _run_grep(ssh, root):
+    script = f"""
+set -euo pipefail
+root={shlex.quote(root)}
+pattern={shlex.quote(PATTERN)}
+files={FILE_COUNT}
+
+start=$(date +%s%N)
+matches=$(grep -r "$pattern" "$root" | wc -l)
+end=$(date +%s%N)
+
+if [ "$matches" -ne "$files" ]; then
+    echo "expected $files grep matches, got $matches" >&2
+    exit 1
+fi
+
+elapsed_us=$(((end - start) / 1000))
+printf 'READ_AHEAD_GREP_RESULT {{"elapsed_us":%s,"matches":%s}}\\n' \\
+    "$elapsed_us" "$matches"
+"""
+    ret = _run_root_script(ssh, script)
+
+    for line in ret.stdout.decode("utf-8").splitlines():
+        if line.startswith("READ_AHEAD_GREP_RESULT "):
+            return json.loads(line.removeprefix("READ_AHEAD_GREP_RESULT "))
+
+    raise AssertionError(
+        "missing grep result line; stdout={}".format(
+            ret.stdout.decode("utf-8", errors="replace")))
+
+
+def _profile_counts(log_name):
+    profile_tool_bin_path = common.binary_path(
+        "cloud/filestore/tools/analytics/profile_tool/filestore-profile-tool")
+    return profile.analyze_profile_log(
+        profile_tool_bin_path,
+        common.output_path(log_name),
+        FILE_SYSTEM_ID)
+
+
+def _profile_delta(before, after):
+    keys = sorted(set(before) | set(after) | set(PROFILE_REQUESTS))
+    return {
+        key: after.get(key, 0) - before.get(key, 0)
+        for key in keys
+        if key in PROFILE_REQUESTS or after.get(key, 0) - before.get(key, 0)
+    }
+
+
+def _assert_expected_path(result):
+    nfs_delta = result["nfs_profile_delta"]
+    vhost_delta = result["vhost_profile_delta"]
+
+    if result["case"] == "enabled":
+        assert nfs_delta["DescribeData"] == 0
+        assert nfs_delta["ReadData"] == 0
+        assert nfs_delta["ReadBlob"] == FILE_COUNT
+        assert vhost_delta["ReadData"] == 0
+        assert vhost_delta["ReadBlob"] == 0
+    else:
+        assert nfs_delta["DescribeData"] == 0
+        assert nfs_delta["ReadData"] == FILE_COUNT
+        assert nfs_delta["ReadBlob"] == FILE_COUNT
+        assert vhost_delta["ReadData"] == FILE_COUNT
+        assert vhost_delta["ReadBlob"] == 0
+
+
+def run_grep_read_ahead_benchmark(case_name):
+    ssh = _ssh()
+    primary_mount = os.getenv("NFS_MOUNT_PATH")
+    workload_name = f"read_ahead_grep_{case_name}"
+    workload_root = os.path.join(primary_mount, workload_name)
+
+    bytes_per_file = _populate_files(ssh, workload_root)
+    _drop_guest_caches(ssh)
+    flush_logs()
+
+    initial_vhost_profile = _profile_counts("vhost-profile.log")
+    initial_nfs_profile = _profile_counts("nfs-profile.log")
+
+    grep_result = _run_grep(ssh, workload_root)
+    flush_logs()
+
+    final_vhost_profile = _profile_counts("vhost-profile.log")
+    final_nfs_profile = _profile_counts("nfs-profile.log")
+
+    result = {
+        "case": case_name,
+        "elapsed_sec": round(grep_result["elapsed_us"] / 1_000_000, 6),
+        "files": FILE_COUNT,
+        "bytes_per_file": bytes_per_file,
+        "matches": grep_result["matches"],
+        "nfs_profile_delta": _profile_delta(
+            initial_nfs_profile,
+            final_nfs_profile),
+        "vhost_profile_delta": _profile_delta(
+            initial_vhost_profile,
+            final_vhost_profile),
+    }
+    _assert_expected_path(result)
+
+    result_path = common.output_path(f"grep-read-ahead-{case_name}.json")
+    with open(result_path, "w") as f:
+        json.dump(result, f, sort_keys=True)
+        f.write("\n")
+
+    print("READ_AHEAD_GREP_RESULT " + json.dumps(result, sort_keys=True))

--- a/cloud/filestore/tests/read_ahead/grep_mount/lib/ya.make
+++ b/cloud/filestore/tests/read_ahead/grep_mount/lib/ya.make
@@ -1,0 +1,13 @@
+PY3_LIBRARY()
+
+PEERDIR(
+    cloud/filestore/tests/python/lib
+    cloud/filestore/tools/testing/profile_log
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+PY_SRCS(
+    __init__.py
+)
+
+END()

--- a/cloud/filestore/tests/read_ahead/grep_mount/ya.make
+++ b/cloud/filestore/tests/read_ahead/grep_mount/ya.make
@@ -1,0 +1,8 @@
+RECURSE(
+    lib
+)
+
+RECURSE_FOR_TESTS(
+    disabled
+    enabled
+)

--- a/cloud/filestore/tests/read_ahead/ya.make
+++ b/cloud/filestore/tests/read_ahead/ya.make
@@ -1,0 +1,3 @@
+RECURSE_FOR_TESTS(
+    grep_mount
+)

--- a/cloud/filestore/tests/ya.make
+++ b/cloud/filestore/tests/ya.make
@@ -27,6 +27,7 @@ RECURSE_FOR_TESTS(
     lease_expiration
     loadtest
     profile_log
+    read_ahead
     registration
     scheme_cache
     service


### PR DESCRIPTION
### Notes
Experiment with returning full file contents (not DescribeDataResponse) for small files on CreateHandle
* for the `grep -r` test: 10-15% performance gain (however, the affected load is not isolated, for example grep of course does `close` which is unaffected -> real performance gain can be higher, or lower due to real network conditions)
* unbounded cache for small files (can be converted to LRU/limited by size)
* if we return DescribeDataResponse, we need to read data from service side and I haven't managed to improve performance in such case. Also, we cannot simply use DescribeDataResponse in CreateHandleResponse, as describe data is part of private protocol
* no unit tests

### Issue
https://github.com/ydb-platform/nbs/issues/5444
