### PR TITLE
Show detached state for devices in DR mon page

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -24,14 +24,17 @@ namespace {
 
 EDeviceStateFlags GetDeviceStateFlags(
     const TDiskRegistryState& state,
-    const TString& deviceUUID)
+    const NProto::TDeviceConfig& device)
 {
     EDeviceStateFlags deviceStateFlags = EDeviceStateFlags::NONE;
-    if (state.IsDirtyDevice(deviceUUID)) {
+    if (state.IsDirtyDevice(device.GetDeviceUUID())) {
         deviceStateFlags |= EDeviceStateFlags::DIRTY;
     }
-    if (state.IsSuspendedDevice(deviceUUID)) {
+    if (state.IsSuspendedDevice(device.GetDeviceUUID())) {
         deviceStateFlags |= EDeviceStateFlags::SUSPENDED;
+    }
+    if (state.IsDeviceDetached(device)) {
+        deviceStateFlags |= EDeviceStateFlags::DETACHED;
     }
     return deviceStateFlags;
 }
@@ -359,7 +362,7 @@ void TDiskRegistryActor::RenderDevicesWithDetails(
             for (size_t index = 0; index < static_cast<size_t>(devices.size());
                  ++index)
             {
-                const auto& device = devices[index];
+                const NProto::TDeviceConfig& device = devices[index];
                 TABLER() {
                     TABLED() {
                         DumpDeviceLink(out, TabletID(), device.GetDeviceUUID());
@@ -371,9 +374,7 @@ void TDiskRegistryActor::RenderDevicesWithDetails(
                         DumpDeviceState(
                             out,
                             device.GetState(),
-                            GetDeviceStateFlags(
-                                *State,
-                                device.GetDeviceUUID()));
+                            GetDeviceStateFlags(*State, device));
                     }
                     TABLED() {
                         out << TInstant::MicroSeconds(device.GetStateTs());
@@ -544,7 +545,7 @@ void TDiskRegistryActor::RenderDeviceHtmlInfo(
             DumpDeviceState(
                 out,
                 device.GetState(),
-                GetDeviceStateFlags(*State, id));
+                GetDeviceStateFlags(*State, device));
         }
         DIV() {
             out << "State Timestamp: "
@@ -671,10 +672,7 @@ void TDiskRegistryActor::RenderAgentHtmlInfo(
         if (agent->UnknownDevicesSize()) {
             auto unknownDevices = agent->GetUnknownDevices();
             SortBy(unknownDevices, dcomp);
-            RenderDevicesWithDetails(
-                out,
-                unknownDevices,
-                "Unknown devices");
+            RenderDevicesWithDetails(out, unknownDevices, "Unknown devices");
         }
     }
 }
@@ -835,8 +833,7 @@ void TDiskRegistryActor::RenderDiskHtmlInfo(
                 dumpAgent(device.GetNodeId());
             }
             TABLED() {
-                EDeviceStateFlags flags =
-                    GetDeviceStateFlags(*State, device.GetDeviceUUID());
+                EDeviceStateFlags flags = GetDeviceStateFlags(*State, device);
                 if (FindPtr(
                         info.MasterDiskId ? masterDiskInfo.DeviceReplacementIds
                                           : info.DeviceReplacementIds,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -185,7 +185,18 @@ TString MakeMirroredDiskDeviceReplacementMessage(
     return std::move(message);
 }
 
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////
+
+bool IsDeviceDetached(
+    const NProto::TAgentConfig& agent,
+    const NProto::TDeviceConfig& device)
+{
+    const auto it = agent.GetPathAttachStates().find(device.GetDeviceName());
+    return it == agent.GetPathAttachStates().end() ||
+           it->second != NProto::PATH_ATTACH_STATE_ATTACHED;
+}
+
+/////////////////////////////////////////////////////////////////////////////////
 
 struct TDevicePoolCounters
 {
@@ -3145,10 +3156,7 @@ bool TDiskRegistryState::CanSecureErase(
     }
 
     if (StorageConfig->GetAttachDetachPathsEnabled()) {
-        if (auto it = agent->GetPathAttachStates().find(device.GetDeviceName());
-            it != agent->GetPathAttachStates().end() &&
-            it->second != NProto::PATH_ATTACH_STATE_ATTACHED)
-        {
+        if (NStorage::IsDeviceDetached(*agent, device)) {
             STORAGE_DEBUG(
                 "Skip SecureErase for device '%s'. Device is detached",
                 device.GetDeviceUUID().c_str());
@@ -4420,17 +4428,12 @@ void TDiskRegistryState::PublishCounters(TInstant now)
                 case NProto::DEVICE_STATE_ONLINE: {
                     ++pool.DevicesInOnlineState;
 
-                    auto it = agent.GetPathAttachStates().find(
-                        device.GetDeviceName());
-
                     const bool deviceShouldBeAttached =
                         agent.GetState() == NProto::AGENT_STATE_ONLINE;
-                    const bool deviceIsAttached =
-                        it != agent.GetPathAttachStates().end() &&
-                        it->second == NProto::PATH_ATTACH_STATE_ATTACHED;
 
                     if (StorageConfig->GetAttachDetachPathsEnabled() &&
-                        deviceShouldBeAttached && !deviceIsAttached)
+                        deviceShouldBeAttached &&
+                        NStorage::IsDeviceDetached(agent, device))
                     {
                         ++detachedDevicesInOnlineState;
                     }
@@ -8697,6 +8700,19 @@ TVector<TString> TDiskRegistryState::GetPathsToAttachOnRegistration(
     }
 
     return pathsToAttach;
+}
+
+bool TDiskRegistryState::IsDeviceDetached(
+    const NProto::TDeviceConfig& device) const
+{
+    if (!StorageConfig->GetAttachDetachPathsEnabled()) {
+        return false;
+    }
+    const auto* agent = AgentList.FindAgent(device.GetNodeId());
+    if (!agent) {
+        return false;
+    }
+    return NStorage::IsDeviceDetached(*agent, device);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -940,6 +940,8 @@ public:
     TVector<TString> GetPathsToAttachOnRegistration(
         const TAgentId& agentId) const;
 
+    bool IsDeviceDetached(const NProto::TDeviceConfig& device) const;
+
 private:
     void ProcessConfig(const NProto::TDiskRegistryConfig& config);
     void ProcessDisks(TVector<NProto::TDiskConfig> disks);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pools.cpp
@@ -1049,6 +1049,53 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePoolsTest)
             UNIT_ASSERT_VALUES_EQUAL(1, infos[0].FreeChunks);
         }
     }
+
+    Y_UNIT_TEST(ShouldReportDetachedDevice)
+    {
+        auto agent = AgentConfig(1, {
+            Device("dev-1", "uuid-1"),
+            Device("dev-2", "uuid-2"),
+            Device("dev-3", "uuid-3"),
+        });
+
+        (*agent.MutablePathAttachStates())["dev-1"] =
+            NProto::PATH_ATTACH_STATE_ATTACHED;
+        (*agent.MutablePathAttachStates())["dev-2"] =
+            NProto::PATH_ATTACH_STATE_DETACHED;
+        // dev-3 has no path attach state entry.
+
+        auto makeState = [&] (bool attachDetachEnabled) {
+            auto storageConfig = CreateDefaultStorageConfigProto();
+            storageConfig.SetAttachDetachPathsEnabled(attachDetachEnabled);
+
+            return TDiskRegistryStateBuilder()
+                .WithStorageConfig(std::move(storageConfig))
+                .WithKnownAgents({agent})
+                .Build();
+        };
+
+        {
+            auto state = makeState(false);
+
+            UNIT_ASSERT(!state->IsDeviceDetached(*state->FindDevice("uuid-1")));
+            UNIT_ASSERT(!state->IsDeviceDetached(*state->FindDevice("uuid-2")));
+            UNIT_ASSERT(!state->IsDeviceDetached(*state->FindDevice("uuid-3")));
+        }
+
+        {
+            auto state = makeState(true);
+
+            UNIT_ASSERT(!state->IsDeviceDetached(*state->FindDevice("uuid-1")));
+            UNIT_ASSERT(state->IsDeviceDetached(*state->FindDevice("uuid-2")));
+            UNIT_ASSERT(state->IsDeviceDetached(*state->FindDevice("uuid-3")));
+
+            constexpr ui32 UnknownNodeId = 42;
+            auto deviceFromUnknownAgent = Device("dev-2", "uuid-unknown");
+            deviceFromUnknownAgent.SetNodeId(UnknownNodeId);
+
+            UNIT_ASSERT(!state->IsDeviceDetached(deviceFromUnknownAgent));
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/example/nbs/nbs-storage.txt
+++ b/example/nbs/nbs-storage.txt
@@ -13,6 +13,9 @@ MirroredMigrationStartAllowed: true
 NonReplicatedDiskRecyclingPeriod: 5000
 NonReplicatedDontSuspendDevices: true
 NonReplicatedMigrationStartAllowed: true
+DiskRegistryAlwaysAllocatesLocalDisks: true
+DiskRegistryCleanupConfigOnRemoveHost: false
+AttachDetachPathsEnabled: true
 
 # Volume
 OverlappingRequestsPolicy: ORP_ENABLE_WITH_CRIT_EVENT


### PR DESCRIPTION
### Notes
Show "detached" state on the DR mon pages:

<img width="1145" height="609" alt="Screenshot 2026-07-02 at 01 30 44" src="https://github.com/user-attachments/assets/a2f51262-1d37-429a-80cc-d406511e2491" />
<img width="820" height="395" alt="Screenshot 2026-07-02 at 01 31 14" src="https://github.com/user-attachments/assets/bf5ed882-7ebb-41e6-8aea-62868823aeac" />

