### PR TITLE
[Filestore] add more profile data for unconfirmed flow

### DIFF
--- a/cloud/filestore/libs/diagnostics/events/profile_events.ev
+++ b/cloud/filestore/libs/diagnostics/events/profile_events.ev
@@ -120,6 +120,8 @@ message TProfileLogRequestInfo {
     optional bool BehaveAsShard = 13;
 
     optional uint32 Flags = 14;
+
+    optional uint64 CommitId = 15;
 };
 
 message TProfileLogRecord {

--- a/cloud/filestore/libs/diagnostics/profile_log_events.cpp
+++ b/cloud/filestore/libs/diagnostics/profile_log_events.cpp
@@ -308,7 +308,7 @@ void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
     const NProtoPrivate::TConfirmAddDataRequest& request)
 {
-    Y_UNUSED(profileLogRequest, request);
+    profileLogRequest.SetCommitId(request.GetCommitId());
 }
 
 template <>
@@ -316,7 +316,7 @@ void InitProfileLogRequestInfo(
     NProto::TProfileLogRequestInfo& profileLogRequest,
     const NProtoPrivate::TCancelAddDataRequest& request)
 {
-    Y_UNUSED(profileLogRequest, request);
+    profileLogRequest.SetCommitId(request.GetCommitId());
 }
 
 template <>

--- a/cloud/filestore/libs/storage/tablet/model/profile_log_events.h
+++ b/cloud/filestore/libs/storage/tablet/model/profile_log_events.h
@@ -32,6 +32,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(PrepareUnlinkDirectoryNodeInShard,  __VA_ARGS__)                       \
     xxx(AbortUnlinkDirectoryNodeInShard,    __VA_ARGS__)                       \
     xxx(AddDataUnconfirmed,                 __VA_ARGS__)                       \
+    xxx(RecoverUnconfirmedData,             __VA_ARGS__)                       \
 // FILESTORE_SYSTEM_REQUESTS
 
 #define FILESTORE_MATERIALIZE_REQUEST(name, ...) name,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -480,6 +480,14 @@ void TIndexTabletActor::HandleGenerateBlobIds(
             EFileStoreSystemRequest::AddDataUnconfirmed,
             ctx.Now());
 
+        AddRange(
+            msg->Record.GetNodeId(),
+            msg->Record.GetHandle(),
+            msg->Record.GetOffset(),
+            msg->Record.GetLength(),
+            profileLogRequest);
+        profileLogRequest.SetCommitId(commitId);
+
         auto requestInfo = CreateRequestInfo(
             SelfId(),
             commitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -483,8 +483,8 @@ void TIndexTabletActor::HandleGenerateBlobIds(
         AddRange(
             msg->Record.GetNodeId(),
             msg->Record.GetHandle(),
-            msg->Record.GetOffset(),
-            msg->Record.GetLength(),
+            byteRange.Offset,
+            byteRange.Length,
             profileLogRequest);
         profileLogRequest.SetCommitId(commitId);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmblobs.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/service/context.h>
+#include <cloud/filestore/libs/storage/tablet/model/profile_log_events.h>
 
 #include <cloud/storage/core/libs/kikimr/helpers.h>
 #include <cloud/storage/core/libs/tablet/blob_id.h>
@@ -321,6 +322,29 @@ void TIndexTabletActor::HandleConfirmBlobsCompleted(
     // each write's safe point. A single AddBlob is ever
     // in flight, so page faults cannot reorder
     Sort(recoverableCommitIds);
+
+    for (const ui64 commitId: recoverableCommitIds) {
+        auto it = UnconfirmedData.find(commitId);
+        TABLET_VERIFY(it != UnconfirmedData.end());
+        const auto& data = it->second.Data;
+        NProto::TProfileLogRequestInfo profileLogRequest;
+        InitTabletProfileLogRequestInfo(
+            profileLogRequest,
+            EFileStoreSystemRequest::RecoverUnconfirmedData,
+            ctx.Now());
+        AddRange(
+            data.GetNodeId(),
+            data.GetOffset(),
+            data.GetLength(),
+            profileLogRequest);
+        profileLogRequest.SetCommitId(commitId);
+        FinalizeProfileLogRequestInfo(
+            std::move(profileLogRequest),
+            ctx.Now(),
+            GetFileSystemId(),
+            {},
+            ProfileLog);
+    }
 
     RecoveredDataToConfirm.assign(
         recoverableCommitIds.begin(),

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -316,7 +316,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         storageConfig.SetAddingUnconfirmedDataEnabled(true);
         storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-        TTestEnv env({}, std::move(storageConfig));
+        const auto profileLog = std::make_shared<TTestProfileLog>();
+
+        TTestEnv env({}, std::move(storageConfig), {}, profileLog);
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
@@ -360,6 +362,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         UNIT_ASSERT_VALUES_EQUAL(1, gbi->Record.BlobsSize());
 
         GenerateBlobIdsPutBlobAndConfirm(env, tablet, *gbi, alignedData);
+
+        const auto& addData = profileLog->Requests[static_cast<ui32>(
+            EFileStoreSystemRequest::AddDataUnconfirmed)];
+        UNIT_ASSERT_VALUES_EQUAL(1, addData.size());
+        const auto& loggedRange = addData[0].Request.GetRanges(0);
+        UNIT_ASSERT_VALUES_EQUAL(id, loggedRange.GetNodeId());
+        UNIT_ASSERT_VALUES_EQUAL(handle, loggedRange.GetHandle());
+        UNIT_ASSERT_VALUES_EQUAL(writeOffset, loggedRange.GetOffset());
+        UNIT_ASSERT_VALUES_EQUAL(writeLength, loggedRange.GetBytes());
 
         TString expected = headData + alignedData + tailData;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1,3 +1,4 @@
+#include "model/profile_log_events.h"
 #include "tablet_schema.h"
 #include "tablet_tx.h"
 
@@ -1225,11 +1226,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             response->GetErrorReason().find("unconfirmed data not found") !=
                 TString::npos,
             response->GetErrorReason());
-        UNIT_ASSERT_VALUES_EQUAL(
-            1,
+        const auto& cancel =
             profileLog
-                ->Requests[static_cast<ui32>(EFileStoreRequest::CancelAddData)]
-                .size());
+                ->Requests[static_cast<ui32>(EFileStoreRequest::CancelAddData)];
+        UNIT_ASSERT_VALUES_EQUAL(1, cancel.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            unknownCommitId,
+            cancel[0].Request.GetCommitId());
     }
 
     Y_UNIT_TEST(ShouldReplyToRepeatedCancelAddDataWhileDeleteInProgress)
@@ -1426,6 +1429,95 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
                 ReadData(tablet, handle, block, 0),
                 "cycle=" << cycle);
         }
+    }
+
+    Y_UNIT_TEST(ShouldLogRecoveryAddBlobsToProfileLog)
+    {
+        const ui32 block = 4_KB;
+        const auto profileLog = std::make_shared<TTestProfileLog>();
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig), {}, profileLog);
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        const ui64 commitId =
+            GenerateBlobIdsAndPutBlob(env, tablet, id, handle, 0, block, 'a');
+        WaitForTabletCommit(env);
+        AssertStorageStats(tablet, 1, 0);
+
+        const auto recoverType =
+            static_cast<ui32>(EFileStoreSystemRequest::RecoverUnconfirmedData);
+        UNIT_ASSERT(profileLog->Requests[recoverType].empty());
+
+        RebootTabletAndCreateHandle(tablet, id);
+
+        const auto& recovered = profileLog->Requests[recoverType];
+        UNIT_ASSERT_VALUES_EQUAL(1, recovered.size());
+
+        const auto& request = recovered[0].Request;
+        UNIT_ASSERT_VALUES_EQUAL(commitId, request.GetCommitId());
+        UNIT_ASSERT_VALUES_EQUAL(1, request.RangesSize());
+
+        const auto& range = request.GetRanges(0);
+        UNIT_ASSERT_VALUES_EQUAL(id, range.GetNodeId());
+        UNIT_ASSERT_VALUES_EQUAL(0, range.GetOffset());
+        UNIT_ASSERT_VALUES_EQUAL(block, range.GetBytes());
+    }
+
+    Y_UNIT_TEST(ShouldLogAddDataUnconfirmedAndConfirmAddDataDetails)
+    {
+        const ui32 block = 4_KB;
+        const auto profileLog = std::make_shared<TTestProfileLog>();
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+
+        TTestEnv env({}, std::move(storageConfig), {}, profileLog);
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        const ui64 commitId =
+            GenerateBlobIdsAndPutBlob(env, tablet, id, handle, 0, block, 'a');
+        WaitForTabletCommit(env);
+
+        tablet.SendConfirmAddDataRequest(commitId);
+        tablet.AssertConfirmAddDataResponse(S_OK);
+
+        const auto& addData = profileLog->Requests[static_cast<ui32>(
+            EFileStoreSystemRequest::AddDataUnconfirmed)];
+        UNIT_ASSERT_VALUES_EQUAL(1, addData.size());
+        const auto& addReq = addData[0].Request;
+        UNIT_ASSERT_VALUES_EQUAL(commitId, addReq.GetCommitId());
+        UNIT_ASSERT_VALUES_EQUAL(1, addReq.RangesSize());
+        UNIT_ASSERT_VALUES_EQUAL(id, addReq.GetRanges(0).GetNodeId());
+        UNIT_ASSERT_VALUES_EQUAL(handle, addReq.GetRanges(0).GetHandle());
+        UNIT_ASSERT_VALUES_EQUAL(0, addReq.GetRanges(0).GetOffset());
+        UNIT_ASSERT_VALUES_EQUAL(block, addReq.GetRanges(0).GetBytes());
+
+        const auto& confirm = profileLog->Requests[static_cast<ui32>(
+            EFileStoreRequest::ConfirmAddData)];
+        UNIT_ASSERT_VALUES_EQUAL(1, confirm.size());
+        UNIT_ASSERT_VALUES_EQUAL(commitId, confirm[0].Request.GetCommitId());
+        UNIT_ASSERT_VALUES_EQUAL(0, confirm[0].Request.RangesSize());
     }
 
     Y_UNIT_TEST(ShouldHandleCommitIdOverflowInAddDataUnconfirmed)

--- a/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/dump_ut.cpp
@@ -94,7 +94,7 @@ Y_UNIT_TEST_SUITE(TDumpTest)
     {
         const auto requests = GetRequestTypes();
 
-        UNIT_ASSERT_VALUES_EQUAL(79, requests.size());
+        UNIT_ASSERT_VALUES_EQUAL(80, requests.size());
 
         ui32 index = 0;
 #define TEST_REQUEST_TYPE(id, name)                                            \
@@ -188,6 +188,7 @@ Y_UNIT_TEST_SUITE(TDumpTest)
         TEST_REQUEST_TYPE(10014, PrepareUnlinkDirectoryNodeInShard);
         TEST_REQUEST_TYPE(10015, AbortUnlinkDirectoryNodeInShard);
         TEST_REQUEST_TYPE(10016, AddDataUnconfirmed);
+        TEST_REQUEST_TYPE(10017, RecoverUnconfirmedData);
 
 #undef TEST_REQUEST_TYPE
     }

--- a/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
+++ b/cloud/filestore/tools/analytics/libs/event-log/request_printer.cpp
@@ -400,6 +400,10 @@ public:
             out << PrintValue("request_flags", request.GetFlags()) << "\t";
         }
 
+        if (request.HasCommitId()) {
+            out << PrintValue("commit_id", request.GetCommitId()) << "\t";
+        }
+
         if (out.empty()) {
             out << "{no_info}";
         } else {


### PR DESCRIPTION
### Notes
Added new system request to see directly recovered unconfirmed data
Added more info about write to addDataUnconfirmed and Confirm/Cancel Data

### Issue
#2293
