### PR TITLE
fix: chunk disambiguation during junit parsing

### DIFF
--- a/.github/scripts/tests/transform_ya_junit.py
+++ b/.github/scripts/tests/transform_ya_junit.py
@@ -18,9 +18,26 @@ from .mute_utils import mute_target, pattern_to_re
 LOGGER = logging.getLogger(__name__)
 
 CompiledPatternPair: TypeAlias = tuple[Pattern[str], Pattern[str]]
-TraceKey: TypeAlias = tuple[str, str] | tuple[str, int, int]
+TraceKey: TypeAlias = tuple[str, str]
+ChunkTraceKey: TypeAlias = tuple[str, int, int]
 TraceEvent: TypeAlias = dict[str, Any]
 LogMap: TypeAlias = dict[str, str]
+
+
+def _escape_github_command(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def emit_transform_warning(message: str) -> None:
+    LOGGER.warning(message)
+    print(f"::warning title=JUnit transform::{_escape_github_command(message)}")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    with open(summary_path, "a") as fp:
+        fp.write(f"\n- **JUnit transform warning:** {message}\n")
 
 
 class YaMuteCheck:
@@ -103,6 +120,7 @@ class YTestReportTrace:
     def __init__(self, out_root: str) -> None:
         self.out_root = out_root
         self.traces: dict[TraceKey, TraceEvent] = {}
+        self.chunk_traces: dict[ChunkTraceKey, list[TraceEvent]] = {}
 
     def load(self, subdir: str) -> None:
         test_results_dir = os.path.join(self.out_root, f"{subdir}/test-results/")
@@ -133,12 +151,15 @@ class YTestReportTrace:
                         self.traces[(class_event, subtest)] = event
                     elif event["name"] == "chunk-event":
                         event = event["value"]
+                        event["test_results_folder"] = folder
                         chunk_idx = event["chunk_index"]
                         chunk_total = event["nchunks"]
                         LOGGER.info(
                             "loaded (%s, %s, %s)", subdir, chunk_idx, chunk_total
                         )
-                        self.traces[(subdir, chunk_idx, chunk_total)] = event
+                        self.chunk_traces.setdefault(
+                            (subdir, chunk_idx, chunk_total), []
+                        ).append(event)
 
     def get_logs(self, class_event: str, name: str) -> LogMap:
         trace = self.traces.get((class_event, name))
@@ -154,8 +175,36 @@ class YTestReportTrace:
 
         return result
 
-    def get_logs_chunks(self, suite: str, idx: int, total: int) -> LogMap:
-        trace = self.traces.get((suite, idx, total))
+    def select_chunk_trace(
+        self, suite: str, idx: int, total: int, failure_text: str | None = None
+    ) -> TraceEvent | None:
+        traces = self.chunk_traces.get((suite, idx, total), [])
+        if not traces:
+            return None
+        if len(traces) == 1 or not failure_text:
+            return traces[0]
+
+        for trace in traces:
+            folder = trace.get("test_results_folder")
+            if folder and f"test-results/{folder}" in failure_text:
+                return trace
+
+        for trace in traces:
+            logs = trace.get("logs", {})
+            for path in logs.values():
+                if path.replace("$(BUILD_ROOT)", self.out_root) in failure_text:
+                    return trace
+
+        emit_transform_warning(
+            "Unable to disambiguate chunk logs for "
+            f"{suite} [{idx}/{total}]; leaving log links empty"
+        )
+        return None
+
+    def get_logs_chunks(
+        self, suite: str, idx: int, total: int, failure_text: str | None = None
+    ) -> LogMap:
+        trace = self.select_chunk_trace(suite, idx, total, failure_text)
         if not trace:
             return {}
 
@@ -178,10 +227,11 @@ class YTestReportTrace:
 
         return logs_dir.replace("$(BUILD_ROOT)", "").lstrip("/")
 
-    def get_log_dir_chunk(self, suite: str, idx: int, total: int) -> str | None:
-        logs_dir = (
-            self.traces.get((suite, idx, total), {}).get("logs", {}).get("logsdir")
-        )
+    def get_log_dir_chunk(
+        self, suite: str, idx: int, total: int, failure_text: str | None = None
+    ) -> str | None:
+        trace = self.select_chunk_trace(suite, idx, total, failure_text)
+        logs_dir = trace.get("logs", {}).get("logsdir") if trace else None
 
         if logs_dir is None:
             return None
@@ -279,6 +329,10 @@ def transform(
                 logs = filter_empty_logs(traces.get_logs(test_cls, test_method))
                 logs_directory = traces.get_log_dir(test_cls, test_method)
             elif "chunk" in test_name:
+                failure = case.find("failure")
+                if failure is None:
+                    failure = case.find("error")
+                failure_text = failure.text if failure is not None else None
                 if "sole" in test_name:
                     chunk_idx = 0
                     chunks_total = 1
@@ -293,12 +347,15 @@ def transform(
                     chunk_idx = int(match.group(1))
                     chunks_total = int(match.group(2))
                 logs = filter_empty_logs(
-                    traces.get_logs_chunks(suite_name, chunk_idx, chunks_total)
+                    traces.get_logs_chunks(
+                        suite_name, chunk_idx, chunks_total, failure_text
+                    )
                 )
                 logs_directory = traces.get_log_dir_chunk(
                     suite_name,
                     chunk_idx,
                     chunks_total,
+                    failure_text,
                 )
             else:
                 continue

--- a/.github/scripts/tests/transform_ya_junit.py
+++ b/.github/scripts/tests/transform_ya_junit.py
@@ -7,8 +7,9 @@ import logging
 import os
 import re
 import shutil
+import sys
 import urllib.parse
-from typing import Any, Pattern, TextIO, TypeAlias
+from typing import Any, NamedTuple, Pattern, TextIO, TypeAlias
 from xml.etree import ElementTree as ET
 
 from ..helpers import setup_logger
@@ -17,11 +18,23 @@ from .mute_utils import mute_target, pattern_to_re
 
 LOGGER = logging.getLogger(__name__)
 
+# TODO: Replace with a named mute rule type in a follow-up cleanup.
 CompiledPatternPair: TypeAlias = tuple[Pattern[str], Pattern[str]]
-TraceKey: TypeAlias = tuple[str, str]
-ChunkTraceKey: TypeAlias = tuple[str, int, int]
+# TODO: Replace these broad trace aliases with typed structures in a follow-up
+# cleanup.
 TraceEvent: TypeAlias = dict[str, Any]
 LogMap: TypeAlias = dict[str, str]
+
+
+class SubtestTraceKey(NamedTuple):
+    test_class: str
+    subtest: str
+
+
+class ChunkTraceKey(NamedTuple):
+    suite: str
+    chunk_index: int
+    chunks_total: int
 
 
 def _escape_github_command(value: str) -> str:
@@ -30,7 +43,10 @@ def _escape_github_command(value: str) -> str:
 
 def emit_transform_warning(message: str) -> None:
     LOGGER.warning(message)
-    print(f"::warning title=JUnit transform::{_escape_github_command(message)}")
+    print(
+        f"::warning title=JUnit transform::{_escape_github_command(message)}",
+        file=sys.stderr,
+    )
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
@@ -119,7 +135,7 @@ class YaMuteCheck:
 class YTestReportTrace:
     def __init__(self, out_root: str) -> None:
         self.out_root = out_root
-        self.traces: dict[TraceKey, TraceEvent] = {}
+        self.traces: dict[SubtestTraceKey, TraceEvent] = {}
         self.chunk_traces: dict[ChunkTraceKey, list[TraceEvent]] = {}
 
     def load(self, subdir: str) -> None:
@@ -148,7 +164,7 @@ class YTestReportTrace:
                         class_event = event["class"].replace("::", ".")
                         subtest = event["subtest"]
                         LOGGER.info("loaded (%s, %s)", class_event, subtest)
-                        self.traces[(class_event, subtest)] = event
+                        self.traces[SubtestTraceKey(class_event, subtest)] = event
                     elif event["name"] == "chunk-event":
                         event = event["value"]
                         event["test_results_folder"] = folder
@@ -158,11 +174,11 @@ class YTestReportTrace:
                             "loaded (%s, %s, %s)", subdir, chunk_idx, chunk_total
                         )
                         self.chunk_traces.setdefault(
-                            (subdir, chunk_idx, chunk_total), []
+                            ChunkTraceKey(subdir, chunk_idx, chunk_total), []
                         ).append(event)
 
     def get_logs(self, class_event: str, name: str) -> LogMap:
-        trace = self.traces.get((class_event, name))
+        trace = self.traces.get(SubtestTraceKey(class_event, name))
         if not trace:
             return {}
 
@@ -176,13 +192,26 @@ class YTestReportTrace:
         return result
 
     def select_chunk_trace(
-        self, suite: str, idx: int, total: int, failure_text: str | None = None
+        self,
+        suite: str,
+        idx: int,
+        total: int,
+        failure_text: str | None = None,
+        warn_on_ambiguity: bool = True,
     ) -> TraceEvent | None:
-        traces = self.chunk_traces.get((suite, idx, total), [])
+        traces = self.chunk_traces.get(ChunkTraceKey(suite, idx, total), [])
         if not traces:
             return None
-        if len(traces) == 1 or not failure_text:
+        if len(traces) == 1:
             return traces[0]
+        if not failure_text:
+            if warn_on_ambiguity:
+                emit_transform_warning(
+                    "Unable to disambiguate chunk logs for "
+                    f"{suite} [{idx}/{total}]: failure text is empty; "
+                    "leaving log links empty"
+                )
+            return None
 
         for trace in traces:
             folder = trace.get("test_results_folder")
@@ -195,10 +224,11 @@ class YTestReportTrace:
                 if path.replace("$(BUILD_ROOT)", self.out_root) in failure_text:
                     return trace
 
-        emit_transform_warning(
-            "Unable to disambiguate chunk logs for "
-            f"{suite} [{idx}/{total}]; leaving log links empty"
-        )
+        if warn_on_ambiguity:
+            emit_transform_warning(
+                "Unable to disambiguate chunk logs for "
+                f"{suite} [{idx}/{total}]; leaving log links empty"
+            )
         return None
 
     def get_logs_chunks(
@@ -219,7 +249,9 @@ class YTestReportTrace:
 
     def get_log_dir(self, class_event: str, name: str) -> str | None:
         logs_dir = (
-            self.traces.get((class_event, name), {}).get("logs", {}).get("logsdir")
+            self.traces.get(SubtestTraceKey(class_event, name), {})
+            .get("logs", {})
+            .get("logsdir")
         )
 
         if logs_dir is None:
@@ -228,9 +260,20 @@ class YTestReportTrace:
         return logs_dir.replace("$(BUILD_ROOT)", "").lstrip("/")
 
     def get_log_dir_chunk(
-        self, suite: str, idx: int, total: int, failure_text: str | None = None
+        self,
+        suite: str,
+        idx: int,
+        total: int,
+        failure_text: str | None = None,
+        warn_on_ambiguity: bool = True,
     ) -> str | None:
-        trace = self.select_chunk_trace(suite, idx, total, failure_text)
+        trace = self.select_chunk_trace(
+            suite,
+            idx,
+            total,
+            failure_text,
+            warn_on_ambiguity=warn_on_ambiguity,
+        )
         logs_dir = trace.get("logs", {}).get("logsdir") if trace else None
 
         if logs_dir is None:
@@ -356,6 +399,7 @@ def transform(
                     chunk_idx,
                     chunks_total,
                     failure_text,
+                    warn_on_ambiguity=False,
                 )
             else:
                 continue

--- a/.github/scripts/tests/transform_ya_junit_test.py
+++ b/.github/scripts/tests/transform_ya_junit_test.py
@@ -137,6 +137,14 @@ def _write_issue_junit(
             """))
 
 
+def _write_message_only_chunk_junit(report: Path, suite_name: str) -> None:
+    root = ET.Element("testsuites")
+    suite = ET.SubElement(root, "testsuite", {"name": suite_name})
+    case = ET.SubElement(suite, "testcase", {"name": "sole chunk chunk"})
+    ET.SubElement(case, "failure", {"message": "RecipeTearDownError"})
+    ET.ElementTree(root).write(report)
+
+
 def test_transform_adds_links_and_copies_logs(tmp_path: Path) -> None:
     ya_out = tmp_path / "ya-out"
     logs_file = ya_out / "suite-name" / "stdout.log"
@@ -307,6 +315,72 @@ def test_transform_does_not_guess_ambiguous_chunk_trace(
         f"**JUnit transform warning:** Unable to disambiguate chunk logs for {suite_name} [0/1]; leaving log links empty"
         in github_summary.read_text()
     )
+
+
+def test_transform_does_not_guess_chunk_trace_without_failure_text(
+    tmp_path: Path,
+) -> None:
+    suite_name = "cloud/filestore/tests/fmdtest/qemu-kikimr-nemesis-test"
+    ya_out = tmp_path / "ya-out"
+
+    for runner in ("py3test", "flake8"):
+        _write_chunk_trace(ya_out, suite_name, runner)
+        log_file = ya_out / suite_name / "test-results" / runner / "run_test.log"
+        log_file.write_text(f"{runner}-log")
+
+    report = tmp_path / "junit.xml"
+    _write_message_only_chunk_junit(report, suite_name)
+
+    output = tmp_path / "out.xml"
+    with report.open("r") as fp:
+        tyj.transform(
+            fp,
+            tyj.YaMuteCheck(),
+            str(ya_out),
+            False,
+            "https://logs/",
+            str(tmp_path / "logs-out"),
+            0,
+            str(output),
+            "https://data",
+        )
+
+    parsed_case = ET.parse(output).getroot().find("./testsuite/testcase")
+    assert parsed_case is not None
+    assert parsed_case.find("properties") is None
+
+
+def test_transform_warning_does_not_corrupt_stdout_xml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    suite_name = "cloud/filestore/tests/fmdtest/qemu-kikimr-nemesis-test"
+    ya_out = tmp_path / "ya-out"
+
+    for runner in ("py3test", "flake8"):
+        _write_chunk_trace(ya_out, suite_name, runner)
+        log_file = ya_out / suite_name / "test-results" / runner / "run_test.log"
+        log_file.write_text(f"{runner}-log")
+
+    report = tmp_path / "junit.xml"
+    _write_issue_junit(report, suite_name, include_py3test_paths=False)
+
+    with report.open("r") as fp:
+        tyj.transform(
+            fp,
+            tyj.YaMuteCheck(),
+            str(ya_out),
+            False,
+            "https://logs/",
+            str(tmp_path / "logs-out"),
+            0,
+            None,
+            "https://data",
+        )
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("<testsuites>")
+    assert "::warning title=JUnit transform::" in captured.err
+    ET.fromstring(captured.out)
 
 
 @pytest.mark.parametrize(

--- a/.github/scripts/tests/transform_ya_junit_test.py
+++ b/.github/scripts/tests/transform_ya_junit_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from textwrap import dedent
 import xml.etree.ElementTree as ET
 
 import pytest
@@ -47,6 +48,27 @@ def _write_trace(ya_out: Path) -> None:
     )
 
 
+def _write_chunk_trace(ya_out: Path, suite_name: str, runner: str) -> None:
+    trace_dir = ya_out / suite_name / "test-results" / runner
+    trace_dir.mkdir(parents=True)
+    trace = trace_dir / "ytest.report.trace"
+    trace.write_text(
+        json.dumps(
+            {
+                "name": "chunk-event",
+                "value": {
+                    "chunk_index": 0,
+                    "nchunks": 1,
+                    "logs": {
+                        "log": f"$(BUILD_ROOT)/{suite_name}/test-results/{runner}/run_test.log",
+                        "logsdir": f"$(BUILD_ROOT)/{suite_name}/test-results/{runner}/testing_out_stuff",
+                    },
+                },
+            }
+        )
+    )
+
+
 def _get_property_value(case: ET.Element, name: str) -> str | None:
     props = case.find("properties")
     if props is None:
@@ -55,6 +77,64 @@ def _get_property_value(case: ET.Element, name: str) -> str | None:
         if prop.get("name") == name:
             return prop.get("value")
     return None
+
+
+def _write_issue_junit(
+    report: Path, suite_name: str, *, include_py3test_paths: bool
+) -> None:
+    log_paths = (
+        f"""
+            log:
+            /home/github/tmp_test/out/{suite_name}/test-results/py3test/run_test.log
+            logsdir:
+            /home/github/tmp_test/out/{suite_name}/test-results/py3test/testing_out_stuff
+            recipe stderr:
+            /home/github/tmp_test/out/{suite_name}/test-results/py3test/testing_out_stuff/recipe_stop_vhost-endpoint-recipe-3.err
+            recipe stdout:
+            /home/github/tmp_test/out/{suite_name}/test-results/py3test/testing_out_stuff/recipe_stop_vhost-endpoint-recipe-3.out
+            stderr:
+            /home/github/tmp_test/out/{suite_name}/test-results/py3test/testing_out_stuff/stderr"""
+        if include_py3test_paths
+        else ""
+    )
+    stderr_tail = (
+        "Stderr tail:bf7e&quot;\\n"
+        "2026-06-29T16:03:20.195137Z :NFS_CLIENT TRACE: "
+        "cloud/filestore/libs/client/client.cpp:341: StopEndpoint "
+        "#12786235345919440230 response received: Error {{ Code: 2147614724 "
+        "Message: &quot;Deadline Exceeded&quot; }}\\n"
+        "2026-06-29T16:03:20.195191Z :NFS_CLIENT TRACE: "
+        "cloud/filestore/libs/client/client.cpp:367: StopEndpoint "
+        "#12786235345919440230 request completed\\n"
+        "filestore-client &quot;/home/github/tmp_test/out/cloud/filestore/apps/"
+        "client/filestore-client stopendpoint --socket-path "
+        "/tmp/test.vhost.eba2e719-d7ee-46ad-a48c-f6567c08bf7e "
+        "--server-address localhost --server-port 28502 --verbose trace&quot; "
+        "failed: (NCloud::TServiceError) "
+        "cloud/filestore/apps/client/lib/stop_endpoint.cpp:37: "
+        "E_RETRY_TIMEOUT Retry timeout (2147483662). Deadline Exceeded | \\n"
+        "2026-06-29T16:03:20.195739Z :NFS_CLIENT INFO: "
+        "cloud/filestore/libs/client/client.cpp:656: Shutting down\\n"
+        "2026-06-29T16:03:20.195750Z :NFS_CLIENT TRACE: "
+        "cloud/storage/core/libs/grpc/executor.h:113: "
+        "CLI1 executor's shutdown() started\\n'"
+    )
+
+    report.write_text(dedent(f"""\
+            <?xml version="1.0" ?>
+            <testsuites>
+                <testsuite name="{suite_name}" tests="3" time="204.62756158700086" failures="1" skipped="0">
+                    <testcase name="sole chunk chunk" time="0.0">
+                        <failure>RecipeTearDownError: vhost-endpoint-recipe-3 failed
+            {stderr_tail}
+            {log_paths}</failure>
+                    </testcase>
+                    <testcase name="test.py.test_create_unlink_steal" time="88.28822920200037"/>
+                    <testcase name="test.py.test_create_list" time="34.255492412999956"/>
+                    <testcase name="test.py.test_create_unlink_steal_list_nodes_internal" time="82.08383997200053"/>
+                </testsuite>
+            </testsuites>
+            """))
 
 
 def test_transform_adds_links_and_copies_logs(tmp_path: Path) -> None:
@@ -143,6 +223,90 @@ def test_transform_skips_malformed_chunk_name_without_crash(tmp_path: Path) -> N
     parsed_case = tree.getroot().find("./testsuite/testcase")
     assert parsed_case is not None
     assert parsed_case.find("properties") is None
+
+
+def test_transform_uses_real_issue_xml_to_pick_py3test_chunk_trace(
+    tmp_path: Path,
+) -> None:
+    suite_name = "cloud/filestore/tests/fmdtest/qemu-kikimr-nemesis-test"
+    ya_out = tmp_path / "ya-out"
+
+    for runner in ("py3test", "flake8"):
+        _write_chunk_trace(ya_out, suite_name, runner)
+        log_file = ya_out / suite_name / "test-results" / runner / "run_test.log"
+        log_file.write_text(f"{runner}-log")
+
+    report = tmp_path / "junit.xml"
+    _write_issue_junit(report, suite_name, include_py3test_paths=True)
+
+    output = tmp_path / "out.xml"
+    logs_out = tmp_path / "logs-out"
+    with report.open("r") as fp:
+        tyj.transform(
+            fp,
+            tyj.YaMuteCheck(),
+            str(ya_out),
+            False,
+            "https://logs/",
+            str(logs_out),
+            0,
+            str(output),
+            "https://data",
+        )
+
+    parsed_case = ET.parse(output).getroot().find("./testsuite/testcase")
+    assert parsed_case is not None
+    assert (
+        _get_property_value(parsed_case, "url:logs_directory")
+        == f"https://data/{suite_name}/test-results/py3test/testing_out_stuff"
+    )
+    assert (
+        _get_property_value(parsed_case, "url:log")
+        == f"https://logs/{suite_name}/test-results/py3test/run_test.log"
+    )
+    assert (
+        logs_out / suite_name / "test-results" / "py3test" / "run_test.log"
+    ).exists()
+
+
+def test_transform_does_not_guess_ambiguous_chunk_trace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    suite_name = "cloud/filestore/tests/fmdtest/qemu-kikimr-nemesis-test"
+    ya_out = tmp_path / "ya-out"
+
+    for runner in ("py3test", "flake8"):
+        _write_chunk_trace(ya_out, suite_name, runner)
+        log_file = ya_out / suite_name / "test-results" / runner / "run_test.log"
+        log_file.write_text(f"{runner}-log")
+
+    report = tmp_path / "junit.xml"
+    _write_issue_junit(report, suite_name, include_py3test_paths=False)
+
+    output = tmp_path / "out.xml"
+    github_summary = tmp_path / "github_step_summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(github_summary))
+
+    with report.open("r") as fp:
+        tyj.transform(
+            fp,
+            tyj.YaMuteCheck(),
+            str(ya_out),
+            False,
+            "https://logs/",
+            str(tmp_path / "logs-out"),
+            0,
+            str(output),
+            "https://data",
+        )
+
+    parsed_case = ET.parse(output).getroot().find("./testsuite/testcase")
+    assert parsed_case is not None
+    assert parsed_case.find("properties") is None
+    assert (
+        f"**JUnit transform warning:** Unable to disambiguate chunk logs for {suite_name} [0/1]; leaving log links empty"
+        in github_summary.read_text()
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
transform_ya_junit.py had clashed by keys when it was parsing junit report here https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/PR-check/28379216539/1/nebius-x86-64/summary/filestore/1/ya-test.html#FAIL
And it wrongfully connected flake8 error instead of test.py error.