### PR TITLE
TTraceProcessorTest::ShouldProcessLotsOfTracks ut tsan race fix

### DIFF
--- a/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
+++ b/cloud/storage/core/libs/diagnostics/trace_processor_mon_ut.cpp
@@ -244,27 +244,24 @@ Y_UNIT_TEST_SUITE(TTraceProcessorTest)
         });
         tp->Start();
 
-        auto threadPool = CreateThreadPool(20);
-        const auto runs = 100;
+        const ui32 runs = 100;
         // lwtrace depot sizes are limited by 1000
         static_assert(runs <= 1000 / REQUEST_COUNT);
 
-        auto doRuns = [&]()
-        {
-            std::latch enqueued{runs};
-
-            for (size_t j = 0; j < runs; ++j) {
-                threadPool->SafeAddFunc(
-                    [&enqueued]()
-                    {
+        auto doRuns = [&] () {
+            std::atomic<ui32> completed = 0;
+            TDeque<THolder<IThreadFactory::IThread>> threads;
+            for (ui32 i = 0; i < 20; ++i) {
+                threads.push_back(SystemThreadFactory()->Run([&]() {
+                    while (completed.fetch_add(1) < runs) {
                         Track();
-
-                        enqueued.count_down();
-                    });
+                    }
+                }));
             }
 
-
-            enqueued.wait();
+            for (auto& t: threads) {
+                t->Join();
+            }
         };
 
         doRuns();
@@ -278,8 +275,6 @@ Y_UNIT_TEST_SUITE(TTraceProcessorTest)
         doRuns();
 
         Check(env, requestCount);
-
-        threadPool->Stop();
     }
 
     Y_UNIT_TEST(SlowRequestThresholdByTrackLength)


### PR DESCRIPTION
### Notes
Fixing the following race:
<h1 id="FAIL"></h1>
    
    
test name | elapsed | status | LOG
-- | -- | -- | --
cloud/storage/core/libs/diagnostics/ut/TTraceProcessorTest.ShouldProcessLotsOfTracks | 1.642s | FAIL | DIR \|                                            STDERR

test name 	elapsed 	status 	LOG
cloud/storage/core/libs/diagnostics/ut/TTraceProcessorTest.ShouldProcessLotsOfTracks 	1.642s 	FAIL 	[DIR](https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/PR-check/28152735819/1/nebius-x86-64-tsan/test_data/1/actions-runner/_work/nbs/nbs/cloud/storage/core/libs/diagnostics/ut/test-results/unittest/testing_out_stuff/index.html) | [STDERR](https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/PR-check/28152735819/1/nebius-x86-64-tsan/logs/1/cloud/storage/core/libs/diagnostics/ut/test-results/unittest/testing_out_stuff/TTraceProcessorTest.ShouldProcessLotsOfTracks.err)

`TEnv::LWManager` destruction races with per-thread `NLWTrace::TCyclicLogImpl<NLWTrace::TTrackLog>::TStorage` destruction which is stored in tls for each of the test threads. 

Fix: replaced `TThreadPool` usage in this test with explicit thread usage + `Join()`s

### Issue
none