### PR TITLE
[NBS] issue-6297: read blob metas along with block masks for cleanup optimization

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1540,6 +1540,49 @@ private:
     }
 };
 
+void FillBlobsInfo(
+    TPartitionDatabase& db,
+    TTxPartition::TCompaction& args,
+    bool& ready,
+    ui64 tabletId)
+{
+    auto blobsToReadBlockMasks = TVector<TPartialBlobId>(
+        args.BlobsToReadBlockMasks.begin(),
+        args.BlobsToReadBlockMasks.end());
+    auto blobsToReadBlobMetas = TVector<TPartialBlobId>(
+        args.BlobsToReadBlobMetas.begin(),
+        args.BlobsToReadBlobMetas.end());
+
+    auto blobsToOutputIndices = DeduplicateBlobInfos(
+        tabletId,
+        blobsToReadBlockMasks,
+        blobsToReadBlobMetas);
+
+    TVector<TBlockMask> blockMasks;
+    blockMasks.resize(args.BlobsToReadBlockMasks.size());
+    TVector<NProto::TBlobMeta> blobMetas;
+    blobMetas.resize(args.BlobsToReadBlobMetas.size());
+    if (!ReadBlobsInfo(
+            db,
+            blobsToOutputIndices,
+            tabletId,
+            blockMasks,
+            blobMetas))
+    {
+        ready = false;
+        return;
+    }
+
+    if (ready) {
+        FillRangeCompactionInfos(
+            args.RangeCompactions,
+            blobsToReadBlobMetas,
+            blobsToReadBlockMasks,
+            blobMetas,
+            blockMasks);
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2099,6 +2142,7 @@ bool TPartitionActor::PrepareCompaction(
             args.CommitId,
             TabletID(),
             IsReadBlockMaskOnCompactionOptimizationEnabled(),
+            IsUseRecreatedBlobMetasOnCleanupEnabled(),
             ready,
             db,
             *State,
@@ -2125,34 +2169,7 @@ bool TPartitionActor::PrepareCompaction(
     State->IncrementBlockMaskReadDuringCompaction(
         args.BlobsToReadBlockMasks.size());
 
-    const TVector<TPartialBlobId> blobsToReadBlockMasks(
-        args.BlobsToReadBlockMasks.begin(),
-        args.BlobsToReadBlockMasks.end());
-    const TVector<TPartialBlobId> blobsToReadBlobMetas(
-        args.BlobsToReadBlobMetas.begin(),
-        args.BlobsToReadBlobMetas.end());
-
-    TVector<TBlockMask> blockMasks;
-    TVector<NProto::TBlobMeta> blobMetas;
-    if (!ReadBlobsInfo(
-            db,
-            blobsToReadBlockMasks,
-            blobsToReadBlobMetas,
-            TabletID(),
-            blockMasks,
-            blobMetas))
-    {
-        ready = false;
-    }
-
-    if (ready) {
-        FillRangeCompactionInfos(
-            args.RangeCompactions,
-            blobsToReadBlobMetas,
-            blobsToReadBlockMasks,
-            blobMetas,
-            blockMasks);
-    }
+    FillBlobsInfo(db, args, ready, TabletID());
 
     return ready;
 }

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1558,10 +1558,8 @@ void FillBlobsInfo(
         blobsToReadBlockMasks,
         blobsToReadBlobMetas);
 
-    TVector<TBlockMask> blockMasks;
-    blockMasks.resize(args.BlobsToReadBlockMasks.size());
-    TVector<NProto::TBlobMeta> blobMetas;
-    blobMetas.resize(args.BlobsToReadBlobMetas.size());
+    TVector<TBlockMask> blockMasks(args.BlobsToReadBlockMasks.size());
+    TVector<NProto::TBlobMeta> blobMetas(args.BlobsToReadBlobMetas.size());
     if (!ReadBlobsInfo(
             db,
             blobsToOutputIndices,

--- a/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_metadata_rebuild_blockcount.cpp
@@ -348,7 +348,8 @@ bool TPartitionActor::PrepareMetadataRebuildBlockCount(
         args.StartBlobId,
         args.FinalBlobId,
         args.BlobCountToRead);
-    auto ready = progress != TPartitionDatabase::EBlobIndexScanProgress::NotReady;
+    auto ready =
+        progress != TPartitionDatabase::EBlobIndexScanProgress::NotReady;
     if (ready) {
         visitor.UpdateTx();
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblobinfo.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblobinfo.cpp
@@ -8,6 +8,8 @@ using namespace NActors;
 
 using namespace NKikimr::NTabletFlatExecutor;
 
+using TOutputIndex = TTxPartition::TCompactionReadBlobInfo::TOutputIndex;
+
 LWTRACE_USING(BLOCKSTORE_STORAGE_PROVIDER);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -18,10 +20,8 @@ void TPartitionActor::HandleCompactionReadBlobInfo(
 {
     auto* msg = ev->Get();
 
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
     TRequestScope timer(*requestInfo);
 
@@ -31,6 +31,11 @@ void TPartitionActor::HandleCompactionReadBlobInfo(
         "CompactionReadBlobInfo",
         requestInfo->CallContext->RequestId);
 
+    auto blobsToOutputIndices = DeduplicateBlobInfos(
+        TabletID(),
+        msg->BlobsToReadBlockMasks,
+        msg->BlobsToReadBlobMetas);
+
     AddTransaction<TEvPartitionPrivate::TCompactionReadBlobInfoMethod>(
         *requestInfo);
 
@@ -38,8 +43,9 @@ void TPartitionActor::HandleCompactionReadBlobInfo(
         ctx,
         CreateTx<TCompactionReadBlobInfo>(
             requestInfo,
-            std::move(msg->BlobsToReadBlockMasks),
-            std::move(msg->BlobsToReadBlobMetas)));
+            std::move(blobsToOutputIndices),
+            msg->BlobsToReadBlockMasks.size(),
+            msg->BlobsToReadBlobMetas.size()));
 }
 
 bool TPartitionActor::PrepareCompactionReadBlobInfo(
@@ -51,10 +57,12 @@ bool TPartitionActor::PrepareCompactionReadBlobInfo(
     TRequestScope timer(*args.RequestInfo);
     TPartitionDatabase db(tx.DB);
 
+    args.BlockMasks.resize(args.BlockMaskCount);
+    args.BlobMetas.resize(args.BlobMetaCount);
+
     return ReadBlobsInfo(
         db,
-        args.BlobsToReadBlockMasks,
-        args.BlobsToReadBlobMetas,
+        args.BlobsToOutputIndices,
         TabletID(),
         args.BlockMasks,
         args.BlobMetas);
@@ -75,22 +83,21 @@ void TPartitionActor::CompleteCompactionReadBlobInfo(
     TTxPartition::TCompactionReadBlobInfo& args)
 {
     STORAGE_VERIFY_C(
-        args.BlockMasks.size() == args.BlobsToReadBlockMasks.size(),
+        args.BlockMasks.size() == args.BlockMaskCount,
         TWellKnownEntityTypes::TABLET,
         TabletID(),
         TStringBuilder() << "Block masks size mismatch: "
                          << args.BlockMasks.size()
-                         << " != " << args.BlobsToReadBlockMasks.size());
+                         << " != " << args.BlockMaskCount);
     STORAGE_VERIFY_C(
-        args.BlobMetas.size() == args.BlobsToReadBlobMetas.size(),
+        args.BlobMetas.size() == args.BlobMetaCount,
         TWellKnownEntityTypes::TABLET,
         TabletID(),
         TStringBuilder() << "Blob metas size mismatch: "
                          << args.BlobMetas.size()
-                         << " != " << args.BlobsToReadBlobMetas.size());
+                         << " != " << args.BlobMetaCount);
 
-    State->IncrementBlockMaskReadDuringCompaction(
-        args.BlobsToReadBlockMasks.size());
+    State->IncrementBlockMaskReadDuringCompaction(args.BlockMaskCount);
 
     TRequestScope timer(*args.RequestInfo);
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.cpp
@@ -421,6 +421,7 @@ void ApplyIncrementalCompactionSkipping(
 void FillBlobsInfoToRead(
     ui64 commitId,
     bool readBlockMaskOnCompactionOptimizationEnabled,
+    bool useRecreatedBlobMetasOnCleanup,
     TTxPartition::TRangeCompaction& args,
     TPartitionState& state,
     THashSet<TPartialBlobId, TPartialBlobIdHash>& blobsToReadBlockMasks,
@@ -436,6 +437,11 @@ void FillBlobsInfoToRead(
             !readBlockMaskOnCompactionOptimizationEnabled)
         {
             blobsToReadBlockMasks.emplace(kv.first);
+            if (useRecreatedBlobMetasOnCleanup) {
+                // additional blob meta read is cheap, so we will read it
+                // anyway, to avoid extra reads on cleanup
+                blobsToReadBlobMetas.emplace(kv.first);
+            }
         } else {
             // The blob is fully available for range compaction and will be
             // overwritten during compaction, so we can skip reading its block
@@ -691,6 +697,7 @@ void PrepareRangeCompaction(
     const ui64 commitId,
     const ui64 tabletId,
     const bool readBlockMaskOnCompactionOptimizationEnabled,
+    const bool useRecreatedBlobMetasOnCleanup,
     bool& ready,
     TPartitionDatabase& db,
     TPartitionState& state,
@@ -733,6 +740,7 @@ void PrepareRangeCompaction(
     FillBlobsInfoToRead(
         commitId,
         readBlockMaskOnCompactionOptimizationEnabled,
+        useRecreatedBlobMetasOnCleanup,
         args,
         state,
         blobsToReadBlockMasks,

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
@@ -118,6 +118,7 @@ void PrepareRangeCompaction(
     const ui64 commitId,
     const ui64 tabletId,
     const bool readBlockMaskOnCompactionOptimizationEnabled,
+    const bool useRecreatedBlobMetasOnCleanup,
     bool& ready,
     TPartitionDatabase& db,
     TPartitionState& state,

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "part_database.h"
 #include "part_events_private.h"
 #include "part_tx.h"
 
@@ -26,7 +27,6 @@ namespace NKikimr {
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
 class TPartitionState;
-class TPartitionDatabase;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_compaction_logic_ut.cpp
@@ -65,21 +65,21 @@ TPartitionState MakeState(size_t blockCount = 2048)
     return TPartitionState(
         DefaultConfig(1, blockCount),
         BuildDefaultCompactionPolicy(5),
-        0,      // compactionScoreHistorySize
-        0,      // cleanupScoreHistorySize
+        0,   // compactionScoreHistorySize
+        0,   // cleanupScoreHistorySize
         DefaultBPConfig(),
         DefaultFreeSpaceConfig(),
-        Max<ui32>(),    // maxIORequestsInFlight
-        0,      // reassignChannelsPercentageThreshold
-        100,    // reassignFreshChannelsPercentageThreshold
-        100,    // reassignMixedChannelsPercentageThreshold
-        false,  // reassignSystemChannelsImmediately
-        5,      // channelCount (System + Log + Index + 1 Merged + Fresh)
-        0,      // mixedIndexCacheSize
-        10000,  // allocationUnit
-        100,    // maxBlobsPerUnit
-        10,     // maxBlobsPerRange
-        1,      // compactionRangeCountPerRun
+        Max<ui32>(),   // maxIORequestsInFlight
+        0,             // reassignChannelsPercentageThreshold
+        100,           // reassignFreshChannelsPercentageThreshold
+        100,           // reassignMixedChannelsPercentageThreshold
+        false,         // reassignSystemChannelsImmediately
+        5,             // channelCount (System + Log + Index + 1 Merged + Fresh)
+        0,             // mixedIndexCacheSize
+        10000,         // allocationUnit
+        100,           // maxBlobsPerUnit
+        10,            // maxBlobsPerRange
+        1,             // compactionRangeCountPerRun
         std::move(threadSafeState));
 }
 
@@ -147,20 +147,23 @@ TPrepareCompleteResult RunPrepareAndComplete(
     THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
     bool ready = true;
 
-    executor.ReadTx([&](TPartitionDatabase db) {
-        PrepareRangeCompaction(
-            *MakeStorageConfig(),
-            0,
-            compactionCommitId,
-            TTestExecutor::TabletId,
-            true,
-            ready,
-            db,
-            state,
-            args,
-            blobsToReadBlockMasks,
-            blobsToReadBlobMetas);
-    });
+    executor.ReadTx(
+        [&](TPartitionDatabase db)
+        {
+            PrepareRangeCompaction(
+                *MakeStorageConfig(),
+                0,
+                compactionCommitId,
+                TTestExecutor::TabletId,
+                true,    // readBlockMaskOnCompactionOptimizationEnabled
+                false,   // useRecreatedBlobMetasOnCleanup
+                ready,
+                db,
+                state,
+                args,
+                blobsToReadBlockMasks,
+                blobsToReadBlobMetas);
+        });
 
     TVector<TBlobCompactionRequest> requests;
     TVector<TRangeCompactionInfo> rangeCompactionInfos;
@@ -203,13 +206,15 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(4);
-            db.WriteMergedBlocks(
-                blobId,
-                TBlockRange32::MakeClosedInterval(0, 3),
-                TBlockMask{});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(
+                    blobId,
+                    TBlockRange32::MakeClosedInterval(0, 3),
+                    TBlockMask{});
+            });
 
         TTxPartition::TRangeCompaction args(
             0,
@@ -218,20 +223,23 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
         bool ready = true;
 
-        executor.ReadTx([&](TPartitionDatabase db) {
-            PrepareRangeCompaction(
-                *MakeStorageConfig(),
-                0,
-                MakeCommitId(0, 100),
-                TTestExecutor::TabletId,
-                false,  // optimization disabled
-                ready,
-                db,
-                state,
-                args,
-                blobsToReadBlockMasks,
-                blobsToReadBlobMetas);
-        });
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    false,   // readBlockMaskOnCompactionOptimizationEnabled
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
 
         UNIT_ASSERT(ready);
         UNIT_ASSERT_VALUES_EQUAL(1, blobsToReadBlockMasks.size());
@@ -247,13 +255,15 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(4);
-            db.WriteMergedBlocks(
-                blobId,
-                TBlockRange32::MakeClosedInterval(0, 3),
-                TBlockMask{});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(
+                    blobId,
+                    TBlockRange32::MakeClosedInterval(0, 3),
+                    TBlockMask{});
+            });
 
         TTxPartition::TRangeCompaction args(
             0,
@@ -262,20 +272,23 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
         bool ready = true;
 
-        executor.ReadTx([&](TPartitionDatabase db) {
-            PrepareRangeCompaction(
-                *MakeStorageConfig(),
-                0,
-                MakeCommitId(0, 100),
-                TTestExecutor::TabletId,
-                true,   // optimization enabled
-                ready,
-                db,
-                state,
-                args,
-                blobsToReadBlockMasks,
-                blobsToReadBlobMetas);
-        });
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    true,    // readBlockMaskOnCompactionOptimizationEnabled
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
 
         UNIT_ASSERT(ready);
         UNIT_ASSERT(blobsToReadBlockMasks.empty());
@@ -292,13 +305,15 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
 
         // Blob [1023..1024] crosses the boundary between range 0 and range 1.
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(2);
-            db.WriteMergedBlocks(
-                blobId,
-                TBlockRange32::MakeClosedInterval(1023, 1024),
-                TBlockMask{});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(2);
+                db.WriteMergedBlocks(
+                    blobId,
+                    TBlockRange32::MakeClosedInterval(1023, 1024),
+                    TBlockMask{});
+            });
 
         TTxPartition::TRangeCompaction args(
             0,
@@ -307,20 +322,23 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
         bool ready = true;
 
-        executor.ReadTx([&](TPartitionDatabase db) {
-            PrepareRangeCompaction(
-                *MakeStorageConfig(),
-                0,
-                MakeCommitId(0, 100),
-                TTestExecutor::TabletId,
-                true,   // optimization enabled
-                ready,
-                db,
-                state,
-                args,
-                blobsToReadBlockMasks,
-                blobsToReadBlobMetas);
-        });
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    true,    // readBlockMaskOnCompactionOptimizationEnabled
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
 
         UNIT_ASSERT(ready);
         UNIT_ASSERT_VALUES_EQUAL(1, blobsToReadBlockMasks.size());
@@ -336,13 +354,15 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(4);
-            db.WriteMergedBlocks(
-                blobId,
-                TBlockRange32::MakeClosedInterval(0, 3),
-                TBlockMask{});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(
+                    blobId,
+                    TBlockRange32::MakeClosedInterval(0, 3),
+                    TBlockMask{});
+            });
 
         state.GetCleanupQueue().Add({blobId, executor.CommitId(), {}});
 
@@ -353,28 +373,31 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
         bool ready = true;
 
-        executor.ReadTx([&](TPartitionDatabase db) {
-            PrepareRangeCompaction(
-                *MakeStorageConfig(),
-                0,
-                MakeCommitId(0, 100),
-                TTestExecutor::TabletId,
-                false,
-                ready,
-                db,
-                state,
-                args,
-                blobsToReadBlockMasks,
-                blobsToReadBlobMetas);
-        });
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    false,   // readBlockMaskOnCompactionOptimizationEnabled
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
 
         UNIT_ASSERT(ready);
         UNIT_ASSERT(blobsToReadBlockMasks.empty());
     }
 
-    // PrepareRangeCompaction: when checksums are enabled and the compacted range
-    // starts before the checksum boundary, every non-fresh merged block puts its
-    // blob into blobsToReadBlobMetas.
+    // PrepareRangeCompaction: when checksums are enabled and the compacted
+    // range starts before the checksum boundary, every non-fresh merged block
+    // puts its blob into blobsToReadBlobMetas.
     Y_UNIT_TEST(PrepareAddsToBlobMetasWhenChecksumsEnabled)
     {
         auto state = MakeState();
@@ -382,13 +405,15 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(4);
-            db.WriteMergedBlocks(
-                blobId,
-                TBlockRange32::MakeClosedInterval(0, 3),
-                TBlockMask{});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(
+                    blobId,
+                    TBlockRange32::MakeClosedInterval(0, 3),
+                    TBlockMask{});
+            });
 
         auto config = MakeStorageConfig(1000 * DefaultBlockSize);
 
@@ -399,20 +424,23 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
         bool ready = true;
 
-        executor.ReadTx([&](TPartitionDatabase db) {
-            PrepareRangeCompaction(
-                *config,
-                0,
-                MakeCommitId(0, 100),
-                TTestExecutor::TabletId,
-                true,
-                ready,
-                db,
-                state,
-                args,
-                blobsToReadBlockMasks,
-                blobsToReadBlobMetas);
-        });
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *config,
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    true,
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
 
         UNIT_ASSERT(ready);
         UNIT_ASSERT_VALUES_EQUAL(1, blobsToReadBlobMetas.size());
@@ -428,13 +456,15 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(4);
-            db.WriteMergedBlocks(
-                blobId,
-                TBlockRange32::MakeClosedInterval(0, 3),
-                TBlockMask{});
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(
+                    blobId,
+                    TBlockRange32::MakeClosedInterval(0, 3),
+                    TBlockMask{});
+            });
 
         TTxPartition::TRangeCompaction args(
             0,
@@ -443,23 +473,92 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
         bool ready = true;
 
-        executor.ReadTx([&](TPartitionDatabase db) {
-            PrepareRangeCompaction(
-                *MakeStorageConfig(),   // DiskPrefixLength == 0 → checksums off
-                0,
-                MakeCommitId(0, 100),
-                TTestExecutor::TabletId,
-                true,
-                ready,
-                db,
-                state,
-                args,
-                blobsToReadBlockMasks,
-                blobsToReadBlobMetas);
-        });
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),   // DiskPrefixLength == 0 → checksums
+                                            // off
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    true,    // readBlockMaskOnCompactionOptimizationEnabled
+                    false,   // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
 
         UNIT_ASSERT(ready);
         UNIT_ASSERT(blobsToReadBlobMetas.empty());
+    }
+
+    // PrepareRangeCompaction: when useRecreatedBlobMetasOnCleanup is enabled,
+    // every blob in blobsToReadBlockMasks is also added to
+    // blobsToReadBlobMetas.
+    Y_UNIT_TEST(
+        PrepareAddsToBlobMetasForEveryBlockMaskBlobWhenUseRecreatedBlobMetasOnCleanupEnabled)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId blobId1;
+        TPartialBlobId blobId2;
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId1 = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(
+                    blobId1,
+                    TBlockRange32::MakeClosedInterval(0, 3),
+                    TBlockMask{});
+
+                blobId2 = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(
+                    blobId2,
+                    TBlockRange32::MakeClosedInterval(4, 7),
+                    TBlockMask{});
+            });
+
+        TTxPartition::TRangeCompaction args(
+            0,
+            TBlockRange32::MakeClosedInterval(0, MaxBlocksCount - 1));
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlockMasks;
+        THashSet<TPartialBlobId, TPartialBlobIdHash> blobsToReadBlobMetas;
+        bool ready = true;
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                PrepareRangeCompaction(
+                    *MakeStorageConfig(),   // checksums off
+                    0,
+                    MakeCommitId(0, 100),
+                    TTestExecutor::TabletId,
+                    false,   // readBlockMaskOnCompactionOptimizationEnabled
+                    true,    // useRecreatedBlobMetasOnCleanup
+                    ready,
+                    db,
+                    state,
+                    args,
+                    blobsToReadBlockMasks,
+                    blobsToReadBlobMetas);
+            });
+
+        UNIT_ASSERT(ready);
+        UNIT_ASSERT_VALUES_EQUAL(2, blobsToReadBlockMasks.size());
+        UNIT_ASSERT(blobsToReadBlockMasks.contains(blobId1));
+        UNIT_ASSERT(blobsToReadBlockMasks.contains(blobId2));
+        UNIT_ASSERT_VALUES_EQUAL(
+            blobsToReadBlockMasks.size(),
+            blobsToReadBlobMetas.size());
+        for (const auto& blobId: blobsToReadBlockMasks) {
+            UNIT_ASSERT(blobsToReadBlobMetas.contains(blobId));
+        }
     }
 
     // CompleteRangeCompaction: when ChecksumsEnabled is true, every non-fresh
@@ -468,7 +567,7 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
     Y_UNIT_TEST(CompleteCreatesChecksumFixupsWhenEnabled)
     {
         auto state = MakeState();
-        auto storageInfo = MakeStorageInfo(1);  // channel 0 configured
+        auto storageInfo = MakeStorageInfo(1);   // channel 0 configured
 
         // Source blob lives on channel 0, generation 0.
         const TPartialBlobId sourceBlobId(0, 1, 0, 4 * DefaultBlockSize, 0, 0);
@@ -568,18 +667,16 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         skipMask.Set(1);
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(4);
-            db.WriteMergedBlocks(blobId, blockRange, skipMask);
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(4);
+                db.WriteMergedBlocks(blobId, blockRange, skipMask);
+            });
 
         const auto compactionCommitId = MakeCommitId(0, 100);
-        const auto result = RunPrepareAndComplete(
-            state,
-            executor,
-            0,
-            compactionCommitId,
-            true);
+        const auto result =
+            RunPrepareAndComplete(state, executor, 0, compactionCommitId, true);
 
         UNIT_ASSERT(result.Ready);
         UNIT_ASSERT_VALUES_EQUAL(1, result.RangeCompactionInfos.size());
@@ -588,8 +685,7 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
             result.RangeCompactionInfos[0].AffectedBlobs;
         UNIT_ASSERT(affectedBlobs.contains(blobId));
 
-        const auto& recreatedMeta =
-            affectedBlobs.at(blobId).RecreatedBlobMeta;
+        const auto& recreatedMeta = affectedBlobs.at(blobId).RecreatedBlobMeta;
         UNIT_ASSERT(recreatedMeta);
         UNIT_ASSERT(recreatedMeta->HasMergedBlocks());
         UNIT_ASSERT(!recreatedMeta->HasMixedBlocks());
@@ -610,18 +706,16 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
 
         TPartialBlobId blobId;
         const TVector<ui32> blockIndices = {0, 1, 2};
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(blockIndices.size());
-            db.WriteMixedBlocks(blobId, blockIndices, 1);
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(blockIndices.size());
+                db.WriteMixedBlocks(blobId, blockIndices, 1);
+            });
 
         const auto compactionCommitId = MakeCommitId(0, 100);
-        const auto result = RunPrepareAndComplete(
-            state,
-            executor,
-            0,
-            compactionCommitId,
-            true);
+        const auto result =
+            RunPrepareAndComplete(state, executor, 0, compactionCommitId, true);
 
         UNIT_ASSERT(result.Ready);
         UNIT_ASSERT_VALUES_EQUAL(1, result.RangeCompactionInfos.size());
@@ -639,17 +733,13 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         UNIT_ASSERT(!recreatedMeta->HasMergedBlocks());
 
         const auto& mixedBlocks = recreatedMeta->GetMixedBlocks();
-        UNIT_ASSERT_VALUES_EQUAL(
-            blockIndices.size(),
-            mixedBlocks.BlocksSize());
+        UNIT_ASSERT_VALUES_EQUAL(blockIndices.size(), mixedBlocks.BlocksSize());
         UNIT_ASSERT_VALUES_EQUAL(
             blockIndices.size(),
             mixedBlocks.CommitIdsSize());
 
         for (size_t i = 0; i < blockIndices.size(); ++i) {
-            UNIT_ASSERT_VALUES_EQUAL(
-                blockIndices[i],
-                mixedBlocks.GetBlocks(i));
+            UNIT_ASSERT_VALUES_EQUAL(blockIndices[i], mixedBlocks.GetBlocks(i));
             UNIT_ASSERT_VALUES_EQUAL(
                 blobId.CommitId(),
                 mixedBlocks.GetCommitIds(i));
@@ -665,18 +755,16 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(3);
-            db.WriteMixedBlocks(blobId, {0, 1, 2}, 2);
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(3);
+                db.WriteMixedBlocks(blobId, {0, 1, 2}, 2);
+            });
 
         const auto compactionCommitId = MakeCommitId(0, 100);
-        const auto result = RunPrepareAndComplete(
-            state,
-            executor,
-            0,
-            compactionCommitId,
-            true);
+        const auto result =
+            RunPrepareAndComplete(state, executor, 0, compactionCommitId, true);
 
         UNIT_ASSERT(result.Ready);
         UNIT_ASSERT_VALUES_EQUAL(1, result.RangeCompactionInfos.size());
@@ -684,14 +772,17 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         const auto& affectedBlobs =
             result.RangeCompactionInfos[0].AffectedBlobs;
         UNIT_ASSERT(affectedBlobs.contains(blobId));
-        UNIT_ASSERT_VALUES_EQUAL(2, affectedBlobs.at(blobId).CompactionRangeCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            affectedBlobs.at(blobId).CompactionRangeCount);
         UNIT_ASSERT(!affectedBlobs.at(blobId).RecreatedBlobMeta);
     }
 
     // PrepareRangeCompaction + CompleteRangeCompaction: mixed blobs that have
     // at least one block with commit id above the compaction commit id do not
     // get RecreatedBlobMeta, even if other blocks are visible to compaction.
-    Y_UNIT_TEST(CompleteSkipsMixedBlobMetaWhenBlockCommitIdExceedsCompactionCommitId)
+    Y_UNIT_TEST(
+        CompleteSkipsMixedBlobMetaWhenBlockCommitIdExceedsCompactionCommitId)
     {
         auto state = MakeState();
         TTestExecutor executor;
@@ -702,22 +793,20 @@ Y_UNIT_TEST_SUITE(TRangeCompactionLogicTest)
         const auto compactionCommitId = MakeCommitId(0, 100);
 
         TPartialBlobId blobId;
-        executor.WriteTx([&](TPartitionDatabase db) {
-            blobId = executor.MakeBlobId(2);
-            state.WriteMixedBlock(
-                db,
-                TMixedBlock(blobId, lowCommitId, 0, 0, 1));
-            state.WriteMixedBlock(
-                db,
-                TMixedBlock(blobId, highCommitId, 1, 1, 1));
-        });
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(2);
+                state.WriteMixedBlock(
+                    db,
+                    TMixedBlock(blobId, lowCommitId, 0, 0, 1));
+                state.WriteMixedBlock(
+                    db,
+                    TMixedBlock(blobId, highCommitId, 1, 1, 1));
+            });
 
-        const auto result = RunPrepareAndComplete(
-            state,
-            executor,
-            0,
-            compactionCommitId,
-            true);
+        const auto result =
+            RunPrepareAndComplete(state, executor, 0, compactionCommitId, true);
 
         UNIT_ASSERT(result.Ready);
         UNIT_ASSERT_VALUES_EQUAL(1, result.RangeCompactionInfos.size());
@@ -742,7 +831,8 @@ Y_UNIT_TEST_SUITE(TRecreateBlobMetasTest)
 
         TAffectedBlob ab;
         ab.MergedBlobsSpecificInfo.ConstructInPlace();
-        ab.MergedBlobsSpecificInfo->BlockRange = TBlockRange32::MakeClosedInterval(10, 20);
+        ab.MergedBlobsSpecificInfo->BlockRange =
+            TBlockRange32::MakeClosedInterval(10, 20);
         ab.MergedBlobsSpecificInfo->SkippedBlocksCount = 11;
         args.AffectedBlobs.emplace(blobId, std::move(ab));
 

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -716,6 +716,7 @@ bool TPartitionDatabase::ReadBlobMeta(
     const TPartialBlobId& blobId,
     TMaybe<NProto::TBlobMeta>& meta)
 {
+    IncrementMethodCallCount(__PRETTY_FUNCTION__);
     using TTable = TPartitionSchema::BlobsIndex;
 
     auto it = Table<TTable>()
@@ -788,6 +789,7 @@ bool TPartitionDatabase::ReadBlockMask(
     const TPartialBlobId& blobId,
     TMaybe<TBlockMask>& blockMask)
 {
+    IncrementMethodCallCount(__PRETTY_FUNCTION__);
     using TTable = TPartitionSchema::BlobsIndex;
 
     auto it = Table<TTable>()
@@ -802,6 +804,31 @@ bool TPartitionDatabase::ReadBlockMask(
         blockMask = BlockMaskFromString(
             it.GetValueOrDefault<TTable::BlockMask>());
     }
+
+    return true;
+}
+
+bool TPartitionDatabase::ReadBlobInfo(
+    const TPartialBlobId& blobId,
+    TMaybe<TBlockMask>& blockMask,
+    TMaybe<NProto::TBlobMeta>& blobMeta)
+{
+    IncrementMethodCallCount(__PRETTY_FUNCTION__);
+    using TTable = TPartitionSchema::BlobsIndex;
+
+    auto it =
+        Table<TTable>().Key(blobId.CommitId(), blobId.UniqueId()).Select();
+
+    if (!it.IsReady()) {
+        return false;   // not ready
+    }
+
+    if (!it.IsValid()) {
+        return true;
+    }
+
+    blockMask = BlockMaskFromString(it.GetValueOrDefault<TTable::BlockMask>());
+    blobMeta = it.GetValue<TTable::BlobMeta>();
 
     return true;
 }

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -1578,7 +1578,7 @@ bool TPartitionDatabaseImpl<TCounters>::ReadUnconfirmedBlobs(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template class TPartitionDatabase;
-template class TPartitionDatabase<TMethodCallCounter>;
+template class TPartitionDatabaseImpl<TNoOpCounter>;
+template class TPartitionDatabaseImpl<TMethodCallCounter>;
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -68,50 +68,51 @@ ui32 UnifyBlobOffsetAndCompactionRangeCount(
     return ui32{compactionRangeCount} << 16 | blobOffset;
 }
 
-std::pair<ui16, ui8> SplitBlobOffsetAndCompactionRangeCount(
-    ui32 value)
+std::pair<ui16, ui8> SplitBlobOffsetAndCompactionRangeCount(ui32 value)
 {
     return {value & Max<ui16>(), value >> 16};
 }
 
-#define COUNT_METHOD_CALL IncrementMethodCallCount(__PRETTY_FUNCTION__);
+#define COUNT_METHOD_CALL Counters(__PRETTY_FUNCTION__);
 
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::InitSchema()
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::InitSchema()
 {
     Materialize<TPartitionSchema>();
 
-    TSchemaInitializer<TPartitionSchema::TTables>::InitStorage(Database.Alter());
+    TSchemaInitializer<TPartitionSchema::TTables>::InitStorage(
+        Database.Alter());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteMeta(const NProto::TPartitionMeta& meta)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteMeta(
+    const NProto::TPartitionMeta& meta)
 {
     using TTable = TPartitionSchema::Meta;
 
-    Table<TTable>()
-        .Key(1)
-        .Update(NIceDb::TUpdate<TTable::PartitionMeta>(meta));
+    Table<TTable>().Key(1).Update(NIceDb::TUpdate<TTable::PartitionMeta>(meta));
 }
 
-bool TPartitionDatabase::ReadMeta(TMaybe<NProto::TPartitionMeta>& meta)
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadMeta(
+    TMaybe<NProto::TPartitionMeta>& meta)
 {
     using TTable = TPartitionSchema::Meta;
 
-    auto it = Table<TTable>()
-        .Key(1)
-        .Select();
+    auto it = Table<TTable>().Key(1).Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
     }
 
     if (it.IsValid()) {
-        meta = it.GetValue<TTable::PartitionMeta>();
+        meta = it.template GetValue<TTable::PartitionMeta>();
     }
 
     return true;
@@ -119,7 +120,8 @@ bool TPartitionDatabase::ReadMeta(TMaybe<NProto::TPartitionMeta>& meta)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteFreshBlock(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteFreshBlock(
     ui32 blockIndex,
     ui64 commitId,
     TBlockDataRef blockContent)
@@ -128,25 +130,27 @@ void TPartitionDatabase::WriteFreshBlock(
 
     Table<TTable>()
         .Key(blockIndex, ReverseCommitId(commitId))
-        .Update(NIceDb::TUpdate<TTable::BlockContent>(blockContent.AsStringBuf()));
+        .Update(
+            NIceDb::TUpdate<TTable::BlockContent>(blockContent.AsStringBuf()));
 }
 
-void TPartitionDatabase::DeleteFreshBlock(ui32 blockIndex, ui64 commitId)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteFreshBlock(
+    ui32 blockIndex,
+    ui64 commitId)
 {
     using TTable = TPartitionSchema::FreshBlocksIndex;
 
-    Table<TTable>()
-        .Key(blockIndex, ReverseCommitId(commitId))
-        .Delete();
+    Table<TTable>().Key(blockIndex, ReverseCommitId(commitId)).Delete();
 }
 
-bool TPartitionDatabase::ReadFreshBlocks(TVector<TOwningFreshBlock>& blocks)
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadFreshBlocks(
+    TVector<TOwningFreshBlock>& blocks)
 {
     using TTable = TPartitionSchema::FreshBlocksIndex;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
@@ -155,12 +159,12 @@ bool TPartitionDatabase::ReadFreshBlocks(TVector<TOwningFreshBlock>& blocks)
     while (it.IsValid()) {
         blocks.emplace_back(
             TBlock{
-                it.GetValue<TTable::BlockIndex>(),
-                ReverseCommitId(it.GetValue<TTable::CommitId>()),
-                true  // isStoredInDb
-            },  /* meta */
-            TString{it.GetValue<TTable::BlockContent>()},  /* content */
-            TPartialBlobId{}  /* blobId*/
+                it.template GetValue<TTable::BlockIndex>(),
+                ReverseCommitId(it.template GetValue<TTable::CommitId>()),
+                true   // isStoredInDb
+            },         /* meta */
+            TString{it.template GetValue<TTable::BlockContent>()}, /* content */
+            TPartialBlobId{}                                       /* blobId*/
         );
 
         if (!it.Next()) {
@@ -173,7 +177,8 @@ bool TPartitionDatabase::ReadFreshBlocks(TVector<TOwningFreshBlock>& blocks)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteMixedBlock(TMixedBlock block)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
@@ -187,8 +192,7 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
             .Key(block.BlockIndex, ReverseCommitId(block.CommitId))
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
-                NIceDb::TUpdate<
-                    TTable::BlobOffsetAndCompactionRangeCount>(
+                NIceDb::TUpdate<TTable::BlobOffsetAndCompactionRangeCount>(
                     blobOffsetAndCompactionRangeCount));
     } else {
         Table<TTable>()
@@ -196,13 +200,13 @@ void TPartitionDatabase::WriteMixedBlock(TMixedBlock block)
             .Update(
                 NIceDb::TUpdate<TTable::BlobCommitId>(block.BlobId.CommitId()),
                 NIceDb::TUpdate<TTable::BlobId>(block.BlobId.UniqueId()),
-                NIceDb::TUpdate<
-                    TTable::BlobOffsetAndCompactionRangeCount>(
+                NIceDb::TUpdate<TTable::BlobOffsetAndCompactionRangeCount>(
                     blobOffsetAndCompactionRangeCount));
     }
 }
 
-void TPartitionDatabase::WriteMixedBlocks(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteMixedBlocks(
     const TPartialBlobId& blobId,
     const TVector<ui32>& blocks,
     ui8 compactionRangeCount)
@@ -220,23 +224,24 @@ void TPartitionDatabase::WriteMixedBlocks(
             .Key(blockIndex, ReverseCommitId(blobId.CommitId()))
             .Update(
                 NIceDb::TUpdate<TTable::BlobId>(blobId.UniqueId()),
-                NIceDb::TUpdate<
-                    TTable::BlobOffsetAndCompactionRangeCount>(
+                NIceDb::TUpdate<TTable::BlobOffsetAndCompactionRangeCount>(
                     blobOffsetAndCompactionRangeCount));
         ++blobOffset;
     }
 }
 
-void TPartitionDatabase::DeleteMixedBlock(ui32 blockIndex, ui64 commitId)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteMixedBlock(
+    ui32 blockIndex,
+    ui64 commitId)
 {
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
-    Table<TTable>()
-        .Key(blockIndex, ReverseCommitId(commitId))
-        .Delete();
+    Table<TTable>().Key(blockIndex, ReverseCommitId(commitId)).Delete();
 }
 
-bool TPartitionDatabase::FindMixedBlocks(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindMixedBlocks(
     IMixedBlocksIndexVisitor& visitor,
     const TBlockRange32& readRange,
     bool precharge,
@@ -245,8 +250,8 @@ bool TPartitionDatabase::FindMixedBlocks(
     using TTable = TPartitionSchema::MixedBlocksIndex;
 
     auto query = Table<TTable>()
-        .GreaterOrEqual(readRange.Start)
-        .LessOrEqual(readRange.End);
+                     .GreaterOrEqual(readRange.Start)
+                     .LessOrEqual(readRange.End);
 
     if (precharge && !query.Precharge()) {
         return false;
@@ -261,21 +266,22 @@ bool TPartitionDatabase::FindMixedBlocks(
     }
 
     while (it.IsValid()) {
-        ui32 blockIndex = it.GetValue<TTable::BlockIndex>();
+        ui32 blockIndex = it.template GetValue<TTable::BlockIndex>();
         Y_DEBUG_ABORT_UNLESS(blockIndex >= readRange.Start);
 
         if (blockIndex > readRange.End) {
-            break;  // out of range
+            break;   // out of range
         }
 
-        ui64 commitId = ReverseCommitId(it.GetValue<TTable::CommitId>());
+        ui64 commitId =
+            ReverseCommitId(it.template GetValue<TTable::CommitId>());
         if (commitId <= maxCommitId) {
-            ui64 blobCommitId = it.GetValue<TTable::BlobCommitId>();
+            ui64 blobCommitId = it.template GetValue<TTable::BlobCommitId>();
             auto blobId = MakePartialBlobId(
                 blobCommitId ? blobCommitId : commitId,
-                it.GetValue<TTable::BlobId>());
+                it.template GetValue<TTable::BlobId>());
 
-            ui32 blobOffsetAndCompactionRangeCount = it.GetValue<
+            ui32 blobOffsetAndCompactionRangeCount = it.template GetValue<
                 TTable::BlobOffsetAndCompactionRangeCount>();
             auto [blobOffset, compactionRangeCount] =
                 SplitBlobOffsetAndCompactionRangeCount(
@@ -302,7 +308,8 @@ bool TPartitionDatabase::FindMixedBlocks(
     return true;
 }
 
-bool TPartitionDatabase::FindMixedBlocks(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindMixedBlocks(
     IMixedBlocksIndexVisitor& visitor,
     const TVector<ui32>& blocks,
     ui64 maxCommitId)
@@ -316,9 +323,9 @@ bool TPartitionDatabase::FindMixedBlocks(
     size_t i = 0;
     for (const auto& readRange: ranges) {
         auto it = Table<TTable>()
-            .GreaterOrEqual(readRange.Start)
-            .LessOrEqual(readRange.End)
-            .Select();
+                      .GreaterOrEqual(readRange.Start)
+                      .LessOrEqual(readRange.End)
+                      .Select();
 
         if (!it.IsReady()) {
             ready = false;
@@ -326,7 +333,7 @@ bool TPartitionDatabase::FindMixedBlocks(
         }
 
         while (it.IsValid()) {
-            ui32 blockIndex = it.GetValue<TTable::BlockIndex>();
+            ui32 blockIndex = it.template GetValue<TTable::BlockIndex>();
             while (blocks[i] < blockIndex) {
                 // skip blocks
                 ++i;
@@ -334,17 +341,18 @@ bool TPartitionDatabase::FindMixedBlocks(
 
             Y_DEBUG_ABORT_UNLESS(blockIndex <= blocks[i]);
             if (blockIndex == blocks[i]) {
-                ui64 commitId = ReverseCommitId(it.GetValue<TTable::CommitId>());
+                ui64 commitId =
+                    ReverseCommitId(it.template GetValue<TTable::CommitId>());
                 if (commitId <= maxCommitId) {
-                    ui64 blobCommitId = it.GetValue<TTable::BlobCommitId>();
+                    ui64 blobCommitId =
+                        it.template GetValue<TTable::BlobCommitId>();
                     auto blobId = MakePartialBlobId(
                         blobCommitId ? blobCommitId : commitId,
-                        it.GetValue<TTable::BlobId>());
+                        it.template GetValue<TTable::BlobId>());
 
                     ui32 blobOffsetAndCompactionRangeCount =
-                        it.GetValue<
-                            TTable::
-                                BlobOffsetAndCompactionRangeCount>();
+                        it.template GetValue<
+                            TTable::BlobOffsetAndCompactionRangeCount>();
                     auto [blobOffset, compactionRangeCount] =
                         SplitBlobOffsetAndCompactionRangeCount(
                             blobOffsetAndCompactionRangeCount);
@@ -356,7 +364,7 @@ bool TPartitionDatabase::FindMixedBlocks(
                             blobOffset,
                             compactionRangeCount))
                     {
-                        return true;    // interrupted
+                        return true;   // interrupted
                     }
                 }
             }
@@ -375,8 +383,8 @@ bool TPartitionDatabase::FindMixedBlocks(
     if (!ready) {
         for (const auto& readRange: ranges) {
             auto query = Table<TTable>()
-                .GreaterOrEqual(readRange.Start)
-                .LessOrEqual(readRange.End);
+                             .GreaterOrEqual(readRange.Start)
+                             .LessOrEqual(readRange.End);
 
             query.Precharge();
         }
@@ -385,7 +393,8 @@ bool TPartitionDatabase::FindMixedBlocks(
     return ready;
 }
 
-bool TPartitionDatabase::FindMixedBlocks(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindMixedBlocks(
     IMixedBlocksIndexVisitor& visitor,
     const TVector<TBlock>& blocks)
 {
@@ -393,7 +402,8 @@ bool TPartitionDatabase::FindMixedBlocks(
 
     bool ready = true;
     for (const auto& [blockIndex, commitId, _]: blocks) {
-        auto query = Table<TTable>().Key(blockIndex, ReverseCommitId(commitId));
+        auto query =
+            TNiceDb::Table<TTable>().Key(blockIndex, ReverseCommitId(commitId));
 
         auto it = query.Select();
 
@@ -407,13 +417,13 @@ bool TPartitionDatabase::FindMixedBlocks(
             continue;
         }
 
-        ui64 blobCommitId = it.GetValue<TTable::BlobCommitId>();
+        ui64 blobCommitId = it.template GetValue<TTable::BlobCommitId>();
         auto blobId = MakePartialBlobId(
             blobCommitId ? blobCommitId : commitId,
-            it.GetValue<TTable::BlobId>());
+            it.template GetValue<TTable::BlobId>());
 
         ui32 blobOffsetAndCompactionRangeCount =
-            it.GetValue<TTable::BlobOffsetAndCompactionRangeCount>();
+            it.template GetValue<TTable::BlobOffsetAndCompactionRangeCount>();
         auto [blobOffset, compactionRangeCount] =
             SplitBlobOffsetAndCompactionRangeCount(
                 blobOffsetAndCompactionRangeCount);
@@ -434,15 +444,16 @@ bool TPartitionDatabase::FindMixedBlocks(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteMergedBlocks(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteMergedBlocks(
     const TPartialBlobId& blobId,
     const TBlockRange32& blockRange,
     const TBlockMask& skipMask)
 {
     using TTable = TPartitionSchema::MergedBlocksIndex;
 
-    auto value = Table<TTable>()
-        .Key(blockRange.End, ReverseCommitId(blobId.CommitId()));
+    auto value =
+        Table<TTable>().Key(blockRange.End, ReverseCommitId(blobId.CommitId()));
 
     value.Update(
         NIceDb::TUpdate<TTable::RangeStart>(blockRange.Start),
@@ -454,7 +465,8 @@ void TPartitionDatabase::WriteMergedBlocks(
     }
 }
 
-void TPartitionDatabase::DeleteMergedBlocks(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteMergedBlocks(
     const TPartialBlobId& blobId,
     const TBlockRange32& blockRange)
 {
@@ -465,7 +477,8 @@ void TPartitionDatabase::DeleteMergedBlocks(
         .Delete();
 }
 
-bool TPartitionDatabase::FindMergedBlocks(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindMergedBlocks(
     IBlocksIndexVisitor& visitor,
     IBlobsVisitor& blobsVisitor,
     const TBlockRange32& readRange,
@@ -476,8 +489,8 @@ bool TPartitionDatabase::FindMergedBlocks(
     using TTable = TPartitionSchema::MergedBlocksIndex;
 
     auto query = Table<TTable>()
-        .GreaterOrEqual(readRange.Start)
-        .LessOrEqual(SafeAdd(readRange.End, maxBlocksInBlob));
+                     .GreaterOrEqual(readRange.Start)
+                     .LessOrEqual(SafeAdd(readRange.End, maxBlocksInBlob));
 
     if (precharge && !query.Precharge()) {
         return false;
@@ -493,14 +506,14 @@ bool TPartitionDatabase::FindMergedBlocks(
 
     while (it.IsValid()) {
         auto range = TBlockRange32::MakeClosedInterval(
-            it.GetValue<TTable::RangeStart>(),
-            it.GetValue<TTable::RangeEnd>());
+            it.template GetValue<TTable::RangeStart>(),
+            it.template GetValue<TTable::RangeEnd>());
 
         Y_DEBUG_ABORT_UNLESS(range.End >= readRange.Start);
         Y_DEBUG_ABORT_UNLESS(range.Size() <= maxBlocksInBlob);
 
         if (SafeDistance(readRange.End, range.End) > maxBlocksInBlob) {
-            break;  // out of range
+            break;   // out of range
         }
 
         ui32 start = Max(range.Start, readRange.Start);
@@ -508,24 +521,27 @@ bool TPartitionDatabase::FindMergedBlocks(
 
         // if there is no intersection - just skip range
         if (start <= end) {
-            ui64 commitId = ReverseCommitId(it.GetValue<TTable::CommitId>());
+            ui64 commitId =
+                ReverseCommitId(it.template GetValue<TTable::CommitId>());
             if (commitId <= maxCommitId) {
                 auto blobId = MakePartialBlobId(
                     commitId,
-                    it.GetValue<TTable::BlobId>());
+                    it.template GetValue<TTable::BlobId>());
 
                 const auto holeMask = BlockMaskFromString(
-                    it.GetValueOrDefault<TTable::HoleMask>());
+                    it.template GetValueOrDefault<TTable::HoleMask>());
 
                 const auto skipMask = BlockMaskFromString(
-                    it.GetValueOrDefault<TTable::SkipMask>());
+                    it.template GetValueOrDefault<TTable::SkipMask>());
 
                 if (!blobsVisitor.Visit(range, blobId, skipMask.Count())) {
                     return true;   // interrupted
                 }
 
                 ui32 skipped = 0;
-                for (ui32 blockIndex = range.Start; blockIndex < start; ++blockIndex) {
+                for (ui32 blockIndex = range.Start; blockIndex < start;
+                     ++blockIndex)
+                {
                     ui16 pos = blockIndex - range.Start;
                     skipped += skipMask.Get(pos);
                 }
@@ -544,8 +560,10 @@ bool TPartitionDatabase::FindMergedBlocks(
                         continue;
                     }
 
-                    if (!visitor.Visit(blockIndex, commitId, blobId, blobOffset)) {
-                        return true;    // interrupted
+                    if (!visitor
+                             .Visit(blockIndex, commitId, blobId, blobOffset))
+                    {
+                        return true;   // interrupted
                     }
                 }
             }
@@ -561,7 +579,8 @@ bool TPartitionDatabase::FindMergedBlocks(
     return true;
 }
 
-bool TPartitionDatabase::FindMergedBlocks(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindMergedBlocks(
     IBlocksIndexVisitor& visitor,
     const TBlockRange32& readRange,
     bool precharge,
@@ -593,7 +612,8 @@ bool TPartitionDatabase::FindMergedBlocks(
         maxCommitId);
 }
 
-bool TPartitionDatabase::FindMergedBlocks(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindMergedBlocks(
     IBlocksIndexVisitor& visitor,
     const TVector<ui32>& blocks,
     ui32 maxBlocksInBlob,
@@ -607,9 +627,9 @@ bool TPartitionDatabase::FindMergedBlocks(
     // read ranges
     for (const auto& readRange: ranges) {
         auto it = Table<TTable>()
-            .GreaterOrEqual(readRange.Start)
-            .LessOrEqual(SafeAdd(readRange.End, maxBlocksInBlob))
-            .Select();
+                      .GreaterOrEqual(readRange.Start)
+                      .LessOrEqual(SafeAdd(readRange.End, maxBlocksInBlob))
+                      .Select();
 
         if (!it.IsReady()) {
             ready = false;
@@ -618,8 +638,8 @@ bool TPartitionDatabase::FindMergedBlocks(
 
         while (it.IsValid()) {
             auto range = TBlockRange32::MakeClosedInterval(
-                it.GetValue<TTable::RangeStart>(),
-                it.GetValue<TTable::RangeEnd>());
+                it.template GetValue<TTable::RangeStart>(),
+                it.template GetValue<TTable::RangeEnd>());
 
             Y_DEBUG_ABORT_UNLESS(range.End >= readRange.Start);
             Y_DEBUG_ABORT_UNLESS(range.Size() <= maxBlocksInBlob);
@@ -629,20 +649,23 @@ bool TPartitionDatabase::FindMergedBlocks(
 
             // if there is no intersection - just skip range
             if (start != end) {
-                ui64 commitId = ReverseCommitId(it.GetValue<TTable::CommitId>());
+                ui64 commitId =
+                    ReverseCommitId(it.template GetValue<TTable::CommitId>());
                 if (commitId <= maxCommitId) {
                     auto blobId = MakePartialBlobId(
                         commitId,
-                        it.GetValue<TTable::BlobId>());
+                        it.template GetValue<TTable::BlobId>());
 
                     const auto holeMask = BlockMaskFromString(
-                        it.GetValueOrDefault<TTable::HoleMask>());
+                        it.template GetValueOrDefault<TTable::HoleMask>());
 
                     const auto skipMask = BlockMaskFromString(
-                        it.GetValueOrDefault<TTable::SkipMask>());
+                        it.template GetValueOrDefault<TTable::SkipMask>());
 
                     ui32 skipped = 0;
-                    for (ui32 blockIndex = range.Start; blockIndex < *start; ++blockIndex) {
+                    for (ui32 blockIndex = range.Start; blockIndex < *start;
+                         ++blockIndex)
+                    {
                         ui16 pos = blockIndex - range.Start;
                         skipped += skipMask.Get(pos);
                     }
@@ -662,7 +685,7 @@ bool TPartitionDatabase::FindMergedBlocks(
                         }
 
                         if (!visitor.Visit(*it, commitId, blobId, blobOffset)) {
-                            return true;    // interrupted
+                            return true;   // interrupted
                         }
                     }
                 }
@@ -681,9 +704,10 @@ bool TPartitionDatabase::FindMergedBlocks(
 
     if (!ready) {
         for (const auto& readRange: ranges) {
-            auto query = Table<TTable>()
-                .GreaterOrEqual(readRange.Start)
-                .LessOrEqual(SafeAdd(readRange.End, maxBlocksInBlob));
+            auto query =
+                Table<TTable>()
+                    .GreaterOrEqual(readRange.Start)
+                    .LessOrEqual(SafeAdd(readRange.End, maxBlocksInBlob));
 
             query.Precharge();
         }
@@ -694,7 +718,8 @@ bool TPartitionDatabase::FindMergedBlocks(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteBlobMeta(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteBlobMeta(
     const TPartialBlobId& blobId,
     const NProto::TBlobMeta& blobMeta)
 {
@@ -702,48 +727,47 @@ void TPartitionDatabase::WriteBlobMeta(
 
     Table<TTable>()
         .Key(blobId.CommitId(), blobId.UniqueId())
-        .Update<TTable::BlobMeta>(blobMeta);
+        .template Update<TTable::BlobMeta>(blobMeta);
 }
 
-void TPartitionDatabase::DeleteBlobMeta(const TPartialBlobId& blobId)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteBlobMeta(const TPartialBlobId& blobId)
 {
     using TTable = TPartitionSchema::BlobsIndex;
 
-    Table<TTable>()
-        .Key(blobId.CommitId(), blobId.UniqueId())
-        .Delete();
+    Table<TTable>().Key(blobId.CommitId(), blobId.UniqueId()).Delete();
 }
 
-bool TPartitionDatabase::ReadBlobMeta(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadBlobMeta(
     const TPartialBlobId& blobId,
     TMaybe<NProto::TBlobMeta>& meta)
 {
     COUNT_METHOD_CALL;
     using TTable = TPartitionSchema::BlobsIndex;
 
-    auto it = Table<TTable>()
-        .Key(blobId.CommitId(), blobId.UniqueId())
-        .Select();
+    auto it =
+        Table<TTable>().Key(blobId.CommitId(), blobId.UniqueId()).Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
     }
 
     if (it.IsValid()) {
-        meta = it.GetValue<TTable::BlobMeta>();
+        meta = it.template GetValue<TTable::BlobMeta>();
     }
 
     return true;
 }
 
-bool TPartitionDatabase::ReadNewBlobs(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadNewBlobs(
     TVector<TPartialBlobId>& blobIds,
     ui64 minCommitId)
 {
     using TTable = TPartitionSchema::BlobsIndex;
 
-    auto query = Table<TTable>()
-        .GreaterOrEqual(minCommitId);
+    auto query = Table<TTable>().GreaterOrEqual(minCommitId);
 
     if (!query.Precharge()) {
         return false;
@@ -758,8 +782,8 @@ bool TPartitionDatabase::ReadNewBlobs(
 
     while (it.IsValid()) {
         auto blobId = MakePartialBlobId(
-            it.GetValue<TTable::CommitId>(),
-            it.GetValue<TTable::BlobId>());
+            it.template GetValue<TTable::CommitId>(),
+            it.template GetValue<TTable::BlobId>());
 
         // we are not interested in deletion markers here
         if (!IsDeletionMarker(blobId)) {
@@ -775,7 +799,8 @@ bool TPartitionDatabase::ReadNewBlobs(
     return true;
 }
 
-void TPartitionDatabase::WriteBlockMask(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteBlockMask(
     const TPartialBlobId& blobId,
     const TBlockMask& blockMask)
 {
@@ -787,7 +812,8 @@ void TPartitionDatabase::WriteBlockMask(
             NIceDb::TUpdate<TTable::BlockMask>(BlockMaskAsString(blockMask)));
 }
 
-bool TPartitionDatabase::ReadBlockMask(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadBlockMask(
     const TPartialBlobId& blobId,
     TMaybe<TBlockMask>& blockMask)
 {
@@ -795,8 +821,8 @@ bool TPartitionDatabase::ReadBlockMask(
     using TTable = TPartitionSchema::BlobsIndex;
 
     auto it = Table<TTable>()
-        .Key(blobId.CommitId(), blobId.UniqueId())
-        .Select<TTable::BlockMask>();
+                  .Key(blobId.CommitId(), blobId.UniqueId())
+                  .template Select<TTable::BlockMask>();
 
     if (!it.IsReady()) {
         return false;   // not ready
@@ -804,13 +830,14 @@ bool TPartitionDatabase::ReadBlockMask(
 
     if (it.IsValid()) {
         blockMask = BlockMaskFromString(
-            it.GetValueOrDefault<TTable::BlockMask>());
+            it.template GetValueOrDefault<TTable::BlockMask>());
     }
 
     return true;
 }
 
-bool TPartitionDatabase::ReadBlobInfo(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadBlobInfo(
     const TPartialBlobId& blobId,
     TMaybe<TBlockMask>& blockMask,
     TMaybe<NProto::TBlobMeta>& blobMeta)
@@ -829,8 +856,9 @@ bool TPartitionDatabase::ReadBlobInfo(
         return true;
     }
 
-    blockMask = BlockMaskFromString(it.GetValueOrDefault<TTable::BlockMask>());
-    blobMeta = it.GetValue<TTable::BlobMeta>();
+    blockMask =
+        BlockMaskFromString(it.template GetValueOrDefault<TTable::BlockMask>());
+    blobMeta = it.template GetValue<TTable::BlobMeta>();
 
     return true;
 }
@@ -842,8 +870,9 @@ enum class EIndexProcResult
     Interrupted,
 };
 
+template <typename TCounters>
 static EIndexProcResult FindBlocksInBlobIndex(
-    TPartitionDatabase& db,
+    TPartitionDatabaseImpl<TCounters>& db,
     IExtendedBlocksIndexVisitor& visitor,
     const ui32 maxBlocksInBlob,
     const TPartialBlobId& blobId,
@@ -851,15 +880,13 @@ static EIndexProcResult FindBlocksInBlobIndex(
     const TBlockMask& blockMask,
     const TBlockRange32& blockRange)
 {
-    auto visit = [&] (
-        ui32 blockIndex,
-        ui64 commitId,
-        const TPartialBlobId& blobId,
-        ui16 blobOffset)
+    auto visit = [&](ui32 blockIndex,
+                     ui64 commitId,
+                     const TPartialBlobId& blobId,
+                     ui16 blobOffset)
     {
-        ui16 maskedBlobOffset = blockMask.Get(blobOffset)
-            ? InvalidBlobOffset
-            : blobOffset;
+        ui16 maskedBlobOffset =
+            blockMask.Get(blobOffset) ? InvalidBlobOffset : blobOffset;
 
         return visitor.Visit(
             blockIndex,
@@ -889,7 +916,8 @@ static EIndexProcResult FindBlocksInBlobIndex(
             }
         } else {
             // each block has its own commitId
-            Y_ABORT_UNLESS(mixedBlocks.BlocksSize() == mixedBlocks.CommitIdsSize());
+            Y_ABORT_UNLESS(
+                mixedBlocks.BlocksSize() == mixedBlocks.CommitIdsSize());
 
             ui16 blobOffset = 0;
             for (size_t i = 0; i < mixedBlocks.BlocksSize(); ++i) {
@@ -903,7 +931,6 @@ static EIndexProcResult FindBlocksInBlobIndex(
                 }
                 ++blobOffset;
             }
-
         }
     } else if (blobMeta.HasMergedBlocks()) {
         const auto& mergedBlocks = blobMeta.GetMergedBlocks();
@@ -921,8 +948,7 @@ static EIndexProcResult FindBlocksInBlobIndex(
             ui16 BlobOffset = InvalidBlobOffset;
         };
 
-        struct TVisitor final
-            : public IBlocksIndexVisitor
+        struct TVisitor final: public IBlocksIndexVisitor
         {
             TBlockRange32 Intersection;
             TPartialBlobId BlobId;
@@ -933,8 +959,7 @@ static EIndexProcResult FindBlocksInBlobIndex(
                 : Intersection(intersection)
                 , BlobId(blobId)
                 , Marks(intersection.Size())
-            {
-            }
+            {}
 
             bool Visit(
                 ui32 blockIndex,
@@ -982,16 +1007,15 @@ static EIndexProcResult FindBlocksInBlobIndex(
     return EIndexProcResult::Ok;
 }
 
-bool TPartitionDatabase::FindBlocksInBlobsIndex(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindBlocksInBlobsIndex(
     IExtendedBlocksIndexVisitor& visitor,
     const ui32 maxBlocksInBlob,
     const TBlockRange32& blockRange)
 {
     using TTable = TPartitionSchema::BlobsIndex;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
@@ -999,13 +1023,13 @@ bool TPartitionDatabase::FindBlocksInBlobsIndex(
 
     while (it.IsValid()) {
         auto blobId = MakePartialBlobId(
-            it.GetValue<TTable::CommitId>(),
-            it.GetValue<TTable::BlobId>());
+            it.template GetValue<TTable::CommitId>(),
+            it.template GetValue<TTable::BlobId>());
 
-        auto blobMeta = it.GetValue<TTable::BlobMeta>();
+        auto blobMeta = it.template GetValue<TTable::BlobMeta>();
 
         auto blockMask = BlockMaskFromString(
-            it.GetValueOrDefault<TTable::BlockMask>());
+            it.template GetValueOrDefault<TTable::BlockMask>());
 
         const auto res = FindBlocksInBlobIndex(
             *this,
@@ -1017,9 +1041,12 @@ bool TPartitionDatabase::FindBlocksInBlobsIndex(
             blockRange);
 
         switch (res) {
-            case EIndexProcResult::Ok: break;
-            case EIndexProcResult::NotReady: return false;
-            case EIndexProcResult::Interrupted: return true;
+            case EIndexProcResult::Ok:
+                break;
+            case EIndexProcResult::NotReady:
+                return false;
+            case EIndexProcResult::Interrupted:
+                return true;
         }
 
         if (!it.Next()) {
@@ -1030,26 +1057,26 @@ bool TPartitionDatabase::FindBlocksInBlobsIndex(
     return true;
 }
 
-bool TPartitionDatabase::FindBlocksInBlobsIndex(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::FindBlocksInBlobsIndex(
     IExtendedBlocksIndexVisitor& visitor,
     const ui32 maxBlocksInBlob,
     const TPartialBlobId& blobId)
 {
     using TTable = TPartitionSchema::BlobsIndex;
 
-    auto it = Table<TTable>()
-        .Key(blobId.CommitId(), blobId.UniqueId())
-        .Select();
+    auto it =
+        Table<TTable>().Key(blobId.CommitId(), blobId.UniqueId()).Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
     }
 
     if (it.IsValid()) {
-        auto blobMeta = it.GetValue<TTable::BlobMeta>();
+        auto blobMeta = it.template GetValue<TTable::BlobMeta>();
 
         auto blockMask = BlockMaskFromString(
-            it.GetValueOrDefault<TTable::BlockMask>());
+            it.template GetValueOrDefault<TTable::BlockMask>());
 
         const auto res = FindBlocksInBlobIndex(
             *this,
@@ -1061,16 +1088,21 @@ bool TPartitionDatabase::FindBlocksInBlobsIndex(
             TBlockRange32::Max());
 
         switch (res) {
-            case EIndexProcResult::Ok: break;
-            case EIndexProcResult::NotReady: return false;
-            case EIndexProcResult::Interrupted: return true;
+            case EIndexProcResult::Ok:
+                break;
+            case EIndexProcResult::NotReady:
+                return false;
+            case EIndexProcResult::Interrupted:
+                return true;
         }
     }
 
     return true;
 }
 
-TPartitionDatabase::EBlobIndexScanProgress TPartitionDatabase::FindBlocksInBlobsIndex(
+template <typename TCounters>
+typename TPartitionDatabaseImpl<TCounters>::EBlobIndexScanProgress
+TPartitionDatabaseImpl<TCounters>::FindBlocksInBlobsIndex(
     IBlobsIndexVisitor& visitor,
     TPartialBlobId startBlobId,
     TPartialBlobId finalBlobId,
@@ -1079,8 +1111,8 @@ TPartitionDatabase::EBlobIndexScanProgress TPartitionDatabase::FindBlocksInBlobs
     using TTable = TPartitionSchema::BlobsIndex;
 
     auto q = Table<TTable>()
-        .GreaterOrEqual(startBlobId.CommitId(), startBlobId.UniqueId())
-        .LessOrEqual(finalBlobId.CommitId(), finalBlobId.UniqueId());
+                 .GreaterOrEqual(startBlobId.CommitId(), startBlobId.UniqueId())
+                 .LessOrEqual(finalBlobId.CommitId(), finalBlobId.UniqueId());
 
     if (!q.Precharge(prechargeRowCount)) {
         return EBlobIndexScanProgress::NotReady;
@@ -1096,16 +1128,15 @@ TPartitionDatabase::EBlobIndexScanProgress TPartitionDatabase::FindBlocksInBlobs
     auto result = EBlobIndexScanProgress::Completed;
 
     while (it.IsValid()) {
-        auto commitId = it.GetValue<TTable::CommitId>();
-        auto uniqId = it.GetValue<TTable::BlobId>();
+        auto commitId = it.template GetValue<TTable::CommitId>();
+        auto uniqId = it.template GetValue<TTable::BlobId>();
 
-        auto blobMeta = it.GetValue<TTable::BlobMeta>();
+        auto blobMeta = it.template GetValue<TTable::BlobMeta>();
 
-        auto blockMask =
-            it.GetValueOrDefault<TTable::BlockMask>();
+        auto blockMask = it.template GetValueOrDefault<TTable::BlockMask>();
 
         if (!visitor.Visit(commitId, uniqId, blobMeta, blockMask)) {
-            break ; // interrupted
+            break;   // interrupted
         }
 
         if (!it.Next()) {
@@ -1120,7 +1151,8 @@ TPartitionDatabase::EBlobIndexScanProgress TPartitionDatabase::FindBlocksInBlobs
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteCompactionMap(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteCompactionMap(
     ui32 blockIndex,
     ui32 blobCount,
     ui32 blockCount)
@@ -1133,16 +1165,16 @@ void TPartitionDatabase::WriteCompactionMap(
         .Update(NIceDb::TUpdate<TTable::BlockCount>(blockCount));
 }
 
-void TPartitionDatabase::DeleteCompactionMap(ui32 blockIndex)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteCompactionMap(ui32 blockIndex)
 {
     using TTable = TPartitionSchema::CompactionMap;
 
-    Table<TTable>()
-        .Key(blockIndex)
-        .Delete();
+    Table<TTable>().Key(blockIndex).Delete();
 }
 
-bool TPartitionDatabase::ReadCompactionMap(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadCompactionMap(
     TVector<TCompactionCounter>& compactionMap)
 {
     using TTable = TPartitionSchema::CompactionMap;
@@ -1155,10 +1187,12 @@ bool TPartitionDatabase::ReadCompactionMap(
 
     while (it.IsValid()) {
         compactionMap.emplace_back(
-            it.GetValue<TTable::BlockIndex>(),
+            it.template GetValue<TTable::BlockIndex>(),
             TRangeStat{
-                ProcessCompactionCounter(it.GetValue<TTable::BlobCount>()),
-                ProcessCompactionCounter(it.GetValue<TTable::BlockCount>()),
+                ProcessCompactionCounter(
+                    it.template GetValue<TTable::BlobCount>()),
+                ProcessCompactionCounter(
+                    it.template GetValue<TTable::BlockCount>()),
                 0,
                 0,
                 0,
@@ -1174,7 +1208,8 @@ bool TPartitionDatabase::ReadCompactionMap(
     return true;
 }
 
-bool TPartitionDatabase::ReadCompactionMap(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadCompactionMap(
     TBlockRange32 rangeBlockIndices,
     TVector<TCompactionCounter>& compactionMap)
 {
@@ -1187,15 +1222,17 @@ bool TPartitionDatabase::ReadCompactionMap(
     }
 
     while (it.IsValid()) {
-        const auto blockIndex = it.GetValue<TTable::BlockIndex>();
+        const auto blockIndex = it.template GetValue<TTable::BlockIndex>();
         if (blockIndex > rangeBlockIndices.End) {
             break;
         }
         compactionMap.emplace_back(
             blockIndex,
             TRangeStat{
-                ProcessCompactionCounter(it.GetValue<TTable::BlobCount>()),
-                ProcessCompactionCounter(it.GetValue<TTable::BlockCount>()),
+                ProcessCompactionCounter(
+                    it.template GetValue<TTable::BlobCount>()),
+                ProcessCompactionCounter(
+                    it.template GetValue<TTable::BlockCount>()),
                 0,
                 0,
                 0,
@@ -1213,7 +1250,8 @@ bool TPartitionDatabase::ReadCompactionMap(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteUsedBlocks(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteUsedBlocks(
     const TCompressedBitmap::TSerializedChunk& chunk)
 {
     using TTable = TPartitionSchema::UsedBlocks;
@@ -1223,30 +1261,31 @@ void TPartitionDatabase::WriteUsedBlocks(
         .Update(NIceDb::TUpdate<TTable::Bitmap>(chunk.Data));
 }
 
-bool TPartitionDatabase::ReadUsedBlocks(TCompressedBitmap& usedBlocks)
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadUsedBlocks(
+    TCompressedBitmap& usedBlocks)
 {
-    return ReadUsedBlocksRaw([&usedBlocks](TCompressedBitmap::TSerializedChunk chunk) {
-        usedBlocks.Update(chunk);
-    });
+    return ReadUsedBlocksRaw(
+        [&usedBlocks](TCompressedBitmap::TSerializedChunk chunk)
+        { usedBlocks.Update(chunk); });
 }
 
-bool TPartitionDatabase::ReadUsedBlocksRaw(std::function<void(TCompressedBitmap::TSerializedChunk)> onChunk)
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadUsedBlocksRaw(
+    std::function<void(TCompressedBitmap::TSerializedChunk)> onChunk)
 {
     using TTable = TPartitionSchema::UsedBlocks;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
     }
 
     while (it.IsValid()) {
-        onChunk({
-            it.GetValue<TTable::RangeIndex>(),
-            it.GetValue<TTable::Bitmap>()
-        });
+        onChunk(
+            {it.template GetValue<TTable::RangeIndex>(),
+             it.template GetValue<TTable::Bitmap>()});
 
         if (!it.Next()) {
             return false;   // not ready
@@ -1258,7 +1297,8 @@ bool TPartitionDatabase::ReadUsedBlocksRaw(std::function<void(TCompressedBitmap:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteLogicalUsedBlocks(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteLogicalUsedBlocks(
     const TCompressedBitmap::TSerializedChunk& chunk)
 {
     using TTable = TPartitionSchema::LogicalUsedBlocks;
@@ -1268,7 +1308,8 @@ void TPartitionDatabase::WriteLogicalUsedBlocks(
         .Update(NIceDb::TUpdate<TTable::Bitmap>(chunk.Data));
 }
 
-bool TPartitionDatabase::ReadLogicalUsedBlocks(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadLogicalUsedBlocks(
     TCompressedBitmap& usedBlocks,
     bool& read)
 {
@@ -1276,9 +1317,7 @@ bool TPartitionDatabase::ReadLogicalUsedBlocks(
 
     read = false;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
@@ -1289,10 +1328,9 @@ bool TPartitionDatabase::ReadLogicalUsedBlocks(
     }
 
     while (it.IsValid()) {
-        usedBlocks.Update({
-            it.GetValue<TTable::RangeIndex>(),
-            it.GetValue<TTable::Bitmap>()
-        });
+        usedBlocks.Update(
+            {it.template GetValue<TTable::RangeIndex>(),
+             it.template GetValue<TTable::Bitmap>()});
 
         if (!it.Next()) {
             return false;   // not ready
@@ -1305,7 +1343,10 @@ bool TPartitionDatabase::ReadLogicalUsedBlocks(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteCheckpoint(const TCheckpoint& checkpoint, bool withoutData)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteCheckpoint(
+    const TCheckpoint& checkpoint,
+    bool withoutData)
 {
     using TTable = TPartitionSchema::Checkpoints;
 
@@ -1314,12 +1355,16 @@ void TPartitionDatabase::WriteCheckpoint(const TCheckpoint& checkpoint, bool wit
         .Update(
             NIceDb::TUpdate<TTable::CommitId>(checkpoint.CommitId),
             NIceDb::TUpdate<TTable::IdempotenceId>(checkpoint.IdempotenceId),
-            NIceDb::TUpdate<TTable::DateCreated>(checkpoint.DateCreated.MicroSeconds()),
+            NIceDb::TUpdate<TTable::DateCreated>(
+                checkpoint.DateCreated.MicroSeconds()),
             NIceDb::TUpdate<TTable::Stats>(checkpoint.Stats),
             NIceDb::TUpdate<TTable::DataDeleted>(withoutData));
 }
 
-void TPartitionDatabase::DeleteCheckpoint(const TString& checkpointId, bool deleteOnlyData)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteCheckpoint(
+    const TString& checkpointId,
+    bool deleteOnlyData)
 {
     using TTable = TPartitionSchema::Checkpoints;
 
@@ -1328,30 +1373,27 @@ void TPartitionDatabase::DeleteCheckpoint(const TString& checkpointId, bool dele
             .Key(checkpointId)
             .Update(NIceDb::TUpdate<TTable::DataDeleted>(true));
     } else {
-        Table<TTable>()
-            .Key(checkpointId)
-            .Delete();
+        Table<TTable>().Key(checkpointId).Delete();
     }
 }
 
-bool TPartitionDatabase::ReadCheckpoints(
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadCheckpoints(
     TVector<TCheckpoint>& checkpoints,
     THashMap<TString, ui64>& checkpointId2CommitId)
 {
     using TTable = TPartitionSchema::Checkpoints;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
     }
 
     while (it.IsValid()) {
-        auto checkpointId = it.GetValue<TTable::CheckpointId>();
-        auto commitId = it.GetValue<TTable::CommitId>();
-        bool isDataDeleted = it.GetValue<TTable::DataDeleted>();
+        auto checkpointId = it.template GetValue<TTable::CheckpointId>();
+        auto commitId = it.template GetValue<TTable::CommitId>();
+        bool isDataDeleted = it.template GetValue<TTable::DataDeleted>();
 
         checkpointId2CommitId.emplace(checkpointId, commitId);
 
@@ -1359,9 +1401,10 @@ bool TPartitionDatabase::ReadCheckpoints(
             checkpoints.emplace_back(
                 checkpointId,
                 commitId,
-                it.GetValue<TTable::IdempotenceId>(),
-                TInstant::MicroSeconds(it.GetValue<TTable::DateCreated>()),
-                it.GetValue<TTable::Stats>());
+                it.template GetValue<TTable::IdempotenceId>(),
+                TInstant::MicroSeconds(
+                    it.template GetValue<TTable::DateCreated>()),
+                it.template GetValue<TTable::Stats>());
         }
 
         if (!it.Next()) {
@@ -1374,7 +1417,8 @@ bool TPartitionDatabase::ReadCheckpoints(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteCleanupQueue(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteCleanupQueue(
     const TPartialBlobId& blobId,
     ui64 commitId)
 {
@@ -1385,7 +1429,8 @@ void TPartitionDatabase::WriteCleanupQueue(
         .Update();
 }
 
-void TPartitionDatabase::DeleteCleanupQueue(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteCleanupQueue(
     const TPartialBlobId& blobId,
     ui64 commitId)
 {
@@ -1396,24 +1441,24 @@ void TPartitionDatabase::DeleteCleanupQueue(
         .Delete();
 }
 
-bool TPartitionDatabase::ReadCleanupQueue(TVector<TCleanupQueueItem>& items)
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadCleanupQueue(
+    TVector<TCleanupQueueItem>& items)
 {
     using TTable = TPartitionSchema::CleanupQueue;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
     }
 
     while (it.IsValid()) {
-        ui64 commitId = it.GetValue<TTable::DeletionCommitId>();
+        ui64 commitId = it.template GetValue<TTable::DeletionCommitId>();
 
         auto blobId = MakePartialBlobId(
-            it.GetValue<TTable::CommitId>(),
-            it.GetValue<TTable::BlobId>());
+            it.template GetValue<TTable::CommitId>(),
+            it.template GetValue<TTable::BlobId>());
 
         items.emplace_back(blobId, commitId);
 
@@ -1427,31 +1472,31 @@ bool TPartitionDatabase::ReadCleanupQueue(TVector<TCleanupQueueItem>& items)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteGarbageBlob(const TPartialBlobId& blobId)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteGarbageBlob(
+    const TPartialBlobId& blobId)
 {
     using TTable = TPartitionSchema::GarbageBlobs;
 
-    Table<TTable>()
-        .Key(blobId.CommitId(), blobId.UniqueId())
-        .Update();
+    Table<TTable>().Key(blobId.CommitId(), blobId.UniqueId()).Update();
 }
 
-void TPartitionDatabase::DeleteGarbageBlob(const TPartialBlobId& blobId)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteGarbageBlob(
+    const TPartialBlobId& blobId)
 {
     using TTable = TPartitionSchema::GarbageBlobs;
 
-    Table<TTable>()
-        .Key(blobId.CommitId(), blobId.UniqueId())
-        .Delete();
+    Table<TTable>().Key(blobId.CommitId(), blobId.UniqueId()).Delete();
 }
 
-bool TPartitionDatabase::ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds)
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadGarbageBlobs(
+    TVector<TPartialBlobId>& blobIds)
 {
     using TTable = TPartitionSchema::GarbageBlobs;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
@@ -1459,8 +1504,8 @@ bool TPartitionDatabase::ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds)
 
     while (it.IsValid()) {
         auto blobId = MakePartialBlobId(
-            it.GetValue<TTable::CommitId>(),
-            it.GetValue<TTable::BlobId>());
+            it.template GetValue<TTable::CommitId>(),
+            it.template GetValue<TTable::BlobId>());
 
         blobIds.push_back(blobId);
 
@@ -1474,7 +1519,8 @@ bool TPartitionDatabase::ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TPartitionDatabase::WriteUnconfirmedBlob(
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::WriteUnconfirmedBlob(
     const TPartialBlobId& blobId,
     const TBlobToConfirm& blob)
 {
@@ -1485,37 +1531,36 @@ void TPartitionDatabase::WriteUnconfirmedBlob(
         .Key(blobId.CommitId(), blobId.UniqueId())
         .Update(
             NIceDb::TUpdate<TTable::RangeStart>(blob.BlockRange.Start),
-            NIceDb::TUpdate<TTable::RangeEnd>(blob.BlockRange.End)
-        );
+            NIceDb::TUpdate<TTable::RangeEnd>(blob.BlockRange.End));
 }
 
-void TPartitionDatabase::DeleteUnconfirmedBlob(const TPartialBlobId& blobId)
+template <typename TCounters>
+void TPartitionDatabaseImpl<TCounters>::DeleteUnconfirmedBlob(
+    const TPartialBlobId& blobId)
 {
     using TTable = TPartitionSchema::UnconfirmedBlobs;
 
-    Table<TTable>()
-        .Key(blobId.CommitId(), blobId.UniqueId())
-        .Delete();
+    Table<TTable>().Key(blobId.CommitId(), blobId.UniqueId()).Delete();
 }
 
-bool TPartitionDatabase::ReadUnconfirmedBlobs(TCommitIdToBlobsToConfirm& blobs)
+template <typename TCounters>
+bool TPartitionDatabaseImpl<TCounters>::ReadUnconfirmedBlobs(
+    TCommitIdToBlobsToConfirm& blobs)
 {
     using TTable = TPartitionSchema::UnconfirmedBlobs;
 
-    auto it = Table<TTable>()
-        .Range()
-        .Select();
+    auto it = Table<TTable>().Range().Select();
 
     if (!it.IsReady()) {
         return false;   // not ready
     }
 
     while (it.IsValid()) {
-        auto commitId = it.GetValue<TTable::CommitId>();
-        auto uniqueId = it.GetValue<TTable::BlobId>();
+        auto commitId = it.template GetValue<TTable::CommitId>();
+        auto uniqueId = it.template GetValue<TTable::BlobId>();
         auto blockRange = TBlockRange32::MakeClosedInterval(
-            it.GetValue<TTable::RangeStart>(),
-            it.GetValue<TTable::RangeEnd>());
+            it.template GetValue<TTable::RangeStart>(),
+            it.template GetValue<TTable::RangeEnd>());
 
         blobs[commitId].emplace_back(
             uniqueId,
@@ -1530,5 +1575,10 @@ bool TPartitionDatabase::ReadUnconfirmedBlobs(TCommitIdToBlobsToConfirm& blobs)
 
     return true;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+template class TPartitionDatabase;
+template class TPartitionDatabase<TMethodCallCounter>;
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_database.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_database.cpp
@@ -74,6 +74,8 @@ std::pair<ui16, ui8> SplitBlobOffsetAndCompactionRangeCount(
     return {value & Max<ui16>(), value >> 16};
 }
 
+#define COUNT_METHOD_CALL IncrementMethodCallCount(__PRETTY_FUNCTION__);
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -716,7 +718,7 @@ bool TPartitionDatabase::ReadBlobMeta(
     const TPartialBlobId& blobId,
     TMaybe<NProto::TBlobMeta>& meta)
 {
-    IncrementMethodCallCount(__PRETTY_FUNCTION__);
+    COUNT_METHOD_CALL;
     using TTable = TPartitionSchema::BlobsIndex;
 
     auto it = Table<TTable>()
@@ -789,7 +791,7 @@ bool TPartitionDatabase::ReadBlockMask(
     const TPartialBlobId& blobId,
     TMaybe<TBlockMask>& blockMask)
 {
-    IncrementMethodCallCount(__PRETTY_FUNCTION__);
+    COUNT_METHOD_CALL;
     using TTable = TPartitionSchema::BlobsIndex;
 
     auto it = Table<TTable>()
@@ -813,7 +815,7 @@ bool TPartitionDatabase::ReadBlobInfo(
     TMaybe<TBlockMask>& blockMask,
     TMaybe<NProto::TBlobMeta>& blobMeta)
 {
-    IncrementMethodCallCount(__PRETTY_FUNCTION__);
+    COUNT_METHOD_CALL;
     using TTable = TPartitionSchema::BlobsIndex;
 
     auto it =

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -36,6 +36,13 @@ public:
         Partial
     };
 
+    THashMap<TString, ui64> MethodCallCounts;
+
+    void IncrementMethodCallCount(const TString& methodName)
+    {
+        MethodCallCounts[methodName]++;
+    }
+
 public:
     TPartitionDatabase(NKikimr::NTable::TDatabase& database)
         : NKikimr::NIceDb::TNiceDb(database)
@@ -149,6 +156,11 @@ public:
     bool ReadBlockMask(
         const TPartialBlobId& blobId,
         TMaybe<TBlockMask>& blockMask);
+
+    bool ReadBlobInfo(
+        const TPartialBlobId& blobId,
+        TMaybe<TBlockMask>& blockMask,
+        TMaybe<NProto::TBlobMeta>& blobMeta);
 
     bool FindBlocksInBlobsIndex(
         IExtendedBlocksIndexVisitor& visitor,

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -36,17 +36,24 @@ public:
         Partial
     };
 
+private:
     THashMap<TString, ui64> MethodCallCounts;
-
-    void IncrementMethodCallCount(const TString& methodName)
-    {
-        MethodCallCounts[methodName]++;
-    }
+    bool NeedCountMethodCalls = false;
 
 public:
     TPartitionDatabase(NKikimr::NTable::TDatabase& database)
         : NKikimr::NIceDb::TNiceDb(database)
     {}
+
+    void SetNeedCountMethodCalls(bool needCountMethodCalls)
+    {
+        NeedCountMethodCalls = needCountMethodCalls;
+    }
+
+    [[nodiscard]] const THashMap<TString, ui64>& GetMethodCallCount() const
+    {
+        return MethodCallCounts;
+    }
 
     void InitSchema();
 
@@ -242,6 +249,14 @@ public:
     void DeleteUnconfirmedBlob(const TPartialBlobId& blobId);
 
     bool ReadUnconfirmedBlobs(TCommitIdToBlobsToConfirm& blobs);
+
+private:
+    void IncrementMethodCallCount(const TString& methodName)
+    {
+        if (Y_UNLIKELY(NeedCountMethodCalls)) {
+            MethodCallCounts[methodName]++;
+        }
+    }
 };
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_database.h
+++ b/cloud/blockstore/libs/storage/partition/part_database.h
@@ -25,8 +25,32 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TPartitionDatabase
-    : public NKikimr::NIceDb::TNiceDb
+class TNoOpCounter
+{
+public:
+    void operator()(TStringBuf)
+    {}
+};
+
+class TMethodCallCounter
+{
+private:
+    THashMap<TString, ui64> MethodCallCounts;
+
+public:
+    void operator()(TStringBuf methodName)
+    {
+        MethodCallCounts[methodName]++;
+    }
+
+    [[nodiscard]] const THashMap<TString, ui64>& GetMethodCallCounts() const
+    {
+        return MethodCallCounts;
+    }
+};
+
+template <typename TCounters>
+class TPartitionDatabaseImpl: public NKikimr::NIceDb::TNiceDb
 {
 public:
     enum class EBlobIndexScanProgress
@@ -37,22 +61,16 @@ public:
     };
 
 private:
-    THashMap<TString, ui64> MethodCallCounts;
-    bool NeedCountMethodCalls = false;
+    TCounters Counters;
 
 public:
-    TPartitionDatabase(NKikimr::NTable::TDatabase& database)
+    TPartitionDatabaseImpl(NKikimr::NTable::TDatabase& database)
         : NKikimr::NIceDb::TNiceDb(database)
     {}
 
-    void SetNeedCountMethodCalls(bool needCountMethodCalls)
+    [[nodiscard]] const TCounters& GetCounters() const
     {
-        NeedCountMethodCalls = needCountMethodCalls;
-    }
-
-    [[nodiscard]] const THashMap<TString, ui64>& GetMethodCallCount() const
-    {
-        return MethodCallCounts;
+        return Counters;
     }
 
     void InitSchema();
@@ -249,14 +267,10 @@ public:
     void DeleteUnconfirmedBlob(const TPartialBlobId& blobId);
 
     bool ReadUnconfirmedBlobs(TCommitIdToBlobsToConfirm& blobs);
-
-private:
-    void IncrementMethodCallCount(const TString& methodName)
-    {
-        if (Y_UNLIKELY(NeedCountMethodCalls)) {
-            MethodCallCounts[methodName]++;
-        }
-    }
 };
+
+using TPartitionDatabase = TPartitionDatabaseImpl<TNoOpCounter>;
+using TPartitionDatabaseWithCounters =
+    TPartitionDatabaseImpl<TMethodCallCounter>;
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.cpp
@@ -11,8 +11,9 @@ namespace {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+template <typename TCounters>
 void ReadBlobInfo(
-    TPartitionDatabase& db,
+    TPartitionDatabaseImpl<TCounters>& db,
     const TPartialBlobId& blobId,
     ui64 tabletId,
     const TOutputIndex& outputIndex,
@@ -37,8 +38,9 @@ void ReadBlobInfo(
     blobMetas[*outputIndex.BlobMetaIndex] = *meta;
 }
 
+template <typename TCounters>
 void ReadBlobMeta(
-    TPartitionDatabase& db,
+    TPartitionDatabaseImpl<TCounters>& db,
     const TPartialBlobId& blobId,
     ui64 tabletId,
     const TOutputIndex& outputIndex,
@@ -59,8 +61,9 @@ void ReadBlobMeta(
     blobMetas[*outputIndex.BlobMetaIndex] = *meta;
 }
 
+template <typename TCounters>
 void ReadBlockMask(
-    TPartitionDatabase& db,
+    TPartitionDatabaseImpl<TCounters>& db,
     const TPartialBlobId& blobId,
     ui64 tabletId,
     const TOutputIndex& outputIndex,
@@ -86,7 +89,7 @@ void ReadBlockMask(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-THashMap<TPartialBlobId, TOutputIndex, TPartialBlobIdHash> DeduplicateBlobInfos(
+TBlobId2IndexMap DeduplicateBlobInfos(
     ui64 tabletId,
     const TVector<TPartialBlobId>& blobsToReadBlockMasks,
     const TVector<TPartialBlobId>& blobsToReadBlobMetas)
@@ -125,12 +128,10 @@ THashMap<TPartialBlobId, TOutputIndex, TPartialBlobIdHash> DeduplicateBlobInfos(
     return blobsToOutputIndices;
 }
 
+template <typename TCounters>
 bool ReadBlobsInfo(
-    TPartitionDatabase& db,
-    const THashMap<
-        TPartialBlobId,
-        TTxPartition::TCompactionReadBlobInfo::TOutputIndex,
-        TPartialBlobIdHash>& blobsToOutputIndices,
+    TPartitionDatabaseImpl<TCounters>& db,
+    const TBlobId2IndexMap& blobsToOutputIndices,
     ui64 tabletId,
     TVector<TBlockMask>& blockMasks,
     TVector<NProto::TBlobMeta>& blobMetas)
@@ -156,5 +157,21 @@ bool ReadBlobsInfo(
 
     return ready;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+template bool ReadBlobsInfo<TNoOpCounter>(
+    TPartitionDatabase& db,
+    const TBlobId2IndexMap& blobsToOutputIndices,
+    ui64 tabletId,
+    TVector<TBlockMask>& blockMasks,
+    TVector<NProto::TBlobMeta>& blobMetas);
+
+template bool ReadBlobsInfo<TMethodCallCounter>(
+    TPartitionDatabaseWithCounters& db,
+    const TBlobId2IndexMap& blobsToOutputIndices,
+    ui64 tabletId,
+    TVector<TBlockMask>& blockMasks,
+    TVector<NProto::TBlobMeta>& blobMetas);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.cpp
@@ -5,50 +5,153 @@
 
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
+using TOutputIndex = TTxPartition::TCompactionReadBlobInfo::TOutputIndex;
+
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+void ReadBlobInfo(
+    TPartitionDatabase& db,
+    const TPartialBlobId& blobId,
+    ui64 tabletId,
+    const TOutputIndex& outputIndex,
+    TVector<TBlockMask>& blockMasks,
+    TVector<NProto::TBlobMeta>& blobMetas,
+    bool& ready)
+{
+    TMaybe<TBlockMask> mask;
+    TMaybe<NProto::TBlobMeta> meta;
+    if (!db.ReadBlobInfo(blobId, mask, meta)) {
+        ready = false;
+        return;
+    }
+    STORAGE_VERIFY_C(
+        mask.Defined() && meta.Defined(),
+        TWellKnownEntityTypes::TABLET,
+        tabletId,
+        TStringBuilder() << "Could not read blob info for blob: "
+                         << MakeBlobId(tabletId, blobId));
+
+    blockMasks[*outputIndex.BlockMaskIndex] = *mask;
+    blobMetas[*outputIndex.BlobMetaIndex] = *meta;
+}
+
+void ReadBlobMeta(
+    TPartitionDatabase& db,
+    const TPartialBlobId& blobId,
+    ui64 tabletId,
+    const TOutputIndex& outputIndex,
+    TVector<NProto::TBlobMeta>& blobMetas,
+    bool& ready)
+{
+    TMaybe<NProto::TBlobMeta> meta;
+    if (!db.ReadBlobMeta(blobId, meta)) {
+        ready = false;
+        return;
+    }
+    STORAGE_VERIFY_C(
+        meta.Defined(),
+        TWellKnownEntityTypes::TABLET,
+        tabletId,
+        TStringBuilder() << "Could not read blob meta for blob: "
+                         << MakeBlobId(tabletId, blobId));
+    blobMetas[*outputIndex.BlobMetaIndex] = *meta;
+}
+
+void ReadBlockMask(
+    TPartitionDatabase& db,
+    const TPartialBlobId& blobId,
+    ui64 tabletId,
+    const TOutputIndex& outputIndex,
+    TVector<TBlockMask>& blockMasks,
+    bool& ready)
+{
+    TMaybe<TBlockMask> mask;
+    if (!db.ReadBlockMask(blobId, mask)) {
+        ready = false;
+        return;
+    }
+    STORAGE_VERIFY_C(
+        mask.Defined(),
+        TWellKnownEntityTypes::TABLET,
+        tabletId,
+        TStringBuilder() << "Could not read block mask for blob: "
+                         << MakeBlobId(tabletId, blobId));
+
+    blockMasks[*outputIndex.BlockMaskIndex] = *mask;
+}
+
+}   // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
+
+THashMap<TPartialBlobId, TOutputIndex, TPartialBlobIdHash> DeduplicateBlobInfos(
+    ui64 tabletId,
+    const TVector<TPartialBlobId>& blobsToReadBlockMasks,
+    const TVector<TPartialBlobId>& blobsToReadBlobMetas)
+{
+    THashMap<TPartialBlobId, TOutputIndex, TPartialBlobIdHash>
+        blobsToOutputIndices;
+
+    for (size_t i = 0; i < blobsToReadBlockMasks.size(); ++i) {
+        const auto& blobId = blobsToReadBlockMasks[i];
+        auto& indexes = blobsToOutputIndices[blobId];
+
+        STORAGE_VERIFY_C(
+            !indexes.BlockMaskIndex,
+            TWellKnownEntityTypes::TABLET,
+            tabletId,
+            "All blobs in blobsToReadBlockMasks must be unique, but "
+                << MakeBlobId(tabletId, blobId) << " is duplicated");
+
+        indexes.BlockMaskIndex = i;
+    }
+
+    for (size_t i = 0; i < blobsToReadBlobMetas.size(); ++i) {
+        const auto& blobId = blobsToReadBlobMetas[i];
+        auto& indexes = blobsToOutputIndices[blobId];
+
+        STORAGE_VERIFY_C(
+            !indexes.BlobMetaIndex,
+            TWellKnownEntityTypes::TABLET,
+            tabletId,
+            "All blobs in blobsToReadBlobMetas must be unique, but "
+                << MakeBlobId(tabletId, blobId) << " is duplicated");
+
+        indexes.BlobMetaIndex = i;
+    }
+
+    return blobsToOutputIndices;
+}
 
 bool ReadBlobsInfo(
     TPartitionDatabase& db,
-    const TVector<TPartialBlobId>& blobsToReadBlockMasks,
-    const TVector<TPartialBlobId>& blobsToReadBlobMetas,
+    const THashMap<
+        TPartialBlobId,
+        TTxPartition::TCompactionReadBlobInfo::TOutputIndex,
+        TPartialBlobIdHash>& blobsToOutputIndices,
     ui64 tabletId,
     TVector<TBlockMask>& blockMasks,
     TVector<NProto::TBlobMeta>& blobMetas)
 {
     bool ready = true;
 
-    blockMasks.resize(blobsToReadBlockMasks.size());
-    for (size_t i = 0; i < blobsToReadBlockMasks.size(); ++i) {
-        const auto& blobId = blobsToReadBlockMasks[i];
-        TMaybe<TBlockMask> mask;
-        if (!db.ReadBlockMask(blobId, mask)) {
-            ready = false;
-            continue;
+    for (const auto& [blobId, outputIndex]: blobsToOutputIndices) {
+        if (outputIndex.BlobMetaIndex && outputIndex.BlockMaskIndex) {
+            ReadBlobInfo(
+                db,
+                blobId,
+                tabletId,
+                outputIndex,
+                blockMasks,
+                blobMetas,
+                ready);
+        } else if (outputIndex.BlobMetaIndex) {
+            ReadBlobMeta(db, blobId, tabletId, outputIndex, blobMetas, ready);
+        } else if (outputIndex.BlockMaskIndex) {
+            ReadBlockMask(db, blobId, tabletId, outputIndex, blockMasks, ready);
         }
-        STORAGE_VERIFY_C(
-            mask.Defined(),
-            TWellKnownEntityTypes::TABLET,
-            tabletId,
-            TStringBuilder() << "Could not read block mask for blob: "
-                             << MakeBlobId(tabletId, blobId));
-        blockMasks[i] = *mask;
-    }
-
-    blobMetas.resize(blobsToReadBlobMetas.size());
-    for (size_t i = 0; i < blobsToReadBlobMetas.size(); ++i) {
-        const auto& blobId = blobsToReadBlobMetas[i];
-        TMaybe<NProto::TBlobMeta> meta;
-        if (!db.ReadBlobMeta(blobId, meta)) {
-            ready = false;
-            continue;
-        }
-        STORAGE_VERIFY_C(
-            meta.Defined(),
-            TWellKnownEntityTypes::TABLET,
-            tabletId,
-            TStringBuilder() << "Could not read blob meta for blob: "
-                             << MakeBlobId(tabletId, blobId));
-        blobMetas[i] = std::move(*meta);
     }
 
     return ready;

--- a/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.h
@@ -7,21 +7,20 @@ namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-THashMap<
+using TBlobId2IndexMap = THashMap<
     TPartialBlobId,
     TTxPartition::TCompactionReadBlobInfo::TOutputIndex,
-    TPartialBlobIdHash>
-DeduplicateBlobInfos(
+    TPartialBlobIdHash>;
+
+TBlobId2IndexMap DeduplicateBlobInfos(
     ui64 tabletId,
     const TVector<TPartialBlobId>& blobsToReadBlockMasks,
     const TVector<TPartialBlobId>& blobsToReadBlobMetas);
 
+template <typename TCounters>
 bool ReadBlobsInfo(
-    TPartitionDatabase& db,
-    const THashMap<
-        TPartialBlobId,
-        TTxPartition::TCompactionReadBlobInfo::TOutputIndex,
-        TPartialBlobIdHash>& blobsToOutputIndices,
+    TPartitionDatabaseImpl<TCounters>& db,
+    const TBlobId2IndexMap& blobsToOutputIndices,
     ui64 tabletId,
     TVector<TBlockMask>& blockMasks,
     TVector<NProto::TBlobMeta>& blobMetas);

--- a/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.h
+++ b/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic.h
@@ -1,15 +1,27 @@
 #pragma once
 
 #include "part_database.h"
+#include "part_tx.h"
 
 namespace NCloud::NBlockStore::NStorage::NPartition {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+THashMap<
+    TPartialBlobId,
+    TTxPartition::TCompactionReadBlobInfo::TOutputIndex,
+    TPartialBlobIdHash>
+DeduplicateBlobInfos(
+    ui64 tabletId,
+    const TVector<TPartialBlobId>& blobsToReadBlockMasks,
+    const TVector<TPartialBlobId>& blobsToReadBlobMetas);
+
 bool ReadBlobsInfo(
     TPartitionDatabase& db,
-    const TVector<TPartialBlobId>& blobsToReadBlockMasks,
-    const TVector<TPartialBlobId>& blobsToReadBlobMetas,
+    const THashMap<
+        TPartialBlobId,
+        TTxPartition::TCompactionReadBlobInfo::TOutputIndex,
+        TPartialBlobIdHash>& blobsToOutputIndices,
     ui64 tabletId,
     TVector<TBlockMask>& blockMasks,
     TVector<NProto::TBlobMeta>& blobMetas);

--- a/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic_ut.cpp
@@ -1,0 +1,187 @@
+#include "part_readblobinfo_logic.h"
+
+#include "part_database.h"
+
+#include <cloud/blockstore/libs/storage/testlib/test_executor.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore::NStorage::NPartition {
+
+namespace {
+
+using TOutputIndex = TTxPartition::TCompactionReadBlobInfo::TOutputIndex;
+
+ui64 GetMethodCallCount(const TPartitionDatabase& db, const TString& methodName)
+{
+    ui64 count = 0;
+    for (const auto& [name, callCount]: db.MethodCallCounts) {
+        if (name.Contains(methodName)) {
+            count += callCount;
+        }
+    }
+    return count;
+}
+
+void AssertOutputIndex(
+    const TOutputIndex& actual,
+    TMaybe<ui32> expectedBlockMaskIndex,
+    TMaybe<ui32> expectedBlobMetaIndex)
+{
+    if (expectedBlockMaskIndex) {
+        UNIT_ASSERT(actual.BlockMaskIndex);
+        UNIT_ASSERT_VALUES_EQUAL(
+            *expectedBlockMaskIndex,
+            *actual.BlockMaskIndex);
+    } else {
+        UNIT_ASSERT(!actual.BlockMaskIndex);
+    }
+
+    if (expectedBlobMetaIndex) {
+        UNIT_ASSERT(actual.BlobMetaIndex);
+        UNIT_ASSERT_VALUES_EQUAL(*expectedBlobMetaIndex, *actual.BlobMetaIndex);
+    } else {
+        UNIT_ASSERT(!actual.BlobMetaIndex);
+    }
+}
+
+NProto::TBlobMeta MakeMergedBlobMeta(ui32 start, ui32 end, ui32 skipped)
+{
+    NProto::TBlobMeta meta;
+    auto& mergedBlocks = *meta.MutableMergedBlocks();
+    mergedBlocks.SetStart(start);
+    mergedBlocks.SetEnd(end);
+    mergedBlocks.SetSkipped(skipped);
+    return meta;
+}
+
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TDeduplicateBlobInfosTest)
+{
+    Y_UNIT_TEST(ShouldIndexBlockMasksOnly)
+    {
+        const TPartialBlobId blob1(1, 0);
+        const TPartialBlobId blob2(2, 0);
+
+        const auto result =
+            DeduplicateBlobInfos(TTestExecutor::TabletId, {blob1, blob2}, {});
+
+        UNIT_ASSERT_VALUES_EQUAL(2, result.size());
+        AssertOutputIndex(result.at(blob1), 0u, Nothing());
+        AssertOutputIndex(result.at(blob2), 1u, Nothing());
+    }
+
+    Y_UNIT_TEST(ShouldIndexBlobMetasOnly)
+    {
+        const TPartialBlobId blob1(1, 0);
+        const TPartialBlobId blob2(2, 0);
+
+        const auto result =
+            DeduplicateBlobInfos(TTestExecutor::TabletId, {}, {blob1, blob2});
+
+        UNIT_ASSERT_VALUES_EQUAL(2, result.size());
+        AssertOutputIndex(result.at(blob1), Nothing(), 0u);
+        AssertOutputIndex(result.at(blob2), Nothing(), 1u);
+    }
+
+    Y_UNIT_TEST(ShouldIndexDisjointBlobSets)
+    {
+        const TPartialBlobId maskBlob1(1, 0);
+        const TPartialBlobId maskBlob2(2, 0);
+        const TPartialBlobId metaBlob1(3, 0);
+        const TPartialBlobId metaBlob2(4, 0);
+
+        const auto result = DeduplicateBlobInfos(
+            TTestExecutor::TabletId,
+            {maskBlob1, maskBlob2},
+            {metaBlob1, metaBlob2});
+
+        UNIT_ASSERT_VALUES_EQUAL(4, result.size());
+        AssertOutputIndex(result.at(maskBlob1), 0u, Nothing());
+        AssertOutputIndex(result.at(maskBlob2), 1u, Nothing());
+        AssertOutputIndex(result.at(metaBlob1), Nothing(), 0u);
+        AssertOutputIndex(result.at(metaBlob2), Nothing(), 1u);
+    }
+
+    Y_UNIT_TEST(ShouldDeduplicateOverlappingBlobs)
+    {
+        const TPartialBlobId sharedBlob(1, 0);
+        const TPartialBlobId maskOnlyBlob(2, 0);
+        const TPartialBlobId metaOnlyBlob(3, 0);
+
+        const auto result = DeduplicateBlobInfos(
+            TTestExecutor::TabletId,
+            {sharedBlob, maskOnlyBlob},
+            {sharedBlob, metaOnlyBlob});
+
+        UNIT_ASSERT_VALUES_EQUAL(3, result.size());
+        AssertOutputIndex(result.at(sharedBlob), 0u, 0u);
+        AssertOutputIndex(result.at(maskOnlyBlob), 1u, Nothing());
+        AssertOutputIndex(result.at(metaOnlyBlob), Nothing(), 1u);
+    }
+}
+
+Y_UNIT_TEST_SUITE(TReadBlobsInfoTest)
+{
+    Y_UNIT_TEST(ShouldReadBlobInfoOnceForOverlappingBlob)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId sharedBlob;
+        NProto::TBlobMeta sharedBlobMeta;
+        TBlockMask sharedBlockMask;
+
+        sharedBlobMeta = MakeMergedBlobMeta(10, 20, 3);
+        sharedBlockMask.Set(1, 5);
+
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                sharedBlob = executor.MakeBlobId();
+                db.WriteBlobMeta(sharedBlob, sharedBlobMeta);
+                db.WriteBlockMask(sharedBlob, sharedBlockMask);
+            });
+
+        const auto blobsToOutputIndices = DeduplicateBlobInfos(
+            TTestExecutor::TabletId,
+            {sharedBlob},
+            {sharedBlob});
+
+        TVector<TBlockMask> blockMasks(1);
+        TVector<NProto::TBlobMeta> blobMetas(1);
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                db.MethodCallCounts.clear();
+
+                const bool ready = ReadBlobsInfo(
+                    db,
+                    blobsToOutputIndices,
+                    TTestExecutor::TabletId,
+                    blockMasks,
+                    blobMetas);
+
+                UNIT_ASSERT(ready);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    1,
+                    GetMethodCallCount(db, "ReadBlobInfo"));
+                UNIT_ASSERT_VALUES_EQUAL(
+                    0,
+                    GetMethodCallCount(db, "ReadBlobMeta"));
+                UNIT_ASSERT_VALUES_EQUAL(
+                    0,
+                    GetMethodCallCount(db, "ReadBlockMask"));
+            });
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            BlockMaskAsString(sharedBlockMask),
+            BlockMaskAsString(blockMasks[0]));
+        google::protobuf::util::MessageDifferencer differencer;
+        UNIT_ASSERT(differencer.Compare(sharedBlobMeta, blobMetas[0]));
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic_ut.cpp
@@ -12,10 +12,13 @@ namespace {
 
 using TOutputIndex = TTxPartition::TCompactionReadBlobInfo::TOutputIndex;
 
-ui64 GetMethodCallCount(const TPartitionDatabase& db, const TString& methodName)
+ui64 GetMethodCallCount(
+    const TPartitionDatabaseWithCounters& db,
+    const TString& methodName)
 {
     ui64 count = 0;
-    for (const auto& [name, callCount]: db.GetMethodCallCount()) {
+    for (const auto& [name, callCount]: db.GetCounters().GetMethodCallCounts())
+    {
         if (name.Contains(methodName)) {
             count += callCount;
         }
@@ -153,9 +156,8 @@ Y_UNIT_TEST_SUITE(TReadBlobsInfoTest)
         TVector<NProto::TBlobMeta> blobMetas(1);
 
         executor.ReadTx(
-            [&](TPartitionDatabase db)
+            [&](TPartitionDatabaseWithCounters db)
             {
-                db.SetNeedCountMethodCalls(true);
                 const bool ready = ReadBlobsInfo(
                     db,
                     blobsToOutputIndices,

--- a/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_readblobinfo_logic_ut.cpp
@@ -15,7 +15,7 @@ using TOutputIndex = TTxPartition::TCompactionReadBlobInfo::TOutputIndex;
 ui64 GetMethodCallCount(const TPartitionDatabase& db, const TString& methodName)
 {
     ui64 count = 0;
-    for (const auto& [name, callCount]: db.MethodCallCounts) {
+    for (const auto& [name, callCount]: db.GetMethodCallCount()) {
         if (name.Contains(methodName)) {
             count += callCount;
         }
@@ -155,8 +155,7 @@ Y_UNIT_TEST_SUITE(TReadBlobsInfoTest)
         executor.ReadTx(
             [&](TPartitionDatabase db)
             {
-                db.MethodCallCounts.clear();
-
+                db.SetNeedCountMethodCalls(true);
                 const bool ready = ReadBlobsInfo(
                     db,
                     blobsToOutputIndices,

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -482,20 +482,31 @@ struct TTxPartition
 
     struct TCompactionReadBlobInfo
     {
+        struct TOutputIndex
+        {
+            std::optional<ui32> BlockMaskIndex;
+            std::optional<ui32> BlobMetaIndex;
+        };
+
         const TRequestInfoPtr RequestInfo;
-        const TVector<TPartialBlobId> BlobsToReadBlockMasks;
-        const TVector<TPartialBlobId> BlobsToReadBlobMetas;
+        const THashMap<TPartialBlobId, TOutputIndex, TPartialBlobIdHash>
+            BlobsToOutputIndices;
+        const size_t BlockMaskCount;
+        const size_t BlobMetaCount;
 
         TVector<TBlockMask> BlockMasks;
         TVector<NProto::TBlobMeta> BlobMetas;
 
         TCompactionReadBlobInfo(
                 TRequestInfoPtr requestInfo,
-                TVector<TPartialBlobId> blobsToReadBlockMasks,
-                TVector<TPartialBlobId> blobsToReadBlobMetas)
+                THashMap<TPartialBlobId, TOutputIndex, TPartialBlobIdHash>
+                    blobsToOutputIndices,
+                size_t blockMaskCount,
+                size_t blobMetaCount)
             : RequestInfo(std::move(requestInfo))
-            , BlobsToReadBlockMasks(std::move(blobsToReadBlockMasks))
-            , BlobsToReadBlobMetas(std::move(blobsToReadBlobMetas))
+            , BlobsToOutputIndices(std::move(blobsToOutputIndices))
+            , BlockMaskCount(blockMaskCount)
+            , BlobMetaCount(blobMetaCount)
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/partition/ut/ya.make
+++ b/cloud/blockstore/libs/storage/partition/ut/ya.make
@@ -6,6 +6,7 @@ SRCS(
     part_cleanup_logic_ut.cpp
     part_compaction_logic_ut.cpp
     part_database_ut.cpp
+    part_readblobinfo_logic_ut.cpp
     part_state_ut.cpp
     part_ut.cpp
 )


### PR DESCRIPTION
### Notes
If we are going to read a block mask for a blob on compaction, we can also read the blob meta for it. Reading one more field by key should be almost free, but this meta can be used later for cleanup, so we only do one blob index read for this blob instead of two.
 
### Issue
#6279 