### PR TITLE
Disable partition2 unit tests in arcadia autocheck

### DIFF
--- a/cloud/blockstore/libs/storage/partition2/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition2/ut/ya.make
@@ -2,6 +2,8 @@ UNITTEST_FOR(cloud/blockstore/libs/storage/partition2)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/medium.inc)
 
+TAG(ya:not_autocheck)
+
 SRCS(
     garbage_queue_ut.cpp
     part2_database_ut.cpp


### PR DESCRIPTION
### Notes
Disable partition2 unit tests for arcadia autocheck by `TAG(ya:not_autocheck)`

### Issue
Partition2 feature is currently not being developed. Currently, the tests fail on YDB 26-1
`ShouldRejectCompactionRequestsIfDataChannelsAreAlmostFull` and `ShouldRejectWriteRequestsIfDataChannelsAreYellow`
