### PR TITLE
issue-6385: fix for truncated bytes visibility bug upon FlushBytes vs Truncate race

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/block.h
+++ b/cloud/filestore/libs/storage/tablet/model/block.h
@@ -159,7 +159,6 @@ struct TBlockBytesMeta
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// XXX not the best place for this struct
 struct TFlushBytesCleanupInfo
 {
     ui64 ChunkId = 0;

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -327,7 +327,7 @@ void TFreshBytes::AddDeletionMarker(
 
     //
     // We need to mark this range as deleted to make the corresponding range
-    // invisible in the previous chunk if read at this commitId or higher.
+    // invisible in the previous chunks if read at this commitId or higher.
     //
 
     c.DeletedRanges.AddRange(nodeId, offset, len, commitId);
@@ -460,8 +460,7 @@ void TFreshBytes::FindBytes(
     ui64 commitId) const
 {
     for (ui64 i = 0; i < Chunks.size(); ++i) {
-        const auto& c = Chunks[i];
-        if (c.FirstCommitId > commitId) {
+        if (Chunks[i].FirstCommitId > commitId) {
             //
             // Chunk CommitId ranges do not overlap and are ordered by
             // FirstCommitId so all the remaining ranges are not visible.
@@ -470,22 +469,59 @@ void TFreshBytes::FindBytes(
             break;
         }
 
-        const TChunk* nextC = nullptr;
-        if (i + 1 < Chunks.size() && Chunks[i + 1].FirstCommitId <= commitId) {
-            nextC = &Chunks[i + 1];
-        }
-        FindBytes(c, nextC, visitor, nodeId, byteRange, commitId);
+        FindBytes(Chunks, i, visitor, nodeId, byteRange, commitId);
     }
 }
 
+/* static */ TVector<TByteRange> TFreshBytes::ApplyDeletedRanges(
+    const TChunks& chunks,
+    ui64 firstChunkIndex,
+    ui64 nodeId,
+    TByteRange initialRange,
+    ui64 commitId)
+{
+    TVector<TByteRange> result(1, initialRange);
+
+    //
+    // Most of the time there will be no other chunks.
+    //
+
+    for (ui64 i = firstChunkIndex; i < chunks.size(); ++i) {
+        const auto& nextChunk = chunks[i];
+        if (nextChunk.FirstCommitId > commitId) {
+            break;
+        }
+
+        TVector<TByteRange> newResult;
+
+        //
+        // Most of the time we'll end up realizing that there're no
+        // deleted ranges to apply and thus we'll end up having just
+        // one range till the very end of this procedure.
+        //
+
+        for (const auto& r: result) {
+            auto split =
+                nextChunk.DeletedRanges.ApplyRanges(nodeId, r, commitId);
+            newResult.reserve(newResult.size() + split.size());
+            newResult.insert(newResult.end(), split.begin(), split.end());
+        }
+
+        result.swap(newResult);
+    }
+
+    return result;
+}
+
 void TFreshBytes::FindBytes(
-    const TChunk& chunk,
-    const TChunk* nextChunk,
+    const TChunks& chunks,
+    ui64 chunkIndex,
     IFreshBytesVisitor& visitor,
     ui64 nodeId,
     TByteRange byteRange,
     ui64 commitId) const
 {
+    const auto& chunk = chunks[chunkIndex];
     auto it = chunk.Refs.upper_bound({nodeId, byteRange.Offset});
     while (it != chunk.Refs.end()
             && it->first.NodeId == nodeId
@@ -499,15 +535,12 @@ void TFreshBytes::FindBytes(
 
         const auto intersection = itRange.Intersect(byteRange);
         if (it->second.CommitId <= commitId && intersection.Length) {
-            TVector<TByteRange> actualRanges;
-            if (nextChunk) {
-                actualRanges = nextChunk->DeletedRanges.ApplyRanges(
-                    nodeId,
-                    intersection,
-                    commitId);
-            } else {
-                actualRanges.push_back(intersection);
-            }
+            auto actualRanges = ApplyDeletedRanges(
+                chunks,
+                chunkIndex + 1,
+                nodeId,
+                intersection,
+                commitId);
 
             for (const auto& actualRange: actualRanges) {
                 TStringBuf data = it->second.Buf.substr(

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -26,6 +26,26 @@ void TDeletedRangeMap::InsertRange(
     };
 }
 
+void TDeletedRangeMap::Advance(
+    ui64& offset,
+    ui64& len,
+    TImpl::const_iterator& it) const
+{
+    TABLET_VERIFY_C(
+        it->first.End > offset,
+        "offset=" << offset << ", len=" << len
+            << ", it->first.NodeId=" << it->first.NodeId
+            << ", it->first.End=" << it->first.End
+            << ", it->second.Len=" << it->second.Len
+            << ", it->second.Offset=" << it->second.Offset
+            << ", it->second.CommitId=" << it->second.CommitId);
+
+    const ui64 shift = Min(it->first.End - offset, len);
+    offset += shift;
+    len -= shift;
+    ++it;
+}
+
 void TDeletedRangeMap::AddRange(
     ui64 nodeId,
     ui64 offset,
@@ -34,8 +54,13 @@ void TDeletedRangeMap::AddRange(
 {
     const ui64 end = offset + len;
 
-    auto it = Ranges.upper_bound({.NodeId = nodeId, .End = offset});
-    while (it != Ranges.end() && it->first.NodeId == nodeId) {
+    auto it = static_cast<const TImpl&>(Ranges)
+        .upper_bound({.NodeId = nodeId, .End = offset});
+    TVector<TByteRange> result;
+    while (it != Ranges.end()
+            && it->first.NodeId == nodeId
+            && it->second.Offset < end)
+    {
         //
         // We expect AddRange calls to be ordered by commitId.
         //
@@ -45,49 +70,32 @@ void TDeletedRangeMap::AddRange(
             "range.CommitId=" << it->second.CommitId
                 << ", commitId=" << commitId);
 
-        const ui64 segmentOffset = it->second.Offset + it->second.Len;
-        TABLET_VERIFY_C(
-            segmentOffset > offset,
-            "segmentOffset=" << segmentOffset << ", offset=" << offset);
-        if (segmentOffset >= end) {
-            //
-            // Next ranges are past the end of our range.
-            //
+        //
+        // [___________________) <--- input range
+        // ____[____) <--- range pointed to by `it`
+        // [___) <--- inserting this segment with `CommitId := commitId`
+        //
 
-            offset = end;
-            break;
-        }
-
-        ++it;
-        ui64 segmentEnd = end;
-        if (it != Ranges.end() && it->first.NodeId == nodeId) {
-            segmentEnd = Min(end, it->second.Offset);
-        }
-
-        if (segmentOffset >= segmentEnd) {
-            //
-            // This range is empty.
-            //
-
-            TABLET_VERIFY_C(
-                segmentOffset == segmentEnd,
-                "segmentOffset=" << segmentOffset
-                    << ", segmentEnd=" << segmentEnd);
-            continue;
+        if (offset < it->second.Offset) {
+            InsertRange(nodeId, offset, it->second.Offset - offset, commitId);
         }
 
         //
-        // Non-empty segment - inserting it and advancing our offset.
+        // [___________________) <--- input range
+        // ____[____) <--- range pointed to by `it`
+        // _________[__________) <--- updating the input range to point to this
         //
 
-        const ui64 segmentLen = segmentEnd - segmentOffset;
-        InsertRange(nodeId, segmentOffset, segmentLen, commitId);
-        offset = segmentEnd;
+        Advance(offset, len, it);
     }
 
-    if (offset < end) {
-        const ui64 segmentLen = end - offset;
-        InsertRange(nodeId, offset, segmentLen, commitId);
+    //
+    // If we still have a non-empty subrange after processing the overlapping
+    // ranges we should insert it as well.
+    //
+
+    if (len) {
+        InsertRange(nodeId, offset, len, commitId);
     }
 }
 
@@ -102,10 +110,20 @@ TVector<TByteRange> TDeletedRangeMap::ApplyRanges(
             && it->first.NodeId == nodeId
             && it->second.Offset < byteRange.End())
     {
+        //
+        // Skipping the ranges that are not visible at `commitId`.
+        //
+
         if (it->second.CommitId > commitId) {
             ++it;
             continue;
         }
+
+        //
+        // [___________________) <--- input range
+        // ____[____) <--- range pointed to by `it`
+        // [___) <--- adding this segment to the result
+        //
 
         if (byteRange.Offset < it->second.Offset) {
             result.push_back(TByteRange(
@@ -113,13 +131,20 @@ TVector<TByteRange> TDeletedRangeMap::ApplyRanges(
                 it->second.Offset - byteRange.Offset,
                 byteRange.BlockSize));
         }
-        const ui64 curDeletedRangeEnd = it->second.Offset + it->second.Len;
-        const ui64 shift =
-            Min(curDeletedRangeEnd - byteRange.Offset, byteRange.Length);
-        byteRange.Offset += shift;
-        byteRange.Length -= shift;
-        ++it;
+
+        //
+        // [___________________) <--- input range
+        // ____[____) <--- range pointed to by `it`
+        // _________[__________) <--- updating the input range to point to this
+        //
+
+        Advance(byteRange.Offset, byteRange.Length, it);
     }
+
+    //
+    // If we still have a non-empty subrange after processing the overlapping
+    // ranges we should insert it as well.
+    //
 
     if (byteRange.Length) {
         result.push_back(byteRange);
@@ -413,7 +438,7 @@ bool TFreshBytes::FinishCleanup(
     TABLET_VERIFY(check);
 
     //
-    // Paged cleanup is used. We should just deleted the cleaned up ranges and
+    // Paged cleanup is used. We should just delete the cleaned up ranges and
     // then the caller will call StartCleanup again for this chunk and the next
     // page will be processed.
     //

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -56,7 +56,6 @@ void TDeletedRangeMap::AddRange(
 
     auto it = static_cast<const TImpl&>(Ranges)
         .upper_bound({.NodeId = nodeId, .End = offset});
-    TVector<TByteRange> result;
     while (it != Ranges.end()
             && it->first.NodeId == nodeId
             && it->second.Offset < end)

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -13,6 +13,123 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TDeletedRangeMap::InsertRange(
+    ui64 nodeId,
+    ui64 offset,
+    ui64 len,
+    ui64 commitId)
+{
+    Ranges[{.NodeId = nodeId, .End = offset + len}] = {
+        .Len = len,
+        .Offset = offset,
+        .CommitId = commitId,
+    };
+}
+
+void TDeletedRangeMap::AddRange(
+    ui64 nodeId,
+    ui64 offset,
+    ui64 len,
+    ui64 commitId)
+{
+    const ui64 end = offset + len;
+
+    auto it = Ranges.upper_bound({.NodeId = nodeId, .End = offset});
+    while (it != Ranges.end() && it->first.NodeId == nodeId) {
+        //
+        // We expect AddRange calls to be ordered by commitId.
+        //
+
+        TABLET_VERIFY_C(
+            it->second.CommitId < commitId,
+            "range.CommitId=" << it->second.CommitId
+                << ", commitId=" << commitId);
+
+        const ui64 segmentOffset = it->second.Offset + it->second.Len;
+        TABLET_VERIFY_C(
+            segmentOffset > offset,
+            "segmentOffset=" << segmentOffset << ", offset=" << offset);
+        if (segmentOffset >= end) {
+            //
+            // Next ranges are past the end of our range.
+            //
+
+            offset = end;
+            break;
+        }
+
+        ++it;
+        ui64 segmentEnd = end;
+        if (it != Ranges.end() && it->first.NodeId == nodeId) {
+            segmentEnd = Min(end, it->second.Offset);
+        }
+
+        if (segmentOffset >= segmentEnd) {
+            //
+            // This range is empty.
+            //
+
+            TABLET_VERIFY_C(
+                segmentOffset == segmentEnd,
+                "segmentOffset=" << segmentOffset
+                    << ", segmentEnd=" << segmentEnd);
+            continue;
+        }
+
+        //
+        // Non-empty segment - inserting it and advancing our offset.
+        //
+
+        const ui64 segmentLen = segmentEnd - segmentOffset;
+        InsertRange(nodeId, segmentOffset, segmentLen, commitId);
+        offset = segmentEnd;
+    }
+
+    if (offset < end) {
+        const ui64 segmentLen = end - offset;
+        InsertRange(nodeId, offset, segmentLen, commitId);
+    }
+}
+
+TVector<TByteRange> TDeletedRangeMap::ApplyRanges(
+    ui64 nodeId,
+    TByteRange byteRange,
+    ui64 commitId) const
+{
+    auto it = Ranges.upper_bound({.NodeId = nodeId, .End = byteRange.Offset});
+    TVector<TByteRange> result;
+    while (it != Ranges.end()
+            && it->first.NodeId == nodeId
+            && it->second.Offset < byteRange.End())
+    {
+        if (it->second.CommitId > commitId) {
+            ++it;
+            continue;
+        }
+
+        if (byteRange.Offset < it->second.Offset) {
+            result.push_back(TByteRange(
+                byteRange.Offset,
+                it->second.Offset - byteRange.Offset,
+                byteRange.BlockSize));
+        }
+        const ui64 curDeletedRangeEnd = it->second.Offset + it->second.Len;
+        const ui64 shift =
+            Min(curDeletedRangeEnd - byteRange.Offset, byteRange.Length);
+        byteRange.Offset += shift;
+        byteRange.Length -= shift;
+        ++it;
+    }
+
+    if (byteRange.Length) {
+        result.push_back(byteRange);
+    }
+
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 TFreshBytes::TFreshBytes(IAllocator* allocator)
     : Allocator(allocator)
     , Chunks(allocator)
@@ -33,8 +150,8 @@ void TFreshBytes::DeleteBytes(
 {
     auto end = offset + len;
 
-    auto lo = c.Refs.upper_bound({nodeId, offset});
-    auto hi = c.Refs.upper_bound({nodeId, end});
+    auto lo = c.Refs.upper_bound({.NodeId = nodeId, .End = offset});
+    auto hi = c.Refs.upper_bound({.NodeId = nodeId, .End = end});
 
     if (lo != c.Refs.end() && lo->first.NodeId == nodeId) {
         if (lo->second.Offset == offset && lo->first.End == end) {
@@ -46,7 +163,7 @@ void TFreshBytes::DeleteBytes(
         if (lo->second.Offset < offset) {
             // cutting lo from the right side
             TABLET_VERIFY_DEBUG(lo->second.CommitId < commitId);
-            auto& loRef = c.Refs[{nodeId, offset}];
+            auto& loRef = c.Refs[{.NodeId = nodeId, .End = offset}];
             loRef = lo->second;
             loRef.Buf = loRef.Buf.substr(0, offset - loRef.Offset);
 
@@ -107,6 +224,10 @@ void TFreshBytes::AddBytes(
     TStringBuf data,
     ui64 commitId)
 {
+    //
+    // Validate CommitId order.
+    //
+
     auto& c = Chunks.back();
     if (c.FirstCommitId == InvalidCommitId) {
         c.FirstCommitId = commitId;
@@ -114,20 +235,33 @@ void TFreshBytes::AddBytes(
         TABLET_VERIFY(commitId >= c.FirstCommitId);
     }
 
+    //
+    // Copy the data into a buffer and update stats.
+    //
+
     TByteVector buffer(Reserve(data.size()), Allocator);
     buffer.assign(data.begin(), data.end());
 
     c.TotalBytes += buffer.size();
     TotalBytes += buffer.size();
 
-    TBytes descriptor{nodeId, offset, buffer.size(), commitId, InvalidCommitId};
+    TBytes descriptor(nodeId, offset, buffer.size(), commitId, InvalidCommitId);
     c.Data.emplace_back(descriptor, std::move(buffer));
 
     TotalDataItemCount++;
 
     const auto& storage = c.Data.back().Data;
-    TKey key{nodeId, offset + storage.size()};
-    TRef ref{TStringBuf(storage.data(), storage.size()), offset, commitId};
+    TKey key{.NodeId = nodeId, .End = offset + storage.size()};
+    TRef ref{
+        .Buf = TStringBuf(storage.data(), storage.size()),
+        .Offset = offset,
+        .CommitId = commitId,
+    };
+
+    //
+    // Delete any data that we might have in this chunk that is covered by this
+    // range and then insert this range.
+    //
 
     DeleteBytes(c, nodeId, offset, data.size(), commitId);
 
@@ -140,8 +274,14 @@ void TFreshBytes::AddDeletionMarker(
     ui64 len,
     ui64 commitId)
 {
+    //
+    // Validate CommitId order.
+    //
+
     auto& c = Chunks.back();
-    if (c.FirstCommitId != InvalidCommitId) {
+    if (c.FirstCommitId == InvalidCommitId) {
+        c.FirstCommitId = commitId;
+    } else {
         TABLET_VERIFY(commitId >= c.FirstCommitId);
     }
 
@@ -154,7 +294,19 @@ void TFreshBytes::AddDeletionMarker(
         len,
         commitId,
         InvalidCommitId});
+
+    //
+    // We need to erase the data in this chunk that's covered by this marker.
+    //
+
     DeleteBytes(c, nodeId, offset, len, commitId);
+
+    //
+    // We need to mark this range as deleted to make the corresponding range
+    // invisible in the previous chunk if read at this commitId or higher.
+    //
+
+    c.DeletedRanges.AddRange(nodeId, offset, len, commitId);
 }
 
 void TFreshBytes::Barrier(ui64 commitId)
@@ -177,6 +329,11 @@ void TFreshBytes::Barrier(ui64 commitId)
 
 void TFreshBytes::OnCheckpoint(ui64 commitId)
 {
+    //
+    // We need to seal the current chunk because the last chunk is mutable and
+    // we want to freeze the current state for this checkpoint.
+    //
+
     Barrier(commitId);
 }
 
@@ -186,6 +343,13 @@ TFlushBytesCleanupInfo TFreshBytes::StartCleanup(
     TVector<TBytes>* deletionMarkers)
 {
     if (Chunks.size() == 1) {
+        //
+        // We need to seal the front chunk only if it's active - i.e. if it's
+        // not the only chunk that we have. The goal is to ensure that no
+        // updates are made to this chunk after that - we want to safely process
+        // it without worrying about any kind of races.
+        //
+
         Barrier(commitId);
     }
 
@@ -197,7 +361,10 @@ TFlushBytesCleanupInfo TFreshBytes::StartCleanup(
         deletionMarkers->push_back(descriptor);
     }
 
-    return {Chunks.front().Id, Chunks.front().ClosingCommitId};
+    return {
+        .ChunkId = Chunks.front().Id,
+        .ClosingCommitId = Chunks.front().ClosingCommitId
+    };
 }
 
 void TFreshBytes::VisitTop(
@@ -245,6 +412,12 @@ bool TFreshBytes::FinishCleanup(
         dataItemCount <= dataSize && deletionMarkerCount <= deletionSize;
     TABLET_VERIFY(check);
 
+    //
+    // Paged cleanup is used. We should just deleted the cleaned up ranges and
+    // then the caller will call StartCleanup again for this chunk and the next
+    // page will be processed.
+    //
+
     chunk.Data.erase(
         chunk.Data.begin(),
         std::next(chunk.Data.begin(), dataItemCount));
@@ -262,17 +435,28 @@ void TFreshBytes::FindBytes(
     TByteRange byteRange,
     ui64 commitId) const
 {
-    for (const auto& c: Chunks) {
+    for (ui64 i = 0; i < Chunks.size(); ++i) {
+        const auto& c = Chunks[i];
         if (c.FirstCommitId > commitId) {
+            //
+            // Chunk CommitId ranges do not overlap and are ordered by
+            // FirstCommitId so all the remaining ranges are not visible.
+            //
+
             break;
         }
 
-        FindBytes(c, visitor, nodeId, byteRange, commitId);
+        const TChunk* nextC = nullptr;
+        if (i + 1 < Chunks.size() && Chunks[i + 1].FirstCommitId <= commitId) {
+            nextC = &Chunks[i + 1];
+        }
+        FindBytes(c, nextC, visitor, nodeId, byteRange, commitId);
     }
 }
 
 void TFreshBytes::FindBytes(
     const TChunk& chunk,
+    const TChunk* nextChunk,
     IFreshBytesVisitor& visitor,
     ui64 nodeId,
     TByteRange byteRange,
@@ -291,17 +475,29 @@ void TFreshBytes::FindBytes(
 
         const auto intersection = itRange.Intersect(byteRange);
         if (it->second.CommitId <= commitId && intersection.Length) {
-            TStringBuf data = it->second.Buf.substr(
-                intersection.Offset - itRange.Offset,
-                intersection.Length);
+            TVector<TByteRange> actualRanges;
+            if (nextChunk) {
+                actualRanges = nextChunk->DeletedRanges.ApplyRanges(
+                    nodeId,
+                    intersection,
+                    commitId);
+            } else {
+                actualRanges.push_back(intersection);
+            }
 
-            visitor.Accept({
-                nodeId,
-                intersection.Offset,
-                intersection.Length,
-                it->second.CommitId,
-                InvalidCommitId
-            }, data);
+            for (const auto& actualRange: actualRanges) {
+                TStringBuf data = it->second.Buf.substr(
+                    actualRange.Offset - itRange.Offset,
+                    actualRange.Length);
+
+                visitor.Accept({
+                    nodeId,
+                    actualRange.Offset,
+                    actualRange.Length,
+                    it->second.CommitId,
+                    InvalidCommitId
+                }, data);
+            }
         }
 
         ++it;

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.cpp
@@ -348,6 +348,7 @@ void TFreshBytes::Barrier(ui64 commitId)
         Chunks.back().ClosingCommitId = commitId;
         Chunks.emplace_back(Allocator);
         Chunks.back().Id = ++LastChunkId;
+        Chunks.back().DeletedRanges.UpdateLogTag(LogTag);
     }
 }
 
@@ -459,6 +460,21 @@ void TFreshBytes::FindBytes(
     TByteRange byteRange,
     ui64 commitId) const
 {
+    FindBytesImpl(
+        visitor,
+        nodeId,
+        byteRange,
+        commitId,
+        true /* applyDeletedRanges */);
+}
+
+void TFreshBytes::FindBytesImpl(
+    IFreshBytesVisitor& visitor,
+    ui64 nodeId,
+    TByteRange byteRange,
+    ui64 commitId,
+    bool applyDeletedRanges) const
+{
     for (ui64 i = 0; i < Chunks.size(); ++i) {
         if (Chunks[i].FirstCommitId > commitId) {
             //
@@ -469,7 +485,14 @@ void TFreshBytes::FindBytes(
             break;
         }
 
-        FindBytes(Chunks, i, visitor, nodeId, byteRange, commitId);
+        FindBytesInChunk(
+            Chunks,
+            i,
+            visitor,
+            nodeId,
+            byteRange,
+            commitId,
+            applyDeletedRanges);
     }
 }
 
@@ -513,13 +536,14 @@ void TFreshBytes::FindBytes(
     return result;
 }
 
-void TFreshBytes::FindBytes(
+/* static */ void TFreshBytes::FindBytesInChunk(
     const TChunks& chunks,
     ui64 chunkIndex,
     IFreshBytesVisitor& visitor,
     ui64 nodeId,
     TByteRange byteRange,
-    ui64 commitId) const
+    ui64 commitId,
+    bool applyDeletedRanges)
 {
     const auto& chunk = chunks[chunkIndex];
     auto it = chunk.Refs.upper_bound({nodeId, byteRange.Offset});
@@ -535,12 +559,17 @@ void TFreshBytes::FindBytes(
 
         const auto intersection = itRange.Intersect(byteRange);
         if (it->second.CommitId <= commitId && intersection.Length) {
-            auto actualRanges = ApplyDeletedRanges(
-                chunks,
-                chunkIndex + 1,
-                nodeId,
-                intersection,
-                commitId);
+            TVector<TByteRange> actualRanges;
+            if (applyDeletedRanges) {
+                actualRanges = ApplyDeletedRanges(
+                    chunks,
+                    chunkIndex + 1,
+                    nodeId,
+                    intersection,
+                    commitId);
+            } else {
+                actualRanges.push_back(intersection);
+            }
 
             for (const auto& actualRange: actualRanges) {
                 TStringBuf data = it->second.Buf.substr(
@@ -576,7 +605,12 @@ bool TFreshBytes::Intersects(ui64 nodeId, TByteRange byteRange) const
         }
     } visitor;
 
-    FindBytes(visitor, nodeId, byteRange, InvalidCommitId);
+    FindBytesImpl(
+        visitor,
+        nodeId,
+        byteRange,
+        InvalidCommitId,
+        false /* applyDeletedRanges */);
 
     return visitor.FoundBytes;
 }

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -44,7 +44,8 @@ private:
 
 private:
     using TKey = TNodeByteRangeKey;
-    TMap<TKey, TDeletedRange, TLess<TKey>, TStlAllocator> Ranges;
+    using TImpl = TMap<TKey, TDeletedRange, TLess<TKey>, TStlAllocator>;
+    TImpl Ranges;
     TString LogTag;
 
 public:
@@ -67,6 +68,10 @@ public:
 
 private:
     void InsertRange(ui64 nodeId, ui64 offset, ui64 len, ui64 commitId);
+    void Advance(
+        ui64& offset,
+        ui64& len,
+        TImpl::const_iterator& it) const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -17,6 +17,60 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TNodeByteRangeKey
+{
+    ui64 NodeId = 0;
+    ui64 End = 0;
+
+    bool operator<(const TNodeByteRangeKey& rhs) const
+    {
+        // (NodeId, End) ASC
+        return NodeId < rhs.NodeId
+            || NodeId == rhs.NodeId && End < rhs.End;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TDeletedRangeMap
+{
+private:
+    struct TDeletedRange
+    {
+        ui64 Len = 0;
+        ui64 Offset = 0;
+        ui64 CommitId = 0;
+    };
+
+private:
+    using TKey = TNodeByteRangeKey;
+    TMap<TKey, TDeletedRange, TLess<TKey>, TStlAllocator> Ranges;
+    TString LogTag;
+
+public:
+    explicit TDeletedRangeMap(IAllocator* allocator)
+        : Ranges(allocator)
+    {}
+
+public:
+    void AddRange(ui64 nodeId, ui64 offset, ui64 len, ui64 commitId);
+
+    TVector<TByteRange> ApplyRanges(
+        ui64 nodeId,
+        TByteRange byteRange,
+        ui64 commitId) const;
+
+    void UpdateLogTag(TString logTag)
+    {
+        LogTag = std::move(logTag);
+    }
+
+private:
+    void InsertRange(ui64 nodeId, ui64 offset, ui64 len, ui64 commitId);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 using TChunkVisitor =
     std::function<void(const TBytes& bytes, bool isDeletionMarker)>;
 
@@ -24,21 +78,9 @@ using TChunkVisitor =
 
 class TFreshBytes
 {
-public:
-    struct TKey
-    {
-        ui64 NodeId = 0;
-        ui64 End = 0;
-
-        bool operator<(const TKey& rhs) const
-        {
-            // (NodeId, End) ASC
-            return NodeId < rhs.NodeId
-                || NodeId == rhs.NodeId && End < rhs.End;
-        }
-    };
-
 private:
+    using TKey = TNodeByteRangeKey;
+
     struct TElement
     {
         TBytes Descriptor;
@@ -59,34 +101,81 @@ private:
 
     struct TChunk
     {
+        //
+        // Bytes of this chunk. Newer writes overwrite overlapping parts of
+        // older writes.
+        //
+
         TMap<TKey, TRef, TLess<TKey>, TStlAllocator> Refs;
         TDeque<TElement, TStlAllocator> Data;
+
+        //
+        // A list of deletion markers - needed upon cleanup to be able to clean
+        // them up in the tablet's local db.
+        //
+
         TDeque<TBytes, TStlAllocator> DeletionMarkers;
+
+        //
+        // Ranges deleted in this chunk. Only the non-overlapping parts of newer
+        // deletions are applied. Needed to apply this chunk's deletions upon
+        // reading previous chunk.
+        //
+
+        TDeletedRangeMap DeletedRanges;
+
+        //
+        // CommitId range for this chunk.
+        //
+
         ui64 FirstCommitId = InvalidCommitId;
+        ui64 ClosingCommitId = 0;
+
+        //
+        // The Id of this chunk. Needed to verify that FinishCleanup is called
+        // for the front chunk.
+        //
+
+        ui64 Id = 0;
+
+        //
+        // Counters.
+        //
+
         ui64 TotalBytes = 0;
         ui64 TotalDeletedBytes = 0;
-        ui64 Id = 0;
-        ui64 ClosingCommitId = 0;
 
         explicit TChunk(IAllocator* allocator)
             : Refs(allocator)
             , Data(allocator)
             , DeletionMarkers(allocator)
+            , DeletedRanges(allocator)
         {}
     };
 
 private:
+    //
+    // Chunks do not overlap by CommitId ranges and are ordered by
+    // FirstCommitId. FirstCommitId for an empty chunk == InvalidCommitId.
+    // A chunk is sealed upon StartCleanup and OnCheckpoint ops - after that no
+    // updates should happen to it, only FinishCleanup.
+    //
+
     IAllocator* Allocator;
     TDeque<TChunk, TStlAllocator> Chunks;
     ui64 LastChunkId = 0;
     TString LogTag;
+
+    //
+    // Total counters.
+    //
 
     ui64 TotalBytes = 0;
     ui64 TotalDeletedBytes = 0;
     ui64 TotalDataItemCount = 0;
 
 public:
-    TFreshBytes(IAllocator* allocator);
+    explicit TFreshBytes(IAllocator* allocator);
     ~TFreshBytes();
 
     size_t GetTotalBytes() const
@@ -107,6 +196,9 @@ public:
     void UpdateLogTag(TString logTag)
     {
         LogTag = std::move(logTag);
+        for (auto& c: Chunks) {
+            c.DeletedRanges.UpdateLogTag(LogTag);
+        }
     }
 
     NProto::TError CheckBytes(
@@ -138,12 +230,18 @@ public:
     bool Intersects(ui64 nodeId, TByteRange byteRange) const;
 
 private:
-    void DeleteBytes(TChunk& c, ui64 nodeId, ui64 offset, ui64 len, ui64 commitId);
+    void DeleteBytes(
+        TChunk& c,
+        ui64 nodeId,
+        ui64 offset,
+        ui64 len,
+        ui64 commitId);
 
     void Barrier(ui64 commitId);
 
     void FindBytes(
         const TChunk& chunk,
+        const TChunk* nextChunk,
         IFreshBytesVisitor& visitor,
         ui64 nodeId,
         TByteRange byteRange,

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -124,7 +124,7 @@ private:
         //
         // Ranges deleted in this chunk. Only the non-overlapping parts of newer
         // deletions are applied. Needed to apply this chunk's deletions upon
-        // reading previous chunk.
+        // reading previous chunks.
         //
 
         TDeletedRangeMap DeletedRanges;
@@ -167,7 +167,8 @@ private:
     //
 
     IAllocator* Allocator;
-    TDeque<TChunk, TStlAllocator> Chunks;
+    using TChunks = TDeque<TChunk, TStlAllocator>;
+    TChunks Chunks;
     ui64 LastChunkId = 0;
     TString LogTag;
 
@@ -245,12 +246,19 @@ private:
     void Barrier(ui64 commitId);
 
     void FindBytes(
-        const TChunk& chunk,
-        const TChunk* nextChunk,
+        const TChunks& chunks,
+        ui64 chunkIndex,
         IFreshBytesVisitor& visitor,
         ui64 nodeId,
         TByteRange byteRange,
         ui64 commitId) const;
+
+    static TVector<TByteRange> ApplyDeletedRanges(
+        const TChunks& chunks,
+        ui64 firstChunkIndex,
+        ui64 nodeId,
+        TByteRange initialRange,
+        ui64 commitId);
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -245,13 +245,21 @@ private:
 
     void Barrier(ui64 commitId);
 
-    void FindBytes(
+    void FindBytesImpl(
+        IFreshBytesVisitor& visitor,
+        ui64 nodeId,
+        TByteRange byteRange,
+        ui64 commitId,
+        bool applyDeletedRanges) const;
+
+    static void FindBytesInChunk(
         const TChunks& chunks,
         ui64 chunkIndex,
         IFreshBytesVisitor& visitor,
         ui64 nodeId,
         TByteRange byteRange,
-        ui64 commitId) const;
+        ui64 commitId,
+        bool applyDeletedRanges);
 
     static TVector<TByteRange> ApplyDeletedRanges(
         const TChunks& chunks,

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
@@ -493,4 +493,330 @@ Y_UNIT_TEST_SUITE(TFreshBytesTest)
     // TODO test with multiple chunks
 }
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString DescribeRanges(const TVector<TByteRange>& ranges)
+{
+    TStringBuilder sb;
+    for (const auto& r: ranges) {
+        if (sb.size()) {
+            sb << " ";
+        }
+        sb << r.Describe();
+    }
+    return sb;
+}
+
+TByteRange R(ui64 offset, ui64 length)
+{
+    return TByteRange(offset, length, 4_KB);
+}
+
+TString D(std::initializer_list<TByteRange> ranges)
+{
+    return DescribeRanges(TVector<TByteRange>(ranges));
+}
+
+TString Apply(
+    const TDeletedRangeMap& map,
+    ui64 nodeId,
+    ui64 offset,
+    ui64 length,
+    ui64 commitId)
+{
+    return DescribeRanges(map.ApplyRanges(nodeId, R(offset, length), commitId));
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDeletedRangeMapTest)
+{
+    Y_UNIT_TEST(ShouldReturnFullRangeWhenEmpty)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        UNIT_ASSERT_VALUES_EQUAL(D({R(0, 100)}), Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldReturnEmptyWhenEmptyMapAndZeroLengthQuery)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 1, 10, 0, 10));
+    }
+
+    Y_UNIT_TEST(ShouldSubtractSingleDeletionFromMiddle)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 30, 20, 5);
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 30), R(50, 50)}),
+            Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldReturnEmptyWhenQueryEqualsDeletion)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 30, 20, 5);
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 1, 30, 20, 10));
+    }
+
+    Y_UNIT_TEST(ShouldReturnEmptyWhenQueryFullyInsideDeletion)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 0, 100, 5);
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 1, 25, 50, 10));
+    }
+
+    Y_UNIT_TEST(ShouldTrimQueryStartWhenDeletionCoversStart)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        // deletion [10, 30) intersects query [15, 40) at the start.
+        map.AddRange(1, 10, 20, 5);
+        UNIT_ASSERT_VALUES_EQUAL(D({R(30, 10)}), Apply(map, 1, 15, 25, 10));
+    }
+
+    Y_UNIT_TEST(ShouldTrimQueryEndWhenDeletionCoversEnd)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        // deletion [30, 60) intersects query [0, 40) at the end.
+        map.AddRange(1, 30, 30, 5);
+        UNIT_ASSERT_VALUES_EQUAL(D({R(0, 30)}), Apply(map, 1, 0, 40, 10));
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreDeletionOutsideOfQuery)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 200, 50, 5);
+        UNIT_ASSERT_VALUES_EQUAL(D({R(0, 100)}), Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreDeletionEndingAtQueryStart)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        // deletion [0, 50) ends exactly at query.Offset (50). No overlap.
+        map.AddRange(1, 0, 50, 5);
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(50, 50)}),
+            Apply(map, 1, 50, 50, 10));
+    }
+
+    Y_UNIT_TEST(ShouldIgnoreDeletionStartingAtQueryEnd)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        // deletion [50, 100) starts exactly at query.End (50). No overlap.
+        map.AddRange(1, 50, 50, 5);
+        UNIT_ASSERT_VALUES_EQUAL(D({R(0, 50)}), Apply(map, 1, 0, 50, 10));
+    }
+
+    Y_UNIT_TEST(ShouldNotApplyDeletionWhenCommitIdTooLow)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 30, 20, 20);
+        // At commit 10 the deletion (commit 20) is not yet visible.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 100)}),
+            Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldApplyDeletionWhenCommitIdEqualsQueryCommitId)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 30, 20, 10);
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 30), R(50, 50)}),
+            Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldSubtractMultipleNonOverlappingDeletions)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 20, 10, 5);
+        map.AddRange(1, 50, 10, 6);
+        map.AddRange(1, 80, 10, 7);
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 20), R(30, 20), R(60, 20), R(90, 10)}),
+            Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldPreserveAdjacentDeletions)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        // Adjacent (touching) ranges are stored as distinct entries and both
+        // apply on read.
+        map.AddRange(1, 0, 10, 5);
+        map.AddRange(1, 10, 10, 6);
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 1, 0, 20, 10));
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(20, 10)}),
+            Apply(map, 1, 0, 30, 10));
+    }
+
+    Y_UNIT_TEST(ShouldCoalesceOutputAcrossInvisibleDeletion)
+    {
+        // Deletions [0, 10)@5 and [20, 30)@15. Reading at commit 10 makes
+        // the second deletion invisible, and ApplyRanges does not split the
+        // output around invisible entries: the tail is returned as a single
+        // range spanning past the invisible deletion.
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 0, 10, 5);
+        map.AddRange(1, 20, 10, 15);
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(10, 30)}),
+            Apply(map, 1, 0, 40, 10));
+        // Reading at commit 15 makes both visible and the output is split.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(10, 10), R(30, 10)}),
+            Apply(map, 1, 0, 40, 15));
+    }
+
+    Y_UNIT_TEST(ShouldKeepOlderCommitIdOnOverlappingAdd)
+    {
+        // First deletion [0, 10)@5. Then AddRange [5, 15)@6. The overlap
+        // [5, 10) keeps commit 5 (older wins on overlap); only [10, 15)
+        // gets commit 6.
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 0, 10, 5);
+        map.AddRange(1, 5, 10, 6);
+
+        // At commit 5, only [0, 10) is visible.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(10, 10)}),
+            Apply(map, 1, 0, 20, 5));
+
+        // At commit 6, [10, 15) is now visible too.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(15, 5)}),
+            Apply(map, 1, 0, 20, 6));
+    }
+
+    Y_UNIT_TEST(ShouldSpanMultipleExistingRangesOnAdd)
+    {
+        // Preexisting deletions [10, 20)@5 and [30, 40)@6.
+        // Add [0, 100)@7: gaps [0,10), [20,30), [40,100) get commit 7.
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 10, 10, 5);
+        map.AddRange(1, 30, 10, 6);
+        map.AddRange(1, 0, 100, 7);
+
+        // At commit 4 nothing is visible.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 100)}),
+            Apply(map, 1, 0, 100, 4));
+
+        // At commit 5 only [10, 20) is visible.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 10), R(20, 80)}),
+            Apply(map, 1, 0, 100, 5));
+
+        // At commit 6 [10, 20) and [30, 40) are visible.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 10), R(20, 10), R(40, 60)}),
+            Apply(map, 1, 0, 100, 6));
+
+        // At commit 7 everything is deleted.
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 1, 0, 100, 7));
+    }
+
+    Y_UNIT_TEST(ShouldNotSplitExistingRangeWhenAddIsFullyContained)
+    {
+        // AddRange fully inside a lower-commit deletion is absorbed: the
+        // pre-existing deletion still covers everything, so the new commitId
+        // never becomes observable within the overlap.
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 0, 100, 5);
+        map.AddRange(1, 30, 20, 10);
+
+        // At commit 5 the whole [0, 100) is deleted.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({}),
+            Apply(map, 1, 0, 100, 5));
+
+        // At commit 4 nothing is deleted.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 100)}),
+            Apply(map, 1, 0, 100, 4));
+
+        // At commit 9 (between 5 and 10) still the [0, 100) deletion applies.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({}),
+            Apply(map, 1, 0, 100, 9));
+    }
+
+    Y_UNIT_TEST(ShouldSplitExistingRangeWhenAddCoversWithBiggerRange)
+    {
+        // Preexisting [30, 50)@5. AddRange [0, 100)@10 becomes
+        // [0, 30)@10, [30, 50)@5 (preserved), [50, 100)@10.
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 30, 20, 5);
+        map.AddRange(1, 0, 100, 10);
+
+        // At commit 7 only [30, 50)@5 is visible.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 30), R(50, 50)}),
+            Apply(map, 1, 0, 100, 7));
+
+        // At commit 10 all three cover the whole range.
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldIsolateDifferentNodeIds)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 0, 100, 5);
+        map.AddRange(2, 50, 20, 5);
+
+        // NodeId 1 has [0, 100) deleted.
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 1, 0, 100, 10));
+
+        // NodeId 2 only has [50, 70) deleted.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 50), R(70, 30)}),
+            Apply(map, 2, 0, 100, 10));
+
+        // NodeId 3 has no deletions.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 100)}),
+            Apply(map, 3, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldNotConsiderDeletionsFromOtherNodeIdWhenSpanning)
+    {
+        // A pre-existing deletion on node 1 must not be touched or spanned
+        // when AddRange is called for node 2.
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 30, 20, 5);
+        map.AddRange(2, 0, 100, 10);
+
+        // Node 2 has [0, 100) deleted.
+        UNIT_ASSERT_VALUES_EQUAL(D({}), Apply(map, 2, 0, 100, 10));
+
+        // Node 1 keeps its original [30, 50) deletion.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 30), R(50, 50)}),
+            Apply(map, 1, 0, 100, 10));
+    }
+
+    Y_UNIT_TEST(ShouldRespectQueryOffsetAfterMap)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 0, 100, 5);
+        // Query that starts past every deletion returns the query unchanged.
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(200, 50)}),
+            Apply(map, 1, 200, 50, 10));
+    }
+
+    Y_UNIT_TEST(ShouldRespectQueryEndBeforeMap)
+    {
+        TDeletedRangeMap map(TDefaultAllocator::Instance());
+        map.AddRange(1, 200, 50, 5);
+        UNIT_ASSERT_VALUES_EQUAL(
+            D({R(0, 100)}),
+            Apply(map, 1, 0, 100, 10));
+    }
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
@@ -233,13 +233,11 @@ Y_UNIT_TEST_SUITE(TFreshBytesTest)
                 TVector<TBytes>({
                     {1, 50, 3, 13, InvalidCommitId},
                     {1, 100, 1, 10, InvalidCommitId},
-                    //{1, 101, 1, 11, InvalidCommitId},
-                    {1, 101, 4, 11, InvalidCommitId}, // XXX
+                    {1, 101, 1, 11, InvalidCommitId},
                     {1, 111, 5, 18, InvalidCommitId},
                 }), visitor.Bytes);
 
-            //UNIT_ASSERT_VALUES_EQUAL("dDd|a|b|yuiop", visitor.Data);
-            UNIT_ASSERT_VALUES_EQUAL("dDd|a|bBbB|yuiop", visitor.Data); // XXX
+            UNIT_ASSERT_VALUES_EQUAL("dDd|a|b|yuiop", visitor.Data);
         }
 
         {

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
@@ -311,6 +311,41 @@ Y_UNIT_TEST_SUITE(TFreshBytesTest)
         COMPARE_BYTES(deletionMarkers, visitedDeletionMarkers);
     }
 
+    Y_UNIT_TEST(ShouldApplyDeletionMarkersFromAllNextChunksToPreviousChunk)
+    {
+        TFreshBytes freshBytes(TDefaultAllocator::Instance());
+
+        freshBytes.AddBytes(1, 100, "abc", 10);
+        freshBytes.OnCheckpoint(11);
+        freshBytes.AddDeletionMarker(1, 100, 1, 12);
+        freshBytes.OnCheckpoint(13);
+        freshBytes.AddDeletionMarker(1, 102, 1, 14);
+
+        {
+            TFreshBytesVisitor visitor;
+            freshBytes.FindBytes(visitor, 1, TByteRange(0, 1000, 4_KB), 13);
+
+            COMPARE_BYTES(
+                TVector<TBytes>({
+                    {1, 101, 2, 10, InvalidCommitId},
+                }), visitor.Bytes);
+
+            UNIT_ASSERT_VALUES_EQUAL("bc", visitor.Data);
+        }
+
+        {
+            TFreshBytesVisitor visitor;
+            freshBytes.FindBytes(visitor, 1, TByteRange(0, 1000, 4_KB), 14);
+
+            COMPARE_BYTES(
+                TVector<TBytes>({
+                    {1, 101, 1, 10, InvalidCommitId},
+                }), visitor.Bytes);
+
+            UNIT_ASSERT_VALUES_EQUAL("b", visitor.Data);
+        }
+    }
+
     Y_UNIT_TEST(ShouldInsertIntervalInTheMiddleOfAnotherInterval)
     {
         TFreshBytes freshBytes(TDefaultAllocator::Instance());

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
@@ -191,6 +191,128 @@ Y_UNIT_TEST_SUITE(TFreshBytesTest)
             visitedDeletionMarkers.size()));
     }
 
+    Y_UNIT_TEST(ShouldApplyDeletionMarkersToPreviousChunks)
+    {
+        TFreshBytes freshBytes(TDefaultAllocator::Instance());
+
+        freshBytes.AddBytes(1, 100, "aAa", 10);
+        freshBytes.AddBytes(1, 101, "bBbB", 11);
+        freshBytes.AddBytes(1, 50, "cCc", 12);
+        freshBytes.AddBytes(1, 50, "dDd", 13);
+        freshBytes.AddBytes(2, 100, "eEeEe", 14);
+        freshBytes.AddBytes(2, 70, "12345678", 15);
+        freshBytes.AddDeletionMarker(2, 100, 3, 16);
+
+        TVector<TBytes> bytes;
+        TVector<TBytes> deletionMarkers;
+        auto info = freshBytes.StartCleanup(17, &bytes, &deletionMarkers);
+
+        COMPARE_BYTES(
+            TVector<TBytes>({
+                {1, 100, 3, 10, InvalidCommitId},
+                {1, 101, 4, 11, InvalidCommitId},
+                {1, 50, 3, 12, InvalidCommitId},
+                {1, 50, 3, 13, InvalidCommitId},
+                {2, 100, 5, 14, InvalidCommitId},
+                {2, 70, 8, 15, InvalidCommitId},
+            }), bytes);
+        COMPARE_BYTES(
+            TVector<TBytes>({
+                {2, 100, 3, 16, InvalidCommitId},
+            }), deletionMarkers);
+        UNIT_ASSERT_VALUES_EQUAL(17, info.ClosingCommitId);
+
+        freshBytes.AddBytes(1, 106, "qwertyuiop", 18);
+        freshBytes.AddDeletionMarker(1, 102, 9, 19);
+
+        {
+            TFreshBytesVisitor visitor;
+            freshBytes.FindBytes(visitor, 1, TByteRange(0, 1000, 4_KB), 19);
+
+            COMPARE_BYTES(
+                TVector<TBytes>({
+                    {1, 50, 3, 13, InvalidCommitId},
+                    {1, 100, 1, 10, InvalidCommitId},
+                    //{1, 101, 1, 11, InvalidCommitId},
+                    {1, 101, 4, 11, InvalidCommitId}, // XXX
+                    {1, 111, 5, 18, InvalidCommitId},
+                }), visitor.Bytes);
+
+            //UNIT_ASSERT_VALUES_EQUAL("dDd|a|b|yuiop", visitor.Data);
+            UNIT_ASSERT_VALUES_EQUAL("dDd|a|bBbB|yuiop", visitor.Data); // XXX
+        }
+
+        {
+            TFreshBytesVisitor visitor;
+            freshBytes.FindBytes(visitor, 2, TByteRange(0, 1000, 4_KB), 19);
+
+            COMPARE_BYTES(
+                TVector<TBytes>({
+                    {2, 70, 8, 15, InvalidCommitId},
+                    {2, 103, 2, 14, InvalidCommitId},
+                }), visitor.Bytes);
+
+            UNIT_ASSERT_VALUES_EQUAL("12345678|Ee", visitor.Data);
+        }
+
+        TVector<TBytes> visitedBytes;
+        TVector<TBytes> visitedDeletionMarkers;
+        auto visitTop = [&] () {
+            visitedBytes.clear();
+            visitedDeletionMarkers.clear();
+            constexpr ui64 itemLimit = 100;
+            freshBytes.VisitTop(
+                itemLimit,
+                [&] (const TBytes& bytes, bool isDel) {
+                    if (isDel) {
+                        visitedDeletionMarkers.push_back(bytes);
+                    } else {
+                        visitedBytes.push_back(bytes);
+                    }
+                }
+            );
+        };
+
+        visitTop();
+        COMPARE_BYTES(bytes, visitedBytes);
+        COMPARE_BYTES(deletionMarkers, visitedDeletionMarkers);
+
+        UNIT_ASSERT(freshBytes.FinishCleanup(
+            info.ChunkId,
+            visitedBytes.size(),
+            visitedDeletionMarkers.size()));
+
+        {
+            TFreshBytesVisitor visitor;
+            freshBytes.FindBytes(visitor, 1, TByteRange(0, 1000, 4_KB), 19);
+
+            COMPARE_BYTES(
+                TVector<TBytes>({
+                    {1, 111, 5, 18, InvalidCommitId},
+                }), visitor.Bytes);
+
+            UNIT_ASSERT_VALUES_EQUAL("yuiop", visitor.Data);
+        }
+
+        {
+            TFreshBytesVisitor visitor;
+            freshBytes.FindBytes(visitor, 2, TByteRange(0, 1000, 4_KB), 19);
+
+            COMPARE_BYTES(
+                TVector<TBytes>({
+                }), visitor.Bytes);
+
+            UNIT_ASSERT_VALUES_EQUAL("", visitor.Data);
+        }
+
+        bytes.clear();
+        deletionMarkers.clear();
+        info = freshBytes.StartCleanup(20, &bytes, &deletionMarkers);
+        visitTop();
+        COMPARE_BYTES(bytes, visitedBytes);
+        COMPARE_BYTES(deletionMarkers, visitedDeletionMarkers);
+    }
+
     Y_UNIT_TEST(ShouldInsertIntervalInTheMiddleOfAnotherInterval)
     {
         TFreshBytes freshBytes(TDefaultAllocator::Instance());

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut.cpp
@@ -344,6 +344,17 @@ Y_UNIT_TEST_SUITE(TFreshBytesTest)
 
             UNIT_ASSERT_VALUES_EQUAL("b", visitor.Data);
         }
+
+        // Even though this range is not visible at current commit id,
+        // Intersects func is still supposed to return true because there's a
+        // range in one of the chunks that actually overlaps with the argument.
+        UNIT_ASSERT(freshBytes.Intersects(1, TByteRange(100, 1, 4_KB)));
+        UNIT_ASSERT(freshBytes.Intersects(1, TByteRange(102, 1, 4_KB)));
+        UNIT_ASSERT(!freshBytes.Intersects(1, TByteRange(103, 1, 4_KB)));
+        UNIT_ASSERT(!freshBytes.Intersects(1, TByteRange(99, 1, 4_KB)));
+        UNIT_ASSERT(freshBytes.Intersects(1, TByteRange(99, 2, 4_KB)));
+        UNIT_ASSERT(freshBytes.Intersects(1, TByteRange(102, 2, 4_KB)));
+        UNIT_ASSERT(!freshBytes.Intersects(2, TByteRange(0, 4_KB, 4_KB)));
     }
 
     Y_UNIT_TEST(ShouldInsertIntervalInTheMiddleOfAnotherInterval)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -699,8 +699,6 @@ void TIndexTabletActor::CompleteTx_FlushBytes(
         }
     };
 
-
-
     THashMap<TBlockLocation, TBlockWithBytes, TBlockLocationHash> blockMap;
 
     struct TSrcBlobInfo

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_truncate.cpp
@@ -326,6 +326,103 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Truncate)
         UNIT_ASSERT_VALUES_EQUAL(data, TString(5_KB, 0));
     }
 
+    Y_UNIT_TEST(ShouldNotReadTruncatedFreshBytesAfterFlushBytesStarts)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        // aligned
+        tablet.WriteData(handle, 0, 8_KB, '1');
+        // non aligned for each block
+        tablet.WriteData(handle, 0, 1_KB, '2');
+        tablet.WriteData(handle, 4_KB, 1_KB, '2');
+
+        TString expected(8_KB, '1');
+
+        TString pattern(1_KB, '2');
+        memcpy(&expected[0], &pattern[0], 1_KB);
+        memcpy(&expected[4_KB], &pattern[0], 1_KB);
+
+        //
+        // Blocking FlushBytes completion.
+        //
+
+        TAutoPtr<IEventHandle> writeBlob;
+        env.GetRuntime().SetEventFilter([&](auto& runtime, auto& event) {
+            Y_UNUSED(runtime);
+            switch (event->GetTypeRewrite()) {
+                case TEvIndexTabletPrivate::EvWriteBlobRequest: {
+                    writeBlob = event.Release();
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        tablet.SendFlushBytesRequest();
+        env.GetRuntime().DispatchEvents({}, TDuration::MilliSeconds(100));
+        UNIT_ASSERT(writeBlob);
+
+        //
+        // Now previous FreshBytes should be stored in FreshBytes chunk 0 and
+        // new FreshBytes deletion markers should go to chunk 1.
+        //
+        // Truncating the file to generate a FreshBytes deletion marker.
+        //
+
+        TSetNodeAttrArgs args(id);
+        args.SetFlag(NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE);
+
+        args.SetSize(4_KB);
+        tablet.SetNodeAttr(args);
+        UNIT_ASSERT_VALUES_EQUAL(4_KB, GetNodeAttrs(tablet, id).GetSize());
+
+        //
+        // And restoring the size of the file back to 8KiB - the last 4KiB
+        // should contain zeroes now.
+        //
+
+        args.SetSize(8_KB);
+        tablet.SetNodeAttr(args);
+        UNIT_ASSERT_VALUES_EQUAL(8_KB, GetNodeAttrs(tablet, id).GetSize());
+
+        auto data = ReadData(tablet, handle, 4_KB, 0);
+        UNIT_ASSERT_VALUES_EQUAL(4_KB, data.size());
+        UNIT_ASSERT_VALUES_EQUAL(expected.substr(0, 4_KB), data);
+
+        data = ReadData(tablet, handle, 4_KB, 4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(4_KB, data.size());
+        UNIT_ASSERT_VALUES_EQUAL(TString(4_KB, 0), data);
+
+        //
+        // After FlushBytes completion the read should keep returning the same
+        // data.
+        //
+
+        env.GetRuntime().Send(writeBlob, nodeIdx);
+        auto response = tablet.RecvFlushBytesResponse();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            S_OK,
+            response->GetStatus(),
+            response->GetErrorReason());
+
+        data = ReadData(tablet, handle, 4_KB, 0);
+        UNIT_ASSERT_VALUES_EQUAL(4_KB, data.size());
+        UNIT_ASSERT_VALUES_EQUAL(expected.substr(0, 4_KB), data);
+
+        data = ReadData(tablet, handle, 4_KB, 4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(4_KB, data.size());
+        UNIT_ASSERT_VALUES_EQUAL(TString(4_KB, 0), data);
+    }
+
     Y_UNIT_TEST(ShouldTruncateEmptyFile)
     {
         TTestEnv env;


### PR DESCRIPTION
### Notes
A detailed description of the problematic scenario can be found in the linked issue.

Next `TFreshBytes` chunk's deleted ranges should be applied when the previous chunk is read. Implementing this via:
* adding a `DeletedRanges` map to each chunk where for each byte range we track the first `CommitId` at which it was deleted
* applying `DeletedRanges` of the next chunk to the ranges read from the previous chunk upon `FindBytes`
* added unit tests both at the `TFreshBytes` level and at the tablet level
* added many comments describing the behaviour and intent of `TFreshBytes` components

Most of the PR is unit tests + comments + cleanup. The core part of the fix is localized in `fresh_bytes.h/cpp` and consists of 3 things:
* implemented `TDeletedRangeMap` and added it to each `TFreshBytes` chunk
* adding each deleted range into this map upon `AddDeletionMarker()`
* looking into `DeletedRanges` of each of the chunks that go after the chunk that we scan upon `FindBytes()`

Will add more comments in a separate PR:
* will document `TFreshBytes` public methods
* will add some comments for block/byte visitors describing the guarantees they rely on

### Issue
https://github.com/ydb-platform/nbs/issues/6385
