### PR TITLE
disk_manager: batch snapshot transfer and retry only failed chunks

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/common/transfer.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/common/transfer.go
@@ -15,6 +15,12 @@ import (
 type Milestone struct {
 	ChunkIndex            uint32
 	TransferredChunkCount uint32
+
+	// CurrentBatchBitmap is used only in batched transfer mode. It holds one bit
+	// per chunk of the batch that starts at ChunkIndex; a set bit means the chunk
+	// is already written. It lets a rescheduled task redo only the not-yet-written
+	// chunks of the current batch. Empty in streaming mode.
+	CurrentBatchBitmap []byte
 }
 
 type baseSource interface {
@@ -82,6 +88,14 @@ type Transferer struct {
 	ChunksInflightLimit uint32
 	ChunkSize           int
 
+	// BatchSize enables batched transfer when greater than zero: chunks are
+	// processed in batches of this many chunk indices, only not-yet-written
+	// chunks are (re)tried, and per-batch progress is persisted via
+	// Milestone.CurrentBatchBitmap so a rescheduled task redoes only the failed
+	// chunks of the current batch. Zero keeps the streaming behavior.
+	// Batched mode currently applies only when ShallowSource is nil.
+	BatchSize uint32
+
 	ShallowCopyWorkerCount   uint32
 	ShallowCopyInflightLimit uint32
 	ShallowSource            ShallowSource
@@ -98,6 +112,10 @@ func (t Transferer) Transfer(
 	milestone Milestone,
 	saveProgress SaveProgress,
 ) (uint32, error) {
+
+	if t.BatchSize > 0 && t.ShallowSource == nil {
+		return t.transferBatched(ctx, source, target, milestone, saveProgress)
+	}
 
 	var cancel func()
 	ctx, cancel = context.WithCancel(ctx)
@@ -420,4 +438,357 @@ func (t Transferer) goWrite(
 	}
 
 	return writerErrors
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Batched transfer.
+//
+// Streaming Transfer cancels the whole worker pool on the first write error and
+// restarts from a coarse milestone, so a degraded target (for example S3 that
+// serves only a fraction of requests) makes almost no progress and amplifies
+// errors. Batched mode instead processes chunks in fixed windows of BatchSize
+// chunk indices. Within a window it writes every not-yet-written chunk once and
+// records the successes in a bitmap, then:
+//   - advances to the next window once the whole window is written;
+//   - on a non-retriable error, fails immediately (as before);
+//   - otherwise, if some chunks are still unwritten, persists the bitmap and
+//     returns a retriable error. The task framework reschedules the task, which
+//     resumes the same window and redoes only the not-yet-written chunks.
+// Already-written chunks are never redone, so the transfer makes monotonic
+// progress even against a heavily degraded target.
+
+func (t Transferer) transferBatched(
+	ctx context.Context,
+	source Source,
+	target Target,
+	milestone Milestone,
+	saveProgress SaveProgress,
+) (uint32, error) {
+
+	chunkCount, err := source.ChunkCount(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	processedChunkIndices := make(chan uint32, t.ChunksInflightLimit)
+	defer close(processedChunkIndices)
+
+	var cancel func()
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+
+	chunkIndices, _, chunkIndicesErrors := source.ChunkIndices(
+		ctx,
+		milestone,
+		processedChunkIndices,
+		common.ChannelWithCancellation{}, // holeChunkIndices
+	)
+
+	chunkPool := &sync.Pool{
+		New: func() interface{} {
+			return &Chunk{Data: make([]byte, t.ChunkSize)}
+		},
+	}
+
+	transferredChunkCount := milestone.TransferredChunkCount
+	batchStart := milestone.ChunkIndex
+	bitmap := newBatchBitmap(t.BatchSize, milestone.CurrentBatchBitmap)
+
+	// pending holds the indices of the current window that still need writing.
+	var pending []uint32
+
+	// writeCurrentBatch runs one pass over pending, updating the bitmap and
+	// transferredChunkCount. It returns whether the whole window is written.
+	writeCurrentBatch := func() (bool, error) {
+		if len(pending) == 0 {
+			return true, nil
+		}
+		return t.runBatchPass(
+			ctx,
+			source,
+			target,
+			chunkPool,
+			pending,
+			batchStart,
+			bitmap,
+			&transferredChunkCount,
+		)
+	}
+
+	rescheduleForUnwritten := func() error {
+		if err := saveProgress(ctx, Milestone{
+			ChunkIndex:            batchStart,
+			TransferredChunkCount: transferredChunkCount,
+			CurrentBatchBitmap:    bitmap.clone(),
+		}); err != nil {
+			return err
+		}
+
+		logging.Warn(
+			ctx,
+			"Batch at chunk %v is not fully written, rescheduling",
+			batchStart,
+		)
+		return errors.NewRetriableErrorf(
+			"batch at chunk %v is not fully written",
+			batchStart,
+		)
+	}
+
+	// finishCurrentBatch processes the current window and, on success, advances
+	// to the next one.
+	finishCurrentBatch := func() error {
+		hadWork := len(pending) > 0
+
+		done, err := writeCurrentBatch()
+		if err != nil {
+			return err
+		}
+		if !done {
+			return rescheduleForUnwritten()
+		}
+
+		batchStart += t.BatchSize
+		bitmap.reset()
+		pending = pending[:0]
+
+		if !hadWork {
+			// Empty window (for example a gap between allocated regions): nothing
+			// was written, so skip the progress save. A crash just re-scans this
+			// range, which writes nothing.
+			return nil
+		}
+		return saveProgress(ctx, Milestone{
+			ChunkIndex:            batchStart,
+			TransferredChunkCount: transferredChunkCount,
+		})
+	}
+
+	indicesDrained := false
+	generationChecked := false
+	for !indicesDrained || !generationChecked {
+		select {
+		case chunkIndex, more := <-chunkIndices:
+			if !more {
+				indicesDrained = true
+				chunkIndices = nil
+				continue
+			}
+
+			for chunkIndex >= batchStart+t.BatchSize {
+				if err := finishCurrentBatch(); err != nil {
+					return 0, err
+				}
+			}
+
+			if !bitmap.isSet(chunkIndex - batchStart) {
+				pending = append(pending, chunkIndex)
+			}
+
+			// Keep the source generator unblocked: it limits the number of
+			// in-flight indices via this channel.
+			select {
+			case processedChunkIndices <- chunkIndex:
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			}
+		case err := <-chunkIndicesErrors:
+			if err != nil {
+				return 0, err
+			}
+			generationChecked = true
+			chunkIndicesErrors = nil
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+
+	// Process the last (partial) window.
+	done, err := writeCurrentBatch()
+	if err != nil {
+		return 0, err
+	}
+	if !done {
+		return 0, rescheduleForUnwritten()
+	}
+
+	if err := saveProgress(ctx, Milestone{
+		ChunkIndex:            chunkCount,
+		TransferredChunkCount: transferredChunkCount,
+	}); err != nil {
+		return 0, err
+	}
+
+	return transferredChunkCount, nil
+}
+
+// runBatchPass writes every index in pending once, using WriterCount workers.
+// Successful writes are recorded in bitmap and counted in transferredChunkCount.
+// It returns whether all pending indices are now written. A non-retriable error
+// stops the pass and is returned; retriable failures just leave the chunk
+// unwritten (to be retried after reschedule).
+func (t Transferer) runBatchPass(
+	ctx context.Context,
+	source Source,
+	target Target,
+	chunkPool *sync.Pool,
+	pending []uint32,
+	batchStart uint32,
+	bitmap *batchBitmap,
+	transferredChunkCount *uint32,
+) (bool, error) {
+
+	passCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	indices := make(chan uint32)
+
+	var mutex sync.Mutex
+	var nonRetriableErr error
+	var panicValue interface{}
+
+	handleErr := func(err error) bool {
+		if errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
+
+			return true
+		}
+		if isNonRetriableError(err) {
+			mutex.Lock()
+			if nonRetriableErr == nil {
+				nonRetriableErr = err
+			}
+			mutex.Unlock()
+			cancel()
+			return true
+		}
+		// Retriable: leave the chunk unwritten, keep going.
+		return false
+	}
+
+	workerCount := t.WriterCount
+	if workerCount == 0 {
+		workerCount = 1
+	}
+
+	var wg sync.WaitGroup
+	for i := uint32(0); i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					mutex.Lock()
+					if panicValue == nil {
+						panicValue = r
+					}
+					mutex.Unlock()
+					cancel()
+				}
+			}()
+
+			chunk := chunkPool.Get().(*Chunk)
+			defer chunkPool.Put(chunk)
+
+			for chunkIndex := range indices {
+				if passCtx.Err() != nil {
+					return
+				}
+
+				chunk.Index = chunkIndex
+				chunk.Zero = false
+
+				if err := source.Read(passCtx, chunk); err != nil {
+					if handleErr(err) {
+						return
+					}
+					continue
+				}
+
+				if !chunk.Zero {
+					chunk.Zero = chunk.CheckDataIsAllZeroes()
+				}
+
+				if err := target.Write(passCtx, *chunk); err != nil {
+					if handleErr(err) {
+						return
+					}
+					continue
+				}
+
+				mutex.Lock()
+				bitmap.set(chunkIndex - batchStart)
+				mutex.Unlock()
+				atomic.AddUint32(transferredChunkCount, 1)
+			}
+		}()
+	}
+
+	for _, chunkIndex := range pending {
+		select {
+		case indices <- chunkIndex:
+		case <-passCtx.Done():
+		}
+	}
+	close(indices)
+	wg.Wait()
+
+	if panicValue != nil {
+		errors.NewPanicError(panicValue).Reraise()
+	}
+	if nonRetriableErr != nil {
+		return false, nonRetriableErr
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	for _, chunkIndex := range pending {
+		if !bitmap.isSet(chunkIndex - batchStart) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func isNonRetriableError(err error) bool {
+	return errors.Is(err, errors.NewEmptyNonRetriableError())
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// batchBitmap tracks which chunks of a batch have been written, one bit each.
+type batchBitmap struct {
+	bits []byte
+}
+
+func newBatchBitmap(batchSize uint32, data []byte) *batchBitmap {
+	size := int((batchSize + 7) / 8)
+	bits := make([]byte, size)
+	// Reuse the persisted bits only if they match the current batch size,
+	// otherwise start clean and redo the whole batch (writes are idempotent).
+	if len(data) == size {
+		copy(bits, data)
+	}
+	return &batchBitmap{bits: bits}
+}
+
+func (b *batchBitmap) set(index uint32) {
+	b.bits[index/8] |= 1 << (index % 8)
+}
+
+func (b *batchBitmap) isSet(index uint32) bool {
+	return b.bits[index/8]&(1<<(index%8)) != 0
+}
+
+func (b *batchBitmap) reset() {
+	for i := range b.bits {
+		b.bits[i] = 0
+	}
+}
+
+func (b *batchBitmap) clone() []byte {
+	out := make([]byte, len(b.bits))
+	copy(out, b.bits)
+	return out
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/common/transfer_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/common/transfer_test.go
@@ -487,3 +487,156 @@ func TestTransferShouldNotUpdateMilestoneWhenShallowCopyIsFailed(t *testing.T) {
 		shallowCopyMilestone.ChunkIndex,
 	)
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+// emitChunkIndices returns the channels for a sourceMock.ChunkIndices stub that
+// emits the contiguous indices [0, chunkCount).
+func emitChunkIndices(chunkCount uint32) (chan uint32, common.ChannelWithCancellation, chan error) {
+	chunkIndices := make(chan uint32, 100500)
+	duplicatedChunkIndices := common.NewChannelWithCancellation(100500)
+	chunkIndicesErrors := make(chan error, 1)
+
+	go func() {
+		for i := uint32(0); i < chunkCount; i++ {
+			chunkIndices <- i
+		}
+
+		chunkIndicesErrors <- nil
+		close(chunkIndices)
+		close(chunkIndicesErrors)
+	}()
+
+	return chunkIndices, duplicatedChunkIndices, chunkIndicesErrors
+}
+
+func TestTransferBatched(t *testing.T) {
+	ctx := newContext()
+	source := &sourceMock{}
+	target := &targetMock{}
+
+	chunkSize := 16
+	chunkCount := uint32(101)
+
+	chunkIndices, duplicatedChunkIndices, chunkIndicesErrors := emitChunkIndices(chunkCount)
+
+	source.On("ChunkCount", mock.Anything).Return(chunkCount, nil)
+	source.On("ChunkIndices", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		chunkIndices,
+		duplicatedChunkIndices,
+		chunkIndicesErrors,
+	)
+	source.On("Read", mock.Anything, mock.Anything).Return(nil)
+	target.On("Write", mock.Anything, mock.Anything).Return(nil)
+
+	transferer := Transferer{
+		ReaderCount:         uint32(11),
+		WriterCount:         uint32(22),
+		ChunksInflightLimit: uint32(100500),
+		ChunkSize:           chunkSize,
+		BatchSize:           uint32(10),
+	}
+
+	transferredChunkCount, err := transferer.Transfer(
+		ctx,
+		source,
+		target,
+		Milestone{},
+		func(context.Context, Milestone) error { return nil },
+	)
+	require.NoError(t, err)
+	require.Equal(t, int(chunkCount), int(transferredChunkCount))
+}
+
+// When some chunk writes fail, the batch is left incomplete, the bitmap is
+// persisted, and a rescheduled transfer redoes only the not-yet-written chunks.
+func TestTransferBatchedResumesOnlyUnwrittenChunks(t *testing.T) {
+	ctx := newContext()
+
+	chunkSize := 16
+	chunkCount := uint32(100)
+
+	transferer := Transferer{
+		ReaderCount:         uint32(4),
+		WriterCount:         uint32(4),
+		ChunksInflightLimit: uint32(100500),
+		ChunkSize:           chunkSize,
+		BatchSize:           uint32(128), // one batch covers all chunks
+	}
+
+	// First run: odd-index writes fail (retriable), even-index writes succeed.
+	source1 := &sourceMock{}
+	target1 := &targetMock{}
+	chunkIndices1, duplicated1, errors1 := emitChunkIndices(chunkCount)
+
+	source1.On("ChunkCount", mock.Anything).Return(chunkCount, nil)
+	source1.On("ChunkIndices", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		chunkIndices1,
+		duplicated1,
+		errors1,
+	)
+	source1.On("Read", mock.Anything, mock.Anything).Return(nil)
+	target1.On("Write", mock.Anything, mock.MatchedBy(func(c Chunk) bool {
+		return c.Index%2 == 0
+	})).Return(nil)
+	target1.On("Write", mock.Anything, mock.MatchedBy(func(c Chunk) bool {
+		return c.Index%2 == 1
+	})).Return(assert.AnError)
+
+	var savedMilestone Milestone
+	_, err := transferer.Transfer(
+		ctx,
+		source1,
+		target1,
+		Milestone{},
+		func(_ context.Context, milestone Milestone) error {
+			savedMilestone = milestone
+			return nil
+		},
+	)
+	require.Error(t, err)
+	require.NotEmpty(t, savedMilestone.CurrentBatchBitmap)
+
+	// Second run resumes with the persisted bitmap. All writes succeed now, and
+	// only the previously-failed (odd) chunks must be written again.
+	source2 := &sourceMock{}
+	target2 := &targetMock{}
+	chunkIndices2, duplicated2, errors2 := emitChunkIndices(chunkCount)
+
+	source2.On("ChunkCount", mock.Anything).Return(chunkCount, nil)
+	source2.On("ChunkIndices", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		chunkIndices2,
+		duplicated2,
+		errors2,
+	)
+	source2.On("Read", mock.Anything, mock.Anything).Return(nil)
+
+	var writeMutex sync.Mutex
+	writtenIndices := make(map[uint32]bool)
+	target2.On("Write", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		chunk := args.Get(1).(Chunk)
+		writeMutex.Lock()
+		writtenIndices[chunk.Index] = true
+		writeMutex.Unlock()
+	})
+
+	transferredChunkCount, err := transferer.Transfer(
+		ctx,
+		source2,
+		target2,
+		savedMilestone,
+		func(context.Context, Milestone) error { return nil },
+	)
+	require.NoError(t, err)
+	require.Equal(t, int(chunkCount), int(transferredChunkCount))
+
+	require.Equal(t, int(chunkCount/2), len(writtenIndices))
+	for index := range writtenIndices {
+		require.Equal(
+			t,
+			uint32(1),
+			index%2,
+			"only previously-failed odd chunks should be rewritten",
+		)
+	}
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/config/config.proto
@@ -16,6 +16,13 @@ message DataplaneConfig {
     optional uint32 WriterCount = 3 [default = 10];
     optional uint32 ChunksInflightLimit = 4 [default = 100];
 
+    // Enables batched snapshot transfer when greater than zero: chunks are
+    // written in batches of this many chunk indices and only not-yet-written
+    // chunks are retried (via task reschedule), so a degraded S3 makes monotonic
+    // progress instead of stalling. Zero keeps the streaming behavior. Currently
+    // honored by createSnapshotFromDisk for full (non-incremental) snapshots.
+    optional uint32 BatchSize = 21 [default = 0];
+
     optional string SnapshotCollectionTimeout = 5 [default = "30m"];
     optional string CollectSnapshotsTaskScheduleInterval = 6 [default = "1m"];
     optional uint32 SnapshotCollectionInflightLimit = 7 [default = 10];

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task.go
@@ -125,6 +125,28 @@ func (t *createSnapshotFromDiskTask) saveProgress(
 	return execCtx.SaveState(ctx)
 }
 
+// transferMilestone builds the milestone the transfer resumes from, restoring
+// the batch progress (including CurrentBatchBitmap) persisted in the task state.
+func (t *createSnapshotFromDiskTask) transferMilestone() common.Milestone {
+	return common.Milestone{
+		ChunkIndex:            t.state.MilestoneChunkIndex,
+		TransferredChunkCount: t.state.TransferredChunkCount,
+		CurrentBatchBitmap:    t.state.CurrentBatchBitmap,
+	}
+}
+
+// applyTransferMilestone persists transfer progress into the task state so a
+// rescheduled task resumes the current batch and redoes only its unwritten
+// chunks.
+func (t *createSnapshotFromDiskTask) applyTransferMilestone(
+	milestone common.Milestone,
+) {
+
+	t.state.MilestoneChunkIndex = milestone.ChunkIndex
+	t.state.TransferredChunkCount = milestone.TransferredChunkCount
+	t.state.CurrentBatchBitmap = milestone.CurrentBatchBitmap
+}
+
 func (t *createSnapshotFromDiskTask) getNbsClient(
 	ctx context.Context,
 ) (nbs_client.Client, error) {
@@ -325,6 +347,7 @@ func (t *createSnapshotFromDiskTask) run(
 		WriterCount:         t.config.GetWriterCount(),
 		ChunksInflightLimit: t.config.GetChunksInflightLimit(),
 		ChunkSize:           chunkSize,
+		BatchSize:           t.config.GetBatchSize(),
 
 		ShallowCopyWorkerCount:   t.config.SnapshotConfig.GetShallowCopyWorkerCount(),
 		ShallowCopyInflightLimit: t.config.SnapshotConfig.GetShallowCopyInflightLimit(),
@@ -345,10 +368,7 @@ func (t *createSnapshotFromDiskTask) run(
 		ctx,
 		source,
 		target,
-		common.Milestone{
-			ChunkIndex:            t.state.MilestoneChunkIndex,
-			TransferredChunkCount: t.state.TransferredChunkCount,
-		},
+		t.transferMilestone(),
 		func(ctx context.Context, milestone common.Milestone) error {
 			if incremental {
 				_, err := t.storage.CheckSnapshotReady(
@@ -365,8 +385,7 @@ func (t *createSnapshotFromDiskTask) run(
 				return err
 			}
 
-			t.state.MilestoneChunkIndex = milestone.ChunkIndex
-			t.state.TransferredChunkCount = milestone.TransferredChunkCount
+			t.applyTransferMilestone(milestone)
 			return t.saveProgress(ctx, execCtx)
 		},
 	)

--- a/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/create_snapshot_from_disk_task_test.go
@@ -1,0 +1,37 @@
+package dataplane
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/common"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/protos"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+// The batched transfer resume relies on the task persisting the milestone
+// (including CurrentBatchBitmap) into its state and restoring it on the next
+// run. Check that this round-trip keeps every field, so a rescheduled task
+// redoes only the unwritten chunks of the current batch.
+func TestCreateSnapshotFromDiskTransferMilestoneRoundTrip(t *testing.T) {
+	task := createSnapshotFromDiskTask{
+		state: &protos.CreateSnapshotFromDiskTaskState{},
+	}
+
+	milestone := common.Milestone{
+		ChunkIndex:            42,
+		TransferredChunkCount: 40,
+		CurrentBatchBitmap:    []byte{0xb1, 0x00, 0xff, 0x0c},
+	}
+
+	task.applyTransferMilestone(milestone)
+
+	require.EqualValues(t, 42, task.state.MilestoneChunkIndex)
+	require.EqualValues(t, 40, task.state.TransferredChunkCount)
+	require.Equal(t, milestone.CurrentBatchBitmap, task.state.CurrentBatchBitmap)
+
+	// The milestone restored for a resumed transfer must equal the one that was
+	// persisted, bitmap included.
+	require.Equal(t, milestone, task.transferMilestone())
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/protos/create_snapshot_from_disk_task.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/protos/create_snapshot_from_disk_task.proto
@@ -41,6 +41,11 @@ message CreateSnapshotFromDiskTaskState {
     optional bool ProxyOverlayDiskCreated = 10;
     string BaseSnapshotId = 12;
     string BaseCheckpointId = 13;
+    // Bitmap of the current batch in batched transfer mode: one bit per chunk of
+    // the batch that starts at MilestoneChunkIndex, a set bit means the chunk is
+    // already written. Lets a rescheduled task redo only the not-yet-written
+    // chunks of the current batch. Empty in streaming mode.
+    bytes CurrentBatchBitmap = 14;
 }
 
 message CreateSnapshotFromDiskMetadata {

--- a/cloud/disk_manager/internal/pkg/dataplane/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/ya.make
@@ -22,6 +22,7 @@ SRCS(
 
 GO_TEST_SRCS(
     collect_snapshots_task_test.go
+    create_snapshot_from_disk_task_test.go
     replicate_disk_task_test.go
 )
 


### PR DESCRIPTION
## Problem

When S3 is degraded and serves only a fraction of requests, `createSnapshotFromDisk` can stall:

- A single retriable write error cancels the whole `Transferer` worker pool (fail-fast).
- The task restarts from `Milestone`, which is a **contiguous-prefix** watermark, so one failed chunk (a "hole") stops it from advancing.
- Under a high failure rate the prefix barely moves, so the transfer makes almost no forward progress and can exhaust the task retry limit.
- The cascade of `context.Canceled` from the cancelled pool also inflates the `s3_client` `errors` metric, which pages the on-call (`manager_dataplane_s3_client_errors`).

## Change

A batched transfer mode in `Transferer`, gated behind a new `BatchSize` config option (`0` = current streaming behavior, unchanged):

- Chunks are processed in fixed windows of `BatchSize` chunk indices.
- Within a window, every not-yet-written chunk is written once; successes are recorded in a bitmap.
- A non-retriable error still fails fast. If chunks remain unwritten (for example S3 degraded), the bitmap is persisted and a **retriable** error is returned — the task reschedules and redoes only the unwritten chunks.
- Progress is persisted as `Milestone.ChunkIndex` (batch start) plus a new `CurrentBatchBitmap` field in `CreateSnapshotFromDiskTaskState`.

Already-written chunks are never redone, so the transfer makes monotonic progress even against a heavily degraded target, and without pool-wide cancellation there is no `context.Canceled` amplification. The "retry" is the existing task reschedule mechanism (with its own backoff and limits) — there is no bespoke in-process retry loop or attempt budget.

## Scope / rollout

- Off by default (`BatchSize = 0`). `Transferer` and `Milestone` are shared by all dataplane tasks; only `createSnapshotFromDisk` reads the new config, and only for **full (non-incremental)** snapshots (`ShallowSource == nil`). The shallow-copy / incremental path is unchanged for now.
- Generated `*.pb.go` is not committed (generated at build time).

## Testing

- `TestTransferBatched` — batched transfer completes and transfers all chunks.
- `TestTransferBatchedResumesOnlyUnwrittenChunks` — when some writes fail, the batch is left incomplete, the bitmap is persisted, and a resumed transfer rewrites **only** the previously-failed chunks.
- `TestCreateSnapshotFromDiskTransferMilestoneRoundTrip` — the task persists the milestone (including `CurrentBatchBitmap`) into its state and restores it unchanged for a resumed transfer.
- `ya make --build relwithdebinfo -tA cloud/disk_manager/internal/pkg/dataplane/common` — all tests pass.
- `ya make --build relwithdebinfo -t cloud/disk_manager/internal/pkg/dataplane -F "*TransferMilestoneRoundTrip*"` — task test passes.
- `ya make --build relwithdebinfo cloud/disk_manager` — full build passes (all `Transferer`/`Milestone` consumers plus regenerated proto/config).

Integration testing against a real degraded S3 is recommended before enabling `BatchSize` in production.
