### PR TITLE
issue-6334: Validate that the external payload conform to the ReadDataRequest and the ReadDataResponse

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -753,7 +753,7 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
                     break;
                 }
                 TRopeUtils::Memcpy(
-                    reinterpret_cast<char*>(iovec.GetBase()),
+                    reinterpret_cast<char*>(iovec.GetBase()) + iovecOffset,
                     it,
                     dataToWrite);
                 remainingBufferSize -= dataToWrite;

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -789,11 +789,12 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
         }
     } else {
         auto& buffer = *readDataResponse.MutableBuffer();
-        buffer.ReserveAndResize(bufferSize);
+        buffer.ReserveAndResize(
+            bufferSize - readDataResponse.GetBufferOffset());
         TRopeUtils::Memcpy(
             buffer.begin(),
             it,
-            payload.size() - readDataResponse.GetBufferOffset());
+            bufferSize - readDataResponse.GetBufferOffset());
     }
 
     // Set the buffer offset to 0 because the response buffer/iovecs do not

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -740,14 +740,15 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
                 << bufferSize << " Actual size: " << payload.size());
     }
 
-    ui64 remainingBufferSize = bufferSize;
-    auto it = payload.begin();
+    auto it = payload.begin() + readDataResponse.GetBufferOffset();
     if (!ReadRequest.GetIovecs().empty()) {
+        ui64 remainingBufferSize =
+            bufferSize - readDataResponse.GetBufferOffset();
         for (auto& iovec: ReadRequest.GetIovecs()) {
-            ui64 currentOffset = 0;
-            while (iovec.GetLength() > currentOffset) {
+            ui64 iovecOffset = 0;
+            while (iovec.GetLength() > iovecOffset) {
                 ui64 dataToWrite =
-                    Min(iovec.GetLength() - currentOffset, remainingBufferSize);
+                    Min(iovec.GetLength() - iovecOffset, remainingBufferSize);
                 if (dataToWrite == 0) {
                     break;
                 }
@@ -756,25 +757,24 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
                     it,
                     dataToWrite);
                 remainingBufferSize -= dataToWrite;
-                currentOffset += dataToWrite;
+                iovecOffset += dataToWrite;
                 it += dataToWrite;
             }
+        }
+
+        if (remainingBufferSize != 0) {
+            return MakeError(
+                E_BADMSG,
+                TStringBuilder()
+                    << "Failed to read buffer from payload. "
+                       " Expected buffer size: "
+                    << bufferSize << " Actual bytes copied from payload: "
+                    << bufferSize - remainingBufferSize);
         }
     } else {
         auto& buffer = *readDataResponse.MutableBuffer();
         buffer.ReserveAndResize(bufferSize);
         TRopeUtils::Memcpy(buffer.begin(), it, payload.size());
-        remainingBufferSize -= payload.size();
-    }
-
-    if (remainingBufferSize != 0) {
-        return MakeError(
-            E_BADMSG,
-            TStringBuilder()
-                << "Failed to read buffer from payload. "
-                   " Expected buffer size: "
-                << bufferSize << " Actual bytes copied from payload: "
-                << bufferSize - remainingBufferSize);
     }
 
     return {};

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -790,8 +790,15 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
     } else {
         auto& buffer = *readDataResponse.MutableBuffer();
         buffer.ReserveAndResize(bufferSize);
-        TRopeUtils::Memcpy(buffer.begin(), it, payload.size());
+        TRopeUtils::Memcpy(
+            buffer.begin(),
+            it,
+            payload.size() - readDataResponse.GetBufferOffset());
     }
+
+    // Set the buffer offset to 0 because the response buffer/iovecs do not
+    // contain data before the offset anymore
+    readDataResponse.SetBufferOffset(0);
 
     return {};
 }
@@ -835,7 +842,7 @@ void TReadDataActor::HandleReadDataResponse(
                         E_BADMSG,
                         TStringBuilder()
                             << "Payload is unavailable or message has more "
-                               "than one payload. Payload count"
+                               "than one payload. Payload count: "
                             << msg->GetPayloadCount()));
                 return;
             }

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -751,20 +751,17 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
     }
 
     auto it = payload.begin() + readDataResponse.GetBufferOffset();
+    ui64 remainingBufferSize = bufferSize - readDataResponse.GetBufferOffset();
     if (!ReadRequest.GetIovecs().empty()) {
-        if (bufferSize - readDataResponse.GetBufferOffset() >
-            ReadRequest.GetLength())
-        {
+        if (remainingBufferSize > ReadRequest.GetLength()) {
             return MakeError(
                 E_BADMSG,
                 TStringBuilder()
                     << "Payload size is more than iovecs size. Expected size: "
-                    << ReadRequest.GetLength() << " Actual size: "
-                    << bufferSize - readDataResponse.GetBufferOffset());
+                    << ReadRequest.GetLength()
+                    << " Actual size: " << remainingBufferSize);
         }
 
-        ui64 remainingBufferSize =
-            bufferSize - readDataResponse.GetBufferOffset();
         for (auto& iovec: ReadRequest.GetIovecs()) {
             ui64 dataToWrite = Min(iovec.GetLength(), remainingBufferSize);
             if (dataToWrite == 0) {
@@ -789,12 +786,8 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
         }
     } else {
         auto& buffer = *readDataResponse.MutableBuffer();
-        buffer.ReserveAndResize(
-            bufferSize - readDataResponse.GetBufferOffset());
-        TRopeUtils::Memcpy(
-            buffer.begin(),
-            it,
-            bufferSize - readDataResponse.GetBufferOffset());
+        buffer.ReserveAndResize(remainingBufferSize);
+        TRopeUtils::Memcpy(buffer.begin(), it, remainingBufferSize);
     }
 
     // Set the buffer offset to 0 because the response buffer/iovecs do not

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -722,6 +722,8 @@ void TReadDataActor::ReadData(
     // Original iovecs should be preserved in this request and pruned during
     // this forwarding on the tablet side
     ReadRequest.MutableIovecs()->Swap(request->Record.MutableIovecs());
+    // Length should be preserved to validate payload size
+    ReadRequest.SetLength(request->Record.GetLength());
 
     // forward request through tablet proxy
     ctx.Send(MakeIndexTabletProxyServiceId(), request.release());
@@ -740,8 +742,27 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
                 << bufferSize << " Actual size: " << payload.size());
     }
 
+    if (readDataResponse.GetBufferOffset() >= bufferSize) {
+        return MakeError(
+            E_BADMSG,
+            TStringBuilder() << "Incorrect buffer offset. Buffer offset: "
+                             << readDataResponse.GetBufferOffset()
+                             << " Buffer size : " << bufferSize);
+    }
+
     auto it = payload.begin() + readDataResponse.GetBufferOffset();
     if (!ReadRequest.GetIovecs().empty()) {
+        if (bufferSize - readDataResponse.GetBufferOffset() >
+            ReadRequest.GetLength())
+        {
+            return MakeError(
+                E_BADMSG,
+                TStringBuilder()
+                    << "Payload size is more than iovecs size. Expected size: "
+                    << ReadRequest.GetLength() << " Actual size: "
+                    << bufferSize - readDataResponse.GetBufferOffset());
+        }
+
         ui64 remainingBufferSize =
             bufferSize - readDataResponse.GetBufferOffset();
         for (auto& iovec: ReadRequest.GetIovecs()) {
@@ -807,19 +828,19 @@ void TReadDataActor::HandleReadDataResponse(
 
         ui64 bufferSize = response->Record.GetLength();
         if (response->Record.GetBuffer().empty() && bufferSize != 0) {
-            if (msg->GetPayloadCount() != 1 ||
-                msg->GetTotalPayloadSize() != bufferSize)
-            {
+            if (msg->GetPayloadCount() != 1) {
                 HandleError(
                     ctx,
                     MakeError(
                         E_BADMSG,
-                        "Payload is unavailable or has an incorrect size"));
+                        TStringBuilder()
+                            << "Payload is unavailable or message has more "
+                               "than one payload. Payload count"
+                            << msg->GetPayloadCount()));
                 return;
             }
-            auto err = ProcessExternalPayload(
-                msg->GetPayload(0),
-                response->Record);
+            auto err =
+                ProcessExternalPayload(msg->GetPayload(0), response->Record);
             if (HasError(err)) {
                 HandleError(ctx, err);
                 return;

--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -745,21 +745,16 @@ NProto::TError TReadDataActor::ProcessExternalPayload(
         ui64 remainingBufferSize =
             bufferSize - readDataResponse.GetBufferOffset();
         for (auto& iovec: ReadRequest.GetIovecs()) {
-            ui64 iovecOffset = 0;
-            while (iovec.GetLength() > iovecOffset) {
-                ui64 dataToWrite =
-                    Min(iovec.GetLength() - iovecOffset, remainingBufferSize);
-                if (dataToWrite == 0) {
-                    break;
-                }
-                TRopeUtils::Memcpy(
-                    reinterpret_cast<char*>(iovec.GetBase()) + iovecOffset,
-                    it,
-                    dataToWrite);
-                remainingBufferSize -= dataToWrite;
-                iovecOffset += dataToWrite;
-                it += dataToWrite;
+            ui64 dataToWrite = Min(iovec.GetLength(), remainingBufferSize);
+            if (dataToWrite == 0) {
+                break;
             }
+            TRopeUtils::Memcpy(
+                reinterpret_cast<char*>(iovec.GetBase()),
+                it,
+                dataToWrite);
+            remainingBufferSize -= dataToWrite;
+            it += dataToWrite;
         }
 
         if (remainingBufferSize != 0) {

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4928,7 +4928,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         testReadDataRequestWithIovecs(std::move(config));
     }
 
-
     Y_UNIT_TEST(ShouldUseExternalPayloadForReadDataRequest)
     {
         NProto::TStorageConfig config;

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4916,10 +4916,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetTwoStageReadEnabled(true);
-
-        for(auto iovecSize : std::vector<size_t>{124, 4_KB, 256_KB}) {
-            testReadDataRequestWithIovecs(std::move(config), iovecSize);
-        }
+        testReadDataRequestWithIovecs(std::move(config));
     }
 
     Y_UNIT_TEST(
@@ -4943,7 +4940,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetExternalReadDataPayload(true);
-        testReadDataRequestWithIovecs(std::move(config));
+        for (auto iovecSize: std::vector<size_t>{124, 4_KB, 256_KB}) {
+            testReadDataRequestWithIovecs(config, iovecSize);
+        }
     }
 
     Y_UNIT_TEST(ShouldHandleToggleServiceState)

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -83,12 +83,18 @@ NProtoPrivate::TSetHasXAttrsResponse ExecuteSetHasXAttrs(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVector<TString> CreateIovecs(size_t num, size_t size)
+TVector<TString> CreateIovecs(size_t totalSize, size_t iovecSize)
 {
     TVector<TString> iovecs;
-    iovecs.reserve(num);
-    for (size_t i = 0; i < num; ++i) {
-        iovecs.emplace_back(size, '\0');
+    size_t fullIovecsCount = totalSize / iovecSize;
+    size_t lastIovecSize = totalSize % iovecSize;
+    size_t totalIovecsCount = fullIovecsCount + (lastIovecSize != 0 ? 1 : 0);
+    iovecs.reserve(totalIovecsCount);
+    for (size_t i = 0; i < fullIovecsCount; ++i) {
+        iovecs.emplace_back(iovecSize, '\0');
+    }
+    if (lastIovecSize != 0) {
+        iovecs.emplace_back(lastIovecSize, '\0');
     }
     return iovecs;
 }
@@ -4858,7 +4864,9 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.AssertWriteDataFailed(headers, fs, nodeId, handle, 0, data);
     }
 
-    void testReadDataRequestWithIovecs(NProto::TStorageConfig config)
+    void testReadDataRequestWithIovecs(
+        NProto::TStorageConfig config,
+        size_t iovecSize = 4_KB)
     {
         TTestEnv env({}, std::move(config));
         ui32 nodeIdx = env.AddDynamicNode();
@@ -4886,7 +4894,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         const auto& data = GenerateValidateData(256_KB);
         service.WriteData(headers, fs, nodeId, handle, 0, data);
 
-        auto iovecs = CreateIovecs(64, 4_KB);
+        auto iovecs = CreateIovecs(data.size(), iovecSize);
         auto readDataResult =
             service
                 .ReadData(headers, fs, nodeId, handle, 0, data.size(), iovecs);
@@ -4908,7 +4916,10 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         NProto::TStorageConfig config;
         config.SetTwoStageReadEnabled(true);
-        testReadDataRequestWithIovecs(std::move(config));
+
+        for(auto iovecSize : std::vector<size_t>{124, 4_KB, 256_KB}) {
+            testReadDataRequestWithIovecs(std::move(config), iovecSize);
+        }
     }
 
     Y_UNIT_TEST(

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4945,6 +4945,16 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldUseExternalPayloadWithIovecsForReadDataRequest)
+    {
+        NProto::TStorageConfig config;
+        config.SetExternalReadDataPayload(true);
+        config.SetZeroCopyReadEnabled(true);
+        for (auto iovecSize: std::vector<size_t>{124, 4_KB, 256_KB}) {
+            testReadDataRequestWithIovecs(config, iovecSize);
+        }
+    }
+
     Y_UNIT_TEST(ShouldHandleToggleServiceState)
     {
         TTestEnv env;


### PR DESCRIPTION
issue: #6334 

1. Apply the buffer offset when processing external payload
2.  refactoring and validation based on @SvartMetal comments https://github.com/ydb-platform/nbs/pull/6263
3. GetTotalPayloadCount method was removed in ydb 25.1