### PR TITLE
Filestore] add SIGUSR1 retries to FUSE loop thread shutdown to mitigate single lost SIGUSR1 wakeup

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -580,12 +580,14 @@ public:
             "stopping FUSE loop thread " << FuseLoopIndex << "."
                                          << BackendQueueIndex);
 
-        // A single signal is not enough: it may be delivered when the loop
-        // thread is not blocked on sem_wait/read yet (e.g. right after it has
-        // checked the session exit flag but before it has entered the
-        // syscall). Such a signal interrupts nothing and the loop thread then
-        // blocks indefinitely, so keep signalling until the loop actually
-        // finishes.
+        // A single signal is not enough. The loop thread runs
+        // fuse_session_loop() (contrib/libs/fuse/lib/fuse_loop.c), which
+        // checks fuse_session_exited() and then calls
+        // fuse_session_receive_buf(), blocking in read() on /dev/fuse. A
+        // signal delivered after the exit flag check but before the thread
+        // has entered the syscall interrupts nothing, and the loop thread
+        // then blocks indefinitely, so keep signalling until the loop
+        // actually finishes.
         SignalInterrupt();
         while (!LoopFinished.WaitT(SignalInterruptInterval)) {
             SignalInterrupt();

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -33,6 +33,7 @@
 #include <util/generic/bitops.h>
 #include <util/generic/string.h>
 #include <util/generic/yexception.h>
+#include <util/system/event.h>
 #include "util/system/file_lock.h"
 #include <util/system/fs.h>
 #include <util/system/info.h>
@@ -541,13 +542,16 @@ class TFuseLoopThread final
     : public ISimpleThread
 {
 private:
+    static constexpr TDuration SignalInterruptInterval =
+        TDuration::MilliSeconds(100);
+
     TSession& Session;
     const ui32 FuseLoopIndex = 0;
     const ui32 BackendQueueIndex = 0;
-    bool InterruptSignaled = false;
     TLog Log;
 
     pthread_t ThreadId = 0;
+    TManualEvent LoopFinished;
 
 public:
     TFuseLoopThread(
@@ -563,17 +567,11 @@ public:
 
     void SignalInterrupt()
     {
-        if (InterruptSignaled) {
-            return;
-        }
-
         if (auto threadId = AtomicGet(ThreadId)) {
             // session loop may get stuck on sem_wait/read.
             // Interrupt it by sending the thread a signal.
             pthread_kill(threadId, SIGUSR1);
         }
-
-        InterruptSignaled = true;
     }
 
     void Stop()
@@ -582,7 +580,16 @@ public:
             "stopping FUSE loop thread " << FuseLoopIndex << "."
                                          << BackendQueueIndex);
 
+        // A single signal is not enough: it may be delivered when the loop
+        // thread is not blocked on sem_wait/read yet (e.g. right after it has
+        // checked the session exit flag but before it has entered the
+        // syscall). Such a signal interrupts nothing and the loop thread then
+        // blocks indefinitely, so keep signalling until the loop actually
+        // finishes.
         SignalInterrupt();
+        while (!LoopFinished.WaitT(SignalInterruptInterval)) {
+            SignalInterrupt();
+        }
         Join();
 
         STORAGE_INFO(
@@ -605,6 +612,7 @@ private:
         fuse_session_loop(Session);
 #endif
 
+        LoopFinished.Signal();
         return nullptr;
     }
 };

--- a/cloud/filestore/tests/python/lib/common.py
+++ b/cloud/filestore/tests/python/lib/common.py
@@ -34,9 +34,13 @@ def shutdown(pid, timeout=60):
     try:
         os.kill(pid, signal.SIGTERM)
         if not wait_for(lambda: __is_dead(pid), timeout):
+            logger.warning(
+                f"process {pid} did not stop in {timeout}s after SIGTERM, "
+                "sending SIGKILL")
             os.kill(pid, signal.SIGKILL)
     except BaseException:
-        pass
+        logger.warning(
+            f"failed to shut down process {pid}", exc_info=True)
 
 
 def daemon_log_files(prefix, cwd):


### PR DESCRIPTION
### Problem
https://github.com/ydb-platform/nbs/actions/runs/27998974260/job/82867193543

### Notes
TFuseLoopThread::Stop() sends one pthread_kill(SIGUSR1), then joins. The loop thread runs while(!fuse_session_exited(se)) read(/dev/fuse). A signal only breaks read() with EINTR if the thread is already sleeping inside it. There is a short window between the exit-flag check and the start of read(). If the signal arrives in that window, the no-op handler eats it. The thread then enters read() with nothing pending and blocks forever. No more FUSE requests come. No more signals are sent. The unmount that would break read() with ENODEV runs only after the join, and the join is already stuck on this thread. This window widens under host load. The bug predates the multi-queue refactor (#4045).
