### PR TITLE
[Filestore] add Forget, ForgetMulti, OpenDir, ReleaseDir, Flush, Fsync, and FsyncDir to EFileStoreRequest, otherwise they are printed as Unknown in the logs and not visible in metrics; merge EFileStoreFuseRequest with EFileStoreRequest to simplify the code

### DIFF
--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -141,32 +141,9 @@ namespace NFuse {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define FILESTORE_MATERIALIZE_REQUEST(name, ...) #name,
-
-static const TString FuseRequestNames[] = {
-    FILESTORE_FUSE_REQUESTS(FILESTORE_MATERIALIZE_REQUEST)
-};
-
-#undef FILESTORE_MATERIALIZE_REQUEST
-
-const TString& GetFileStoreFuseRequestName(EFileStoreFuseRequest requestType)
-{
-    const auto index = static_cast<size_t>(requestType);
-    if (index >= FileStoreFuseRequestStart &&
-            index < FileStoreFuseRequestStart + FileStoreFuseRequestCount)
-    {
-        return FuseRequestNames[index - FileStoreFuseRequestStart];
-    }
-
-    static const TString unknown = "Unknown";
-    return unknown;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
-    EFileStoreFuseRequest requestType,
+    EFileStoreRequest requestType,
     TInstant currentTs)
 {
     profileLogRequest.SetRequestType(static_cast<ui32>(requestType));

--- a/cloud/filestore/libs/diagnostics/profile_log_events.h
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.h
@@ -32,38 +32,15 @@ class TIovec;
 
 }   // namespace NProto
 
+enum class EFileStoreRequest;
+
 namespace NFuse {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define FILESTORE_FUSE_REQUESTS(xxx, ...)                                      \
-    xxx(Flush,              __VA_ARGS__)                                       \
-    xxx(Fsync,              __VA_ARGS__)                                       \
-    xxx(FsyncDir,           __VA_ARGS__)                                       \
-// FILESTORE_FUSE_REQUESTS
-
-#define FILESTORE_MATERIALIZE_REQUEST(name, ...) name,
-
-enum class EFileStoreFuseRequest
-{
-    MIN = 1'000,    // to combine with service requests
-    FILESTORE_FUSE_REQUESTS(FILESTORE_MATERIALIZE_REQUEST)
-    MAX
-};
-
-#undef FILESTORE_MATERIALIZE_REQUEST
-
-constexpr size_t FileStoreFuseRequestStart =
-    static_cast<size_t>(EFileStoreFuseRequest::MIN) + 1;
-
-constexpr size_t FileStoreFuseRequestCount =
-    static_cast<size_t>(EFileStoreFuseRequest::MAX) - FileStoreFuseRequestStart;
-
-const TString& GetFileStoreFuseRequestName(EFileStoreFuseRequest requestType);
-
 void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
-    EFileStoreFuseRequest requestType,
+    EFileStoreRequest requestType,
     TInstant currentTs);
 
 void FinalizeProfileLogRequestInfo(

--- a/cloud/filestore/libs/diagnostics/profile_log_events_ut.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events_ut.cpp
@@ -3,6 +3,7 @@
 #include "profile_log.h"
 
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/public/api/protos/checkpoint.pb.h>
 #include <cloud/filestore/public/api/protos/data.pb.h>
 #include <cloud/filestore/public/api/protos/locks.pb.h>
@@ -1101,32 +1102,16 @@ Y_UNIT_TEST_SUITE(TProfileLogEventsTest)
             profileLogRequest.GetRanges(0).GetActualBytes());
     }
 
-    Y_UNIT_TEST(ShouldGetCorrectFuseRequestName)
-    {
-        UNIT_ASSERT_VALUES_EQUAL(
-            "Unknown",
-            GetFileStoreFuseRequestName(NFuse::EFileStoreFuseRequest::MIN));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            "Flush",
-            GetFileStoreFuseRequestName(NFuse::EFileStoreFuseRequest::Flush));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            "Fsync",
-            GetFileStoreFuseRequestName(NFuse::EFileStoreFuseRequest::Fsync));
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            "Unknown",
-            GetFileStoreFuseRequestName(NFuse::EFileStoreFuseRequest::MAX));
-    }
-
     Y_UNIT_TEST(ShouldCorrectlyInitProfileLogRequest)
     {
         const auto timestamp = TInstant::MilliSeconds(12);
-        const auto requestType = NFuse::EFileStoreFuseRequest::Flush;
+        const auto requestType = EFileStoreRequest::FuseFlush;
 
         NProto::TProfileLogRequestInfo profileLogRequest;
-        InitProfileLogRequestInfo(profileLogRequest, requestType, timestamp);
+        NFuse::InitProfileLogRequestInfo(
+            profileLogRequest,
+            requestType,
+            timestamp);
 
         UNIT_ASSERT_VALUES_EQUAL(
             timestamp.MicroSeconds(),

--- a/cloud/filestore/libs/service/auth_scheme.cpp
+++ b/cloud/filestore/libs/service/auth_scheme.cpp
@@ -109,8 +109,8 @@ TPermissionList GetRequestPermissions(EFileStoreRequest requestType)
         case EFileStoreRequest::ReleaseDir:
             Y_ABORT("ReleaseDir must have been handled separately");
 
-        case EFileStoreRequest::Flush:
-            Y_ABORT("Flush must have been handled separately");
+        case EFileStoreRequest::FuseFlush:
+            Y_ABORT("FuseFlush must have been handled separately");
 
         case EFileStoreRequest::MAX:
             Y_ABORT("EFileStoreRequest::MAX is not valid");

--- a/cloud/filestore/libs/service/auth_scheme.cpp
+++ b/cloud/filestore/libs/service/auth_scheme.cpp
@@ -97,6 +97,21 @@ TPermissionList GetRequestPermissions(EFileStoreRequest requestType)
         case EFileStoreRequest::ListEndpoints:
             return CreatePermissionList({EPermission::List});
 
+        case EFileStoreRequest::Forget:
+            Y_ABORT("Forget must have been handled separately");
+
+        case EFileStoreRequest::ForgetMulti:
+            Y_ABORT("ForgetMulti must have been handled separately");
+
+        case EFileStoreRequest::OpenDir:
+            Y_ABORT("OpenDir must have been handled separately");
+
+        case EFileStoreRequest::ReleaseDir:
+            Y_ABORT("ReleaseDir must have been handled separately");
+
+        case EFileStoreRequest::Flush:
+            Y_ABORT("Flush must have been handled separately");
+
         case EFileStoreRequest::MAX:
             Y_ABORT("EFileStoreRequest::MAX is not valid");
     }

--- a/cloud/filestore/libs/service/auth_scheme.cpp
+++ b/cloud/filestore/libs/service/auth_scheme.cpp
@@ -98,6 +98,27 @@ TPermissionList GetRequestPermissions(EFileStoreRequest requestType)
         case EFileStoreRequest::ListEndpoints:
             return CreatePermissionList({EPermission::List});
 
+        case EFileStoreRequest::Forget:
+            Y_ABORT("Forget must have been handled separately");
+
+        case EFileStoreRequest::ForgetMulti:
+            Y_ABORT("ForgetMulti must have been handled separately");
+
+        case EFileStoreRequest::OpenDir:
+            Y_ABORT("OpenDir must have been handled separately");
+
+        case EFileStoreRequest::ReleaseDir:
+            Y_ABORT("ReleaseDir must have been handled separately");
+
+        case EFileStoreRequest::FuseFlush:
+            Y_ABORT("FuseFlush must have been handled separately");
+
+        case EFileStoreRequest::FuseFsync:
+            Y_ABORT("FuseFsync must have been handled separately");
+
+        case EFileStoreRequest::FuseFsyncDir:
+            Y_ABORT("FuseFsyncDir must have been handled separately");
+
         case EFileStoreRequest::MAX:
             Y_ABORT("EFileStoreRequest::MAX is not valid");
     }

--- a/cloud/filestore/libs/service/request.cpp
+++ b/cloud/filestore/libs/service/request.cpp
@@ -141,6 +141,11 @@ static const TString RequestNames[] = {
     "WriteBlob",
     "ConfirmAddData",
     "CancelAddData",
+    "Forget",
+    "ForgetMulti",
+    "OpenDir",
+    "ReleaseDir",
+    "Flush",
 };
 
 static_assert(

--- a/cloud/filestore/libs/service/request.cpp
+++ b/cloud/filestore/libs/service/request.cpp
@@ -203,6 +203,13 @@ static const TString RequestNames[] = {
     "ConfirmAddData",
     "CancelAddData",
     "ConfirmCreateHandle",
+    "Forget",
+    "ForgetMulti",
+    "OpenDir",
+    "ReleaseDir",
+    "FuseFlush",
+    "FuseFsync",
+    "FuseFsyncDir",
 };
 
 static_assert(

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -163,7 +163,7 @@ enum class EFileStoreRequest
     ForgetMulti,
     OpenDir,
     ReleaseDir,
-    Flush,
+    FuseFlush,
     MAX
 };
 

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -158,6 +158,12 @@ enum class EFileStoreRequest
     WriteBlob,
     ConfirmAddData,
     CancelAddData,
+    // These are auxiliary requests. They are here for observability.
+    Forget,
+    ForgetMulti,
+    OpenDir,
+    ReleaseDir,
+    Flush,
     MAX
 };
 

--- a/cloud/filestore/libs/service/request.h
+++ b/cloud/filestore/libs/service/request.h
@@ -211,7 +211,14 @@ enum class EFileStoreRequest
     ConfirmAddData = 58,
     CancelAddData = 59,
     ConfirmCreateHandle = 60,
-    MAX = 61,
+    Forget = 61,
+    ForgetMulti = 62,
+    OpenDir = 63,
+    ReleaseDir = 64,
+    FuseFlush = 65,
+    FuseFsync = 66,
+    FuseFsyncDir = 67,
+    MAX = 68,
 };
 
 constexpr size_t FileStoreRequestCount = static_cast<size_t>(EFileStoreRequest::MAX);

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -961,7 +961,7 @@ void TFileSystem::Flush(
     const auto reqId = callContext->RequestId;
 
     NProto::TProfileLogRequestInfo requestInfo;
-    InitProfileLogRequestInfo(requestInfo, EFileStoreFuseRequest::Flush, Now());
+    InitProfileLogRequestInfo(requestInfo, EFileStoreRequest::FuseFlush, Now());
     InitNodeInfo(requestInfo, true, TNodeId{ino}, THandle{fi->fh});
     requestInfo.SetLoopThreadId(callContext->LoopThreadId);
 
@@ -1025,7 +1025,7 @@ void TFileSystem::FSync(
     const auto reqId = callContext->RequestId;
 
     NProto::TProfileLogRequestInfo requestInfo;
-    InitProfileLogRequestInfo(requestInfo, EFileStoreFuseRequest::Fsync, Now());
+    InitProfileLogRequestInfo(requestInfo, EFileStoreRequest::FuseFsync, Now());
     InitNodeInfo(
         requestInfo,
         datasync,
@@ -1149,7 +1149,7 @@ void TFileSystem::FSyncDir(
     NProto::TProfileLogRequestInfo requestInfo;
     InitProfileLogRequestInfo(
         requestInfo,
-        EFileStoreFuseRequest::FsyncDir,
+        EFileStoreRequest::FuseFsyncDir,
         Now());
     InitNodeInfo(
         requestInfo,

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1702,10 +1702,10 @@ private:
             CALL(Lookup, EFileStoreRequest::GetNodeAttr, 0, req, parent, name);
         };
         ops.forget = [] (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup) {
-            CALL(Forget, EFileStoreRequest::MAX, 0, req, ino, nlookup);
+            CALL(Forget, EFileStoreRequest::Forget, 0, req, ino, nlookup);
         };
         ops.forget_multi = [] (fuse_req_t req, size_t count, fuse_forget_data* forgets) {
-            CALL(ForgetMulti, EFileStoreRequest::MAX, 0, req, count, forgets);
+            CALL(ForgetMulti, EFileStoreRequest::ForgetMulti, 0, req, count, forgets);
         };
         ops.mkdir = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode) {
             CALL(MkDir, EFileStoreRequest::CreateNode, 0, req, parent, name, mode);
@@ -1774,7 +1774,7 @@ private:
         //
 
         ops.opendir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(OpenDir, EFileStoreRequest::MAX, 0, req, ino, fi);
+            CALL(OpenDir, EFileStoreRequest::OpenDir, 0, req, ino, fi);
         };
 #if defined(FUSE_VIRTIO)
         ops.readdirplus = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
@@ -1786,7 +1786,7 @@ private:
         };
 #endif
         ops.releasedir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(ReleaseDir, EFileStoreRequest::MAX, 0, req, ino, fi);
+            CALL(ReleaseDir, EFileStoreRequest::ReleaseDir, 0, req, ino, fi);
         };
 
         //
@@ -1812,13 +1812,13 @@ private:
             CALL(FAllocate, EFileStoreRequest::AllocateData, length, req, ino, mode, offset, length, fi);
         };
         ops.flush = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Flush, EFileStoreRequest::MAX, 0, req, ino, fi);
+            CALL(Flush, EFileStoreRequest::FuseFlush, 0, req, ino, fi);
         };
         ops.fsync = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSync, EFileStoreRequest::MAX, 0, req, ino, datasync, fi);
+            CALL(FSync, EFileStoreRequest::FuseFsync, 0, req, ino, datasync, fi);
         };
         ops.fsyncdir = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSyncDir, EFileStoreRequest::MAX, 0, req, ino, datasync, fi);
+            CALL(FSyncDir, EFileStoreRequest::FuseFsyncDir, 0, req, ino, datasync, fi);
         };
         ops.release = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
             CALL(Release, EFileStoreRequest::DestroyHandle, 0, req, ino, fi);

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1675,10 +1675,10 @@ private:
             CALL(Lookup, EFileStoreRequest::GetNodeAttr, 0, req, parent, name);
         };
         ops.forget = [] (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup) {
-            CALL(Forget, EFileStoreRequest::MAX, 0, req, ino, nlookup);
+            CALL(Forget, EFileStoreRequest::Forget, 0, req, ino, nlookup);
         };
         ops.forget_multi = [] (fuse_req_t req, size_t count, fuse_forget_data* forgets) {
-            CALL(ForgetMulti, EFileStoreRequest::MAX, 0, req, count, forgets);
+            CALL(ForgetMulti, EFileStoreRequest::ForgetMulti, 0, req, count, forgets);
         };
         ops.mkdir = [] (fuse_req_t req, fuse_ino_t parent, const char* name, mode_t mode) {
             CALL(MkDir, EFileStoreRequest::CreateNode, 0, req, parent, name, mode);
@@ -1747,7 +1747,7 @@ private:
         //
 
         ops.opendir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(OpenDir, EFileStoreRequest::MAX, 0, req, ino, fi);
+            CALL(OpenDir, EFileStoreRequest::OpenDir, 0, req, ino, fi);
         };
 #if defined(FUSE_VIRTIO)
         ops.readdirplus = [] (fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, fuse_file_info* fi) {
@@ -1759,7 +1759,7 @@ private:
         };
 #endif
         ops.releasedir = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(ReleaseDir, EFileStoreRequest::MAX, 0, req, ino, fi);
+            CALL(ReleaseDir, EFileStoreRequest::ReleaseDir, 0, req, ino, fi);
         };
 
         //
@@ -1785,13 +1785,13 @@ private:
             CALL(FAllocate, EFileStoreRequest::AllocateData, length, req, ino, mode, offset, length, fi);
         };
         ops.flush = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Flush, EFileStoreRequest::MAX, 0, req, ino, fi);
+            CALL(Flush, EFileStoreRequest::Flush, 0, req, ino, fi);
         };
         ops.fsync = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSync, EFileStoreRequest::MAX, 0, req, ino, datasync, fi);
+            CALL(FSync, EFileStoreRequest::Fsync, 0, req, ino, datasync, fi);
         };
         ops.fsyncdir = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
-            CALL(FSyncDir, EFileStoreRequest::MAX, 0, req, ino, datasync, fi);
+            CALL(FSyncDir, EFileStoreRequest::FsyncDir, 0, req, ino, datasync, fi);
         };
         ops.release = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
             CALL(Release, EFileStoreRequest::DestroyHandle, 0, req, ino, fi);

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1785,7 +1785,7 @@ private:
             CALL(FAllocate, EFileStoreRequest::AllocateData, length, req, ino, mode, offset, length, fi);
         };
         ops.flush = [] (fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi) {
-            CALL(Flush, EFileStoreRequest::Flush, 0, req, ino, fi);
+            CALL(Flush, EFileStoreRequest::FuseFlush, 0, req, ino, fi);
         };
         ops.fsync = [] (fuse_req_t req, fuse_ino_t ino, int datasync, fuse_file_info* fi) {
             CALL(FSync, EFileStoreRequest::Fsync, 0, req, ino, datasync, fi);

--- a/cloud/filestore/tests/profile_log/qemu-kikimr-test/canondata/test.test_profile_log/results.txt
+++ b/cloud/filestore/tests/profile_log/qemu-kikimr-test/canondata/test.test_profile_log/results.txt
@@ -13,7 +13,7 @@ CreateHandle
 CreateNode
 CreateSession
 DestroyHandle
-Flush
+FuseFlush
 GetNodeAttr
 GetNodeXAttr
 ListNodeXAttr

--- a/cloud/filestore/tests/profile_log/qemu-local-test/canondata/test.test_profile_log/results.txt
+++ b/cloud/filestore/tests/profile_log/qemu-local-test/canondata/test.test_profile_log/results.txt
@@ -19,4 +19,4 @@ StatFileStore
 UnlinkNode
 WriteData
 VHOST profile:
-Flush
+FuseFlush

--- a/cloud/filestore/tools/analytics/libs/event-log/dump.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump.cpp
@@ -33,18 +33,27 @@ TVector<ui32> GetItemOrder(const NProto::TProfileLogRecord& record)
     return order;
 }
 
-TString RequestName(const ui32 requestType)
+ui32 NormalizeRequestTypeLegacy(ui32 requestType)
 {
+    switch (requestType) {
+        case 1001:  // legacy EFileStoreFuseRequest::Flush
+            return static_cast<ui32>(EFileStoreRequest::FuseFlush);
+        case 1002:  // legacy EFileStoreFuseRequest::Fsync
+            return static_cast<ui32>(EFileStoreRequest::FuseFsync);
+        case 1003:  // legacy EFileStoreFuseRequest::FsyncDir
+            return static_cast<ui32>(EFileStoreRequest::FuseFsyncDir);
+        default:
+            return requestType;
+    }
+}
+
+TString RequestName(const ui32 rawRequestType)
+{
+    const ui32 requestType = NormalizeRequestTypeLegacy(rawRequestType);
     TString name;
     if (requestType < static_cast<ui32>(EFileStoreRequest::MAX)) {
         name = GetFileStoreRequestName(
             static_cast<EFileStoreRequest>(requestType));
-    } else if (
-        requestType > static_cast<ui32>(NFuse::EFileStoreFuseRequest::MIN) &&
-        requestType < static_cast<ui32>(NFuse::EFileStoreFuseRequest::MAX))
-    {
-        name = GetFileStoreFuseRequestName(
-            static_cast<NFuse::EFileStoreFuseRequest>(requestType));
     } else if (
         requestType > static_cast<ui32>(NStorage::EFileStoreSystemRequest::MIN) &&
         requestType < static_cast<ui32>(NStorage::EFileStoreSystemRequest::MAX))
@@ -66,12 +75,6 @@ TVector<TRequestTypeInfo> GetRequestTypes()
     TVector<TRequestTypeInfo> ans;
     ans.reserve(2 * FileStoreRequestCount);
     for (ui32 i = 0; i < static_cast<ui32>(EFileStoreRequest::MAX); ++i) {
-        ans.emplace_back(i, RequestName(i));
-    }
-    for (ui32 i = static_cast<ui32>(NFuse::EFileStoreFuseRequest::MIN) + 1;
-         i < static_cast<ui32>(NFuse::EFileStoreFuseRequest::MAX);
-         ++i)
-    {
         ans.emplace_back(i, RequestName(i));
     }
     for (ui32 i = static_cast<ui32>(NStorage::EFileStoreSystemRequest::MIN) + 1;

--- a/cloud/filestore/tools/analytics/libs/event-log/dump.h
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump.h
@@ -42,6 +42,15 @@ void DumpDiscardedRequestCount(
     IOutputStream* out);
 
 TString RequestName(const ui32 requestType);
+
+// Translates legacy profile log request type ids, written by older versions
+// via the removed EFileStoreFuseRequest enum (Flush = 1001, Fsync = 1002,
+// FsyncDir = 1003), to the current EFileStoreRequest values. Returns other
+// values unchanged.
+// TODO(#6799): this function (and the support for the legacy values) should be
+// deleted after all profile logs written by older versions have been
+// rotated.
+ui32 NormalizeRequestTypeLegacy(ui32 requestType);
 TVector<TRequestTypeInfo> GetRequestTypes();
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
@@ -61,16 +61,24 @@ Y_UNIT_TEST_SUITE(TDumpTest)
 #undef TEST_SYSTEM_API
 
 
-#define TEST_FUSE_API(name, ...)                                               \
-    UNIT_ASSERT_VALUES_EQUAL(                                                  \
-        #name,                                                                 \
-        RequestName(                                                           \
-            static_cast<ui32>(NFuse::EFileStoreFuseRequest::name)));           \
-// TEST_FUSE_API
+        UNIT_ASSERT_VALUES_EQUAL(
+            "FuseFlush",
+            RequestName(static_cast<ui32>(EFileStoreRequest::FuseFlush)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "FuseFsync",
+            RequestName(static_cast<ui32>(EFileStoreRequest::FuseFsync)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "FuseFsyncDir",
+            RequestName(static_cast<ui32>(EFileStoreRequest::FuseFsyncDir)));
 
-        FILESTORE_FUSE_REQUESTS(TEST_FUSE_API);
-
-#undef TEST_FUSE_API
+        // Legacy ids written to profile logs by older versions must keep
+        // being parsed
+        // TODO(#6799): should be removed.
+        UNIT_ASSERT_VALUES_EQUAL("FuseFlush", RequestName(1001));
+        UNIT_ASSERT_VALUES_EQUAL("FuseFsync", RequestName(1002));
+        UNIT_ASSERT_VALUES_EQUAL("FuseFsyncDir", RequestName(1003));
+        UNIT_ASSERT_VALUES_EQUAL("Unknown-1000", RequestName(1000));
+        UNIT_ASSERT_VALUES_EQUAL("Unknown-1004", RequestName(1004));
 
         UNIT_ASSERT_VALUES_EQUAL(
             TStringBuilder()
@@ -94,7 +102,7 @@ Y_UNIT_TEST_SUITE(TDumpTest)
     {
         const auto requests = GetRequestTypes();
 
-        UNIT_ASSERT_VALUES_EQUAL(81, requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(85, requests.size());
 
         ui32 index = 0;
 #define TEST_REQUEST_TYPE(id, name)                                            \
@@ -167,10 +175,14 @@ Y_UNIT_TEST_SUITE(TDumpTest)
         TEST_REQUEST_TYPE(59, CancelAddData);
         TEST_REQUEST_TYPE(60, ConfirmCreateHandle);
 
-        // Fuse
-        TEST_REQUEST_TYPE(1001, Flush);
-        TEST_REQUEST_TYPE(1002, Fsync);
-        TEST_REQUEST_TYPE(1003, FsyncDir);
+        // Fuse-level (vfs_fuse) requests
+        TEST_REQUEST_TYPE(61, Forget);
+        TEST_REQUEST_TYPE(62, ForgetMulti);
+        TEST_REQUEST_TYPE(63, OpenDir);
+        TEST_REQUEST_TYPE(64, ReleaseDir);
+        TEST_REQUEST_TYPE(65, FuseFlush);
+        TEST_REQUEST_TYPE(66, FuseFsync);
+        TEST_REQUEST_TYPE(67, FuseFsyncDir);
 
         // Tablet
         TEST_REQUEST_TYPE(10001, Flush);

--- a/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
@@ -94,7 +94,7 @@ Y_UNIT_TEST_SUITE(TDumpTest)
     {
         const auto requests = GetRequestTypes();
 
-        UNIT_ASSERT_VALUES_EQUAL(80, requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(85, requests.size());
 
         ui32 index = 0;
 #define TEST_REQUEST_TYPE(id, name)                                            \

--- a/cloud/filestore/tools/analytics/libs/event-log/request_filter.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_filter.cpp
@@ -1,5 +1,7 @@
 #include "request_filter.h"
 
+#include "dump.h"
+
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
 #include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/libs/storage/tablet/model/profile_log_events.h>
@@ -229,7 +231,7 @@ public:
             IRequestFilterPtr nextFilter,
             TSet<ui32> requestTypes)
         : NextFilter(std::move(nextFilter))
-        , RequestTypes(std::move(requestTypes))
+        , RequestTypes(NormalizeRequestTypes(std::move(requestTypes)))
     {}
 
     NProto::TProfileLogRecord GetFilteredRecord(
@@ -237,7 +239,9 @@ public:
     {
         NProto::TProfileLogRecord answer;
         for (const auto& profileLogRequest: record.GetRequests()) {
-            if (RequestTypes.count(profileLogRequest.GetRequestType())) {
+            if (RequestTypes.count(
+                    NormalizeRequestTypeLegacy(profileLogRequest.GetRequestType())))
+            {
                 answer.MutableRequests()->Add(
                     NProto::TProfileLogRequestInfo(profileLogRequest));
             }
@@ -249,6 +253,20 @@ public:
         }
 
         return NProto::TProfileLogRecord();
+    }
+
+private:
+    // Filtering is done in the normalized id space, so that both the
+    // supplied request types and the request types stored in the records may
+    // be legacy ones.
+    // TODO(#6799): should be removed.
+    static TSet<ui32> NormalizeRequestTypes(TSet<ui32> requestTypes)
+    {
+        TSet<ui32> normalized;
+        for (const ui32 requestType: requestTypes) {
+            normalized.insert(NormalizeRequestTypeLegacy(requestType));
+        }
+        return normalized;
     }
 };
 

--- a/cloud/filestore/tools/analytics/libs/event-log/request_filter_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_filter_ut.cpp
@@ -913,6 +913,82 @@ Y_UNIT_TEST_SUITE(TRequestFilterTest)
             filter->GetFilteredRecord(ThirdRecord).ShortDebugString());
     }
 
+    Y_UNIT_TEST_F(ShouldFilterByLegacyRequestTypeRecord, TEnv)
+    {
+        NProto::TProfileLogRecord record;
+        record.SetFileSystemId("fs");
+
+        auto* newRequest = record.AddRequests();
+        newRequest->SetRequestType(
+            static_cast<ui32>(EFileStoreRequest::FuseFlush));
+
+        auto* legacyRequest = record.AddRequests();
+        // Legacy id written to profile logs by older versions
+        // (EFileStoreFuseRequest::Flush).
+        // TODO(#6799): should be removed.
+        legacyRequest->SetRequestType(1001);
+
+        // Both the supplied request types and the request types stored in
+        // the records may be legacy ones
+        for (const ui32 requestType:
+             {static_cast<ui32>(EFileStoreRequest::FuseFlush), 1001u})
+        {
+            auto filter = CreateRequestFilterByRequestType(
+                CreateRequestFilterAccept(),
+                {requestType});
+
+            const auto filtered = filter->GetFilteredRecord(record);
+            UNIT_ASSERT_VALUES_EQUAL("fs", filtered.GetFileSystemId());
+            UNIT_ASSERT_VALUES_EQUAL(2, filtered.RequestsSize());
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldNotConflateFsyncWithLegacyFuseFsync, TEnv)
+    {
+        NProto::TProfileLogRecord record;
+        record.SetFileSystemId("fs");
+
+        auto* rpcRequest = record.AddRequests();
+        rpcRequest->SetRequestType(
+            static_cast<ui32>(EFileStoreRequest::Fsync));
+
+        auto* legacyFuseRequest = record.AddRequests();
+        // Legacy id written to profile logs by older versions
+        // (EFileStoreFuseRequest::Fsync).
+        // TODO(#6799): should be removed.
+        legacyFuseRequest->SetRequestType(1002);
+
+        // The Fsync protocol request and the fuse-level FuseFsync request
+        // are different request types, so they can be filtered
+        // independently, legacy ids included
+        {
+            auto filter = CreateRequestFilterByRequestType(
+                CreateRequestFilterAccept(),
+                {static_cast<ui32>(EFileStoreRequest::Fsync)});
+
+            const auto filtered = filter->GetFilteredRecord(record);
+            UNIT_ASSERT_VALUES_EQUAL(1, filtered.RequestsSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui32>(EFileStoreRequest::Fsync),
+                filtered.GetRequests(0).GetRequestType());
+        }
+
+        for (const ui32 requestType:
+             {static_cast<ui32>(EFileStoreRequest::FuseFsync), 1002u})
+        {
+            auto filter = CreateRequestFilterByRequestType(
+                CreateRequestFilterAccept(),
+                {requestType});
+
+            const auto filtered = filter->GetFilteredRecord(record);
+            UNIT_ASSERT_VALUES_EQUAL(1, filtered.RequestsSize());
+            // The filtered record keeps the original (legacy) request type
+            UNIT_ASSERT_VALUES_EQUAL(
+                1002u,
+                filtered.GetRequests(0).GetRequestType());
+        }
+    }
+
     Y_UNIT_TEST_F(ShouldFilterByRangeRecord, TEnv) {
         auto filter = CreateRequestFilterByRange(
             CreateRequestFilterAccept(),

--- a/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
@@ -1,5 +1,7 @@
 #include "request_printer.h"
 
+#include "dump.h"
+
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
 #include <cloud/filestore/libs/diagnostics/profile_log_events.h>
 #include <cloud/filestore/libs/service/request.h>
@@ -709,8 +711,9 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IRequestPrinterPtr CreateRequestPrinter(ui32 requestType)
+IRequestPrinterPtr CreateRequestPrinter(ui32 rawRequestType)
 {
+    const ui32 requestType = NormalizeRequestTypeLegacy(rawRequestType);
     if (requestType < static_cast<ui32>(EFileStoreRequest::MAX)) {
         switch (static_cast<EFileStoreRequest>(requestType)) {
             case EFileStoreRequest::AccessNode:
@@ -723,17 +726,9 @@ IRequestPrinterPtr CreateRequestPrinter(ui32 requestType)
             case EFileStoreRequest::CreateCheckpoint:
             case EFileStoreRequest::DestroyCheckpoint:
                 return std::make_shared<TCreateDestroyCheckpointRequestPrinter>();
-            default:
-                break;
-        }
-    } else if (
-        requestType > static_cast<ui32>(NFuse::EFileStoreFuseRequest::MIN) &&
-        requestType < static_cast<ui32>(NFuse::EFileStoreFuseRequest::MAX))
-    {
-        switch (static_cast<NFuse::EFileStoreFuseRequest>(requestType)) {
-            case NFuse::EFileStoreFuseRequest::Flush:
-            case NFuse::EFileStoreFuseRequest::Fsync:
-            case NFuse::EFileStoreFuseRequest::FsyncDir:
+            case EFileStoreRequest::FuseFlush:
+            case EFileStoreRequest::FuseFsync:
+            case EFileStoreRequest::FuseFsyncDir:
                 return std::make_shared<TFlushFsyncRequestPrinter>();
             default:
                 break;

--- a/cloud/filestore/tools/analytics/libs/event-log/request_printer_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_printer_ut.cpp
@@ -284,7 +284,27 @@ Y_UNIT_TEST_SUITE(TRequestPrinterTest)
     Y_UNIT_TEST_F(ShouldPrintRequestInfoForFlushRequestType, TEnv)
     {
         Request.SetRequestType(
-            static_cast<ui32>(NFuse::EFileStoreFuseRequest::Flush));
+            static_cast<ui32>(EFileStoreRequest::FuseFlush));
+
+        auto printer = CreateRequestPrinter(Request.GetRequestType());
+        UNIT_ASSERT_VALUES_EQUAL("{no_info}", printer->DumpInfo(Request));
+
+        auto* nodeInfo = Request.MutableNodeInfo();
+        nodeInfo->SetMode(1);
+        nodeInfo->SetNodeId(123);
+        nodeInfo->SetHandle(456);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "{data_only=1, node_id=123, handle=456}",
+            printer->DumpInfo(Request));
+    }
+
+    Y_UNIT_TEST_F(ShouldPrintRequestInfoForLegacyFlushRequestType, TEnv)
+    {
+        // Legacy id written to profile logs by older versions
+        // (EFileStoreFuseRequest::Flush).
+        // TODO(#6799): should be removed.
+        Request.SetRequestType(1001);
 
         auto printer = CreateRequestPrinter(Request.GetRequestType());
         UNIT_ASSERT_VALUES_EQUAL("{no_info}", printer->DumpInfo(Request));
@@ -302,7 +322,7 @@ Y_UNIT_TEST_SUITE(TRequestPrinterTest)
     Y_UNIT_TEST_F(ShouldPrintRequestInfoForFsyncRequestType, TEnv)
     {
         Request.SetRequestType(
-            static_cast<ui32>(NFuse::EFileStoreFuseRequest::Fsync));
+            static_cast<ui32>(EFileStoreRequest::FuseFsync));
 
         auto printer = CreateRequestPrinter(Request.GetRequestType());
         UNIT_ASSERT_VALUES_EQUAL("{no_info}", printer->DumpInfo(Request));

--- a/cloud/filestore/tools/testing/loadtest/lib/request_replay.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_replay.cpp
@@ -119,7 +119,7 @@ TFuture<TCompletedRequest> IReplayRequestGenerator::ProcessRequest(
     const NProto::TProfileLogRequestInfo& request)
 {
     const auto& action = request.GetRequestType();
-    switch (static_cast<EFileStoreRequest>(action)) {
+    switch (static_cast<EFileStoreRequest>(NormalizeRequestTypeLegacy(action))) {
         case EFileStoreRequest::ReadData:
             return DoReadData(request);
         case EFileStoreRequest::WriteData:
@@ -155,12 +155,7 @@ TFuture<TCompletedRequest> IReplayRequestGenerator::ProcessRequest(
         case EFileStoreRequest::GetNodeXAttr:
             return {};
 
-        default:
-            break;
-    }
-
-    switch (static_cast<NFuse::EFileStoreFuseRequest>(action)) {
-        case NFuse::EFileStoreFuseRequest::Flush:
+        case EFileStoreRequest::FuseFlush:
             return DoFlush(request);
 
         default:


### PR DESCRIPTION
### Notes

Example
```
2026-06-25T21:09:23.518586Z :NFS_FUSE WARN: cloud/filestore/libs/diagnostics/request_stats.cpp:134: Unknown #2166049196 [f:zzz][c:nbs.csi.nebius.ai-xxx-yyy] RESPONSE request too slow(total_time: 3m 34s, execution_time: 3m 34s, predicted_postponed_time: 0, postponed_time: 0, backoff_time: 0, size: 0 B, error: S_OK)
```

### Issue
Put links to the related issues here
