### PR TITLE
[Filestore] fix data loss if FlushBytes receives an error during ReadBlob or WriteBlob

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -895,14 +895,28 @@ void TIndexTabletActor::HandleFlushBytesCompleted(
 {
     const auto* msg = ev->Get();
 
+    ReleaseMixedBlocks(msg->MixedBlocksRanges);
+    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
+    WorkerActors.erase(ev->Sender);
+
+    const auto error = msg->GetError();
+
+    if (HasError(error)) {
+        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+            "%s FlushBytes failed (%s)",
+            LogTag.c_str(),
+            FormatError(error).c_str());
+
+        CompleteBlobIndexOp();
+        FlushState.Complete();
+        EnqueueBlobIndexOpIfNeeded(ctx);
+        return;
+    }
+
     LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
         "%s FlushBytes completed (%s)",
         LogTag.c_str(),
         FormatError(msg->GetError()).c_str());
-
-    ReleaseMixedBlocks(msg->MixedBlocksRanges);
-    TABLET_VERIFY(TryReleaseCollectBarrier(msg->CommitId));
-    WorkerActors.erase(ev->Sender);
 
     Metrics.FlushBytes.Update(1, msg->Size, msg->Time);
 
@@ -917,7 +931,6 @@ void TIndexTabletActor::HandleFlushBytesCompleted(
         msg->CallContext,
         "TrimBytes");
 
-    // FIXME: validate for errors
     ExecuteTx<TTrimBytes>(ctx, std::move(requestInfo), msg->ChunkId);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -902,7 +902,7 @@ void TIndexTabletActor::HandleFlushBytesCompleted(
     const auto error = msg->GetError();
 
     if (HasError(error)) {
-        LOG_DEBUG(ctx, TFileStoreComponents::TABLET,
+        LOG_ERROR(ctx, TFileStoreComponents::TABLET,
             "%s FlushBytes failed (%s)",
             LogTag.c_str(),
             FormatError(error).c_str());

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -522,88 +522,46 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
         }
 
-        struct TObservedFlushBytesPut
-        {
-            TActorId WriteBlobActor;
-            ui64 Cookie = 0;
-            TLogoBlobID BlobId;
-        };
-
-        bool rewriteFlushBytesPutResults = true;
-
-        TVector<TObservedFlushBytesPut> observedFlushBytesPuts;
-        THashSet<TActorId> failedFlushBytesWriteBlobActors;
-
-        ui32 rewrittenPutResults = 0;
+        ui32 rejectedPutResults = 0;
         ui32 droppedFailedWriteBlobCompleted = 0;
 
         env.GetRuntime().SetEventFilter(
             [&] (auto& runtime, auto& event) {
-                Y_UNUSED(runtime);
-
                 switch (event->GetTypeRewrite()) {
                     case TEvBlobStorage::EvPut: {
-                        auto* msg =
-                            event->template Get<TEvBlobStorage::TEvPut>();
+                        auto* msg = event->template Get<TEvBlobStorage::TEvPut>();
 
-                        // FlushBytes writes its destination blob via async
-                        // WriteBlob.
-                        //
-                        // The filter is installed only after the setup writes,
-                        // so this should target the FlushBytes destination
-                        // blob rather than the initial 128 KiB base-data
-                        // write.
-                        if (rewriteFlushBytesPutResults &&
-                            msg->HandleClass == NKikimrBlobStorage::AsyncBlob &&
-                            msg->Id.TabletID() == tabletId &&
-                            msg->Id.BlobSize() == block)
+                        // FlushBytes writes its destination blob through async
+                        // blob
+                        if (msg->HandleClass != NKikimrBlobStorage::AsyncBlob ||
+                            msg->Id.TabletID() != tabletId ||
+                            msg->Id.BlobSize() != block)
                         {
-                            observedFlushBytesPuts.push_back({
-                                event->Sender,  // TWriteBlobActor
-                                event->Cookie,
-                                msg->Id,
-                            });
-                        }
-
-                        break;
-                    }
-
-                    case TEvBlobStorage::EvPutResult: {
-                        if (!rewriteFlushBytesPutResults) {
                             break;
                         }
 
-                        auto* msg = event->template Get<
-                            TEvBlobStorage::TEvPutResult>();
+                        auto response = std::make_unique<TEvBlobStorage::TEvPutResult>(
+                            NKikimrProto::ERROR,
+                            msg->Id,
+                            NKikimr::TStorageStatusFlags(),
+                            NKikimr::GroupIDFromBlobStorageProxyID(event->Recipient),
+                            0.0f);
 
-                        bool isFlushBytesPutResult = false;
+                        response->ErrorReason =
+                            "injected FlushBytes TEvPut failure";
 
-                        for (const auto& put: observedFlushBytesPuts) {
-                            if (event->Recipient == put.WriteBlobActor &&
-                                event->Cookie == put.Cookie &&
-                                msg->Id == put.BlobId)
-                            {
-                                isFlushBytesPutResult = true;
-                                break;
-                            }
-                        }
+                        runtime.Schedule(new IEventHandle(
+                            event->Sender,      // recipient: TWriteBlobActor
+                            event->Recipient,   // sender: BS proxy
+                            response.release(),
+                            0,
+                            event->Cookie
+                        ), TDuration::Zero(), nodeIdx);
 
-                        if (!isFlushBytesPutResult) {
-                            break;
-                        }
+                        ++rejectedPutResults;
 
-                        // Rewrite the real BlobStorage response into a failed
-                        // write.  TWriteBlobActor will naturally convert this
-                        // into TEvWriteBlobResponse(E_REJECTED) for
-                        // TFlushBytesActor.
-                        msg->Status = NKikimrProto::ERROR;
-                        msg->ErrorReason =
-                            "injected FlushBytes TEvPutResult failure";
-
-                        failedFlushBytesWriteBlobActors.insert(event->Recipient);
-                        ++rewrittenPutResults;
-
-                        break;
+                        // Consume the original TEvPut. BlobStorage never sees it.
+                        return true;
                     }
 
                     case TEvIndexTabletPrivate::EvWriteBlobCompleted: {
@@ -618,9 +576,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                         // By dropping this notification, we emulate the case
                         // where it was reordered with TEvWriteBlobResponse,
                         // which reached the tablet before it suicided.
-                        if (failedFlushBytesWriteBlobActors.contains(event->Sender) &&
-                            FAILED(msg->GetStatus()))
-                        {
+                        if (FAILED(msg->GetStatus())) {
                             ++droppedFailedWriteBlobCompleted;
                             return true;
                         }
@@ -635,19 +591,18 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         auto flushBytesResponse = tablet.AssertFlushBytesFailed();
         UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, flushBytesResponse->GetStatus());
 
-        UNIT_ASSERT(!observedFlushBytesPuts.empty());
-        UNIT_ASSERT(rewrittenPutResults);
+        UNIT_ASSERT(rejectedPutResults);
 
         // Let TEvFlushBytesCompleted(error) be processed by the tablet.
         env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
 
         UNIT_ASSERT(droppedFailedWriteBlobCompleted);
+        env.GetRuntime().SetEventFilter(
+            TTestActorRuntimeBase::DefaultFilterFunc);
 
         {
             auto response = tablet.ReadData(handle, 0, block);
             const auto& actual = response->Record.GetBuffer();
-
-            UNIT_ASSERT_VALUES_EQUAL(block, actual.size());
 
             // Data loss. On the buggy code this range becomes
             // "0000000000" because the fresh-byte overlay was trimmed even
@@ -680,6 +635,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             // On buggy code this becomes 0 because failed FlushBytes still
             // trims the source fresh bytes.
             UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
+        }
+
+        tablet.FlushBytes();
+
+        // Check again, just in case.
+        {
+            auto response = tablet.ReadData(handle, 0, block);
+            const auto& actual = response->Record.GetBuffer();
+            UNIT_ASSERT_VALUES_EQUAL(expected, actual);
         }
 
         tablet.DestroyHandle(handle);
@@ -739,61 +703,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
         }
 
-        bool rewriteFlushBytesGetResults = true;
-        TActorId flushBytesReadBlobActor;
-        ui64 flushBytesReadBlobCookie = 0;
-
-        ui32 observedFlushBytesGets = 0;
         ui32 rewrittenGetResults = 0;
 
         env.GetRuntime().SetEventFilter(
-            [&] (auto& runtime, auto& event) {
-                Y_UNUSED(runtime);
-
+            [&] (auto&, auto& event) {
                 switch (event->GetTypeRewrite()) {
-                    case TEvBlobStorage::EvGet: {
-                        auto* msg = event->template Get<TEvBlobStorage::TEvGet>();
-
-                        if (!rewriteFlushBytesGetResults ||
-                            msg->GetHandleClass != NKikimrBlobStorage::AsyncRead)
-                        {
-                            break;
-                        }
-
-                        bool isFlushBytesRead = false;
-
-                        for (ui32 i = 0; i < msg->QuerySize; ++i) {
-                            const auto& query = msg->Queries[i];
-
-                            if (query.Id.TabletID() == tabletId &&
-                                query.Id.BlobSize() == rangeSize)
-                            {
-                                isFlushBytesRead = true;
-                                break;
-                            }
-                        }
-
-                        if (isFlushBytesRead) {
-                            // This is the real TEvGet issued by TReadBlobActor for
-                            // FlushBytes. Let it go to BlobStorage, but remember who
-                            // should receive the real TEvGetResult.
-                            flushBytesReadBlobActor = event->Sender;
-                            flushBytesReadBlobCookie = event->Cookie;
-                            ++observedFlushBytesGets;
-                        }
-
-                        break;
-                    }
-
                     case TEvBlobStorage::EvGetResult: {
-                        if (!rewriteFlushBytesGetResults ||
-                            !observedFlushBytesGets ||
-                            event->Recipient != flushBytesReadBlobActor ||
-                            event->Cookie != flushBytesReadBlobCookie)
-                        {
-                            break;
-                        }
-
                         auto* msg = event->template Get<
                             TEvBlobStorage::TEvGetResult>();
 
@@ -815,21 +730,17 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         auto flushBytesResponse = tablet.AssertFlushBytesFailed();
         UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, flushBytesResponse->GetStatus());
 
-        UNIT_ASSERT(observedFlushBytesGets);
         UNIT_ASSERT(rewrittenGetResults);
 
         // Let TEvReadBlobCompleted and TEvFlushBytesCompleted(error) be processed.
         env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
 
-        rewriteFlushBytesGetResults = false;
         env.GetRuntime().SetEventFilter(
             TTestActorRuntimeBase::DefaultFilterFunc);
 
         {
             auto response = tablet.ReadData(handle, 0, rangeSize);
             const auto& actual = response->Record.GetBuffer();
-
-            UNIT_ASSERT_VALUES_EQUAL(rangeSize, actual.size());
 
             // Data loss. On buggy code this becomes "0000000000",
             // because the fresh byte overlay was trimmed after failed FlushBytes.
@@ -863,6 +774,16 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             // Buggy code trims these bytes even though FlushBytes failed at
             // ReadBlob.
             UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
+        }
+
+        tablet.FlushBytes();
+
+        // Check again, just in case.
+        {
+            auto response = tablet.ReadData(handle, 0, rangeSize);
+            const auto& actual = response->Record.GetBuffer();
+
+            UNIT_ASSERT_VALUES_EQUAL(expected, actual);
         }
 
         tablet.DestroyHandle(handle);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -472,6 +472,402 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
     }
 
+    TABLET_TEST(ShouldNotTrimFreshBytesIfFlushBytesWriteBlobFails)
+    {
+        const auto block = tabletConfig.BlockSize;
+
+        TTestEnv env;
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+
+        tablet.InitSession("client", "session");
+
+        auto nodeId = CreateNode(
+            tablet,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, nodeId);
+
+        // Make the file one full block long and fill it with visible base data.
+        // Depending on config this may remain a fresh block or become a mixed
+        // blob.
+        tablet.WriteData(handle, 0, block, '0');
+
+        // Fresh byte overlay that FlushBytes will try to merge into a full
+        // block and write as a mixed blob.
+        tablet.WriteData(handle, 100, 10, 'a');
+
+        TString expected(block, '0');
+        memset(&expected[100], 'a', 10);
+
+        ui64 mixedBlobsCountBefore = 0;
+        ui64 mixedBlocksCountBefore = 0;
+        ui64 garbageBlocksCountBefore = 0;
+        ui64 freshBlocksCountBefore = 0;
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+
+            mixedBlobsCountBefore = stats.GetMixedBlobsCount();
+            mixedBlocksCountBefore = stats.GetMixedBlocksCount();
+            garbageBlocksCountBefore = stats.GetGarbageBlocksCount();
+            freshBlocksCountBefore = stats.GetFreshBlocksCount();
+
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
+        }
+
+        struct TObservedFlushBytesPut
+        {
+            TActorId WriteBlobActor;
+            ui64 Cookie = 0;
+            TLogoBlobID BlobId;
+        };
+
+        bool rewriteFlushBytesPutResults = true;
+
+        TVector<TObservedFlushBytesPut> observedFlushBytesPuts;
+        THashSet<TActorId> failedFlushBytesWriteBlobActors;
+
+        ui32 rewrittenPutResults = 0;
+        ui32 droppedFailedWriteBlobCompleted = 0;
+
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, auto& event) {
+                Y_UNUSED(runtime);
+
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvPut: {
+                        auto* msg =
+                            event->template Get<TEvBlobStorage::TEvPut>();
+
+                        // FlushBytes writes its destination blob via async
+                        // WriteBlob.
+                        //
+                        // The filter is installed only after the setup writes,
+                        // so this should target the FlushBytes destination
+                        // blob rather than the initial 128 KiB base-data
+                        // write.
+                        if (rewriteFlushBytesPutResults &&
+                            msg->HandleClass == NKikimrBlobStorage::AsyncBlob &&
+                            msg->Id.TabletID() == tabletId &&
+                            msg->Id.BlobSize() == block)
+                        {
+                            observedFlushBytesPuts.push_back({
+                                event->Sender,  // TWriteBlobActor
+                                event->Cookie,
+                                msg->Id,
+                            });
+                        }
+
+                        break;
+                    }
+
+                    case TEvBlobStorage::EvPutResult: {
+                        if (!rewriteFlushBytesPutResults) {
+                            break;
+                        }
+
+                        auto* msg = event->template Get<
+                            TEvBlobStorage::TEvPutResult>();
+
+                        bool isFlushBytesPutResult = false;
+
+                        for (const auto& put: observedFlushBytesPuts) {
+                            if (event->Recipient == put.WriteBlobActor &&
+                                event->Cookie == put.Cookie &&
+                                msg->Id == put.BlobId)
+                            {
+                                isFlushBytesPutResult = true;
+                                break;
+                            }
+                        }
+
+                        if (!isFlushBytesPutResult) {
+                            break;
+                        }
+
+                        // Rewrite the real BlobStorage response into a failed
+                        // write.  TWriteBlobActor will naturally convert this
+                        // into TEvWriteBlobResponse(E_REJECTED) for
+                        // TFlushBytesActor.
+                        msg->Status = NKikimrProto::ERROR;
+                        msg->ErrorReason =
+                            "injected FlushBytes TEvPutResult failure";
+
+                        failedFlushBytesWriteBlobActors.insert(event->Recipient);
+                        ++rewrittenPutResults;
+
+                        break;
+                    }
+
+                    case TEvIndexTabletPrivate::EvWriteBlobCompleted: {
+                        auto* msg = event->template Get<
+                            TEvIndexTabletPrivate::TEvWriteBlobCompleted>();
+
+                        // A failed TEvPutResult also makes TWriteBlobActor
+                        // send a failed TEvWriteBlobCompleted to the tablet.
+                        // The generic WriteBlobCompleted handler treats that
+                        // as fatal and suicides the tablet.
+                        //
+                        // By dropping this notification, we emulate the case
+                        // where it was reordered with TEvWriteBlobResponse,
+                        // which reached the tablet before it suicided.
+                        if (failedFlushBytesWriteBlobActors.contains(event->Sender) &&
+                            FAILED(msg->GetStatus()))
+                        {
+                            ++droppedFailedWriteBlobCompleted;
+                            return true;
+                        }
+
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        auto flushBytesResponse = tablet.AssertFlushBytesFailed();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, flushBytesResponse->GetStatus());
+
+        UNIT_ASSERT(!observedFlushBytesPuts.empty());
+        UNIT_ASSERT(rewrittenPutResults);
+
+        // Let TEvFlushBytesCompleted(error) be processed by the tablet.
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        UNIT_ASSERT(droppedFailedWriteBlobCompleted);
+
+        {
+            auto response = tablet.ReadData(handle, 0, block);
+            const auto& actual = response->Record.GetBuffer();
+
+            UNIT_ASSERT_VALUES_EQUAL(block, actual.size());
+
+            // Data loss. On the buggy code this range becomes
+            // "0000000000" because the fresh-byte overlay was trimmed even
+            // though the destination TEvPut failed.
+            UNIT_ASSERT_VALUES_EQUAL(TString(10, 'a'), actual.substr(100, 10));
+            UNIT_ASSERT_VALUES_EQUAL(expected, actual);
+        }
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+
+            // Failed FlushBytes must not publish a new metadata-visible blob.
+            UNIT_ASSERT_VALUES_EQUAL(
+                mixedBlobsCountBefore,
+                stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                mixedBlocksCountBefore,
+                stats.GetMixedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                garbageBlocksCountBefore,
+                stats.GetGarbageBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                freshBlocksCountBefore,
+                stats.GetFreshBlocksCount());
+
+            // On buggy code this becomes 0 because failed FlushBytes still
+            // trims the source fresh bytes.
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
+        }
+
+        tablet.DestroyHandle(handle);
+    }
+
+    TABLET_TEST(ShouldNotTrimFreshBytesIfFlushBytesReadBlobFails)
+    {
+        const auto block = tabletConfig.BlockSize;
+        const auto rangeSize = 3 * block;
+
+        TTestEnv env;
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(
+            env.GetRuntime(),
+            nodeIdx,
+            tabletId,
+            tabletConfig);
+
+        tablet.InitSession("client", "session");
+
+        auto nodeId = CreateNode(
+            tablet,
+            TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, nodeId);
+
+        // Force base data into a real blob. Later FlushBytes will need to read
+        // this blob before applying the fresh-byte overlay.
+        tablet.WriteData(handle, 0, rangeSize, '0');
+        tablet.Flush();
+
+        // Fresh-byte overlay on top of the middle block.
+        tablet.WriteData(handle, block + 100, 10, 'a');
+
+        TString expected(rangeSize, '0');
+        memset(expected.begin() + block + 100, 'a', 10);
+
+        ui64 mixedBlobsCountBefore = 0;
+        ui64 mixedBlocksCountBefore = 0;
+        ui64 garbageBlocksCountBefore = 0;
+        ui64 freshBlocksCountBefore = 0;
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+
+            mixedBlobsCountBefore = stats.GetMixedBlobsCount();
+            mixedBlocksCountBefore = stats.GetMixedBlocksCount();
+            garbageBlocksCountBefore = stats.GetGarbageBlocksCount();
+            freshBlocksCountBefore = stats.GetFreshBlocksCount();
+
+            UNIT_ASSERT_VALUES_EQUAL(1, mixedBlobsCountBefore);
+            UNIT_ASSERT_VALUES_EQUAL(3, mixedBlocksCountBefore);
+            UNIT_ASSERT_VALUES_EQUAL(0, garbageBlocksCountBefore);
+            UNIT_ASSERT_VALUES_EQUAL(0, freshBlocksCountBefore);
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
+        }
+
+        bool rewriteFlushBytesGetResults = true;
+        TActorId flushBytesReadBlobActor;
+        ui64 flushBytesReadBlobCookie = 0;
+
+        ui32 observedFlushBytesGets = 0;
+        ui32 rewrittenGetResults = 0;
+
+        env.GetRuntime().SetEventFilter(
+            [&] (auto& runtime, auto& event) {
+                Y_UNUSED(runtime);
+
+                switch (event->GetTypeRewrite()) {
+                    case TEvBlobStorage::EvGet: {
+                        auto* msg = event->template Get<TEvBlobStorage::TEvGet>();
+
+                        if (!rewriteFlushBytesGetResults ||
+                            msg->GetHandleClass != NKikimrBlobStorage::AsyncRead)
+                        {
+                            break;
+                        }
+
+                        bool isFlushBytesRead = false;
+
+                        for (ui32 i = 0; i < msg->QuerySize; ++i) {
+                            const auto& query = msg->Queries[i];
+
+                            if (query.Id.TabletID() == tabletId &&
+                                query.Id.BlobSize() == rangeSize)
+                            {
+                                isFlushBytesRead = true;
+                                break;
+                            }
+                        }
+
+                        if (isFlushBytesRead) {
+                            // This is the real TEvGet issued by TReadBlobActor for
+                            // FlushBytes. Let it go to BlobStorage, but remember who
+                            // should receive the real TEvGetResult.
+                            flushBytesReadBlobActor = event->Sender;
+                            flushBytesReadBlobCookie = event->Cookie;
+                            ++observedFlushBytesGets;
+                        }
+
+                        break;
+                    }
+
+                    case TEvBlobStorage::EvGetResult: {
+                        if (!rewriteFlushBytesGetResults ||
+                            !observedFlushBytesGets ||
+                            event->Recipient != flushBytesReadBlobActor ||
+                            event->Cookie != flushBytesReadBlobCookie)
+                        {
+                            break;
+                        }
+
+                        auto* msg = event->template Get<
+                            TEvBlobStorage::TEvGetResult>();
+
+                        // Rewrite the real BlobStorage response into a failed read.
+                        // TReadBlobActor checks this top-level Status before it
+                        // consumes msg->Responses[i].Buffer.
+                        msg->Status = NKikimrProto::ERROR;
+                        msg->ErrorReason =
+                            "injected FlushBytes TEvGetResult failure";
+
+                        ++rewrittenGetResults;
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        auto flushBytesResponse = tablet.AssertFlushBytesFailed();
+        UNIT_ASSERT_VALUES_EQUAL(E_REJECTED, flushBytesResponse->GetStatus());
+
+        UNIT_ASSERT(observedFlushBytesGets);
+        UNIT_ASSERT(rewrittenGetResults);
+
+        // Let TEvReadBlobCompleted and TEvFlushBytesCompleted(error) be processed.
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+
+        rewriteFlushBytesGetResults = false;
+        env.GetRuntime().SetEventFilter(
+            TTestActorRuntimeBase::DefaultFilterFunc);
+
+        {
+            auto response = tablet.ReadData(handle, 0, rangeSize);
+            const auto& actual = response->Record.GetBuffer();
+
+            UNIT_ASSERT_VALUES_EQUAL(rangeSize, actual.size());
+
+            // Data loss. On buggy code this becomes "0000000000",
+            // because the fresh byte overlay was trimmed after failed FlushBytes.
+            UNIT_ASSERT_VALUES_EQUAL(
+                TString(10, 'a'),
+                actual.substr(block + 100, 10));
+
+            UNIT_ASSERT_VALUES_EQUAL(expected, actual);
+        }
+
+        {
+            auto response = tablet.GetStorageStats();
+            const auto& stats = response->Record.GetStats();
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                mixedBlobsCountBefore,
+                stats.GetMixedBlobsCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                mixedBlocksCountBefore,
+                stats.GetMixedBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                garbageBlocksCountBefore,
+                stats.GetGarbageBlocksCount());
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                freshBlocksCountBefore,
+                stats.GetFreshBlocksCount());
+
+            // Buggy code trims these bytes even though FlushBytes failed at
+            // ReadBlob.
+            UNIT_ASSERT_VALUES_EQUAL(10, stats.GetFreshBytesCount());
+        }
+
+        tablet.DestroyHandle(handle);
+    }
+
     TABLET_TEST(ShouldAcceptLargeUnalignedWrites)
     {
         const auto rangeSize = 4 * tabletConfig.BlockSize;


### PR DESCRIPTION
### Notes
If `FlushBytesActor` receives an error during `ReadBlob` or `WriteBlob`, it unconditionally calls `TrimBytes`, which results in data loss.

### Issue
#6361
