### PR TITLE
[NBS] Added decrementing WriteOrZeroRequestsInProgress on fresh hard limit exceeded; Added processing drain requests on zero blocks completed;

### DIFF
--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -631,8 +631,7 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                     UNIT_ASSERT(addFreshBlocksRequestObserved);
                 }
 
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
+                return false;
             });
 
         auto partition = testEnv.GetPartitionClient();
@@ -662,8 +661,7 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
 
                     return false;
                 }
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
+                return false;
             });
 
         auto partition = testEnv.GetPartitionClient();
@@ -706,8 +704,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
         InitTestActorRuntime(testEnv, config);
         auto& runtime = testEnv.GetRuntime();
 
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
         runtime.SetEventFilter(
             [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
@@ -718,11 +714,8 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                     UNIT_ASSERT_VALUES_UNEQUAL(
                         testEnv.FreshBlocksWriterActorId,
                         event->GetRecipientRewrite());
-
-                    return false;
                 }
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
+                return false;
             });
 
         auto partition = testEnv.GetPartitionClient();
@@ -750,17 +743,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
     {
         TMyTestEnv testEnv;
         InitTestActorRuntime(testEnv, DefaultConfig(), 2048);
-        auto& runtime = testEnv.GetRuntime();
-
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
-        runtime.SetEventFilter(
-            [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
-            {
-                Y_UNUSED(runtime);
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
-            });
 
         auto partition = testEnv.GetPartitionClient();
         partition.WaitReady();
@@ -930,8 +912,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
         InitTestActorRuntime(testEnv);
         auto& runtime = testEnv.GetRuntime();
 
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
         runtime.SetEventFilter(
             [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
@@ -944,8 +924,7 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
 
                     return false;
                 }
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
+                return false;
             });
 
         auto partition = testEnv.GetPartitionClient();
@@ -1016,8 +995,7 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                 {
                     ++addFreshBlocksCount;
                 }
-                return event->GetTypeRewrite() ==
-                       TEvPartitionCommonPrivate::EvTrimFreshLogRequest;
+                return false;
             });
 
         auto partition = testEnv.GetPartitionClient();
@@ -1165,11 +1143,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                     !stolenPutRequest && stealPutRequest)
                 {
                     stolenPutRequest.reset(event.Release());
-                    return TTestActorRuntime::EEventAction::DROP;
-                }
-
-                if (event->GetTypeRewrite() == TEvPartitionCommonPrivate::EvTrimFreshLogRequest)
-                {
                     return TTestActorRuntime::EEventAction::DROP;
                 }
 
@@ -1661,6 +1634,87 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
 
         doTest(true);
         doTest(false);
+    }
+
+    Y_UNIT_TEST(ShouldDrainWhenFreshByteCountHardLimitExceeded)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshBlocksWriterEnabled(true);
+        config.SetFreshByteCountHardLimit(8_KB);
+        config.SetFlushThreshold(4_MB);
+
+        TMyTestEnv testEnv;
+        InitTestActorRuntime(testEnv, config);
+
+        auto partition = testEnv.GetPartitionClient();
+        partition.WaitReady();
+
+        auto fbwClient = testEnv.GetFreshBlocksWriterClient();
+        fbwClient.WaitReady();
+
+        fbwClient.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+        fbwClient.WriteBlocks(TBlockRange32::MakeOneBlock(0), 1);
+
+        fbwClient.SendWriteBlocksRequest(TBlockRange32::MakeOneBlock(0), 1);
+        auto response = fbwClient.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+        UNIT_ASSERT(
+            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
+
+        fbwClient.Drain();
+    }
+
+    Y_UNIT_TEST(ShouldDrainWhenHasZeroBlocksRequestsInProgress)
+    {
+        auto config = DefaultConfig();
+
+        TMyTestEnv testEnv;
+        InitTestActorRuntime(testEnv, config);
+
+        auto partition = testEnv.GetPartitionClient();
+        partition.WaitReady();
+
+        auto fbwClient = testEnv.GetFreshBlocksWriterClient();
+        fbwClient.WaitReady();
+
+        auto& runtime = testEnv.GetRuntime();
+
+        bool interceptZeroBlocksCompleted = false;
+        std::unique_ptr<IEventHandle> zeroBlocksCompletedEvent;
+        bool drainResponseObserved = false;
+
+        runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                        TEvPartitionCommonPrivate::EvZeroFreshBlocksCompleted &&
+                    interceptZeroBlocksCompleted)
+                {
+                    zeroBlocksCompletedEvent.reset(event.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+
+                drainResponseObserved |=
+                    event->GetTypeRewrite() == TEvPartition::EvDrainResponse;
+
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        interceptZeroBlocksCompleted = true;
+        fbwClient.ZeroBlocks(0);
+        interceptZeroBlocksCompleted = false;
+
+        fbwClient.SendDrainRequest();
+        runtime.DispatchEvents({}, 10ms);
+        UNIT_ASSERT(zeroBlocksCompletedEvent);
+        UNIT_ASSERT(!drainResponseObserved);
+
+        runtime.SendAsync(zeroBlocksCompletedEvent.release());
+
+        fbwClient.RecvDrainResponse();
     }
 }
 

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_ut.cpp
@@ -650,17 +650,14 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
         InitTestActorRuntime(testEnv);
         auto& runtime = testEnv.GetRuntime();
 
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
         runtime.SetEventFilter(
             [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {
                 Y_UNUSED(runtime);
                 if (event->GetTypeRewrite() == TEvService::EvWriteBlocksRequest) {
                     UNIT_ASSERT_VALUES_UNEQUAL(testEnv.PartitionActorId, event->GetRecipientRewrite());
-
-                    return false;
                 }
+
                 return false;
             });
 
@@ -921,8 +918,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
                     UNIT_ASSERT_VALUES_UNEQUAL(
                         testEnv.PartitionActorId,
                         event->GetRecipientRewrite());
-
-                    return false;
                 }
                 return false;
             });
@@ -983,8 +978,6 @@ Y_UNIT_TEST_SUITE(TFreshBlocksWriterTest)
 
         ui64 addFreshBlocksCount = 0;
 
-        // TODO(issue-4875): remove trim events dropping after adding trim
-        // synchronization
         runtime.SetEventFilter(
             [&](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event)
             {

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -53,6 +53,8 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
                 r.Data.RequestInfo->CallContext->RequestId);
 
             NCloud::Reply(ctx, *r.Data.RequestInfo, std::move(response));
+
+            SharedState->WriteAndZeroRequestsInProgress.fetch_sub(1);
         }
 
         return;

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -57,6 +57,8 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
             SharedState->WriteAndZeroRequestsInProgress.fetch_sub(1);
         }
 
+        SharedState->AccessDrainActorCompanion()->ProcessDrainRequests(ctx);
+
         return;
     }
 

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_zeroblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_zeroblocks.cpp
@@ -112,6 +112,8 @@ void TFreshBlocksWriterActor::HandleZeroBlocksCompleted(
         commitId,
         blocksCount,
         HasError(msg->GetError()));
+
+    SharedState->AccessDrainActorCompanion()->ProcessDrainRequests(ctx);
 }
 
 }  // namespace NCloud::NBlockStore::NStorage::NFreshBlocksWriter

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -61,6 +61,8 @@ void TPartitionActor::WriteFreshBlocks(
                 r.Data.RequestInfo->CallContext->RequestId);
 
             NCloud::Reply(ctx, *r.Data.RequestInfo, std::move(response));
+
+            SharedState->WriteAndZeroRequestsInProgress.fetch_sub(1);
         }
 
         return;

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -65,6 +65,8 @@ void TPartitionActor::WriteFreshBlocks(
             SharedState->WriteAndZeroRequestsInProgress.fetch_sub(1);
         }
 
+        SharedState->AccessDrainActorCompanion()->ProcessDrainRequests(ctx);
+
         return;
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -15302,6 +15302,32 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         updateCounters();
         UNIT_ASSERT_VALUES_EQUAL(100, storedBytesCountToDiskSizeRatio);
     }
+
+    Y_UNIT_TEST(ShouldDrainWhenFreshByteCountHardLimitExceeded)
+    {
+        auto config = DefaultConfig();
+        config.SetFreshByteCountHardLimit(8_KB);
+        config.SetFreshChannelWriteRequestsEnabled(true);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        partition.WriteBlocks(0, 1);
+        partition.WriteBlocks(0, 1);
+
+        partition.SendWriteBlocksRequest(0, 1);
+        auto response = partition.RecvWriteBlocksResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            response->GetStatus(),
+            response->GetErrorReason());
+        UNIT_ASSERT(
+            HasProtoFlag(response->GetError().GetFlags(), NProto::EF_SILENT));
+
+        partition.Drain();
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition_common/io_companion.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/io_companion.cpp
@@ -49,7 +49,7 @@ void TIOCompanion::ProcessIOQueue(const TActorContext& ctx, ui32 channel)
 {
     while (auto request = ChannelsState.DequeueIORequest(channel)) {
         auto actorId = NCloud::Register(ctx, std::move(request->Actor));
-        LOG_DEBUG(
+        LOG_TRACE(
             ctx,
             TBlockStoreComponents::PARTITION,
             "%s registered request actor with id [%lu]",


### PR DESCRIPTION
### Notes
Stuck Drain requests casing stuck for the CreateCheckpoint requests for multipartition disks.
In the same time wile checkpoint is created, volume will reject all write requests, so user request will stuck too.

Now we have some cases in which drain requests can stuck and trigger max time alert:
1. if we exceed fresh bytes count hard limit
2. if last request  was fresh zero request and Fresh Blocks Writer enabled
  
in first case we increment requests counter before calling WriteFreshBlock
https://github.com/ydb-platform/nbs/blob/25ac27219d5a060a37c132bf690de1799f360dab/cloud/blockstore/libs/storage/partition/part_actor_writeblocks.cpp#L270
and if fresh bytes count is exceed we will reject request but will not decrement counter
https://github.com/ydb-platform/nbs/blob/7087fbf57e80ba077fc34168074d451ca828ed1d/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp#L43-L67
so next checkpoint creation will stuck forever.

In second case we just not calling ProcessDrainRequests after zero blocks request ended.
 