### PR TITLE
issue-6385: block/byte visitor layers extracted and documented, TFreshBytes API documentation, FlushBytes logic comments

### DIFF
--- a/cloud/filestore/libs/storage/tablet/model/blob_builder.h
+++ b/cloud/filestore/libs/storage/tablet/model/blob_builder.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include "blob.h"
+#include "layer.h"
 
 #include <cloud/filestore/libs/storage/model/public.h>
 

--- a/cloud/filestore/libs/storage/tablet/model/block.h
+++ b/cloud/filestore/libs/storage/tablet/model/block.h
@@ -242,54 +242,11 @@ struct TBlockLocationInBlobHash
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct IFreshBlockVisitor
-{
-    virtual ~IFreshBlockVisitor() = default;
-
-    virtual void Accept(const TBlock& block, TStringBuf blockData) = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct IMixedBlockVisitor
-{
-    virtual ~IMixedBlockVisitor() = default;
-
-    // Accepts |blocksCount| consecutive |block|'s with offset |blobOffset|
-    // from the beginning of the blob with |blobId|
-    virtual void Accept(
-        const TBlock& block,
-        const TPartialBlobId& blobId,
-        ui32 blobOffset,
-        ui32 blocksCount) = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct ILargeBlockVisitor
-{
-    virtual ~ILargeBlockVisitor() = default;
-
-    virtual void Accept(
-        const TBlockDeletion& marker) = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct IFreshBytesVisitor
-{
-    virtual ~IFreshBytesVisitor() = default;
-
-    virtual void Accept(const TBytes& bytes, TStringBuf data) = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct IBlockLocation2RangeIndex
 {
     virtual ~IBlockLocation2RangeIndex() = default;
 
-    virtual ui32 Calc(ui64 nodeId, ui32 blockIndex) const = 0;
+    [[nodiscard]] virtual ui32 Calc(ui64 nodeId, ui32 blockIndex) const = 0;
 };
 
 IBlockLocation2RangeIndexPtr CreateRangeIdHasher(ui32 type);

--- a/cloud/filestore/libs/storage/tablet/model/fresh_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_blocks.h
@@ -4,6 +4,7 @@
 
 #include "alloc.h"
 #include "block.h"
+#include "layer.h"
 
 #include <util/generic/map.h>
 #include <util/generic/maybe.h>

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -207,32 +207,120 @@ public:
         }
     }
 
+    /**
+     * Validates whether the supplied bytes can be added. Can be called before
+     * AddBytes.
+     *
+     * @param nodeId - NodeId.
+     * @param offset - Offset within the file.
+     * @param data - Bytes to add.
+     * @param commitId - CommitId at which these bytes appeared.
+     *
+     * @return - E_REJECTED upon failure, S_OK - otherwise.
+     */
     NProto::TError CheckBytes(
         ui64 nodeId,
         ui64 offset,
         TStringBuf data,
         ui64 commitId) const;
+
+    /**
+     * Adds a range of bytes into the last chunk. CommitIds should grow
+     * monotonically.
+     *
+     * @param nodeId - NodeId.
+     * @param offset - Offset within the file.
+     * @param data - Bytes to add.
+     * @param commitId - CommitId at which these bytes appeared.
+     */
     void AddBytes(ui64 nodeId, ui64 offset, TStringBuf data, ui64 commitId);
+
+    /**
+     * Registers this range as deleted in the last chunk. Deletes overlapping
+     * byte ranges in this chunk in-place and remembers this range to apply this
+     * deletion when previous chunks are read.
+     *
+     * @param nodeId - NodeId.
+     * @param offset - Offset within the file.
+     * @param len - Length of the range.
+     * @param commitId - CommitId at which this range was deleted.
+     */
     void AddDeletionMarker(ui64 nodeId, ui64 offset, ui64 len, ui64 commitId);
 
+    /**
+     * Seals the last chunk and creates a new empty one. Needed to make a frozen
+     * snapshot of the current state of this data structure. CommitId order is
+     * again expected to be monotonic.
+     *
+     * @param commitId - CommitId of the checkpoint.
+     */
     void OnCheckpoint(ui64 commitId);
 
+    /**
+     * If there's only one chunk it gets sealed and a new chunk is created.
+     * This method is supposed to be used to copy the bytes in this chunk
+     * elsewhere and then delete this chunk via FinishCleanup.
+     *
+     * @param commitId - CommitId of the moment when cleanup starts.
+     * @param entries (out) - Returns the bytes in the last chunk.
+     * @param deletionMarkers (out) - Returns the deletion markers in the last
+     *  chunk.
+     *
+     * @return - Chunk meta of the sealed chunk.
+     */
     TFlushBytesCleanupInfo StartCleanup(
         ui64 commitId,
         TVector<TBytes>* entries,
         TVector<TBytes>* deletionMarkers);
+
+    /**
+     * Applies the supplied visitor to the items in the first chunk.
+     *
+     * @param itemLimit - Limits the number of traversed items.
+     * @param visitor - The visitor.
+     */
     void VisitTop(ui64 itemLimit, const TChunkVisitor& visitor);
+
+    /**
+     * Completes the cleanup that was initiated via StartCleanup.
+     *
+     * @param chunkId - The id of the chunk - supposed to be obtained from the
+     *  chunk meta returned by StartCleanup.
+     * @param dataItemCount - Limits the number of cleaned up byte items.
+     * @param deletionMarkerCount - Limits the number of cleaned up deletion
+     *  marker items.
+     *
+     * @return - true if the chunk is now empty, false - otherwise.
+     */
     bool FinishCleanup(
         ui64 chunkId,
         ui64 dataItemCount,
         ui64 deletionMarkerCount);
 
+    /**
+     * Applies the supplied visitor to the bytes stored in this structure that
+     * are visible at the supplied commit-id.
+     *
+     * @param visitor - The visitor.
+     * @param nodeId - NodeId filter.
+     * @param byteRange - Range filter.
+     * @param commitId - The commit-id at which we want to read, newer bytes and
+     *  deletions will be skipped.
+     */
     void FindBytes(
         IFreshBytesVisitor& visitor,
         ui64 nodeId,
         TByteRange byteRange,
         ui64 commitId) const;
 
+    /**
+     * Checks whether the supplied range overlaps with any of the stored ranges.
+     *
+     * @param nodeId - NodeId filter.
+     * @param byteRange - Range filter.
+     *
+     * @return - true if overlapping ranges exist, false - otherwise.
+     */
     bool Intersects(ui64 nodeId, TByteRange byteRange) const;
 
 private:

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include "block.h"
+#include "layer.h"
 
 #include <cloud/storage/core/libs/common/byte_range.h>
 #include <cloud/storage/core/libs/common/byte_vector.h>

--- a/cloud/filestore/libs/storage/tablet/model/large_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/large_blocks.h
@@ -4,6 +4,7 @@
 
 #include "block.h"
 #include "deletion_markers.h"
+#include "layer.h"
 
 #include <util/generic/vector.h>
 #include <util/memory/alloc.h>

--- a/cloud/filestore/libs/storage/tablet/model/layer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/layer.cpp
@@ -1,0 +1,1 @@
+#include "layer.h"

--- a/cloud/filestore/libs/storage/tablet/model/layer.h
+++ b/cloud/filestore/libs/storage/tablet/model/layer.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "block.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+/**
+ * Block & byte index consists of 4 layers:
+ * 1. fresh blocks (buffer for small aligned writes)
+ * 2. mixed blocks (stores most of the data)
+ * 3. large blocks (wide deletion markers)
+ * 4. fresh bytes (buffer for unaligned writes)
+ *
+ * Deletions (both overwrites and explicit deletions) are applied to:
+ * 1. fresh blocks - always
+ * 2. mixed blocks - if the deleted range is below some threshold
+ * 3. large blocks - if the deleted range is above some threshold
+ * 4. fresh bytes - always
+ *
+ * Each block has:
+ * * MinCommitId - when it became visible
+ * * MaxCommitId - when it got overwritten/deleted (if it's still visible, the
+ *  value here is InvalidCommitId)
+ *
+ * Fresh bytes layer doesn't store MaxCommitIds so no deletion markers can be
+ * applied to it post factum. That's why fresh bytes layer must be visited last
+ * upon read.
+ *
+ * Large blocks layer can hide some of the blocks in the mixed blocks layer so
+ * it should be visited after mixed blocks layer.
+ *
+ * In general, the following lookup order is recommended:
+ * 1. fresh blocks
+ * 2. mixed blocks
+ * 3. large blocks
+ * 4. fresh bytes
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IFreshBlockVisitor
+{
+    virtual ~IFreshBlockVisitor() = default;
+
+    virtual void Accept(const TBlock& block, TStringBuf blockData) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IMixedBlockVisitor
+{
+    virtual ~IMixedBlockVisitor() = default;
+
+    // Accepts |blocksCount| consecutive |block|'s with offset |blobOffset|
+    // from the beginning of the blob with |blobId|
+    virtual void Accept(
+        const TBlock& block,
+        const TPartialBlobId& blobId,
+        ui32 blobOffset,
+        ui32 blocksCount) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct ILargeBlockVisitor
+{
+    virtual ~ILargeBlockVisitor() = default;
+
+    virtual void Accept(const TBlockDeletion& marker) = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IFreshBytesVisitor
+{
+    virtual ~IFreshBytesVisitor() = default;
+
+    virtual void Accept(const TBytes& bytes, TStringBuf data) = 0;
+};
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/model/layer.h
+++ b/cloud/filestore/libs/storage/tablet/model/layer.h
@@ -6,15 +6,16 @@ namespace NCloud::NFileStore::NStorage {
 
 /**
  * Block & byte index consists of 4 layers:
- * 1. fresh blocks (buffer for small aligned writes)
- * 2. mixed blocks (stores most of the data)
- * 3. large blocks (wide deletion markers)
- * 4. fresh bytes (buffer for unaligned writes)
+ * 1. fresh blocks - buffer for small block-aligned writes
+ * 2. mixed blocks - stores most of the data, block-aligned
+ * 3. large blocks - wide deletion markers, block-aligned
+ * 4. fresh bytes - buffer for unaligned writes, each item lies entirely within
+ *  one block
  *
  * Deletions (both overwrites and explicit deletions) are applied to:
  * 1. fresh blocks - always
- * 2. mixed blocks - if the deleted range is below some threshold
- * 3. large blocks - if the deleted range is above some threshold
+ * 2. mixed blocks - if the deleted range length is below some threshold
+ * 3. large blocks - if the deleted range length is above some threshold
  * 4. fresh bytes - always
  *
  * Each block has:
@@ -22,9 +23,12 @@ namespace NCloud::NFileStore::NStorage {
  * * MaxCommitId - when it got overwritten/deleted (if it's still visible, the
  *  value here is InvalidCommitId)
  *
- * Fresh bytes layer doesn't store MaxCommitIds so no deletion markers can be
- * applied to it post factum. That's why fresh bytes layer must be visited last
- * upon read.
+ * Since writes to fresh bytes by definition do not cover whole blocks there's
+ * no way to generate block-level deletion markers upon such writes so fresh
+ * bytes layer should be visited last upon read and any visited bytes should be
+ * assumed to overwrite anything visited before that. This is made possible
+ * because fresh bytes layer is assumed to be organized in such a way that newer
+ * byte ranges are visited after older byte ranges.
  *
  * Large blocks layer can hide some of the blocks in the mixed blocks layer so
  * it should be visited after mixed blocks layer.

--- a/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
+++ b/cloud/filestore/libs/storage/tablet/model/mixed_blocks.h
@@ -6,6 +6,7 @@
 #include "block.h"
 #include "block_list.h"
 #include "deletion_markers.h"
+#include "layer.h"
 
 #include <util/generic/vector.h>
 #include <util/memory/alloc.h>

--- a/cloud/filestore/libs/storage/tablet/model/ya.make
+++ b/cloud/filestore/libs/storage/tablet/model/ya.make
@@ -25,6 +25,7 @@ SRCS(
     group_by.cpp
     internal_request_id.cpp
     large_blocks.cpp
+    layer.cpp
     metadata_cache.cpp
     mixed_blocks.cpp
     node_ref.cpp

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -21,6 +21,10 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * Single-block visitor used for an individual byte range during FlushBytes.
+ * Each byte range is supposed to lie entirely within one block.
+ */
 class TReadBlockVisitor final
     : public IFreshBlockVisitor
     , public IMixedBlockVisitor
@@ -96,6 +100,15 @@ public:
         TABLET_VERIFY(!ApplyingByteLayer);
 
         if (BlockMinCommitId < deletion.CommitId) {
+            //
+            // There's no need to save deletion commit-id because after the
+            // large-blocks layer only fresh-bytes are applied and all deletion
+            // markers are supposed to be also applied directly to the
+            // fresh-bytes layer when a deletion is made so a situation when
+            // older fresh bytes are applied after a newer large-blocks deletion
+            // is applied shouldn't happen.
+            //
+
             Block.Block = {};
         }
     }
@@ -123,6 +136,18 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * This actor performs a compaction-like operation:
+ * 1. takes blob index info and the overlapping fresh bytes as input
+ * 2. reads source blobs
+ * 3. writes fresh bytes on top of them
+ * 4. writes new blobs with fresh bytes applied
+ * 5. calls AddBlob op to:
+ *  5.1 add those new blobs to the index
+ *  5.2 update source blob blocklists
+ *  5.3 erase source blocks
+ * 6. reports completion after which the processed fresh bytes will be trimmed
+ */
 class TFlushBytesActor final
     : public TActorBootstrapped<TFlushBytesActor>
 {


### PR DESCRIPTION
### Notes
Follow-up for https://github.com/ydb-platform/nbs/pull/6389

* comments explaining the logic in `TFreshBytes` and in `FlushBytes` op
* extracted block/byte layer visitors into `layer.h/cpp` and added a big comment explaining how these layers are structured

### Issue
https://github.com/ydb-platform/nbs/issues/6385
