### PR TITLE
issue-6295: [Filestore] fix cross-shard stale dupCache hard link response handling

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -36,7 +36,6 @@ private:
 
     // Response data
     bool ShardResponded = false;
-    NProto::TCreateNodeResponse ShardResponse;
 
     // Stats for reporting
     IProfileLogPtr ProfileLog;
@@ -161,14 +160,19 @@ void TLinkActor::HandleShardResponse(
     CreateNodeRequest.MutableLink()->SetTargetNode(
         msg->Record.GetNode().GetId());
     CreateNodeRequest.MutableLink()->SetShardNodeName(ShardNodeName);
-    ShardResponse = std::move(msg->Record);
+    // Carry the shard node attrs so the leader can write a complete DupCache
+    // entry (non-zero Id). Without this the leader stores a zero-id entry and
+    // returns E_REJECTED on any retry of the same requestId.
+    // TODO(#2667): remove once TLinkActor has a proper retry mechanism.
+    auto shardResponse = std::move(msg->Record);
+    *CreateNodeRequest.MutableShardNodeAttr() = shardResponse.GetNode();
 
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::SERVICE,
         "[%s] Creating nodeRef in leader for %s, %lu",
         LogTag.c_str(),
-        ShardResponse.ShortDebugString().Quote().c_str(),
+        shardResponse.ShortDebugString().Quote().c_str(),
         CreateNodeRequest.GetLink().GetTargetNode());
 
     request->Record = std::move(CreateNodeRequest);
@@ -205,10 +209,6 @@ void TLinkActor::HandleLeaderResponse(
         "[%s] NodeRef created in leader for %lu",
         LogTag.c_str(),
         msg->Record.GetNode().GetId());
-
-    // TODO(#2667): some attributes from the shard response could be invalid
-    // by the time the leader response is received
-    msg->Record.MutableNode()->Swap(ShardResponse.MutableNode());
 
     ReplyAndDie(ctx, std::move(msg->Record));
 }

--- a/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createnode.cpp
@@ -165,8 +165,6 @@ void TLinkActor::HandleShardResponse(
     // returns E_REJECTED on any retry of the same requestId.
     // TODO(#2667): remove once TLinkActor has a proper retry mechanism.
     auto shardResponse = std::move(msg->Record);
-    *CreateNodeRequest.MutableShardNodeAttr() = shardResponse.GetNode();
-
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::SERVICE,
@@ -174,6 +172,8 @@ void TLinkActor::HandleShardResponse(
         LogTag.c_str(),
         shardResponse.ShortDebugString().Quote().c_str(),
         CreateNodeRequest.GetLink().GetTargetNode());
+
+    CreateNodeRequest.MutableShardNodeAttr()->Swap(shardResponse.MutableNode());
 
     request->Record = std::move(CreateNodeRequest);
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -6223,6 +6223,75 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             TCreateNodeArgs::Link(dirId, "link1", file1Id));
     }
 
+    // Regression test for the DupCache bug with cross-shard hard links.
+    //
+    // When a hard link's target node lives in a shard, TLinkActor (service
+    // side) creates the shard node first and then sends a nodeRef-creation
+    // request to the leader. The leader used to write a DupCache entry with
+    // node id = 0 for such requests. On retry (same requestId) the zero-id
+    // guard in HandleCreateNode would fire and return E_REJECTED ("node not
+    // yet created in shard") even though the hard link was fully committed.
+    //
+    // After the fix TLinkActor forwards the shard node attrs in the leader
+    // request (ShardNodeAttr field). The leader populates the DupCache entry
+    // with a real node id so retry returns S_OK with the original node attrs.
+    SERVICE_TEST(ShouldNotReturnSpuriousRejectedOnCrossShardHardLinkRetry)
+    {
+        config.SetDirectoryCreationInShardsEnabled(true);
+
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto headers = service.InitSession(fsConfig.FsId, "client");
+
+        const auto dirId =
+            service
+                .CreateNode(
+                    headers,
+                    TCreateNodeArgs::Directory(RootNodeId, "dir"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(dirId));
+
+        const auto fileId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(dirId, "file"))
+                ->Record.GetNode()
+                .GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, ExtractShardNo(fileId));
+
+        // First attempt — must succeed.
+        const ui64 requestId = 111;
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::Link(dirId, "link", fileId),
+            requestId);
+
+        auto response = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetError().GetCode(),
+            response->GetError().GetMessage());
+
+        const auto firstNodeId = response->Record.GetNode().GetId();
+        UNIT_ASSERT_VALUES_UNEQUAL(0, firstNodeId);
+
+        // Retry with the same requestId. Before the fix the DupCache zero-id
+        // entry caused E_REJECTED here. After the fix the DupCache entry holds
+        // the real node attrs so the retry returns S_OK with the same node id.
+        service.SendCreateNodeRequest(
+            headers,
+            TCreateNodeArgs::Link(dirId, "link", fileId),
+            requestId);
+
+        response = service.RecvCreateNodeResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetError().GetCode(),
+            response->GetError().GetMessage());
+        UNIT_ASSERT_VALUES_EQUAL(firstNodeId, response->Record.GetNode().GetId());
+    }
+
     // See #5826 for more details
     SERVICE_TEST(ShouldRejectHardLinkFromShardDirToMainTabletNode)
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -848,6 +848,13 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             *args.Response.MutableNode(),
             args.ChildNodeId,
             args.ChildNode->Attrs);
+    } else if (args.TargetNodeId != InvalidNodeId) {
+        // Cross-shard hard link: shard node was created by TLinkActor before
+        // this request reached the leader. The shard node attrs are forwarded
+        // in the request so the DupCache entry gets a non-zero Id and returns
+        // the correct response on retry.
+        // TODO(#2667): remove once TLinkActor has a proper retry mechanism.
+        *args.Response.MutableNode() = args.Request.GetShardNodeAttr();
     }
 
     // shards shouldn't commit CreateNode DupCache entries since:

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -183,6 +183,7 @@ message TCreateNodeRequest
         TBlockDevice BlockDevice = 15;
     }
 
+    // TODO(#2667): remove once harlinks are created on the tablet side
     // If set, the node will be created in the shard FS.
     string ShardFileSystemId = 12;
 
@@ -196,6 +197,13 @@ message TCreateNodeRequest
     uint64 OriginalNodeId = 17;
 
     bytes OriginalName = 18;
+
+    // For cross-shard hard links: the node attrs returned by the shard after
+    // creating the link. Carried by TLinkActor so the leader can write a
+    // complete DupCache entry (non-zero Id) and return the correct response
+    // on retry.
+    // TODO(#2667): remove once harlinks are created on the tablet side
+    TNodeAttr ShardNodeAttr = 19;
 }
 
 message TCreateNodeResponse

--- a/cloud/filestore/public/api/protos/node.proto
+++ b/cloud/filestore/public/api/protos/node.proto
@@ -183,7 +183,7 @@ message TCreateNodeRequest
         TBlockDevice BlockDevice = 15;
     }
 
-    // TODO(#2667): remove once harlinks are created on the tablet side
+    // TODO(#2667): remove once hardlinks are created on the tablet side
     // If set, the node will be created in the shard FS.
     string ShardFileSystemId = 12;
 
@@ -202,7 +202,7 @@ message TCreateNodeRequest
     // creating the link. Carried by TLinkActor so the leader can write a
     // complete DupCache entry (non-zero Id) and return the correct response
     // on retry.
-    // TODO(#2667): remove once harlinks are created on the tablet side
+    // TODO(#2667): remove once hardlinks are created on the tablet side
     TNodeAttr ShardNodeAttr = 19;
 }
 


### PR DESCRIPTION
### Notes
More details in the issue

### Issue
#6295
