### PR TITLE
issue-1751: [Filestore] Resolve a data race in WriteBackCache when WriteData request may be evicted while TReadResponseBuilder::AugmentResponseWithCachedData is running

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.cpp
@@ -193,8 +193,10 @@ void TNodeCache::VisitUnflushedRequests(
     }
 }
 
-TCachedData
-TNodeCache::GetCachedData(ui64 offset, ui64 byteCount, ui64 pinId) const
+TCachedData TNodeCache::GetCachedData(
+    ui64 offset,
+    ui64 byteCount,
+    ui64 maxEvictableSequenceId) const
 {
     if (CachedData.empty()) {
         return {};
@@ -213,18 +215,21 @@ TNodeCache::GetCachedData(ui64 offset, ui64 byteCount, ui64 pinId) const
     CachedData.VisitOverlapping(
         offset,
         offset + byteCount,
-        [&result, offset, end = offset + byteCount, pinId](auto it)
+        [&result, offset, end = offset + byteCount, maxEvictableSequenceId](
+            auto it)
         {
             const ui64 partOffset = Max(offset, it->second.Begin);
             const ui64 partByteCount = Min(end, it->second.End) - partOffset;
 
             TCachedWriteDataRequest* request = it->second.Value;
 
-            // Flushed requests with SequenceId > PinId are protected from
-            // eviction. Requests with SequenceId <= PinId may be evicted at
-            // any moment and data pointer may become dangling - these parts
-            // should be served from backend storage instead of cache.
-            if (request->GetSequenceId() > pinId) {
+            // Requests with SequenceId > maxEvictableSequenceId are pinned and
+            // are safe to be used.
+            // Requests with SequenceId <= maxEvictableSequenceId may be evicted
+            // at any moment and data pointers may become dangling - these parts
+            // should be taken from ReadData response from the backend storage
+            // instead of cache.
+            if (request->GetSequenceId() > maxEvictableSequenceId) {
                 TStringBuf data = request->GetBuffer(partOffset, partByteCount);
                 result.Parts.push_back({partOffset - offset, data});
             }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.cpp
@@ -193,7 +193,8 @@ void TNodeCache::VisitUnflushedRequests(
     }
 }
 
-TCachedData TNodeCache::GetCachedData(ui64 offset, ui64 byteCount) const
+TCachedData
+TNodeCache::GetCachedData(ui64 offset, ui64 byteCount, ui64 pinId) const
 {
     if (CachedData.empty()) {
         return {};
@@ -202,18 +203,31 @@ TCachedData TNodeCache::GetCachedData(ui64 offset, ui64 byteCount) const
     const ui64 end = CachedData.rbegin()->second.End;
 
     TCachedData result;
+
+    // ReadDataByteCount is intentionally computed from the maximal cached write
+    // end offset, not only from the parts visible under this read pin.
+    // This value is only a response-size hint: writes can only extend the node
+    // size, so the maximal observed written offset is safe to expose.
     result.ReadDataByteCount = end > offset ? Min(byteCount, end - offset) : 0;
 
     CachedData.VisitOverlapping(
         offset,
         offset + byteCount,
-        [&result, offset, end = offset + byteCount](auto it)
+        [&result, offset, end = offset + byteCount, pinId](auto it)
         {
             const ui64 partOffset = Max(offset, it->second.Begin);
             const ui64 partByteCount = Min(end, it->second.End) - partOffset;
+
             TCachedWriteDataRequest* request = it->second.Value;
-            TStringBuf data = request->GetBuffer(partOffset, partByteCount);
-            result.Parts.push_back({partOffset - offset, data});
+
+            // Flushed requests with SequenceId > PinId are protected from
+            // eviction. Requests with SequenceId <= PinId may be evicted at
+            // any moment and data pointer may become dangling - these parts
+            // should be served from backend storage instead of cache.
+            if (request->GetSequenceId() > pinId) {
+                TStringBuf data = request->GetBuffer(partOffset, partByteCount);
+                result.Parts.push_back({partOffset - offset, data});
+            }
         });
 
     return result;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
@@ -87,7 +87,11 @@ public:
         TCachedWriteDataRequestVisitor visitor,
         ui64 maxSequenceId) const;
 
-    TCachedData GetCachedData(ui64 offset, ui64 byteCount, ui64 pinId) const;
+    TCachedData GetCachedData(
+        ui64 offset,
+        ui64 byteCount,
+        ui64 maxEvictableSequenceId) const;
+
     ui64 GetMaxWrittenOffset() const;
     void ResetMaxWrittenOffset();
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
@@ -87,7 +87,7 @@ public:
         TCachedWriteDataRequestVisitor visitor,
         ui64 maxSequenceId) const;
 
-    TCachedData GetCachedData(ui64 offset, ui64 byteCount) const;
+    TCachedData GetCachedData(ui64 offset, ui64 byteCount, ui64 pinId) const;
     ui64 GetMaxWrittenOffset() const;
     void ResetMaxWrittenOffset();
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
@@ -138,9 +138,9 @@ struct TBootstrap
         return std::get<1>(std::move(res));
     }
 
-    TString GetCachedData(ui64 offset, ui64 byteCount) const
+    TString GetCachedData(ui64 offset, ui64 byteCount, ui64 pinId = 0) const
     {
-        auto cachedData = Cache.GetCachedData(offset, byteCount);
+        auto cachedData = Cache.GetCachedData(offset, byteCount, pinId);
 
         TStringBuilder out;
         for (const auto& part: cachedData.Parts) {
@@ -174,7 +174,8 @@ struct TBootstrap
 TVector<TTestCaseWriteDataEntryPart> CalculateDataPartsToRead(
     const TVector<TTestCaseWriteDataEntry>& testCaseEntries,
     ui64 offset,
-    ui64 byteCount)
+    ui64 byteCount,
+    ui64 pinId = 0)
 {
     Y_ABORT_UNLESS(testCaseEntries.size() < 255);
 
@@ -184,7 +185,7 @@ TVector<TTestCaseWriteDataEntryPart> CalculateDataPartsToRead(
         char c = static_cast<char>(i + 1);
         b.PushUnflushed(e.Offset, TString(e.Length, c));   // dummy buffer
     }
-    auto cachedData = b.Cache.GetCachedData(offset, byteCount);
+    auto cachedData = b.Cache.GetCachedData(offset, byteCount, pinId);
     TVector<TTestCaseWriteDataEntryPart> res;
     for (const auto& part: cachedData.Parts) {
         ui32 i = part.Data[0] - 1;
@@ -433,6 +434,22 @@ Y_UNIT_TEST_SUITE(TNodeCacheTest)
         }
 
         TestShouldCorrectlyCalculateDataPartsToReadWithReferenceImpl(entries);
+    }
+
+    Y_UNIT_TEST(ShouldHandlePinId)
+    {
+        TBootstrap b;
+
+        b.PushUnflushed(1, "abc");
+        b.PushUnflushed(3, "def");
+        b.PushUnflushed(5, "xyz");
+
+        b.Cache.MoveFrontUnflushedRequestToFlushed();
+
+        UNIT_ASSERT_VALUES_EQUAL("1:ab, 3:de, 5:xyz", b.GetCachedData(0, 9, 0));
+        UNIT_ASSERT_VALUES_EQUAL("3:de, 5:xyz", b.GetCachedData(0, 9, 1));
+        UNIT_ASSERT_VALUES_EQUAL("5:xyz", b.GetCachedData(0, 9, 2));
+        UNIT_ASSERT_VALUES_EQUAL("", b.GetCachedData(0, 9, 3));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
@@ -138,9 +138,13 @@ struct TBootstrap
         return std::get<1>(std::move(res));
     }
 
-    TString GetCachedData(ui64 offset, ui64 byteCount, ui64 pinId = 0) const
+    TString GetCachedData(
+        ui64 offset,
+        ui64 byteCount,
+        ui64 maxEvictableSequenceId = 0) const
     {
-        auto cachedData = Cache.GetCachedData(offset, byteCount, pinId);
+        auto cachedData =
+            Cache.GetCachedData(offset, byteCount, maxEvictableSequenceId);
 
         TStringBuilder out;
         for (const auto& part: cachedData.Parts) {
@@ -174,8 +178,7 @@ struct TBootstrap
 TVector<TTestCaseWriteDataEntryPart> CalculateDataPartsToRead(
     const TVector<TTestCaseWriteDataEntry>& testCaseEntries,
     ui64 offset,
-    ui64 byteCount,
-    ui64 pinId = 0)
+    ui64 byteCount)
 {
     Y_ABORT_UNLESS(testCaseEntries.size() < 255);
 
@@ -185,7 +188,10 @@ TVector<TTestCaseWriteDataEntryPart> CalculateDataPartsToRead(
         char c = static_cast<char>(i + 1);
         b.PushUnflushed(e.Offset, TString(e.Length, c));   // dummy buffer
     }
-    auto cachedData = b.Cache.GetCachedData(offset, byteCount, pinId);
+    auto cachedData = b.Cache.GetCachedData(
+        offset,
+        byteCount,
+        /* maxEvictableSequenceId = */ 0);
     TVector<TTestCaseWriteDataEntryPart> res;
     for (const auto& part: cachedData.Parts) {
         ui32 i = part.Data[0] - 1;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state_holder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state_holder.cpp
@@ -81,7 +81,7 @@ void TNodeStateHolder::DeleteNodeState(ui64 nodeId)
     Stats->IncrementDeletedNodeCount();
 }
 
-ui64 TNodeStateHolder::Pin()
+TNodeStatePin TNodeStateHolder::Pin()
 {
     const ui64 pinId = ++SequenceId;
     Pins[pinId] = Timer->Now();
@@ -89,7 +89,7 @@ ui64 TNodeStateHolder::Pin()
     return pinId;
 }
 
-void TNodeStateHolder::Unpin(ui64 pinId)
+void TNodeStateHolder::Unpin(TNodeStatePin pinId)
 {
     auto pinIt = Pins.find(pinId);
     Y_ABORT_UNLESS(pinIt != Pins.end(), "Pin %lu is not found", pinId);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state_holder.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state_holder.h
@@ -12,6 +12,10 @@ namespace NCloud::NFileStore::NFuse::NWriteBackCache {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TNodeStatePin = ui64;
+
+////////////////////////////////////////////////////////////////////////////////
+
 // TNodeStateHolder owns in-memory node state objects and supports a simple
 // "logical delete" mechanism combined with pinning.
 // Not thread-safe: the caller is responsible for synchronization.
@@ -70,8 +74,8 @@ public:
     // than DeletionSequenceId.
     void DeleteNodeState(ui64 nodeId);
 
-    [[nodiscard]] ui64 Pin();
-    void Unpin(ui64 pinId);
+    [[nodiscard]] TNodeStatePin Pin();
+    void Unpin(TNodeStatePin pinId);
 
     void UpdateStats() const;
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
@@ -343,9 +343,9 @@ TReadResponseBuilder::TReadResponseBuilder(
 std::optional<NProto::TReadDataResponse>
 TReadResponseBuilder::TryFullyServeFromCache(
     TWriteBackCacheState& state,
-    TWriteBackCacheState::TPin pinId) const
+    TNodeCachedDataPin pin) const
 {
-    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pinId);
+    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pin);
     Validate(cachedData, Length);
 
     ui64 contiguousCachedDataByteCount = 0;
@@ -368,9 +368,9 @@ TReadResponseBuilder::TryFullyServeFromCache(
 bool TReadResponseBuilder::AugmentResponseWithCachedData(
     NProto::TReadDataResponse& response,
     TWriteBackCacheState& state,
-    TWriteBackCacheState::TPin pinId) const
+    TNodeCachedDataPin pin) const
 {
-    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pinId);
+    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pin);
     Validate(cachedData, Length);
 
     AugmentResponseWithCachedData(response, cachedData);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.cpp
@@ -341,9 +341,11 @@ TReadResponseBuilder::TReadResponseBuilder(
 }
 
 std::optional<NProto::TReadDataResponse>
-TReadResponseBuilder::TryFullyServeFromCache(TWriteBackCacheState& state) const
+TReadResponseBuilder::TryFullyServeFromCache(
+    TWriteBackCacheState& state,
+    TWriteBackCacheState::TPin pinId) const
 {
-    auto cachedData = state.GetCachedData(NodeId, Offset, Length);
+    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pinId);
     Validate(cachedData, Length);
 
     ui64 contiguousCachedDataByteCount = 0;
@@ -365,9 +367,10 @@ TReadResponseBuilder::TryFullyServeFromCache(TWriteBackCacheState& state) const
 
 bool TReadResponseBuilder::AugmentResponseWithCachedData(
     NProto::TReadDataResponse& response,
-    TWriteBackCacheState& state) const
+    TWriteBackCacheState& state,
+    TWriteBackCacheState::TPin pinId) const
 {
-    auto cachedData = state.GetCachedData(NodeId, Offset, Length);
+    auto cachedData = state.GetCachedData(NodeId, Offset, Length, pinId);
     Validate(cachedData, Length);
 
     AugmentResponseWithCachedData(response, cachedData);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.h
@@ -33,14 +33,16 @@ public:
     // If the entire requested byte range is available in the cache, returns
     // a populated TReadDataResponse or std::nullopt otherwise
     std::optional<NProto::TReadDataResponse> TryFullyServeFromCache(
-        TWriteBackCacheState& state) const;
+        TWriteBackCacheState& state,
+        TWriteBackCacheState::TPin pinId) const;
 
     // Apply cached data on top of the response returned from backend.
     // Returns true if the response was augmented with cached data.
     // Returns false if no cached data was applied to the response.
     bool AugmentResponseWithCachedData(
         NProto::TReadDataResponse& response,
-        TWriteBackCacheState& state) const;
+        TWriteBackCacheState& state,
+        TWriteBackCacheState::TPin pinId) const;
 
 private:
     void AugmentResponseWithCachedData(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder.h
@@ -34,7 +34,7 @@ public:
     // a populated TReadDataResponse or std::nullopt otherwise
     std::optional<NProto::TReadDataResponse> TryFullyServeFromCache(
         TWriteBackCacheState& state,
-        TWriteBackCacheState::TPin pinId) const;
+        TNodeCachedDataPin pin) const;
 
     // Apply cached data on top of the response returned from backend.
     // Returns true if the response was augmented with cached data.
@@ -42,7 +42,7 @@ public:
     bool AugmentResponseWithCachedData(
         NProto::TReadDataResponse& response,
         TWriteBackCacheState& state,
-        TWriteBackCacheState::TPin pinId) const;
+        TNodeCachedDataPin pin) const;
 
 private:
     void AugmentResponseWithCachedData(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
@@ -85,7 +85,7 @@ public:
         }
 
         TReadResponseBuilder builder(*request);
-        builder.AugmentResponseWithCachedData(response, State);
+        builder.AugmentResponseWithCachedData(response, State, 0);
 
         return result.substr(0, response.GetLength());
     }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/read_response_builder_ut.cpp
@@ -85,7 +85,7 @@ public:
         }
 
         TReadResponseBuilder builder(*request);
-        builder.AugmentResponseWithCachedData(response, State, 0);
+        builder.AugmentResponseWithCachedData(response, State, /* pin = */ {});
 
         return result.substr(0, response.GetLength());
     }

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -223,15 +223,14 @@ public:
             return MakeFuture(std::move(response));
         }
 
-        // Prevent cached data parts from being evicted from storage until
+        // Prevent unflushed data parts from being evicted from storage until
         // the response is completed
-        const auto pinId = State.PinCachedData(request->GetNodeId());
+        const auto pin = State.PinCachedData(request->GetNodeId());
 
         TReadResponseBuilder responseBuilder(*request);
-        if (auto response =
-                responseBuilder.TryFullyServeFromCache(State, pinId))
+        if (auto response = responseBuilder.TryFullyServeFromCache(State, pin))
         {
-            State.UnpinCachedData(request->GetNodeId(), pinId);
+            State.UnpinCachedData(request->GetNodeId(), pin);
             InternalStats->AddReadDataStats(
                 EReadDataRequestCacheStatus::FullHit);
             return MakeFuture(std::move(*response));
@@ -239,7 +238,7 @@ public:
 
         auto callback = [ptr = weak_from_this(),
                          responseBuilder = std::move(responseBuilder),
-                         pinId](TFuture<NProto::TReadDataResponse> future)
+                         pin](TFuture<NProto::TReadDataResponse> future)
         {
             auto response = UnsafeExtractValue(future);
 
@@ -249,7 +248,7 @@ public:
                         responseBuilder.AugmentResponseWithCachedData(
                             response,
                             self->State,
-                            pinId);
+                            pin);
 
                     if (cachedDataApplied) {
                         self->InternalStats->AddReadDataStats(
@@ -259,7 +258,7 @@ public:
                             EReadDataRequestCacheStatus::Miss);
                     }
                 }
-                self->State.UnpinCachedData(responseBuilder.GetNodeId(), pinId);
+                self->State.UnpinCachedData(responseBuilder.GetNodeId(), pin);
             }
             return response;
         };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp
@@ -228,7 +228,9 @@ public:
         const auto pinId = State.PinCachedData(request->GetNodeId());
 
         TReadResponseBuilder responseBuilder(*request);
-        if (auto response = responseBuilder.TryFullyServeFromCache(State)) {
+        if (auto response =
+                responseBuilder.TryFullyServeFromCache(State, pinId))
+        {
             State.UnpinCachedData(request->GetNodeId(), pinId);
             InternalStats->AddReadDataStats(
                 EReadDataRequestCacheStatus::FullHit);
@@ -246,7 +248,8 @@ public:
                     bool cachedDataApplied =
                         responseBuilder.AugmentResponseWithCachedData(
                             response,
-                            self->State);
+                            self->State,
+                            pinId);
 
                     if (cachedDataApplied) {
                         self->InternalStats->AddReadDataStats(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -177,7 +177,8 @@ void TWriteBackCacheState::TriggerPeriodicFlushAll()
 TCachedData TWriteBackCacheState::GetCachedData(
     ui64 nodeId,
     ui64 offset,
-    ui64 byteCount) const
+    ui64 byteCount,
+    TPin pinId) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
@@ -186,7 +187,7 @@ TCachedData TWriteBackCacheState::GetCachedData(
         return {};
     }
 
-    return nodeState->Cache.GetCachedData(offset, byteCount);
+    return nodeState->Cache.GetCachedData(offset, byteCount, pinId);
 }
 
 ui64 TWriteBackCacheState::GetMaxWrittenOffset(ui64 nodeId) const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -178,7 +178,7 @@ TCachedData TWriteBackCacheState::GetCachedData(
     ui64 nodeId,
     ui64 offset,
     ui64 byteCount,
-    TPin pinId) const
+    TNodeCachedDataPin pin) const
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
@@ -187,7 +187,10 @@ TCachedData TWriteBackCacheState::GetCachedData(
         return {};
     }
 
-    return nodeState->Cache.GetCachedData(offset, byteCount, pinId);
+    return nodeState->Cache.GetCachedData(
+        offset,
+        byteCount,
+        pin.MaxEvictableSequenceId);
 }
 
 ui64 TWriteBackCacheState::GetMaxWrittenOffset(ui64 nodeId) const
@@ -214,7 +217,7 @@ void TWriteBackCacheState::ResetMaxWrittenOffset(ui64 nodeId)
     nodeState.Cache.ResetMaxWrittenOffset();
 }
 
-TWriteBackCacheState::TPin TWriteBackCacheState::PinCachedData(ui64 nodeId)
+TNodeCachedDataPin TWriteBackCacheState::PinCachedData(ui64 nodeId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
@@ -230,21 +233,21 @@ TWriteBackCacheState::TPin TWriteBackCacheState::PinCachedData(ui64 nodeId)
 
     nodeState.CachedDataPins.insert(allowedToEvictMaxSequenceId);
 
-    return allowedToEvictMaxSequenceId;
+    return {.MaxEvictableSequenceId = allowedToEvictMaxSequenceId};
 }
 
-void TWriteBackCacheState::UnpinCachedData(ui64 nodeId, TPin pinId)
+void TWriteBackCacheState::UnpinCachedData(ui64 nodeId, TNodeCachedDataPin pin)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
     auto* nodeState = Nodes.GetNodeState(nodeId, /* includeDeleted= */ false);
     Y_ABORT_UNLESS(nodeState, "Node %lu not found", nodeId);
 
-    auto it = nodeState->CachedDataPins.find(pinId);
+    auto it = nodeState->CachedDataPins.find(pin.MaxEvictableSequenceId);
     Y_ABORT_UNLESS(
         it != nodeState->CachedDataPins.end(),
         "Pin %lu not found for node %lu",
-        pinId,
+        pin.MaxEvictableSequenceId,
         nodeId);
 
     nodeState->CachedDataPins.erase(it);
@@ -252,14 +255,14 @@ void TWriteBackCacheState::UnpinCachedData(ui64 nodeId, TPin pinId)
     EvictUnpinnedFlushedEntries(nodeId, *nodeState);
 }
 
-TWriteBackCacheState::TPin TWriteBackCacheState::PinNodeStates()
+TNodeStatePin TWriteBackCacheState::PinNodeStates()
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 
     return Nodes.Pin();
 }
 
-void TWriteBackCacheState::UnpinNodeStates(TPin pinId)
+void TWriteBackCacheState::UnpinNodeStates(TNodeStatePin pinId)
 {
     auto guard = LockStateAndPostponeQueuedOperations();
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -113,8 +113,11 @@ public:
 
     void TriggerPeriodicFlushAll();
 
-    // Includes both flushed and unflushed data
-    TCachedData GetCachedData(ui64 nodeId, ui64 offset, ui64 byteCount) const;
+    // Includes both flushed and unflushed data.
+    // TCachedData::Parts is calculated over pinned data.
+    // TCachedData::ReadDataByteCount is calculated over all data.
+    TCachedData
+    GetCachedData(ui64 nodeId, ui64 offset, ui64 byteCount, TPin pinId) const;
 
     // Used to adjust node size according to cached data
     ui64 GetMaxWrittenOffset(ui64 nodeId) const;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -40,6 +40,13 @@ enum class EFlushRetryStatus
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TNodeCachedDataPin
+{
+    const ui64 MaxEvictableSequenceId;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 // The class is thread safe
 class TWriteBackCacheState
 {
@@ -75,7 +82,6 @@ private:
 
 public:
     using TEntryVisitor = TFunctionRef<bool(const TCachedWriteDataRequest*)>;
-    using TPin = ui64;
 
     TWriteBackCacheState(
         IQueuedOperationsProcessor& processor,
@@ -116,8 +122,11 @@ public:
     // Includes both flushed and unflushed data.
     // TCachedData::Parts is calculated over pinned data.
     // TCachedData::ReadDataByteCount is calculated over all data.
-    TCachedData
-    GetCachedData(ui64 nodeId, ui64 offset, ui64 byteCount, TPin pinId) const;
+    TCachedData GetCachedData(
+        ui64 nodeId,
+        ui64 offset,
+        ui64 byteCount,
+        TNodeCachedDataPin pin) const;
 
     // Used to adjust node size according to cached data
     ui64 GetMaxWrittenOffset(ui64 nodeId) const;
@@ -127,13 +136,13 @@ public:
     void ResetMaxWrittenOffset(ui64 nodeId);
 
     // Prevent WriteData requests from being evicted from cache after flush
-    TPin PinCachedData(ui64 nodeId);
-    void UnpinCachedData(ui64 nodeId, TPin pinId);
+    TNodeCachedDataPin PinCachedData(ui64 nodeId);
+    void UnpinCachedData(ui64 nodeId, TNodeCachedDataPin pin);
 
     // Keep NodeStates alive
     // Used to prevent data race and return correct node size
-    TPin PinNodeStates();
-    void UnpinNodeStates(TPin pinId);
+    TNodeStatePin PinNodeStates();
+    void UnpinNodeStates(TNodeStatePin pinId);
 
     // Visit unflushed cached requests in the increasing order of SequenceId
     void VisitUnflushedRequests(

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -128,17 +128,20 @@ struct TBootstrap
 
     TString VisitCachedData(ui64 nodeId) const
     {
-        return VisitCachedData(nodeId, 0, Max<ui64>(), 0);
+        return VisitCachedData(nodeId, 0, Max<ui64>(), {});
     }
 
     TString VisitCachedData(
         ui64 nodeId,
         ui64 offset,
         ui64 byteCount,
-        ui64 pinId = 0) const
+        ui64 maxEvictableSequenceId = 0) const
     {
+        auto pin = TNodeCachedDataPin{
+            .MaxEvictableSequenceId = maxEvictableSequenceId};
+
         auto cachedData =
-            State->GetCachedData(nodeId, offset, byteCount, pinId);
+            State->GetCachedData(nodeId, offset, byteCount, pin);
 
         TStringBuilder out;
         for (const auto& part: cachedData.Parts) {
@@ -235,7 +238,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
 
         // pin0 references to SequenceId = 0
         auto pin0 = b.State->PinCachedData(1);
-        UNIT_ASSERT_VALUES_EQUAL(0, pin0);
+        UNIT_ASSERT_VALUES_EQUAL(0, pin0.MaxEvictableSequenceId);
 
         UNIT_ASSERT(b.Add(1, 101, 0, "0").GetValue());  // SequenceId = 1
         b.State->AddFlushRequest(1);    // SequenceId = 2
@@ -245,14 +248,14 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
         // pin1, pin2 reference to the same SequenceId = 1
         auto pin1 = b.State->PinCachedData(1);
         auto pin2 = b.State->PinCachedData(1);
-        UNIT_ASSERT_VALUES_EQUAL(1, pin1);
-        UNIT_ASSERT_VALUES_EQUAL(1, pin2);
+        UNIT_ASSERT_VALUES_EQUAL(1, pin1.MaxEvictableSequenceId);
+        UNIT_ASSERT_VALUES_EQUAL(1, pin2.MaxEvictableSequenceId);
 
         // pin3 references to the same SequenceId = 1 because no requests were
         // flushed
         UNIT_ASSERT(b.Add(1, 101, 1, "a").GetValue());  // SequenceId = 3
         auto pin3 = b.State->PinCachedData(1);
-        UNIT_ASSERT_VALUES_EQUAL(1, pin3);
+        UNIT_ASSERT_VALUES_EQUAL(1, pin3.MaxEvictableSequenceId);
 
         // Evict data pinned by pin0
         UNIT_ASSERT_VALUES_EQUAL("0:0, 1:a", b.VisitCachedData(1));
@@ -269,7 +272,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
 
         // pin4 references to SequenceId = 4
         auto pin4 = b.State->PinCachedData(1);
-        UNIT_ASSERT_VALUES_EQUAL(4, pin4);
+        UNIT_ASSERT_VALUES_EQUAL(4, pin4.MaxEvictableSequenceId);
         UNIT_ASSERT(b.Add(1, 104, 4, "d").GetValue());  // SequenceId = 6
 
         b.State->UnpinCachedData(1, pin2);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -128,12 +128,17 @@ struct TBootstrap
 
     TString VisitCachedData(ui64 nodeId) const
     {
-        return VisitCachedData(nodeId, 0, Max<ui64>());
+        return VisitCachedData(nodeId, 0, Max<ui64>(), 0);
     }
 
-    TString VisitCachedData(ui64 nodeId, ui64 offset, ui64 byteCount) const
+    TString VisitCachedData(
+        ui64 nodeId,
+        ui64 offset,
+        ui64 byteCount,
+        ui64 pinId = 0) const
     {
-        auto cachedData = State->GetCachedData(nodeId, offset, byteCount);
+        auto cachedData =
+            State->GetCachedData(nodeId, offset, byteCount, pinId);
 
         TStringBuilder out;
         for (const auto& part: cachedData.Parts) {
@@ -1303,6 +1308,18 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
 
         UNIT_ASSERT(w2.HasValue());
         UNIT_ASSERT_VALUES_EQUAL(E_FS_NOSPC, w2.GetValue().GetCode());
+    }
+
+    Y_UNIT_TEST(ShouldHandlePinId)
+    {
+        TBootstrap b;
+
+        UNIT_ASSERT(b.Add(1, 101, 1, "abc").GetValue());
+        UNIT_ASSERT(b.Add(1, 101, 2, "def").GetValue());
+
+        UNIT_ASSERT_VALUES_EQUAL("1:a, 2:def", b.VisitCachedData(1, 1, 4, 0));
+        UNIT_ASSERT_VALUES_EQUAL("2:def", b.VisitCachedData(1, 1, 4, 1));
+        UNIT_ASSERT_VALUES_EQUAL("", b.VisitCachedData(1, 1, 4, 2));
     }
 }
 

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2566,6 +2566,68 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
 
         writerThread2.join();
     }
+
+    Y_UNIT_TEST(UseOnlyPinnedDataForReadData)
+    {
+        // ReadData acquires pin that prevents unflushed requests from being
+        // evicted from cache. But this pin doesn’t affect already flushed
+        // requests that are held by another pin. If that pin is released while
+        // ReadData is in TReadResponseBuilder::AugmentResponseWithCachedData,
+        // it may return garbage.
+
+        TBootstrap b;
+
+        // Writing to a log consumes a lot of CPU and significantly decreases
+        // reproduction probability
+        b.Log.CloseLog();
+
+        // Manually control ReadData completion
+        auto promise = NewPromise<NProto::TReadDataResponse>();
+
+        b.Session->ReadDataHandler = [&](auto, auto request)
+        {
+            if (request->GetLength() == 10) {
+                return promise.GetFuture();
+            }
+
+            NProto::TReadDataResponse res;
+            res.SetBuffer("abc");
+            return MakeFuture(std::move(res));
+        };
+
+        std::atomic<bool> stopRequested = false;
+
+        std::thread writerThread(
+            [&]()
+            {
+                while (!stopRequested) {
+                    b.ReadFromCache(1, 0, 10);
+                    b.WriteToCacheSync(1, 0, "abc");
+                    b.FlushCache(1);
+
+                    NProto::TReadDataResponse res;
+                    res.SetBuffer("abc");
+                    promise.SetValue(std::move(res));
+                    promise = NewPromise<NProto::TReadDataResponse>();
+
+                    // WriteData request is evicted here and is replaced by
+                    // a new request in the same memory address
+                    b.WriteToCacheSync(2, 0, "def");
+                    b.FlushCache(2);
+                }
+            });
+
+        Y_DEFER
+        {
+            stopRequested = true;
+            writerThread.join();
+        };
+
+        for (int attempt = 0; attempt < 1000000; attempt++) {
+            auto readResult = b.ReadFromCache(1, 0, 3).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL("abc", readResult.GetBuffer());
+        }
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2623,7 +2623,11 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
             writerThread.join();
         };
 
-        for (int attempt = 0; attempt < 1000000; attempt++) {
+        auto deadline = TInstant::Now() + TDuration::Seconds(5);
+        auto remainingIterations = 1000000;
+
+        while (remainingIterations > 0 && TInstant::Now() < deadline) {
+            remainingIterations--;
             auto readResult = b.ReadFromCache(1, 0, 3).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL("abc", readResult.GetBuffer());
         }


### PR DESCRIPTION
### Notes
ReadData acquires pin that prevents unflushed requests from being evicted from cache. But this pin doesn’t affect already flushed requests that are held by another pin. If that pin is released while ReadData is in TReadResponseBuilder::AugmentResponseWithCachedData, it may return garbage.

Proposed solution: `TWriteBachCacheState::GetCachedData` takes a parameter PinId and filter out flushed data that are not held by this pin.

Note: sanitizers didn't find it because the pointer was valid (it pointed into a memory-mapped file).

### Issue
https://github.com/ydb-platform/nbs/issues/1751
