### PR TITLE
[Filestore] Handle requests with three-stage write disabled in TWriteDataActor

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -152,6 +152,8 @@ private:
     const NCloud::NProto::EStorageMediaKind MediaKind;
     TRope Rope;
 
+    const bool UseThreeStageWrite = true;
+
 public:
     TWriteDataActor(
         NProto::TWriteDataRequest request,
@@ -163,7 +165,8 @@ public:
         IRequestStatsPtr requestStats,
         IProfileLogPtr profileLog,
         ITraceSerializerPtr traceSerializer,
-        NCloud::NProto::EStorageMediaKind mediaKind)
+        NCloud::NProto::EStorageMediaKind mediaKind,
+        bool useThreeStageWrite)
         : WriteRequest(std::move(request))
         , Range(range)
         , BlobRange(Range.AlignedSubRange())
@@ -175,10 +178,17 @@ public:
         , ProfileLog(std::move(profileLog))
         , TraceSerializer(std::move(traceSerializer))
         , MediaKind(mediaKind)
+        , UseThreeStageWrite(useThreeStageWrite)
     {}
 
     void Bootstrap(const TActorContext& ctx)
     {
+        if (!UseThreeStageWrite) {
+            WriteData(ctx, NProto::TError());
+            Become(&TThis::StateWork);
+            return;
+        }
+
         FILESTORE_TRACK(
             RequestReceived_ServiceWorker,
             RequestInfo->CallContext,
@@ -806,17 +816,19 @@ private:
 
         MoveIovecsToBuffer(WriteRequest);
 
-        LOG_WARN(
-            ctx,
-            TFileStoreComponents::SERVICE,
-            "%s Falling back to WriteData for %lu, %lu, %lu (%lu bytes). "
-            "Message: %s",
-            LogTag.c_str(),
-            WriteRequest.GetNodeId(),
-            WriteRequest.GetHandle(),
-            WriteRequest.GetOffset(),
-            NFileStore::CalculateByteCount(WriteRequest),
-            FormatError(error).Quote().c_str());
+        if (HasError(error)) {
+            LOG_WARN(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "%s Falling back to WriteData for %lu, %lu, %lu (%lu bytes). "
+                "Message: %s",
+                LogTag.c_str(),
+                WriteRequest.GetNodeId(),
+                WriteRequest.GetHandle(),
+                WriteRequest.GetOffset(),
+                NFileStore::CalculateByteCount(WriteRequest),
+                FormatError(error).Quote().c_str());
+        }
 
         auto request = std::make_unique<TEvService::TEvWriteDataRequest>();
         request->Record = std::move(WriteRequest);
@@ -990,14 +1002,6 @@ void TStorageServiceActor::HandleWriteData(
 
     const auto threeStageWriteAllowed = IsThreeStageWriteEnabled(filestore);
 
-    if (!threeStageWriteAllowed) {
-        // If three-stage write is disabled, forward the request to the tablet
-        // in the same way as all other requests.
-        MoveIovecsToBuffer(msg->Record);
-        ForwardRequest<TEvService::TWriteDataMethod>(ctx, ev);
-        return;
-    }
-
     ui32 blockSize = filestore.GetBlockSize();
 
     const auto bytesCount = NFileStore::CalculateByteCount(msg->Record);
@@ -1012,55 +1016,54 @@ void TStorageServiceActor::HandleWriteData(
         filestore.GetFeatures().GetBlockChecksumsInProfileLogEnabled() ||
         StorageConfig->GetBlockChecksumsInProfileLogEnabled();
 
+    auto logTag = filestore.GetFileSystemId();
     if (threeStageWriteEnabled) {
-        auto logTag = filestore.GetFileSystemId();
         LOG_DEBUG(
             ctx,
             TFileStoreComponents::SERVICE,
             "%s Using three-stage write for request, size: %lu",
             logTag.c_str(),
             bytesCount);
-
-        auto [cookie, inflight] = CreateInFlightRequest(
-            TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
-            session->MediaKind,
-            session->RequestStats,
-            startTime);
-
-        InitProfileLogRequestInfo(
-            inflight->AccessProfileLogRequest(),
-            msg->Record);
-        inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
-        if (blockChecksumsEnabled) {
-            CalculateWriteDataRequestChecksums(
-                msg->Record,
-                blockSize,
-                inflight->AccessProfileLogRequest());
-        }
-
-        auto requestInfo =
-            CreateRequestInfo(SelfId(), cookie, msg->CallContext);
-
-        auto actor = std::make_unique<TWriteDataActor>(
-            std::move(msg->Record),
-            range,
-            std::move(requestInfo),
-            std::move(logTag),
-            filestore.GetFeatures().GetWriteBlobDisabled(),
-            filestore.GetFeatures().GetUnconfirmedFlowEnabled(),
-            session->RequestStats,
-            ProfileLog,
-            TraceSerializer,
-            session->MediaKind);
-        NCloud::Register(ctx, std::move(actor));
     } else {
         LOG_DEBUG(
             ctx,
             TFileStoreComponents::SERVICE,
             "Forwarding WriteData request to tablet");
-        MoveIovecsToBuffer(msg->Record);
-        ForwardRequest<TEvService::TWriteDataMethod>(ctx, ev);
     }
+
+    auto [cookie, inflight] = CreateInFlightRequest(
+        TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
+        session->MediaKind,
+        session->RequestStats,
+        startTime);
+
+    InitProfileLogRequestInfo(
+        inflight->AccessProfileLogRequest(),
+        msg->Record);
+    inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
+    if (blockChecksumsEnabled) {
+        CalculateWriteDataRequestChecksums(
+            msg->Record,
+            blockSize,
+            inflight->AccessProfileLogRequest());
+    }
+
+    auto requestInfo =
+        CreateRequestInfo(SelfId(), cookie, msg->CallContext);
+
+    auto actor = std::make_unique<TWriteDataActor>(
+        std::move(msg->Record),
+        range,
+        std::move(requestInfo),
+        std::move(logTag),
+        filestore.GetFeatures().GetWriteBlobDisabled(),
+        filestore.GetFeatures().GetUnconfirmedFlowEnabled(),
+        session->RequestStats,
+        ProfileLog,
+        TraceSerializer,
+        session->MediaKind,
+        threeStageWriteEnabled);
+    NCloud::Register(ctx, std::move(actor));
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -1040,9 +1040,7 @@ void TStorageServiceActor::HandleWriteData(
         session->RequestStats,
         startTime);
 
-    InitProfileLogRequestInfo(
-        inflight->AccessProfileLogRequest(),
-        msg->Record);
+    InitProfileLogRequestInfo(inflight->AccessProfileLogRequest(), msg->Record);
     inflight->AccessProfileLogRequest().SetClientId(session->ClientId);
     if (blockChecksumsEnabled) {
         CalculateWriteDataRequestChecksums(
@@ -1051,8 +1049,7 @@ void TStorageServiceActor::HandleWriteData(
             inflight->AccessProfileLogRequest());
     }
 
-    auto requestInfo =
-        CreateRequestInfo(SelfId(), cookie, msg->CallContext);
+    auto requestInfo = CreateRequestInfo(SelfId(), cookie, msg->CallContext);
 
     auto actor = std::make_unique<TWriteDataActor>(
         std::move(msg->Record),

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -189,7 +189,7 @@ public:
                 TFileStoreComponents::SERVICE,
                 "Forwarding WriteData request to tablet");
 
-            WriteData(ctx, false);
+            WriteData(ctx, false /* isFallback */);
             Become(&TThis::StateWork);
             return;
         }
@@ -299,7 +299,7 @@ private:
         if (HasError(error)) {
             if (error.GetCode() != E_FS_THROTTLED) {
                 LogFallbackToWriteData(ctx, error);
-                WriteData(ctx, true);
+                WriteData(ctx, true /* isFallback */);
             } else {
                 HandleError(ctx, error);
             }
@@ -484,7 +484,7 @@ private:
                 return CancelAddData(ctx);
             }
 
-            return WriteData(ctx, true);
+            return WriteData(ctx, true /* isFallback */);
         }
 
         // It is implicitly expected that cookies are generated in increasing
@@ -627,7 +627,7 @@ private:
 
         if (HasError(msg->GetError())) {
             LogFallbackToWriteData(ctx, msg->GetError());
-            WriteData(ctx, true);
+            WriteData(ctx, true /* isFallback */);
             return;
         }
 
@@ -724,7 +724,7 @@ private:
 
             ResetTabletProxyRetryState();
             LogFallbackToWriteData(ctx, msg->GetError());
-            return WriteData(ctx, true);
+            return WriteData(ctx, true /* isFallback */);
         }
 
         ResetTabletProxyRetryState();
@@ -756,7 +756,7 @@ private:
         }
 
         ResetTabletProxyRetryState();
-        WriteData(ctx, true);
+        WriteData(ctx, true /* isFallback */);
     }
 
     void HandleWakeup(

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -816,7 +816,8 @@ private:
 
         MoveIovecsToBuffer(WriteRequest);
 
-        if (HasError(error)) {
+        bool isFallback = HasError(error);
+        if (isFallback) {
             LOG_WARN(
                 ctx,
                 TFileStoreComponents::SERVICE,
@@ -832,7 +833,9 @@ private:
 
         auto request = std::make_unique<TEvService::TEvWriteDataRequest>();
         request->Record = std::move(WriteRequest);
-        request->Record.MutableHeaders()->SetThrottlingDisabled(true);
+        if (isFallback) {
+            request->Record.MutableHeaders()->SetThrottlingDisabled(true);
+        }
         request->CallContext = RequestInfo->CallContext;
         auto* trace =
             request->Record.MutableHeaders()->MutableInternal()->MutableTrace();

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -756,6 +756,7 @@ private:
         }
 
         ResetTabletProxyRetryState();
+        LogFallbackToWriteData(ctx, WriteBlobError);
         WriteData(ctx, true /* isFallback */);
     }
 

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -152,7 +152,7 @@ private:
     const NCloud::NProto::EStorageMediaKind MediaKind;
     TRope Rope;
 
-    const bool UseThreeStageWrite = true;
+    const bool UseThreeStageWrite = false;
 
 public:
     TWriteDataActor(
@@ -184,10 +184,22 @@ public:
     void Bootstrap(const TActorContext& ctx)
     {
         if (!UseThreeStageWrite) {
-            WriteData(ctx, NProto::TError());
+            LOG_DEBUG(
+                ctx,
+                TFileStoreComponents::SERVICE,
+                "Forwarding WriteData request to tablet");
+
+            WriteData(ctx, false);
             Become(&TThis::StateWork);
             return;
         }
+
+        LOG_DEBUG(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "%s Using three-stage write for request, size: %lu",
+            LogTag.c_str(),
+            Range.Length);
 
         FILESTORE_TRACK(
             RequestReceived_ServiceWorker,
@@ -286,7 +298,8 @@ private:
 
         if (HasError(error)) {
             if (error.GetCode() != E_FS_THROTTLED) {
-                WriteData(ctx, error);
+                LogFallbackToWriteData(ctx, error);
+                WriteData(ctx, true);
             } else {
                 HandleError(ctx, error);
             }
@@ -471,7 +484,7 @@ private:
                 return CancelAddData(ctx);
             }
 
-            return WriteData(ctx, error);
+            return WriteData(ctx, true);
         }
 
         // It is implicitly expected that cookies are generated in increasing
@@ -613,7 +626,8 @@ private:
         InFlightRequest->Complete(ctx.Now(), msg->GetError());
 
         if (HasError(msg->GetError())) {
-            WriteData(ctx, msg->GetError());
+            LogFallbackToWriteData(ctx, msg->GetError());
+            WriteData(ctx, true);
             return;
         }
 
@@ -709,7 +723,8 @@ private:
             }
 
             ResetTabletProxyRetryState();
-            return WriteData(ctx, msg->GetError());
+            LogFallbackToWriteData(ctx, msg->GetError());
+            return WriteData(ctx, true);
         }
 
         ResetTabletProxyRetryState();
@@ -741,7 +756,7 @@ private:
         }
 
         ResetTabletProxyRetryState();
-        WriteData(ctx, WriteBlobError);
+        WriteData(ctx, true);
     }
 
     void HandleWakeup(
@@ -804,10 +819,30 @@ private:
         TabletProxyRetryDelayProvider.Reset();
     }
 
+    inline void LogFallbackToWriteData(
+        const TActorContext& ctx,
+        const NProto::TError& error)
+    {
+        LOG_WARN(
+            ctx,
+            TFileStoreComponents::SERVICE,
+            "%s Falling back to WriteData for %lu, %lu, %lu (%lu bytes). "
+            "Message: %s",
+            LogTag.c_str(),
+            WriteRequest.GetNodeId(),
+            WriteRequest.GetHandle(),
+            WriteRequest.GetOffset(),
+            NFileStore::CalculateByteCount(WriteRequest),
+            FormatError(error).Quote().c_str());
+    }
+
     /**
-     * @brief Fallback to regular write if two-stage write fails for any reason
+     * @brief Use regular write if three-stage write fails for any reason or
+     * disabled in filesystem configuration
+     * @param isFallback true if this is a fallback write after three-stage
+     * write failed
      */
-    void WriteData(const TActorContext& ctx, const NProto::TError& error)
+    void WriteData(const TActorContext& ctx, bool isFallback)
     {
         FILESTORE_TRACK(
             RequestReceived_ServiceWorker,
@@ -815,22 +850,6 @@ private:
             "WriteData");
 
         MoveIovecsToBuffer(WriteRequest);
-
-        bool isFallback = HasError(error);
-        if (isFallback) {
-            LOG_WARN(
-                ctx,
-                TFileStoreComponents::SERVICE,
-                "%s Falling back to WriteData for %lu, %lu, %lu (%lu bytes). "
-                "Message: %s",
-                LogTag.c_str(),
-                WriteRequest.GetNodeId(),
-                WriteRequest.GetHandle(),
-                WriteRequest.GetOffset(),
-                NFileStore::CalculateByteCount(WriteRequest),
-                FormatError(error).Quote().c_str());
-        }
-
         auto request = std::make_unique<TEvService::TEvWriteDataRequest>();
         request->Record = std::move(WriteRequest);
         if (isFallback) {
@@ -1020,20 +1039,6 @@ void TStorageServiceActor::HandleWriteData(
         StorageConfig->GetBlockChecksumsInProfileLogEnabled();
 
     auto logTag = filestore.GetFileSystemId();
-    if (threeStageWriteEnabled) {
-        LOG_DEBUG(
-            ctx,
-            TFileStoreComponents::SERVICE,
-            "%s Using three-stage write for request, size: %lu",
-            logTag.c_str(),
-            bytesCount);
-    } else {
-        LOG_DEBUG(
-            ctx,
-            TFileStoreComponents::SERVICE,
-            "Forwarding WriteData request to tablet");
-    }
-
     auto [cookie, inflight] = CreateInFlightRequest(
         TRequestInfo(ev->Sender, ev->Cookie, msg->CallContext),
         session->MediaKind,


### PR DESCRIPTION
prefactoring for issue: https://github.com/ydb-platform/nbs/issues/6334

Handle requests with three-stage write disabled in TWriteDataActor to avoid copying iovecs into a buffer in the singleton TStorageServiceActor.

The 1 MiB FIO tests showed a significant improvement in write bandwidth, increasing from 3 GiB/s to 7.3 GiB/s.