### PR TITLE
fix: not included paths to ya make build graph

### DIFF
--- a/.github/scripts/build_graph/README.md
+++ b/.github/scripts/build_graph/README.md
@@ -1,0 +1,76 @@
+# Build Graph Helpers
+
+Helpers in this directory inspect `ya dump dir-graph --split` output. They are
+intended for catching `ya.make` files that exist in the checkout but are not
+reachable from the expected `RECURSE` / `RECURSE_FOR_TESTS` graph.
+
+## Cloud Reachability Check
+
+Run from the repository root:
+
+```bash
+python3 .github/scripts/build_graph/check_reachable_yamakes.py \
+    --ignore-file .github/scripts/build_graph/cloud-reachability-ignore.txt \
+    --print-reachable-count
+```
+
+By default this checks all `cloud/**/ya.make` files from these roots:
+
+```text
+cloud/blockstore
+cloud/disk_manager
+cloud/filestore
+cloud/storage
+cloud/tasks
+```
+
+The script sets `YA_CACHE_DIR=/tmp/ya-cache` if it is not already set and runs:
+
+```bash
+./ya dump dir-graph --noya-tc -t --split <roots...>
+```
+
+`-t` is required because it enables `RECURSE_FOR_TESTS` traversal.
+
+## Reusing A Saved Graph
+
+When iterating, save the graph once and reuse it:
+
+```bash
+python3 .github/scripts/build_graph/check_reachable_yamakes.py \
+    --save-graph-json /tmp/cloud-dir-graph.json \
+    --ignore-file .github/scripts/build_graph/cloud-reachability-ignore.txt
+
+python3 .github/scripts/build_graph/check_reachable_yamakes.py \
+    --graph-json /tmp/cloud-dir-graph.json \
+    --ignore-file .github/scripts/build_graph/cloud-reachability-ignore.txt
+```
+
+## Modes
+
+Default mode is `ya-style`:
+
+```text
+RECURSE closure from roots, then INCLUDE deps from those recurse-reachable dirs.
+```
+
+This matches the useful practical check: it excludes helper libraries that are
+reachable as ordinary build dependencies.
+
+For a stricter view, use:
+
+```bash
+python3 .github/scripts/build_graph/check_reachable_yamakes.py --mode recurse
+```
+
+That follows only `RECURSE` edges and reports more helper targets.
+
+## Interpreting Results
+
+Output paths are `ya.make` files that are not reachable under the selected mode.
+A real test target in this list usually means its parent needs a
+`RECURSE_FOR_TESTS(...)` entry, or an ancestor library directory needs a
+`RECURSE(...)` entry so its own test recurse can be traversed.
+
+Known intentional exceptions belong in `cloud-reachability-ignore.txt` with a
+short explanation.

--- a/.github/scripts/build_graph/check_reachable_yamakes.py
+++ b/.github/scripts/build_graph/check_reachable_yamakes.py
@@ -204,9 +204,7 @@ def main() -> int:
 
     reachable = _reachable_dirs(graph, roots, scopes, args.mode)
     all_yamakes = _all_yamake_dirs(scopes)
-    missing = sorted(
-        path for path in all_yamakes - reachable if path not in ignores
-    )
+    missing = sorted(path for path in all_yamakes - reachable if path not in ignores)
 
     if args.print_reachable_count:
         print(f"graph_nodes={len(graph)}", file=sys.stderr)

--- a/.github/scripts/build_graph/check_reachable_yamakes.py
+++ b/.github/scripts/build_graph/check_reachable_yamakes.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections import deque
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, Sequence
+
+DEFAULT_CLOUD_ROOTS = (
+    "cloud/blockstore",
+    "cloud/disk_manager",
+    "cloud/filestore",
+    "cloud/storage",
+    "cloud/tasks",
+)
+
+
+Graph = Mapping[str, Mapping[str, list[str]]]
+
+
+def _normalize_path(value: str) -> str:
+    value = value.strip().strip("/")
+    if value.endswith("/ya.make"):
+        value = value[: -len("/ya.make")]
+    return value
+
+
+def _load_ignores(paths: Sequence[Path], inline_ignores: Sequence[str]) -> set[str]:
+    ignores = {_normalize_path(value) for value in inline_ignores if value.strip()}
+    for path in paths:
+        for line in path.read_text().splitlines():
+            line = line.split("#", 1)[0].strip()
+            if line:
+                ignores.add(_normalize_path(line))
+    return ignores
+
+
+def _run_ya_dump(ya_bin: str, roots: Sequence[str]) -> Graph:
+    command = [
+        ya_bin,
+        "dump",
+        "dir-graph",
+        "--noya-tc",
+        "-t",
+        "--split",
+        *roots,
+    ]
+    print(f"++ {' '.join(command)}", file=sys.stderr)
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr, end="")
+        raise SystemExit(result.returncode)
+    return json.loads(result.stdout)
+
+
+def _load_graph(path: Path | None, ya_bin: str, roots: Sequence[str]) -> Graph:
+    if path is not None:
+        return json.loads(path.read_text())
+    return _run_ya_dump(ya_bin, roots)
+
+
+def _write_graph(path: Path | None, graph: Graph) -> None:
+    if path is None:
+        return
+    path.write_text(json.dumps(graph, indent=2, sort_keys=True) + "\n")
+
+
+def _closure(
+    graph: Graph,
+    starts: Iterable[str],
+    selector: Callable[[Mapping[str, list[str]]], Iterable[str] | None],
+    scopes: Sequence[str],
+) -> set[str]:
+    seen = {_normalize_path(start) for start in starts}
+    queue = deque(seen)
+    scope_prefixes = tuple(f"{_normalize_path(scope)}/" for scope in scopes)
+    scope_roots = {_normalize_path(scope) for scope in scopes}
+
+    while queue:
+        current = queue.pop()
+        for next_dir in selector(graph.get(current, {})) or ():
+            next_dir = _normalize_path(next_dir)
+            if next_dir in seen:
+                continue
+            if next_dir not in scope_roots and not next_dir.startswith(scope_prefixes):
+                continue
+            seen.add(next_dir)
+            queue.append(next_dir)
+    return seen
+
+
+def _reachable_dirs(
+    graph: Graph,
+    roots: Sequence[str],
+    scopes: Sequence[str],
+    mode: str,
+) -> set[str]:
+    recurse_dirs = _closure(graph, roots, lambda node: node.get("RECURSE"), scopes)
+    if mode == "recurse":
+        return recurse_dirs
+    if mode == "ya-style":
+        return _closure(graph, recurse_dirs, lambda node: node.get("INCLUDE"), scopes)
+    raise ValueError(f"unsupported mode: {mode}")
+
+
+def _all_yamake_dirs(scopes: Sequence[str]) -> set[str]:
+    result: set[str] = set()
+    for scope in scopes:
+        scope_path = Path(scope)
+        if scope_path.exists():
+            result.update(
+                _normalize_path(str(path.parent))
+                for path in scope_path.rglob("ya.make")
+                if path.is_file()
+            )
+    return result
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Find ya.make files that are not reachable from selected roots in "
+            "ya dump dir-graph --split output."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        action="append",
+        dest="roots",
+        default=[],
+        help=(
+            "Root directory passed to ya dump dir-graph. May be repeated. "
+            "Defaults to cloud component roots."
+        ),
+    )
+    parser.add_argument(
+        "--scope",
+        action="append",
+        dest="scopes",
+        default=[],
+        help="Directory whose ya.make files should be checked. May be repeated. Defaults to cloud.",
+    )
+    parser.add_argument("--ya-bin", default="./ya", help="Path to ya binary/script.")
+    parser.add_argument(
+        "--graph-json",
+        type=Path,
+        help="Use an existing ya dump dir-graph --split JSON file instead of running ya.",
+    )
+    parser.add_argument(
+        "--save-graph-json",
+        type=Path,
+        help="Write the generated or loaded graph JSON to this path.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("ya-style", "recurse"),
+        default="ya-style",
+        help=(
+            "ya-style follows RECURSE from roots, then INCLUDE deps from those dirs. "
+            "recurse follows only RECURSE edges."
+        ),
+    )
+    parser.add_argument(
+        "--ignore-file",
+        action="append",
+        type=Path,
+        default=[],
+        help="File with ya.make paths or directories to ignore. # comments are supported.",
+    )
+    parser.add_argument(
+        "--ignore",
+        action="append",
+        default=[],
+        help="ya.make path or directory to ignore. May be repeated.",
+    )
+    parser.add_argument(
+        "--print-reachable-count",
+        action="store_true",
+        help="Print graph and reachable counts before missing paths.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    roots = tuple(_normalize_path(root) for root in (args.roots or DEFAULT_CLOUD_ROOTS))
+    scopes = tuple(_normalize_path(scope) for scope in (args.scopes or ("cloud",)))
+    ignores = _load_ignores(args.ignore_file, args.ignore)
+
+    graph = _load_graph(args.graph_json, args.ya_bin, roots)
+    _write_graph(args.save_graph_json, graph)
+
+    reachable = _reachable_dirs(graph, roots, scopes, args.mode)
+    all_yamakes = _all_yamake_dirs(scopes)
+    missing = sorted(
+        path for path in all_yamakes - reachable if path not in ignores
+    )
+
+    if args.print_reachable_count:
+        print(f"graph_nodes={len(graph)}", file=sys.stderr)
+        print(f"roots={len(roots)}", file=sys.stderr)
+        print(f"scopes={len(scopes)}", file=sys.stderr)
+        print(f"all_yamakes={len(all_yamakes)}", file=sys.stderr)
+        print(f"reachable_dirs={len(reachable)}", file=sys.stderr)
+        print(f"ignored={len(ignores)}", file=sys.stderr)
+        print(f"missing={len(missing)}", file=sys.stderr)
+
+    for path in missing:
+        print(f"{path}/ya.make")
+
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("YA_CACHE_DIR", "/tmp/ya-cache")
+    raise SystemExit(main())

--- a/.github/scripts/build_graph/cloud-reachability-ignore.txt
+++ b/.github/scripts/build_graph/cloud-reachability-ignore.txt
@@ -1,0 +1,21 @@
+# Known non-actionable results for the cloud component graph.
+#
+# Entries may be either directories or ya.make paths. Keep comments explaining
+# why each path is not expected to be reachable from the cloud component roots.
+
+# Standalone aggregate targets, not part of regular root traversal.
+cloud/blockstore/buildall
+cloud/filestore/buildall
+
+# Conditional wrapper. The real package is pulled directly by CSI tests:
+# cloud/blockstore/tools/testing/csi-sanity/bin.
+cloud/blockstore/tools/testing/csi-sanity
+
+# Empty marker/data directory from the fs_posix_compliance imported suite.
+cloud/filestore/tools/testing/fs_posix_compliance/suite/tests/rmdir
+
+# Aggregator only. Users depend directly on cloud/storage/core/libs/iam/iface.
+cloud/storage/core/libs/iam
+
+# legacy
+cloud/vm/blockstore/lib/ut

--- a/cloud/blockstore/libs/storage/ya.make
+++ b/cloud/blockstore/libs/storage/ya.make
@@ -22,4 +22,5 @@ RECURSE(
     volume
     volume_balancer
     volume_proxy
+    volume_throttling_manager
 )

--- a/cloud/filestore/libs/storage/model/ya.make
+++ b/cloud/filestore/libs/storage/model/ya.make
@@ -19,3 +19,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/cloud/filestore/libs/vfs_fuse/ya.make
+++ b/cloud/filestore/libs/vfs_fuse/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
 END()
 
 RECURSE(
+    counters
     protos
     vhost
     write_back_cache

--- a/cloud/filestore/tests/fs_posix_compliance/ya.make
+++ b/cloud/filestore/tests/fs_posix_compliance/ya.make
@@ -5,6 +5,7 @@ RECURSE_FOR_TESTS(
     qemu-kikimr-multishard2-test
     qemu-kikimr-nemesis-test
     qemu-kikimr-test
+    qemu-local-acl-test
     qemu-local-noserver-test
     qemu-local-test
     qemu_xattrs_test

--- a/cloud/filestore/tests/loadtest/ya.make
+++ b/cloud/filestore/tests/loadtest/ya.make
@@ -1,6 +1,7 @@
 RECURSE_FOR_TESTS(
     service-kikimr-auth-test
     service-kikimr-datashard-like-test
+    service-kikimr-datashard-like-with-page-size-test
     service-kikimr-emergency-test
     service-kikimr-memshard-test
     service-kikimr-nemesis-test

--- a/cloud/filestore/tests/loadtest/ya.make
+++ b/cloud/filestore/tests/loadtest/ya.make
@@ -1,7 +1,6 @@
 RECURSE_FOR_TESTS(
     service-kikimr-auth-test
     service-kikimr-datashard-like-test
-    service-kikimr-datashard-like-with-page-size-test
     service-kikimr-emergency-test
     service-kikimr-memshard-test
     service-kikimr-nemesis-test

--- a/cloud/storage/core/libs/ss_proxy/ya.make
+++ b/cloud/storage/core/libs/ss_proxy/ya.make
@@ -28,6 +28,10 @@ PEERDIR(
 
 END()
 
+RECURSE(
+    model
+)
+
 RECURSE_FOR_TESTS(
     ut
 )

--- a/cloud/storage/core/libs/ya.make
+++ b/cloud/storage/core/libs/ya.make
@@ -9,6 +9,7 @@ RECURSE(
     diagnostics
     endpoints
     features
+    file_backed_containers
     grpc
     hive_proxy
     http


### PR DESCRIPTION
PoC of script that finds missed ya.make files that are not reachable from root (technically from cloud/* dirs).

This also adds missed dirs with ones that are missed intentionally.
