### PR TITLE
Add peerName to TEvAuthorizeTicket request

### DIFF
--- a/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
@@ -99,7 +99,8 @@ private:
 
         auto request = std::make_unique<TEvAuth::TEvAuthorizationRequest>(
             std::move(AuthToken),
-            std::move(Permissions));
+            std::move(Permissions),
+            Peer);
 
         LWTRACK(
             AuthRequestSent_Proxy,

--- a/cloud/filestore/libs/endpoint/service_auth.cpp
+++ b/cloud/filestore/libs/endpoint/service_auth.cpp
@@ -91,7 +91,8 @@ private:
             ctx,
             std::move(permissions),
             internal.GetAuthToken(),
-            TDuration::MilliSeconds(headers.GetRequestTimeout()));
+            TDuration::MilliSeconds(headers.GetRequestTimeout()),
+            internal.GetPeer());
 
         return HandleAuthResponse<TRequest, TResponse>(
             std::move(authResponse),

--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -436,6 +436,7 @@ void TAppContext::ValidateRequest(
 
     internal.Clear();
     internal.SetRequestSource(*source);
+    internal.SetPeer(TString(context.peer()));
 
     // we will only get token from secure control channel
     if (source == NProto::SOURCE_SECURE_CONTROL_CHANNEL) {

--- a/cloud/filestore/libs/server/server_ut.cpp
+++ b/cloud/filestore/libs/server/server_ut.cpp
@@ -606,6 +606,9 @@ Y_UNIT_TEST_SUITE(TServerTest)
                     "test",
                     request->GetHeaders().GetInternal().GetAuthToken()
                 );
+                UNIT_ASSERT(
+                    !request->GetHeaders().GetInternal().GetPeer().empty()
+                );
                 return MakeFuture<NProto::TPingResponse>();
             };
 
@@ -647,6 +650,9 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 UNIT_ASSERT_VALUES_EQUAL(
                     "test",
                     request->GetHeaders().GetInternal().GetAuthToken()
+                );
+                UNIT_ASSERT(
+                    !request->GetHeaders().GetInternal().GetPeer().empty()
                 );
                 return MakeFuture<NProto::TPingResponse>();
             };
@@ -756,6 +762,9 @@ Y_UNIT_TEST_SUITE(TServerTest)
                 UNIT_ASSERT_VALUES_EQUAL(
                     int(NProto::SOURCE_FD_CONTROL_CHANNEL),
                     int(request->GetHeaders().GetInternal().GetRequestSource())
+                );
+                UNIT_ASSERT(
+                    !request->GetHeaders().GetInternal().GetPeer().empty()
                 );
                 return MakeFuture<NProto::TPingResponse>();
             };

--- a/cloud/filestore/libs/service/auth_provider.h
+++ b/cloud/filestore/libs/service/auth_provider.h
@@ -28,7 +28,8 @@ struct IAuthProvider
         TCallContextPtr callContext,
         TPermissionList permissions,
         TString authToken,
-        TDuration requestTimeout) = 0;
+        TDuration requestTimeout,
+        TString peer) = 0;
 };
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/libs/service/service_auth.cpp
+++ b/cloud/filestore/libs/service/service_auth.cpp
@@ -95,7 +95,8 @@ private:
             ctx,
             std::move(permissions),
             internal.GetAuthToken(),
-            TDuration::MilliSeconds(headers.GetRequestTimeout()));
+            TDuration::MilliSeconds(headers.GetRequestTimeout()),
+            internal.GetPeer());
 
         return HandleAuthResponse<TRequest, TResponse>(
             std::move(authResponse),

--- a/cloud/filestore/libs/service_kikimr/auth_provider_kikimr.cpp
+++ b/cloud/filestore/libs/service_kikimr/auth_provider_kikimr.cpp
@@ -40,6 +40,7 @@ private:
     TCallContextPtr CallContext;
 
     const TDuration RequestTimeout;
+    const TString Peer;
 
     bool RequestCompleted = false;
 
@@ -49,12 +50,14 @@ public:
             TString authToken,
             TPromise<NProto::TError> response,
             TCallContextPtr callContext,
-            TDuration requestTimeout)
+            TDuration requestTimeout,
+            TString peer)
         : Permissions(permissions)
         , AuthToken(std::move(authToken))
         , Response(std::move(response))
         , CallContext(std::move(callContext))
         , RequestTimeout(requestTimeout)
+        , Peer(std::move(peer))
     {}
 
     ~TRequestActor() override
@@ -88,7 +91,8 @@ private:
 
         auto request = std::make_unique<TEvAuth::TEvAuthorizationRequest>(
             std::move(AuthToken),
-            std::move(Permissions));
+            std::move(Permissions),
+            Peer);
 
         FILESTORE_TRACK(
             AuthRequestSent_Proxy,
@@ -200,7 +204,8 @@ public:
         TCallContextPtr callContext,
         TPermissionList permissions,
         TString authToken,
-        TDuration requestTimeout) override
+        TDuration requestTimeout,
+        TString peer) override
     {
         auto response = NewPromise<NProto::TError>();
 
@@ -209,7 +214,8 @@ public:
             std::move(authToken),
             response,
             std::move(callContext),
-            requestTimeout));
+            requestTimeout,
+            std::move(peer)));
 
         return response.GetFuture();
     }

--- a/cloud/filestore/public/api/protos/headers.proto
+++ b/cloud/filestore/public/api/protos/headers.proto
@@ -50,6 +50,9 @@ message THeaders
         // If this request is sent from another tablet, that tablet can put its
         // TabletId into this field.
         uint64 ClientTabletId = 4;
+
+        // Peer address of the request sender.
+        string Peer = 5;
     }
 
     // Internal header, should not be used outside.

--- a/cloud/storage/core/libs/api/authorizer.h
+++ b/cloud/storage/core/libs/api/authorizer.h
@@ -30,12 +30,15 @@ struct TEvAuth
     {
         const TString Token;
         const TPermissionList Permissions;
+        const TString PeerName;
 
         TAuthorizationRequest(
                 TString token,
-                TPermissionList permissions)
+                TPermissionList permissions,
+                TString peerName)
             : Token(std::move(token))
             , Permissions(std::move(permissions))
+            , PeerName(std::move(peerName))
         {}
     };
 

--- a/cloud/storage/core/libs/auth/authorizer.cpp
+++ b/cloud/storage/core/libs/auth/authorizer.cpp
@@ -177,6 +177,7 @@ private:
     const TString Token;
     const TVector<TString> Permissions;
     const TVector<std::pair<TString, TString>> Attributes;
+    const TString PeerName;
     IEventHandlePtr OriginalRequest;
     const TAuthCountersPtr Counters;
 
@@ -187,6 +188,7 @@ public:
             TString token,
             TVector<TString> permissions,
             TVector<std::pair<TString, TString>> attributes,
+            TString peerName,
             IEventHandlePtr originalRequest,
             TAuthCountersPtr counters)
         : Component(component)
@@ -194,6 +196,7 @@ public:
         , Token(std::move(token))
         , Permissions(std::move(permissions))
         , Attributes(std::move(attributes))
+        , PeerName(std::move(peerName))
         , OriginalRequest(std::move(originalRequest))
         , Counters(std::move(counters))
     {}
@@ -208,9 +211,11 @@ public:
             ctx,
             MakeTicketParserID(),
             std::make_unique<TEvTicketParser::TEvAuthorizeTicket>(
-                Token,
-                Attributes,
-                Permissions));
+                TEvTicketParser::TEvAuthorizeTicket::TInitializationFields{
+                    .Ticket = Token,
+                    .PeerName = PeerName,
+                    .Entries = {{Permissions, Attributes}}
+                }));
 
         TThis::Become(&TThis::StateWork);
     }
@@ -425,6 +430,7 @@ private:
                 msg->Token,
                 GetPermissionStrings(msg->Permissions),
                 BuildAttributes(FolderId),
+                msg->PeerName,
                 IEventHandlePtr(ev.Release()),
                 Counters));
     }

--- a/cloud/storage/core/libs/auth/authorizer_ut.cpp
+++ b/cloud/storage/core/libs/auth/authorizer_ut.cpp
@@ -242,6 +242,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         UNIT_ASSERT_EQUAL(event.Entries[0].Permissions.size(), 2);
         UNIT_ASSERT_EQUAL(event.Entries[0].Permissions[0].Permission, "nbsInternal.disks.read");
         UNIT_ASSERT_EQUAL(event.Entries[0].Permissions[1].Permission, "nbsInternal.disks.write");
+        UNIT_ASSERT_EQUAL(event.PeerName, "192.168.0.101");
     }
 
     Y_UNIT_TEST(AuthorizeWithAuthorizerDisabledWhenIgnoring)
@@ -611,6 +612,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -657,6 +659,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -703,6 +706,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -747,6 +751,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -793,6 +798,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -839,6 +845,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -888,6 +895,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -932,6 +940,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -976,6 +985,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -1022,6 +1032,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -1069,6 +1080,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -1117,6 +1129,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,
@@ -1231,6 +1244,7 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
         testEnv.DispatchEvents();
 
         UNIT_ASSERT_EQUAL(authorizeEvents.size(), 1ul);
+        UNIT_ASSERT_EQUAL(authorizeEvents[0]->Get()->PeerName, "192.168.0.101");
 
         testEnv.Send(
             authorizeEvents[0]->Sender,

--- a/cloud/storage/core/libs/auth/authorizer_ut.cpp
+++ b/cloud/storage/core/libs/auth/authorizer_ut.cpp
@@ -225,7 +225,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -268,7 +269,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, event->GetStatus());
@@ -303,7 +305,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, event->GetStatus());
@@ -340,7 +343,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(E_UNAUTHORIZED, event->GetStatus());
@@ -377,7 +381,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 TString(),
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, event->GetStatus());
@@ -412,7 +417,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 TString(),
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, event->GetStatus());
@@ -449,7 +455,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 TString(),
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(E_UNAUTHORIZED, event->GetStatus());
@@ -486,7 +493,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, event->GetStatus());
@@ -521,7 +529,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(E_UNAUTHORIZED, event->GetStatus());
@@ -558,7 +567,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         auto event = testEnv.GrabAuthorizationResponse();
         UNIT_ASSERT_VALUES_EQUAL(E_UNAUTHORIZED, event->GetStatus());
@@ -595,7 +605,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -640,7 +651,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -685,7 +697,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -728,7 +741,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -773,7 +787,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -818,7 +833,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -866,7 +882,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -909,7 +926,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -952,7 +970,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -997,7 +1016,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -1043,7 +1063,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -1090,7 +1111,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -1133,17 +1155,20 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
             authorizerActorID,
             std::make_unique<TEvAuth::TEvAuthorizationRequest>(
                 AuthToken1,
-                CreatePermissionList({EPermission::Read})));
+                CreatePermissionList({EPermission::Read}),
+                "192.168.0.101"));
         testEnv.Send(
             authorizerActorID,
             std::make_unique<TEvAuth::TEvAuthorizationRequest>(
                 AuthToken2,
-                CreatePermissionList({EPermission::Create})));
+                CreatePermissionList({EPermission::Create}),
+                "192.168.0.101"));
         testEnv.Send(
             authorizerActorID,
             std::make_unique<TEvAuth::TEvAuthorizationRequest>(
                 AuthToken1,
-                CreatePermissionList({EPermission::Write})));
+                CreatePermissionList({EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 
@@ -1200,7 +1225,8 @@ Y_UNIT_TEST_SUITE(TAuthorizerActorTest)
                 AuthToken1,
                 CreatePermissionList({
                     EPermission::Read,
-                    EPermission::Write})));
+                    EPermission::Write}),
+                "192.168.0.101"));
 
         testEnv.DispatchEvents();
 


### PR DESCRIPTION
### Notes

- PeerName to TAuthorizer event constructor was added
- New field to filestore proto was added and used on the beginning of the request execution
- PeerName from blockstore and filestore was passed to TAuthorizer event
