### PR TITLE
[NBS] Always initialize the NvmeManager component

### DIFF
--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -479,13 +479,10 @@ void TBootstrapYdb::InitDiskAgentBackend()
         Y_ABORT_UNLESS(Spdk, "SPDK backend should be already initialized");
     }
 
-    Y_ABORT_IF(NvmeManager);
     Y_ABORT_IF(FileIOServiceProvider);
     Y_ABORT_IF(LocalStorageProvider);
-    Y_ABORT_UNLESS(Logging);
 
-    auto r = CreateDiskAgentBackendComponents(Logging, config);
-    NvmeManager = std::move(r.NvmeManager);
+    auto r = CreateDiskAgentBackendComponents(NvmeManager, config);
     FileIOServiceProvider = std::move(r.FileIOServiceProvider);
     LocalStorageProvider = std::move(r.StorageProvider);
 
@@ -595,6 +592,11 @@ void TBootstrapYdb::InitKikimrService()
     auto monitoring = std::make_shared<TMonitoringProxy>();
     Logging = logging;
     Monitoring = monitoring;
+
+    NvmeManager = CreateNvmeManager(
+        Logging,
+        Configs->DiskAgentConfig->GetSecureEraseTimeout(),
+        Configs->DiskAgentConfig->GetNVMeAdminCmdTimeout());
 
     std::shared_ptr<TFakeRdmaClientProxy> fakeRdmaClientProxy;
     if (Configs->ServerConfig->GetUseFakeRdmaClient() &&

--- a/cloud/blockstore/libs/disk_agent/bootstrap.cpp
+++ b/cloud/blockstore/libs/disk_agent/bootstrap.cpp
@@ -373,13 +373,10 @@ bool TBootstrap::InitBackend()
         SpdkLogInitializer = std::move(spdkParts.LogInitializer);
     }
 
-    Y_ABORT_IF(NvmeManager);
     Y_ABORT_IF(FileIOServiceProvider);
     Y_ABORT_IF(LocalStorageProvider);
-    Y_ABORT_UNLESS(Logging);
 
-    auto r = CreateDiskAgentBackendComponents(Logging, config);
-    NvmeManager = std::move(r.NvmeManager);
+    auto r = CreateDiskAgentBackendComponents(NvmeManager, config);
     FileIOServiceProvider = std::move(r.FileIOServiceProvider);
     LocalStorageProvider = std::move(r.StorageProvider);
 
@@ -494,6 +491,11 @@ bool TBootstrap::InitKikimrService()
 
         STORAGE_INFO("AsyncLogger initialized");
     }
+
+    NvmeManager = CreateNvmeManager(
+        Logging,
+        Configs->DiskAgentConfig->GetSecureEraseTimeout(),
+        Configs->DiskAgentConfig->GetNVMeAdminCmdTimeout());
 
     if (InitBackend() && Configs->RdmaConfig) {
         InitRdmaServer(*Configs->RdmaConfig);

--- a/cloud/blockstore/libs/storage/disk_agent/model/bootstrap.cpp
+++ b/cloud/blockstore/libs/storage/disk_agent/model/bootstrap.cpp
@@ -162,47 +162,24 @@ IStorageProviderPtr CreateStorageProvider(
     return result;
 }
 
-NNvme::INvmeManagerPtr CreateNvmeManager(
-    ILoggingServicePtr logging,
-    const TDiskAgentConfig& config)
-{
-    switch (config.GetBackend()) {
-        case NProto::DISK_AGENT_BACKEND_SPDK:
-            break;
-        case NProto::DISK_AGENT_BACKEND_AIO:
-        case NProto::DISK_AGENT_BACKEND_NULL:
-        case NProto::DISK_AGENT_BACKEND_IO_URING:
-        case NProto::DISK_AGENT_BACKEND_IO_URING_NULL:
-            return NNvme::CreateNvmeManager(
-                std::move(logging),
-                config.GetSecureEraseTimeout(),
-                config.GetNVMeAdminCmdTimeout());
-    }
-
-    return nullptr;
-}
-
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TCreateDiskAgentBackendComponentsResult CreateDiskAgentBackendComponents(
-    ILoggingServicePtr logging,
+    NNvme::INvmeManagerPtr nvmeManager,
     const TDiskAgentConfig& config)
 {
-    Y_ABORT_UNLESS(logging);
-
     if (config.GetBackend() == NProto::DISK_AGENT_BACKEND_SPDK) {
         return {};
     }
 
-    auto nvmeManager = CreateNvmeManager(std::move(logging), config);
     auto provider = CreateFileIOServiceProvider(config);
 
     return {
-        .NvmeManager = nvmeManager,
         .FileIOServiceProvider = provider,
-        .StorageProvider = CreateStorageProvider(config, provider, nvmeManager),
+        .StorageProvider =
+            CreateStorageProvider(config, provider, std::move(nvmeManager)),
     };
 }
 

--- a/cloud/blockstore/libs/storage/disk_agent/model/bootstrap.h
+++ b/cloud/blockstore/libs/storage/disk_agent/model/bootstrap.h
@@ -15,13 +15,12 @@ namespace NCloud::NBlockStore::NStorage {
 
 struct TCreateDiskAgentBackendComponentsResult
 {
-    NNvme::INvmeManagerPtr NvmeManager;
     NServer::IFileIOServiceProviderPtr FileIOServiceProvider;
     IStorageProviderPtr StorageProvider;
 };
 
 TCreateDiskAgentBackendComponentsResult CreateDiskAgentBackendComponents(
-    ILoggingServicePtr logging,
+    NNvme::INvmeManagerPtr nvmeManager,
     const TDiskAgentConfig& config);
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
NvmeManager is required not only by Disk Agent, but also by LocalNVMeService, so it should be initialized even when Disk Agent is disabled.
