### PR TITLE
Add ability to send CMS requests from DR monitoring page

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -398,6 +398,16 @@ private:
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
 
+    void HandleHttpInfo_SendCmsHostRequest(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        TRequestInfoPtr requestInfo);
+
+    void HandleHttpInfo_SendCmsDeviceRequest(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        TRequestInfoPtr requestInfo);
+
     void HandleHttpInfo_RenderDisks(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_cms.cpp
@@ -102,6 +102,7 @@ void TCmsRequestActor::SendNextRequest(const TActorContext& ctx)
             auto request = std::make_unique<TRequest>(
                 action.GetHost(),
                 NProto::EAgentState::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 action.GetDryRun());
 
             NCloud::Send(
@@ -118,6 +119,7 @@ void TCmsRequestActor::SendNextRequest(const TActorContext& ctx)
                 action.GetHost(),
                 action.GetDevice(),
                 NProto::EDeviceState::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 /*shouldResumeDevice=*/false,
                 action.GetDryRun());
 
@@ -151,6 +153,7 @@ void TCmsRequestActor::SendNextRequest(const TActorContext& ctx)
                 action.GetHost(),
                 action.GetDevice(),
                 NProto::EDeviceState::DEVICE_STATE_ONLINE,
+                /*customMessage=*/TString(),
                 /*shouldResumeDevice=*/false,
                 action.GetDryRun());
 
@@ -167,6 +170,7 @@ void TCmsRequestActor::SendNextRequest(const TActorContext& ctx)
             auto request = std::make_unique<TRequest>(
                 action.GetHost(),
                 NProto::EAgentState::AGENT_STATE_ONLINE,
+                /*customMessage=*/TString(),
                 action.GetDryRun());
 
             NCloud::Send(
@@ -180,6 +184,7 @@ void TCmsRequestActor::SendNextRequest(const TActorContext& ctx)
             using TRequest = TEvDiskRegistryPrivate::TEvPurgeHostCmsRequest;
             auto request = std::make_unique<TRequest>(
                 action.GetHost(),
+                /*customMessage=*/TString(),
                 action.GetDryRun());
 
             NCloud::Send(ctx, Owner, std::move(request));

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -7,6 +7,7 @@
 
 #include <library/cpp/monlib/service/pages/templates.h>
 
+#include <util/generic/set.h>
 #include <util/stream/str.h>
 #include <util/string/join.h>
 
@@ -111,8 +112,16 @@ void BuildChangeDeviceStateButton(
     ui64 tabletId,
     const TString& deviceUUID)
 {
+    HTML(out) {
+        TAG(TH4) {
+            BuildMenuButton(out, "device-state-change");
+            out << "Change Device State";
+        }
+    }
+
     out << Sprintf(
-        R"(<form name="devtSateChange%s" method="post">
+        R"(<div class='collapse form-group' id='%s'>
+            <form name="devtSateChange%s" method="post">
             <br>
             <label for="NewState">Change device state to:</label>
             <select name="NewState">
@@ -131,7 +140,9 @@ void BuildChangeDeviceStateButton(
             <input type='hidden' name='action' value='changeDeviceState'/>
             <input type='hidden' name='DeviceUUID' value='%s'/>
             <input type='hidden' name='TabletID' value='%lu'/>
-            </form>)",
+            </form>
+        </div>)",
+        "device-state-change",
         deviceUUID.c_str(),
         EDeviceState_Name(NProto::DEVICE_STATE_ONLINE).c_str(),
         EDeviceState_Name(NProto::DEVICE_STATE_WARNING).c_str(),
@@ -144,8 +155,16 @@ void BuildChangeAgentStateButton(
     ui64 tabletId,
     const TString& agentId)
 {
+    HTML(out) {
+        TAG(TH4) {
+            BuildMenuButton(out, "agent-state-change");
+            out << "Change Agent State";
+        }
+    }
+
     out << Sprintf(
-        R"(<form name="agentStateChange%s" method="post">
+        R"(<div class='collapse form-group' id='%s'>
+            <form name="agentStateChange%s" method="post">
             <br>
             <label for="NewState">Change agent state to:</label>
             <select name="NewState">
@@ -164,10 +183,121 @@ void BuildChangeAgentStateButton(
             <input type='hidden' name='action' value='changeAgentState'/>
             <input type='hidden' name='AgentID' value='%s'/>
             <input type='hidden' name='TabletID' value='%lu'/>
-            </form>)",
+            </form>
+            <hr>
+        </div>)",
+        "agent-state-change",
         agentId.c_str(),
         EAgentState_Name(NProto::AGENT_STATE_ONLINE).c_str(),
         EAgentState_Name(NProto::AGENT_STATE_WARNING).c_str(),
+        agentId.c_str(),
+        tabletId);
+}
+
+void BuildSendCmsAgentRequestMenu(
+    IOutputStream& out,
+    ui64 tabletId,
+    const TString& agentId)
+{
+    HTML(out) {
+        TAG(TH4) {
+            BuildMenuButton(out, "agent-cms-request");
+            out << "Agent CMS Requests";
+        }
+    }
+
+    out << Sprintf(
+        R"(<div class='collapse form-group' id='%s'>
+            <form name="agentCmsRequest" method="post">
+            <br>
+            <label for="CmsAction">CMS request:</label>
+            <select name="CmsAction">
+                <option value="%u">ADD_HOST</option>
+                <option value="%u">REMOVE_HOST</option>
+                <option value="%u">PURGE_HOST</option>
+            </select>
+            <br>
+            <label>
+                <input type="checkbox" name="DryRun" value="1" checked>
+                Dry run
+            </label>
+            <br>
+            <input type="submit" value="Send request">
+            <input type='hidden' name='action' value='sendCmsHostRequest'/>
+            <input type='hidden' name='AgentID' value='%s'/>
+            <input type='hidden' name='TabletID' value='%lu'/>
+            </form>
+            <hr>
+        </div>)",
+        "agent-cms-request",
+        static_cast<ui32>(NProto::TAction::ADD_HOST),
+        static_cast<ui32>(NProto::TAction::REMOVE_HOST),
+        static_cast<ui32>(NProto::TAction::PURGE_HOST),
+        agentId.c_str(),
+        tabletId);
+}
+
+void BuildSendCmsDeviceRequestMenu(
+    IOutputStream& out,
+    ui64 tabletId,
+    const TString& agentId,
+    const TSet<TString>& deviceNames)
+{
+    if (deviceNames.empty()) {
+        return;
+    }
+
+    HTML(out) {
+        TAG(TH4) {
+            BuildMenuButton(out, "device-cms-request");
+            out << "Device CMS Requests";
+        }
+    }
+
+    auto constructDeviceNameOptions = [&deviceNames]() -> TString
+    {
+        TStringBuilder result;
+        for (const auto& deviceName: deviceNames) {
+            result << Sprintf(
+                          R"(<option value="%s">%s</option>)",
+                          deviceName.c_str(),
+                          deviceName.c_str())
+                   << Endl;
+        }
+        return result;
+    };
+
+    out << Sprintf(
+        R"(<div class='collapse form-group' id='%s'>
+            <form name="deviceCmsRequest" method="post">
+            <br>
+            <label for="CmsAction">CMS request:</label>
+            <select name="CmsAction">
+                <option value="%u">ADD_DEVICE</option>
+                <option value="%u">REMOVE_DEVICE</option>
+            </select>
+            <br>
+            <label for="DeviceName">Device path (Name):</label>
+            <select name="DeviceName">
+                %s
+            </select>
+            <br>
+            <label>
+                <input type="checkbox" name="DryRun" value="1" checked>
+                Dry run
+            </label>
+            <br>
+            <input type="submit" value="Send request">
+            <input type='hidden' name='action' value='sendCmsDeviceRequest'/>
+            <input type='hidden' name='AgentID' value='%s'/>
+            <input type='hidden' name='TabletID' value='%lu'/>
+            </form>
+            <hr>
+        </div>)",
+        "device-cms-request",
+        static_cast<ui32>(NProto::TAction::ADD_DEVICE),
+        static_cast<ui32>(NProto::TAction::REMOVE_DEVICE),
+        constructDeviceNameOptions().c_str(),
         agentId.c_str(),
         tabletId);
 }
@@ -637,19 +767,6 @@ void TDiskRegistryActor::RenderAgentHtmlInfo(
             out << "State Timestamp: "
                 << TInstant::MicroSeconds(agent->GetStateTs());
         }
-        DIV() {
-            if (Config->GetEnableToChangeStatesFromDiskRegistryMonpage()) {
-                if (agent->GetState() !=
-                    NProto::EAgentState::AGENT_STATE_UNAVAILABLE)
-                {
-                    BuildChangeAgentStateButton(
-                        out,
-                        TabletID(),
-                        agent->GetAgentId());
-                }
-            }
-
-        }
         DIV() { out << "State Message: " << agent->GetStateMessage(); }
         DIV() {
             out << "CMS Timestamp: "
@@ -658,6 +775,35 @@ void TDiskRegistryActor::RenderAgentHtmlInfo(
         DIV() {
             out << "Work Timestamp: "
                 << TInstant::Seconds(agent->GetWorkTs());
+        }
+        DIV () {
+            if (Config->GetEnableToChangeStatesFromDiskRegistryMonpage() &&
+                agent->GetState() !=
+                    NProto::EAgentState::AGENT_STATE_UNAVAILABLE)
+            {
+                BuildChangeAgentStateButton(
+                    out,
+                    TabletID(),
+                    agent->GetAgentId());
+
+                BuildSendCmsAgentRequestMenu(
+                    out,
+                    TabletID(),
+                    agent->GetAgentId());
+
+                TSet<TString> deviceNames;
+                for (const auto& device: agent->GetDevices()) {
+                    deviceNames.insert(device.GetDeviceName());
+                }
+                for (const auto& device: agent->GetUnknownDevices()) {
+                    deviceNames.insert(device.GetDeviceName());
+                }
+                BuildSendCmsDeviceRequestMenu(
+                    out,
+                    TabletID(),
+                    agent->GetAgentId(),
+                    deviceNames);
+            }
         }
 
         auto dcomp = [] (const auto& d) {
@@ -2619,6 +2765,10 @@ void TDiskRegistryActor::HandleHttpInfo(
          &TDiskRegistryActor::HandleHttpInfo_ChangeDeviseState},
         {"changeAgentState",
          &TDiskRegistryActor::HandleHttpInfo_ChangeAgentState},
+        {"sendCmsHostRequest",
+         &TDiskRegistryActor::HandleHttpInfo_SendCmsHostRequest},
+        {"sendCmsDeviceRequest",
+         &TDiskRegistryActor::HandleHttpInfo_SendCmsDeviceRequest},
         {"resetTransactionLatencyStats",
          &TDiskRegistryActor::HandleHttpInfo_ResetTransactionLatencyStats},
     }};

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_cms.cpp
@@ -98,6 +98,7 @@ void TSendCmsRequestActor::Bootstrap(const TActorContext& ctx)
                 TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>(
                 AgentID,
                 NProto::AGENT_STATE_ONLINE,
+                /*customMessage=*/"monpage",
                 DryRun);
 
             NCloud::Send(ctx, Owner, std::move(request));
@@ -109,6 +110,7 @@ void TSendCmsRequestActor::Bootstrap(const TActorContext& ctx)
                 TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>(
                 AgentID,
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/"monpage",
                 DryRun);
 
             NCloud::Send(ctx, Owner, std::move(request));
@@ -119,6 +121,7 @@ void TSendCmsRequestActor::Bootstrap(const TActorContext& ctx)
             auto request = std::make_unique<
                 TEvDiskRegistryPrivate::TEvPurgeHostCmsRequest>(
                 AgentID,
+                /*customMessage=*/"monpage",
                 DryRun);
 
             NCloud::Send(ctx, Owner, std::move(request));
@@ -131,7 +134,8 @@ void TSendCmsRequestActor::Bootstrap(const TActorContext& ctx)
                 AgentID,
                 DevicePath,
                 NProto::DEVICE_STATE_ONLINE,
-                false,
+                /*customMessage=*/"monpage",
+                /*shouldResumeDevice=*/false,
                 DryRun);
 
             NCloud::Send(ctx, Owner, std::move(request));
@@ -144,7 +148,8 @@ void TSendCmsRequestActor::Bootstrap(const TActorContext& ctx)
                 AgentID,
                 DevicePath,
                 NProto::DEVICE_STATE_WARNING,
-                false,
+                /*customMessage=*/"monpage",
+                /*shouldResumeDevice=*/false,
                 DryRun);
 
             NCloud::Send(ctx, Owner, std::move(request));

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring_cms.cpp
@@ -1,0 +1,453 @@
+#include "disk_registry_actor.h"
+
+#include <cloud/blockstore/libs/storage/core/monitoring_utils.h>
+
+#include <util/string/cast.h>
+#include <util/string/join.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+
+using namespace NMonitoringUtils;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSendCmsRequestActor final
+    : public TActorBootstrapped<TSendCmsRequestActor>
+{
+private:
+    const TActorId Owner;
+    const ui64 TabletID;
+    const TRequestInfoPtr RequestInfo;
+    const TString AgentID;
+    const TString DevicePath;
+    const NProto::TAction_EType ActionType;
+    const bool DryRun;
+
+public:
+    TSendCmsRequestActor(
+        const TActorId& owner,
+        ui64 tabletID,
+        TRequestInfoPtr requestInfo,
+        TString agentId,
+        TString devicePath,
+        NProto::TAction_EType actionType,
+        bool dryRun);
+
+    void Bootstrap(const TActorContext& ctx);
+
+private:
+    void Notify(
+        const TActorContext& ctx,
+        const TString& message,
+        EAlertLevel alertLevel);
+
+    void ReplyAndDie(
+        const TActorContext& ctx,
+        const NProto::TError& error,
+        TDuration timeout = {},
+        const TVector<TString>& dependentDiskIds = {});
+
+    STFUNC(StateWork);
+
+    void HandleUpdateCmsHostStateResponse(
+        const TEvDiskRegistryPrivate::TEvUpdateCmsHostStateResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandlePurgeHostCmsResponse(
+        const TEvDiskRegistryPrivate::TEvPurgeHostCmsResponse::TPtr& ev,
+        const TActorContext& ctx);
+
+    void HandleUpdateCmsHostDeviceStateResponse(
+        const TEvDiskRegistryPrivate::TEvUpdateCmsHostDeviceStateResponse::TPtr&
+            ev,
+        const TActorContext& ctx);
+
+    void HandlePoisonPill(
+        const TEvents::TEvPoisonPill::TPtr& ev,
+        const TActorContext& ctx);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSendCmsRequestActor::TSendCmsRequestActor(
+    const TActorId& owner,
+    ui64 tabletID,
+    TRequestInfoPtr requestInfo,
+    TString agentId,
+    TString devicePath,
+    NProto::TAction_EType actionType,
+    bool dryRun)
+    : Owner(owner)
+    , TabletID(tabletID)
+    , RequestInfo(std::move(requestInfo))
+    , AgentID(std::move(agentId))
+    , DevicePath(std::move(devicePath))
+    , ActionType(actionType)
+    , DryRun(dryRun)
+{}
+
+void TSendCmsRequestActor::Bootstrap(const TActorContext& ctx)
+{
+    switch (ActionType) {
+        case NProto::TAction::ADD_HOST: {
+            auto request = std::make_unique<
+                TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>(
+                AgentID,
+                NProto::AGENT_STATE_ONLINE,
+                DryRun);
+
+            NCloud::Send(ctx, Owner, std::move(request));
+            break;
+        }
+
+        case NProto::TAction::REMOVE_HOST: {
+            auto request = std::make_unique<
+                TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>(
+                AgentID,
+                NProto::AGENT_STATE_WARNING,
+                DryRun);
+
+            NCloud::Send(ctx, Owner, std::move(request));
+            break;
+        }
+
+        case NProto::TAction::PURGE_HOST: {
+            auto request = std::make_unique<
+                TEvDiskRegistryPrivate::TEvPurgeHostCmsRequest>(
+                AgentID,
+                DryRun);
+
+            NCloud::Send(ctx, Owner, std::move(request));
+            break;
+        }
+
+        case NProto::TAction::ADD_DEVICE: {
+            auto request = std::make_unique<
+                TEvDiskRegistryPrivate::TEvUpdateCmsHostDeviceStateRequest>(
+                AgentID,
+                DevicePath,
+                NProto::DEVICE_STATE_ONLINE,
+                false,
+                DryRun);
+
+            NCloud::Send(ctx, Owner, std::move(request));
+            break;
+        }
+
+        case NProto::TAction::REMOVE_DEVICE: {
+            auto request = std::make_unique<
+                TEvDiskRegistryPrivate::TEvUpdateCmsHostDeviceStateRequest>(
+                AgentID,
+                DevicePath,
+                NProto::DEVICE_STATE_WARNING,
+                false,
+                DryRun);
+
+            NCloud::Send(ctx, Owner, std::move(request));
+            break;
+        }
+
+        default:
+            ReplyAndDie(
+                ctx,
+                MakeError(
+                    E_ARGUMENT,
+                    TStringBuilder() << "Invalid CMS request: "
+                                     << static_cast<ui32>(ActionType)));
+            return;
+    }
+
+    Become(&TThis::StateWork);
+}
+
+void TSendCmsRequestActor::Notify(
+    const TActorContext& ctx,
+    const TString& message,
+    EAlertLevel alertLevel)
+{
+    TStringStream out;
+    BuildNotifyPageWithRedirect(
+        out,
+        message,
+        TStringBuilder() << "../tablets/app?action=agent&TabletID=" << TabletID
+                         << "&AgentID=" << AgentID,
+        alertLevel);
+
+    auto response = std::make_unique<NMon::TEvRemoteHttpInfoRes>(out.Str());
+    NCloud::Reply(ctx, *RequestInfo, std::move(response));
+}
+
+void TSendCmsRequestActor::ReplyAndDie(
+    const TActorContext& ctx,
+    const NProto::TError& error,
+    TDuration timeout,
+    const TVector<TString>& dependentDiskIds)
+{
+    const auto actionName = NProto::TAction_EType_Name(ActionType);
+    if (!HasError(error)) {
+        Notify(
+            ctx,
+            TStringBuilder()
+                << "CMS request " << actionName << " successfully completed",
+            EAlertLevel::SUCCESS);
+    } else {
+        TStringBuilder message;
+        message << "failed to send CMS request " << actionName << " for agent "
+                << AgentID.Quote() << ": " << FormatError(error);
+        if (timeout) {
+            message << ", retry timeout: " << timeout.Seconds() << "s";
+        }
+        if (!dependentDiskIds.empty()) {
+            message << ", dependent disks: " << JoinSeq(", ", dependentDiskIds);
+        }
+
+        Notify(ctx, message, EAlertLevel::DANGER);
+    }
+
+    NCloud::Send(
+        ctx,
+        Owner,
+        std::make_unique<TEvDiskRegistryPrivate::TEvOperationCompleted>());
+
+    Die(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TSendCmsRequestActor::HandlePoisonPill(
+    const TEvents::TEvPoisonPill::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+    ReplyAndDie(ctx, MakeTabletIsDeadError(E_REJECTED, __LOCATION__));
+}
+
+void TSendCmsRequestActor::HandleUpdateCmsHostStateResponse(
+    const TEvDiskRegistryPrivate::TEvUpdateCmsHostStateResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* response = ev->Get();
+
+    ReplyAndDie(
+        ctx,
+        response->GetError(),
+        response->Timeout,
+        response->DependentDiskIds);
+}
+
+void TSendCmsRequestActor::HandlePurgeHostCmsResponse(
+    const TEvDiskRegistryPrivate::TEvPurgeHostCmsResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* response = ev->Get();
+
+    ReplyAndDie(
+        ctx,
+        response->GetError(),
+        response->Timeout,
+        response->DependentDiskIds);
+}
+
+void TSendCmsRequestActor::HandleUpdateCmsHostDeviceStateResponse(
+    const TEvDiskRegistryPrivate::TEvUpdateCmsHostDeviceStateResponse::TPtr& ev,
+    const TActorContext& ctx)
+{
+    const auto* response = ev->Get();
+
+    ReplyAndDie(
+        ctx,
+        response->GetError(),
+        response->Timeout,
+        response->DependentDiskIds);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+STFUNC(TSendCmsRequestActor::StateWork)
+{
+    switch (ev->GetTypeRewrite()) {
+        HFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvUpdateCmsHostStateResponse,
+            HandleUpdateCmsHostStateResponse);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvPurgeHostCmsResponse,
+            HandlePurgeHostCmsResponse);
+
+        HFunc(
+            TEvDiskRegistryPrivate::TEvUpdateCmsHostDeviceStateResponse,
+            HandleUpdateCmsHostDeviceStateResponse);
+
+        default:
+            HandleUnexpectedEvent(
+                ev,
+                TBlockStoreComponents::DISK_REGISTRY_WORKER,
+                __PRETTY_FUNCTION__);
+            break;
+    }
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDiskRegistryActor::HandleHttpInfo_SendCmsHostRequest(
+    const TActorContext& ctx,
+    const TCgiParameters& params,
+    TRequestInfoPtr requestInfo)
+{
+    if (!Config->GetEnableToChangeStatesFromDiskRegistryMonpage()) {
+        RejectHttpRequest(
+            ctx,
+            *requestInfo,
+            "Can't send CMS request from monpage");
+        return;
+    }
+
+    const auto& actionRaw = params.Get("CmsAction");
+    const auto& agentId = params.Get("AgentID");
+    const bool dryRun = params.Has("DryRun");
+
+    if (!actionRaw) {
+        RejectHttpRequest(ctx, *requestInfo, "No CMS request is given");
+        return;
+    }
+
+    if (!agentId) {
+        RejectHttpRequest(ctx, *requestInfo, "No agent id is given");
+        return;
+    }
+
+    ui32 actionTypeValue = static_cast<ui32>(NProto::TAction::UNKNOWN);
+    if (!TryFromString(actionRaw, actionTypeValue)) {
+        RejectHttpRequest(
+            ctx,
+            *requestInfo,
+            TStringBuilder()
+                << "Could not parse CMS request type: " << actionRaw);
+        return;
+    }
+    const auto actionType = static_cast<NProto::TAction_EType>(actionTypeValue);
+
+    switch (actionType) {
+        case NProto::TAction::ADD_HOST:
+        case NProto::TAction::REMOVE_HOST:
+        case NProto::TAction::PURGE_HOST:
+            break;
+
+        default:
+            RejectHttpRequest(
+                ctx,
+                *requestInfo,
+                TStringBuilder() << "Invalid CMS request type: " << actionRaw);
+            return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "Send CMS request %s for agent[%s] from monitoring page (dryRun=%s)",
+        NProto::TAction_EType_Name(actionType).c_str(),
+        agentId.c_str(),
+        dryRun ? "true" : "false");
+
+    auto actor = NCloud::Register<TSendCmsRequestActor>(
+        ctx,
+        SelfId(),
+        TabletID(),
+        std::move(requestInfo),
+        agentId,
+        TString(),   // devicePath
+        actionType,
+        dryRun);
+
+    Actors.insert(actor);
+}
+
+void TDiskRegistryActor::HandleHttpInfo_SendCmsDeviceRequest(
+    const TActorContext& ctx,
+    const TCgiParameters& params,
+    TRequestInfoPtr requestInfo)
+{
+    if (!Config->GetEnableToChangeStatesFromDiskRegistryMonpage()) {
+        RejectHttpRequest(
+            ctx,
+            *requestInfo,
+            "Can't send CMS request from monpage");
+        return;
+    }
+
+    const auto& actionRaw = params.Get("CmsAction");
+    const auto& deviceName = params.Get("DeviceName");
+    const auto& agentId = params.Get("AgentID");
+    const bool dryRun = params.Has("DryRun");
+
+    if (!actionRaw) {
+        RejectHttpRequest(ctx, *requestInfo, "No CMS request is given");
+        return;
+    }
+
+    if (!deviceName) {
+        RejectHttpRequest(ctx, *requestInfo, "No device name is given");
+        return;
+    }
+
+    if (!agentId) {
+        RejectHttpRequest(ctx, *requestInfo, "No agent id is given");
+        return;
+    }
+
+    ui32 actionTypeValue = static_cast<ui32>(NProto::TAction::UNKNOWN);
+    if (!TryFromString(actionRaw, actionTypeValue)) {
+        RejectHttpRequest(
+            ctx,
+            *requestInfo,
+            TStringBuilder()
+                << "Could not parse CMS request type: " << actionRaw);
+        return;
+    }
+    const auto actionType = static_cast<NProto::TAction_EType>(actionTypeValue);
+
+    switch (actionType) {
+        case NProto::TAction::ADD_DEVICE:
+        case NProto::TAction::REMOVE_DEVICE:
+            break;
+
+        default:
+            RejectHttpRequest(
+                ctx,
+                *requestInfo,
+                TStringBuilder() << "Invalid CMS request type: " << actionRaw);
+            return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::DISK_REGISTRY,
+        "Send CMS request %s for path[%s] on agent[%s] from monitoring page "
+        "(dryRun=%s)",
+        NProto::TAction_EType_Name(actionType).c_str(),
+        deviceName.c_str(),
+        agentId.c_str(),
+        dryRun ? "true" : "false");
+
+    auto actor = NCloud::Register<TSendCmsRequestActor>(
+        ctx,
+        SelfId(),
+        TabletID(),
+        std::move(requestInfo),
+        agentId,
+        deviceName,
+        actionType,
+        dryRun);
+
+    Actors.insert(actor);
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_purge_host_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_purge_host_cms.cpp
@@ -48,6 +48,7 @@ void TDiskRegistryActor::HandlePurgeHostCms(
         ctx,
         std::move(requestInfo),
         std::move(msg->Host),
+        std::move(msg->CustomMessage),
         msg->DryRun);
 }
 
@@ -74,6 +75,7 @@ void TDiskRegistryActor::ExecutePurgeHostCms(
     args.Error = State->PurgeHost(
         db,
         args.Host,
+        args.CustomMessage,
         ctx.Now(),
         args.DryRun,
         args.AffectedDisks);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_resume_device.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_resume_device.cpp
@@ -64,6 +64,7 @@ void TResumeDeviceActor::Bootstrap(const TActorContext& ctx)
         Request.GetAgentId(),
         Request.GetPath(),
         NProto::EDeviceState::DEVICE_STATE_ONLINE,
+        /*customMessage=*/"resume device",
         /*shouldResumeDevice=*/true,
         Request.GetDryRun());
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_device_state.cpp
@@ -54,6 +54,7 @@ void TDiskRegistryActor::HandleUpdateCmsHostDeviceState(
         std::move(msg->Host),
         std::move(msg->Path),
         msg->State,
+        std::move(msg->CustomMessage),
         msg->ShouldResumeDevice,
         msg->DryRun);
 }
@@ -85,6 +86,7 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostDeviceState(
         args.Host,
         args.Path,
         args.State,
+        args.CustomMessage,
         args.TxTs,
         args.ShouldResumeDevice,
         args.DryRun);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_update_cms_host_state.cpp
@@ -50,6 +50,7 @@ void TDiskRegistryActor::HandleUpdateCmsHostState(
         std::move(requestInfo),
         std::move(msg->Host),
         msg->State,
+        std::move(msg->CustomMessage),
         msg->DryRun);
 }
 
@@ -80,6 +81,7 @@ void TDiskRegistryActor::ExecuteUpdateCmsHostState(
         db,
         args.Host,
         args.State,
+        args.CustomMessage,
         args.TxTs,
         args.DryRun,
         args.AffectedDisks,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -528,6 +528,7 @@ struct TEvDiskRegistryPrivate
         TString Host;
         TString Path;
         NProto::EDeviceState State;
+        TString CustomMessage;
         bool ShouldResumeDevice;
         bool DryRun;
 
@@ -535,11 +536,13 @@ struct TEvDiskRegistryPrivate
                 TString host,
                 TString path,
                 NProto::EDeviceState state,
+                TString customMessage,
                 bool shouldResumeDevice,
                 bool dryRun)
             : Host(std::move(host))
             , Path(std::move(path))
             , State(state)
+            , CustomMessage(std::move(customMessage))
             , ShouldResumeDevice(shouldResumeDevice)
             , DryRun(dryRun)
         {}
@@ -553,14 +556,17 @@ struct TEvDiskRegistryPrivate
     {
         TString Host;
         NProto::EAgentState State;
+        TString CustomMessage;
         bool DryRun;
 
         TUpdateCmsHostStateRequest(
                 TString host,
                 NProto::EAgentState state,
+                TString customMessage,
                 bool dryRun)
             : Host(std::move(host))
             , State(state)
+            , CustomMessage(std::move(customMessage))
             , DryRun(dryRun)
         {}
     };
@@ -588,12 +594,15 @@ struct TEvDiskRegistryPrivate
     struct TPurgeHostCmsRequest
     {
         TString Host;
+        TString CustomMessage;
         bool DryRun;
 
         TPurgeHostCmsRequest(
                 TString host,
+                TString customMessage,
                 bool dryRun)
             : Host(std::move(host))
+            , CustomMessage(std::move(customMessage))
             , DryRun(dryRun)
         {}
     };

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -5603,6 +5603,7 @@ NProto::TError TDiskRegistryState::UpdateCmsHostState(
     TDiskRegistryDatabase& db,
     const TString& agentId,
     NProto::EAgentState newState,
+    const TString& customMessage,
     TInstant now,
     bool dryRun,
     TVector<TDiskId>& affectedDisks,
@@ -5683,7 +5684,12 @@ NProto::TError TDiskRegistryState::UpdateCmsHostState(
     }
 
     if (agent->GetState() != NProto::AGENT_STATE_UNAVAILABLE) {
-        ChangeAgentState(*agent, newState, now, "cms action");
+        TStringBuilder stateMessage;
+        stateMessage << "cms action";
+        if (!customMessage.empty()) {
+            stateMessage << " (" << customMessage << ")";
+        }
+        ChangeAgentState(*agent, newState, now, stateMessage);
     }
 
     agent->SetCmsTs(cmsTs.MicroSeconds());
@@ -5723,6 +5729,7 @@ NProto::TError TDiskRegistryState::UpdateCmsHostState(
 NProto::TError TDiskRegistryState::PurgeHost(
     TDiskRegistryDatabase& db,
     const TString& agentId,
+    const TString& customMessage,
     TInstant now,
     bool dryRun,
     TVector<TDiskId>& affectedDisks)
@@ -5740,6 +5747,7 @@ NProto::TError TDiskRegistryState::PurgeHost(
         db,
         agentId,
         NProto::AGENT_STATE_WARNING,
+        customMessage,
         now,
         dryRun,
         affectedDisks,
@@ -6165,6 +6173,7 @@ auto TDiskRegistryState::AddNewDevices(
     TDiskRegistryDatabase& db,
     NProto::TAgentConfig& agent,
     const TString& path,
+    const TString& customMessage,
     TInstant now,
     bool shouldResume,
     bool dryRun) -> TUpdateCmsDeviceStateResult
@@ -6195,8 +6204,14 @@ auto TDiskRegistryState::AddNewDevices(
         ids.push_back(device->GetDeviceUUID());
 
         device->SetState(NProto::DEVICE_STATE_ONLINE);
-        device->SetStateMessage("cms add device action");
         device->SetStateTs(now.MicroSeconds());
+
+        TStringBuilder stateMessage;
+        stateMessage << "cms add device action";
+        if (!customMessage.empty()) {
+            stateMessage << " (" << customMessage << ")";
+        }
+        device->SetStateMessage(stateMessage);
     }
 
     STORAGE_INFO("add new devices: AgentId=" << agent.GetAgentId()
@@ -6242,6 +6257,7 @@ NProto::TError TDiskRegistryState::CmsAddDevice(
     TDiskRegistryDatabase& db,
     NProto::TAgentConfig& agent,
     NProto::TDeviceConfig& device,
+    const TString& customMessage,
     TInstant now,
     bool shouldResume,
     bool dryRun,
@@ -6270,7 +6286,12 @@ NProto::TError TDiskRegistryState::CmsAddDevice(
 
     if (device.GetState() != NProto::DEVICE_STATE_ERROR) {
         device.SetState(NProto::DEVICE_STATE_ONLINE);
-        device.SetStateMessage("cms add device action");
+        TStringBuilder stateMessage;
+        stateMessage << "cms add device action";
+        if (!customMessage.empty()) {
+            stateMessage << " (" << customMessage << ")";
+        }
+        device.SetStateMessage(stateMessage);
     }
 
     device.SetStateTs(now.MicroSeconds());
@@ -6290,6 +6311,7 @@ NProto::TError TDiskRegistryState::CmsRemoveDevice(
     TDiskRegistryDatabase& db,
     NProto::TAgentConfig& agent,
     NProto::TDeviceConfig& device,
+    const TString& customMessage,
     TInstant now,
     bool dryRun,
     TDiskId& affectedDisk,
@@ -6347,7 +6369,12 @@ NProto::TError TDiskRegistryState::CmsRemoveDevice(
 
     if (device.GetState() != NProto::DEVICE_STATE_ERROR) {
         device.SetState(NProto::DEVICE_STATE_WARNING);
-        device.SetStateMessage("cms remove device action");
+        TStringBuilder stateMessage;
+        stateMessage << "cms remove device action";
+        if (!customMessage.empty()) {
+            stateMessage << " (" << customMessage << ")";
+        }
+        device.SetStateMessage(stateMessage);
     }
 
     device.SetStateTs(now.MicroSeconds());
@@ -6363,6 +6390,7 @@ auto TDiskRegistryState::UpdateCmsDeviceState(
     const TAgentId& agentId,
     const TString& path,
     NProto::EDeviceState newState,
+    const TString& customMessage,
     TInstant now,
     bool shouldResume,
     bool dryRun) -> TUpdateCmsDeviceStateResult
@@ -6376,7 +6404,14 @@ auto TDiskRegistryState::UpdateCmsDeviceState(
     auto [agent, devices] = ResolveDevices(agentId, path);
 
     if (agent && devices.empty() && newState == NProto::DEVICE_STATE_ONLINE) {
-        return AddNewDevices(db, *agent, path, now, shouldResume, dryRun);
+        return AddNewDevices(
+            db,
+            *agent,
+            path,
+            customMessage,
+            now,
+            shouldResume,
+            dryRun);
     }
 
     if (!agent || devices.empty()) {
@@ -6398,6 +6433,7 @@ auto TDiskRegistryState::UpdateCmsDeviceState(
                 db,
                 *agent,
                 device,
+                customMessage,
                 now,
                 shouldResume,
                 dryRun,
@@ -6416,6 +6452,7 @@ auto TDiskRegistryState::UpdateCmsDeviceState(
             db,
             *agent,
             device,
+            customMessage,
             now,
             dryRun,
             affectedDisk,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -627,6 +627,7 @@ public:
         TDiskRegistryDatabase& db,
         const TString& agentId,
         NProto::EAgentState state,
+        const TString& customMessage,
         TInstant now,
         bool dryRun,
         TVector<TDiskId>& affectedDisks,
@@ -635,6 +636,7 @@ public:
     NProto::TError PurgeHost(
         TDiskRegistryDatabase& db,
         const TString& agentId,
+        const TString& customMessage,
         TInstant now,
         bool dryRun,
         TVector<TDiskId>& affectedDisks);
@@ -662,6 +664,7 @@ public:
         const TAgentId& agentId,
         const TString& path,
         NProto::EDeviceState state,
+        const TString& customMessage,
         TInstant now,
         bool shouldResume,
         bool dryRun);
@@ -1354,6 +1357,7 @@ private:
         TDiskRegistryDatabase& db,
         NProto::TAgentConfig& agent,
         NProto::TDeviceConfig& device,
+        const TString& customMessage,
         TInstant now,
         bool shouldResume,
         bool dryRun,
@@ -1363,6 +1367,7 @@ private:
         TDiskRegistryDatabase& db,
         NProto::TAgentConfig& agent,
         const TString& path,
+        const TString& customMessage,
         TInstant now,
         bool shouldResume,
         bool dryRun);
@@ -1376,6 +1381,7 @@ private:
         TDiskRegistryDatabase& db,
         NProto::TAgentConfig& agent,
         NProto::TDeviceConfig& device,
+        const TString& customMessage,
         TInstant now,
         bool dryRun,
         TDiskId& affectedDisk,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_benchmark.cpp
@@ -250,6 +250,7 @@ static void AddHost(benchmark::State& benchmarkState)
                     db,
                     agentId,
                     NProto::AGENT_STATE_ONLINE,
+                    /*customMessage=*/TString(),
                     TInstant::Now(),
                     /*dryRun=*/false,
                     affectedDisks,
@@ -313,6 +314,7 @@ static void AddSameHostMultipleTimes(benchmark::State& benchmarkState)
                     db,
                     agentId,
                     NProto::AGENT_STATE_ONLINE,
+                    /*customMessage=*/TString(),
                     TInstant::Now(),
                     /*dryRun=*/false,
                     affectedDisks,
@@ -374,6 +376,7 @@ static void PurgeHost(benchmark::State& benchmarkState)
                 auto error = state.PurgeHost(
                     db,
                     agentId,
+                    /*customMessage=*/TString(),
                     TInstant::Now(),
                     /*dryRun=*/false,
                     affectedDisks);

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut.cpp
@@ -6024,6 +6024,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agent1.GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString("test-message"),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6033,6 +6034,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 storageConfig->GetNonReplicatedInfraTimeout(),
                 cmsTimeout);
+
+            const NProto::TAgentConfig* agentPtr =
+                state.FindAgent(agent1.GetNodeId());
+            UNIT_ASSERT(agentPtr);
+            UNIT_ASSERT_VALUES_EQUAL(
+                "cms action (test-message)",
+                agentPtr->GetStateMessage());
 
             Sort(affectedDisks);
             UNIT_ASSERT_VALUES_EQUAL(2, affectedDisks.size());
@@ -6093,6 +6101,13 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 UNIT_ASSERT_VALUES_EQUAL(ts, *res);
             }
 
+            const NProto::TAgentConfig* agentPtr =
+                state.FindAgent(agent1.GetNodeId());
+            UNIT_ASSERT(agentPtr);
+            UNIT_ASSERT_VALUES_EQUAL(
+                "state message",
+                agentPtr->GetStateMessage());
+
             UNIT_ASSERT_VALUES_EQUAL(2, affectedDisks.size());
             UNIT_ASSERT_VALUES_EQUAL(4, state.GetDiskStateUpdates().size());
         });
@@ -6107,6 +6122,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agent1.GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts + TDuration::Seconds(10),
                 false, // dryRun
                 affectedDisks,
@@ -6131,6 +6147,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agent1.GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts + TDuration::Seconds(10),
                 false, // dryRun
                 affectedDisks,
@@ -6208,6 +6225,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agent1.GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6244,6 +6262,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agent1.GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6267,6 +6286,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agent1.GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts + TDuration::Seconds(10),
                 false, // dryRun
                 affectedDisks,
@@ -6314,6 +6334,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agent1.GetAgentId(),
                 "dev-2",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false,   // shouldResumeDevice
                 false);  // dryRun
@@ -6372,6 +6393,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agent1.GetAgentId(),
                 "dev-2",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts + TDuration::Seconds(10),
                 false,  // shouldResumeDevice
                 false); // dryRun
@@ -6676,6 +6698,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[0].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6710,6 +6733,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[1].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6740,6 +6764,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[2].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6802,6 +6827,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[2].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6833,6 +6859,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[2].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -6868,6 +6895,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[2].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -7137,6 +7165,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[0].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -7168,6 +7197,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 agents[1].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false, // dryRun
                 affectedDisks,
@@ -7647,6 +7677,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agent1.GetAgentId(),
                 "dev-2",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false,  // shouldResumeDevice
                 false); // dryRun
@@ -7662,6 +7693,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agent1.GetAgentId(),
                 "dev-2",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts + TDuration::Seconds(10),
                 false,   // shouldResumeDevice
                 true);   // dryRun
@@ -7700,6 +7732,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 agent1.GetAgentId(),
                 "dev-2",
                 desiredState,
+                /*customMessage=*/TString(),
                 Now(),
                 false,    // shouldResumeDevice
                 false);   // dryRun
@@ -7795,6 +7828,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 "agent-1",
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts,
                 false,
                 affectedDisks,
@@ -7812,6 +7846,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateTest)
                 db,
                 "agent-1",
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 ts + TDuration::Seconds(10),
                 true,
                 affectedDisks,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_cms.cpp
@@ -61,40 +61,45 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
             UNIT_ASSERT_VALUES_EQUAL(0, state.GetConfigVersion());
         });
 
-        executor.WriteTx([&] (TDiskRegistryDatabase db) {
-            auto result = state.UpdateCmsDeviceState(
-                db,
-                agentConfig.GetAgentId(),
-                "NVMENBS01",
-                NProto::DEVICE_STATE_ONLINE,
-                Now(),
-                false,  // shouldResumeDevice
-                false); // dryRun
+        executor.WriteTx(
+            [&](TDiskRegistryDatabase db)
+            {
+                auto result = state.UpdateCmsDeviceState(
+                    db,
+                    agentConfig.GetAgentId(),
+                    "NVMENBS01",
+                    NProto::DEVICE_STATE_ONLINE,
+                    /*customMessage=*/TString(),
+                    Now(),
+                    false,    // shouldResumeDevice
+                    false);   // dryRun
 
-            UNIT_ASSERT_SUCCESS(result.Error);
+                UNIT_ASSERT_SUCCESS(result.Error);
 
-            UNIT_ASSERT_VALUES_EQUAL(1, state.GetConfig().KnownAgentsSize());
-            UNIT_ASSERT_VALUES_EQUAL(1, state.GetConfigVersion());
-            UNIT_ASSERT_VALUES_EQUAL(
-                1,
-                state.GetConfig().GetKnownAgents(0).DevicesSize());
-            UNIT_ASSERT_VALUES_EQUAL(
-                "uuid-1.1",
-                state.GetConfig().GetKnownAgents(0).GetDevices(0).GetDeviceUUID());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    1,
+                    state.GetConfig().KnownAgentsSize());
+                UNIT_ASSERT_VALUES_EQUAL(1, state.GetConfigVersion());
+                const NProto::TAgentConfig& knownAgent =
+                    state.GetConfig().GetKnownAgents(0);
+                UNIT_ASSERT_VALUES_EQUAL(1, knownAgent.DevicesSize());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "uuid-1.1",
+                    knownAgent.GetDevices(0).GetDeviceUUID());
 
-            ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.AffectedDisks);
-            UNIT_ASSERT_VALUES_EQUAL(TDuration {}, result.Timeout);
-            UNIT_ASSERT_VALUES_EQUAL(0, state.GetSuspendedDevices().size());
-            UNIT_ASSERT_VALUES_EQUAL(1, state.GetDirtyDevices().size());
-            UNIT_ASSERT_VALUES_EQUAL(0, state.GetBrokenDevices().size());
+                ASSERT_VECTORS_EQUAL(TVector<TString>{}, result.AffectedDisks);
+                UNIT_ASSERT_VALUES_EQUAL(TDuration{}, result.Timeout);
+                UNIT_ASSERT_VALUES_EQUAL(0, state.GetSuspendedDevices().size());
+                UNIT_ASSERT_VALUES_EQUAL(1, state.GetDirtyDevices().size());
+                UNIT_ASSERT_VALUES_EQUAL(0, state.GetBrokenDevices().size());
 
-            UNIT_ASSERT_VALUES_EQUAL(1, state.GetAgents().size());
+                UNIT_ASSERT_VALUES_EQUAL(1, state.GetAgents().size());
 
-            const auto& agent = state.GetAgents()[0];
+                const auto& agent = state.GetAgents()[0];
 
-            UNIT_ASSERT_VALUES_EQUAL(1, agent.DevicesSize());
-            UNIT_ASSERT_VALUES_EQUAL(3, agent.UnknownDevicesSize());
-        });
+                UNIT_ASSERT_VALUES_EQUAL(1, agent.DevicesSize());
+                UNIT_ASSERT_VALUES_EQUAL(3, agent.UnknownDevicesSize());
+            });
     }
 
     Y_UNIT_TEST(ShouldRemoveDevice)
@@ -145,6 +150,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 agentConfig.GetAgentId(),
                 "NVMENBS01",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString("test-message"),
                 Now(),
                 false,  // shouldResumeDevice
                 false); // dryRun
@@ -168,6 +174,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
 
             UNIT_ASSERT_VALUES_EQUAL(4, agent.DevicesSize());
             UNIT_ASSERT_VALUES_EQUAL(0, agent.UnknownDevicesSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "cms remove device action (test-message)",
+                agent.GetDevices(0).GetStateMessage());
         });
     }
 
@@ -236,6 +245,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 agentConfig.GetAgentId(),
                 "NVMENBS01",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 Now(),
                 false,  // shouldResumeDevice
                 false); // dryRun
@@ -266,6 +276,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 agentConfig.GetAgentId(),
                 "NVMENBS01",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 Now(),
                 false,  // shouldResumeDevice
                 false); // dryRun
@@ -395,6 +406,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 db,
                 agentConfig.GetAgentId(),
                 NProto::AGENT_STATE_ONLINE,
+                /*customMessage=*/TString(),
                 Now(),
                 false, // dryRun
                 affectedDisks,
@@ -547,6 +559,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     db,
                     agents[0].GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString("test-message"),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -560,9 +573,17 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 UNIT_ASSERT_SUCCESS(state.PurgeHost(
                     db,
                     agents[0].GetAgentId(),
+                    /*customMessage=*/TString("test-purge-message"),
                     Now(),
                     false,   // dryRun
                     affectedDisks));
+
+                const NProto::TAgentConfig* agentPtr =
+                    state.FindAgent(agents[0].GetAgentId());
+                UNIT_ASSERT(agentPtr);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    agentPtr->GetStateMessage(),
+                    "cms action (test-purge-message)");
 
                 UNIT_ASSERT_VALUES_EQUAL(
                     2,
@@ -595,11 +616,19 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     db,
                     agents[1].GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString("test-remove-message"),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
                     timeout);
                 UNIT_ASSERT_VALUES_EQUAL(E_TRY_AGAIN, error.GetCode());
+
+                const NProto::TAgentConfig* agentPtr =
+                    state.FindAgent(agents[1].GetAgentId());
+                UNIT_ASSERT(agentPtr);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "cms action (test-remove-message)",
+                    agentPtr->GetStateMessage());
 
                 UNIT_ASSERT_SUCCESS(state.MarkDiskForCleanup(db, "nrd0"));
                 UNIT_ASSERT_SUCCESS(state.DeallocateDisk(db, "nrd0"));
@@ -609,6 +638,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     db,
                     agents[1].GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(""),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -622,9 +652,16 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 UNIT_ASSERT_SUCCESS(state.PurgeHost(
                     db,
                     agents[1].GetAgentId(),
+                    /*customMessage=*/TString(""),
                     Now(),
                     false,   // dryRun
                     affectedDisks));
+
+                agentPtr = state.FindAgent(agents[1].GetAgentId());
+                UNIT_ASSERT(agentPtr);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    "cms action",
+                    agentPtr->GetStateMessage());
 
                 UNIT_ASSERT_VALUES_EQUAL(
                     1,
@@ -683,6 +720,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     db,
                     agents[2].GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -696,6 +734,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 UNIT_ASSERT_SUCCESS(state.PurgeHost(
                     db,
                     agents[2].GetAgentId(),
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks));
@@ -785,6 +824,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     db,
                     agent.GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -795,6 +835,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 UNIT_ASSERT_SUCCESS(state.PurgeHost(
                     db,
                     agent.GetAgentId(),
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks));
@@ -930,6 +971,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                 UNIT_ASSERT_SUCCESS(state.PurgeHost(
                     db,
                     agents[0].GetAgentId(),
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks));
@@ -1044,6 +1086,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     db,
                     agents[0].GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -1100,6 +1143,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCMSTest)
                     db,
                     agents[0].GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_create.cpp
@@ -538,6 +538,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateCreateTest)
                 agentConfig.GetAgentId(),
                 testDeviceName,
                 NProto::DEVICE_STATE_ONLINE,
+                /*customMessage=*/TString(),
                 Now(),
                 false,  // shouldResumeDevice
                 false); // dryRun

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_migration.cpp
@@ -1320,6 +1320,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     db,
                     agents[0].agentid(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -1404,6 +1405,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     db,
                     agents[0].agentid(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -1502,6 +1504,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     db,
                     agents[0].agentid(),
                     NProto::AGENT_STATE_ONLINE,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -1529,6 +1532,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     db,
                     agents[0].agentid(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,   // dryRun
                     affectedDisks,
@@ -1573,6 +1577,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     agents[0].agentid(),
                     agents[0].GetDevices()[0].GetDeviceName(),
                     NProto::DEVICE_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,    // shouldResumeDevice
                     false);   // dryRun
@@ -1654,6 +1659,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     agents[0].agentid(),
                     agents[0].GetDevices()[0].GetDeviceName(),
                     NProto::DEVICE_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,    // shouldResumeDevice
                     false);   // dryRun
@@ -1697,6 +1703,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     agents[0].agentid(),
                     agents[0].GetDevices()[0].GetDeviceName(),
                     NProto::DEVICE_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,    // shouldResumeDevice
                     false);   // dryRun
@@ -1752,6 +1759,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     agents[0].agentid(),
                     agents[0].GetDevices()[0].GetDeviceName(),
                     NProto::DEVICE_STATE_ONLINE,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,    // shouldResumeDevice
                     false);   // dryRun
@@ -1774,6 +1782,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMigrationTest)
                     agents[0].agentid(),
                     agents[0].GetDevices()[0].GetDeviceName(),
                     NProto::DEVICE_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     Now(),
                     false,    // shouldResumeDevice
                     false);   // dryRun

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_mirrored_disks.cpp
@@ -1242,6 +1242,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                 agentConfig1.GetAgentId(),
                 "dev-3",
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 Now(),
                 false,  // shouldResumeDevice
                 false); // dryRun
@@ -2984,6 +2985,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                     db,
                     agentConfig1.GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     changeStateTs,
                     false,  // dryRun
                     affectedDisks,
@@ -2996,6 +2998,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                     agentConfig1.GetAgentId(),
                     "dev-1",
                     NProto::DEVICE_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     changeStateTs,
                     false,  // shouldResumeDevice
                     false); // dryRun
@@ -3106,6 +3109,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                     db,
                     agentConfig1.GetAgentId(),
                     NProto::AGENT_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     changeStateTs,
                     false,  // dryRun
                     affectedDisks,
@@ -3118,6 +3122,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateMirroredDisksTest)
                     agentConfig1.GetAgentId(),
                     "dev-1",
                     NProto::DEVICE_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     changeStateTs,
                     false,  // shouldResumeDevice
                     false); // dryRun

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pending_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_pending_cleanup.cpp
@@ -79,6 +79,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStatePendingCleanupTest)
                 devices[0].GetAgentId(),
                 devices[0].GetDeviceName(),
                 NProto::DEVICE_STATE_WARNING,
+                /*customMessage=*/TString(),
                 {},     // now
                 false,  // shouldResumeDevice
                 false); // dryRun

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state_ut_suspend.cpp
@@ -182,6 +182,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                 Agents[1].GetAgentId(),
                 "dev-2",
                 NProto::DEVICE_STATE_ONLINE,
+                /*customMessage=*/TString(),
                 TInstant::FromValue(1),
                 true,     // shouldResumeDevice
                 false);   // dryRun
@@ -289,6 +290,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                     Agents[1].GetAgentId(),
                     d.GetDeviceName(),
                     NProto::DEVICE_STATE_WARNING,
+                    /*customMessage=*/TString(),
                     TInstant::FromValue(1),
                     false,  // shouldResumeDevice
                     false); // dryRun
@@ -311,8 +313,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                 auto r = state.PurgeHost(
                     db,
                     Agents[1].GetAgentId(),
+                    /*customMessage=*/TString(),
                     TInstant::FromValue(2),
-                    false,   // dryRun
+                    /*dryRun=*/false,
                     affectedDisks);
                 UNIT_ASSERT_VALUES_EQUAL(S_OK, r.GetCode());
 
@@ -333,6 +336,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
                 db,
                 Agents[2].GetAgentId(),
                 NProto::AGENT_STATE_WARNING,
+                /*customMessage=*/TString(),
                 TInstant::FromValue(3),
                 false,  // dryRun
                 affectedDisks,
@@ -351,8 +355,9 @@ Y_UNIT_TEST_SUITE(TDiskRegistryStateSuspendTest)
             UNIT_ASSERT_SUCCESS(state.PurgeHost(
                 db,
                 Agents[2].GetAgentId(),
+                /*customMessage=*/TString(),
                 TInstant::FromValue(4),
-                false,  // dryRun
+                /*dryRun=*/false,
                 affectedDisks));
 
             const auto* agent = state.FindAgent(Agents[2].GetAgentId());

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_tx.h
@@ -629,6 +629,7 @@ struct TTxDiskRegistry
         const TString Host;
         const TString Path;
         const NProto::EDeviceState State;
+        const TString CustomMessage;
         const bool ShouldResumeDevice;
         const bool DryRun;
 
@@ -642,12 +643,14 @@ struct TTxDiskRegistry
                 TString host,
                 TString path,
                 NProto::EDeviceState state,
+                TString customMessage,
                 bool shouldResumeDevice,
                 bool dryRun)
             : RequestInfo(std::move(requestInfo))
             , Host(std::move(host))
             , Path(std::move(path))
             , State(state)
+            , CustomMessage(std::move(customMessage))
             , ShouldResumeDevice(shouldResumeDevice)
             , DryRun(dryRun)
         {}
@@ -668,6 +671,7 @@ struct TTxDiskRegistry
         const TRequestInfoPtr RequestInfo;
         const TString Host;
         const NProto::EAgentState State;
+        const TString CustomMessage;
         const bool DryRun;
 
         NProto::TError Error;
@@ -679,10 +683,12 @@ struct TTxDiskRegistry
                 TRequestInfoPtr requestInfo,
                 TString host,
                 NProto::EAgentState state,
+                TString customMessage,
                 bool dryRun)
             : RequestInfo(std::move(requestInfo))
             , Host(std::move(host))
             , State(state)
+            , CustomMessage(std::move(customMessage))
             , DryRun(dryRun)
         {}
 
@@ -701,6 +707,7 @@ struct TTxDiskRegistry
     {
         const TRequestInfoPtr RequestInfo;
         const TString Host;
+        const TString CustomMessage;
         const bool DryRun;
 
         NProto::TError Error;
@@ -709,9 +716,11 @@ struct TTxDiskRegistry
         TPurgeHostCms(
                 TRequestInfoPtr requestInfo,
                 TString host,
+                TString customMessage,
                 bool dryRun)
             : RequestInfo(std::move(requestInfo))
             , Host(std::move(host))
+            , CustomMessage(std::move(customMessage))
             , DryRun(dryRun)
         {}
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_monitoring_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_monitoring_cms.cpp
@@ -321,7 +321,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryMonitoringCmsTest)
                 {
                     auto* msg = event->Get<
                         TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>();
-                    captured.emplace(msg->Host, msg->State, msg->DryRun);
+                    captured.emplace(
+                        msg->Host,
+                        msg->State,
+                        msg->CustomMessage,
+                        msg->DryRun);
                 }
                 return TTestActorRuntime::DefaultObserverFunc(event);
             });
@@ -358,7 +362,11 @@ Y_UNIT_TEST_SUITE(TDiskRegistryMonitoringCmsTest)
                 {
                     auto* msg = event->Get<
                         TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>();
-                    captured.emplace(msg->Host, msg->State, msg->DryRun);
+                    captured.emplace(
+                        msg->Host,
+                        msg->State,
+                        msg->CustomMessage,
+                        msg->DryRun);
                 }
                 return TTestActorRuntime::DefaultObserverFunc(event);
             });
@@ -393,7 +401,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryMonitoringCmsTest)
                 {
                     auto* msg = event->Get<
                         TEvDiskRegistryPrivate::TEvPurgeHostCmsRequest>();
-                    captured.emplace(msg->Host, msg->DryRun);
+                    captured.emplace(msg->Host, msg->CustomMessage, msg->DryRun);
                 }
                 return TTestActorRuntime::DefaultObserverFunc(event);
             });
@@ -432,6 +440,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryMonitoringCmsTest)
                         msg->Host,
                         msg->Path,
                         msg->State,
+                        msg->CustomMessage,
                         msg->ShouldResumeDevice,
                         msg->DryRun);
                 }
@@ -480,6 +489,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryMonitoringCmsTest)
                         msg->Host,
                         msg->Path,
                         msg->State,
+                        msg->CustomMessage,
                         msg->ShouldResumeDevice,
                         msg->DryRun);
                 }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_monitoring_cms.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_monitoring_cms.cpp
@@ -1,0 +1,512 @@
+#include "disk_registry.h"
+
+#include "disk_registry_actor.h"
+
+#include <cloud/blockstore/libs/storage/api/disk_agent.h>
+#include <cloud/blockstore/libs/storage/api/service.h>
+#include <cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h>
+#include <cloud/blockstore/libs/storage/disk_registry/testlib/test_env.h>
+
+#include <contrib/ydb/core/testlib/basics/runtime.h>
+#include <contrib/ydb/library/actors/core/mon.h>
+#include <contrib/ydb/library/actors/protos/actors.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NBlockStore::NStorage {
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NDiskRegistryTest;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TStorageServiceConfig CreateStorageConfig(bool enableMonpageStateChange)
+{
+    auto config = CreateDefaultStorageConfig();
+    config.SetEnableToChangeStatesFromDiskRegistryMonpage(
+        enableMonpageStateChange);
+    return config;
+}
+
+std::unique_ptr<NMon::TEvRemoteHttpInfo> MakeRequest(
+    ui64 tabletId,
+    const TString& action,
+    const TVector<std::pair<TString, TString>>& params,
+    HTTP_METHOD method = HTTP_METHOD_POST)
+{
+    NActorsProto::TRemoteHttpInfo info;
+    info.SetMethod(method);
+    info.SetPath("/app");
+
+    auto addQueryParam = [&](const TString& key, const TString& value)
+    {
+        auto* p = info.AddQueryParams();
+        p->SetKey(key);
+        p->SetValue(value);
+    };
+
+    auto addPostParam = [&](const TString& key, const TString& value)
+    {
+        auto* p = info.AddPostParams();
+        p->SetKey(key);
+        p->SetValue(value);
+    };
+
+    addQueryParam("TabletID", ToString(tabletId));
+    if (method == HTTP_METHOD_POST) {
+        addPostParam("action", action);
+        addPostParam("TabletID", ToString(tabletId));
+        for (const auto& [k, v]: params) {
+            addPostParam(k, v);
+        }
+    } else {
+        addQueryParam("action", action);
+        for (const auto& [k, v]: params) {
+            addQueryParam(k, v);
+        }
+    }
+
+    return std::make_unique<NMon::TEvRemoteHttpInfo>(info);
+}
+
+TString SendAndRecv(
+    TTestActorRuntime& runtime,
+    const TActorId& sender,
+    const TActorId& pipe,
+    std::unique_ptr<NMon::TEvRemoteHttpInfo> request)
+{
+    runtime.SendToPipe(pipe, sender, request.release(), 0, 0);
+
+    TAutoPtr<IEventHandle> handle;
+    auto response = runtime.GrabEdgeEventRethrow<NMon::TEvRemoteHttpInfoRes>(
+        handle,
+        WaitTimeout);
+    UNIT_ASSERT(response);
+    return response->Html;
+}
+
+struct TFixture: public NUnitTest::TBaseFixture
+{
+    std::unique_ptr<TDiskRegistryTestRuntime> Runtime;
+    std::optional<TDiskRegistryClient> DiskRegistry;
+    TActorId Sender;
+    TActorId PipeClient;
+
+    void Setup(bool enableMonpageStateChange)
+    {
+        const auto agent = CreateAgentConfig(
+            "agent-1",
+            {
+                Device("dev-1", "uuid-1", "rack-1", 10_GB),
+                Device("dev-2", "uuid-2", "rack-1", 10_GB),
+            });
+
+        auto storageConfig = std::make_shared<TStorageConfig>(
+            CreateStorageConfig(enableMonpageStateChange),
+            std::make_shared<NFeatures::TFeaturesConfig>(
+                NCloud::NProto::TFeaturesConfig()));
+
+        Runtime = TTestRuntimeBuilder()
+                      .WithAgents({agent})
+                      .With(storageConfig)
+                      .Build();
+
+        DiskRegistry.emplace(*Runtime);
+        DiskRegistry->WaitReady();
+        DiskRegistry->SetWritableState(true);
+        DiskRegistry->UpdateConfig(CreateRegistryConfig(0, {agent}));
+        RegisterAndWaitForAgents(*Runtime, {agent});
+
+        Sender = Runtime->AllocateEdgeActor(0);
+        PipeClient = Runtime->ConnectToPipe(
+            TestTabletId,
+            Sender,
+            0,
+            NKikimr::GetPipeConfigWithRetries());
+    }
+
+    TString Send(
+        const TString& action,
+        const TVector<std::pair<TString, TString>>& params,
+        HTTP_METHOD method = HTTP_METHOD_POST)
+    {
+        return SendAndRecv(
+            *Runtime,
+            Sender,
+            PipeClient,
+            MakeRequest(TestTabletId, action, params, method));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDiskRegistryMonitoringCmsTest)
+{
+    Y_UNIT_TEST_F(
+        ShouldRejectHostRequestWhenMonpageStateChangeDisabled,
+        TFixture)
+    {
+        Setup(false /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_HOST))},
+            });
+
+        UNIT_ASSERT_C(
+            html.Contains("Can't send CMS request from monpage"),
+            html);
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldRejectDeviceRequestWhenMonpageStateChangeDisabled,
+        TFixture)
+    {
+        Setup(false /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsDeviceRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"DeviceName", "dev-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_DEVICE))},
+            });
+
+        UNIT_ASSERT_C(
+            html.Contains("Can't send CMS request from monpage"),
+            html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectHostRequestWithoutCmsAction, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+            });
+
+        UNIT_ASSERT_C(html.Contains("No CMS request is given"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectHostRequestWithoutAgentId, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_HOST))},
+            });
+
+        UNIT_ASSERT_C(html.Contains("No agent id is given"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectHostRequestWithUnparseableAction, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction", "not-a-number"},
+            });
+
+        UNIT_ASSERT_C(html.Contains("Could not parse CMS request type"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectHostRequestWithDeviceActionType, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::ADD_DEVICE))},
+            });
+
+        UNIT_ASSERT_C(html.Contains("Invalid CMS request type"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectDeviceRequestWithoutDeviceName, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsDeviceRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_DEVICE))},
+            });
+
+        UNIT_ASSERT_C(html.Contains("No device name is given"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectDeviceRequestWithoutAgentId, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsDeviceRequest",
+            {
+                {"DeviceName", "dev-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_DEVICE))},
+            });
+
+        UNIT_ASSERT_C(html.Contains("No agent id is given"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectDeviceRequestWithHostActionType, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsDeviceRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"DeviceName", "dev-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_HOST))},
+            });
+
+        UNIT_ASSERT_C(html.Contains("Invalid CMS request type"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldRejectRequestWithWrongHttpMethod, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_HOST))},
+            },
+            HTTP_METHOD_GET);
+
+        UNIT_ASSERT_C(html.Contains("Wrong HTTP method"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldEmitUpdateCmsHostStateForAddHost, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        std::optional<TEvDiskRegistryPrivate::TUpdateCmsHostStateRequest>
+            captured;
+        Runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskRegistryPrivate::EvUpdateCmsHostStateRequest)
+                {
+                    auto* msg = event->Get<
+                        TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>();
+                    captured.emplace(msg->Host, msg->State, msg->DryRun);
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::ADD_HOST))},
+                {"DryRun", "1"},
+            });
+
+        UNIT_ASSERT_C(captured.has_value(), "no UpdateCmsHostState request");
+        UNIT_ASSERT_VALUES_EQUAL("agent-1", captured->Host);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NProto::AGENT_STATE_ONLINE),
+            static_cast<int>(captured->State));
+        UNIT_ASSERT(captured->DryRun);
+        UNIT_ASSERT_C(html.Contains("CMS request ADD_HOST"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldEmitUpdateCmsHostStateForRemoveHost, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        std::optional<TEvDiskRegistryPrivate::TUpdateCmsHostStateRequest>
+            captured;
+        Runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskRegistryPrivate::EvUpdateCmsHostStateRequest)
+                {
+                    auto* msg = event->Get<
+                        TEvDiskRegistryPrivate::TEvUpdateCmsHostStateRequest>();
+                    captured.emplace(msg->Host, msg->State, msg->DryRun);
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_HOST))},
+            });
+
+        UNIT_ASSERT_C(captured.has_value(), "no UpdateCmsHostState request");
+        UNIT_ASSERT_VALUES_EQUAL("agent-1", captured->Host);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NProto::AGENT_STATE_WARNING),
+            static_cast<int>(captured->State));
+        UNIT_ASSERT(!captured->DryRun);
+        UNIT_ASSERT_C(html.Contains("CMS request REMOVE_HOST"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldEmitPurgeHostCmsForPurgeHost, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        std::optional<TEvDiskRegistryPrivate::TPurgeHostCmsRequest> captured;
+        Runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskRegistryPrivate::EvPurgeHostCmsRequest)
+                {
+                    auto* msg = event->Get<
+                        TEvDiskRegistryPrivate::TEvPurgeHostCmsRequest>();
+                    captured.emplace(msg->Host, msg->DryRun);
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto html = Send(
+            "sendCmsHostRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::PURGE_HOST))},
+                {"DryRun", "1"},
+            });
+
+        UNIT_ASSERT_C(captured.has_value(), "no PurgeHostCms request");
+        UNIT_ASSERT_VALUES_EQUAL("agent-1", captured->Host);
+        UNIT_ASSERT(captured->DryRun);
+        UNIT_ASSERT_C(html.Contains("CMS request PURGE_HOST"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldEmitUpdateCmsHostDeviceStateForAddDevice, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        std::optional<TEvDiskRegistryPrivate::TUpdateCmsHostDeviceStateRequest>
+            captured;
+        Runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskRegistryPrivate::EvUpdateCmsHostDeviceStateRequest)
+                {
+                    auto* msg =
+                        event->Get<TEvDiskRegistryPrivate::
+                                       TEvUpdateCmsHostDeviceStateRequest>();
+                    captured.emplace(
+                        msg->Host,
+                        msg->Path,
+                        msg->State,
+                        msg->ShouldResumeDevice,
+                        msg->DryRun);
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto html = Send(
+            "sendCmsDeviceRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"DeviceName", "dev-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::ADD_DEVICE))},
+                {"DryRun", "1"},
+            });
+
+        UNIT_ASSERT_C(
+            captured.has_value(),
+            "no UpdateCmsHostDeviceState request");
+        UNIT_ASSERT_VALUES_EQUAL("agent-1", captured->Host);
+        UNIT_ASSERT_VALUES_EQUAL("dev-1", captured->Path);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NProto::DEVICE_STATE_ONLINE),
+            static_cast<int>(captured->State));
+        UNIT_ASSERT(!captured->ShouldResumeDevice);
+        UNIT_ASSERT(captured->DryRun);
+        UNIT_ASSERT_C(html.Contains("CMS request ADD_DEVICE"), html);
+    }
+
+    Y_UNIT_TEST_F(ShouldEmitUpdateCmsHostDeviceStateForRemoveDevice, TFixture)
+    {
+        Setup(true /* enableMonpageStateChange */);
+
+        std::optional<TEvDiskRegistryPrivate::TUpdateCmsHostDeviceStateRequest>
+            captured;
+        Runtime->SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvDiskRegistryPrivate::EvUpdateCmsHostDeviceStateRequest)
+                {
+                    auto* msg =
+                        event->Get<TEvDiskRegistryPrivate::
+                                       TEvUpdateCmsHostDeviceStateRequest>();
+                    captured.emplace(
+                        msg->Host,
+                        msg->Path,
+                        msg->State,
+                        msg->ShouldResumeDevice,
+                        msg->DryRun);
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto html = Send(
+            "sendCmsDeviceRequest",
+            {
+                {"AgentID", "agent-1"},
+                {"DeviceName", "dev-1"},
+                {"CmsAction",
+                 ToString(static_cast<ui32>(NProto::TAction::REMOVE_DEVICE))},
+            });
+
+        UNIT_ASSERT_C(
+            captured.has_value(),
+            "no UpdateCmsHostDeviceState request");
+        UNIT_ASSERT_VALUES_EQUAL("agent-1", captured->Host);
+        UNIT_ASSERT_VALUES_EQUAL("dev-1", captured->Path);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NProto::DEVICE_STATE_WARNING),
+            static_cast<int>(captured->State));
+        UNIT_ASSERT(!captured->ShouldResumeDevice);
+        UNIT_ASSERT(!captured->DryRun);
+        UNIT_ASSERT_C(html.Contains("CMS request REMOVE_DEVICE"), html);
+    }
+}
+
+}   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/disk_registry/ut_monitoring_cms/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ut_monitoring_cms/ya.make
@@ -1,0 +1,19 @@
+UNITTEST_FOR(cloud/blockstore/libs/storage/disk_registry)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+SRCS(
+    ../disk_registry_ut_monitoring_cms.cpp
+)
+
+PEERDIR(
+    cloud/blockstore/config
+    cloud/blockstore/libs/storage/api
+    cloud/blockstore/libs/storage/disk_registry/testlib
+    cloud/blockstore/libs/storage/testlib
+
+    contrib/ydb/core/testlib/basics
+    contrib/ydb/library/actors/protos
+)
+
+END()

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -30,6 +30,7 @@ SRCS(
     disk_registry_actor_migration.cpp
     disk_registry_actor_monitoring_replace_device.cpp
     disk_registry_actor_monitoring_volume_realloc.cpp
+    disk_registry_actor_monitoring_cms.cpp
     disk_registry_actor_monitoring.cpp
     disk_registry_actor_notify.cpp
     disk_registry_actor_notify_users.cpp
@@ -111,6 +112,7 @@ RECURSE_FOR_TESTS(
     ut_create
     ut_migration
     ut_mirrored_disk_migration
+    ut_monitoring_cms
     ut_notify
     ut_pools
     ut_restore


### PR DESCRIPTION
### Notes
1) Added ability to send CMS requests from DR's mon page. On the agent's overview page user now can send `ADD_HOST`, `REMOVE_HOST` and `PURGE_HOST` for agent and `ADD_DEVICE` and `REMOVE_DEVICE` for each DeviceName. These are hidden under menus. CMS sent from mon page will have custom state message to distinguish from public API.

<img width="1131" height="648" alt="Screenshot 2026-07-03 at 18 15 46" src="https://github.com/user-attachments/assets/3e278e60-4fd2-4e6b-b27c-496a1dd4b4d8" />
<img width="1126" height="833" alt="Screenshot 2026-07-03 at 18 15 59" src="https://github.com/user-attachments/assets/868187a8-5341-44e0-b78a-6685b957b363" />




2) Previously existing buttons for changing agent's and device's state are also now hidden under menus.

<img width="367" height="488" alt="Screenshot 2026-07-02 at 23 12 14" src="https://github.com/user-attachments/assets/b5bb1864-d7c3-40b4-a140-f82feb7db588" />

