### PR TITLE
[NBS] remove deprecated calls to get Hive tablet id

### DIFF
--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
@@ -42,7 +42,7 @@ THiveProxyActor::THiveProxyActor(
     , LogComponent(config.LogComponent)
     , TabletBootInfoBackupFilePath(config.TabletBootInfoBackupFilePath)
     , UseBinaryFormatForTabletBootInfoBackup(config.UseBinaryFormatForTabletBootInfoBackup)
-    , TenantHiveTabletId(config.TenantHiveTabletId)
+    , HiveTabletId(config.TenantHiveTabletId)
     , Counters(std::move(counters))
 {}
 
@@ -67,6 +67,10 @@ void THiveProxyActor::Bootstrap(const TActorContext& ctx)
     if (Counters) {
         HiveReconnectTimeCounter = Counters->GetCounter("HiveReconnectTime", true);
     }
+
+    if (!HiveTabletId) {
+        HiveTabletId = AppData(ctx)->DomainsInfo->GetHive();
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,37 +84,6 @@ void THiveProxyActor::SendRequest(
     if (HiveDisconnected) {
         HiveReconnectStartCycles = GetCycleCount();
     }
-}
-
-ui64 THiveProxyActor::GetHive(
-    const TActorContext& ctx,
-    ui64 tabletId,
-    ui32 hiveIdx)
-{
-    if (TenantHiveTabletId) {
-        return TenantHiveTabletId;
-    }
-
-    auto domainsInfo = AppData(ctx)->DomainsInfo;
-    Y_ABORT_UNLESS(domainsInfo->Domains);
-
-    ui32 domainUid = TDomainsInfo::BadDomainId;
-    if (tabletId) {
-        domainUid = domainsInfo->GetDomainUidByTabletId(tabletId);
-        if (domainUid == TDomainsInfo::BadDomainId) {
-            LOG_WARN_S(ctx, LogComponent,
-                "Missing domain for tablet " << tabletId
-                    << " using default domain");
-        }
-    }
-    if (domainUid == TDomainsInfo::BadDomainId) {
-        domainUid = domainsInfo->Domains.begin()->first;
-    }
-
-    const auto& domain = domainsInfo->GetDomain(domainUid);
-    ui32 hiveUid = domain.GetHiveUidByIdx(hiveIdx);
-    ui64 hive = domainsInfo->GetHive(hiveUid);
-    return hive;
 }
 
 void THiveProxyActor::SendLockRequest(
@@ -199,11 +172,10 @@ void THiveProxyActor::AddTabletMetrics(
 
 void THiveProxyActor::ScheduleSendTabletMetrics(const TActorContext& ctx, ui64 hive)
 {
-    auto* state = HiveStates.FindPtr(hive);
-    STORAGE_VERIFY(state, "Hive", hive);
-    if (!state->ScheduledSendTabletMetrics) {
+    auto& state = HiveState;
+    if (!state.ScheduledSendTabletMetrics) {
         ctx.Schedule(BatchTimeout, new TEvHiveProxyPrivate::TEvSendTabletMetrics(hive));
-        state->ScheduledSendTabletMetrics = true;
+        state.ScheduledSendTabletMetrics = true;
     }
 }
 
@@ -212,12 +184,11 @@ void THiveProxyActor::SendTabletMetrics(
     ui64 hive,
     bool resend)
 {
-    auto* state = HiveStates.FindPtr(hive);
-    STORAGE_VERIFY(state, "Hive", hive);
-    state->ScheduledSendTabletMetrics = false;
+    auto& state = HiveState;
+    state.ScheduledSendTabletMetrics = false;
     TAutoPtr<TEvHive::TEvTabletMetrics> event = MakeHolder<TEvHive::TEvTabletMetrics>();
     NKikimrHive::TEvTabletMetrics& record = event->Record;
-    for (auto& prTabletId: state->UpdatedTabletMetrics) {
+    for (auto& prTabletId: state.UpdatedTabletMetrics) {
         AddTabletMetrics(prTabletId.first, prTabletId.second, record);
         prTabletId.second.OnSendStats(resend);
     }
@@ -274,86 +245,89 @@ void THiveProxyActor::HandleConnectionError(
     Y_UNUSED(error);
     Y_UNUSED(connectFailed);
 
+    Y_DEBUG_ABORT_UNLESS(hive == HiveTabletId);
+
     HiveDisconnected = true;
 
-    LOG_ERROR_S(ctx, LogComponent,
-        "Pipe to hive" << hive << " has been reset ");
+    LOG_ERROR_S(
+        ctx,
+        LogComponent,
+        "Pipe to hive " << hive << " has been reset ");
 
     // Hive is a tablet, so it should eventually get up
     // Re-send all outstanding requests
-    if (auto* states = HiveStates.FindPtr(hive)) {
-        for (auto& kv: states->LockStates) {
-            ui64 tabletId = kv.first;
-            auto* state = &kv.second;
-            if (state->Phase == PHASE_LOCKED) {
-                // Link failed while locked, need to reconnect
-                state->Phase = PHASE_RECONNECT;
-            }
-            if (state->Phase == PHASE_LOCKING ||
-                state->Phase == PHASE_RECONNECT)
-            {
-                SendLockRequest(
-                    ctx,
-                    hive,
-                    tabletId,
-                    state->Phase == PHASE_RECONNECT);
-            } else if (state->Phase == PHASE_UNLOCKING) {
-                // Hive is a tablet, keep retrying requests
-                SendUnlockRequest(ctx, hive, tabletId);
-            }
+    auto& states = HiveState;
+    for (auto& kv: states.LockStates) {
+        ui64 tabletId = kv.first;
+        auto* state = &kv.second;
+        if (state->Phase == PHASE_LOCKED) {
+            // Link failed while locked, need to reconnect
+            state->Phase = PHASE_RECONNECT;
         }
-
-        // SendNextCreateOrLookupRequest() won't send any requests after the
-        // first undelivery. Reject and hope that clients will retry.
-        for (auto& [_, queue]: states->CreateRequests) {
-            while (!queue.empty()) {
-                TCreateOrLookupRequest request = std::move(queue.front());
-                queue.pop_front();
-
-                std::unique_ptr<IEventBase> response;
-                auto error =
-                    MakeError(E_REJECTED, "Pipe to hive has been reset.");
-                if (request.IsLookup) {
-                    response =
-                        std::make_unique<TEvHiveProxy::TEvLookupTabletResponse>(
-                            error);
-                } else {
-                    response =
-                        std::make_unique<TEvHiveProxy::TEvCreateTabletResponse>(
-                            error);
-                }
-                NCloud::Reply(ctx, request, std::move(response));
-            }
-        }
-        states->CreateRequests.clear();
-
-        for (auto& kv: states->GetInfoRequests) {
-            ui64 tabletId = kv.first;
-            auto& requests = kv.second;
-            if (!requests.empty()) {
-                SendGetTabletStorageInfoRequest(ctx, hive, tabletId);
-            }
-        }
-
-        if (!states->ScheduledSendTabletMetrics) {
-            SendTabletMetrics(
+        if (state->Phase == PHASE_LOCKING ||
+            state->Phase == PHASE_RECONNECT)
+        {
+            SendLockRequest(
                 ctx,
                 hive,
-                true   // resend
-            );
+                tabletId,
+                state->Phase == PHASE_RECONNECT);
+        } else if (state->Phase == PHASE_UNLOCKING) {
+            // Hive is a tablet, keep retrying requests
+            SendUnlockRequest(ctx, hive, tabletId);
         }
+    }
 
-        for (const auto& actorId: states->Actors) {
-            auto clientId = ClientCache->Prepare(ctx, hive);
-            if (!HiveReconnectStartCycles) {
-                HiveReconnectStartCycles = GetCycleCount();
+    // SendNextCreateOrLookupRequest() won't send any requests after the
+    // first undelivery. Reject and hope that clients will retry.
+    for (auto& [_, queue]: states.CreateRequests) {
+        while (!queue.empty()) {
+            TCreateOrLookupRequest request = std::move(queue.front());
+            queue.pop_front();
+
+            std::unique_ptr<IEventBase> response;
+            auto error =
+                MakeError(E_REJECTED, "Pipe to hive has been reset.");
+            if (request.IsLookup) {
+                response =
+                    std::make_unique<TEvHiveProxy::TEvLookupTabletResponse>(
+                        error);
+            } else {
+                response =
+                    std::make_unique<TEvHiveProxy::TEvCreateTabletResponse>(
+                        error);
             }
-            NCloud::Send<TEvHiveProxyPrivate::TEvChangeTabletClient>(
-                ctx,
-                actorId,
-                0,
-                clientId);
+            NCloud::Reply(ctx, request, std::move(response));
         }
+    }
+    states.CreateRequests.clear();
+
+    for (auto& kv: states.GetInfoRequests) {
+        ui64 tabletId = kv.first;
+        auto& requests = kv.second;
+        if (!requests.empty()) {
+            SendGetTabletStorageInfoRequest(ctx, hive, tabletId);
+        }
+    }
+
+    if (!states.ScheduledSendTabletMetrics) {
+        SendTabletMetrics(
+            ctx,
+            hive,
+            true   // resend
+        );
+    }
+
+    for (const auto& actorId: states.Actors) {
+        auto clientId = ClientCache->Prepare(ctx, hive);
+        if (!HiveReconnectStartCycles) {
+            HiveReconnectStartCycles = GetCycleCount();
+        }
+        NCloud::Send<TEvHiveProxyPrivate::TEvChangeTabletClient>(
+            ctx,
+            actorId,
+            0,
+            clientId);
     }
 }
 
@@ -362,13 +336,12 @@ void THiveProxyActor::HandleLockTabletExecutionLost(
     const TActorContext& ctx)
 {
     ui64 tabletId = ev->Get()->Record.GetTabletID();
-    ui64 hive = GetHive(ctx, tabletId);
-    auto* states = HiveStates.FindPtr(hive);
-    auto* state = states ? states->LockStates.FindPtr(tabletId) : nullptr;
+    auto& states = HiveState;
+    auto* state = states.LockStates.FindPtr(tabletId);
     if (!state || state->Phase == PHASE_LOCKING) {
         // Unexpected notification, ignore
         LOG_WARN_S(ctx, LogComponent,
-            "Unexpected lock lost notification from hive " << hive
+            "Unexpected lock lost notification from hive " << HiveTabletId
                 << " for tablet " << tabletId);
         return;
     }
@@ -387,7 +360,7 @@ void THiveProxyActor::HandleLockTabletExecutionLost(
         ctx,
         state,
         MakeError(E_REJECTED, "Lock lost upon HIVE notification"));
-    states->LockStates.erase(tabletId);
+    states.LockStates.erase(tabletId);
 }
 
 bool THiveProxyActor::HandleRequests(STFUNC_SIG)
@@ -406,13 +379,8 @@ void THiveProxyActor::HandleRequestFinished(
     const TEvHiveProxyPrivate::TEvRequestFinished::TPtr& ev,
     const TActorContext& ctx)
 {
-    const auto* msg = ev->Get();
-
-    ui64 hive = GetHive(ctx, msg->TabletId);
-
-    if (auto* state = HiveStates.FindPtr(hive)) {
-        state->Actors.erase(ev->Sender);
-    }
+    Y_UNUSED(ctx);
+    HiveState.Actors.erase(ev->Sender);
 }
 
 void THiveProxyActor::HandleTabletMetrics(
@@ -422,10 +390,8 @@ void THiveProxyActor::HandleTabletMetrics(
     const auto* msg = ev->Get();
 
     const auto& metrics = msg->ResourceValues;
-    ui64 hive = GetHive(ctx, msg->TabletId);
-    auto* state = HiveStates.FindPtr(hive);
-    STORAGE_VERIFY(state, "Hive", hive);
-    auto& tabletData = state->UpdatedTabletMetrics[msg->TabletId];
+    auto& state = HiveState;
+    auto& tabletData = state.UpdatedTabletMetrics[msg->TabletId];
     tabletData.SlaveID = msg->FollowerId;
 
     bool hasChanges = false;
@@ -481,8 +447,8 @@ void THiveProxyActor::HandleTabletMetrics(
 
     tabletData.OnUpdateStats();
 
-    if (!state->ScheduledSendTabletMetrics) {
-        ScheduleSendTabletMetrics(ctx, hive);
+    if (!state.ScheduledSendTabletMetrics) {
+        ScheduleSendTabletMetrics(ctx, HiveTabletId);
     }
 }
 
@@ -506,18 +472,16 @@ void THiveProxyActor::HandleMetricsResponse(
     auto size = msg->Record.TabletIdSize();
     Y_DEBUG_ABORT_UNLESS(msg->Record.FollowerIdSize() == size);
 
+    auto& state = HiveState;
     for (size_t i = 0; i < size; ++i) {
-        ui64 hive = GetHive(ctx, msg->Record.GetTabletId(i));
-        auto* state = HiveStates.FindPtr(hive);
-        STORAGE_VERIFY(state, "Hive", hive);
-        auto uit = state->UpdatedTabletMetrics.find(msg->Record.GetTabletId(i));
-        if (uit != state->UpdatedTabletMetrics.end()) {
+        auto uit = state.UpdatedTabletMetrics.find(msg->Record.GetTabletId(i));
+        if (uit != state.UpdatedTabletMetrics.end()) {
             uit->second.OnHiveAck();
             if (uit->second.IsEmpty()) {
-                state->UpdatedTabletMetrics.erase(uit);
+                state.UpdatedTabletMetrics.erase(uit);
             } else {
-                if (!state->ScheduledSendTabletMetrics) {
-                    ScheduleSendTabletMetrics(ctx, hive);
+                if (!state.ScheduledSendTabletMetrics) {
+                    ScheduleSendTabletMetrics(ctx, HiveTabletId);
                 }
             }
         }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.cpp
@@ -77,41 +77,40 @@ void THiveProxyActor::Bootstrap(const TActorContext& ctx)
 
 void THiveProxyActor::SendRequest(
     const TActorContext& ctx,
-    ui64 hive,
     IEventBase* request)
 {
-    ClientCache->Send(ctx, hive, request);
+    ClientCache->Send(ctx, HiveTabletId, request);
     if (HiveDisconnected) {
         HiveReconnectStartCycles = GetCycleCount();
     }
 }
 
 void THiveProxyActor::SendLockRequest(
-    const TActorContext& ctx, ui64 hive, ui64 tabletId, bool reconnect)
+    const TActorContext& ctx, ui64 tabletId, bool reconnect)
 {
     auto hiveRequest =
         std::make_unique<TEvHive::TEvLockTabletExecution>(tabletId);
     hiveRequest->Record.SetMaxReconnectTimeout(
         LockExpireTimeout.MilliSeconds());
     hiveRequest->Record.SetReconnect(reconnect);
-    SendRequest(ctx, hive, hiveRequest.release());
+    SendRequest(ctx, hiveRequest.release());
 }
 
 void THiveProxyActor::SendUnlockRequest(
-    const TActorContext& ctx, ui64 hive, ui64 tabletId)
+    const TActorContext& ctx, ui64 tabletId)
 {
     auto hiveRequest =
         std::make_unique<TEvHive::TEvUnlockTabletExecution>(tabletId);
-    SendRequest(ctx, hive, hiveRequest.release());
+    SendRequest(ctx, hiveRequest.release());
 }
 
 void THiveProxyActor::SendGetTabletStorageInfoRequest(
     const TActorContext& ctx,
-    ui64 hive, ui64 tabletId)
+    ui64 tabletId)
 {
     auto hiveRequest =
         std::make_unique<TEvHive::TEvGetTabletStorageInfo>(tabletId);
-    SendRequest(ctx, hive, hiveRequest.release());
+    SendRequest(ctx, hiveRequest.release());
 }
 
 void THiveProxyActor::SendLockReply(
@@ -170,18 +169,17 @@ void THiveProxyActor::AddTabletMetrics(
     metrics.MutableResourceUsage()->MergeFrom(tabletData.ResourceValues);
 }
 
-void THiveProxyActor::ScheduleSendTabletMetrics(const TActorContext& ctx, ui64 hive)
+void THiveProxyActor::ScheduleSendTabletMetrics(const TActorContext& ctx)
 {
     auto& state = HiveState;
     if (!state.ScheduledSendTabletMetrics) {
-        ctx.Schedule(BatchTimeout, new TEvHiveProxyPrivate::TEvSendTabletMetrics(hive));
+        ctx.Schedule(BatchTimeout, new TEvHiveProxyPrivate::TEvSendTabletMetrics());
         state.ScheduledSendTabletMetrics = true;
     }
 }
 
 void THiveProxyActor::SendTabletMetrics(
     const TActorContext& ctx,
-    ui64 hive,
     bool resend)
 {
     auto& state = HiveState;
@@ -193,7 +191,7 @@ void THiveProxyActor::SendTabletMetrics(
         prTabletId.second.OnSendStats(resend);
     }
     if (record.TabletMetricsSize() > 0) {
-        SendRequest(ctx, hive, event.Release());
+        SendRequest(ctx, event.Release());
     }
 }
 
@@ -205,12 +203,13 @@ void THiveProxyActor::HandleConnect(
 {
     const auto* msg = ev->Get();
 
-    ui64 hive = msg->TabletId;
+    Y_DEBUG_ABORT_UNLESS(msg->TabletId == HiveTabletId);
+
     if (!ClientCache->OnConnect(ev)) {
         // Connect to hive failed
         auto error = MakeKikimrError(msg->Status, TStringBuilder()
-            << "Connect to hive " << hive << " failed");
-        HandleConnectionError(ctx, error, hive, true);
+            << "Connect to hive " << HiveTabletId << " failed");
+        HandleConnectionError(ctx, error, true);
     } else if (HiveReconnectStartCycles) {
         if (HiveReconnectTimeCounter) {
             HiveReconnectTimeCounter->Add(
@@ -228,31 +227,29 @@ void THiveProxyActor::HandleDisconnect(
 {
     const auto* msg = ev->Get();
 
-    ui64 hive = msg->TabletId;
+    Y_DEBUG_ABORT_UNLESS(msg->TabletId == HiveTabletId);
+
     ClientCache->OnDisconnect(ev);
 
     auto error = MakeError(E_REJECTED, TStringBuilder()
-        << "Disconnected from hive " << hive);
-    HandleConnectionError(ctx, error, hive, false);
+        << "Disconnected from hive " << HiveTabletId);
+    HandleConnectionError(ctx, error, false);
 }
 
 void THiveProxyActor::HandleConnectionError(
     const TActorContext& ctx,
     const NProto::TError& error,
-    ui64 hive,
     bool connectFailed)
 {
     Y_UNUSED(error);
     Y_UNUSED(connectFailed);
-
-    Y_DEBUG_ABORT_UNLESS(hive == HiveTabletId);
 
     HiveDisconnected = true;
 
     LOG_ERROR_S(
         ctx,
         LogComponent,
-        "Pipe to hive " << hive << " has been reset ");
+        "Pipe to hive " << HiveTabletId << " has been reset ");
 
     // Hive is a tablet, so it should eventually get up
     // Re-send all outstanding requests
@@ -269,12 +266,11 @@ void THiveProxyActor::HandleConnectionError(
         {
             SendLockRequest(
                 ctx,
-                hive,
                 tabletId,
                 state->Phase == PHASE_RECONNECT);
         } else if (state->Phase == PHASE_UNLOCKING) {
             // Hive is a tablet, keep retrying requests
-            SendUnlockRequest(ctx, hive, tabletId);
+            SendUnlockRequest(ctx, tabletId);
         }
     }
 
@@ -306,20 +302,19 @@ void THiveProxyActor::HandleConnectionError(
         ui64 tabletId = kv.first;
         auto& requests = kv.second;
         if (!requests.empty()) {
-            SendGetTabletStorageInfoRequest(ctx, hive, tabletId);
+            SendGetTabletStorageInfoRequest(ctx, tabletId);
         }
     }
 
     if (!states.ScheduledSendTabletMetrics) {
         SendTabletMetrics(
             ctx,
-            hive,
             true   // resend
         );
     }
 
     for (const auto& actorId: states.Actors) {
-        auto clientId = ClientCache->Prepare(ctx, hive);
+        auto clientId = ClientCache->Prepare(ctx, HiveTabletId);
         if (!HiveReconnectStartCycles) {
             HiveReconnectStartCycles = GetCycleCount();
         }
@@ -448,7 +443,7 @@ void THiveProxyActor::HandleTabletMetrics(
     tabletData.OnUpdateStats();
 
     if (!state.ScheduledSendTabletMetrics) {
-        ScheduleSendTabletMetrics(ctx, HiveTabletId);
+        ScheduleSendTabletMetrics(ctx);
     }
 }
 
@@ -456,10 +451,9 @@ void THiveProxyActor::HandleSendTabletMetrics(
     const TEvHiveProxyPrivate::TEvSendTabletMetrics::TPtr& ev,
     const TActorContext& ctx)
 {
-    const auto* msg = ev->Get();
+    Y_UNUSED(ev);
     SendTabletMetrics(
         ctx,
-        msg->Hive,
         false      // resend
     );
 }
@@ -481,7 +475,7 @@ void THiveProxyActor::HandleMetricsResponse(
                 state.UpdatedTabletMetrics.erase(uit);
             } else {
                 if (!state.ScheduledSendTabletMetrics) {
-                    ScheduleSendTabletMetrics(ctx, HiveTabletId);
+                    ScheduleSendTabletMetrics(ctx);
                 }
             }
         }

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
@@ -197,7 +197,6 @@ private:
 
     void SendRequest(
         const NActors::TActorContext& ctx,
-        ui64 hive,
         NActors::IEventBase* request);
 
     void SendNextCreateOrLookupRequest(
@@ -219,7 +218,7 @@ private:
         TLockState* state,
         const NProto::TError& error = {});
 
-    void ScheduleSendTabletMetrics(const NActors::TActorContext& ctx, ui64 hive);
+    void ScheduleSendTabletMetrics(const NActors::TActorContext& ctx);
 
     void AddTabletMetrics(
         ui64 tabletId,
@@ -228,7 +227,6 @@ private:
 
     void SendTabletMetrics(
         const NActors::TActorContext& ctx,
-        ui64 hiveId,
         bool resend);
 
     void HandleConnect(
@@ -242,12 +240,10 @@ private:
     void HandleConnectionError(
         const NActors::TActorContext& ctx,
         const NProto::TError& error,
-        ui64 hive,
         bool connectFailed);
 
     void SendLockRequest(
         const NActors::TActorContext& ctx,
-        ui64 hive,
         ui64 tabletId,
         bool reconnect = false);
 
@@ -261,7 +257,6 @@ private:
 
     void SendUnlockRequest(
         const NActors::TActorContext& ctx,
-        ui64 hive,
         ui64 tabletId);
 
     void HandleUnlockTabletExecutionResult(
@@ -270,7 +265,6 @@ private:
 
     void SendGetTabletStorageInfoRequest(
         const NActors::TActorContext& ctx,
-        ui64 hive,
         ui64 tabletId);
 
     void HandleGetTabletStorageInfoRegistered(

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor.h
@@ -167,7 +167,7 @@ private:
     static constexpr TDuration BatchTimeout = TDuration::Seconds(2);
 
     std::unique_ptr<NKikimr::NTabletPipe::IClientCache> ClientCache;
-    THashMap<ui64, THiveState> HiveStates;
+    THiveState HiveState;
 
     const TDuration LockExpireTimeout;
     const int LogComponent;
@@ -176,7 +176,7 @@ private:
     bool UseBinaryFormatForTabletBootInfoBackup;
     NActors::TActorId TabletBootInfoBackup;
 
-    const ui64 TenantHiveTabletId;
+    ui64 HiveTabletId;
 
     const NMonitoring::TDynamicCounterPtr Counters;
     NMonitoring::TDynamicCounters::TCounterPtr HiveReconnectTimeCounter;
@@ -199,11 +199,6 @@ private:
         const NActors::TActorContext& ctx,
         ui64 hive,
         NActors::IEventBase* request);
-
-    ui64 GetHive(
-        const NActors::TActorContext& ctx,
-        ui64 tabletId,
-        ui32 hiveIdx = Max());
 
     void SendNextCreateOrLookupRequest(
         const NActors::TActorContext& ctx,

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_bootext.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_bootext.cpp
@@ -239,9 +239,8 @@ void THiveProxyActor::HandleBootExternal(
     const auto* msg = ev->Get();
 
     ui64 tabletId = msg->TabletId;
-    ui64 hive = GetHive(ctx, tabletId);
 
-    auto clientId = ClientCache->Prepare(ctx, hive);
+    auto clientId = ClientCache->Prepare(ctx, HiveTabletId);
     auto requestId = NCloud::Register<TBootRequestActor>(
         ctx,
         SelfId(),
@@ -252,7 +251,7 @@ void THiveProxyActor::HandleBootExternal(
         TabletBootInfoBackup,
         msg->RequestTimeout
     );
-    HiveStates[hive].Actors.insert(requestId);
+    HiveState.Actors.insert(requestId);
 }
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_create.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_create.cpp
@@ -53,7 +53,8 @@ void THiveProxyActor::HandleCreateTablet(
         msg->Request.GetOwner(),
         msg->Request.GetOwnerIdx());
 
-    auto& queue = HiveStates[msg->HiveId].CreateRequests[key];
+    Y_ABORT_UNLESS(msg->HiveId == HiveTabletId);
+    auto& queue = HiveState.CreateRequests[key];
     queue.emplace_back(false, ev.Release());
 
     SendNextCreateOrLookupRequest(ctx, queue);
@@ -67,7 +68,8 @@ void THiveProxyActor::HandleLookupTablet(
 
     const auto key = std::make_pair(msg->Owner, msg->OwnerIdx);
 
-    auto& queue = HiveStates[msg->HiveId].CreateRequests[key];
+    Y_ABORT_UNLESS(msg->HiveId == HiveTabletId);
+    auto& queue = HiveState.CreateRequests[key];
     queue.emplace_back(true, ev.Release());
 
     SendNextCreateOrLookupRequest(ctx, queue);
@@ -79,8 +81,8 @@ void THiveProxyActor::HandleCreateTabletReply(
 {
     const auto* msg = ev->Get();
 
-    const auto hiveId = ev->Cookie;
-    auto& state = HiveStates[hiveId];
+    Y_ABORT_UNLESS(ev->Cookie == HiveTabletId);
+    auto& state = HiveState;
 
     const auto key = std::make_pair(
          msg->Record.GetOwner(),

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_drain.cpp
@@ -127,10 +127,9 @@ void THiveProxyActor::HandleDrainNode(
     const TEvHiveProxy::TEvDrainNodeRequest::TPtr& ev,
     const TActorContext& ctx)
 {
-    ui64 hive = GetHive(ctx, 0);
-    auto clientId = ClientCache->Prepare(ctx, hive);
+    auto clientId = ClientCache->Prepare(ctx, HiveTabletId);
 
-    HiveStates[hive].Actors.insert(NCloud::Register<TDrainNodeRequestActor>(
+    HiveState.Actors.insert(NCloud::Register<TDrainNodeRequestActor>(
         ctx,
         SelfId(),
         ev->Get()->KeepDown,

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_getinfo.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_getinfo.cpp
@@ -15,14 +15,13 @@ void THiveProxyActor::HandleGetStorageInfo(
     const auto* msg = ev->Get();
 
     ui64 tabletId = msg->TabletId;
-    ui64 hive = GetHive(ctx, tabletId);
 
-    auto& requests = HiveStates[hive].GetInfoRequests[tabletId];
+    auto& requests = HiveState.GetInfoRequests[tabletId];
     requests.emplace_back(ev->Sender, ev->Cookie);
 
     if (requests.size() == 1) {
         // Send request to hive on the first incoming request
-        SendGetTabletStorageInfoRequest(ctx, hive, tabletId);
+        SendGetTabletStorageInfoRequest(ctx, HiveTabletId, tabletId);
     }
 }
 
@@ -41,7 +40,6 @@ void THiveProxyActor::HandleGetTabletStorageInfoResult(
     const auto* msg = ev->Get();
 
     ui64 tabletId = msg->Record.GetTabletID();
-    ui64 hive = GetHive(ctx, tabletId);
 
     NProto::TError error;
     TTabletStorageInfoPtr storageInfo;
@@ -53,8 +51,8 @@ void THiveProxyActor::HandleGetTabletStorageInfoResult(
         storageInfo = TabletStorageInfoFromProto(msg->Record.GetInfo());
     }
 
-    auto& states = HiveStates[hive];
-    auto& requests = states.GetInfoRequests[tabletId];
+    auto& state = HiveState;
+    auto& requests = state.GetInfoRequests[tabletId];
     while (!requests.empty()) {
         auto response = std::make_unique<TEvHiveProxy::TEvGetStorageInfoResponse>(
             error,
@@ -63,7 +61,7 @@ void THiveProxyActor::HandleGetTabletStorageInfoResult(
         NCloud::Reply(ctx, requests.front(), std::move(response));
         requests.pop_front();
     }
-    states.GetInfoRequests.erase(tabletId);
+    state.GetInfoRequests.erase(tabletId);
 }
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_getinfo.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_getinfo.cpp
@@ -21,7 +21,7 @@ void THiveProxyActor::HandleGetStorageInfo(
 
     if (requests.size() == 1) {
         // Send request to hive on the first incoming request
-        SendGetTabletStorageInfoRequest(ctx, HiveTabletId, tabletId);
+        SendGetTabletStorageInfoRequest(ctx, tabletId);
     }
 }
 

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_lock.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_lock.cpp
@@ -36,7 +36,7 @@ void THiveProxyActor::HandleLockTablet(
     state.Phase = PHASE_LOCKING;
     state.LockRequest = {ev->Sender, ev->Cookie};
 
-    SendLockRequest(ctx, HiveTabletId, tabletId);
+    SendLockRequest(ctx, tabletId);
 }
 
 void THiveProxyActor::HandleLockTabletExecutionResult(
@@ -54,7 +54,7 @@ void THiveProxyActor::HandleLockTabletExecutionResult(
         LOG_WARN_S(ctx, LogComponent,
             "Unexpected lock reply from hive " << HiveTabletId
                 << " for tablet " << tabletId);
-        SendUnlockRequest(ctx, HiveTabletId, tabletId);
+        SendUnlockRequest(ctx, tabletId);
         return;
     }
 
@@ -122,7 +122,7 @@ void THiveProxyActor::HandleLockTabletExecutionResult(
 
     if (state->UnlockRequest) {
         state->Phase = PHASE_UNLOCKING;
-        SendUnlockRequest(ctx, HiveTabletId, tabletId);
+        SendUnlockRequest(ctx, tabletId);
     }
 }
 

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_lock.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_lock.cpp
@@ -18,9 +18,8 @@ void THiveProxyActor::HandleLockTablet(
     const auto* msg = ev->Get();
 
     ui64 tabletId = msg->TabletId;
-    ui64 hive = GetHive(ctx, tabletId);
 
-    auto& tablets = HiveStates[hive].LockStates;
+    auto& tablets = HiveState.LockStates;
     auto& state = tablets[tabletId];
     if (state.Owner) {
         ReportHiveProxyConcurrentLockError();
@@ -37,7 +36,7 @@ void THiveProxyActor::HandleLockTablet(
     state.Phase = PHASE_LOCKING;
     state.LockRequest = {ev->Sender, ev->Cookie};
 
-    SendLockRequest(ctx, hive, tabletId);
+    SendLockRequest(ctx, HiveTabletId, tabletId);
 }
 
 void THiveProxyActor::HandleLockTabletExecutionResult(
@@ -47,23 +46,22 @@ void THiveProxyActor::HandleLockTabletExecutionResult(
     const auto* msg = ev->Get();
 
     ui64 tabletId = msg->Record.GetTabletID();
-    ui64 hive = GetHive(ctx, tabletId);
 
-    auto* states = HiveStates.FindPtr(hive);
-    auto* state = states ? states->LockStates.FindPtr(tabletId) : nullptr;
+    auto& states = HiveState;
+    auto* state = states.LockStates.FindPtr(tabletId);
     if (!state || state->Phase == PHASE_UNLOCKING) {
         // Unexpected lock reply, send an unlock request
         LOG_WARN_S(ctx, LogComponent,
-            "Unexpected lock reply from hive " << hive
+            "Unexpected lock reply from hive " << HiveTabletId
                 << " for tablet " << tabletId);
-        SendUnlockRequest(ctx, hive, tabletId);
+        SendUnlockRequest(ctx, HiveTabletId, tabletId);
         return;
     }
 
     if (state->Phase == PHASE_LOCKED) {
         // Already locked, ignore duplicate results
         LOG_WARN_S(ctx, LogComponent,
-            "Ignored duplicate lock reply from hive " << hive
+            "Ignored duplicate lock reply from hive " << HiveTabletId
                 << " for tablet " << tabletId);
         return;
     }
@@ -100,7 +98,7 @@ void THiveProxyActor::HandleLockTabletExecutionResult(
             }
         }
 
-        states->LockStates.erase(tabletId);
+        states.LockStates.erase(tabletId);
         return;
     }
 
@@ -124,7 +122,7 @@ void THiveProxyActor::HandleLockTabletExecutionResult(
 
     if (state->UnlockRequest) {
         state->Phase = PHASE_UNLOCKING;
-        SendUnlockRequest(ctx, hive, tabletId);
+        SendUnlockRequest(ctx, HiveTabletId, tabletId);
     }
 }
 

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_reassign.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_reassign.cpp
@@ -122,10 +122,9 @@ void THiveProxyActor::HandleReassignTablet(
 {
     auto* msg = ev->Get();
 
-    ui64 hive = GetHive(ctx, msg->TabletId);
-    auto clientId = ClientCache->Prepare(ctx, hive);
+    auto clientId = ClientCache->Prepare(ctx, HiveTabletId);
 
-    HiveStates[hive].Actors.insert(NCloud::Register<TReassignRequestActor>(
+    HiveState.Actors.insert(NCloud::Register<TReassignRequestActor>(
         ctx,
         SelfId(),
         LogComponent,

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
@@ -17,10 +17,9 @@ void THiveProxyActor::HandleUnlockTablet(
     const auto* msg = ev->Get();
 
     ui64 tabletId = msg->TabletId;
-    ui64 hive = GetHive(ctx, tabletId);
 
-    auto* states = HiveStates.FindPtr(hive);
-    auto* state = states ? states->LockStates.FindPtr(tabletId) : nullptr;
+    auto& states = HiveState;
+    auto* state = states.LockStates.FindPtr(tabletId);
     if (!state) {
         // Unlock with a paired lock
         auto error = MakeError(E_ARGUMENT, "Unlock without a matching Lock");
@@ -55,7 +54,7 @@ void THiveProxyActor::HandleUnlockTablet(
     if (state->Phase == PHASE_LOCKED) {
         // It is possible to send unlock request right now
         state->Phase = PHASE_UNLOCKING;
-        SendUnlockRequest(ctx, hive, tabletId);
+        SendUnlockRequest(ctx, HiveTabletId, tabletId);
     }
 }
 
@@ -66,14 +65,13 @@ void THiveProxyActor::HandleUnlockTabletExecutionResult(
     const auto* msg = ev->Get();
 
     ui64 tabletId = msg->Record.GetTabletID();
-    ui64 hive = GetHive(ctx, tabletId);
 
-    auto* states = HiveStates.FindPtr(hive);
-    auto* state = states ? states->LockStates.FindPtr(tabletId) : nullptr;
+    auto& states = HiveState;
+    auto* state = states.LockStates.FindPtr(tabletId);
     if (!state || state->Phase != PHASE_UNLOCKING) {
         // Unexpected unlock reply, ignore
         LOG_WARN_S(ctx, LogComponent,
-            "Unexpected unlock reply from hive " << hive
+            "Unexpected unlock reply from hive " << HiveTabletId
                 << " for tablet " << tabletId);
         return;
     }
@@ -91,7 +89,7 @@ void THiveProxyActor::HandleUnlockTabletExecutionResult(
     }
 
     SendUnlockReply(ctx, state, error);
-    states->LockStates.erase(tabletId);
+    states.LockStates.erase(tabletId);
 }
 
 }   // namespace NCloud::NStorage

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_actor_unlock.cpp
@@ -54,7 +54,7 @@ void THiveProxyActor::HandleUnlockTablet(
     if (state->Phase == PHASE_LOCKED) {
         // It is possible to send unlock request right now
         state->Phase = PHASE_UNLOCKING;
-        SendUnlockRequest(ctx, HiveTabletId, tabletId);
+        SendUnlockRequest(ctx, tabletId);
     }
 }
 

--- a/cloud/storage/core/libs/hive_proxy/hive_proxy_events_private.h
+++ b/cloud/storage/core/libs/hive_proxy/hive_proxy_events_private.h
@@ -45,11 +45,6 @@ struct TEvHiveProxyPrivate
 
     struct TSendTabletMetrics
     {
-        const ui64 Hive;
-
-        explicit TSendTabletMetrics(ui64 hive)
-            : Hive(hive)
-        {}
     };
 
     //


### PR DESCRIPTION
### Issue
core/base/domain.h
        // NEVER USE THIS
        /*[[deprecated]]*/ ui32 GetHiveUidByIdx(ui32) const { return 0; }
        /*[[deprecated]]*/ static constexpr ui32 DefaultStateStorageGroup = 1;
        /*[[deprecated]]*/ static constexpr ui32 DefaultHiveUid = 1;
