### PR TITLE
Unescape grpc peer in logs

### DIFF
--- a/cloud/blockstore/libs/diagnostics/server_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/server_stats.cpp
@@ -10,6 +10,7 @@
 
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
+
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/diagnostics/monitoring.h>
@@ -18,6 +19,7 @@
 #include <library/cpp/monlib/service/pages/html_mon_page.h>
 #include <library/cpp/monlib/service/pages/index_mon_page.h>
 #include <library/cpp/monlib/service/pages/templates.h>
+#include <library/cpp/string_utils/quote/quote.h>
 
 namespace NCloud::NBlockStore {
 
@@ -315,7 +317,7 @@ void TServerStats::RequestStarted(
             req.ClientId,
             RequestInstanceId)
         << " REQUEST " << message
-        << ", peer: " << req.Peer);
+        << ", peer: " << UrlUnescapeRet(req.Peer));
 
     LWTRACK(
         RequestStarted,
@@ -568,7 +570,7 @@ void TServerStats::RequestCompleted(
         << ", unaligned: " << req.Unaligned
         << maxTimeSuppressedMessage
         << ", error: " << FormatError(error)
-        << ", peer: " << req.Peer
+        << ", peer: " << UrlUnescapeRet(req.Peer)
         << ")");
 }
 

--- a/cloud/blockstore/libs/diagnostics/ya.make
+++ b/cloud/blockstore/libs/diagnostics/ya.make
@@ -52,6 +52,7 @@ PEERDIR(
     library/cpp/monlib/service
     library/cpp/monlib/service/pages
     library/cpp/monlib/service/pages/tablesorter
+    library/cpp/string_utils/quote
     library/cpp/threading/hot_swap
 )
 

--- a/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
+++ b/cloud/blockstore/libs/service_kikimr/auth_provider_kikimr.cpp
@@ -6,13 +6,15 @@
 #include <cloud/blockstore/libs/service/context.h>
 #include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/libs/storage/core/probes.h>
-#include <cloud/storage/core/libs/kikimr/actorsystem.h>
 
 #include <cloud/storage/core/libs/api/authorizer.h>
 #include <cloud/storage/core/libs/auth/authorizer.h>
+#include <cloud/storage/core/libs/kikimr/actorsystem.h>
 
 #include <contrib/ydb/library/actors/core/actor_bootstrapped.h>
 #include <contrib/ydb/library/actors/core/log.h>
+
+#include <library/cpp/string_utils/quote/quote.h>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -162,7 +164,7 @@ private:
         if (FAILED(msg->GetStatus())) {
             LOG_WARN_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
                 TRequestInfo(RequestType, CallContext->RequestId, DiskId)
-                << " unauthorized request, peer: " << Peer);
+                << " unauthorized request, peer: " << UrlUnescapeRet(Peer));
         }
 
         CompleteRequest(ctx, msg->Error);
@@ -176,7 +178,7 @@ private:
 
         LOG_WARN_S(ctx, TBlockStoreComponents::SERVICE_PROXY,
             TRequestInfo(RequestType, CallContext->RequestId, DiskId)
-            << " request timed out, peer: " << Peer);
+            << " request timed out, peer: " << UrlUnescapeRet(Peer));
 
         NProto::TError error;
         error.SetCode(E_REJECTED);  // TODO: E_TIMEOUT

--- a/cloud/blockstore/libs/service_kikimr/ya.make
+++ b/cloud/blockstore/libs/service_kikimr/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     cloud/storage/core/libs/auth
 
     contrib/ydb/library/actors/core
+    library/cpp/string_utils/quote
 )
 
 END()


### PR DESCRIPTION
### Notes
Peer in logs before this PR looked like this:
```
peer: ipv6:%5B2001:db8::1%5D:12345
```

Now:
```
peer: ipv6:[2001:db8::1]:12345
```

This PR unescapes "[]" symbols.
