### PR TITLE
issue-6271: [Filestore] Delete AllowCache from TGetStorageStatsRequest

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_ut.cpp
@@ -1146,8 +1146,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         {
             NProtoPrivate::TGetStorageStatsRequest request;
             request.SetFileSystemId(fsId);
-            request.SetAllowCache(true);
-            request.SetCacheTTL(30000); // in ms
+            request.SetCacheTTL(Max<ui32>()); // in ms
 
             NProtoPrivate::TGetStorageStatsResponse response =
                 GetStorageStats(service, request);
@@ -1158,7 +1157,6 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
         for (ui64 i = 0; i < shardsCount; ++i) {
             NProtoPrivate::TGetStorageStatsRequest request;
             request.SetFileSystemId(fileSystems[i].Id);
-            request.SetAllowCache(false);
             request.SetMode(
                 NProtoPrivate::STATS_REQUEST_MODE_FORCE_FETCH_SHARDS);
 
@@ -1293,8 +1291,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceActionsTest)
 
         NProtoPrivate::TGetStorageStatsRequest request;
         request.SetFileSystemId(fsId);
-        request.SetAllowCache(true);
-        request.SetCacheTTL(30000); // in ms
+        request.SetCacheTTL(Max<ui32>()); // in ms
 
         NProtoPrivate::TGetStorageStatsResponse response =
             GetStorageStats(service, request);

--- a/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_destroyfs.cpp
@@ -178,7 +178,7 @@ void TDestroyFileStoreActor::GetStorageStats(const TActorContext& ctx)
 {
     auto request =
         std::make_unique<TEvIndexTablet::TEvGetStorageStatsRequest>();
-    request->Record.SetAllowCache(true);
+    request->Record.SetCacheTTL(Max<ui32>());
     request->Record.SetFileSystemId(FileSystemId);
     request->Record.SetMode(NProtoPrivate::STATS_REQUEST_MODE_GET_ONLY_SELF);
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -64,15 +64,13 @@ NProtoPrivate::TGetFileSystemTopologyResponse GetFileSystemTopology(
 NProtoPrivate::TGetStorageStatsResponse GetStorageStats(
     TServiceClient& service,
     const TString& fsId,
-    const bool allowCache = false,
-    const ui32 cacheTTLMs = 0,
+    const ui32 cacheTTL = 0,
     const NProtoPrivate::EStatsRequestMode mode =
         NProtoPrivate::STATS_REQUEST_MODE_DEFAULT)
 {
     NProtoPrivate::TGetStorageStatsRequest request;
     request.SetFileSystemId(fsId);
-    request.SetAllowCache(allowCache);
-    request.SetCacheTTL(cacheTTLMs);
+    request.SetCacheTTL(cacheTTL);
     request.SetMode(mode);
     TString buf;
     google::protobuf::util::MessageToJsonString(request, &buf);
@@ -91,18 +89,16 @@ void CheckShardsSize(
     const ui64 blocksCount)
 {
     const auto mainStats =
-        GetStorageStats(service, fsConfig.FsId, false /* allowCache */);
+        GetStorageStats(service, fsConfig.FsId);
     const auto shard1Stats = GetStorageStats(
         service,
         fsConfig.Shard1Id,
-        false /* allowCache */,
-        0 /* cacheTTLMs */,
+        0 /* cacheTTL */,
         NProtoPrivate::STATS_REQUEST_MODE_FORCE_FETCH_SHARDS);
     const auto shard2Stats = GetStorageStats(
         service,
         fsConfig.Shard2Id,
-        false /* allowCache */,
-        0 /* cacheTTLMs */,
+        0 /* cacheTTL */,
         NProtoPrivate::STATS_REQUEST_MODE_FORCE_FETCH_SHARDS);
     UNIT_ASSERT_EQUAL(blocksCount, mainStats.GetStats().GetTotalBlocksCount());
     UNIT_ASSERT_EQUAL(
@@ -2561,7 +2557,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.FsId,
-                true /* allowCache */);
+                Max<ui32>() /* cacheTTL */);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 (data1.size() + data2.size()) / 4_KB,
@@ -2580,7 +2576,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.FsId,
-                true /* allowCache */);
+                Max<ui32>() /* cacheTTL */);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 (data1.size() + data2.size()) / 4_KB,
@@ -2711,8 +2707,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.FsId,
-                false /* allowCache */,
-                0, /* cacheTTLMs */
+                0, /* cacheTTL */
                 NProtoPrivate::STATS_REQUEST_MODE_GET_ONLY_SELF);
             const auto& stats = response.GetStats();
             // No blocks are used by the main filesystem itself, all blocks are
@@ -2732,8 +2727,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         {
             const auto response = GetStorageStats(
                 service,
-                fsConfig.Shard2Id,
-                false /* allowCache */);
+                fsConfig.Shard2Id);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 data2.size() / 4_KB,
@@ -2746,8 +2740,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.Shard1Id,
-                false /* allowCache */,
-                0 /* cacheTTLMs */,
+                0 /* cacheTTL */,
                 NProtoPrivate::STATS_REQUEST_MODE_FORCE_FETCH_SHARDS);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
@@ -2759,8 +2752,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.Shard2Id,
-                false /* allowCache */,
-                0 /* cacheTTLMs */,
+                0 /* cacheTTL */,
                 NProtoPrivate::STATS_REQUEST_MODE_FORCE_FETCH_SHARDS);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
@@ -3196,7 +3188,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.FsId,
-                true /* allowCache */);
+                Max<ui32>() /* cacheTTL */);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 (data1.size() + data2.size()) / 4_KB,
@@ -3271,7 +3263,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.FsId,
-                true /* allowCache */);
+                Max<ui32>() /* cacheTTL */);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 (data1.size() + data2.size()) / 4_KB,
@@ -3313,7 +3305,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             const auto response = GetStorageStats(
                 service,
                 fsConfig.FsId,
-                true /* allowCache */);
+                Max<ui32>() /* cacheTTL */);
             const auto& stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(
                 (data1.size() + data2.size()) / 4_KB,
@@ -6670,8 +6662,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             response = GetStorageStats(
                 service,
                 fsConfig.Shard1Id,
-                true /* allowCache */,
-                30000 /* cacheTTLMs */,
+                Max<ui32>() /* cacheTTL */,
                 NProtoPrivate::STATS_REQUEST_MODE_FORCE_FETCH_SHARDS);
             stats = response.GetStats();
             UNIT_ASSERT_VALUES_EQUAL(2, stats.ShardStatsSize());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -764,9 +764,9 @@ void TIndexTabletActor::HandleGetStorageStats(
         ? GetFileSystem().GetShardFileSystemIds()
         : Default<google::protobuf::RepeatedPtrField<TString>>();
 
-    const bool allowCache = req.GetAllowCache() || (req.GetCacheTTL() &&
+    const bool allowCache = req.GetCacheTTL() &&
                             ctx.Now() - CachedAggregateStatsTs <
-                                TDuration::MilliSeconds(req.GetCacheTTL()));
+                                TDuration::MilliSeconds(req.GetCacheTTL());
 
     if (allowCache && pollShards) {
         *stats = CachedAggregateStats;

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -198,8 +198,9 @@ message TGetStorageStatsRequest
     // The same but for garbage score.
     uint32 CompactionRangeCountByGarbageScore = 5;
 
-    // Use cached data, don't require up-to-date stats.
-    bool AllowCache = 6;
+    // AllowCache used to take this place.
+    reserved 6;
+    reserved "AllowCache";
 
     // Statitics fetching mode: DEFAULT/FORCE_FETCH_SHARDS/GET_ONLY_SELF.
     // By default requests to shards do not fetch other shards, requests

--- a/doc/filestore/design/sharding.md
+++ b/doc/filestore/design/sharding.md
@@ -18,7 +18,7 @@ The following aggregate metrics are exported:
 * AggregateUsedBytesCount - sum(UsedBytesCount) over all shards
 
 `GetStorageStats` requests are sent to the shards in background each 15 seconds.
-Cached shard metrics can be retrieved by using `AllowCache: true` flag in `TGetStorageStatsRequest`.
+Cached shard metrics can be retrieved by using `CacheTTL` property of `TGetStorageStatsRequest`.
 Shard metrics such as UsedBytesCount, CurrentLoad and Suffer are displayed on the main tablet monpage.
 Shard metrics are used by ShardBalancer in the main tablet to pessimize file creation in shards with low free space.
 


### PR DESCRIPTION
### Notes
TGetStorageStatsRequest::AllowCache is deleted as we can allow cache by specifying large enough CacheTTL 

### Issue
#6271
