### PR TITLE
filestore: TEndpointManager::Drain() shouldn't crash for non-started TEndpointManager

### DIFF
--- a/cloud/filestore/libs/endpoint/endpoint_manager.cpp
+++ b/cloud/filestore/libs/endpoint/endpoint_manager.cpp
@@ -103,6 +103,7 @@ private:
     const ui32 SocketAccessMode;
 
     TExecutorPtr Executor = TExecutor::Create("SVC");
+    bool Started = false;
     TLog Log;
 
     // Fields may only be accessed from the Executor thread
@@ -131,6 +132,7 @@ public:
     void Start() override
     {
         Executor->Start();
+        Started = true;
     }
 
     void Stop() override
@@ -140,7 +142,11 @@ public:
 
     void Drain() override
     {
-        Executor->Execute([this]() { return DoDrain(); }).GetValueSync();
+        if (Started) {
+            Executor->Execute([this]() {
+                return DoDrain();
+            }).GetValueSync();
+        }
     }
 
 #define FILESTORE_IMPLEMENT_METHOD(name, ...)                                  \
@@ -149,6 +155,7 @@ public:                                                                        \
         TCallContextPtr callContext,                                           \
         std::shared_ptr<NProto::T##name##Request> request) override            \
     {                                                                          \
+        Y_ABORT_UNLESS(Started);                                               \
         Y_UNUSED(callContext);                                                 \
         return Executor->Execute([this, request = std::move(request)] {        \
             return Do##name(*request);                                         \

--- a/cloud/filestore/libs/endpoint/endpoint_manager_ut.cpp
+++ b/cloud/filestore/libs/endpoint/endpoint_manager_ut.cpp
@@ -763,6 +763,26 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
 
         UNIT_ASSERT_VALUES_EQUAL(0, endpoint->SuspendCalls.load());
     }
+
+    Y_UNIT_TEST(DrainShouldBeNoOpIfNotStarted)
+    {
+        const TString dirPath = "./" + CreateGuidAsString();
+        auto endpointStorage = CreateFileEndpointStorage(dirPath);
+        TTempDir endpointDir(dirPath);
+        auto listener = std::make_shared<TTestEndpointListener>();
+        listener->CreateEndpointHandler =
+            [&] (const NProto::TEndpointConfig&) {
+                return nullptr;
+            };
+
+        auto service = CreateEndpointManager(
+            CreateLoggingService("console"),
+            endpointStorage,
+            listener,
+            MODE0660);
+
+        service->Drain();
+    }
 }
 
 }   // namespace NCloud::NFileStore::NServer


### PR DESCRIPTION
### Notes
Currently `TEndpointManager::Drain()` tries to access `TEndpointManager::Executor::Thread::Dispatcher` which is `nullptr` before `Start()` is called. At the same time we call `Stop()` whenever `Init()` or `Start()` fail and sometimes that means that `TEndpointManager` is created but not started yet: https://github.com/ydb-platform/nbs/blob/da706bc3ae9fe45768abc0d3902ca8a2c9a16ce4/cloud/storage/core/libs/daemon/app.h#L40

The cleanest way to fix this seems to actually turn `Drain()` into a no-op if `TEndpointManager` is not started yet.

### Issue
none
