### PR TITLE
Fix remove GetTotalPayloadSize() from tablet_ut

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -9155,7 +9155,6 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT(buffer.empty());
         UNIT_ASSERT_VALUES_EQUAL(data.size(), response->Record.GetLength());
         UNIT_ASSERT_VALUES_EQUAL(1, response->GetPayloadCount());
-        UNIT_ASSERT_VALUES_EQUAL(data.size(), response->GetTotalPayloadSize());
         auto& payload = response->GetPayload(0);
         UNIT_ASSERT_VALUES_EQUAL(data.size(), payload.size());
         UNIT_ASSERT_VALUES_EQUAL(data, payload.ConvertToString());


### PR DESCRIPTION
### Notes
Fix remove `GetTotalPayloadSize()` from `cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp`

https://github.com/ydb-platform/nbs/pull/6203 

### Issue

Test `cloud/filestore/libs/storage/tablet/ut` build error with ydb code >=25-1 
`error: no member named 'GetTotalPayloadSize'`

Full log:
```
$(SOURCE_ROOT)/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp:9158:57: error: no member named 'GetTotalPayloadSize' in 'NCloud::NFileStore::NStorage::TProtoResponseEvent<NCloud::NFileStore::NProto::TReadDataResponse, 275054746>'
 9158 |         UNIT_ASSERT_VALUES_EQUAL(data.size(), response->GetTotalPayloadSize());
      |                                               ~~~~~~~~~~^
$(SOURCE_ROOT)/library/cpp/testing/unittest/registar.h:754:70: note: expanded from macro 'UNIT_ASSERT_VALUES_EQUAL'
  754 | #define UNIT_ASSERT_VALUES_EQUAL(A, B) UNIT_ASSERT_VALUES_EQUAL_C(A, B, "")
      |                                                                      ^
$(SOURCE_ROOT)/library/cpp/testing/unittest/registar.h:749:38: note: expanded from macro 'UNIT_ASSERT_VALUES_EQUAL_C'
  749 |     UNIT_ASSERT_VALUES_EQUAL_IMPL(A, B, C, true, "==", "!=")
      |                                      ^
$(SOURCE_ROOT)/library/cpp/testing/unittest/registar.h:737:62: note: expanded from macro 'UNIT_ASSERT_VALUES_EQUAL_IMPL'
  737 |         if (!::NUnitTest::NPrivate::CompareAndMakeStrings(A, B, _as, _asInd, _bs, _bsInd, _usePlainDiff, EQflag)) {                    \
      |                                                              ^
1 error generated.
```
