### PR TITLE
[Disk Manager] Handle res.Err() in scanFilesystemSnapshotStates

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
@@ -134,7 +134,7 @@ func scanFilesystemSnapshotStates(ctx context.Context, res persistence.Result) (
 		}
 	}
 
-	// NOTE: always check stream query result after iteration.
+	// NOTE: always check query result after iteration.
 	if res.Err() != nil {
 		return nil, errors.NewRetriableError(res.Err())
 	}

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
@@ -134,6 +134,11 @@ func scanFilesystemSnapshotStates(ctx context.Context, res persistence.Result) (
 		}
 	}
 
+	// NOTE: always check stream query result after iteration.
+	if res.Err() != nil {
+		return nil, errors.NewRetriableError(res.Err())
+	}
+
 	return states, nil
 }
 


### PR DESCRIPTION
### Notes
We use CheckFilesystemSnapshotReady in snapshot transfer tasks (snapshot <-> fs). 
And when we cancel the context within tests, it returns nil state, which leads to silent non-retriable error, which fails tests.