### PR TITLE
issue-1541: process only read-only handles asynchronously during close

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -121,4 +121,7 @@ message TFileSystemConfig
     // inode. Needed only for backends that may reuse inode ids (local
     // filestore); not needed for the ydb-based backend.
     optional bool XAttrCacheInvalidateOnCreateEnabled = 35;
+
+    // Async processing of destroy handle requests only for read only handles.
+    optional bool AsyncDestroyReadOnlyHandleEnabled = 36;
 }

--- a/cloud/filestore/config/server.proto
+++ b/cloud/filestore/config/server.proto
@@ -224,6 +224,9 @@ message TLocalServiceConfig
 
     // Maximum serialized size of one persistent handle.
     optional uint64 DirectoryHandlesPersistentHandleMaxSize = 41;
+
+    // Async processing of destroy handle requests only for read only handles.
+    optional bool AsyncDestroyReadOnlyHandleEnabled = 42;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -842,4 +842,7 @@ message TStorageConfig
     // Enables the RDMA side channel for tablet-proxied requests in
     // filestore-server and filestore-vhost.
     optional bool TabletDirectRdmaEnabled = 524;
+
+    // Async processing of destroy handle requests only for read only handles.
+    optional bool AsyncDestroyReadOnlyHandleEnabled = 525;
 }

--- a/cloud/filestore/libs/service_local/config.cpp
+++ b/cloud/filestore/libs/service_local/config.cpp
@@ -28,6 +28,7 @@ namespace {
     xxx(DirectIoAlign,               ui32,          4_KB                      )\
     xxx(GuestWriteBackCacheEnabled,  bool,          false                     )\
     xxx(AsyncDestroyHandleEnabled,   bool,          false                     )\
+    xxx(AsyncDestroyReadOnlyHandleEnabled, bool,    false                     )\
     xxx(AsyncHandleOperationPeriod,  TDuration,     50ms                      )\
     xxx(OpenNodeByHandleEnabled,     bool,          false                     )\
     xxx(NodeCleanupBatchSize,        ui32,          1000                      )\

--- a/cloud/filestore/libs/service_local/config.h
+++ b/cloud/filestore/libs/service_local/config.h
@@ -105,6 +105,7 @@ public:
     void DumpHtml(IOutputStream& out) const;
 
     bool GetAsyncDestroyHandleEnabled() const;
+    bool GetAsyncDestroyReadOnlyHandleEnabled() const;
     TDuration GetAsyncHandleOperationPeriod() const;
 
     bool GetOpenNodeByHandleEnabled() const;

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -41,6 +41,8 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
             Config->GetGuestWriteBackCacheEnabled());
         features->SetAsyncDestroyHandleEnabled(
             Config->GetAsyncDestroyHandleEnabled());
+        features->SetAsyncDestroyReadOnlyHandleEnabled(
+            Config->GetAsyncDestroyReadOnlyHandleEnabled());
         features->SetAsyncHandleOperationPeriod(
             Config->GetAsyncHandleOperationPeriod().MilliSeconds());
         // The local service publishes only the legacy ZeroCopyEnabled feature,

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -257,6 +257,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(NonNetworkMetricsBalancingFactor,               ui32,       1_KB      )\
                                                                                \
     xxx(AsyncDestroyHandleEnabled,                      bool,       false     )\
+    xxx(AsyncDestroyReadOnlyHandleEnabled,              bool,       false     )\
     xxx(TabletUnsafeAsyncReadOnlyCreateHandleEnabled,   bool,       false     )\
     xxx(TabletUnsafeAsyncDestroyHandleEnabled,          bool,       false     )\
     xxx(AsyncHandleOperationPeriod,    TDuration,  TDuration::MilliSeconds(50))\

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -271,6 +271,7 @@ public:
     bool GetUseUnlimitedBTreeNodeRefsCacheInShards() const;
 
     bool GetAsyncDestroyHandleEnabled() const;
+    bool GetAsyncDestroyReadOnlyHandleEnabled() const;
     bool GetTabletUnsafeAsyncReadOnlyCreateHandleEnabled() const;
     bool GetTabletUnsafeAsyncDestroyHandleEnabled() const;
     TDuration GetAsyncHandleOperationPeriod() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -48,6 +48,8 @@ void FillFeatures(
     }
     features->SetAsyncDestroyHandleEnabled(
         config.GetAsyncDestroyHandleEnabled());
+    features->SetAsyncDestroyReadOnlyHandleEnabled(
+        config.GetAsyncDestroyReadOnlyHandleEnabled());
     features->SetAsyncHandleOperationPeriod(
         config.GetAsyncHandleOperationPeriod().MilliSeconds());
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -821,6 +821,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetAttrTimeout(TDuration::Seconds(20).MilliSeconds());
         config.SetPreferredBlockSizeMultiplier(2);
         config.SetAsyncDestroyHandleEnabled(true);
+        config.SetAsyncDestroyReadOnlyHandleEnabled(true);
         config.SetAsyncHandleOperationPeriod(
             TDuration::MilliSeconds(100).MilliSeconds());
         config.SetGuestPageCacheDisabled(true);
@@ -852,6 +853,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetThreeStageWriteThreshold(10_MB);
         features.SetPreferredBlockSize(4_KB * 2);
         features.SetAsyncDestroyHandleEnabled(true);
+        features.SetAsyncDestroyReadOnlyHandleEnabled(true);
         features.SetAsyncHandleOperationPeriod(
             TDuration::MilliSeconds(100).MilliSeconds());
         features.SetGuestPageCacheDisabled(true);

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -29,7 +29,8 @@ namespace {
                                                                                \
     xxx(PreferredBlockSize,     ui32,           0                             )\
                                                                                \
-    xxx(AsyncDestroyHandleEnabled,  bool,       false                         )\
+    xxx(AsyncDestroyHandleEnabled,          bool,       false                 )\
+    xxx(AsyncDestroyReadOnlyHandleEnabled,  bool,       false                 )\
     xxx(AsyncHandleOperationPeriod, TDuration,  TDuration::MilliSeconds(50)   )\
                                                                                \
     xxx(DirectIoEnabled,            bool,       false                         )\

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -39,6 +39,7 @@ public:
     ui32 GetPreferredBlockSize() const;
 
     bool GetAsyncDestroyHandleEnabled() const;
+    bool GetAsyncDestroyReadOnlyHandleEnabled() const;
     TDuration GetAsyncHandleOperationPeriod() const;
 
     bool GetDirectIoEnabled() const;

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -99,14 +99,17 @@ void TFileSystem::Reset()
 
 void TFileSystem::ScheduleProcessHandleOpsQueue()
 {
-    if (Config->GetAsyncDestroyHandleEnabled()) {
+    if (Config->GetAsyncDestroyHandleEnabled() ||
+        Config->GetAsyncDestroyReadOnlyHandleEnabled())
+    {
         Scheduler->Schedule(
-        Timer->Now() + Config->GetAsyncHandleOperationPeriod(),
-        [=, ptr = weak_from_this()] () {
-            if (auto self = ptr.lock()) {
-                self->ProcessHandleOpsQueue();
-            }
-        });
+            Timer->Now() + Config->GetAsyncHandleOperationPeriod(),
+            [=, ptr = weak_from_this()]()
+            {
+                if (auto self = ptr.lock()) {
+                    self->ProcessHandleOpsQueue();
+                }
+            });
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -99,9 +99,7 @@ void TFileSystem::Reset()
 
 void TFileSystem::ScheduleProcessHandleOpsQueue()
 {
-    if (Config->GetAsyncDestroyHandleEnabled() ||
-        Config->GetAsyncDestroyReadOnlyHandleEnabled())
-    {
+    if (HandleOpsQueue) {
         Scheduler->Schedule(
             Timer->Now() + Config->GetAsyncHandleOperationPeriod(),
             [=, ptr = weak_from_this()]()

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.h
@@ -473,6 +473,7 @@ private:
         fuse_req_t req,
         fuse_ino_t ino,
         ui64 handle,
+        bool asyncDestroyHandleEnabled,
         const NCloud::NProto::TError& writeBackCacheError);
     void CompleteAsyncDestroyHandle(
         TCallContext& callContext,

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -273,6 +273,7 @@ void TFileSystem::ReleaseImpl(
     fuse_req_t req,
     fuse_ino_t ino,
     ui64 handle,
+    bool processAsynchronously,
     const NCloud::NProto::TError& writeBackCacheError)
 {
     // If WriteBackCache was used, Release() previously asked it to flush the
@@ -283,7 +284,7 @@ void TFileSystem::ReleaseImpl(
     // - DestroyHandle fails -> return DestroyHandle error;
     // - DestroyHandle succeeds -> return writeBackCacheError
 
-    if (Config->GetAsyncDestroyHandleEnabled()) {
+    if (processAsynchronously) {
         if (!ProcessAsyncRelease(
                 callContext,
                 req,
@@ -332,6 +333,9 @@ void TFileSystem::Release(
     fuse_file_info* fi)
 {
     auto handle = fi->fh;
+    const bool readOnly = (fi->flags & O_ACCMODE) == O_RDONLY;
+    const bool processAsynchronously = Config->GetAsyncDestroyHandleEnabled() ||
+        (Config->GetAsyncDestroyReadOnlyHandleEnabled() && readOnly);
 
     STORAGE_DEBUG("Release #" << ino << " @" << handle);
 
@@ -350,13 +354,25 @@ void TFileSystem::Release(
                 {
                     if (auto self = ptr.lock()) {
                         const NProto::TError& error = future.GetValue();
-                        self->ReleaseImpl(callContext, req, ino, handle, error);
+                        self->ReleaseImpl(
+                            callContext,
+                            req,
+                            ino,
+                            handle,
+                            processAsynchronously,
+                            error);
                     }
                 });
         return;
     }
 
-    ReleaseImpl(std::move(callContext), req, ino, handle, {});
+    ReleaseImpl(
+        std::move(callContext),
+        req,
+        ino,
+        handle,
+        processAsynchronously,
+        {});
 }
 
 void TFileSystem::Read(

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -259,7 +259,9 @@ struct TBootstrap
         proto.SetDebug(true);
         proto.SetSocketPath(SocketPath);
         proto.SetFileSystemId(FileSystemId);
-        if (featuresConfig.GetAsyncDestroyHandleEnabled()) {
+        if (featuresConfig.GetAsyncDestroyHandleEnabled() ||
+            featuresConfig.GetAsyncDestroyReadOnlyHandleEnabled())
+        {
             proto.SetHandleOpsQueuePath(TempDir.Path() / "HandleOpsQueue");
             proto.SetHandleOpsQueueSize(handleOpsQueueSize);
         }
@@ -3069,6 +3071,101 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         responsePromise2.SetValue(NProto::TDestroyHandleResponse{});
 
         UNIT_ASSERT_VALUES_EQUAL(2U, handlerCalled.load());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            AtomicGet(counters->GetCounter("InProgress")->GetAtomic()));
+    }
+
+    Y_UNIT_TEST(ShouldProcessReadOnlyDestroyHandleRequestsAsynchronously)
+    {
+        NProto::TFileStoreFeatures features;
+        features.SetAsyncDestroyReadOnlyHandleEnabled(true);
+        auto scheduler = std::make_shared<TTestScheduler>();
+        TBootstrap bootstrap(CreateWallClockTimer(), scheduler, features);
+
+        const ui64 readOnlyHandle = 2;
+        const ui64 readOnlyNodeId = 10;
+        const ui64 writeHandle = 5;
+        const ui64 writeNodeId = 11;
+        std::atomic_bool readOnlyReleaseFinished = false;
+        std::atomic_bool writeReleaseFinished = false;
+        std::atomic_uint handlerCalled = 0;
+        auto counters = bootstrap.Counters->FindSubgroup("component", "fs_ut")
+                            ->FindSubgroup("request", "DestroyHandle");
+        auto readOnlyResponsePromise =
+            NewPromise<NProto::TDestroyHandleResponse>();
+        auto writeResponsePromise =
+            NewPromise<NProto::TDestroyHandleResponse>();
+        bootstrap.Service->SetHandlerDestroyHandle(
+            [&,
+             readOnlyResponsePromise,
+             writeResponsePromise](auto callContext, auto request) mutable
+            {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    1,
+                    AtomicGet(counters->GetCounter("InProgress")->GetAtomic()));
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    FileSystemId,
+                    callContext->FileSystemId);
+
+                ++handlerCalled;
+                if (request->GetHandle() == readOnlyHandle) {
+                    UNIT_ASSERT(readOnlyReleaseFinished);
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        readOnlyNodeId,
+                        request->GetNodeId());
+                    return readOnlyResponsePromise;
+                }
+
+                if (request->GetHandle() == writeHandle) {
+                    UNIT_ASSERT(!writeReleaseFinished);
+                    UNIT_ASSERT_VALUES_EQUAL(writeNodeId, request->GetNodeId());
+                    return writeResponsePromise;
+                }
+
+                UNIT_ASSERT_C(false, "Unexpected DestroyHandle request");
+                return NewPromise<NProto::TDestroyHandleResponse>();
+            });
+
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        auto future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            readOnlyNodeId,
+            readOnlyHandle,
+            O_RDONLY);
+        UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
+        readOnlyReleaseFinished = true;
+        UNIT_ASSERT_VALUES_EQUAL(0U, handlerCalled.load());
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            AtomicGet(counters->GetCounter("InProgress")->GetAtomic()));
+
+        scheduler->RunAllScheduledTasks();
+        UNIT_ASSERT_VALUES_EQUAL(1U, handlerCalled.load());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            AtomicGet(counters->GetCounter("InProgress")->GetAtomic()));
+        readOnlyResponsePromise.SetValue(NProto::TDestroyHandleResponse{});
+
+        future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            writeNodeId,
+            writeHandle,
+            O_WRONLY);
+        UNIT_ASSERT_EXCEPTION(
+            future.GetValue(ExceptionWaitTimeout),
+            yexception);
+        UNIT_ASSERT_VALUES_EQUAL(2U, handlerCalled.load());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            AtomicGet(counters->GetCounter("InProgress")->GetAtomic()));
+
+        writeResponsePromise.SetValue(NProto::TDestroyHandleResponse{});
+        UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
+        writeReleaseFinished = true;
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             AtomicGet(counters->GetCounter("InProgress")->GetAtomic()));

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -3057,10 +3057,15 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             bootstrap.Stop();
         };
 
-        auto future =
-            bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId1, handle1);
+        auto future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            nodeId1,
+            handle1,
+            O_RDONLY);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
-        future = bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId2, handle2);
+        future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            nodeId2,
+            handle2,
+            O_RDONLY);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
         releaseFinished = true;
 
@@ -3207,8 +3212,10 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             bootstrap.Stop();
         };
 
-        auto future =
-            bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId, handle);
+        auto future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            nodeId,
+            handle,
+            O_RDONLY);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
 
         destroyFinished.GetFuture().Wait(WaitTimeout);
@@ -3242,8 +3249,10 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
             bootstrap.Stop();
         };
 
-        auto future =
-            bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId, handle);
+        auto future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            nodeId,
+            handle,
+            O_RDONLY);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
 
         scheduler->RunAllScheduledTasks();
@@ -3301,15 +3310,19 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         auto counters = bootstrap.Counters
             ->FindSubgroup("component", "fs_ut")
             ->FindSubgroup("request", "DestroyHandle");
-        auto future =
-            bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId1, handle1);
+        auto future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            nodeId1,
+            handle1,
+            O_RDONLY);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
         UNIT_ASSERT_VALUES_EQUAL(
             0,
             AtomicGet(counters->GetCounter("InProgress")->GetAtomic()));
 
-        future =
-            bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId2, handle2);
+        future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            nodeId2,
+            handle2,
+            O_RDONLY);
 
         // Second request should wait until the first request is processed.
         UNIT_ASSERT_EXCEPTION(
@@ -3848,8 +3861,10 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         // should not write (flush) data from cache immediately
         UNIT_ASSERT_VALUES_EQUAL(0, writeDataCalled.load());
 
-        auto future =
-            bootstrap.Fuse->SendRequest<TReleaseRequest>(nodeId, handleId);
+        auto future = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+            nodeId,
+            handleId,
+            O_WRONLY);
         UNIT_ASSERT_NO_EXCEPTION(future.GetValue(WaitTimeout));
         UNIT_ASSERT_VALUES_EQUAL(1, destroyHandleCalled.load());
         // cache should be flushed
@@ -5475,12 +5490,18 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         UNIT_ASSERT(writeDSync->Out->Header.error);
 
         // 4. Release - should fail because data is dropped
-        auto release = std::make_shared<TReleaseRequest>(NodeId, NodeId + 1);
+        auto release = std::make_shared<TReleaseRequest>(
+            NodeId,
+            NodeId + 1,
+            O_WRONLY);
         UNIT_ASSERT(bootstrap.Fuse->SendRequest(release).Wait(WaitTimeout));
         UNIT_ASSERT(release->Out->Header.error);
 
         // 5. Release again - success because of no data in the cache
-        auto release2 = std::make_shared<TReleaseRequest>(NodeId, NodeId + 1);
+        auto release2 = std::make_shared<TReleaseRequest>(
+            NodeId,
+            NodeId + 1,
+            O_WRONLY);
         UNIT_ASSERT(bootstrap.Fuse->SendRequest(release2).Wait(WaitTimeout));
         UNIT_ASSERT(!release2->Out->Header.error);
     }

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -992,7 +992,9 @@ private:
             SessionId = response.GetSession().GetSessionId();
 
             THandleOpsQueuePtr handleOpsQueue;
-            if (FileSystemConfig->GetAsyncDestroyHandleEnabled()) {
+            if (FileSystemConfig->GetAsyncDestroyHandleEnabled() ||
+                FileSystemConfig->GetAsyncDestroyReadOnlyHandleEnabled())
+            {
                 if (Config->GetHandleOpsQueuePath()) {
                     auto path = TFsPath(Config->GetHandleOpsQueuePath()) /
                         FileSystemConfig->GetFileSystemId() /
@@ -1281,6 +1283,8 @@ private:
             features.GetXAttrCacheInvalidateOnCreateEnabled());
         config.SetAsyncDestroyHandleEnabled(
             features.GetAsyncDestroyHandleEnabled());
+        config.SetAsyncDestroyReadOnlyHandleEnabled(
+            features.GetAsyncDestroyReadOnlyHandleEnabled());
         config.SetAsyncHandleOperationPeriod(
             features.GetAsyncHandleOperationPeriod());
 

--- a/cloud/filestore/libs/vhost/request.h
+++ b/cloud/filestore/libs/vhost/request.h
@@ -552,11 +552,12 @@ struct TSetXAttrValueRequest
 struct TReleaseRequest
     : public TRequestBase<fuse_release_in, void, void>
 {
-    TReleaseRequest(ui64 nodeId, ui64 fh)
+    TReleaseRequest(ui64 nodeId, ui64 fh, int flags = 0)
     {
         In->Header.opcode = FUSE_RELEASE;
         In->Header.nodeid = nodeId;
         In->Body.fh = fh;
+        In->Body.flags = flags;
     }
 };
 

--- a/cloud/filestore/libs/vhost/request.h
+++ b/cloud/filestore/libs/vhost/request.h
@@ -552,7 +552,7 @@ struct TSetXAttrValueRequest
 struct TReleaseRequest
     : public TRequestBase<fuse_release_in, void, void>
 {
-    TReleaseRequest(ui64 nodeId, ui64 fh, int flags = 0)
+    TReleaseRequest(ui64 nodeId, ui64 fh, int flags)
     {
         In->Header.opcode = FUSE_RELEASE;
         In->Header.nodeid = nodeId;

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -61,6 +61,7 @@ message TFileStoreFeatures
     bool ExternalReadDataPayload = 46;
     optional bool TabletDirectRdmaEnabled = 47;
     bool XAttrCacheInvalidateOnCreateEnabled = 48;
+    bool AsyncDestroyReadOnlyHandleEnabled = 49;
 }
 
 message TFileStore


### PR DESCRIPTION
### Notes
We want to enable async destroy only for files opened read-only, as a safer option

### Issue
#1541 