### PR TITLE
[Filestore] Remove latency histogram metrics from tablet-side metrics

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/request_metrics.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/request_metrics.cpp
@@ -14,7 +14,6 @@ void TTabletRequestMetrics::Update(
     TimeSumUs.fetch_add(
         d.MicroSeconds(),
         std::memory_order_relaxed);
-    Time.Record(d);
 }
 
 void TTabletRequestMetrics::UpdatePrev(TInstant now)

--- a/cloud/filestore/libs/storage/tablet/model/request_metrics.h
+++ b/cloud/filestore/libs/storage/tablet/model/request_metrics.h
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <cloud/filestore/libs/diagnostics/metrics/histogram.h>
+#include <util/datetime/base.h>
+#include <util/system/types.h>
+
+#include <atomic>
 
 namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
-
-using TLatHistogram =
-    NMetrics::THistogram<NMetrics::EHistUnit::HU_TIME_MICROSECONDS>;
 
 struct TTabletRequestMetrics
 {
     std::atomic<i64> Count = 0;
     std::atomic<i64> RequestBytes = 0;
     std::atomic<i64> TimeSumUs = 0;
-    TLatHistogram Time;
 
     ui64 PrevCount = 0;
     ui64 PrevRequestBytes = 0;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -302,7 +302,7 @@ void TIndexTabletActor::HandleGenerateBlobIds(
     const TEvIndexTablet::TEvGenerateBlobIdsRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    auto startedTs = ctx.Now();
+    const auto startedTs = ctx.Now();
 
     auto* msg = ev->Get();
 
@@ -446,17 +446,16 @@ void TIndexTabletActor::HandleGenerateBlobIds(
             response->Record);
     }
 
-    Metrics.GenerateBlobIds.Count.fetch_add(1, std::memory_order_relaxed);
     ui64 generateBlobIdsBytes = msg->Record.GetLength();
     if (canUseUnconfirmed) {
         for (const auto& part: msg->Record.GetUnalignedDataRanges()) {
             generateBlobIdsBytes += part.GetContent().size();
         }
     }
-    Metrics.GenerateBlobIds.RequestBytes.fetch_add(
+    Metrics.GenerateBlobIds.Update(
+        1,
         generateBlobIdsBytes,
-        std::memory_order_relaxed);
-    Metrics.GenerateBlobIds.Time.Record(ctx.Now() - startedTs);
+        ctx.Now() - startedTs);
 
     NCloud::Reply(ctx, *ev, std::move(response));
 

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -365,9 +365,6 @@ void TTabletMetrics::Register(
         EAggregationType::AT_SUM,                                              \
         EMetricType::MT_DERIVATIVE);                                           \
                                                                                \
-    name.Time.Register(                                                        \
-        AggregatableFsRegistry,                                                \
-        {CreateLabel("request", #name), CreateLabel("histogram", "Time")});    \
 // FILESTORE_TABLET_METRICS_REGISTER_REQUEST
 
     FILESTORE_TABLET_METRICS_REQUESTS(FILESTORE_TABLET_METRICS_REGISTER_REQUEST)

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -4,8 +4,10 @@
 
 #include "tablet_tx.h"
 
+#include <cloud/filestore/libs/diagnostics/metrics/histogram.h>
 #include <cloud/filestore/libs/diagnostics/metrics/public.h>
 #include <cloud/filestore/libs/diagnostics/metrics/window_calculator.h>
+
 #include <cloud/filestore/libs/storage/api/tablet.h>
 #include <cloud/filestore/libs/storage/core/tablet_counters.h>
 #include <cloud/filestore/libs/storage/model/block_buffer.h>
@@ -254,6 +256,9 @@ struct TTabletMetrics
     std::atomic<i64> OrphanNodesCount{0};
 
     NMetrics::TDefaultWindowCalculator MaxUsedQuota{0};
+
+    using TLatHistogram =
+        NMetrics::THistogram<NMetrics::EHistUnit::HU_TIME_MICROSECONDS>;
     TLatHistogram ReadDataPostponed;
     TLatHistogram WriteDataPostponed;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_counters.cpp
@@ -416,42 +416,6 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Counters)
         }
 
         registry->Visit(TInstant::Zero(), Visitor);
-        Visitor.ValidateExpectedHistogram({
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "WriteBlob"}}, 0},
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "ReadBlob"}}, 0},
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "WriteData"}}, 0},
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "ReadData"}}, 0},
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "DescribeData"}}, 0},
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "GenerateBlobIds"}}, 0},
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "AddData"}}, 0},
-        }, false);
-        Visitor.ValidateExpectedHistogram({
-            {{
-                {"histogram", "Time"},
-                {"filesystem", "test"},
-                {"request", "PatchBlob"}}, 0},
-        }, true);
         Visitor.ValidateExpectedCounters({
             {{
                 {"sensor", "Count"},


### PR DESCRIPTION
### Notes
These histograms are too excessive and produce too many unused metrics – better to separately add quantile calculations

### Issue
Simple change, no issue
