### PR TITLE
[Filestore] emulate page faults in tests

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -845,4 +845,8 @@ message TStorageConfig
 
     // Async processing of destroy handle requests only for read only handles.
     optional bool AsyncDestroyReadOnlyHandleEnabled = 525;
+    
+    // Enables injecting of errors in TIndexTabletDatabase. Must be only used in tests!
+    optional bool FakeReadFailuresEnabled = 526;
+    optional float FakeReadFailuresProbabilityPercentage = 527;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -847,6 +847,6 @@ message TStorageConfig
     optional bool AsyncDestroyReadOnlyHandleEnabled = 525;
     
     // Enables injecting of errors in TIndexTabletDatabase. Must be only used in tests!
-    optional bool FakeReadFailuresEnabled = 526;
-    optional float FakeReadFailuresProbabilityPercentage = 527;
+    optional bool FakeTxPageFaultsEnabled = 526;
+    optional float FakeTxPageFaultsProbabilityPercentage = 527;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -380,6 +380,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(SoftBackpressureMaxReadBandwidth,              ui32,    30 * 1024     )\
     xxx(SoftBackpressureMaxWriteIops,                  ui32,    10'000        )\
     xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
+    xxx(FakeReadFailuresEnabled,                       bool,    false         )\
+    xxx(FakeReadFailuresProbabilityPercentage,         float,   0             )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -380,8 +380,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(SoftBackpressureMaxReadBandwidth,              ui32,    30 * 1024     )\
     xxx(SoftBackpressureMaxWriteIops,                  ui32,    10'000        )\
     xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
-    xxx(FakeReadFailuresEnabled,                       bool,    false         )\
-    xxx(FakeReadFailuresProbabilityPercentage,         float,   0             )\
+    xxx(FakeTxPageFaultsEnabled,                       bool,    false         )\
+    xxx(FakeTxPageFaultsProbabilityPercentage,         float,   0             )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -437,6 +437,9 @@ public:
     ui32 GetSoftBackpressureMaxReadBandwidth() const;
     ui32 GetSoftBackpressureMaxWriteIops() const;
     ui32 GetSoftBackpressureMaxReadIops() const;
+
+    bool GetFakeReadFailuresEnabled() const;
+    float GetFakeReadFailuresProbabilityPercentage() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -438,8 +438,8 @@ public:
     ui32 GetSoftBackpressureMaxWriteIops() const;
     ui32 GetSoftBackpressureMaxReadIops() const;
 
-    bool GetFakeReadFailuresEnabled() const;
-    float GetFakeReadFailuresProbabilityPercentage() const;
+    bool GetFakeTxPageFaultsEnabled() const;
+    float GetFakeTxPageFaultsProbabilityPercentage() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet.h
+++ b/cloud/filestore/libs/storage/core/tablet.h
@@ -143,26 +143,6 @@ protected:
             Generation = tx.Generation;
             Step = tx.Step;
 
-            // Reschedule (restart) the transaction from PrepareTx when the
-            // injected rescheduler asks for it. In production this is a no-op
-            // stub; tests inject an implementation to make the transaction
-            // restart/reorder path.
-            if (Self->TxRescheduler->ShouldReschedule()) {
-                LOG_INFO(
-                    ctx,
-                    T::LogComponent,
-                    "[%lu] Forced reschedule of %s (gen: %u, step: %u)",
-                    Self->TabletID(),
-                    TTx::Name,
-                    Generation,
-                    Step);
-
-                Args.Clear();
-                Args.OnRestart();
-                tx.Reschedule();
-                return false;
-            }
-
             TX_TRACK(TxPrepare);
             LOG_TRACE(ctx, T::LogComponent,
                 "[%lu] PrepareTx %s (gen: %u, step: %u)",
@@ -176,6 +156,22 @@ protected:
 
                 Args.Clear();
                 Args.OnRestart();
+
+                // Reschedules the transaction from PrepareTx assuming the rescheduler
+                // was triggered during PrepareTx() call.
+                if (Y_UNLIKELY(Self->TxRescheduler && Self->TxRescheduler->IsTriggered())) {
+                    Self->TxRescheduler->Reset();
+                    LOG_INFO(
+                        ctx,
+                        T::LogComponent,
+                        "[%lu] Forced reschedule of %s (gen: %u, step: %u)",
+                        Self->TabletID(),
+                        TTx::Name,
+                        Generation,
+                        Step);
+                    tx.Reschedule();
+                }
+
                 return false;
             }
 
@@ -355,7 +351,7 @@ protected:
         {                                                                      \
             TCPUUsageTimerGuard t(target.AccessCPUUsageTimer());               \
             if (target.ValidateTx_##name(ctx, args)) {                         \
-                dbType db(tx.DB, args.NodeUpdates);                            \
+                dbType db(tx.DB, args.NodeUpdates, target.TxRescheduler);      \
                 return target.PrepareTx_##name(ctx, db, args);                 \
             }                                                                  \
             return true;                                                       \

--- a/cloud/filestore/libs/storage/core/tablet.h
+++ b/cloud/filestore/libs/storage/core/tablet.h
@@ -164,11 +164,12 @@ protected:
                     LOG_INFO(
                         ctx,
                         T::LogComponent,
-                        "[%lu] Forced reschedule of %s (gen: %u, step: %u)",
+                        "[%lu] Forced reschedule of %s (gen: %u, step: %u, random seed=%lu)",
                         Self->TabletID(),
                         TTx::Name,
                         Generation,
-                        Step);
+                        Step,
+                        Self->TxRescheduler->GetSeed());
                     tx.Reschedule();
                 }
 

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
@@ -1,5 +1,11 @@
 #include "tablet_tx_rescheduler.h"
 
+#include <cloud/filestore/libs/storage/api/components.h>
+
+#include <contrib/ydb/library/actors/core/actor.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <util/random/mersenne.h>
 #include <util/random/random.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -18,15 +24,21 @@ class TRandomTxRescheduler final
 private:
     const float Probability = 0;
     bool Triggered = false;
+    ui64 Seed;
+    TMersenne<ui64> RandomGen;
 
 public:
-    explicit TRandomTxRescheduler(float probabilityPercentage)
+    explicit TRandomTxRescheduler(float probabilityPercentage,
+                                  std::optional<ui64> randomSeed)
         : Probability(probabilityPercentage / 100.0F)
-    {}
+        , Seed(randomSeed ? *randomSeed : RandomNumber<ui64>())
+        , RandomGen(Seed)
+    {
+    }
 
     bool ShouldReschedule() override
     {
-        const bool ret = RandomNumber<float>() < Probability;
+        const bool ret = RandomGen.GenRandReal4() < Probability;
         Triggered |= ret;
         return ret;
     }
@@ -40,15 +52,22 @@ public:
     {
         Triggered = false;
     }
+
+    ui64 GetSeed() const override
+    {
+        return Seed;
+    }
 };
 
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ITxReschedulerPtr CreateRescheduler(float probabilityPercentage)
+ITxReschedulerPtr CreateRescheduler(TReschedulerParams params)
 {
-    return std::make_shared<TRandomTxRescheduler>(probabilityPercentage);
+    return std::make_shared<TRandomTxRescheduler>(
+        params.ProbabilityPercentage,
+        params.RandomSeed);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
@@ -1,18 +1,44 @@
 #include "tablet_tx_rescheduler.h"
 
+#include <util/random/random.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TNoOpTxRescheduler final
+// With a given probability decides if a transaction should be rescheduled.
+// Used in tests to exercise behaviour in case of transaction restarts/reorderings.
+// Note that it does not reschedule anything by itself and only serves for communication
+// between TIndexActorDatabase and Tx::Execute().
+class TRandomTxRescheduler final
     : public ITxRescheduler
 {
+private:
+    const float Probability = 0;
+    bool Triggered = false;
+
 public:
+    explicit TRandomTxRescheduler(float probabilityPercentage)
+        : Probability(probabilityPercentage / 100.0F)
+    {}
+
     bool ShouldReschedule() override
     {
-        return false;
+        const bool ret = RandomNumber<float>() < Probability;
+        Triggered |= ret;
+        return ret;
+    }
+
+    bool IsTriggered() const override
+    {
+        return Triggered;
+    }
+
+    void Reset() override
+    {
+        Triggered = false;
     }
 };
 
@@ -20,9 +46,9 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ITxReschedulerPtr CreateNoOpTxRescheduler()
+ITxReschedulerPtr CreateRescheduler(float probabilityPercentage)
 {
-    return std::make_shared<TNoOpTxRescheduler>();
+    return std::make_shared<TRandomTxRescheduler>(probabilityPercentage);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
@@ -3,6 +3,7 @@
 #include <util/system/types.h>
 
 #include <memory>
+#include <optional>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -18,6 +19,7 @@ struct ITxRescheduler
     virtual bool ShouldReschedule() = 0;
     virtual bool IsTriggered() const = 0;
     virtual void Reset() = 0;
+    virtual ui64 GetSeed() const = 0;
 };
 
 using ITxReschedulerPtr = std::shared_ptr<ITxRescheduler>;
@@ -26,6 +28,12 @@ using ITxReschedulerPtr = std::shared_ptr<ITxRescheduler>;
 
 // Creates a rescheduler that forces a read transaction to be restarted
 // with a given probability.
-ITxReschedulerPtr CreateRescheduler(float probabilityPercentage);
+struct TReschedulerParams
+{
+    float ProbabilityPercentage = 1;
+    std::optional<ui64> RandomSeed;
+};
+
+ITxReschedulerPtr CreateRescheduler(TReschedulerParams params);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <util/system/types.h>
+
 #include <memory>
 
 namespace NCloud::NFileStore::NStorage {
@@ -7,20 +9,23 @@ namespace NCloud::NFileStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 // Decides whether a tablet transaction should be rescheduled (restarted) from
-// PrepareTx. Production uses a no-op stub; tests inject an implementation that
-// reschedules to make the transaction restart/reorder path.
+// PrepareTx. Tests inject an implementation that reschedules to make the
+// transaction restart/reorder path.
 struct ITxRescheduler
 {
     virtual ~ITxRescheduler() = default;
 
     virtual bool ShouldReschedule() = 0;
+    virtual bool IsTriggered() const = 0;
+    virtual void Reset() = 0;
 };
 
 using ITxReschedulerPtr = std::shared_ptr<ITxRescheduler>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Default rescheduler used in production: never reschedules.
-ITxReschedulerPtr CreateNoOpTxRescheduler();
+// Creates a rescheduler that forces a read transaction to be restarted
+// with a given probability.
+ITxReschedulerPtr CreateRescheduler(float probabilityPercentage);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -246,9 +246,9 @@ public:
                     systemCounters,
                     metricsRegistry,
                     fastShardServer,
-                    config->GetFakeReadFailuresEnabled() ?
+                    config->GetFakeTxPageFaultsEnabled() ?
                         CreateRescheduler({
-                            .ProbabilityPercentage = config->GetFakeReadFailuresProbabilityPercentage(),
+                            .ProbabilityPercentage = config->GetFakeTxPageFaultsProbabilityPercentage(),
                             .RandomSeed = std::nullopt
                         }) : nullptr);
                 return actor.release();

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -246,7 +246,9 @@ public:
                     systemCounters,
                     metricsRegistry,
                     fastShardServer,
-                    CreateNoOpTxRescheduler());
+                    config->GetFakeReadFailuresEnabled() ?
+                        CreateRescheduler(config->GetFakeReadFailuresProbabilityPercentage()) :
+                        nullptr);
                 return actor.release();
             };
 

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -247,8 +247,10 @@ public:
                     metricsRegistry,
                     fastShardServer,
                     config->GetFakeReadFailuresEnabled() ?
-                        CreateRescheduler(config->GetFakeReadFailuresProbabilityPercentage()) :
-                        nullptr);
+                        CreateRescheduler({
+                            .ProbabilityPercentage = config->GetFakeReadFailuresProbabilityPercentage(),
+                            .RandomSeed = std::nullopt
+                        }) : nullptr);
                 return actor.release();
             };
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -371,7 +371,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     config.SetAutomaticallyCreatedShardSize(fsConfig.ShardBlockCount * 4_KB); \
     config.SetShardAllocationUnit(fsConfig.ShardBlockCount * 4_KB);           \
                                                                               \
-    TTestEnv env({.PageFaultFakesEnabled = false}, config);                   \
+    TTestEnv env({.FakePageFaultsEnabled = false}, config);                   \
                                                                               \
     ui32 nodeIdx = env.AddDynamicNode();                                      \
                                                                               \
@@ -1583,7 +1583,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldNotReturnInvalidShardNoErrorForDirectShardRequests)
     {
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3048,7 +3048,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3126,7 +3126,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4153,7 +4153,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4177,7 +4177,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4194,7 +4194,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4357,7 +4357,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(2);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4414,7 +4414,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4468,7 +4468,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4609,7 +4609,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(1);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4683,7 +4683,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4735,7 +4735,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4939,7 +4939,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateShardList)
     {
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5235,7 +5235,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldCreateSessionDirectlyInShard)
     {
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5275,7 +5275,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5436,7 +5436,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardBalancerDesiredFreeSpaceReserve(1_MB);
         config.SetShardBalancerPrecisionBytes(4_KB);
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5567,7 +5567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(4_TB);
         config.SetAutomaticallyCreatedShardSize(5_TB);
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5935,7 +5935,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6049,7 +6049,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6123,7 +6123,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // mode
         config.SetStrictFileSystemSizeEnforcementEnabled(false);
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6342,7 +6342,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -6410,7 +6410,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -8144,7 +8144,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8248,7 +8248,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8295,7 +8295,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8363,7 +8363,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8567,7 +8567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             .MainFsBlockCount = fsSize
         };
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -9334,7 +9334,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "testfilesystem-filesystem1234id";
 
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
         service.CreateFileStore(fsId, fsSize);
@@ -9546,7 +9546,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateFilesystemIdDuringCreation)
     {
-        TTestEnv env({.PageFaultFakesEnabled = false}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -9615,7 +9615,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         {
             // Create a filesystem without shards.
-            TTestEnv env({.PageFaultFakesEnabled = false}, config);
+            TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
             ui32 nodeIdx = env.AddDynamicNode();
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -371,7 +371,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     config.SetAutomaticallyCreatedShardSize(fsConfig.ShardBlockCount * 4_KB); \
     config.SetShardAllocationUnit(fsConfig.ShardBlockCount * 4_KB);           \
                                                                               \
-    TTestEnv env({}, config);                                                 \
+    TTestEnv env({.PageFaultFakesEnabled = false}, config);                   \
                                                                               \
     ui32 nodeIdx = env.AddDynamicNode();                                      \
                                                                               \
@@ -1583,7 +1583,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldNotReturnInvalidShardNoErrorForDirectShardRequests)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3048,7 +3048,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3126,7 +3126,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4153,7 +4153,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4177,7 +4177,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4194,7 +4194,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4357,7 +4357,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(2);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4414,7 +4414,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4468,7 +4468,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4609,7 +4609,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(1);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4683,7 +4683,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4735,7 +4735,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4939,7 +4939,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateShardList)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5235,7 +5235,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldCreateSessionDirectlyInShard)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5275,7 +5275,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5436,7 +5436,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardBalancerDesiredFreeSpaceReserve(1_MB);
         config.SetShardBalancerPrecisionBytes(4_KB);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5567,7 +5567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(4_TB);
         config.SetAutomaticallyCreatedShardSize(5_TB);
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5935,7 +5935,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6049,7 +6049,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6123,7 +6123,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // mode
         config.SetStrictFileSystemSizeEnforcementEnabled(false);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6342,7 +6342,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -6410,7 +6410,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -8144,7 +8144,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8248,7 +8248,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8295,7 +8295,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8363,7 +8363,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8567,7 +8567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             .MainFsBlockCount = fsSize
         };
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -9334,7 +9334,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "testfilesystem-filesystem1234id";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
         service.CreateFileStore(fsId, fsSize);
@@ -9546,7 +9546,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateFilesystemIdDuringCreation)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.PageFaultFakesEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -9615,7 +9615,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         {
             // Create a filesystem without shards.
-            TTestEnv env({}, config);
+            TTestEnv env({.PageFaultFakesEnabled = false}, config);
 
             ui32 nodeIdx = env.AddDynamicNode();
 

--- a/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
+++ b/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
@@ -64,7 +64,7 @@ struct TTabletSetup
             .LogPriority_NFS = NActors::NLog::PRI_ALERT,
             .LogPriority_KiKiMR = NActors::NLog::PRI_ALERT,
             .LogPriority_Others = NActors::NLog::PRI_ALERT,
-            .PageFaultFakesEnabled = false})
+            .FakePageFaultsEnabled = false})
     {
         NCloud::NFileStore::NProto::TStorageConfig storageConfig;
         storageConfig.SetInMemoryIndexCacheEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
+++ b/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
@@ -63,7 +63,8 @@ struct TTabletSetup
             // Turn off logging in order to reduce performance overhead
             .LogPriority_NFS = NActors::NLog::PRI_ALERT,
             .LogPriority_KiKiMR = NActors::NLog::PRI_ALERT,
-            .LogPriority_Others = NActors::NLog::PRI_ALERT})
+            .LogPriority_Others = NActors::NLog::PRI_ALERT,
+            .PageFaultFakesEnabled = false})
     {
         NCloud::NFileStore::NProto::TStorageConfig storageConfig;
         storageConfig.SetInMemoryIndexCacheEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -491,7 +491,7 @@ bool TIndexTabletActor::PrepareTx_AddBlob(
 {
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -133,7 +133,7 @@ bool TIndexTabletActor::ValidateAddDataRequest(
     }
     ui64 commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
 
     if (!ReadNode(db, args.NodeId, commitId, args.Node)) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -129,7 +129,7 @@ bool TIndexTabletActor::PrepareTx_AllocateData(
     args.NodeId = handle->GetNodeId();
     args.CommitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
@@ -15,7 +15,7 @@ bool TIndexTabletActor::PrepareTx_ChangeStorageConfig(
     TTransactionContext& tx,
     TTxIndexTablet::TChangeStorageConfig& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
     if (args.MergeWithStorageConfigFromTabletDB) {
         return db.ReadStorageConfig(args.StorageConfigFromDB);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -94,7 +94,7 @@ bool TIndexTabletActor::PrepareTx_Cleanup(
 {
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -607,7 +607,7 @@ bool TIndexTabletActor::PrepareTx_Compaction(
 {
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -219,8 +219,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
         return true;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
-
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
     // There could be two cases:
     // * access by parentId/name
     // * access by nodeId

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -602,7 +602,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
         FILESTORE_VALIDATE_DUPTX_SESSION(CreateNode, args);
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -70,7 +70,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
 
     args.CommitId = checkpoint->GetCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     bool ready = true;
     switch (args.Mode) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -74,7 +74,7 @@ bool TIndexTabletActor::PrepareTx_DestroyHandle(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
     if (!ReadNode(db, handle->GetNodeId(), commitId, args.Node)) {
         return false;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -105,7 +105,7 @@ bool TIndexTabletActor::PrepareTx_DestroySession(
         args.SessionId.c_str(),
         args.SessionSeqNo);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     bool ready = true;
     auto commitId = GetCurrentCommitId();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_dumprange.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_dumprange.cpp
@@ -44,7 +44,7 @@ bool TIndexTabletActor::PrepareTx_DumpCompactionRange(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
     if (!LoadMixedBlocks(db, args.RangeId)) {
         return false;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
@@ -63,7 +63,7 @@ bool TIndexTabletActor::PrepareTx_FilterAliveNodes(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
     TMaybe<IIndexTabletDatabase::TNode> node;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -660,7 +660,7 @@ bool TIndexTabletActor::PrepareTx_FlushBytes(
     TTransactionContext& tx,
     TTxIndexTablet::TFlushBytes& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
 
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -95,7 +95,7 @@ bool TIndexTabletActor::PrepareTx_LoadState(
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Loading tablet state data");
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
 
     std::initializer_list<bool> results = {
         db.ReadFileSystem(args.FileSystem),
@@ -671,7 +671,7 @@ bool TIndexTabletActor::PrepareTx_LoadCompactionMapChunk(
         LogTag << " Loading compaction map chunk "
             << args.FirstRangeId << ", " << args.RangeCount);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
 
     bool ready = db.ReadCompactionMap(
         args.CompactionMap,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -280,7 +280,7 @@ bool TIndexTabletActor::PrepareTx_GetOpLogEntry(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
     return db.ReadOpLogEntry(args.EntryId, args.Entry);
 }
 
@@ -342,7 +342,7 @@ bool TIndexTabletActor::PrepareTx_ListOpLogEntries(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
     return db.ReadOpLog(args.Entries);
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
@@ -66,7 +66,7 @@ bool TIndexTabletActor::PrepareTx_RemoveNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(RemoveNodeXAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -291,7 +291,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -505,7 +505,7 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -426,7 +426,7 @@ bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -483,7 +483,7 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
         return; // nothing to do
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -698,7 +698,7 @@ bool TIndexTabletActor::PrepareTx_CommitRenameNodeInSource(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -90,7 +90,7 @@ bool TIndexTabletActor::PrepareTx_ResetSession(
         args.SessionSeqNo,
         args.Request.GetSessionState().size());
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     bool ready = true;
     auto commitId = GetCurrentCommitId();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_responselog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_responselog.cpp
@@ -111,7 +111,7 @@ bool TIndexTabletActor::PrepareTx_GetResponseLogEntry(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    TIndexTabletDatabase db(tx.DB, TxRescheduler);
     return db.ReadResponseLogEntry(
         args.ClientTabletId,
         args.RequestId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -93,7 +93,7 @@ bool TIndexTabletActor::PrepareTx_SetNodeAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
@@ -72,7 +72,7 @@ bool TIndexTabletActor::PrepareTx_SetNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeXAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -382,7 +382,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
         FILESTORE_VALIDATE_DUPTX_SESSION(UnlinkNode, args);
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -669,7 +669,7 @@ bool TIndexTabletActor::PrepareTx_CompleteUnlinkNode(
 {
     Y_UNUSED(ctx, tx, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     // TODO(2674): we should pass commitId from the request, not generate it
     args.CommitId = GetCurrentCommitId();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
@@ -208,7 +208,7 @@ bool TIndexTabletActor::PrepareTx_AbortUnlinkDirectoryNode(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
@@ -50,7 +50,7 @@ bool TIndexTabletActor::PrepareTx_PrepareUnlinkDirectoryNode(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     args.CommitId = GetCurrentCommitId();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
@@ -47,7 +47,7 @@ bool TIndexTabletActor::PrepareTx_UnsafeCreateNode(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
     return ReadNode(db, args.Request.GetNode().GetId(), commitId, args.Node);
 }
 
@@ -140,7 +140,7 @@ bool TIndexTabletActor::PrepareTx_UnsafeDeleteNode(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
     return ReadNode(db, args.Request.GetId(), commitId, args.Node);
 }
 
@@ -226,7 +226,7 @@ bool TIndexTabletActor::PrepareTx_UnsafeUpdateNode(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
     return ReadNode(db, args.Request.GetNode().GetId(), commitId, args.Node);
 }
 
@@ -505,7 +505,7 @@ bool TIndexTabletActor::PrepareTx_UnsafeDeleteNodeRef(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
     return ReadNodeRef(
         db,
         args.Request.GetParentId(),
@@ -606,7 +606,7 @@ bool TIndexTabletActor::PrepareTx_UnsafeUpdateNodeRef(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
     return ReadNodeRef(
         db,
         args.Request.GetParentId(),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -248,7 +248,7 @@ bool TIndexTabletActor::PrepareTx_WriteData(
         args.NodeId,
         args.ByteRange.Describe().c_str());
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates, TxRescheduler);
 
     if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_database.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.cpp
@@ -42,6 +42,11 @@ bool TIndexTabletDatabase::ReadFileSystem(NProto::TFileSystem& fileSystem)
 {
     using TTable = TIndexTabletSchema::FileSystem;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(FileSystemMetaId)
         .Select();
@@ -60,6 +65,11 @@ bool TIndexTabletDatabase::ReadFileSystem(NProto::TFileSystem& fileSystem)
 bool TIndexTabletDatabase::ReadFileSystemStats(NProto::TFileSystemStats& stats)
 {
     using TTable = TIndexTabletSchema::FileSystem;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Key(FileSystemMetaId)
@@ -112,6 +122,11 @@ bool TIndexTabletDatabase::ReadStorageConfig(
 {
     using TTable = TIndexTabletSchema::FileSystem;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(FileSystemMetaId)
         .Select<TTable::TColumns>();
@@ -161,6 +176,11 @@ bool TIndexTabletDatabase::ReadNode(
 {
     using TTable = TIndexTabletSchema::Nodes;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(nodeId)
         .Select();
@@ -193,6 +213,11 @@ bool TIndexTabletDatabase::ReadNodes(
     TVector<TNode>& nodes)
 {
     using TTable = TIndexTabletSchema::Nodes;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>().GreaterOrEqual(startNodeId).Select();
 
@@ -255,6 +280,11 @@ bool TIndexTabletDatabase::ReadNodeVer(
     TMaybe<TNode>& node)
 {
     using TTable = TIndexTabletSchema::Nodes_Ver;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .GreaterOrEqual(nodeId, ReverseCommitId(commitId))
@@ -329,6 +359,11 @@ bool TIndexTabletDatabase::ReadNodeAttr(
 {
     using TTable = TIndexTabletSchema::NodeAttrs;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(nodeId, name)
         .Select();
@@ -362,6 +397,11 @@ bool TIndexTabletDatabase::ReadNodeAttrs(
     TVector<TNodeAttr>& attrs)
 {
     using TTable = TIndexTabletSchema::NodeAttrs;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(nodeId)
@@ -435,6 +475,11 @@ bool TIndexTabletDatabase::ReadNodeAttrVer(
 {
     using TTable = TIndexTabletSchema::NodeAttrs_Ver;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .GreaterOrEqual(nodeId, name, ReverseCommitId(commitId))
         .Select();
@@ -480,6 +525,11 @@ bool TIndexTabletDatabase::ReadNodeAttrVers(
     TVector<TNodeAttr>& attrs)
 {
     using TTable = TIndexTabletSchema::NodeAttrs_Ver;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(nodeId)
@@ -548,6 +598,11 @@ bool TIndexTabletDatabase::ReadNodeRef(
 {
     using TTable = TIndexTabletSchema::NodeRefs;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(nodeId, name)
         .Select();
@@ -586,6 +641,11 @@ bool TIndexTabletDatabase::ReadNodeRefsBase(
     ui32* skippedRefs,
     NProto::EListNodesSizeMode sizeMode)
 {
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     using TTableBase = typename TIndexTabletSchema::NodeRefs;
     auto it = Table<TTable>()
         .GreaterOrEqual(nodeId, cookie)
@@ -708,6 +768,11 @@ bool TIndexTabletDatabase::ReadNodeRefs(
 {
     using TTable = TIndexTabletSchema::NodeRefs;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     if (!startNodeId && startCookie.empty()) {
         Table<TTable>().Precharge();
     }
@@ -749,6 +814,11 @@ bool TIndexTabletDatabase::PrechargeNodeRefs(
     ui64 bytesToPrecharge)
 {
     using TTable = TIndexTabletSchema::NodeRefs;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     return Table<TTable>()
         .GreaterOrEqual(nodeId, cookie)
@@ -801,6 +871,11 @@ bool TIndexTabletDatabase::ReadNodeRefVer(
 {
     using TTable = TIndexTabletSchema::NodeRefs_Ver;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .GreaterOrEqual(nodeId, name, ReverseCommitId(commitId))
         .Select();
@@ -847,6 +922,11 @@ bool TIndexTabletDatabase::ReadNodeRefVers(
     TVector<TNodeRef>& refs)
 {
     using TTable = TIndexTabletSchema::NodeRefs_Ver;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(nodeId)
@@ -907,6 +987,11 @@ bool TIndexTabletDatabase::ReadTruncateQueue(TVector<NProto::TTruncateEntry>& en
 {
     using TTable = TIndexTabletSchema::TruncateQueue;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -949,6 +1034,11 @@ void TIndexTabletDatabase::DeleteSession(const TString& sessionId)
 bool TIndexTabletDatabase::ReadSessions(TVector<NProto::TSession>& sessions)
 {
     using TTable = TIndexTabletSchema::Sessions;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();
@@ -1017,6 +1107,11 @@ bool TIndexTabletDatabase::ReadSessionHandles(
 {
     using TTable = TIndexTabletSchema::SessionHandles;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -1028,6 +1123,11 @@ bool TIndexTabletDatabase::ReadSessionHandles(
     TVector<NProto::TSessionHandle>& handles)
 {
     using TTable = TIndexTabletSchema::SessionHandles;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(sessionId)
@@ -1084,6 +1184,11 @@ bool TIndexTabletDatabase::ReadSessionLocks(
 {
     using TTable = TIndexTabletSchema::SessionLocks;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -1095,6 +1200,11 @@ bool TIndexTabletDatabase::ReadSessionLocks(
     TVector<NProto::TSessionLock>& locks)
 {
     using TTable = TIndexTabletSchema::SessionLocks;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(sessionId)
@@ -1130,6 +1240,11 @@ bool TIndexTabletDatabase::ReadSessionDupCacheEntries(
     TVector<NProto::TDupCacheEntry>& entries)
 {
     using TTable = TIndexTabletSchema::SessionDupCache;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();
@@ -1197,6 +1312,11 @@ void TIndexTabletDatabase::DeleteFreshBytes(
 bool TIndexTabletDatabase::ReadFreshBytes(TVector<TFreshBytesEntry>& bytes)
 {
     using TTable = TIndexTabletSchema::FreshBytes;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();
@@ -1277,6 +1397,11 @@ bool TIndexTabletDatabase::ReadFreshBlocks(TVector<TFreshBlock>& blocks)
 {
     using TTable = TIndexTabletSchema::FreshBlocks;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -1356,6 +1481,11 @@ bool TIndexTabletDatabase::ReadMixedBlocks(
 {
     using TTable = TIndexTabletSchema::MixedBlocks;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(rangeId, blobId.CommitId(), blobId.UniqueId())
         .Select();
@@ -1395,6 +1525,11 @@ bool TIndexTabletDatabase::ReadMixedBlocks(
     IAllocator* alloc)
 {
     using TTable = TIndexTabletSchema::MixedBlocks;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(rangeId)
@@ -1470,6 +1605,11 @@ bool TIndexTabletDatabase::ReadDeletionMarkers(
 {
     using TTable = TIndexTabletSchema::DeletionMarkers;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Prefix(rangeId)
         .Select();
@@ -1526,6 +1666,11 @@ bool TIndexTabletDatabase::ReadLargeDeletionMarkers(
 {
     using TTable = TIndexTabletSchema::LargeDeletionMarkers;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -1573,6 +1718,11 @@ bool TIndexTabletDatabase::ReadOrphanNodes(TVector<ui64>& nodeIds)
 {
     using TTable = TIndexTabletSchema::OrphanNodes;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -1615,6 +1765,11 @@ void TIndexTabletDatabase::DeleteNewBlob(const TPartialBlobId& blobId)
 bool TIndexTabletDatabase::ReadNewBlobs(TVector<TPartialBlobId>& blobIds)
 {
     using TTable = TIndexTabletSchema::NewBlobs;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();
@@ -1660,6 +1815,11 @@ void TIndexTabletDatabase::DeleteGarbageBlob(const TPartialBlobId& blobId)
 bool TIndexTabletDatabase::ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds)
 {
     using TTable = TIndexTabletSchema::GarbageBlobs;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();
@@ -1708,6 +1868,11 @@ bool TIndexTabletDatabase::ReadCheckpoints(
 {
     using TTable = TIndexTabletSchema::Checkpoints;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -1753,6 +1918,11 @@ bool TIndexTabletDatabase::ReadCheckpointNodes(
     size_t maxCount)
 {
     using TTable = TIndexTabletSchema::CheckpointNodes;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(checkpointId)
@@ -1807,6 +1977,11 @@ bool TIndexTabletDatabase::ReadCheckpointBlobs(
     size_t maxCount)
 {
     using TTable = TIndexTabletSchema::CheckpointBlobs;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Prefix(checkpointId)
@@ -1888,6 +2063,11 @@ bool TIndexTabletDatabase::ReadCompactionMap(
 {
     using TTable = TIndexTabletSchema::CompactionMap;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     if (!firstRangeId && prechargeAll) {
         Table<TTable>().Precharge();
     }
@@ -1929,6 +2109,11 @@ bool TIndexTabletDatabase::ReadTabletStorageInfo(
     NCloud::NProto::TTabletStorageInfo& tabletStorageInfo)
 {
     using TTable = TIndexTabletSchema::TabletStorageInfo;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Key(FileSystemMetaId)
@@ -1982,6 +2167,11 @@ bool TIndexTabletDatabase::ReadSessionHistoryEntries(
 {
     using TTable = TIndexTabletSchema::SessionHistory;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Select();
 
@@ -2027,6 +2217,11 @@ bool TIndexTabletDatabase::ReadOpLogEntry(
 {
     using TTable = TIndexTabletSchema::OpLog;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(entryId)
         .Select();
@@ -2045,6 +2240,11 @@ bool TIndexTabletDatabase::ReadOpLogEntry(
 bool TIndexTabletDatabase::ReadOpLog(TVector<NProto::TOpLogEntry>& opLog)
 {
     using TTable = TIndexTabletSchema::OpLog;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();
@@ -2095,6 +2295,11 @@ bool TIndexTabletDatabase::ReadResponseLogEntry(
 {
     using TTable = TIndexTabletSchema::ResponseLog;
 
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
+
     auto it = Table<TTable>()
         .Key(clientTabletId, requestId)
         .Select();
@@ -2114,6 +2319,11 @@ bool TIndexTabletDatabase::ReadResponseLog(
     TVector<NProtoPrivate::TResponseLogEntry>& responseLog)
 {
     using TTable = TIndexTabletSchema::ResponseLog;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();
@@ -2137,8 +2347,9 @@ bool TIndexTabletDatabase::ReadResponseLog(
 
 TIndexTabletDatabaseProxy::TIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
-        TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates)
-    : TIndexTabletDatabase(database)
+        TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates,
+        ITxReschedulerPtr rescheduler)
+    : TIndexTabletDatabase(database, std::move(rescheduler))
     , NodeUpdates(nodeUpdates)
 {}
 
@@ -2467,6 +2678,11 @@ bool TIndexTabletDatabase::ReadUnconfirmedData(
     TVector<TUnconfirmedDataEntry>& entries)
 {
     using TTable = TIndexTabletSchema::UnconfirmedData;
+
+    if (Y_UNLIKELY(ShouldFailReadInTest()))
+    {
+        return false;
+    }
 
     auto it = Table<TTable>()
         .Select();

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -6,6 +6,7 @@
 #include "tablet_state_iface.h"
 
 #include <cloud/filestore/config/storage.pb.h>
+#include <cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h>
 #include <cloud/filestore/libs/storage/tablet/model/block_list.h>
 #include <cloud/filestore/libs/storage/tablet/model/compaction_map.h>
 #include <cloud/filestore/libs/storage/tablet/model/deletion_markers.h>
@@ -68,8 +69,10 @@ class TIndexTabletDatabase
     , public NKikimr::NIceDb::TNiceDb
 {
 public:
-    TIndexTabletDatabase(NKikimr::NTable::TDatabase& database)
+    TIndexTabletDatabase(NKikimr::NTable::TDatabase& database,
+        ITxReschedulerPtr rescheduler = {})
         : NKikimr::NIceDb::TNiceDb(database)
+        , TestReadRescheduler(std::move(rescheduler))
     {}
 
     void InitSchema();
@@ -576,6 +579,13 @@ public:
     void DeleteUnconfirmedData(ui64 commitId);
 
     bool ReadUnconfirmedData(TVector<TUnconfirmedDataEntry>& entries);
+
+private:
+    ITxReschedulerPtr TestReadRescheduler;
+
+    bool ShouldFailReadInTest() {
+        return TestReadRescheduler && TestReadRescheduler->ShouldReschedule();
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -587,7 +597,8 @@ class TIndexTabletDatabaseProxy: public TIndexTabletDatabase
 public:
     TIndexTabletDatabaseProxy(
         NKikimr::NTable::TDatabase& database,
-        TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
+        TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates,
+        ITxReschedulerPtr rescheduler = {});
 
     //
     // Nodes

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1460,7 +1460,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             storageConfig.SetAddingUnconfirmedDataEnabled(true);
             storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-            TTestEnv env({.PageFaultProbabilityPercentage = 5}, std::move(storageConfig));
+            TTestEnv env({.FakePageFaultsProbabilityPercentage = 5}, std::move(storageConfig));
             ui32 nodeIdx = env.AddDynamicNode();
             ui64 tabletId = env.BootIndexTablet(nodeIdx);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -4,7 +4,6 @@
 
 #include <cloud/filestore/libs/service/error.h>
 #include <cloud/filestore/libs/service/request.h>
-#include <cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h>
 #include <cloud/filestore/libs/storage/testlib/tablet_client.h>
 #include <cloud/filestore/libs/storage/testlib/test_env.h>
 
@@ -29,24 +28,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Reschedules transactions with probability 1/Ratio, to exercise the recovery
-// confirmation path under transaction restarts/reorderings.
-class TRandomTxRescheduler final
-    : public ITxRescheduler
-{
-private:
-    const ui32 Ratio;
-
-public:
-    explicit TRandomTxRescheduler(ui32 ratio)
-        : Ratio(ratio)
-    {}
-
-    bool ShouldReschedule() override
-    {
-        return Ratio > 0 && RandomNumber<ui32>(Ratio) == 0;
-    }
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1479,10 +1460,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             storageConfig.SetAddingUnconfirmedDataEnabled(true);
             storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-            TTestEnv env({}, std::move(storageConfig));
-            // Inject a rescheduler so recovery confirmation is exercised under
-            // transaction restarts/reorderings.
-            env.SetTxRescheduler(std::make_shared<TRandomTxRescheduler>(3));
+            TTestEnv env({.PageFaultProbabilityPercentage = 5}, std::move(storageConfig));
             ui32 nodeIdx = env.AddDynamicNode();
             ui64 tabletId = env.BootIndexTablet(nodeIdx);
 

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -476,7 +476,10 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
             Registry,
             nullptr /* fastShardServer */,
             Config.PageFaultFakesEnabled ?
-                CreateRescheduler(Config.PageFaultProbabilityPercentage) : nullptr);
+                CreateRescheduler({
+                    .ProbabilityPercentage = Config.PageFaultProbabilityPercentage,
+                    .RandomSeed = Config.PageFaultRandomSeed
+                }) : nullptr);
         return actor.release();
     };
 
@@ -610,7 +613,10 @@ void TTestEnv::SetupLocalServiceConfig(
             Registry,
             nullptr /* fastShardServer */,
             Config.PageFaultFakesEnabled ?
-                CreateRescheduler(Config.PageFaultProbabilityPercentage) : nullptr);
+                CreateRescheduler({
+                    .ProbabilityPercentage = Config.PageFaultProbabilityPercentage,
+                    .RandomSeed = Config.PageFaultRandomSeed
+                }) : nullptr);
         return actor.release();
     };
 

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -475,7 +475,8 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            TxRescheduler);
+            Config.PageFaultFakesEnabled ?
+                CreateRescheduler(Config.PageFaultProbabilityPercentage) : nullptr);
         return actor.release();
     };
 
@@ -608,7 +609,8 @@ void TTestEnv::SetupLocalServiceConfig(
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            TxRescheduler);
+            Config.PageFaultFakesEnabled ?
+                CreateRescheduler(Config.PageFaultProbabilityPercentage) : nullptr);
         return actor.release();
     };
 

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -475,10 +475,10 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            Config.PageFaultFakesEnabled ?
+            Config.FakePageFaultsEnabled ?
                 CreateRescheduler({
-                    .ProbabilityPercentage = Config.PageFaultProbabilityPercentage,
-                    .RandomSeed = Config.PageFaultRandomSeed
+                    .ProbabilityPercentage = Config.FakePageFaultsProbabilityPercentage,
+                    .RandomSeed = Config.FakePageFaultsRandomSeed
                 }) : nullptr);
         return actor.release();
     };
@@ -612,10 +612,10 @@ void TTestEnv::SetupLocalServiceConfig(
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            Config.PageFaultFakesEnabled ?
+            Config.FakePageFaultsEnabled ?
                 CreateRescheduler({
-                    .ProbabilityPercentage = Config.PageFaultProbabilityPercentage,
-                    .RandomSeed = Config.PageFaultRandomSeed
+                    .ProbabilityPercentage = Config.FakePageFaultsProbabilityPercentage,
+                    .RandomSeed = Config.FakePageFaultsRandomSeed
                 }) : nullptr);
         return actor.release();
     };

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -76,6 +76,10 @@ struct TTestEnvConfig
     NActors::NLog::EPriority LogPriority_NFS = NActors::NLog::PRI_TRACE;
     NActors::NLog::EPriority LogPriority_KiKiMR = NActors::NLog::PRI_WARN;
     NActors::NLog::EPriority LogPriority_Others = NActors::NLog::PRI_WARN;
+
+    // This controls probability that read will be restarted
+    bool PageFaultFakesEnabled = true;
+    float PageFaultProbabilityPercentage = 1;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -90,7 +94,6 @@ private:
     IProfileLogPtr ProfileLog;
     ITraceSerializerPtr TraceSerializer;
     TSystemCountersPtr SystemCounters;
-    ITxReschedulerPtr TxRescheduler = CreateNoOpTxRescheduler();
 
     NKikimr::TTestBasicRuntime Runtime;
     TVector<ui32> GroupIds;
@@ -118,14 +121,6 @@ public:
     NActors::TTestActorRuntime& GetRuntime()
     {
         return Runtime;
-    }
-
-    // Inject a transaction rescheduler.
-    // Defaults to a no-op stub; tests set a custom one to exercise the
-    // transaction restart/reorder path. Must be set before BootIndexTablet.
-    void SetTxRescheduler(ITxReschedulerPtr txRescheduler)
-    {
-        TxRescheduler = std::move(txRescheduler);
     }
 
     TStorageConfigPtr GetStorageConfig() const

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -80,6 +80,7 @@ struct TTestEnvConfig
     // This controls probability that read will be restarted
     bool PageFaultFakesEnabled = true;
     float PageFaultProbabilityPercentage = 1;
+    std::optional<ui64> PageFaultRandomSeed = std::nullopt;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -78,9 +78,9 @@ struct TTestEnvConfig
     NActors::NLog::EPriority LogPriority_Others = NActors::NLog::PRI_WARN;
 
     // This controls probability that read will be restarted
-    bool PageFaultFakesEnabled = true;
-    float PageFaultProbabilityPercentage = 1;
-    std::optional<ui64> PageFaultRandomSeed = std::nullopt;
+    bool FakePageFaultsEnabled = true;
+    float FakePageFaultsProbabilityPercentage = 1;
+    std::optional<ui64> FakePageFaultsRandomSeed = std::nullopt;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -33,3 +33,5 @@ GidPropagationEnabled: true
 NodeRefsNoAutoPrecharge: true
 UseCustomReadDataResponseParser: true
 MaxShardManagementRequestsInFlight: 3
+FakeReadFailuresEnabled: true
+FakeReadFailuresProbabilityPercentage: 0.1

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -33,5 +33,5 @@ GidPropagationEnabled: true
 NodeRefsNoAutoPrecharge: true
 UseCustomReadDataResponseParser: true
 MaxShardManagementRequestsInFlight: 3
-FakeReadFailuresEnabled: true
-FakeReadFailuresProbabilityPercentage: 0.1
+FakeTxPageFaultsEnabled: true
+FakeTxPageFaultsProbabilityPercentage: 0.1


### PR DESCRIPTION
### Notes
This change enables randomly restarting transactions in all tests using TTestEnv.  Additionally, it allows to do the same in larger/integration tests and exposes new configuration in storage config.

Currently there is some gap in testing transactions restarted due to "page faults" in YDB, which reschedule and restart read transactions after some delay. As we did not find a way to trigger page faults in YDB, I extended previously existing failure injection to all Read* methods of TInMemoryIndexState. 

### Issue
#6467

