### PR TITLE
enable tablet restarter for selected tests

### DIFF
--- a/cloud/filestore/tests/async_close_test/ya.make
+++ b/cloud/filestore/tests/async_close_test/ya.make
@@ -30,4 +30,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/close_to_open_consistency/ya.make
+++ b/cloud/filestore/tests/close_to_open_consistency/ya.make
@@ -29,4 +29,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/directory_handles/ya.make
+++ b/cloud/filestore/tests/directory_handles/ya.make
@@ -38,4 +38,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
@@ -34,4 +34,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
@@ -35,4 +35,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
@@ -27,4 +27,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
@@ -25,4 +25,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/qemu.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/loadtest/service-kikimr-emergency-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-emergency-test/ya.make
@@ -27,4 +27,7 @@ SET(NFS_BS_CACHE_FILE_PATH "bs_cache.txt")
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/loadtest/service-kikimr-nemesis-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-nemesis-test/ya.make
@@ -27,4 +27,7 @@ SET(
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
@@ -27,4 +27,7 @@ SET(
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()

--- a/cloud/filestore/tests/loadtest/service-kikimr-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-test/ya.make
@@ -25,4 +25,7 @@ SET(
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 
+DEFAULT(FILESTORE_TABLETS_RESTART_INTERVAL 5)
+INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/tablets-restarter.inc)
+
 END()


### PR DESCRIPTION
### Notes
This PR expands the set of tests for which tablet restarter is enabled.

### Issue
https://github.com/ydb-platform/nbs/issues/6467