### PR TITLE
[Blockstore] Close split local sglist before replying on error

### DIFF
--- a/cloud/blockstore/libs/service/split_request_service.cpp
+++ b/cloud/blockstore/libs/service/split_request_service.cpp
@@ -245,19 +245,21 @@ private:
         }
         // Reply to client without lock.
 
+        if constexpr (TBlockStoreMethodTraits<TRequest>::IsLocalRequest()) {
+            if (hasError) {
+                // Cancel all sub requests before completing the parent request.
+                // SetValue() invokes future callbacks synchronously and those
+                // callbacks may move the original request.
+                Request->Sglist.Close();
+            }
+        }
+
         if constexpr (TBlockStoreMethodTraits<TRequest>::IsReadRequest()) {
             promise.SetValue(
                 hasError ? std::move(response)
                          : MergeReadResponses(SubResponses));
         } else {
             promise.SetValue(std::move(response));
-        }
-
-        if constexpr (TBlockStoreMethodTraits<TRequest>::IsLocalRequest()) {
-            if (hasError) {
-                // Cancel all sub requests in case of error.
-                Request->Sglist.Close();
-            }
         }
     }
 };

--- a/cloud/blockstore/libs/service/split_request_service_reentrant_ut.cpp
+++ b/cloud/blockstore/libs/service/split_request_service_reentrant_ut.cpp
@@ -1,0 +1,180 @@
+#include "split_request_service.h"
+
+#include <cloud/blockstore/libs/common/block_range.h>
+#include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/service_method.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/sglist.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore {
+
+using namespace NThreading;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui64 DefaultBlockSize = 2;
+constexpr ui64 StripeSize = 6;
+const char* const DefaultDiskId = "vol1";
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestBlockStore: public TBlockStoreImpl<TTestBlockStore, IBlockStore>
+{
+    struct TRequestInfo
+    {
+        TPromise<NProto::TWriteBlocksLocalResponse> Promise =
+            NewPromise<NProto::TWriteBlocksLocalResponse>();
+        std::shared_ptr<NProto::TWriteBlocksLocalRequest> Request;
+    };
+
+    TMap<TBlockRange64, TRequestInfo, TBlockRangeComparator>
+        WriteBlocksLocalPromises;
+
+    TStorageBuffer AllocateBuffer(size_t bytesCount) override
+    {
+        Y_UNUSED(bytesCount);
+        return nullptr;
+    }
+
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
+    TFuture<NProto::TWriteBlocksLocalResponse> WriteBlocksLocal(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TWriteBlocksLocalRequest> request) override
+    {
+        Y_UNUSED(callContext);
+
+        auto range = TBlockRangeHelper::GetRange(*request, DefaultBlockSize);
+        auto& info =
+            WriteBlocksLocalPromises[range] = {.Request = std::move(request)};
+        return info.Promise;
+    }
+
+    TFuture<NProto::TMountVolumeResponse> MountVolume(
+        TCallContextPtr callContext,
+        std::shared_ptr<NProto::TMountVolumeRequest> request) override
+    {
+        Y_UNUSED(callContext);
+
+        NProto::TMountVolumeResponse response;
+        auto& volume = *response.MutableVolume();
+        volume.SetDiskId(request->GetDiskId());
+        volume.SetBlockSize(DefaultBlockSize);
+        volume.SetStorageMediaKind(NProto::STORAGE_MEDIA_SSD_NONREPLICATED);
+        auto& device = *response.MutableVolume()->MutableDevices()->Add();
+        device.SetBlockCount(StripeSize);
+
+        return MakeFuture(std::move(response));
+    }
+
+    template <typename TMethod>
+    TFuture<typename TMethod::TResponse> Execute(
+        TCallContextPtr callContext,
+        std::shared_ptr<typename TMethod::TRequest> request)
+    {
+        Y_UNUSED(callContext);
+        Y_UNUSED(request);
+        return MakeFuture<typename TMethod::TResponse>();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TSplitRequestServiceReentrantTest)
+{
+    Y_UNIT_TEST(ShouldCloseLocalSglistBeforeCompletingOnSubRequestError)
+    {
+        auto storage = std::make_shared<TTestBlockStore>();
+        auto service = CreateSplitRequestService(storage);
+
+        {
+            auto request = std::make_shared<NProto::TMountVolumeRequest>();
+            request->SetDiskId(DefaultDiskId);
+
+            auto future = service->MountVolume(
+                MakeIntrusive<TCallContext>(),
+                std::move(request));
+            const auto& response = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                FormatError(response.GetError()));
+        }
+
+        const TString data = "aabbccddeeffgghhjjkk";
+        const auto range =
+            TBlockRange64::WithLength(1, data.size() / DefaultBlockSize);
+
+        auto request = std::make_shared<NProto::TWriteBlocksLocalRequest>();
+        request->SetDiskId(DefaultDiskId);
+        request->SetStartIndex(range.Start);
+        request->SetBlockSize(DefaultBlockSize);
+        request->BlocksCount = range.Size();
+        request->Sglist = TGuardedSgList({
+            TBlockDataRef(data.data(), data.size())});
+
+        auto requestRef = request;
+        auto future = service->WriteBlocksLocal(
+            MakeIntrusive<TCallContext>(),
+            std::move(request));
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+
+        UNIT_ASSERT_VALUES_EQUAL(2, storage->WriteBlocksLocalPromises.size());
+        auto* firstWrite = storage->WriteBlocksLocalPromises.FindPtr(
+            TBlockRange64::WithLength(1, 5));
+        auto* secondWrite = storage->WriteBlocksLocalPromises.FindPtr(
+            TBlockRange64::WithLength(6, 5));
+        UNIT_ASSERT(firstWrite != nullptr);
+        UNIT_ASSERT(secondWrite != nullptr);
+
+        bool callbackCalled = false;
+        bool secondSglistClosedBeforeCallback = false;
+        future.Subscribe(
+            [requestRef,
+             secondWrite,
+             &callbackCalled,
+             &secondSglistClosedBeforeCallback](
+                const TFuture<NProto::TWriteBlocksLocalResponse>&) mutable
+            {
+                callbackCalled = true;
+                secondSglistClosedBeforeCallback =
+                    !secondWrite->Request->Sglist.Acquire();
+
+                // Reproduce a continuation that moves the original request
+                // while OnSubResponse() is still on the stack.
+                auto movedRequest = std::move(*requestRef);
+                Y_UNUSED(movedRequest);
+            });
+
+        {
+            auto guard = secondWrite->Request->Sglist.Acquire();
+            UNIT_ASSERT(guard);
+        }
+
+        NProto::TWriteBlocksLocalResponse response;
+        *response.MutableError() = MakeError(E_REJECTED);
+        firstWrite->Promise.SetValue(std::move(response));
+
+        UNIT_ASSERT(callbackCalled);
+        UNIT_ASSERT(secondSglistClosedBeforeCallback);
+
+        const auto& result = future.GetValue(TDuration::MilliSeconds(1));
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            result.GetError().GetCode(),
+            FormatError(result.GetError()));
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/service/ut/ya.make
+++ b/cloud/blockstore/libs/service/ut/ya.make
@@ -9,6 +9,7 @@ SRCS(
     overlapping_requests_guard_service_ut.cpp
     request_ut.cpp
     service_filtered_ut.cpp
+    split_request_service_reentrant_ut.cpp
     split_request_service_ut.cpp
     storage_ut.cpp
 )


### PR DESCRIPTION
## Problem

`TCompositeRequest::OnSubResponse()` completed the parent promise before closing the parent `TGuardedSgList` when a local subrequest failed.

`NThreading::TPromise::SetValue()` invokes subscribed callbacks synchronously. A callback can therefore move the original `TWriteBlocksLocalRequest` while `OnSubResponse()` is still on the stack. The following `Request->Sglist.Close()` then runs on a moved-from `TGuardedSgList` and aborts on `Y_ABORT_UNLESS(GuardedObject)`.

## Fix

Close the parent local sglist before completing the parent promise. This cancels sibling subrequests before any user-visible callback can run or move the original request.

## Regression test

Added `TSplitRequestServiceReentrantTest::ShouldCloseLocalSglistBeforeCompletingOnSubRequestError`.

The test:

- splits a `WriteBlocksLocal` request into two subrequests;
- completes the first subrequest with an error;
- subscribes a reentrant callback to the parent future;
- verifies the second subrequest sglist is already closed inside that callback;
- moves the original request from the callback, reproducing the old abort condition.

Before the fix, the test aborts in `TGuardedSgList::Close()`. With the new ordering, it completes with `E_REJECTED`.

## Testing

Not run locally because this environment does not contain an NBS checkout/build toolchain. The focused CI command is:

```bash
./ya make -tt cloud/blockstore/libs/service/ut \
    -F TSplitRequestServiceReentrantTest::ShouldCloseLocalSglistBeforeCompletingOnSubRequestError
```
