### PR TITLE
[filestore] Fix crash on stop vhost in case of error

### DIFF
--- a/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/vhost/bootstrap.cpp
@@ -610,9 +610,11 @@ void TBootstrapVhost::StopComponents()
     FILESTORE_LOG_STOP_COMPONENT(TcMallocStatsUpdater);
     FILESTORE_LOG_STOP_COMPONENT(ModuleStatsUpdater);
 
-    const auto& serviceConfig = *Configs->VhostServiceConfig;
-    if (serviceConfig.GetSideChannelType() == NProto::SCT_TCP) {
-        NStorage::NFastShard::Destroy();
+    if (Configs->VhostServiceConfig) {
+        const auto& serviceConfig = *Configs->VhostServiceConfig;
+        if (serviceConfig.GetSideChannelType() == NProto::SCT_TCP) {
+            NStorage::NFastShard::Destroy();
+        }
     }
 }
 


### PR DESCRIPTION
### Issue
Process filestore-vhost crashed on vla04-3ct31r1-11b.cloud.yandex.net cluster pre-prod

Core was generated by `/usr/bin/filestore-vhost --app-config /Berkanavt/nfs-server/cfg/nfs-vhost.txt -'.
#0 NCloud::NFileStore::NVhost::TVhostServiceConfig::GetSideChannelType (this=0x0) at /-S/cloud/filestore/libs/endpoint_vhost/config.cpp:194
[Current thread is 173 (LWP 1214313)]

Thread 173 (LWP 1214313):
#0 NCloud::NFileStore::NVhost::TVhostServiceConfig::GetSideChannelType (this=0x0) at /-S/cloud/filestore/libs/endpoint_vhost/config.cpp +194
#1 NCloud::NFileStore::NDaemon::TBootstrapVhost::StopComponents (this=0x7ffe688ce230) at /-S/cloud/filestore/libs/daemon/vhost/bootstrap.cpp +614
#2 NCloud::NFileStore::NDaemon::TBootstrapCommon::Stop (this=0x7ffe688ce230) at /-S/cloud/filestore/libs/daemon/common/bootstrap.cpp +119
#3 NCloud::DoMain<NCloud::NFileStore::NDaemon::TBootstrapVhost> (bootstrap=..., argc=40, argv=<optimized out>) at /-S/cloud/storage/core/libs/daemon/app.h +40
#4 main (argc=40, argv=0x7ffe688ce5e8) at /-S/cloud/filestore/apps/vhost/main.cpp +22