### PR TITLE
[Filestore] add MapPopulate parameter to TMmapRequest

### DIFF
--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -1313,7 +1313,8 @@ public:
         Result = this->AppCtx.State->CreateMmapRegion(
             this->Request->GetFilePath(),
             this->Request->GetSize(),
-            this->Request->GetPageSize());
+            this->Request->GetPageSize(),
+            this->Request->GetMapPopulate());
         NProto::TMmapResponse response;
 
         if (NCloud::HasError(Result)) {

--- a/cloud/filestore/libs/server/server_memory_state.cpp
+++ b/cloud/filestore/libs/server/server_memory_state.cpp
@@ -41,7 +41,8 @@ TServerState::~TServerState()
 TResultOrError<TMmapRegionMetadata> TServerState::CreateMmapRegion(
     const TString& filePath,
     size_t size,
-    ui32 pageSize)
+    ui32 pageSize,
+    bool mapPopulate)
 {
     if (size < MinPageSize) {
         return MakeError(E_ARGUMENT, "Size must be greater or equal to 4 KB");
@@ -89,11 +90,16 @@ TResultOrError<TMmapRegionMetadata> TServerState::CreateMmapRegion(
                 fullPath.c_str()));
     }
 
+    int flags = MAP_SHARED;
+    if (mapPopulate) {
+        flags |= MAP_POPULATE;
+    }
+
     void* addr = mmap(
         nullptr,
         size,
         PROT_READ | PROT_WRITE,
-        MAP_SHARED,
+        flags,
         file,
         0 /* offset */);
     if (addr == MAP_FAILED) {

--- a/cloud/filestore/libs/server/server_memory_state.h
+++ b/cloud/filestore/libs/server/server_memory_state.h
@@ -139,7 +139,8 @@ public:
     TResultOrError<TMmapRegionMetadata> CreateMmapRegion(
         const TString& filePath,
         size_t size /* in bytes */,
-        ui32 pageSize /* in bytes */);
+        ui32 pageSize /* in bytes */,
+        bool mapPopulate = false);
 
     NProto::TError DestroyMmapRegion(ui64 mmapId);
 

--- a/cloud/filestore/libs/server/server_memory_state_ut.cpp
+++ b/cloud/filestore/libs/server/server_memory_state_ut.cpp
@@ -50,9 +50,14 @@ Y_UNIT_TEST_SUITE(TServerStateTest)
 
         const size_t fileSize = 4096;
         const ui32 pageSize = 1024;
+        bool mapPopulate = true;
         TString relativePath = env.CreateTestFile("test_file.dat", fileSize);
 
-        auto result = state.CreateMmapRegion(relativePath, fileSize, pageSize);
+        auto result = state.CreateMmapRegion(
+            relativePath,
+            fileSize,
+            pageSize,
+            mapPopulate);
 
         UNIT_ASSERT_C(!HasError(result), FormatError(result.GetError()));
 

--- a/cloud/filestore/public/api/protos/server.proto
+++ b/cloud/filestore/public/api/protos/server.proto
@@ -66,6 +66,9 @@ message TMmapRequest
     // will be rejected.
     // If PageSize is 0, these constraints are disabled.
     optional uint32 PageSize = 4;
+
+    // Populate page tables for a mapping
+    optional bool MapPopulate = 5;
 }
 
 message TMmapResponse

--- a/cloud/filestore/public/sdk/python/client/client.py
+++ b/cloud/filestore/public/sdk/python/client/client.py
@@ -699,6 +699,7 @@ class Client(object):
         file_path: str,
         size: int,
         page_size: Optional[int] = 0,
+        map_populate: Optional[bool] = False,
         idempotence_id: Optional[str] = None,
         timestamp: Optional[int] = None,
         trace_id: Optional[str] = None,
@@ -707,7 +708,8 @@ class Client(object):
         request = protos.TMmapRequest(
             FilePath=file_path,
             Size=size,
-            PageSize=page_size
+            PageSize=page_size,
+            MapPopulate=map_populate,
         )
         return self.__impl.mmap(
             request, idempotence_id, timestamp, trace_id, request_timeout)

--- a/cloud/filestore/tests/service/service-kikimr-parentless-handleless-test/shared_memory_test.py
+++ b/cloud/filestore/tests/service/service-kikimr-parentless-handleless-test/shared_memory_test.py
@@ -74,7 +74,7 @@ def setup_test_filestore(nfs_client, fs_name, shard_count=None):
     return session_id, node
 
 
-def create_mmap_region(nfs_client, filename, size, page_size=0) -> (int, str):
+def create_mmap_region(nfs_client, filename, size, page_size=0, map_populate=False) -> (int, str):
     """Create a file and mmap it, returning the region ID and file path."""
     base_path = os.path.join(common.output_path(), "shm")
     file_path = os.path.join(base_path, filename)
@@ -82,7 +82,12 @@ def create_mmap_region(nfs_client, filename, size, page_size=0) -> (int, str):
     with open(file_path, "wb") as f:
         f.truncate(size)
 
-    response = nfs_client.mmap(file_path=filename, size=size, page_size=page_size)
+    response = nfs_client.mmap(
+        file_path=filename,
+        size=size,
+        page_size=page_size,
+        map_populate=map_populate
+    )
     return response.Id, file_path
 
 
@@ -91,7 +96,7 @@ def test_mmap_unmmap():
     port = os.getenv("NFS_SERVER_PORT")
 
     with CreateClient(f"localhost:{port}", log=logger) as nfs_client:
-        region_id, file_path = create_mmap_region(nfs_client, "testfile", 4096, 1024)
+        region_id, file_path = create_mmap_region(nfs_client, "testfile", 4096, 1024, True)
         logger.info(f"Successfully mmaped file with region ID: {region_id}")
 
         regions = nfs_client.list_mmap_regions()


### PR DESCRIPTION
issue: #6353

Use MapPopulate parameter to allocate shared memory pages on the same numa node as a filestore process