### PR TITLE
feat: check out, in pr.yaml, fresh main ref for all github actions

### DIFF
--- a/.github/workflows/build_and_test_proxy.yaml
+++ b/.github/workflows/build_and_test_proxy.yaml
@@ -3,6 +3,18 @@ name: Build and test proxy
 on:
   workflow_call:
     inputs:
+      actions_checkout_ref:
+        required: false
+        type: string
+        default: ""
+      code_checkout_ref:
+        required: false
+        type: string
+        default: ""
+      code_rebase_ref:
+        required: false
+        type: string
+        default: ""
       mode:
         required: true
         type: string
@@ -70,34 +82,13 @@ jobs:
     outputs:
       matrix_include: ${{ steps.build-matrix-include.outputs.matrix_include }}
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          sparse-checkout: '.github'
-          clean: true
+          ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false
@@ -124,34 +115,13 @@ jobs:
     needs: plan
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          sparse-checkout: '.github'
-          clean: true
+          ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false
@@ -176,6 +146,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix_include) }}
     with:
+      actions_checkout_ref: ${{ inputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ inputs.code_checkout_ref }}
+      code_rebase_ref: ${{ inputs.code_rebase_ref }}
       component: ${{ matrix.component == 'all' && '' || matrix.component }}
       build_target: ${{ matrix.build_target }}
       test_target:  ${{ matrix.test_target }}
@@ -205,6 +178,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix_include) }}
     with:
+      actions_checkout_ref: ${{ inputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ inputs.code_checkout_ref }}
+      code_rebase_ref: ${{ inputs.code_rebase_ref }}
       component: ${{ matrix.component == 'all' && '' || matrix.component }}
       build_target: ${{ matrix.build_target }}
       test_target:  ${{ matrix.test_target }}
@@ -233,6 +209,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix_include) }}
     with:
+      actions_checkout_ref: ${{ inputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ inputs.code_checkout_ref }}
+      code_rebase_ref: ${{ inputs.code_rebase_ref }}
       component: ${{ matrix.component == 'all' && '' || matrix.component }}
       build_target: ${{ matrix.build_target }}
       test_target:  ${{ matrix.test_target }}

--- a/.github/workflows/on_demand_build_and_test.yaml
+++ b/.github/workflows/on_demand_build_and_test.yaml
@@ -78,6 +78,15 @@ on:
         description: "Per ya make test attempt timeout in minutes"
   workflow_call:
     inputs:
+      actions_checkout_ref:
+        type: string
+        default: ""
+      code_checkout_ref:
+        type: string
+        default: ""
+      code_rebase_ref:
+        type: string
+        default: ""
       component:
         type: string
         default: ""
@@ -173,34 +182,13 @@ jobs:
       test_threads: ${{ steps.calculate-threads.outputs.test_threads || '32' }}
       link_threads: ${{ steps.calculate-threads.outputs.link_threads || '24' }}
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          sparse-checkout: '.github'
-          clean: true
+          ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false
@@ -242,6 +230,9 @@ jobs:
     needs:
       - provide-runner
     with:
+      actions_checkout_ref: ${{ inputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ inputs.code_checkout_ref }}
+      code_rebase_ref: ${{ inputs.code_rebase_ref }}
       runner_kind: self-hosted
       runner_label: ${{ needs.provide-runner.outputs.label }}
       runner_instance_id: ${{ needs.provide-runner.outputs.instance-id }}
@@ -294,34 +285,13 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          sparse-checkout: '.github'
-          clean: true
+          ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -170,8 +170,17 @@ jobs:
       if: ${{ inputs.actions_checkout_ref != '' }}
       shell: bash
       run: |
+        code_config="$(mktemp -d)"
+        if [ -e .github/config ]; then
+            cp -a .github/config "$code_config/config"
+        fi
         rm -rf .github
         cp -a trusted-actions/.github .github
+        rm -rf .github/config
+        if [ -e "$code_config/config" ]; then
+            mv "$code_config/config" .github/config
+        fi
+        rm -rf "$code_config"
         rm -rf trusted-actions
 
     - name: mark workload as running

--- a/.github/workflows/on_demand_build_and_test_ya.yaml
+++ b/.github/workflows/on_demand_build_and_test_ya.yaml
@@ -3,6 +3,15 @@ name: Build and test
 on:
   workflow_call:
     inputs:
+      actions_checkout_ref:
+        type: string
+        default: ""
+      code_checkout_ref:
+        type: string
+        default: ""
+      code_rebase_ref:
+        type: string
+        default: ""
       component:
         type: string
         default: ""
@@ -118,15 +127,17 @@ jobs:
     - name: Checkout PR
       uses: actions/checkout@v7
       timeout-minutes: 10
-      if: github.event.pull_request.head.sha != ''
+      if: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
       with:
         submodules: true
         clean: true
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
         fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
     - name: Rebase PR
-      if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+      if: ${{ (inputs.code_checkout_ref || github.event.pull_request.head.sha) && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
+      env:
+        CODE_REBASE_REF: ${{ inputs.code_rebase_ref || github.event.pull_request.base.ref }}
       run: |
         if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
             echo "Removing stale rebase state left on runner checkout"
@@ -134,16 +145,34 @@ jobs:
         fi
         git config user.email "robot-nbs@nebius.com"
         git config user.name "Robot NBS"
-        git fetch origin ${{ github.event.pull_request.base.ref }}
-        git rebase origin/${{ github.event.pull_request.base.ref }}
+        git fetch origin "${CODE_REBASE_REF}"
+        git rebase "origin/${CODE_REBASE_REF}"
         git submodule update --init --recursive
     - name: Checkout
       uses: actions/checkout@v7
       timeout-minutes: 10
-      if: github.event.pull_request.head.sha == ''
+      if: ${{ !(inputs.code_checkout_ref || github.event.pull_request.head.sha) }}
       with:
         submodules: true
         clean: true
+
+    - name: Checkout workflow actions
+      if: ${{ inputs.actions_checkout_ref != '' }}
+      uses: actions/checkout@v7
+      timeout-minutes: 10
+      with:
+        submodules: false
+        sparse-checkout: '.github'
+        clean: true
+        path: trusted-actions
+        ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
+    - name: Replace workspace workflow actions
+      if: ${{ inputs.actions_checkout_ref != '' }}
+      shell: bash
+      run: |
+        rm -rf .github
+        cp -a trusted-actions/.github .github
+        rm -rf trusted-actions
 
     - name: mark workload as running
       id: workload-comment

--- a/.github/workflows/on_hybrid_build_and_test.yaml
+++ b/.github/workflows/on_hybrid_build_and_test.yaml
@@ -78,6 +78,15 @@ on:
         description: "Per ya make test attempt timeout in minutes"
   workflow_call:
     inputs:
+      actions_checkout_ref:
+        type: string
+        default: ""
+      code_checkout_ref:
+        type: string
+        default: ""
+      code_rebase_ref:
+        type: string
+        default: ""
       component:
         type: string
         default: ""
@@ -173,34 +182,13 @@ jobs:
       test_threads: ${{ steps.calculate-threads.outputs.test_threads || '32' }}
       link_threads: ${{ steps.calculate-threads.outputs.link_threads || '24' }}
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          sparse-checkout: '.github'
-          clean: true
+          ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false
@@ -241,6 +229,9 @@ jobs:
     needs:
       - provide-runner
     with:
+      actions_checkout_ref: ${{ inputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ inputs.code_checkout_ref }}
+      code_rebase_ref: ${{ inputs.code_rebase_ref }}
       runner_kind: self-hosted
       runner_label: ${{ needs.provide-runner.outputs.label }}
       runner_instance_id: ${{ needs.provide-runner.outputs.instance-id }}
@@ -293,34 +284,13 @@ jobs:
     runs-on: [ self-hosted, "self-hosted", "runner_light" ]
     if: always()
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          sparse-checkout: '.github'
-          clean: true
+          ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -3,6 +3,15 @@ name: Build and test (ya) on pooled runners
 on:
   workflow_call:
     inputs:
+      actions_checkout_ref:
+        type: string
+        default: ""
+      code_checkout_ref:
+        type: string
+        default: ""
+      code_rebase_ref:
+        type: string
+        default: ""
       component:
         type: string
         default: ""
@@ -118,15 +127,17 @@ jobs:
     - name: Checkout PR
       uses: actions/checkout@v7
       timeout-minutes: 10
-      if: github.event.pull_request.head.sha != ''
+      if: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
       with:
         submodules: true
         clean: true
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
         fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
     - name: Rebase PR
-      if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+      if: ${{ (inputs.code_checkout_ref || github.event.pull_request.head.sha) && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
+      env:
+        CODE_REBASE_REF: ${{ inputs.code_rebase_ref || github.event.pull_request.base.ref }}
       run: |
         if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
             echo "Removing stale rebase state left on runner checkout"
@@ -134,16 +145,34 @@ jobs:
         fi
         git config user.email "robot-nbs@nebius.com"
         git config user.name "Robot NBS"
-        git fetch origin ${{ github.event.pull_request.base.ref }}
-        git rebase origin/${{ github.event.pull_request.base.ref }}
+        git fetch origin "${CODE_REBASE_REF}"
+        git rebase "origin/${CODE_REBASE_REF}"
         git submodule update --init --recursive
     - name: Checkout
       uses: actions/checkout@v7
       timeout-minutes: 10
-      if: github.event.pull_request.head.sha == ''
+      if: ${{ !(inputs.code_checkout_ref || github.event.pull_request.head.sha) }}
       with:
         submodules: true
         clean: true
+
+    - name: Checkout workflow actions
+      if: ${{ inputs.actions_checkout_ref != '' }}
+      uses: actions/checkout@v7
+      timeout-minutes: 10
+      with:
+        submodules: false
+        sparse-checkout: '.github'
+        clean: true
+        path: trusted-actions
+        ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
+    - name: Replace workspace workflow actions
+      if: ${{ inputs.actions_checkout_ref != '' }}
+      shell: bash
+      run: |
+        rm -rf .github
+        cp -a trusted-actions/.github .github
+        rm -rf trusted-actions
 
     - name: mark workload as running
       id: workload-comment

--- a/.github/workflows/on_hybrid_build_and_test_ya.yaml
+++ b/.github/workflows/on_hybrid_build_and_test_ya.yaml
@@ -170,8 +170,17 @@ jobs:
       if: ${{ inputs.actions_checkout_ref != '' }}
       shell: bash
       run: |
+        code_config="$(mktemp -d)"
+        if [ -e .github/config ]; then
+            cp -a .github/config "$code_config/config"
+        fi
         rm -rf .github
         cp -a trusted-actions/.github .github
+        rm -rf .github/config
+        if [ -e "$code_config/config" ]; then
+            mv "$code_config/config" .github/config
+        fi
+        rm -rf "$code_config"
         rm -rf trusted-actions
 
     - name: mark workload as running

--- a/.github/workflows/on_pooled_build_and_test.yaml
+++ b/.github/workflows/on_pooled_build_and_test.yaml
@@ -77,6 +77,15 @@ on:
         description: "Per ya make test attempt timeout in minutes"
   workflow_call:
     inputs:
+      actions_checkout_ref:
+        type: string
+        default: ""
+      code_checkout_ref:
+        type: string
+        default: ""
+      code_rebase_ref:
+        type: string
+        default: ""
       component:
         type: string
         default: ""
@@ -154,6 +163,9 @@ jobs:
     name: Build and test NBS [build_preset=${{ inputs.build_preset }} component=${{ inputs.component == '' && 'all' || inputs.component }} target_platform=${{ inputs.target_platform == '' && 'native' || inputs.target_platform }}]
     uses: ./.github/workflows/on_pooled_build_and_test_ya.yaml
     with:
+      actions_checkout_ref: ${{ inputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ inputs.code_checkout_ref }}
+      code_rebase_ref: ${{ inputs.code_rebase_ref }}
       runner_kind: self-hosted
       runner_flavor: "heavy"
       component: ${{ inputs.component }}

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -177,8 +177,17 @@ jobs:
       if: ${{ inputs.actions_checkout_ref != '' }}
       shell: bash
       run: |
+        code_config="$(mktemp -d)"
+        if [ -e .github/config ]; then
+            cp -a .github/config "$code_config/config"
+        fi
         rm -rf .github
         cp -a trusted-actions/.github .github
+        rm -rf .github/config
+        if [ -e "$code_config/config" ]; then
+            mv "$code_config/config" .github/config
+        fi
+        rm -rf "$code_config"
         rm -rf trusted-actions
 
     - name: set up nebius cli
@@ -419,8 +428,17 @@ jobs:
         if: ${{ inputs.actions_checkout_ref != '' }}
         shell: bash
         run: |
+          code_config="$(mktemp -d)"
+          if [ -e .github/config ]; then
+              cp -a .github/config "$code_config/config"
+          fi
           rm -rf .github
           cp -a trusted-actions/.github .github
+          rm -rf .github/config
+          if [ -e "$code_config/config" ]; then
+              mv "$code_config/config" .github/config
+          fi
+          rm -rf "$code_config"
           rm -rf trusted-actions
 
       - name: set up nebius cli

--- a/.github/workflows/on_pooled_build_and_test_ya.yaml
+++ b/.github/workflows/on_pooled_build_and_test_ya.yaml
@@ -3,6 +3,15 @@ name: Build and test (ya) on pooled runners
 on:
   workflow_call:
     inputs:
+      actions_checkout_ref:
+        type: string
+        default: ""
+      code_checkout_ref:
+        type: string
+        default: ""
+      code_rebase_ref:
+        type: string
+        default: ""
       component:
         type: string
         default: ""
@@ -124,15 +133,17 @@ jobs:
     - name: Checkout PR
       uses: actions/checkout@v7
       timeout-minutes: 10
-      if: github.event.pull_request.head.sha != ''
+      if: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
       with:
         submodules: true
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
         fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
         clean: true
     - name: Rebase PR
-      if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+      if: ${{ (inputs.code_checkout_ref || github.event.pull_request.head.sha) && contains(github.event.pull_request.labels.*.name, 'rebase') }}
       shell: bash
+      env:
+        CODE_REBASE_REF: ${{ inputs.code_rebase_ref || github.event.pull_request.base.ref }}
       run: |
         if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
             echo "Removing stale rebase state left on runner checkout"
@@ -140,17 +151,35 @@ jobs:
         fi
         git config user.email "robot-nbs@nebius.com"
         git config user.name "Robot NBS"
-        git fetch origin ${{ github.event.pull_request.base.ref }}
-        git rebase origin/${{ github.event.pull_request.base.ref }}
+        git fetch origin "${CODE_REBASE_REF}"
+        git rebase "origin/${CODE_REBASE_REF}"
         git submodule update --init --recursive
     - name: Checkout
       uses: actions/checkout@v7
       timeout-minutes: 10
-      if: github.event.pull_request.head.sha == ''
+      if: ${{ !(inputs.code_checkout_ref || github.event.pull_request.head.sha) }}
       with:
         submodules: true
         set-safe-directory: '*'
         clean: true
+
+    - name: Checkout workflow actions
+      if: ${{ inputs.actions_checkout_ref != '' }}
+      uses: actions/checkout@v7
+      timeout-minutes: 10
+      with:
+        submodules: false
+        sparse-checkout: '.github'
+        clean: true
+        path: trusted-actions
+        ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
+    - name: Replace workspace workflow actions
+      if: ${{ inputs.actions_checkout_ref != '' }}
+      shell: bash
+      run: |
+        rm -rf .github
+        cp -a trusted-actions/.github .github
+        rm -rf trusted-actions
 
     - name: set up nebius cli
       id: cli
@@ -346,15 +375,17 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v7
         timeout-minutes: 10
-        if: github.event.pull_request.head.sha != ''
+        if: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
         with:
           submodules: true
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.code_checkout_ref || github.event.pull_request.head.sha }}
           fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
       - name: Rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
+        if: ${{ (inputs.code_checkout_ref || github.event.pull_request.head.sha) && contains(github.event.pull_request.labels.*.name, 'rebase') }}
         shell: bash
+        env:
+          CODE_REBASE_REF: ${{ inputs.code_rebase_ref || github.event.pull_request.base.ref }}
         run: |
           if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
               echo "Removing stale rebase state left on runner checkout"
@@ -362,17 +393,35 @@ jobs:
           fi
           git config user.email "robot-nbs@nebius.com"
           git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
+          git fetch origin "${CODE_REBASE_REF}"
+          git rebase "origin/${CODE_REBASE_REF}"
           git submodule update --init --recursive
       - name: Checkout
         uses: actions/checkout@v7
         timeout-minutes: 10
-        if: github.event.pull_request.head.sha == ''
+        if: ${{ !(inputs.code_checkout_ref || github.event.pull_request.head.sha) }}
         with:
           submodules: true
           set-safe-directory: '*'
           clean: true
+
+      - name: Checkout workflow actions
+        if: ${{ inputs.actions_checkout_ref != '' }}
+        uses: actions/checkout@v7
+        timeout-minutes: 10
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+          path: trusted-actions
+          ref: ${{ inputs.actions_checkout_ref || inputs.code_checkout_ref || github.event.pull_request.head.sha || github.sha }}
+      - name: Replace workspace workflow actions
+        if: ${{ inputs.actions_checkout_ref != '' }}
+        shell: bash
+        run: |
+          rm -rf .github
+          cp -a trusted-actions/.github .github
+          rm -rf trusted-actions
 
       - name: set up nebius cli
         id: cli

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-actions-checkout-ref:
+    runs-on: [self-hosted, "self-hosted", "runner_light"]
+    outputs:
+      actions_checkout_ref: ${{ steps.resolve-ref.outputs.actions_checkout_ref }}
+    steps:
+      - name: checkout actions from main
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+          ref: main
+      - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
+        if: ${{ always() }}
+        run: git config core.sparseCheckout false
+        continue-on-error: true
+      - name: resolve actions checkout ref
+        id: resolve-ref
+        shell: bash
+        run: echo "actions_checkout_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   check-running-allowed:
+    needs:
+      - resolve-actions-checkout-ref
     runs-on: [self-hosted, "self-hosted", "runner_light"]
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result }}
@@ -39,7 +62,7 @@ jobs:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
       - name: Check if running tests is allowed
         id: check-ownership-membership
         uses: actions/github-script@v9
@@ -92,6 +115,7 @@ jobs:
 
   create-build-and-test-target-var:
     needs:
+      - resolve-actions-checkout-ref
       - check-trigger-label
       - check-running-allowed
     if: needs.check-running-allowed.outputs.result == 'true' && needs.check-trigger-label.outputs.allowed == 'true'
@@ -99,34 +123,13 @@ jobs:
     outputs:
       matrix_include: ${{ steps.set-build-and-test-targets.outputs.matrix_include }}
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          clean: true
-          sparse-checkout: '.github'
+          ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false
@@ -138,7 +141,7 @@ jobs:
           scheduling_type: ${{ vars.NEBIUS_SCHEDULING_TYPE || 'on_demand' }}
 
   build_and_test:
-    needs: [check-running-allowed, create-build-and-test-target-var]
+    needs: [resolve-actions-checkout-ref, check-running-allowed, create-build-and-test-target-var]
     if: needs.check-running-allowed.outputs.result == 'true'
     strategy:
       fail-fast: false
@@ -146,6 +149,9 @@ jobs:
     name: Build and test (${{ matrix.mode }}${{ matrix.vm_name_suffix }})
     uses: ./.github/workflows/build_and_test_proxy.yaml
     with:
+      actions_checkout_ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ github.event.pull_request.head.sha }}
+      code_rebase_ref: ${{ github.event.pull_request.base.ref }}
       mode: ${{ matrix.mode }}
       allow_split_workload: ${{ !contains(toJSON(matrix), '"allow_split_workload"') || matrix.allow_split_workload }}
       build_target: ${{ matrix.build_target }}
@@ -164,38 +170,17 @@ jobs:
     secrets: inherit
 
   finalize-build-and-test-comments:
-    needs: [check-running-allowed, create-build-and-test-target-var, build_and_test]
+    needs: [resolve-actions-checkout-ref, check-running-allowed, create-build-and-test-target-var, build_and_test]
     if: ${{ always() && needs.check-running-allowed.outputs.result == 'true' && needs.create-build-and-test-target-var.outputs.matrix_include != '' }}
     runs-on: [self-hosted, "self-hosted", "runner_light"]
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          clean: true
-          sparse-checkout: '.github'
+          ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,7 +37,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-actions-checkout-ref:
+    runs-on: [self-hosted, "self-hosted", "runner_light"]
+    outputs:
+      actions_checkout_ref: ${{ steps.resolve-ref.outputs.actions_checkout_ref }}
+    steps:
+      - name: checkout actions from main
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+          sparse-checkout: '.github'
+          clean: true
+          ref: main
+      - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
+        if: ${{ always() }}
+        run: git config core.sparseCheckout false
+        continue-on-error: true
+      - name: resolve actions checkout ref
+        id: resolve-ref
+        shell: bash
+        run: echo "actions_checkout_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   check-running-allowed:
+    needs:
+      - resolve-actions-checkout-ref
     if: >-
       ${{
         (
@@ -63,7 +86,7 @@ jobs:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
       - name: Check if running tests is allowed
         id: check-ownership-membership
         uses: actions/github-script@v9
@@ -111,40 +134,20 @@ jobs:
 
   create-build-and-test-target-var:
     needs:
+      - resolve-actions-checkout-ref
       - check-running-allowed
     if: needs.check-running-allowed.outputs.result == 'true'
     runs-on: [self-hosted, "self-hosted", "runner_light"]
     outputs:
       matrix_include: ${{ steps.set-build-and-test-targets.outputs.matrix_include }}
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          clean: true
-          sparse-checkout: '.github'
+          ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false
@@ -156,7 +159,7 @@ jobs:
           scheduling_type: ${{ vars.NEBIUS_SCHEDULING_TYPE || 'on_demand' }}
 
   build_and_test:
-    needs: [check-running-allowed, create-build-and-test-target-var]
+    needs: [resolve-actions-checkout-ref, check-running-allowed, create-build-and-test-target-var]
     if: needs.check-running-allowed.outputs.result == 'true'
     strategy:
       fail-fast: false
@@ -164,6 +167,9 @@ jobs:
     name: Build and test (${{ matrix.mode }}${{ matrix.vm_name_suffix }})
     uses: ./.github/workflows/build_and_test_proxy.yaml
     with:
+      actions_checkout_ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
+      code_checkout_ref: ${{ github.event.pull_request.head.sha }}
+      code_rebase_ref: ${{ github.event.pull_request.base.ref }}
       mode: ${{ matrix.mode }}
       allow_split_workload: ${{ !contains(toJSON(matrix), '"allow_split_workload"') || matrix.allow_split_workload }}
       build_target: ${{ matrix.build_target }}
@@ -182,38 +188,17 @@ jobs:
     secrets: inherit
 
   finalize-build-and-test-comments:
-    needs: [check-running-allowed, create-build-and-test-target-var, build_and_test]
+    needs: [resolve-actions-checkout-ref, check-running-allowed, create-build-and-test-target-var, build_and_test]
     if: ${{ always() && needs.check-running-allowed.outputs.result == 'true' && needs.create-build-and-test-target-var.outputs.matrix_include != '' }}
     runs-on: [self-hosted, "self-hosted", "runner_light"]
     steps:
-      - name: checkout PR
+      - name: checkout workflow actions
         uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha != ''
         with:
           submodules: false
           sparse-checkout: '.github'
           clean: true
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ !contains(github.event.pull_request.labels.*.name, 'rebase') && 1 || 0 }}
-      - name: rebase PR
-        if: ${{ github.event.pull_request.head.sha != '' && contains(github.event.pull_request.labels.*.name, 'rebase') }}
-        shell: bash
-        run: |
-          if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
-              echo "Removing stale rebase state left on runner checkout"
-              rm -rf .git/rebase-merge .git/rebase-apply
-          fi
-          git config user.email "robot-nbs@nebius.com"
-          git config user.name "Robot NBS"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git rebase origin/${{ github.event.pull_request.base.ref }}
-      - name: checkout
-        uses: actions/checkout@v7
-        if: github.event.pull_request.head.sha == ''
-        with:
-          submodules: false
-          clean: true
-          sparse-checkout: '.github'
+          ref: ${{ needs.resolve-actions-checkout-ref.outputs.actions_checkout_ref }}
       - name: disable sparse checkout (workaround for actions/checkout/issues/2249)
         if: ${{ always() }}
         run: git config core.sparseCheckout false


### PR DESCRIPTION
Trying to fix the issue where there were incompatible changes to Github Actions during PR run and user needed to rebase because of that.

Also addresses issues where rebase broke stuff and we were not able to create/free runner.

In future changes we will pin usage of `uses: ydb-platform/nbs/.github/workflows/build_and_test_proxy.yaml@main`

