### PR TITLE
issue-6358: filestore - support for MinShardCount

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -830,4 +830,8 @@ message TStorageConfig
     optional uint32 SoftBackpressureMaxReadBandwidth = 519;    // in MiB/s
     optional uint32 SoftBackpressureMaxWriteIops = 520;
     optional uint32 SoftBackpressureMaxReadIops = 521;
+
+    // Sets the minimum shard count that each filesystem would have regardless
+    // of its size.
+    optional uint32 MinShardCount = 522;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -318,6 +318,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
                                                                                \
     xxx(BlockChecksumsInProfileLogEnabled, bool,      false                   )\
                                                                                \
+    xxx(MinShardCount,                     ui32,      0                       )\
     xxx(MaxShardCount,                     ui32,      254                     )\
                                                                                \
     xxx(ReadBlobDisabled,                  bool,      false                   )\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -383,6 +383,7 @@ public:
 
     [[nodiscard]] bool GetBlockChecksumsInProfileLogEnabled() const;
 
+    ui32 GetMinShardCount() const;
     ui32 GetMaxShardCount() const;
 
     bool GetReadBlobDisabled() const;

--- a/cloud/filestore/libs/storage/core/model.cpp
+++ b/cloud/filestore/libs/storage/core/model.cpp
@@ -505,17 +505,18 @@ ui32 ComputeShardCount(
     const ui64 blocksCount,
     const ui32 blockSize,
     const ui64 shardAllocationUnit,
+    const ui32 minShardCount,
     const ui32 maxShardCount)
 {
     const double fileStoreSize = blocksCount * blockSize;
 
-    if (fileStoreSize < shardAllocationUnit) {
+    if (!minShardCount && fileStoreSize < shardAllocationUnit) {
         // No need in using sharding for small enough filesystems
         return 0;
     }
 
     const ui32 shardCount = std::ceil(fileStoreSize / shardAllocationUnit);
-    return Min(shardCount, maxShardCount);
+    return Min(Max(shardCount, minShardCount), maxShardCount);
 }
 
 TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
@@ -538,6 +539,7 @@ TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(
             fileStore.GetBlocksCount(),
             fileStore.GetBlockSize(),
             config.GetShardAllocationUnit(),
+            config.GetMinShardCount(),
             config.GetMaxShardCount());
     result.ShardConfigs.resize(shardCount);
     for (ui32 i = 0; i < shardCount; ++i) {

--- a/cloud/filestore/libs/storage/core/model.h
+++ b/cloud/filestore/libs/storage/core/model.h
@@ -22,6 +22,7 @@ ui32 ComputeShardCount(
     const ui64 blocksCount,
     const ui32 blockSize,
     const ui64 shardAllocationUnit,
+    const ui32 minShardCount,
     const ui32 maxShardCount);
 
 TMultiShardFileStoreConfig SetupMultiShardFileStorePerformanceAndChannels(

--- a/cloud/filestore/libs/storage/core/model_ut.cpp
+++ b/cloud/filestore/libs/storage/core/model_ut.cpp
@@ -2342,7 +2342,7 @@ Y_UNIT_TEST_SUITE(TModel)
         StorageConfig.SetSSDMaxWriteIops(Max<ui32>());
         StorageConfig.SetMaxShardCount(254);
 
-        auto OldMaxWriteIops = ClientPerformanceProfile.GetMaxWriteIops();
+        auto oldMaxWriteIops = ClientPerformanceProfile.GetMaxWriteIops();
         ClientPerformanceProfile.ClearMaxWriteIops();
 
         KikimrConfig.SetBlocksCount(4_TB / 4_KB);
@@ -2358,7 +2358,7 @@ Y_UNIT_TEST_SUITE(TModel)
             128000,
             fs.MainFileSystemConfig.GetPerformanceProfileMaxWriteIops());
 
-        ClientPerformanceProfile.SetMaxWriteIops(OldMaxWriteIops);
+        ClientPerformanceProfile.SetMaxWriteIops(oldMaxWriteIops);
 
         KikimrConfig.SetBlocksCount(4_TB / 4_KB + 1);
         fs = SetupMultiShardFileStorePerformanceAndChannels(
@@ -2408,6 +2408,63 @@ Y_UNIT_TEST_SUITE(TModel)
         UNIT_ASSERT(!fs.MainFileSystemConfig.GetIsSystem());
         for (const auto& sc: fs.ShardConfigs) {
             UNIT_ASSERT(sc.GetIsSystem());
+        }
+    }
+
+    Y_UNIT_TEST_F(ShouldCreateMinNumberOfShards, TConfigs)
+    {
+        using namespace ::NCloud::NProto;
+        KikimrConfig.SetBlockSize(4_KB);
+
+        // Disable media type override.
+        StorageConfig.SetAutomaticShardCreationEnabled(true);
+        StorageConfig.SetShardAllocationUnit(4_TB);
+        StorageConfig.SetStrictFileSystemSizeEnforcementEnabled(true);
+        StorageConfig.SetMinShardCount(20);
+        StorageConfig.SetMaxShardCount(254);
+
+        KikimrConfig.SetBlocksCount(1_TB / 4_KB);
+        auto fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile,
+            0);
+        UNIT_ASSERT_VALUES_EQUAL(20, fs.ShardConfigs.size());
+
+        for (const auto& sc: fs.ShardConfigs) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                KikimrConfig.GetBlocksCount(),
+                sc.GetBlocksCount());
+        }
+
+        KikimrConfig.SetBlocksCount(
+            StorageConfig.GetShardAllocationUnit() * 19 / 4_KB);
+        fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile,
+            0);
+        UNIT_ASSERT_VALUES_EQUAL(20, fs.ShardConfigs.size());
+
+        for (const auto& sc: fs.ShardConfigs) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                KikimrConfig.GetBlocksCount(),
+                sc.GetBlocksCount());
+        }
+
+        KikimrConfig.SetBlocksCount(
+            StorageConfig.GetShardAllocationUnit() * 21 / 4_KB);
+        fs = SetupMultiShardFileStorePerformanceAndChannels(
+            StorageConfig,
+            KikimrConfig,
+            ClientPerformanceProfile,
+            0);
+        UNIT_ASSERT_VALUES_EQUAL(21, fs.ShardConfigs.size());
+
+        for (const auto& sc: fs.ShardConfigs) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                KikimrConfig.GetBlocksCount(),
+                sc.GetBlocksCount());
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -250,8 +250,11 @@ void TIndexTabletActor::HandleCreateSession(
         msg->CallContext);
     requestInfo->StartedTs = ctx.Now();
 
+    // TODO(#6310): Replace with a proper check. We need to test whether
+    // filesystem create operation has completed, expected-shard-count
+    // heuristic is too fragile.
     const auto expectedShardCount =
-        CalculateExpectedShardCount(Config->GetMaxShardCount());
+        CalculateMinExpectedShardCount(Config->GetMaxShardCount());
     const auto actualShardCount = GetFileSystem().ShardFileSystemIdsSize();
     if (actualShardCount < expectedShardCount) {
         auto message = TStringBuilder() << "Shard count smaller than expected: "

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -322,7 +322,7 @@ THandlesStats TIndexTabletState::GetHandlesStats() const
     return Impl->HandlesStats;
 }
 
-ui64 TIndexTabletState::CalculateExpectedShardCount(
+ui64 TIndexTabletState::CalculateMinExpectedShardCount(
     const ui32 maxShardCount) const
 {
     if (FileSystem.GetShardNo()) {
@@ -339,6 +339,7 @@ ui64 TIndexTabletState::CalculateExpectedShardCount(
             FileSystem.GetBlocksCount(),
             FileSystem.GetBlockSize(),
             FileSystem.GetShardAllocationUnit(),
+            0 /* minShardCount */,
             maxShardCount);
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -441,7 +441,7 @@ public:
         return AllocatorRegistry.GetAllocator(tag);
     }
 
-    ui64 CalculateExpectedShardCount(ui32 maxShardCount) const;
+    ui64 CalculateMinExpectedShardCount(ui32 maxShardCount) const;
 
     void InitInMemoryIndexState(const TStorageConfig& config);
 


### PR DESCRIPTION
### Notes
Implemented the ability to set up min-shard-count for fs create/resize ops to be able to provide some base level of performance for all filesystems regardless of their size. More details in https://github.com/ydb-platform/nbs/issues/6358. 

### Issue
https://github.com/ydb-platform/nbs/issues/6358
https://github.com/ydb-platform/nbs/issues/6310
