### PR TITLE
issue-5895: temporarily disabled fastshard server ut under msan

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/server/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ya.make
@@ -27,7 +27,8 @@ PEERDIR(
 
 END()
 
-IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+# TODO(#5895): fix silk bootstrap/shutdown under msan
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB AND SANITIZER_TYPE != "memory")
     RECURSE_FOR_TESTS(
         ut
     )


### PR DESCRIPTION
### Notes
There's a bug (presumably in `contrib/libs/silk`) because of which seemingly benign uninitialized memory accesses sometimes happen upon shutdown. Temporarily disabling the affected unit test suite under `msan`. 

### Issue
https://github.com/ydb-platform/nbs/issues/5895