### PR TITLE
[NBS] use recreated blob metas on cleanup, instead of reading them

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1618,4 +1618,7 @@ message TStorageServiceConfig
     // If true, the recreated blob metas are verified on cleanup.
     // We check that there is no leaked blocks in the mixed index.
     optional bool VerifyRecreatedBlobMetasOnCleanup = 512;
+
+    // Use readed or recreated on compaction blob metas during cleanup.
+    optional bool UseRecreatedBlobMetasOnCleanup = 513;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1619,6 +1619,6 @@ message TStorageServiceConfig
     // We check that there is no leaked blocks in the mixed index.
     optional bool VerifyRecreatedBlobMetasOnCleanup = 512;
 
-    // Use readed or recreated on compaction blob metas during cleanup.
+    // Use read or recreated on compaction blob metas during cleanup.
     optional bool UseRecreatedBlobMetasOnCleanup = 513;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1619,6 +1619,6 @@ message TStorageServiceConfig
     // We check that there is no leaked blocks in the mixed index.
     optional bool VerifyRecreatedBlobMetasOnCleanup = 512;
 
-    // Use read or recreated on compaction blob metas during cleanup.
+    // // Use read or recreated compaction blob metas during cleanup.
     optional bool UseRecreatedBlobMetasOnCleanup = 513;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1619,6 +1619,6 @@ message TStorageServiceConfig
     // We check that there is no leaked blocks in the mixed index.
     optional bool VerifyRecreatedBlobMetasOnCleanup = 512;
 
-    // // Use read or recreated compaction blob metas during cleanup.
+    // Use read or recreated compaction blob metas during cleanup.
     optional bool UseRecreatedBlobMetasOnCleanup = 513;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -714,6 +714,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(VolumeBalancerGentlePreemptionTimeout,      TDuration,  Hours(72)     )\
     xxx(SplitByCompactionRangeMaxBlobCount,         ui64,       0             )\
     xxx(VerifyRecreatedBlobMetasOnCleanup,          bool,       false         )\
+    xxx(UseRecreatedBlobMetasOnCleanup,             bool,       false         )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on
@@ -754,6 +755,7 @@ BLOCKSTORE_STORAGE_CONFIG(BLOCKSTORE_STORAGE_DECLARE_CONFIG)
     xxx(ReadBlockMaskOnCompactionOptimization)                                 \
     xxx(SplitCompactionTx)                                                     \
     xxx(VerifyRecreatedBlobMetasOnCleanup)                                     \
+    xxx(UseRecreatedBlobMetasOnCleanup)                                       \
 
 // BLOCKSTORE_BINARY_FEATURES
 

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -432,6 +432,11 @@ public:
         const TString& folderId,
         const TString& diskId) const;
 
+    [[nodiscard]] bool IsUseRecreatedBlobMetasOnCleanupFeatureEnabled(
+        const TString& cloudId,
+        const TString& folderId,
+        const TString& diskId) const;
+
     TDuration GetMaxTimedOutDeviceStateDurationFeatureValue(
         const TString& cloudId,
         const TString& folderId,
@@ -846,6 +851,8 @@ public:
     [[nodiscard]] ui64 GetSplitByCompactionRangeMaxBlobCount() const;
 
     [[nodiscard]] bool GetVerifyRecreatedBlobMetasOnCleanup() const;
+
+    [[nodiscard]] bool GetUseRecreatedBlobMetasOnCleanup() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -1068,6 +1068,15 @@ bool TPartitionActor::IsVerifyRecreatedBlobMetasOnCleanupEnabled() const
                PartitionConfig.GetDiskId());
 }
 
+bool TPartitionActor::IsUseRecreatedBlobMetasOnCleanupEnabled() const
+{
+    return Config->GetUseRecreatedBlobMetasOnCleanup() ||
+           Config->IsUseRecreatedBlobMetasOnCleanupFeatureEnabled(
+               PartitionConfig.GetCloudId(),
+               PartitionConfig.GetFolderId(),
+               PartitionConfig.GetDiskId());
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 STFUNC(TPartitionActor::StateBoot)

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -487,6 +487,7 @@ private:
     [[nodiscard]] bool IsFreshBlocksWriterEnabled() const;
     [[nodiscard]] bool IsReadBlockMaskOnCompactionOptimizationEnabled() const;
     [[nodiscard]] bool IsVerifyRecreatedBlobMetasOnCleanupEnabled() const;
+    [[nodiscard]] bool IsUseRecreatedBlobMetasOnCleanupEnabled() const;
 
     void ProcessStorageStatusFlags(
         const NActors::TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
@@ -192,6 +192,7 @@ bool TPartitionActor::PrepareCleanup(
 
     TPartitionDatabase db(tx.DB);
     return PrepareCleanupTransaction(
+        IsUseRecreatedBlobMetasOnCleanupEnabled(),
         IsVerifyRecreatedBlobMetasOnCleanupEnabled(),
         TabletID(),
         PartitionConfig.GetDiskId(),
@@ -211,6 +212,7 @@ void TPartitionActor::ExecuteCleanup(
         TActorContext::ActorSystem(),
         LogTitle,
         TabletID(),
+        IsUseRecreatedBlobMetasOnCleanupEnabled(),
         db,
         args,
         *State);

--- a/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
@@ -176,9 +176,14 @@ void TPartitionActor::HandleCleanup(
 
     AddTransaction<TEvPartitionPrivate::TCleanupMethod>(*requestInfo);
 
-    ExecuteTx(
-        ctx,
-        CreateTx<TCleanup>(requestInfo, commitId, std::move(cleanupQueue)));
+    auto tx = CreateTx<TCleanup>(
+        requestInfo,
+        commitId,
+        IsUseRecreatedBlobMetasOnCleanupEnabled(),
+        IsVerifyRecreatedBlobMetasOnCleanupEnabled(),
+        std::move(cleanupQueue));
+
+    ExecuteTx(ctx, std::move(tx));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -192,8 +197,6 @@ bool TPartitionActor::PrepareCleanup(
 
     TPartitionDatabase db(tx.DB);
     return PrepareCleanupTransaction(
-        IsUseRecreatedBlobMetasOnCleanupEnabled(),
-        IsVerifyRecreatedBlobMetasOnCleanupEnabled(),
         TabletID(),
         PartitionConfig.GetDiskId(),
         db,
@@ -212,7 +215,6 @@ void TPartitionActor::ExecuteCleanup(
         TActorContext::ActorSystem(),
         LogTitle,
         TabletID(),
-        IsUseRecreatedBlobMetasOnCleanupEnabled(),
         db,
         args,
         *State);

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1995,7 +1995,8 @@ void TPartitionActor::CompleteCompaction(
             mergedBlobThreshold,
             args.CommitId,
             TabletID(),
-            IsVerifyRecreatedBlobMetasOnCleanupEnabled(),   // shouldRecreateBlobMetas
+            IsVerifyRecreatedBlobMetasOnCleanupEnabled() ||
+                IsUseRecreatedBlobMetasOnCleanupEnabled(),   // shouldRecreateBlobMetas
             *Info(),
             *State,
             rangeCompaction,

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -315,7 +315,8 @@ void ExecuteCleanupTransaction(
                 ui64 blockCountInBlob = 0;
                 if (args.UseRecreatedBlobMeta) {
                     STORAGE_VERIFY_C(
-                        item.BlobId.BlobSize() % state.GetBlockSize() == 0,
+                        state.GetBlockSize() > 0 &&
+                            item.BlobId.BlobSize() % state.GetBlockSize() == 0,
                         TWellKnownEntityTypes::TABLET,
                         state.GetConfig().GetDiskId(),
                         "Blob size is not divisible by block size, blob: "

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -187,8 +187,6 @@ TVerifyBlocksMetaResult VerifyRecreatedBlobMeta(
 }
 
 bool PrepareCleanupTransaction(
-    const bool useRecreatedBlobMeta,
-    const bool verifyRecreatedBlobMetasOnCleanup,
     const ui64 tabletId,
     const TString& diskId,
     TPartitionDatabase& db,
@@ -205,7 +203,7 @@ bool PrepareCleanupTransaction(
         // no need to read blob meta for blobs with already known blocks
         const bool hasValidMetaInCleanupQueue =
             item.BlobMeta.HasMixedBlocks() || item.BlobMeta.HasMergedBlocks();
-        if (hasValidMetaInCleanupQueue && useRecreatedBlobMeta) {
+        if (hasValidMetaInCleanupQueue && args.UseRecreatedBlobMeta) {
             blobMetas[item.BlobId] = item.BlobMeta;
             continue;
         }
@@ -220,8 +218,8 @@ bool PrepareCleanupTransaction(
             auto& meta = blobMetas[item.BlobId];
             meta = std::move(blobMeta.GetRef());
 
-            const bool needToVerify =
-                verifyRecreatedBlobMetasOnCleanup && hasValidMetaInCleanupQueue;
+            const bool needToVerify = args.VerifyRecreatedBlobMetasOnCleanup &&
+                                      hasValidMetaInCleanupQueue;
             if (!needToVerify) {
                 continue;
             }
@@ -279,7 +277,6 @@ void ExecuteCleanupTransaction(
     const NActors::TActorSystem* actorSystem,
     const TLogTitle& logTitle,
     const ui64 tabletId,
-    const bool useRecreatedBlobMeta,
     TPartitionDatabase& db,
     TTxPartition::TCleanup& args,
     TPartitionState& state)
@@ -316,7 +313,7 @@ void ExecuteCleanupTransaction(
             ++mixedBlobsCount;
             if (!IsDeletionMarker(item.BlobId)) {
                 ui64 blockCountInBlob = 0;
-                if (useRecreatedBlobMeta) {
+                if (args.UseRecreatedBlobMeta) {
                     STORAGE_VERIFY_C(
                         item.BlobId.BlobSize() % state.GetBlockSize() == 0,
                         TWellKnownEntityTypes::TABLET,

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -211,7 +211,7 @@ bool PrepareCleanupTransaction(
         }
 
         TMaybe<NProto::TBlobMeta> blobMeta;
-        ++args.ReadedBlobMetasCount;
+        ++args.ReadBlobMetasCount;
         if (db.ReadBlobMeta(item.BlobId, blobMeta)) {
             Y_ABORT_UNLESS(
                 blobMeta.Defined(),
@@ -315,6 +315,7 @@ void ExecuteCleanupTransaction(
 
             ++mixedBlobsCount;
             if (!IsDeletionMarker(item.BlobId)) {
+                ui64 blockCountInBlob = 0;
                 if (useRecreatedBlobMeta) {
                     STORAGE_VERIFY_C(
                         item.BlobId.BlobSize() % state.GetBlockSize() == 0,
@@ -322,17 +323,16 @@ void ExecuteCleanupTransaction(
                         state.GetConfig().GetDiskId(),
                         "Blob size is not divisible by block size, blob: "
                             << ToString(MakeBlobId(tabletId, item.BlobId)));
-                    ui64 blockCountInBlob =
+                    blockCountInBlob =
                         item.BlobId.BlobSize() / state.GetBlockSize();
-                    state.DecrementMixedBlocksCount(blockCountInBlob);
                 } else {
-                    // Mins for block counts are needed due to some
-                    // inconsistencies
-                    // caused by NBS-1422
-                    state.DecrementMixedBlocksCount(
-                        Min(mixedBlocks.BlocksSize(),
-                            state.GetMixedBlocksCount()));
+                    blockCountInBlob = mixedBlocks.BlocksSize();
                 }
+                // Mins for block counts are needed due to some
+                // inconsistencies
+                // caused by NBS-1422
+                state.DecrementMixedBlocksCount(
+                    Min(blockCountInBlob, state.GetMixedBlocksCount()));
             }
         } else if (blobMeta.HasMergedBlocks()) {
             const auto& mergedBlocks = blobMeta.GetMergedBlocks();

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -187,6 +187,7 @@ TVerifyBlocksMetaResult VerifyRecreatedBlobMeta(
 }
 
 bool PrepareCleanupTransaction(
+    const bool useRecreatedBlobMeta,
     const bool verifyRecreatedBlobMetasOnCleanup,
     const ui64 tabletId,
     const TString& diskId,
@@ -204,8 +205,13 @@ bool PrepareCleanupTransaction(
         // no need to read blob meta for blobs with already known blocks
         const bool hasValidMetaInCleanupQueue =
             item.BlobMeta.HasMixedBlocks() || item.BlobMeta.HasMergedBlocks();
+        if (hasValidMetaInCleanupQueue && useRecreatedBlobMeta) {
+            blobMetas[item.BlobId] = item.BlobMeta;
+            continue;
+        }
 
         TMaybe<NProto::TBlobMeta> blobMeta;
+        ++args.ReadedBlobMetasCount;
         if (db.ReadBlobMeta(item.BlobId, blobMeta)) {
             Y_ABORT_UNLESS(
                 blobMeta.Defined(),
@@ -253,7 +259,16 @@ bool PrepareCleanupTransaction(
         args.CleanupQueue.erase(itemsToRemove.begin(), itemsToRemove.end());
 
         for (const auto& item: args.CleanupQueue) {
-            args.BlobsMeta.push_back(std::move(blobMetas[item.BlobId]));
+            auto* blobMeta = blobMetas.FindPtr(item.BlobId);
+
+            STORAGE_VERIFY_C(
+                blobMeta,
+                TWellKnownEntityTypes::TABLET,
+                tabletId,
+                "Blob meta not found for blob "
+                    << MakeBlobId(tabletId, item.BlobId));
+
+            args.BlobsMeta.push_back(std::move(*blobMeta));
         }
     }
 
@@ -264,6 +279,7 @@ void ExecuteCleanupTransaction(
     const NActors::TActorSystem* actorSystem,
     const TLogTitle& logTitle,
     const ui64 tabletId,
+    const bool useRecreatedBlobMeta,
     TPartitionDatabase& db,
     TTxPartition::TCleanup& args,
     TPartitionState& state)
@@ -299,10 +315,24 @@ void ExecuteCleanupTransaction(
 
             ++mixedBlobsCount;
             if (!IsDeletionMarker(item.BlobId)) {
-                // Mins for block counts are needed due to some inconsistencies caused by
-                // NBS-1422
-                state.DecrementMixedBlocksCount(
-                    Min(mixedBlocks.BlocksSize(), state.GetMixedBlocksCount()));
+                if (useRecreatedBlobMeta) {
+                    STORAGE_VERIFY_C(
+                        item.BlobId.BlobSize() % state.GetBlockSize() == 0,
+                        TWellKnownEntityTypes::TABLET,
+                        state.GetConfig().GetDiskId(),
+                        "Blob size is not divisible by block size, blob: "
+                            << ToString(MakeBlobId(tabletId, item.BlobId)));
+                    ui64 blockCountInBlob =
+                        item.BlobId.BlobSize() / state.GetBlockSize();
+                    state.DecrementMixedBlocksCount(blockCountInBlob);
+                } else {
+                    // Mins for block counts are needed due to some
+                    // inconsistencies
+                    // caused by NBS-1422
+                    state.DecrementMixedBlocksCount(
+                        Min(mixedBlocks.BlocksSize(),
+                            state.GetMixedBlocksCount()));
+                }
             }
         } else if (blobMeta.HasMergedBlocks()) {
             const auto& mergedBlocks = blobMeta.GetMergedBlocks();

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.h
@@ -23,8 +23,6 @@ TVerifyBlocksMetaResult VerifyRecreatedBlobMeta(
     const NProto::TBlobMeta& recreatedBlobMeta);
 
 bool PrepareCleanupTransaction(
-    const bool useRecreatedBlobMeta,
-    const bool verifyRecreatedBlobMetasOnCleanup,
     const ui64 tabletId,
     const TString& diskId,
     TPartitionDatabase& db,
@@ -34,7 +32,6 @@ void ExecuteCleanupTransaction(
     const NActors::TActorSystem* actorSystem,
     const TLogTitle& logTitle,
     const ui64 tabletId,
-    const bool useRecreatedBlobMeta,
     TPartitionDatabase& db,
     TTxPartition::TCleanup& args,
     TPartitionState& state);

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.h
@@ -23,6 +23,7 @@ TVerifyBlocksMetaResult VerifyRecreatedBlobMeta(
     const NProto::TBlobMeta& recreatedBlobMeta);
 
 bool PrepareCleanupTransaction(
+    const bool useRecreatedBlobMeta,
     const bool verifyRecreatedBlobMetasOnCleanup,
     const ui64 tabletId,
     const TString& diskId,
@@ -33,6 +34,7 @@ void ExecuteCleanupTransaction(
     const NActors::TActorSystem* actorSystem,
     const TLogTitle& logTitle,
     const ui64 tabletId,
+    const bool useRecreatedBlobMeta,
     TPartitionDatabase& db,
     TTxPartition::TCleanup& args,
     TPartitionState& state);

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -645,7 +645,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
 
         RunPrepareAndExecute(
             executor,
-            env
+            env,
             state,
             args,
             true,   // verifyRecreatedBlobMetasOnCleanup
@@ -671,6 +671,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
     {
         auto state = MakeState();
         TTestExecutor executor;
+        TTestEnv env;
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         const ui64 deletionCommitId = MakeCommitId(0, 50);
@@ -691,6 +692,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
         RunPrepareAndExecute(
             executor,
+            env,
             state,
             args,
             false,   // verifyRecreatedBlobMetasOnCleanup
@@ -702,7 +704,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         UNIT_ASSERT_VALUES_EQUAL(0, state.GetCleanupQueue().GetCount());
 
         // No blob metas were read from the database
-        UNIT_ASSERT_VALUES_EQUAL(0, args.ReadedBlobMetasCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, args.ReadBlobMetasCount);
 
         executor.ReadTx(
             [&](TPartitionDatabase db)
@@ -719,6 +721,8 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
     {
         auto state = MakeState();
         TTestExecutor executor;
+        TTestEnv env;
+
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         const ui64 deletionCommitId = MakeCommitId(0, 50);
@@ -743,6 +747,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
         RunPrepareAndExecute(
             executor,
+            env,
             state,
             args,
             false,   // verifyRecreatedBlobMetasOnCleanup
@@ -755,7 +760,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         UNIT_ASSERT_VALUES_EQUAL(0, state.GetMixedBlocksCount());
 
         // No blob metas were read from the database
-        UNIT_ASSERT_VALUES_EQUAL(0, args.ReadedBlobMetasCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, args.ReadBlobMetasCount);
 
         executor.ReadTx(
             [&](TPartitionDatabase db)

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -254,11 +254,15 @@ bool HasGarbageBlob(TPartitionDatabase& db, const TPartialBlobId& blobId)
 
 TTxPartition::TCleanup MakeCleanupArgs(
     const TVector<TCleanupQueueItem>& cleanupQueue,
-    ui64 cleanupCommitId)
+    ui64 cleanupCommitId,
+    bool useRecreatedBlobMeta,
+    bool verifyRecreatedBlobMetasOnCleanup)
 {
     return TTxPartition::TCleanup(
         MakeIntrusive<TRequestInfo>(),
         cleanupCommitId,
+        useRecreatedBlobMeta,
+        verifyRecreatedBlobMetasOnCleanup,
         cleanupQueue);
 }
 
@@ -266,16 +270,12 @@ void RunPrepareAndExecute(
     TTestExecutor& executor,
     TTestEnv& env,
     TPartitionState& state,
-    TTxPartition::TCleanup& args,
-    bool verifyRecreatedBlobMetasOnCleanup,
-    bool useRecreatedBlobMeta)
+    TTxPartition::TCleanup& args)
 {
     executor.ReadTx(
         [&](TPartitionDatabase db)
         {
             const bool ready = PrepareCleanupTransaction(
-                useRecreatedBlobMeta,
-                verifyRecreatedBlobMetasOnCleanup,
                 TTestExecutor::TabletId,
                 "test-disk",
                 db,
@@ -297,7 +297,6 @@ void RunPrepareAndExecute(
                         1,
                         0}),
                 TTestExecutor::TabletId,
-                useRecreatedBlobMeta,
                 db,
                 args,
                 state);
@@ -566,7 +565,10 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
 
         auto args = MakeCleanupArgs(
             state.GetCleanupQueue().GetItems(cleanupCommitId),
-            cleanupCommitId);
+            cleanupCommitId,
+            false,   // useRecreatedBlobMeta
+            false    // verifyRecreatedBlobMetasOnCleanup
+        );
 
         executor.ReadTx(
             [&](TPartitionDatabase db)
@@ -577,14 +579,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
                 UNIT_ASSERT(HasMergedBlob(db, setup.MergedBlobId, 10, 13));
             });
 
-        RunPrepareAndExecute(
-            executor,
-            env,
-            state,
-            args,
-            false,   // verifyRecreatedBlobMetasOnCleanup
-            false    // useRecreatedBlobMeta
-        );
+        RunPrepareAndExecute(executor, env, state, args);
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
         UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
@@ -641,16 +636,14 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             deletionCommitId,
             setup.MergedBlobMeta);
 
-        auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
-
-        RunPrepareAndExecute(
-            executor,
-            env,
-            state,
-            args,
-            true,   // verifyRecreatedBlobMetasOnCleanup
-            false   // useRecreatedBlobMeta
+        auto args = MakeCleanupArgs(
+            cleanupQueue,
+            cleanupCommitId,
+            false,   // useRecreatedBlobMeta
+            true     // verifyRecreatedBlobMetasOnCleanup
         );
+
+        RunPrepareAndExecute(executor, env, state, args);
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
         UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
@@ -689,15 +682,13 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             deletionCommitId,
             setup.MergedBlobMeta);
 
-        auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
-        RunPrepareAndExecute(
-            executor,
-            env,
-            state,
-            args,
-            false,   // verifyRecreatedBlobMetasOnCleanup
-            true     // useRecreatedBlobMeta
+        auto args = MakeCleanupArgs(
+            cleanupQueue,
+            cleanupCommitId,
+            true,   // useRecreatedBlobMeta
+            false   // verifyRecreatedBlobMetasOnCleanup
         );
+        RunPrepareAndExecute(executor, env, state, args);
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
         UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
@@ -744,15 +735,13 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             deletionCommitId,
             setup.MergedBlobMeta);
 
-        auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
-        RunPrepareAndExecute(
-            executor,
-            env,
-            state,
-            args,
-            false,   // verifyRecreatedBlobMetasOnCleanup
-            true     // useRecreatedBlobMeta
+        auto args = MakeCleanupArgs(
+            cleanupQueue,
+            cleanupCommitId,
+            true,   // useRecreatedBlobMeta
+            false   // verifyRecreatedBlobMetasOnCleanup
         );
+        RunPrepareAndExecute(executor, env, state, args);
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
         UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
@@ -772,7 +761,6 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
                 UNIT_ASSERT(HasGarbageBlob(db, setup.MergedBlobId));
             });
     }
-
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -267,12 +267,14 @@ void RunPrepareAndExecute(
     TTestEnv& env,
     TPartitionState& state,
     TTxPartition::TCleanup& args,
-    bool verifyRecreatedBlobMetasOnCleanup)
+    bool verifyRecreatedBlobMetasOnCleanup,
+    bool useRecreatedBlobMeta)
 {
     executor.ReadTx(
         [&](TPartitionDatabase db)
         {
             const bool ready = PrepareCleanupTransaction(
+                useRecreatedBlobMeta,
                 verifyRecreatedBlobMetasOnCleanup,
                 TTestExecutor::TabletId,
                 "test-disk",
@@ -295,6 +297,7 @@ void RunPrepareAndExecute(
                         1,
                         0}),
                 TTestExecutor::TabletId,
+                useRecreatedBlobMeta,
                 db,
                 args,
                 state);
@@ -574,7 +577,14 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
                 UNIT_ASSERT(HasMergedBlob(db, setup.MergedBlobId, 10, 13));
             });
 
-        RunPrepareAndExecute(executor, env, state, args, false);
+        RunPrepareAndExecute(
+            executor,
+            env,
+            state,
+            args,
+            false,   // verifyRecreatedBlobMetasOnCleanup
+            false    // useRecreatedBlobMeta
+        );
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
         UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
@@ -632,7 +642,15 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             setup.MergedBlobMeta);
 
         auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
-        RunPrepareAndExecute(executor, env, state, args, true);
+
+        RunPrepareAndExecute(
+            executor,
+            env
+            state,
+            args,
+            true,   // verifyRecreatedBlobMetasOnCleanup
+            false   // useRecreatedBlobMeta
+        );
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
         UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
@@ -648,6 +666,108 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
                 UNIT_ASSERT(HasGarbageBlob(db, setup.MergedBlobId));
             });
     }
+
+    Y_UNIT_TEST(ShouldCleanupMixedAndMergedBlobsWhenUseRecreatedBlobMeta)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        const ui64 deletionCommitId = MakeCommitId(0, 50);
+        const ui64 cleanupCommitId = MakeCommitId(0, 100);
+        const auto setup =
+            SetupMixedAndMergedBlobs(executor, state, deletionCommitId);
+
+        TVector<TCleanupQueueItem> cleanupQueue;
+        cleanupQueue.emplace_back(
+            setup.MixedBlobId,
+            deletionCommitId,
+            setup.MixedBlobMeta);
+        cleanupQueue.emplace_back(
+            setup.MergedBlobId,
+            deletionCommitId,
+            setup.MergedBlobMeta);
+
+        auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
+        RunPrepareAndExecute(
+            executor,
+            state,
+            args,
+            false,   // verifyRecreatedBlobMetasOnCleanup
+            true     // useRecreatedBlobMeta
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, state.GetCleanupQueue().GetCount());
+
+        // No blob metas were read from the database
+        UNIT_ASSERT_VALUES_EQUAL(0, args.ReadedBlobMetasCount);
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                UNIT_ASSERT(
+                    !HasMixedBlock(db, 0, setup.MixedBlobId.CommitId()));
+                UNIT_ASSERT(!HasMergedBlob(db, setup.MergedBlobId, 10, 13));
+                UNIT_ASSERT(HasGarbageBlob(db, setup.MixedBlobId));
+                UNIT_ASSERT(HasGarbageBlob(db, setup.MergedBlobId));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyDecrementMixedAndMergedBytesCountWhenUseRecreatedBlobMeta)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        const ui64 deletionCommitId = MakeCommitId(0, 50);
+        const ui64 cleanupCommitId = MakeCommitId(0, 100);
+        const auto setup =
+            SetupMixedAndMergedBlobs(executor, state, deletionCommitId);
+
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            { db.DeleteMixedBlock(2, setup.MixedBlobId.CommitId()); });
+
+        TVector<TCleanupQueueItem> cleanupQueue;
+        cleanupQueue.emplace_back(
+            setup.MixedBlobId,
+            deletionCommitId,
+            MakeMixedBlobMeta({0, 1}));
+        cleanupQueue.emplace_back(
+            setup.MergedBlobId,
+            deletionCommitId,
+            setup.MergedBlobMeta);
+
+        auto args = MakeCleanupArgs(cleanupQueue, cleanupCommitId);
+        RunPrepareAndExecute(
+            executor,
+            state,
+            args,
+            false,   // verifyRecreatedBlobMetasOnCleanup
+            true     // useRecreatedBlobMeta
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
+        UNIT_ASSERT_VALUES_EQUAL(2, args.BlobsMeta.size());
+        UNIT_ASSERT_VALUES_EQUAL(0, state.GetCleanupQueue().GetCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, state.GetMixedBlocksCount());
+
+        // No blob metas were read from the database
+        UNIT_ASSERT_VALUES_EQUAL(0, args.ReadedBlobMetasCount);
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                UNIT_ASSERT(
+                    !HasMixedBlock(db, 0, setup.MixedBlobId.CommitId()));
+                UNIT_ASSERT(!HasMergedBlob(db, setup.MergedBlobId, 10, 13));
+                UNIT_ASSERT(HasGarbageBlob(db, setup.MixedBlobId));
+                UNIT_ASSERT(HasGarbageBlob(db, setup.MergedBlobId));
+            });
+    }
+
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -626,6 +626,9 @@ struct TTxPartition
         const TRequestInfoPtr RequestInfo;
 
         const ui64 CommitId;
+        const bool UseRecreatedBlobMeta;
+        const bool VerifyRecreatedBlobMetasOnCleanup;
+
         TVector<TCleanupQueueItem> CleanupQueue;
 
         TVector<NProto::TBlobMeta> BlobsMeta;
@@ -635,9 +638,13 @@ struct TTxPartition
         TCleanup(
                 TRequestInfoPtr requestInfo,
                 ui64 commitId,
+                bool useRecreatedBlobMeta,
+                bool verifyRecreatedBlobMetasOnCleanup,
                 TVector<TCleanupQueueItem> cleanupQueue)
             : RequestInfo(std::move(requestInfo))
             , CommitId(commitId)
+            , UseRecreatedBlobMeta(useRecreatedBlobMeta)
+            , VerifyRecreatedBlobMetasOnCleanup(verifyRecreatedBlobMetasOnCleanup)
             , CleanupQueue(std::move(cleanupQueue))
         {}
 

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -630,7 +630,7 @@ struct TTxPartition
 
         TVector<NProto::TBlobMeta> BlobsMeta;
 
-        ui64 ReadedBlobMetasCount = 0;
+        ui64 ReadBlobMetasCount = 0;
 
         TCleanup(
                 TRequestInfoPtr requestInfo,
@@ -643,7 +643,7 @@ struct TTxPartition
 
         void Clear()
         {
-            ReadedBlobMetasCount = 0;
+            ReadBlobMetasCount = 0;
             BlobsMeta.clear();
         }
     };

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -630,6 +630,8 @@ struct TTxPartition
 
         TVector<NProto::TBlobMeta> BlobsMeta;
 
+        ui64 ReadedBlobMetasCount = 0;
+
         TCleanup(
                 TRequestInfoPtr requestInfo,
                 ui64 commitId,
@@ -641,6 +643,7 @@ struct TTxPartition
 
         void Clear()
         {
+            ReadedBlobMetasCount = 0;
             BlobsMeta.clear();
         }
     };

--- a/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
+++ b/cloud/blockstore/tests/loadtest/local-newfeatures/test.py
@@ -193,6 +193,13 @@ def storage_config_with_new_features_enabled():
     return storage
 
 
+def storage_config_with_use_recreated_blob_metas_on_cleanup_enabled():
+    storage = ordinary_prod_storage_config()
+    storage.UseRecreatedBlobMetasOnCleanup = True
+
+    return storage
+
+
 class TestCase(object):
 
     def __init__(
@@ -353,6 +360,14 @@ TESTS = [
             storage_config_with_read_block_mask_on_compaction_optimization_enabled(
                 True
             ),
+        ],
+        None,
+    ),
+    TestCase(
+        "version1-use-recreated-blob-metas-on-cleanup-enabled",
+        "cloud/blockstore/tests/loadtest/local-newfeatures/local-tablet-version-1-multiple-ranges.txt",
+        [
+            storage_config_with_use_recreated_blob_metas_on_cleanup_enabled(),
         ],
         None,
     ),


### PR DESCRIPTION
### Notes
Added using recreated metas instead of reading them

### Issue
#6279 
