### PR TITLE
[Filestore] increase vfs_fuse benchmark timeout

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/bench/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/bench/ya.make
@@ -1,5 +1,8 @@
 Y_BENCHMARK()
 
+SIZE(medium)
+TIMEOUT(300)
+
 IF (SANITIZER_TYPE)
     TAG(ya:manual)
 ENDIF()


### PR DESCRIPTION
### Notes
Prevent benchmark chunks from being killed by the default 60s timeout when running the full benchmark set

- mark `cloud/filestore/libs/vfs_fuse/bench` as `SIZE(medium)` and set `TIMEOUT(300)`

### Issue
the same as https://github.com/ydb-platform/nbs/pull/6261
