### PR TITLE
[Filestore] Call FuseLoop->Unmount() on a separate thread instead of Scheduler

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -361,10 +361,14 @@ struct TBootstrap
         // Scheduled tasks are not run automatically when TTestScheduler is used
         auto testScheduler = dynamic_cast<TTestScheduler*>(Scheduler.get());
         if (testScheduler) {
-            testScheduler->RunAllScheduledTasks();
+            auto now = TInstant::Now();
+            while (!stop.HasValue() && !stop.HasException()) {
+                UNIT_ASSERT(TInstant::Now() - now < WaitTimeout);
+                testScheduler->RunAllScheduledTasks();
+            }
+        } else {
+            UNIT_ASSERT(stop.Wait(WaitTimeout));
         }
-
-        UNIT_ASSERT(stop.Wait(WaitTimeout));
 
         if (Scheduler) {
             // It is not allowed to stop Scheduler in the subscriber of

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1388,7 +1388,7 @@ private:
                     }
                 });
         } else {
-            StopAsyncDestroySession(std::move(stopCompleted));
+            StopAsyncFuseLoopUnmount(std::move(stopCompleted));
         }
     }
 
@@ -1422,14 +1422,41 @@ private:
                 Config->GetClientId().Quote().c_str()));
         }
 
-        StopAsyncDestroySession(std::move(stopCompleted));
+        StopAsyncFuseLoopUnmount(std::move(stopCompleted));
+    }
+
+    void StopAsyncFuseLoopUnmount(TPromise<void> stopCompleted)
+    {
+        // Calling FuseLoop->Unmount() from the scheduler thread may result
+        // in deadlock because of synchronous wait in ResetSessionState()
+        SystemThreadFactory()->Run(
+            [w = weak_from_this(), s = std::move(stopCompleted)]() mutable
+            {
+                if (auto p = w.lock()) {
+                    p->FuseLoop->Unmount();
+                    p->FuseLoop = nullptr;
+
+                    // Continuing execution on a non-joinable thread may result
+                    // in a race when global singletons are destroyed while
+                    // TFileSystemLoop that depends on them is still alive
+                    p->Scheduler->Schedule(
+                        TInstant::Zero(),
+                        [w = std::move(w), s = std::move(s)]() mutable
+                        {
+                            if (auto p = w.lock()) {
+                                p->StopAsyncDestroySession(std::move(s));
+                            } else {
+                                s.SetValue();
+                            }
+                        });
+                } else {
+                    s.SetValue();
+                }
+            });
     }
 
     void StopAsyncDestroySession(TPromise<void> stopCompleted)
     {
-        FuseLoop->Unmount();
-        FuseLoop = nullptr;
-
         auto callContext = MakeIntrusive<TCallContext>(
             Config->GetFileSystemId(),
             CreateRequestId());


### PR DESCRIPTION
### Notes
Resolve deadlock on session stop in filestore.

Root cause: destroy synchronously waits for ResetSessionState
https://github.com/ydb-platform/nbs/blob/7568cd6f6b7a60b7df56e847e1f1b4e3470ce589/cloud/filestore/libs/vfs_fuse/loop.cpp#L1539

This wait happens on the stack of StopAsyncOnCompletionQueueStopped
https://github.com/ydb-platform/nbs/blob/7568cd6f6b7a60b7df56e847e1f1b4e3470ce589/cloud/filestore/libs/vfs_fuse/loop.cpp#L1369

which is executed in the Scheduler's thread
https://github.com/ydb-platform/nbs/blob/7568cd6f6b7a60b7df56e847e1f1b4e3470ce589/cloud/filestore/libs/vfs_fuse/loop.cpp#L822

The deadlock happens because ResetSessionState cannot make progress: it also needs the same Scheduler thread.

Solution: execute FuseLoop->Unmount() on a separate thread instead of Scheduler.

