### PR TITLE
issue-6414: [Filestore] TIndexTabletActor::CachedAggregatedStats refactoring

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -8630,12 +8630,12 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             &TTestActorRuntimeBase::DefaultFilterFunc);
         using TCompletion = TEvIndexTabletPrivate::TEvAggregateStatsCompleted;
         NProtoPrivate::TStorageStats statsForTablet;
-        TVector<TShardStats> shardStats(2);
+        statsForTablet.AddShardStats()->SetShardId(fsConfig.Shard1Id);
+        statsForTablet.AddShardStats()->SetShardId(fsConfig.Shard2Id);
 
         auto completion = std::make_unique<TCompletion>(
             NProto::TError(),
             std::move(statsForTablet),
-            std::move(shardStats),
             TInstant());
 
         env.GetRuntime().Send(

--- a/cloud/filestore/libs/storage/tablet/events/tablet_private.h
+++ b/cloud/filestore/libs/storage/tablet/events/tablet_private.h
@@ -1201,7 +1201,6 @@ struct TEvIndexTabletPrivate
     struct TAggregateStatsCompleted
     {
         NProtoPrivate::TStorageStats AggregateStats;
-        TVector<TShardStats> ShardStats;
         TInstant StartedTs;
         bool IsBackgroundRequest = false;
     };

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.cpp
@@ -63,14 +63,14 @@ TShardBalancerBase::TShardBalancerBase(
     , PrecisionBytes(precisionBytes)
     , DesiredFreeSpaceReserve(desiredFreeSpaceReserve)
     , MinFreeSpaceReserve(minFreeSpaceReserve)
-    , Ids(std::move(shardIds))
 {
-    for (ui32 i = 0; i < Ids.size(); ++i) {
+    for (ui32 i = 0; i < shardIds.size(); ++i) {
         Metas.emplace_back(
             i,
             // Before the first update shards are treated like empty with
-            // infinite capacity. maxFileBlocks is used as inifinity here.
+            // infinite capacity. maxFileBlocks is used as infinity here.
             TShardStats{
+                .ShardId = shardIds[i],
                 .TotalBlocksCount = maxFileBlocks,
                 .UsedBlocksCount = 0,
                 .UsedNodesCount = 0,
@@ -123,15 +123,15 @@ size_t TShardBalancerBase::FindUpperBoundAmongAllShardsToFitFile(
     return std::distance(Metas.begin(), e);
 }
 
-TVector<IShardBalancer::TShardDescr>
+TVector<TShardStats>
 TShardBalancerBase::MakeOrderedShardList() const
 {
-    TVector<TShardDescr> shardDescrs;
-    shardDescrs.reserve(Metas.size());
+    TVector<TShardStats> shardStats;
+    shardStats.reserve(Metas.size());
     for (const auto& meta: Metas) {
-        shardDescrs.emplace_back(Ids[meta.ShardIdx], meta.Stats);
+        shardStats.emplace_back(meta.Stats);
     }
-    return shardDescrs;
+    return shardStats;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -145,7 +145,7 @@ NProto::TError TShardBalancerRoundRobin::SelectShard(
         return MakeError(E_FS_NOSPC, "all shards are full");
     }
 
-    *shardId = Ids[Metas[(ShardSelector++) % endIdx].ShardIdx];
+    *shardId = Metas[(ShardSelector++) % endIdx].Stats.ShardId;
     return {};
 }
 
@@ -161,7 +161,7 @@ NProto::TError TShardBalancerRandom::SelectShard(
     }
 
     const auto idx = RandomNumber<ui32>(endIdx);
-    *shardId = Ids[Metas[idx].ShardIdx];
+    *shardId = Metas[idx].Stats.ShardId;
     return {};
 }
 
@@ -240,7 +240,7 @@ NProto::TError TShardBalancerWeightedRandom::SelectShard(
     Y_ABORT_UNLESS(it != WeightPrefixSums.begin());
     const size_t idx = std::distance(WeightPrefixSums.begin(), it) - 1;
     Y_ABORT_UNLESS(idx < Metas.size());
-    *shardId = Ids[Metas[idx].ShardIdx];
+    *shardId = Metas[idx].Stats.ShardId;
     return {};
 }
 

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer.h
@@ -15,6 +15,7 @@ namespace NCloud::NFileStore::NStorage {
 
 struct TShardStats
 {
+    TString ShardId;
     ui64 TotalBlocksCount = 0;
     ui64 UsedBlocksCount = 0;
     ui64 UsedNodesCount = 0;
@@ -38,17 +39,6 @@ public:
         {}
     };
 
-    struct TShardDescr
-    {
-        TString ShardId;
-        TShardStats Stats;
-
-        TShardDescr(TString shardId, TShardStats stats)
-            : ShardId(std::move(shardId))
-            , Stats(stats)
-        {}
-    };
-
     virtual ~IShardBalancer() = default;
 
     virtual NProto::TError Update(
@@ -65,13 +55,13 @@ public:
     /**
      * @brief Builds and returns the shard list ordered from best to worst.
      *
-     * This method builds a new vector with shard descrs so it's not supposed to
+     * This method builds a new vector with TShardStats so it's not supposed to
      * be used often because it's expensive. The main intended use case is
      * introspection - log this info with debug loglevel or show it on monpages.
      *
-     * @return The list of shard descrs.
+     * @return The list of shard TShardStats.
      */
-    [[nodiscard]] virtual TVector<TShardDescr> MakeOrderedShardList() const = 0;
+    [[nodiscard]] virtual TVector<TShardStats> MakeOrderedShardList() const = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -94,7 +84,6 @@ private:
     ui64 MinFreeSpaceReserve = 0;
 
 protected:
-    TVector<TString> Ids;
     TVector<TShardMeta> Metas;
 
     /**
@@ -121,7 +110,7 @@ public:
         std::optional<ui64> desiredFreeSpaceReserve,
         std::optional<ui64> minFreeSpaceReserve) override;
 
-    [[nodiscard]] TVector<TShardDescr> MakeOrderedShardList() const override;
+    [[nodiscard]] TVector<TShardStats> MakeOrderedShardList() const override;
 };
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/shard_balancer_ut.cpp
@@ -60,11 +60,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         ASSERT_NO_SB_ERROR(0, "s5");
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 3_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, 3_TB / 4_KB, 0, 0},
         }));
 
         // order changed: s1, s3, s4, s2, s5
@@ -83,11 +83,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // order changed: s1, s2, s3, s4, s5
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 4_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, 4_TB / 4_KB, 0, 0},
         }));
 
         ASSERT_NO_SB_ERROR(0, "s1");
@@ -105,11 +105,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // order changed: s1, s2, s3, s4
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
         }));
 
         ASSERT_NO_SB_ERROR(0, "s3");
@@ -128,11 +128,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // tier 2: s3, s5
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
         }));
 
         ASSERT_NO_SB_ERROR(0, "s1");
@@ -144,11 +144,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // order changed: s3, s1, s5
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, (4_TB + 400_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, (4_TB + 400_GB) / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, (4_TB + 500_GB) / 4_KB, 0, 0},
         }));
 
         ASSERT_NO_SB_ERROR(0, "s5");
@@ -162,11 +162,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // 1 close to full shard left: s3
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, (5_TB - 512_KB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, (5_TB - 512_KB) / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, (4_TB + 300_GB) / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
         }));
 
         ASSERT_NO_SB_ERROR(0, "s3");
@@ -175,11 +175,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // out of space
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, (5_TB - 512_KB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB + 300_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, (5_TB - 512_KB) / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, (5_TB + 100_GB) / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, (5_TB + 300_GB) / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
         }));
 
         ASSERT_SB_ERROR(0, E_FS_NOSPC);
@@ -262,11 +262,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
             {"s1", "s2", "s3", "s4", "s5"});
 
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, 512_GB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, 3_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, 512_GB / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, (1_TB + 1_GB) / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, 3_TB / 4_KB, 0, 0},
         }));
 
         // 1 TiB can fit in any shard
@@ -341,11 +341,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
 
         // Now let's fill up last 3 shards to their limits
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, 0, 0, 0},
-            {5_TB / 4_KB, 0, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, 0, 0, 0},
+            {"s2", 5_TB / 4_KB, 0, 0, 0},
+            {"s3", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
         }));
 
         // 1 TiB can now fit only in s1 or s2
@@ -372,14 +372,16 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
 
     Y_UNIT_TEST(ShouldBalanceShardsWeightedRandom)
     {
+        const TVector<TString> shardIds = {"s1", "s2", "s3", "s4", "s5"};
+        const ui64 shardCount = shardIds.size();
+
         TShardBalancerWeightedRandom balancer(
             BlockSize,
             PrecisionBytes,
             MaxFileBlocks,
             1_TB /* desiredFreeSpaceReserve */,
             0 /* minFreeSpaceReserve */,
-            {"s1", "s2", "s3", "s4", "s5"});
-        const ui64 shardCount = 5;
+            shardIds);
 
         // 1 TiB can fit in any shard
 
@@ -409,11 +411,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // Now let's fill up last 2 shards to their limits and leave first 3
         // shards 1:2:3 free space
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, (5_TB - 1_TB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB - 2_TB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB - 3_TB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, (5_TB - 1_TB) / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, (5_TB - 2_TB) / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, (5_TB - 3_TB) / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, 5_TB / 4_KB, 0, 0},
         }));
 
         // It is expected that s1, s2, s3 will be selected with 1:2:3 ratio
@@ -447,14 +449,17 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
 
         // If we fill up all the shards with less than 1 TiB left it should not
         // be possible to select any shard
-        ASSERT_NO_ERROR(balancer.Update(
-            TVector<TShardStats>(
-                shardCount,
-                TShardStats{
-                    .TotalBlocksCount = 5_TB / 4_KB,
-                    .UsedBlocksCount = (5_TB - 500_GB) / 4_KB,
-                    .CurrentLoad = 0,
-                    .Suffer = 0})));
+        TVector<TShardStats> shardStats;
+        shardStats.reserve(shardIds.size());
+        for (const auto& shardId: shardIds) {
+            shardStats.emplace_back(
+                shardId,
+                5_TB / 4_KB,
+                (5_TB - 500_GB) / 4_KB,
+                0,
+                0);
+        }
+        ASSERT_NO_ERROR(balancer.Update(shardStats));
         for (ui64 i = 0; i < iterations; ++i) {
             ASSERT_SB_ERROR(1_TB, E_FS_NOSPC);
         }
@@ -466,11 +471,11 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
         // For a situation where in every shard there is less than 1 TiB left,
         // we should disregard additional 1 TiB reserve
         ASSERT_NO_ERROR(balancer.Update({
-            {5_TB / 4_KB, (5_TB - 1_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB - 2_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB - 3_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB - 4_GB) / 4_KB, 0, 0},
-            {5_TB / 4_KB, (5_TB - 5_GB) / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, (5_TB - 1_GB) / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, (5_TB - 2_GB) / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, (5_TB - 3_GB) / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, (5_TB - 4_GB) / 4_KB, 0, 0},
+            {"s5", 5_TB / 4_KB, (5_TB - 5_GB) / 4_KB, 0, 0},
         }));
         // Trying to allocate 3 GiB should result in s3, s4, s5 being selected
         // in a 3:4:5 ratio
@@ -534,10 +539,10 @@ Y_UNIT_TEST_SUITE(TShardBalancerTest)
             {"s1", "s2", "s3", "s4", "s5"});
 
         auto e = balancer.Update({
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
-            {5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s1", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s2", 5_TB / 4_KB, 2_TB / 4_KB, 0, 0},
+            {"s3", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
+            {"s4", 5_TB / 4_KB, 1_TB / 4_KB, 0, 0},
         });
 
         UNIT_ASSERT_VALUES_EQUAL_C(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -140,7 +140,6 @@ private:
     TCPUUsageTimer CPUUsageTimer{Metrics.CPUUsageMicros};
 
     NProtoPrivate::TStorageStats CachedAggregateStats;
-    TVector<TShardStats> CachedShardStats;
     TInstant CachedStatsFetchingStartTs;
     TInstant CachedAggregateStatsTs;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -30,7 +30,6 @@ private:
     TString MainFileSystemId;
     const google::protobuf::RepeatedPtrField<TString> ShardIds;
     std::unique_ptr<TEvIndexTablet::TEvGetStorageStatsResponse> Response;
-    TVector<TShardStats> ShardStats;
     int Responses = 0;
 
 public:
@@ -84,8 +83,15 @@ TAggregateStatsActor::TAggregateStatsActor(
     , MainFileSystemId(std::move(mainFileSystemId))
     , ShardIds(std::move(shardIds))
     , Response(std::move(response))
-    , ShardStats(ShardIds.size())
-{}
+{
+    auto& dst = *Response->Record.MutableStats();
+    auto& shardStats = *dst.MutableShardStats();
+    shardStats.Clear();
+    shardStats.Reserve(ShardIds.size());
+    for (const auto& shardId: ShardIds) {
+        shardStats.Add()->SetShardId(shardId);
+    }
+}
 
 void TAggregateStatsActor::Bootstrap(const TActorContext& ctx)
 {
@@ -189,12 +195,12 @@ void TAggregateStatsActor::HandleGetStorageStatsResponse(
         dst.GetUsedNodesCount());
 
     if (shardIndex < ShardIds.size()) {
-        auto& ss = ShardStats[shardIndex];
-        ss.CurrentLoad = src.GetCurrentLoad();
-        ss.Suffer = src.GetSuffer();
-        ss.TotalBlocksCount = src.GetTotalBlocksCount();
-        ss.UsedBlocksCount = src.GetUsedBlocksCount();
-        ss.UsedNodesCount = src.GetUsedNodesCount();
+        auto& ss = (*dst.MutableShardStats())[shardIndex];
+        ss.SetCurrentLoad(src.GetCurrentLoad());
+        ss.SetSuffer(src.GetSuffer());
+        ss.SetTotalBlocksCount(src.GetTotalBlocksCount());
+        ss.SetUsedBlocksCount(src.GetUsedBlocksCount());
+        ss.SetUsedNodesCount(src.GetUsedNodesCount());
     }
 
     if (++Responses == requestsCount) {
@@ -223,23 +229,12 @@ void TAggregateStatsActor::ReplyAndDie(
     NProtoPrivate::TStorageStats statsForTablet = Response->Record.GetStats();
     if (RequestInfo) {
         startedTs = RequestInfo->StartedTs;
-        auto* stats = Response->Record.MutableStats();
-        for (size_t i = 0; i < ShardStats.size(); ++i) {
-            auto* ss = stats->AddShardStats();
-            ss->SetShardId(ShardIds[i]);
-            ss->SetTotalBlocksCount(ShardStats[i].TotalBlocksCount);
-            ss->SetUsedBlocksCount(ShardStats[i].UsedBlocksCount);
-            ss->SetUsedNodesCount(ShardStats[i].UsedNodesCount);
-            ss->SetCurrentLoad(ShardStats[i].CurrentLoad);
-            ss->SetSuffer(ShardStats[i].Suffer);
-        }
         NCloud::Reply(ctx, *RequestInfo, std::move(Response));
     }
 
     auto response = std::make_unique<TCompletion>(
         error,
         std::move(statsForTablet),
-        std::move(ShardStats),
         startedTs,
         !RequestInfo /* isBackgroundRequest */);
     NCloud::Send(ctx, Tablet, std::move(response));
@@ -267,7 +262,7 @@ STFUNC(TAggregateStatsActor::StateWork)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TString DescribeShardList(const TVector<IShardBalancer::TShardDescr>& shards)
+TString DescribeShardList(const TVector<TShardStats>& shards)
 {
     TStringBuilder sb;
     for (ui32 i = 0; i < shards.size(); ++i) {
@@ -277,13 +272,29 @@ TString DescribeShardList(const TVector<IShardBalancer::TShardDescr>& shards)
 
         const auto& s = shards[i];
         sb << "id=" << s.ShardId
-            << " blocks=" << s.Stats.UsedBlocksCount
-            << "/" << s.Stats.TotalBlocksCount
-            << " nodes=" << s.Stats.UsedNodesCount
-            << " load=" << s.Stats.CurrentLoad
-            << " suffer=" << s.Stats.Suffer;
+            << " blocks=" << s.UsedBlocksCount
+            << "/" << s.TotalBlocksCount
+            << " nodes=" << s.UsedNodesCount
+            << " load=" << s.CurrentLoad
+            << " suffer=" << s.Suffer;
     }
     return sb;
+}
+
+void FillShardStats(
+    const NProtoPrivate::TStorageStats& storageStats,
+    TVector<TShardStats>& shardStats)
+{
+    shardStats.reserve(storageStats.ShardStatsSize());
+    for (const auto& srcShardStats: storageStats.GetShardStats()) {
+        shardStats.emplace_back(
+            srcShardStats.GetShardId(),
+            srcShardStats.GetTotalBlocksCount(),
+            srcShardStats.GetUsedBlocksCount(),
+            srcShardStats.GetUsedNodesCount(),
+            srcShardStats.GetCurrentLoad(),
+            srcShardStats.GetSuffer());
+    }
 }
 
 }   // namespace
@@ -770,17 +781,6 @@ void TIndexTabletActor::HandleGetStorageStats(
 
     if (allowCache && pollShards) {
         *stats = CachedAggregateStats;
-        const ui32 shardMetricsCount =
-            Min<ui32>(shardIds.size(), CachedShardStats.size());
-        for (ui32 i = 0; i < shardMetricsCount; ++i) {
-            auto* ss = stats->AddShardStats();
-            ss->SetShardId(shardIds[i]);
-            ss->SetTotalBlocksCount(CachedShardStats[i].TotalBlocksCount);
-            ss->SetUsedBlocksCount(CachedShardStats[i].UsedBlocksCount);
-            ss->SetUsedNodesCount(CachedShardStats[i].UsedNodesCount);
-            ss->SetCurrentLoad(CachedShardStats[i].CurrentLoad);
-            ss->SetSuffer(CachedShardStats[i].Suffer);
-        }
     } else {
         FillSelfStorageStats(stats);
     }
@@ -866,7 +866,7 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
             "%s Background shard stats fetch completed in %s, ShardsCount: %lu",
             LogTag.c_str(),
             backgroundRequestDuration.ToString().c_str(),
-            msg->ShardStats.size());
+            msg->AggregateStats.GetShardStats().size());
         CachedStatsFetchingStartTs = TInstant::Zero();
     }
 
@@ -878,9 +878,10 @@ void TIndexTabletActor::HandleAggregateStatsCompleted(
             Metrics.GetStorageStats.Update(1, 0, ctx.Now() - msg->StartedTs);
         }
         CachedAggregateStats = std::move(msg->AggregateStats);
-        CachedShardStats = std::move(msg->ShardStats);
 
-        auto error = UpdateShardBalancer(CachedShardStats);
+        TVector<TShardStats> shardStats;
+        FillShardStats(CachedAggregateStats, shardStats);
+        auto error = UpdateShardBalancer(shardStats);
         if (HasError(error)) {
             LOG_WARN(
                 ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -195,7 +195,7 @@ void TAggregateStatsActor::HandleGetStorageStatsResponse(
         dst.GetUsedNodesCount());
 
     if (shardIndex < ShardIds.size()) {
-        auto& ss = (*dst.MutableShardStats())[shardIndex];
+        auto& ss = *dst.MutableShardStats(shardIndex);
         ss.SetCurrentLoad(src.GetCurrentLoad());
         ss.SetSuffer(src.GetSuffer());
         ss.SetTotalBlocksCount(src.GetTotalBlocksCount());

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1099,29 +1099,36 @@ void TIndexTabletActor::HandleHttpInfo_Default(
 
                 ui32 shardNo = 0;
                 for (const auto& shardId: shardIds) {
-                    TShardStats ss;
-                    if (shardNo < CachedShardStats.size()) {
-                        ss = CachedShardStats[shardNo];
+                    NProtoPrivate::TShardStats ss;
+                    if (shardNo < CachedAggregateStats.ShardStatsSize()) {
+                        ss = CachedAggregateStats.GetShardStats(shardNo);
                     }
-                    TABLER() {
-                        TABLED() { out << ++shardNo; }
-                        TABLED() {
+                    TABLER () {
+                        TABLED () {
+                            out << ++shardNo;
+                        }
+                        TABLED () {
                             out << "<a href='../filestore/service?action=search"
-                                << "&Filesystem=" << shardId << "'>"
-                                << shardId << "</a>";
+                                << "&Filesystem=" << shardId << "'>" << shardId
+                                << "</a>";
                         }
-                        TABLED() {
-                            out << ss.UsedBlocksCount * GetBlockSize();
+                        TABLED () {
+                            out << ss.GetUsedBlocksCount() * GetBlockSize();
                         }
-                        TABLED() {
-                            out << ss.UsedNodesCount;
+                        TABLED () {
+                            out << ss.GetUsedNodesCount();
                         }
-                        TABLED() {
-                            out << (ss.TotalBlocksCount - ss.UsedBlocksCount)
-                                * GetBlockSize();
+                        TABLED () {
+                            out << (ss.GetTotalBlocksCount() -
+                                    ss.GetUsedBlocksCount()) *
+                                       GetBlockSize();
                         }
-                        TABLED() { out << ss.CurrentLoad; }
-                        TABLED() { out << ss.Suffer; }
+                        TABLED () {
+                            out << ss.GetCurrentLoad();
+                        }
+                        TABLED () {
+                            out << ss.GetSuffer();
+                        }
                     }
                 }
             }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1103,32 +1103,26 @@ void TIndexTabletActor::HandleHttpInfo_Default(
                     if (shardNo < CachedAggregateStats.ShardStatsSize()) {
                         ss = CachedAggregateStats.GetShardStats(shardNo);
                     }
-                    TABLER () {
-                        TABLED () {
-                            out << ++shardNo;
-                        }
-                        TABLED () {
+                    TABLER() {
+                        TABLED() { out << ++shardNo; }
+                        TABLED() {
                             out << "<a href='../filestore/service?action=search"
-                                << "&Filesystem=" << shardId << "'>" << shardId
-                                << "</a>";
+                                << "&Filesystem=" << shardId << "'>"
+                                << shardId << "</a>";
                         }
-                        TABLED () {
+                        TABLED() {
                             out << ss.GetUsedBlocksCount() * GetBlockSize();
                         }
-                        TABLED () {
+                        TABLED() {
                             out << ss.GetUsedNodesCount();
                         }
-                        TABLED () {
+                        TABLED() {
                             out << (ss.GetTotalBlocksCount() -
                                     ss.GetUsedBlocksCount()) *
                                        GetBlockSize();
                         }
-                        TABLED () {
-                            out << ss.GetCurrentLoad();
-                        }
-                        TABLED () {
-                            out << ss.GetSuffer();
-                        }
+                        TABLED() { out << ss.GetCurrentLoad(); }
+                        TABLED() { out << ss.GetSuffer(); }
                     }
                 }
             }

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -454,7 +454,7 @@ public:
 
     NProto::TError UpdateShardBalancer(const TVector<TShardStats>& stats);
 
-    TVector<IShardBalancer::TShardDescr> MakeOrderedShardList() const;
+    TVector<TShardStats> MakeOrderedShardList() const;
 
     //
     // FileSystem Stats

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -1627,7 +1627,7 @@ NProto::TError TIndexTabletState::UpdateShardBalancer(
         minFreeSpaceReserve);
 }
 
-TVector<IShardBalancer::TShardDescr>
+TVector<TShardStats>
 TIndexTabletState::MakeOrderedShardList() const
 {
     return Impl->ShardBalancer->MakeOrderedShardList();


### PR DESCRIPTION
### Notes
As a preliminary step to #6414 some refactoring was made.
1. TIndexTabletActor::CachedShardStats is deleted as the same shards stats may be stored inside CachedAggregateStats.
(NProtoPrivate::TStorageStats::ShardStats)
2. NProtoPrivate::TShardStats and NStorage::TShardStats (from shard_balancer.h)  are made equivalent, that allowed to delete IShardBalancer::TShardDescr

### Issue
#6414
