### PR TITLE
chore: rework Github client init

### DIFF
--- a/.github/scripts/calculate_run_times_for_label_combinations.py
+++ b/.github/scripts/calculate_run_times_for_label_combinations.py
@@ -27,8 +27,12 @@ from datetime import datetime, timedelta, timezone
 from typing import DefaultDict, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
-from github import Github
 from tabulate import tabulate
+
+try:
+    from .helpers import github_client
+except ImportError:
+    from helpers import github_client
 
 LOG = logging.getLogger("pr_workflow_run_tests_stats")
 
@@ -482,7 +486,7 @@ def main() -> int:
         return 2
 
     owner, name = args.repo.split("/", 1)
-    gh = Github(token)
+    gh = github_client(token)
     repo = gh.get_repo(f"{owner}/{name}")
 
     # created_since vs days

--- a/.github/scripts/github_actions_variables.py
+++ b/.github/scripts/github_actions_variables.py
@@ -1,20 +1,17 @@
 import argparse
 import os
 
-from github import Github
-
-from .helpers import fetch_repo_variable, setup_logger
+from .helpers import fetch_repo_variable, github_client, setup_logger
 
 logger = setup_logger()
 
 
 def update_variable(
-    github_token: str,
+    github,
     github_repository: str,
     variable_name: str,
     value: str,
 ) -> None:
-    github = Github(github_token)
     _, variable = fetch_repo_variable(github, github_repository, variable_name)
     old_value = variable.value
 
@@ -49,9 +46,10 @@ def main():
         help="New variable value.",
     )
     args = parser.parse_args()
+    github = github_client(args.github_token)
 
     update_variable(
-        github_token=args.github_token,
+        github=github,
         github_repository=args.github_repo,
         variable_name=args.variable_name,
         value=args.value,

--- a/.github/scripts/github_runner_release.py
+++ b/.github/scripts/github_runner_release.py
@@ -3,6 +3,7 @@ import os
 
 from .helpers import (
     GITHUB_RUNNER_LATEST_VERSION,
+    github_client,
     github_output,
     resolve_github_runner_release,
     setup_logger,
@@ -27,7 +28,8 @@ def main():
     )
     args = parser.parse_args()
 
-    release = resolve_github_runner_release(args.version, args.github_token)
+    github = github_client(args.github_token)
+    release = resolve_github_runner_release(github, args.version)
     logger.info(
         "Resolved GitHub runner release version=%s sha256_by_arch=%s",
         release.version,

--- a/.github/scripts/github_team_public_keys.py
+++ b/.github/scripts/github_team_public_keys.py
@@ -2,13 +2,10 @@ import argparse
 import os
 import sys
 
-from github import Auth as GithubAuth
-from github import Github
-
 try:
-    from .helpers import fetch_github_team_public_keys, setup_logger
+    from .helpers import fetch_github_team_public_keys, github_client, setup_logger
 except ImportError:
-    from helpers import fetch_github_team_public_keys, setup_logger
+    from helpers import fetch_github_team_public_keys, github_client, setup_logger
 
 
 def parse_args():
@@ -40,7 +37,7 @@ def main() -> int:
         print(f"Missing required arguments: {', '.join(missing_args)}", file=sys.stderr)
         return 2
 
-    gh = Github(auth=GithubAuth.Token(args.github_token))
+    gh = github_client(args.github_token)
     for key in fetch_github_team_public_keys(
         gh, args.github_org, args.github_team_slug
     ):

--- a/.github/scripts/helpers.py
+++ b/.github/scripts/helpers.py
@@ -471,7 +471,7 @@ def github_client(github_token: str | None = None) -> Github:
 
 def github_client_from_env() -> Github:
     github_token = os.environ.get("GITHUB_TOKEN")
-    if github_token is None:
+    if github_token is None or not github_token.strip():
         raise Exception("GITHUB_TOKEN environment variable is not set")
 
     return github_client(github_token)

--- a/.github/scripts/helpers.py
+++ b/.github/scripts/helpers.py
@@ -7,6 +7,7 @@ import requests
 import re
 import asyncio
 import functools
+import inspect
 import time
 from dataclasses import dataclass
 import datetime
@@ -219,9 +220,11 @@ def retry(
     retry_exceptions: tuple[type[BaseException], ...] = (Exception,),
     retry_result: Callable[[object], bool] | None = None,
     attempt_arg: str | None = None,
-    on_final_exception: Callable[[BaseException], None] | None = None,
+    on_final_exception: Callable[..., None] | None = None,
 ) -> callable:
     def decorator(func: callable) -> callable:
+        func_signature = inspect.signature(func)
+
         def build_call_kwargs(kwargs: dict, attempt: int) -> dict:
             call_kwargs = dict(kwargs)
             if attempt_arg:
@@ -262,6 +265,20 @@ def retry(
                 interval_sec,
             )
 
+        def call_final_exception_handler(
+            exception: BaseException, args: tuple, kwargs: dict
+        ) -> None:
+            if not on_final_exception:
+                return
+
+            parameters = inspect.signature(on_final_exception).parameters
+            if len(parameters) == 1:
+                on_final_exception(exception)
+            else:
+                on_final_exception(
+                    exception, func_signature.bind_partial(*args, **kwargs)
+                )
+
         if asyncio.iscoroutinefunction(func):
 
             @functools.wraps(func)
@@ -272,8 +289,7 @@ def retry(
                     except retry_exceptions as e:
                         if attempt == attempts:
                             log_final_exception(e)
-                            if on_final_exception:
-                                on_final_exception(e)
+                            call_final_exception_handler(e, args, kwargs)
                             raise
 
                         log_retry_exception(attempt, e)
@@ -304,8 +320,7 @@ def retry(
                 except retry_exceptions as e:
                     if attempt == attempts:
                         log_final_exception(e)
-                        if on_final_exception:
-                            on_final_exception(e)
+                        call_final_exception_handler(e, args, kwargs)
                         raise
 
                     log_retry_exception(attempt, e)

--- a/.github/scripts/helpers.py
+++ b/.github/scripts/helpers.py
@@ -356,8 +356,8 @@ def fetch_repo_variable(github_client, github_repository: str, variable_name: st
     interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
     retry_exceptions=PYGITHUB_RETRY_EXCEPTIONS,
 )
-def fetch_github_team(gh: Github, github_org: str, team_slug: str) -> Team:
-    org = gh.get_organization(github_org)
+def fetch_github_team(github: Github, github_org: str, team_slug: str) -> Team:
+    org = github.get_organization(github_org)
     return org.get_team_by_slug(team_slug)
 
 
@@ -380,10 +380,10 @@ def fetch_github_member_public_keys(member: NamedUser) -> list[str]:
 
 
 def fetch_github_team_public_keys(
-    gh: Github, github_org: str, team_slug: str
+    github: Github, github_org: str, team_slug: str
 ) -> list[str]:
     logger = logging.getLogger(__name__)
-    team = fetch_github_team(gh, github_org, team_slug)
+    team = fetch_github_team(github, github_org, team_slug)
     members: list[NamedUser] = fetch_github_team_members(team)
 
     ssh_keys: list[str] = []
@@ -469,6 +469,18 @@ def github_client(github_token: str | None = None) -> Github:
     return Github()
 
 
+def github_client_from_env() -> Github:
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token is None:
+        raise Exception("GITHUB_TOKEN environment variable is not set")
+
+    return github_client(github_token)
+
+
+def github_runner_repo(github: Github):
+    return github.get_repo("actions/runner")
+
+
 def git_release_payload(release: GitRelease) -> dict:
     return {
         "tag_name": release.tag_name,
@@ -482,11 +494,9 @@ def git_release_payload(release: GitRelease) -> dict:
     interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
     retry_exceptions=PYGITHUB_RETRY_EXCEPTIONS,
 )
-def get_github_runner_release(
-    version: str, github_token: str | None = None
-) -> GithubRunnerRelease:
+def get_github_runner_release(github: Github, version: str) -> GithubRunnerRelease:
     normalized_version = normalize_github_runner_version(version)
-    repo = github_client(github_token).get_repo("actions/runner")
+    repo = github_runner_repo(github)
     release = repo.get_release(f"v{normalized_version}")
     return extract_github_runner_release(git_release_payload(release))
 
@@ -497,27 +507,25 @@ def get_github_runner_release(
     retry_exceptions=PYGITHUB_RETRY_EXCEPTIONS,
 )
 def get_latest_github_runner_release(
-    github_token: str | None = None,
+    github: Github,
 ) -> GithubRunnerRelease:
-    repo = github_client(github_token).get_repo("actions/runner")
+    repo = github_runner_repo(github)
     release = repo.get_latest_release()
     return extract_github_runner_release(git_release_payload(release))
 
 
-def get_latest_github_runner_version(github_token: str | None = None) -> str:
-    return get_latest_github_runner_release(github_token).version
+def get_latest_github_runner_version(github: Github) -> str:
+    return get_latest_github_runner_release(github).version
 
 
-def resolve_github_runner_version(version: str, github_token: str | None = None) -> str:
-    return resolve_github_runner_release(version, github_token).version
+def resolve_github_runner_version(github: Github, version: str) -> str:
+    return resolve_github_runner_release(github, version).version
 
 
-def resolve_github_runner_release(
-    version: str, github_token: str | None = None
-) -> GithubRunnerRelease:
+def resolve_github_runner_release(github: Github, version: str) -> GithubRunnerRelease:
     if (version or "").strip().lower() in ("", GITHUB_RUNNER_LATEST_VERSION):
-        return get_latest_github_runner_release(github_token)
-    return get_github_runner_release(version, github_token)
+        return get_latest_github_runner_release(github)
+    return get_github_runner_release(github, version)
 
 
 def vm_suffix_for_component(component: str) -> str:

--- a/.github/scripts/helpers_test.py
+++ b/.github/scripts/helpers_test.py
@@ -350,7 +350,29 @@ def test_extract_github_runner_release_rejects_missing_tag_name():
         h.extract_github_runner_release(payload)
 
 
-def test_get_github_runner_release_fetches_release_by_tag(monkeypatch):
+def test_github_client_from_env_uses_github_token(monkeypatch):
+    calls = []
+    github = object()
+
+    def fake_github_client(token):
+        calls.append(token)
+        return github
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(h, "github_client", fake_github_client)
+
+    assert h.github_client_from_env() is github
+    assert calls == ["token"]
+
+
+def test_github_client_from_env_requires_github_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    with pytest.raises(Exception, match="GITHUB_TOKEN environment variable is not set"):
+        h.github_client_from_env()
+
+
+def test_get_github_runner_release_fetches_release_by_tag():
     class FakeRepo:
         def get_release(self, tag):
             assert tag == "v2.331.0"
@@ -368,19 +390,13 @@ def test_get_github_runner_release_fetches_release_by_tag(monkeypatch):
             assert repo == "actions/runner"
             return FakeRepo()
 
-    def fake_github_client(token):
-        assert token == "token"
-        return FakeGithub()
-
-    monkeypatch.setattr(h, "github_client", fake_github_client)
-
-    release = h.get_github_runner_release("v2.331.0", "token")
+    release = h.get_github_runner_release(FakeGithub(), "v2.331.0")
 
     assert release.version == "2.331.0"
     assert release.sha256_by_arch["x64"] == "a" * 64
 
 
-def test_get_latest_github_runner_release_fetches_latest(monkeypatch):
+def test_get_latest_github_runner_release_fetches_latest():
     class FakeRepo:
         def get_latest_release(self):
             payload = make_runner_release_payload("2.332.0")
@@ -397,13 +413,7 @@ def test_get_latest_github_runner_release_fetches_latest(monkeypatch):
             assert repo == "actions/runner"
             return FakeRepo()
 
-    def fake_github_client(token):
-        assert token == "token"
-        return FakeGithub()
-
-    monkeypatch.setattr(h, "github_client", fake_github_client)
-
-    release = h.get_latest_github_runner_release("token")
+    release = h.get_latest_github_runner_release(FakeGithub())
 
     assert release.version == "2.332.0"
     assert release.sha256_by_arch["arm64"] == "b" * 64
@@ -437,25 +447,27 @@ def test_get_jobs_raw_fetches_workflow_jobs_with_pygithub(monkeypatch):
 
 def test_resolve_github_runner_release_treats_empty_as_latest(monkeypatch):
     calls = []
+    github = object()
 
-    def fake_get_latest(github_token):
-        calls.append(github_token)
+    def fake_get_latest(received_github):
+        calls.append(received_github)
         return h.GithubRunnerRelease(version="2.332.0", sha256_by_arch={})
 
     monkeypatch.setattr(h, "get_latest_github_runner_release", fake_get_latest)
 
-    assert h.resolve_github_runner_release("", "token").version == "2.332.0"
-    assert calls == ["token"]
+    assert h.resolve_github_runner_release(github, "").version == "2.332.0"
+    assert calls == [github]
 
 
 def test_resolve_github_runner_release_fetches_pinned_version(monkeypatch):
     calls = []
+    github = object()
 
-    def fake_get_release(version, github_token):
-        calls.append((version, github_token))
+    def fake_get_release(received_github, version):
+        calls.append((received_github, version))
         return h.GithubRunnerRelease(version="2.331.0", sha256_by_arch={})
 
     monkeypatch.setattr(h, "get_github_runner_release", fake_get_release)
 
-    assert h.resolve_github_runner_release("v2.331.0", "token").version == "2.331.0"
-    assert calls == [("v2.331.0", "token")]
+    assert h.resolve_github_runner_release(github, "v2.331.0").version == "2.331.0"
+    assert calls == [(github, "v2.331.0")]

--- a/.github/scripts/nebius_manage_images.py
+++ b/.github/scripts/nebius_manage_images.py
@@ -2,8 +2,7 @@ import os
 import asyncio
 import argparse
 from dataclasses import dataclass
-from .helpers import setup_logger, convert_size, fetch_repo_variable
-from github import Github
+from .helpers import setup_logger, convert_size, fetch_repo_variable, github_client
 from nebius.sdk import SDK
 from nebius.aio.cli_config import Config
 from nebius.aio.service_error import RequestError
@@ -137,7 +136,7 @@ async def remove_image_by_id(service: ImageServiceClient, image_id: str) -> None
 async def main(
     sdk: SDK,
     options: ManageImagesOptions,
-    github_client_factory=Github,
+    github_client_factory=github_client,
     image_service_factory=ImageServiceClient,
 ) -> None:
     github = github_client_factory(options.github_token)

--- a/.github/scripts/nebius_manage_vm.py
+++ b/.github/scripts/nebius_manage_vm.py
@@ -607,7 +607,7 @@ async def create_vm(
         # VM to avoid orphaned resources
         try:
             runner_id = wait_runner_by_name(
-                gh, args.github_repo_owner, args.github_repo, instance_id
+                github, args.github_repo_owner, args.github_repo, instance_id
             )
         except Exception:
             logger.error(

--- a/.github/scripts/nebius_manage_vm.py
+++ b/.github/scripts/nebius_manage_vm.py
@@ -23,7 +23,7 @@ from .helpers import (
     GITHUB_API_RETRY_INTERVAL_SEC,
     GITHUB_RUNNER_LATEST_VERSION,
     fetch_github_team_public_keys,
-    github_client,
+    github_client_from_env,
     resolve_github_runner_release,
 )
 from github import Github
@@ -197,15 +197,15 @@ def generate_cloud_init_script(
 
 
 def resolve_runner_release_for_update(
+    github: Github,
     version: str,
-    github_token: str,
     override_existing_runner: str,
 ) -> tuple[str, dict[str, str]]:
     if not truthy(override_existing_runner):
         logger.info("Runner update is disabled, skipping GitHub runner release lookup")
         return "", {}
 
-    release = resolve_github_runner_release(version, github_token)
+    release = resolve_github_runner_release(github, version)
     logger.info(
         "Resolved GitHub runner release for update: version=%s sha256_by_arch=%s",
         release.version,
@@ -235,8 +235,8 @@ if not hasattr(Repository, "create_self_hosted_runner_registration_token"):
     interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
     retry_exceptions=PYGITHUB_RETRY_EXCEPTIONS + (ValueError,),
 )
-def get_runner_token(client: Github, github_repo_owner: str, github_repo: str) -> str:
-    repo = client.get_repo(f"{github_repo_owner}/{github_repo}")
+def get_runner_token(github: Github, github_repo_owner: str, github_repo: str) -> str:
+    repo = github.get_repo(f"{github_repo_owner}/{github_repo}")
     registration_token = repo.create_self_hosted_runner_registration_token()
     token = registration_token.token
     expires_at = registration_token.expires_at
@@ -251,14 +251,14 @@ def get_runner_token(client: Github, github_repo_owner: str, github_repo: str) -
 
 
 def find_runner_by_name(
-    client: Github, github_repo_owner: str, github_repo: str, vm_id: str
+    github: Github, github_repo_owner: str, github_repo: str, vm_id: str
 ) -> Optional[str]:
     logger.info(
         "Checking whether VM %s is registered as Github Runner",
         vm_id,
     )
 
-    runners = client.get_repo(
+    runners = github.get_repo(
         f"{github_repo_owner}/{github_repo}"
     ).get_self_hosted_runners()
 
@@ -282,9 +282,9 @@ def find_runner_by_name(
     retry_result=lambda result: result is None,
 )
 def wait_runner_by_name(
-    client: Github, github_repo_owner: str, github_repo: str, vm_id: str
+    github: Github, github_repo_owner: str, github_repo: str, vm_id: str
 ) -> Optional[str]:
-    return find_runner_by_name(client, github_repo_owner, github_repo, vm_id)
+    return find_runner_by_name(github, github_repo_owner, github_repo, vm_id)
 
 
 def build_disk_request(
@@ -347,14 +347,16 @@ async def create_disk(sdk: SDK, args: argparse.Namespace) -> str:
 def report_create_vm_final_failure(
     exception: BaseException, call_args: inspect.BoundArguments
 ) -> None:
+    del call_args
+
     if os.environ.get("GITHUB_EVENT_NAME") != "pull_request":
         return
 
     pr_number = int(os.environ.get("GITHUB_REF").split("/")[-1])
     repo_name = os.environ.get("GITHUB_REPOSITORY")
-    gh = call_args.arguments["github"]
+    github = github_client_from_env()
     comment = f"VM creation failed after 30 minutes: {exception}"
-    repo = gh.get_repo(repo_name)
+    repo = github.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
     pr.create_issue_comment(comment)
 
@@ -470,9 +472,7 @@ def extract_instance_ips(instance, no_public_ip: bool) -> tuple[str, Optional[st
     attempt_arg="attempt",
     on_final_exception=report_create_vm_final_failure,
 )
-async def create_vm(
-    sdk: SDK, args: argparse.Namespace, github: Github, attempt: int = 0
-):
+async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
     logger.info(
         "Trying to create VM at %s (attempt=%d)",
         time.ctime(time.time()),
@@ -485,7 +485,7 @@ async def create_vm(
         disk_size=args.disk_size,
     )
 
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    github = github_client_from_env()
 
     runner_registration_token = get_runner_token(
         github, args.github_repo_owner, args.github_repo
@@ -514,8 +514,8 @@ async def create_vm(
         github_runner_version,
         github_runner_sha256_by_arch,
     ) = resolve_runner_release_for_update(
+        github,
         args.github_runner_version,
-        GITHUB_TOKEN,
         args.github_override_existing_runner,
     )
 
@@ -637,8 +637,8 @@ async def create_vm(
     interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
     retry_exceptions=PYGITHUB_RETRY_EXCEPTIONS,
 )
-def get_self_hosted_runner(client: Github, repo: str, runner_id: str):
-    return client.get_repo(repo).get_self_hosted_runner(runner_id)
+def get_self_hosted_runner(github: Github, repo: str, runner_id: str):
+    return github.get_repo(repo).get_self_hosted_runner(runner_id)
 
 
 @retry(
@@ -646,14 +646,14 @@ def get_self_hosted_runner(client: Github, repo: str, runner_id: str):
     interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
     retry_exceptions=PYGITHUB_RETRY_EXCEPTIONS,
 )
-def remove_self_hosted_runner(client: Github, repo: str, runner_id: str) -> bool:
-    return client.get_repo(repo).remove_self_hosted_runner(runner_id)
+def remove_self_hosted_runner(github: Github, repo: str, runner_id: str) -> bool:
+    return github.get_repo(repo).remove_self_hosted_runner(runner_id)
 
 
 def remove_runner_from_github(
-    client: Github, github_repo_owner: str, github_repo: str, vm_id: str, apply: bool
+    github: Github, github_repo_owner: str, github_repo: str, vm_id: str, apply: bool
 ) -> str:
-    runner_id = find_runner_by_name(client, github_repo_owner, github_repo, vm_id)
+    runner_id = find_runner_by_name(github, github_repo_owner, github_repo, vm_id)
     repo = os.environ.get("GITHUB_REPOSITORY")
 
     if runner_id is None:
@@ -662,7 +662,7 @@ def remove_runner_from_github(
         logger.info("Runner with name %s not found, skipping", vm_id)
         return "not_found"
 
-    runner = get_self_hosted_runner(client, repo, runner_id)
+    runner = get_self_hosted_runner(github, repo, runner_id)
     if runner is None:
         logger.info("Runner with name %s not found, skipping", vm_id)
         return "not_found"
@@ -678,7 +678,7 @@ def remove_runner_from_github(
         return "busy"
 
     if apply:
-        result = remove_self_hosted_runner(client, repo, runner_id)
+        result = remove_self_hosted_runner(github, repo, runner_id)
 
         if not result:
             # removed throwing exception here, because removing VM is more important
@@ -884,10 +884,12 @@ async def search_vm_cleanup_candidates_by_labels(sdk: SDK, args: argparse.Namesp
     return candidates
 
 
-async def remove_vm(sdk: SDK, args: argparse.Namespace, github: Github):
+async def remove_vm(sdk: SDK, args: argparse.Namespace):
     if not args.id:
         await search_vm_cleanup_candidates_by_labels(sdk, args)
         return
+
+    github = github_client_from_env()
 
     result = remove_runner_from_github(
         github, args.github_repo_owner, args.github_repo, args.id, args.apply
@@ -1076,8 +1078,7 @@ async def main() -> None:
     sdk = SDK(config_reader=Config())
 
     if hasattr(args, "func"):
-        github = github_client(os.environ["GITHUB_TOKEN"])
-        await args.func(sdk, args, github)
+        await args.func(sdk, args)
     else:
         parser.print_help()
 

--- a/.github/scripts/nebius_manage_vm.py
+++ b/.github/scripts/nebius_manage_vm.py
@@ -1,4 +1,5 @@
 import argparse
+import inspect
 import math
 import os
 from pathlib import Path
@@ -22,9 +23,9 @@ from .helpers import (
     GITHUB_API_RETRY_INTERVAL_SEC,
     GITHUB_RUNNER_LATEST_VERSION,
     fetch_github_team_public_keys,
+    github_client,
     resolve_github_runner_release,
 )
-from github import Auth as GithubAuth
 from github import Github
 from github.Repository import Repository
 from github.SelfHostedActionsRunnerToken import SelfHostedActionsRunnerToken
@@ -234,12 +235,8 @@ if not hasattr(Repository, "create_self_hosted_runner_registration_token"):
     interval_sec=GITHUB_API_RETRY_INTERVAL_SEC,
     retry_exceptions=PYGITHUB_RETRY_EXCEPTIONS + (ValueError,),
 )
-def get_runner_token(
-    github_repo_owner: str, github_repo: str, github_token: str
-) -> str:
-    repo = Github(auth=GithubAuth.Token(github_token)).get_repo(
-        f"{github_repo_owner}/{github_repo}"
-    )
+def get_runner_token(client: Github, github_repo_owner: str, github_repo: str) -> str:
+    repo = client.get_repo(f"{github_repo_owner}/{github_repo}")
     registration_token = repo.create_self_hosted_runner_registration_token()
     token = registration_token.token
     expires_at = registration_token.expires_at
@@ -347,15 +344,16 @@ async def create_disk(sdk: SDK, args: argparse.Namespace) -> str:
     return request.resource_id
 
 
-def report_create_vm_final_failure(exception: BaseException) -> None:
+def report_create_vm_final_failure(
+    exception: BaseException, call_args: inspect.BoundArguments
+) -> None:
     if os.environ.get("GITHUB_EVENT_NAME") != "pull_request":
         return
 
     pr_number = int(os.environ.get("GITHUB_REF").split("/")[-1])
     repo_name = os.environ.get("GITHUB_REPOSITORY")
-    github_token = os.environ.get("GITHUB_TOKEN")
+    gh = call_args.arguments["github"]
     comment = f"VM creation failed after 30 minutes: {exception}"
-    gh = Github(auth=GithubAuth.Token(github_token))
     repo = gh.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
     pr.create_issue_comment(comment)
@@ -472,7 +470,9 @@ def extract_instance_ips(instance, no_public_ip: bool) -> tuple[str, Optional[st
     attempt_arg="attempt",
     on_final_exception=report_create_vm_final_failure,
 )
-async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
+async def create_vm(
+    sdk: SDK, args: argparse.Namespace, github: Github, attempt: int = 0
+):
     logger.info(
         "Trying to create VM at %s (attempt=%d)",
         time.ctime(time.time()),
@@ -487,16 +487,14 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
 
     GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 
-    gh = Github(auth=GithubAuth.Token(GITHUB_TOKEN))
-
     runner_registration_token = get_runner_token(
-        args.github_repo_owner, args.github_repo, GITHUB_TOKEN
+        github, args.github_repo_owner, args.github_repo
     )
 
     ssh_keys = []
     if args.github_org and args.github_team_slug:
         ssh_keys = fetch_github_team_public_keys(
-            gh, args.github_org, args.github_team_slug
+            github, args.github_org, args.github_team_slug
         )
     else:
         logger.info(
@@ -886,17 +884,13 @@ async def search_vm_cleanup_candidates_by_labels(sdk: SDK, args: argparse.Namesp
     return candidates
 
 
-async def remove_vm(sdk: SDK, args: argparse.Namespace):
+async def remove_vm(sdk: SDK, args: argparse.Namespace, github: Github):
     if not args.id:
         await search_vm_cleanup_candidates_by_labels(sdk, args)
         return
 
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-
-    gh = Github(auth=GithubAuth.Token(GITHUB_TOKEN))
-
     result = remove_runner_from_github(
-        gh, args.github_repo_owner, args.github_repo, args.id, args.apply
+        github, args.github_repo_owner, args.github_repo, args.id, args.apply
     )
     if result == "not_found":
         logger.info("Runner with name %s not found in github, we can continue", args.id)
@@ -1082,7 +1076,8 @@ async def main() -> None:
     sdk = SDK(config_reader=Config())
 
     if hasattr(args, "func"):
-        await args.func(sdk, args)
+        github = github_client(os.environ["GITHUB_TOKEN"])
+        await args.func(sdk, args, github)
     else:
         parser.print_help()
 

--- a/.github/scripts/nebius_manage_vm_test.py
+++ b/.github/scripts/nebius_manage_vm_test.py
@@ -146,18 +146,13 @@ def test_get_runner_token_retries_github_errors(monkeypatch, capsys):
             )
 
     class FakeGithub:
-        def __init__(self, auth):
-            assert auth == ("token", "github-token")
-
         def get_repo(self, repo):
             assert repo == "owner/repo"
             return FakeRepo()
 
-    monkeypatch.setattr(m.GithubAuth, "Token", lambda token: ("token", token))
-    monkeypatch.setattr(m, "Github", FakeGithub)
     monkeypatch.setattr(m.time, "sleep", sleeps.append)
 
-    assert m.get_runner_token("owner", "repo", "github-token") == "runner-token"
+    assert m.get_runner_token(FakeGithub(), "owner", "repo") == "runner-token"
     assert len(attempts) == 2
     assert sleeps == [m.GITHUB_API_RETRY_INTERVAL_SEC]
     assert "::add-mask::runner-token" in capsys.readouterr().out
@@ -186,18 +181,13 @@ def test_get_runner_token_retries_transport_errors(monkeypatch, exception_type):
             )
 
     class FakeGithub:
-        def __init__(self, auth):
-            assert auth == ("token", "github-token")
-
         def get_repo(self, repo):
             assert repo == "owner/repo"
             return FakeRepo()
 
-    monkeypatch.setattr(m.GithubAuth, "Token", lambda token: ("token", token))
-    monkeypatch.setattr(m, "Github", FakeGithub)
     monkeypatch.setattr(m.time, "sleep", sleeps.append)
 
-    assert m.get_runner_token("owner", "repo", "github-token") == "runner-token"
+    assert m.get_runner_token(FakeGithub(), "owner", "repo") == "runner-token"
     assert len(attempts) == 2
     assert sleeps == [m.GITHUB_API_RETRY_INTERVAL_SEC]
 
@@ -212,19 +202,14 @@ def test_get_runner_token_reports_missing_token_after_retries(monkeypatch):
             return SimpleNamespace(token="", expires_at="2026-05-04T16:00:00Z")
 
     class FakeGithub:
-        def __init__(self, auth):
-            assert auth == ("token", "github-token")
-
         def get_repo(self, repo):
             assert repo == "owner/repo"
             return FakeRepo()
 
-    monkeypatch.setattr(m.GithubAuth, "Token", lambda token: ("token", token))
-    monkeypatch.setattr(m, "Github", FakeGithub)
     monkeypatch.setattr(m.time, "sleep", sleeps.append)
 
     with pytest.raises(ValueError) as err:
-        m.get_runner_token("owner", "repo", "github-token")
+        m.get_runner_token(FakeGithub(), "owner", "repo")
 
     assert str(err.value) == "Failed to get runner registration token"
     assert len(attempts) == m.GITHUB_API_RETRY_ATTEMPTS
@@ -957,6 +942,6 @@ def test_remove_vm_with_empty_id_only_searches_by_labels(monkeypatch):
     sdk = object()
     args = argparse.Namespace(id="", labels={"run": "1-1"})
 
-    asyncio.run(m.remove_vm(sdk, args))
+    asyncio.run(m.remove_vm(sdk, args, None))
 
     assert searches == [(sdk, args)]

--- a/.github/scripts/nebius_manage_vm_test.py
+++ b/.github/scripts/nebius_manage_vm_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import argparse
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -243,7 +244,7 @@ def test_repository_registration_token_extension_uses_pygithub_requester():
     assert registration_token.expires_at.isoformat() == "2026-05-04T16:00:00+00:00"
 
 
-def test_get_latest_github_runner_version_strips_tag_prefix(monkeypatch):
+def test_get_latest_github_runner_version_strips_tag_prefix():
     class FakeRepo:
         def get_latest_release(self):
             payload = make_runner_release_payload("2.332.0")
@@ -260,13 +261,7 @@ def test_get_latest_github_runner_version_strips_tag_prefix(monkeypatch):
             assert repo == "actions/runner"
             return FakeRepo()
 
-    def fake_github_client(token):
-        assert token == "github-token"
-        return FakeGithub()
-
-    monkeypatch.setattr(h, "github_client", fake_github_client)
-
-    assert h.get_latest_github_runner_version("github-token") == "2.332.0"
+    assert h.get_latest_github_runner_version(FakeGithub()) == "2.332.0"
 
 
 def make_runner_release_payload(version="2.332.0"):
@@ -301,7 +296,7 @@ def test_extract_github_runner_release_returns_arch_sha_from_body():
     }
 
 
-def test_get_github_runner_release_fetches_tag_and_sha(monkeypatch):
+def test_get_github_runner_release_fetches_tag_and_sha():
     class FakeRepo:
         def get_release(self, tag):
             assert tag == "v2.331.0"
@@ -319,13 +314,7 @@ def test_get_github_runner_release_fetches_tag_and_sha(monkeypatch):
             assert repo == "actions/runner"
             return FakeRepo()
 
-    def fake_github_client(token):
-        assert token == "github-token"
-        return FakeGithub()
-
-    monkeypatch.setattr(h, "github_client", fake_github_client)
-
-    release = h.get_github_runner_release("v2.331.0", "github-token")
+    release = h.get_github_runner_release(FakeGithub(), "v2.331.0")
 
     assert release.version == "2.331.0"
     assert release.sha256_by_arch["x64"] == "a" * 64
@@ -333,9 +322,10 @@ def test_get_github_runner_release_fetches_tag_and_sha(monkeypatch):
 
 def test_resolve_github_runner_release_fetches_latest(monkeypatch):
     calls = []
+    github = object()
 
-    def fake_get_latest(github_token):
-        calls.append(github_token)
+    def fake_get_latest(received_github):
+        calls.append(received_github)
         return h.GithubRunnerRelease(
             version="2.332.0",
             sha256_by_arch={"x64": "a" * 64, "arm64": "b" * 64},
@@ -343,17 +333,18 @@ def test_resolve_github_runner_release_fetches_latest(monkeypatch):
 
     monkeypatch.setattr(h, "get_latest_github_runner_release", fake_get_latest)
 
-    release = h.resolve_github_runner_release("latest", "github-token")
+    release = h.resolve_github_runner_release(github, "latest")
 
     assert release.version == "2.332.0"
-    assert calls == ["github-token"]
+    assert calls == [github]
 
 
 def test_resolve_github_runner_version_fetches_latest(monkeypatch):
     calls = []
+    github = object()
 
-    def fake_get_latest(github_token):
-        calls.append(github_token)
+    def fake_get_latest(received_github):
+        calls.append(received_github)
         return h.GithubRunnerRelease(
             version="2.332.0",
             sha256_by_arch={"x64": "a" * 64, "arm64": "b" * 64},
@@ -361,15 +352,16 @@ def test_resolve_github_runner_version_fetches_latest(monkeypatch):
 
     monkeypatch.setattr(h, "get_latest_github_runner_release", fake_get_latest)
 
-    assert h.resolve_github_runner_version("latest", "github-token") == "2.332.0"
-    assert calls == ["github-token"]
+    assert h.resolve_github_runner_version(github, "latest") == "2.332.0"
+    assert calls == [github]
 
 
 def test_resolve_github_runner_version_fetches_literal_release(monkeypatch):
     calls = []
+    github = object()
 
-    def fake_get_release(version, github_token):
-        calls.append((version, github_token))
+    def fake_get_release(received_github, version):
+        calls.append((received_github, version))
         return h.GithubRunnerRelease(
             version="2.331.0",
             sha256_by_arch={"x64": "a" * 64, "arm64": "b" * 64},
@@ -377,8 +369,8 @@ def test_resolve_github_runner_version_fetches_literal_release(monkeypatch):
 
     monkeypatch.setattr(h, "get_github_runner_release", fake_get_release)
 
-    assert h.resolve_github_runner_version("v2.331.0", "github-token") == "2.331.0"
-    assert calls == [("v2.331.0", "github-token")]
+    assert h.resolve_github_runner_version(github, "v2.331.0") == "2.331.0"
+    assert calls == [(github, "v2.331.0")]
 
 
 def test_generate_cloud_init_script_renders_repo_template(monkeypatch):
@@ -435,12 +427,12 @@ def test_generate_cloud_init_script_renders_repo_template(monkeypatch):
 def test_resolve_runner_release_for_update_skips_lookup_when_override_disabled(
     monkeypatch,
 ):
-    def fail_resolve(version, github_token):
-        raise AssertionError(f"unexpected release lookup for {version} {github_token}")
+    def fail_resolve(github, version):
+        raise AssertionError(f"unexpected release lookup for {github} {version}")
 
     monkeypatch.setattr(m, "resolve_github_runner_release", fail_resolve)
 
-    assert m.resolve_runner_release_for_update("latest", "github-token", "false") == (
+    assert m.resolve_runner_release_for_update(object(), "latest", "false") == (
         "",
         {},
     )
@@ -448,9 +440,10 @@ def test_resolve_runner_release_for_update_skips_lookup_when_override_disabled(
 
 def test_resolve_runner_release_for_update_resolves_when_override_enabled(monkeypatch):
     calls = []
+    github = object()
 
-    def fake_resolve(version, github_token):
-        calls.append((version, github_token))
+    def fake_resolve(received_github, version):
+        calls.append((received_github, version))
         return h.GithubRunnerRelease(
             version="2.332.0",
             sha256_by_arch={"x64": "a" * 64, "arm64": "b" * 64},
@@ -458,11 +451,11 @@ def test_resolve_runner_release_for_update_resolves_when_override_enabled(monkey
 
     monkeypatch.setattr(m, "resolve_github_runner_release", fake_resolve)
 
-    assert m.resolve_runner_release_for_update("latest", "github-token", "true") == (
+    assert m.resolve_runner_release_for_update(github, "latest", "true") == (
         "2.332.0",
         {"x64": "a" * 64, "arm64": "b" * 64},
     )
-    assert calls == [("latest", "github-token")]
+    assert calls == [(github, "latest")]
 
 
 def test_wait_runner_by_name_retries_github_lookup_errors(monkeypatch):
@@ -942,6 +935,52 @@ def test_remove_vm_with_empty_id_only_searches_by_labels(monkeypatch):
     sdk = object()
     args = argparse.Namespace(id="", labels={"run": "1-1"})
 
-    asyncio.run(m.remove_vm(sdk, args, None))
+    asyncio.run(m.remove_vm(sdk, args))
 
     assert searches == [(sdk, args)]
+
+
+def test_main_remove_with_empty_id_does_not_require_github_token(monkeypatch):
+    searches = []
+    sdk = object()
+
+    async def fake_search(search_sdk, args):
+        searches.append((search_sdk, args))
+        return []
+
+    def fake_github_client_from_env():
+        raise AssertionError("github_client_from_env should not be called")
+
+    def fake_sdk(**kwargs):
+        assert "config_reader" in kwargs
+        return sdk
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "nebius_manage_vm.py",
+            "remove",
+            "--parent-id",
+            "parent-id",
+            "--id",
+            "",
+            "--github-repo-owner",
+            "owner",
+            "--github-repo",
+            "repo",
+            "--labels",
+            "run=1-1",
+        ],
+    )
+    monkeypatch.setattr(m, "SDK", fake_sdk)
+    monkeypatch.setattr(m, "Config", lambda: object())
+    monkeypatch.setattr(m, "github_client_from_env", fake_github_client_from_env)
+    monkeypatch.setattr(m, "search_vm_cleanup_candidates_by_labels", fake_search)
+
+    asyncio.run(m.main())
+
+    assert len(searches) == 1
+    assert searches[0][0] is sdk
+    assert searches[0][1].labels == {"run": "1-1"}

--- a/.github/scripts/nebius_populate_vms.py
+++ b/.github/scripts/nebius_populate_vms.py
@@ -5,6 +5,7 @@ import asyncio
 import argparse
 import datetime
 from grpc import StatusCode
+from github import Github
 from typing import List
 from .helpers import github_client
 from nebius.sdk import SDK

--- a/.github/scripts/nebius_populate_vms.py
+++ b/.github/scripts/nebius_populate_vms.py
@@ -4,9 +4,9 @@ import os
 import asyncio
 import argparse
 import datetime
-from github import Github
 from grpc import StatusCode
 from typing import List
+from .helpers import github_client
 from nebius.sdk import SDK
 from nebius.aio.cli_config import Config
 from nebius.api.nebius.compute.v1 import (
@@ -515,7 +515,7 @@ async def main():
         raise RuntimeError("GITHUB_TOKEN environment variable is not set")
 
     sdk = SDK(config_reader=Config())
-    github = Github(github_token)
+    github = github_client(github_token)
 
     if args.loop:
         start_time = time.time()

--- a/.github/scripts/nebius_runners_wait_times.py
+++ b/.github/scripts/nebius_runners_wait_times.py
@@ -4,12 +4,11 @@ import os
 import argparse
 import datetime
 import numpy as np
-from github import Github
 from tabulate import tabulate
 from collections import defaultdict
 from dateutil import parser as dateparser
 from dateutil.relativedelta import relativedelta
-from .helpers import setup_logger, get_jobs_raw, classify_runner
+from .helpers import setup_logger, github_client, get_jobs_raw, classify_runner
 
 logger = setup_logger()
 
@@ -98,7 +97,7 @@ def output_results(all_jobs: list[dict], summary, threshold: int):
     )
 
 
-def main(start, end, threshold):
+def main(start, end, threshold, github_token, repo):
     logger.info(f"Fetching workflow runs from {start} to {end}")
     all_jobs = []
     summary = defaultdict(lambda: {"total_wait": 0.0, "count": 0, "waits": []})
@@ -113,7 +112,7 @@ def main(start, end, threshold):
             continue
 
         try:
-            jobs = get_jobs_raw(GITHUB_TOKEN, repo.full_name, run.id)
+            jobs = get_jobs_raw(github_token, repo.full_name, run.id)
         except Exception as e:
             logger.warning(f"Failed to get jobs for run {run.id}: {e}")
             continue
@@ -203,13 +202,13 @@ if __name__ == "__main__":
     start = parse_datetime(args.since, now)
     end = parse_datetime(args.until, now)
 
-    GITHUB_TOKEN = args.token if args.token else os.getenv("GITHUB_TOKEN")
-    if not GITHUB_TOKEN:
+    github_token = args.token if args.token else os.getenv("GITHUB_TOKEN")
+    if not github_token:
         raise EnvironmentError(
             "GITHUB_TOKEN environment variable not set or passed as argument."
         )
 
-    g = Github(GITHUB_TOKEN)
+    g = github_client(github_token)
     repo = g.get_repo(f"{args.owner}/{args.repo}")
 
-    main(start, end, args.threshold)
+    main(start, end, args.threshold, github_token, repo)

--- a/.github/scripts/nebius_watch_runners.py
+++ b/.github/scripts/nebius_watch_runners.py
@@ -2,10 +2,10 @@
 import os
 import asyncio
 import argparse
-from github import Github
 from tabulate import tabulate
 from .helpers import (
     setup_logger,
+    github_client,
     get_jobs_raw,
     compact_workflow_name,
     compact_job_name,
@@ -65,7 +65,7 @@ async def main():
     service = InstanceServiceClient(sdk)
     operation_service = service.operation_service()
 
-    g = Github(token)
+    g = github_client(token)
     repo = g.get_repo(f"{args.owner}/{args.repo}")
 
     # Fetch self-hosted runners

--- a/.github/scripts/nightly_pr_check.py
+++ b/.github/scripts/nightly_pr_check.py
@@ -12,7 +12,6 @@ from typing import Any
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
-from github import Auth as GithubAuth, Github
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 from github.WorkflowRun import WorkflowRun as GithubWorkflowRun
@@ -21,6 +20,7 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from .helpers import (
     find_current_job_url,
     get_build_preset_from_workflow_name,
+    github_client,
     get_s3_report_uri,
     get_s3_report_url,
     get_s3_workflow_reports_path,
@@ -112,9 +112,8 @@ def load_event() -> dict[str, Any]:
 
 
 def get_github_context(
-    token: str, repository: str, event: dict[str, Any]
+    gh, repository: str, event: dict[str, Any]
 ) -> tuple[Repository, PullRequest]:
-    gh = Github(auth=GithubAuth.Token(token))
     repo = gh.get_repo(repository)
     pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
     return repo, pr
@@ -832,7 +831,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_context() -> tuple[
+def load_context(gh) -> tuple[
     str,
     str,
     Repository,
@@ -849,7 +848,7 @@ def load_context() -> tuple[
     token = os.environ["GITHUB_TOKEN"]
     repository = os.environ["GITHUB_REPOSITORY"]
     event = load_event()
-    repo, pr_object = get_github_context(token, repository, event)
+    repo, pr_object = get_github_context(gh, repository, event)
     pr = event["pull_request"]
     pr_number = int(pr["number"])
     head_ref = pr["head"]["ref"]
@@ -877,7 +876,7 @@ def load_context() -> tuple[
     )
 
 
-def cancel_mode() -> int:
+def cancel_mode(gh) -> int:
     (
         _token,
         _repository,
@@ -891,7 +890,7 @@ def cancel_mode() -> int:
         runs,
         marker,
         collector_url,
-    ) = load_context()
+    ) = load_context(gh)
 
     if not runs:
         logger.info("No nightly PR labels found; nothing to cancel")
@@ -933,8 +932,9 @@ def main() -> int:
     signal.signal(signal.SIGTERM, request_cancellation)
 
     args = parse_args()
+    gh = github_client(os.environ["GITHUB_TOKEN"])
     if args.mode == "cancel":
-        return cancel_mode()
+        return cancel_mode(gh)
 
     (
         _token,
@@ -949,7 +949,7 @@ def main() -> int:
         runs,
         marker,
         collector_url,
-    ) = load_context()
+    ) = load_context(gh)
 
     if not runs:
         logger.info("No nightly PR labels found; nothing to dispatch")

--- a/.github/scripts/tests/finalize_workload_comments.py
+++ b/.github/scripts/tests/finalize_workload_comments.py
@@ -5,16 +5,13 @@ import argparse
 import json
 import os
 
-from github import Auth as GithubAuth, Github
 from github.PullRequest import PullRequest
 
-from ..helpers import setup_logger
+from ..helpers import github_client, setup_logger
 from . import generate_summary as gs
 
 
-def get_pull_request() -> PullRequest:
-    gh = Github(auth=GithubAuth.Token(os.environ["GITHUB_TOKEN"]))
-
+def get_pull_request(gh) -> PullRequest:
     with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
         event = json.load(fp)
 
@@ -58,7 +55,7 @@ def main() -> None:
     ):
         return
 
-    pr = get_pull_request()
+    pr = get_pull_request(github_client(os.environ["GITHUB_TOKEN"]))
     run_number = int(os.environ.get("GITHUB_RUN_NUMBER", "0"))
 
     for build_preset in iter_build_presets(args.matrix_include):

--- a/.github/scripts/tests/generate_summary.py
+++ b/.github/scripts/tests/generate_summary.py
@@ -21,7 +21,7 @@ from xml.etree import ElementTree as ET
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
-from ..helpers import setup_logger
+from ..helpers import github_client, setup_logger
 from .junit_utils import get_property_value, iter_xml_files
 
 LOGGER = logging.getLogger(__name__)
@@ -1347,10 +1347,9 @@ def main() -> None:
     ):
         return
 
-    from github import Auth as GithubAuth, Github
     from github.PullRequest import PullRequest
 
-    gh = Github(auth=GithubAuth.Token(os.environ["GITHUB_TOKEN"]))
+    gh = github_client(os.environ["GITHUB_TOKEN"])
 
     with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
         event = json.load(fp)

--- a/.github/scripts/tests/workload_comment.py
+++ b/.github/scripts/tests/workload_comment.py
@@ -5,16 +5,13 @@ import argparse
 import json
 import os
 
-from github import Auth as GithubAuth, Github
 from github.PullRequest import PullRequest
 
-from ..helpers import find_current_job_url, setup_logger
+from ..helpers import find_current_job_url, github_client, setup_logger
 from . import generate_summary as gs
 
 
-def get_pull_request() -> PullRequest:
-    gh = Github(auth=GithubAuth.Token(os.environ["GITHUB_TOKEN"]))
-
+def get_pull_request(gh) -> PullRequest:
     with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
         event = json.load(fp)
 
@@ -79,7 +76,7 @@ def main() -> None:
     ):
         return
 
-    pr = get_pull_request()
+    pr = get_pull_request(github_client(os.environ["GITHUB_TOKEN"]))
     run_number = int(os.environ.get("GITHUB_RUN_NUMBER", "0"))
 
     if args.command == "init":

--- a/.github/scripts/workflow_artifact_download.py
+++ b/.github/scripts/workflow_artifact_download.py
@@ -2,14 +2,13 @@ import os
 import requests
 import zipfile
 import io
-from github import Github
 from typing import List, Optional
 import argparse
 
 try:
-    from .helpers import setup_logger
+    from .helpers import github_client, setup_logger
 except ImportError:
-    from helpers import setup_logger
+    from helpers import github_client, setup_logger
 
 logger = setup_logger(name=__name__)
 
@@ -79,7 +78,7 @@ def main(
     files_to_extract: Optional[List[str]],
     github_output: str,
 ) -> None:
-    g = Github(github_token)
+    g = github_client(github_token)
     repo = g.get_repo(github_repository)
     if workflow_run_id != 0:
         workflow_runs = [repo.get_workflow_run(workflow_run_id)]


### PR DESCRIPTION
Refactoring includes trying to init GH client once, at script start and passing it down. It solves problem where you can't really tell what is needed for this specific script to work.
