### PR TITLE
[Filestore] Narrow cachebypass overlap, add metrics 

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_readdata.cpp
@@ -957,6 +957,9 @@ void TReadDataActor::ReplyTwoStageAndDie(const TActorContext& ctx)
             zeroInterval.End - zeroInterval.Start);
     }
 
+    // The actual file size may already be bigger than the returned one (see
+    // TDescribeDataResponse::FileSize), it can only be used to clamp the read
+    // range.
     const auto end = Min(DescribeResponse.GetFileSize(), OriginByteRange.End());
     if (end <= OriginByteRange.Offset) {
         BlockBuffer->clear();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -178,39 +178,42 @@ private:
         UpdateNodeAttrs(db, args);
     }
 
-    std::pair<ui64, ui64> CalculateCacheBypassRange(
+    TByteRange CalculateCacheBypassRange(
         const TTxIndexTablet::TAddBlob& args) const
     {
+        const ui32 blockSize = Tablet.GetBlockSize();
         const auto& writeRange = args.WriteRanges.front();
+        const auto node = args.Nodes.find(writeRange.NodeId);
 
         // On CommitIdOverflow no data is written, but the tablet is about to
-        // be stopped, so no assumptions are made and all reads for the node
+        // be stopped; a missing node means that the old file size is unknown.
+        // In both cases no assumptions are made and all reads for the node
         // are bypassed.
-        if (args.CommitId == InvalidCommitId) {
-            return {0, Max<ui64>()};
+        if (args.CommitId == InvalidCommitId || node == args.Nodes.end()) {
+            return TByteRange::MaxEnd(0, blockSize);
         }
-
-        const ui64 blockSize = Tablet.GetBlockSize();
 
         ui64 begin = writeRange.MaxOffset;
         for (const auto& blob: args.MergedBlobs) {
-            begin = Min(begin, blob.Block.BlockIndex * blockSize);
+            begin = Min(
+                begin,
+                static_cast<ui64>(blob.Block.BlockIndex) * blockSize);
         }
         for (const auto& part: args.UnalignedDataParts) {
-            begin =
-                Min(begin, part.BlockIndex * blockSize + part.OffsetInBlock);
+            begin = Min(
+                begin,
+                static_cast<ui64>(part.BlockIndex) * blockSize +
+                    part.OffsetInBlock);
         }
 
-        auto node = args.Nodes.find(writeRange.NodeId);
-        if (node == args.Nodes.end()) {
-            return {0, Max<ui64>()};
+        const ui64 fileSize = node->Attrs.GetSize();
+        if (writeRange.MaxOffset > fileSize) {
+            // The write changes the file size, so cached file sizes become
+            // stale for all offsets starting from the old one.
+            return TByteRange::MaxEnd(Min(begin, fileSize), blockSize);
         }
 
-        if (writeRange.MaxOffset > node->Attrs.GetSize()) {
-            return {Min(begin, node->Attrs.GetSize()), Max<ui64>()};
-        }
-
-        return {begin, writeRange.MaxOffset};
+        return TByteRange(begin, writeRange.MaxOffset - begin, blockSize);
     }
 
     void Execute_AddBlob_WriteUnconfirmed(
@@ -235,12 +238,10 @@ private:
             !HasError(args.Error) || args.CommitIdOverflow,
             "Error: " << FormatError(args.Error));
 
-        const auto [bypassBegin, bypassEnd] = CalculateCacheBypassRange(args);
         Tablet.ActivateCacheReadBypass(
             args.WriteRanges.front().NodeId,
             args.CommitId,
-            bypassBegin,
-            bypassEnd);
+            CalculateCacheBypassRange(args));
 
         if (HasError(args.Error)) {
             return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -178,6 +178,41 @@ private:
         UpdateNodeAttrs(db, args);
     }
 
+    std::pair<ui64, ui64> CalculateCacheBypassRange(
+        const TTxIndexTablet::TAddBlob& args) const
+    {
+        const auto& writeRange = args.WriteRanges.front();
+
+        // On CommitIdOverflow no data is written, but the tablet is about to
+        // be stopped, so no assumptions are made and all reads for the node
+        // are bypassed.
+        if (args.CommitId == InvalidCommitId) {
+            return {0, Max<ui64>()};
+        }
+
+        const ui64 blockSize = Tablet.GetBlockSize();
+
+        ui64 begin = writeRange.MaxOffset;
+        for (const auto& blob: args.MergedBlobs) {
+            begin = Min(begin, blob.Block.BlockIndex * blockSize);
+        }
+        for (const auto& part: args.UnalignedDataParts) {
+            begin =
+                Min(begin, part.BlockIndex * blockSize + part.OffsetInBlock);
+        }
+
+        auto node = args.Nodes.find(writeRange.NodeId);
+        if (node == args.Nodes.end()) {
+            return {0, Max<ui64>()};
+        }
+
+        if (writeRange.MaxOffset > node->Attrs.GetSize()) {
+            return {Min(begin, node->Attrs.GetSize()), Max<ui64>()};
+        }
+
+        return {begin, writeRange.MaxOffset};
+    }
+
     void Execute_AddBlob_WriteUnconfirmed(
         const TActorContext& ctx,
         TIndexTabletDatabase& db,
@@ -200,9 +235,12 @@ private:
             !HasError(args.Error) || args.CommitIdOverflow,
             "Error: " << FormatError(args.Error));
 
+        const auto [bypassBegin, bypassEnd] = CalculateCacheBypassRange(args);
         Tablet.ActivateCacheReadBypass(
             args.WriteRanges.front().NodeId,
-            args.CommitId);
+            args.CommitId,
+            bypassBegin,
+            bypassEnd);
 
         if (HasError(args.Error)) {
             return;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_counters.cpp
@@ -451,6 +451,8 @@ void TIndexTabletActor::UpdateMetrics(
     Store(Metrics.UnwritableChannelCount, channelsStats.UnwritableChannelCount);
     Store(Metrics.ChannelsToMoveCount, channelsStats.ChannelsToMoveCount);
     Store(Metrics.ReadAheadCacheNodeCount, readAheadStats.NodeCount);
+    Store(Metrics.ReadNodeCacheBypassCount, GetReadNodeCacheBypassCount());
+    Store(Metrics.ReadAheadCacheBypassCount, GetReadAheadCacheBypassCount());
 
     Store(
         Metrics.InMemoryIndexStateNodesCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
@@ -20,10 +20,9 @@ void TCacheReadBypass::UpdateLogTag(TString logTag)
 void TCacheReadBypass::Activate(
     ui64 nodeId,
     ui64 commitId,
-    ui64 begin,
-    ui64 end)
+    const TByteRange& range)
 {
-    ActiveWritesByNodeId[nodeId].push_back({commitId, begin, end});
+    ActiveWritesByNodeId[nodeId].push_back({commitId, range});
 }
 
 void TCacheReadBypass::Deactivate(ui64 nodeId, ui64 commitId)
@@ -57,7 +56,7 @@ bool TCacheReadBypass::ShouldBypassRead(ui64 nodeId, ui64 commitId) const
 {
     // Reads without a byte range may observe any part of the node, including
     // its size.
-    const bool bypass = ShouldBypassReadImpl(nodeId, commitId, 0, Max<ui64>());
+    const bool bypass = ShouldBypassReadImpl(nodeId, commitId, nullptr);
     if (bypass) {
         ++BypassedNodeReadCount;
     }
@@ -67,10 +66,9 @@ bool TCacheReadBypass::ShouldBypassRead(ui64 nodeId, ui64 commitId) const
 bool TCacheReadBypass::ShouldBypassRead(
     ui64 nodeId,
     ui64 commitId,
-    ui64 begin,
-    ui64 end) const
+    const TByteRange& range) const
 {
-    const bool bypass = ShouldBypassReadImpl(nodeId, commitId, begin, end);
+    const bool bypass = ShouldBypassReadImpl(nodeId, commitId, &range);
     if (bypass) {
         ++BypassedRangeReadCount;
     }
@@ -80,8 +78,7 @@ bool TCacheReadBypass::ShouldBypassRead(
 bool TCacheReadBypass::ShouldBypassReadImpl(
     ui64 nodeId,
     ui64 commitId,
-    ui64 begin,
-    ui64 end) const
+    const TByteRange* range) const
 {
     // If recovery is in progress, reading from the cache is not possible.
     if (!UnconfirmedRecoveryReady) {
@@ -101,17 +98,16 @@ bool TCacheReadBypass::ShouldBypassReadImpl(
         return false;
     }
 
-    // Commit ids are generated monotonically when unconfirmed data is
-    // materialized by AddBlob, and this queue is activated/deactivated in the
-    // same order.
-    //
     // A read at "commitId" can observe only writes with commit ids <=
-    // "commitId", so the writes visible to the read form a prefix of the
-    // queue. If some visible write intersects the read range, the caches may
-    // miss data visible to this read, so the read must bypass them and go
-    // through the database path to keep the snapshot consistent. Writes that
-    // are newer than the read snapshot or do not intersect the read range
-    // cannot affect the result of the read.
+    // "commitId", and commit ids in the queue are monotonically increasing
+    // (they are generated when unconfirmed data is materialized by AddBlob,
+    // and the queue is activated/deactivated in the same order), so the
+    // writes visible to the read form a prefix of the queue. If some visible
+    // write intersects the read range, the caches may miss data visible to
+    // this read, so the read must bypass them and go through the database
+    // path to keep the snapshot consistent. Writes that are newer than the
+    // read snapshot or do not intersect the read range cannot affect the
+    // result of the read.
     for (const auto& write: it->second) {
         // The InvalidCommitId comparison handles the CommitIdOverflow case.
         const bool visible =
@@ -120,7 +116,7 @@ bool TCacheReadBypass::ShouldBypassReadImpl(
             break;
         }
 
-        if (write.Begin < end && begin < write.End) {
+        if (!range || range->Overlaps(write.Range)) {
             return true;
         }
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.cpp
@@ -4,6 +4,8 @@
 
 #include <cloud/storage/core/libs/tablet/model/commit.h>
 
+#include <util/generic/utility.h>
+
 #include <utility>
 
 namespace NCloud::NFileStore::NStorage {
@@ -15,29 +17,33 @@ void TCacheReadBypass::UpdateLogTag(TString logTag)
     LogTag = std::move(logTag);
 }
 
-void TCacheReadBypass::Activate(ui64 nodeId, ui64 commitId)
+void TCacheReadBypass::Activate(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 begin,
+    ui64 end)
 {
-    CommitIdsByNodeId[nodeId].push_back(commitId);
+    ActiveWritesByNodeId[nodeId].push_back({commitId, begin, end});
 }
 
 void TCacheReadBypass::Deactivate(ui64 nodeId, ui64 commitId)
 {
-    auto nodeIt = CommitIdsByNodeId.find(nodeId);
+    auto nodeIt = ActiveWritesByNodeId.find(nodeId);
     TABLET_VERIFY_C(
-        nodeIt != CommitIdsByNodeId.end(),
+        nodeIt != ActiveWritesByNodeId.end(),
         "nodeId: " << nodeId << ", commitId: " << commitId);
     TABLET_VERIFY_C(
         !nodeIt->second.empty(),
         "nodeId: " << nodeId << ", commitId: " << commitId);
     TABLET_VERIFY_C(
-        nodeIt->second.front() == commitId,
+        nodeIt->second.front().CommitId == commitId,
         "nodeId: " << nodeId << ", expected commitId: " << commitId
-                   << ", actual commitId: " << nodeIt->second.front()
+                   << ", actual commitId: " << nodeIt->second.front().CommitId
                    << ", queue size: " << nodeIt->second.size());
 
     nodeIt->second.pop_front();
     if (nodeIt->second.empty()) {
-        CommitIdsByNodeId.erase(nodeIt);
+        ActiveWritesByNodeId.erase(nodeIt);
     }
 }
 
@@ -49,6 +55,34 @@ void TCacheReadBypass::SetUnconfirmedRecoveryReady(
 
 bool TCacheReadBypass::ShouldBypassRead(ui64 nodeId, ui64 commitId) const
 {
+    // Reads without a byte range may observe any part of the node, including
+    // its size.
+    const bool bypass = ShouldBypassReadImpl(nodeId, commitId, 0, Max<ui64>());
+    if (bypass) {
+        ++BypassedNodeReadCount;
+    }
+    return bypass;
+}
+
+bool TCacheReadBypass::ShouldBypassRead(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 begin,
+    ui64 end) const
+{
+    const bool bypass = ShouldBypassReadImpl(nodeId, commitId, begin, end);
+    if (bypass) {
+        ++BypassedRangeReadCount;
+    }
+    return bypass;
+}
+
+bool TCacheReadBypass::ShouldBypassReadImpl(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 begin,
+    ui64 end) const
+{
     // If recovery is in progress, reading from the cache is not possible.
     if (!UnconfirmedRecoveryReady) {
         return true;
@@ -57,30 +91,51 @@ bool TCacheReadBypass::ShouldBypassRead(ui64 nodeId, ui64 commitId) const
     // No records at all. The map is always empty after the recovery phase if
     // unconfirmed data is disabled, as it is the only client of this API for
     // now.
-    if (CommitIdsByNodeId.empty()) {
+    if (ActiveWritesByNodeId.empty()) {
         return false;
     }
 
     // If there are no records for the given node, we can read from the cache.
-    const auto it = CommitIdsByNodeId.find(nodeId);
-    if (it == CommitIdsByNodeId.end() || it->second.empty()) {
+    const auto it = ActiveWritesByNodeId.find(nodeId);
+    if (it == ActiveWritesByNodeId.end() || it->second.empty()) {
         return false;
     }
 
     // Commit ids are generated monotonically when unconfirmed data is
     // materialized by AddBlob, and this queue is activated/deactivated in the
-    // same order. Thus the front item is the oldest write that may still be
-    // missing from in-memory caches.
+    // same order.
     //
     // A read at "commitId" can observe only writes with commit ids <=
-    // "commitId". If the oldest active write is newer than the read snapshot,
-    // all other active writes are newer as well and the cache cannot miss any
-    // data visible to this read. Otherwise at least one visible write is still
-    // active, so the read must bypass the cache and go through the database
-    // path to keep the snapshot consistent.
-    const ui64 frontCommitId = it->second.front();
-    // The InvalidCommitId comparison handles the CommitIdOverflow case.
-    return frontCommitId == InvalidCommitId || frontCommitId <= commitId;
+    // "commitId", so the writes visible to the read form a prefix of the
+    // queue. If some visible write intersects the read range, the caches may
+    // miss data visible to this read, so the read must bypass them and go
+    // through the database path to keep the snapshot consistent. Writes that
+    // are newer than the read snapshot or do not intersect the read range
+    // cannot affect the result of the read.
+    for (const auto& write: it->second) {
+        // The InvalidCommitId comparison handles the CommitIdOverflow case.
+        const bool visible =
+            write.CommitId == InvalidCommitId || write.CommitId <= commitId;
+        if (!visible) {
+            break;
+        }
+
+        if (write.Begin < end && begin < write.End) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+ui64 TCacheReadBypass::GetBypassedNodeReadCount() const
+{
+    return BypassedNodeReadCount;
+}
+
+ui64 TCacheReadBypass::GetBypassedRangeReadCount() const
+{
+    return BypassedRangeReadCount;
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.h
@@ -15,21 +15,50 @@ namespace NCloud::NFileStore::NStorage {
  */
 class TCacheReadBypass
 {
+private:
+    struct TActiveWrite
+    {
+        ui64 CommitId = 0;
+        // Affected byte range, End is exclusive. Writes that may change the
+        // file size are registered with End == Max<ui64>(), because cached
+        // file sizes become stale for all offsets starting from the old file
+        // size.
+        ui64 Begin = 0;
+        ui64 End = 0;
+    };
+
 public:
     void UpdateLogTag(TString logTag);
 
-    void Activate(ui64 nodeId, ui64 commitId);
+    void Activate(ui64 nodeId, ui64 commitId, ui64 begin, ui64 end);
 
     void Deactivate(ui64 nodeId, ui64 commitId);
 
     void SetUnconfirmedRecoveryReady(bool unconfirmedRecoveryReady);
 
+    // Checks reads that are not bound to a byte range (e.g. node attrs
+    // containing file size). Such reads bypass the cache if any active write
+    // is visible to them.
     bool ShouldBypassRead(ui64 nodeId, ui64 commitId) const;
+
+    // Checks reads bound to the [begin, end) byte range. Such reads bypass
+    // the cache only if some visible active write intersects the range.
+    bool ShouldBypassRead(ui64 nodeId, ui64 commitId, ui64 begin, ui64 end)
+        const;
+
+    ui64 GetBypassedNodeReadCount() const;
+    ui64 GetBypassedRangeReadCount() const;
+
+private:
+    bool ShouldBypassReadImpl(ui64 nodeId, ui64 commitId, ui64 begin, ui64 end)
+        const;
 
 private:
     TString LogTag;
     bool UnconfirmedRecoveryReady = false;
-    THashMap<ui64, TDeque<ui64>> CommitIdsByNodeId;
+    THashMap<ui64, TDeque<TActiveWrite>> ActiveWritesByNodeId;
+    mutable ui64 BypassedNodeReadCount = 0;
+    mutable ui64 BypassedRangeReadCount = 0;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_cache_read_bypass.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cloud/storage/core/libs/common/byte_range.h>
+
 #include <util/generic/deque.h>
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
@@ -19,18 +21,16 @@ private:
     struct TActiveWrite
     {
         ui64 CommitId = 0;
-        // Affected byte range, End is exclusive. Writes that may change the
-        // file size are registered with End == Max<ui64>(), because cached
-        // file sizes become stale for all offsets starting from the old file
-        // size.
-        ui64 Begin = 0;
-        ui64 End = 0;
+        // Affected byte range. Writes that may change the file size are
+        // registered with Range.End() == Max<ui64>(), because cached file
+        // sizes become stale for all offsets starting from the old file size.
+        TByteRange Range;
     };
 
 public:
     void UpdateLogTag(TString logTag);
 
-    void Activate(ui64 nodeId, ui64 commitId, ui64 begin, ui64 end);
+    void Activate(ui64 nodeId, ui64 commitId, const TByteRange& range);
 
     void Deactivate(ui64 nodeId, ui64 commitId);
 
@@ -41,17 +41,20 @@ public:
     // is visible to them.
     bool ShouldBypassRead(ui64 nodeId, ui64 commitId) const;
 
-    // Checks reads bound to the [begin, end) byte range. Such reads bypass
-    // the cache only if some visible active write intersects the range.
-    bool ShouldBypassRead(ui64 nodeId, ui64 commitId, ui64 begin, ui64 end)
+    // Checks reads bound to a byte range. Such reads bypass the cache only if
+    // some visible active write intersects the range.
+    bool ShouldBypassRead(ui64 nodeId, ui64 commitId, const TByteRange& range)
         const;
 
     ui64 GetBypassedNodeReadCount() const;
     ui64 GetBypassedRangeReadCount() const;
 
 private:
-    bool ShouldBypassReadImpl(ui64 nodeId, ui64 commitId, ui64 begin, ui64 end)
-        const;
+    // range == nullptr checks reads of the whole node.
+    bool ShouldBypassReadImpl(
+        ui64 nodeId,
+        ui64 commitId,
+        const TByteRange* range) const;
 
 private:
     TString LogTag;

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.cpp
@@ -200,6 +200,12 @@ void TTabletMetrics::Register(
     REGISTER_AGGREGATABLE_SUM(
         ReadAheadCacheNodeCount,
         EMetricType::MT_ABSOLUTE);
+    REGISTER_AGGREGATABLE_SUM(
+        ReadNodeCacheBypassCount,
+        EMetricType::MT_DERIVATIVE);
+    REGISTER_AGGREGATABLE_SUM(
+        ReadAheadCacheBypassCount,
+        EMetricType::MT_DERIVATIVE);
 
     REGISTER_AGGREGATABLE_SUM(
         InMemoryIndexStateROCacheHitCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_counters.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_counters.h
@@ -165,6 +165,8 @@ struct TTabletMetrics
 
     std::atomic<i64> ReadAheadCacheHitCount{0};
     std::atomic<i64> ReadAheadCacheNodeCount{0};
+    std::atomic<i64> ReadNodeCacheBypassCount{0};
+    std::atomic<i64> ReadAheadCacheBypassCount{0};
 
     // Read-only transactions that used fast path (in-memory index state)
     std::atomic<i64> InMemoryIndexStateROCacheHitCount{0};

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1019,8 +1019,16 @@ public:
         ui64 nodeId,
         const TByteRange& requestRange) const;
 
-    void ActivateCacheReadBypass(ui64 nodeId, ui64 commitId);
+    // [begin, end) is the byte range affected by the write, end == Max<ui64>()
+    // if the write may change the file size.
+    void ActivateCacheReadBypass(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 begin,
+        ui64 end);
     void DeactivateCacheReadBypass(ui64 nodeId, ui64 commitId);
+    ui64 GetReadNodeCacheBypassCount() const;
+    ui64 GetReadAheadCacheBypassCount() const;
 
     //
     // FreshBytes

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1019,13 +1019,11 @@ public:
         ui64 nodeId,
         const TByteRange& requestRange) const;
 
-    // [begin, end) is the byte range affected by the write, end == Max<ui64>()
-    // if the write may change the file size.
+    // range.End() == Max<ui64>() marks a write that may change the file size.
     void ActivateCacheReadBypass(
         ui64 nodeId,
         ui64 commitId,
-        ui64 begin,
-        ui64 end);
+        const TByteRange& range);
     void DeactivateCacheReadBypass(ui64 nodeId, ui64 commitId);
     ui64 GetReadNodeCacheBypassCount() const;
     ui64 GetReadAheadCacheBypassCount() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -160,11 +160,6 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeAttr(
     const TString& name,
     TMaybe<TNodeAttr>& attr)
 {
-    // TODO (#5912) use waiting queue instead of going full TX flow
-    if (CacheReadBypass.ShouldBypassRead(nodeId, commitId)) {
-        return false;
-    }
-
     auto it = NodeAttrs.Find(TNodeAttrsKey(nodeId, name));
     if (it == NodeAttrs.End()) {
         return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -421,14 +421,28 @@ bool TIndexTabletState::HasDataOverlapWithUnconfirmed(
     return hasDataOverlap(UnconfirmedData) || hasDataOverlap(ConfirmedData);
 }
 
-void TIndexTabletState::ActivateCacheReadBypass(ui64 nodeId, ui64 commitId)
+void TIndexTabletState::ActivateCacheReadBypass(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 begin,
+    ui64 end)
 {
-    Impl->CacheReadBypass.Activate(nodeId, commitId);
+    Impl->CacheReadBypass.Activate(nodeId, commitId, begin, end);
 }
 
 void TIndexTabletState::DeactivateCacheReadBypass(ui64 nodeId, ui64 commitId)
 {
     Impl->CacheReadBypass.Deactivate(nodeId, commitId);
+}
+
+ui64 TIndexTabletState::GetReadNodeCacheBypassCount() const
+{
+    return Impl->CacheReadBypass.GetBypassedNodeReadCount();
+}
+
+ui64 TIndexTabletState::GetReadAheadCacheBypassCount() const
+{
+    return Impl->CacheReadBypass.GetBypassedRangeReadCount();
 }
 
 void TIndexTabletState::SetUnconfirmedRecoveryReady(bool value)
@@ -1525,7 +1539,12 @@ bool TIndexTabletState::TryFillDescribeResult(
     const TByteRange& range,
     NProtoPrivate::TDescribeDataResponse* response)
 {
-    if (Impl->CacheReadBypass.ShouldBypassRead(nodeId, commitId)) {
+    if (Impl->CacheReadBypass.ShouldBypassRead(
+            nodeId,
+            commitId,
+            range.Offset,
+            range.End()))
+    {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -424,10 +424,9 @@ bool TIndexTabletState::HasDataOverlapWithUnconfirmed(
 void TIndexTabletState::ActivateCacheReadBypass(
     ui64 nodeId,
     ui64 commitId,
-    ui64 begin,
-    ui64 end)
+    const TByteRange& range)
 {
-    Impl->CacheReadBypass.Activate(nodeId, commitId, begin, end);
+    Impl->CacheReadBypass.Activate(nodeId, commitId, range);
 }
 
 void TIndexTabletState::DeactivateCacheReadBypass(ui64 nodeId, ui64 commitId)
@@ -1539,12 +1538,7 @@ bool TIndexTabletState::TryFillDescribeResult(
     const TByteRange& range,
     NProtoPrivate::TDescribeDataResponse* response)
 {
-    if (Impl->CacheReadBypass.ShouldBypassRead(
-            nodeId,
-            commitId,
-            range.Offset,
-            range.End()))
-    {
+    if (Impl->CacheReadBypass.ShouldBypassRead(nodeId, commitId, range)) {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -174,7 +174,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
         // ReadNode is not bound to a byte range, so it should be bypassed by
         // an active write to any range of the node.
-        cacheBypass.Activate(nodeId1, commitId2, 1000, 2000);
+        cacheBypass.Activate(nodeId1, commitId2, TByteRange(1000, 1000, 4_KB));
 
         node.Clear();
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
@@ -193,8 +193,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         cacheBypass.Activate(
             nodeId1,
             InvalidCommitId,
-            0,
-            Max<ui64>());
+            TByteRange::MaxEnd(0, 4_KB));
 
         node.Clear();
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId1, node));
@@ -225,7 +224,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                 .Node = nodeAttrs1,
             }}});
 
-        cacheBypass.Activate(nodeId1, commitId2, 0, Max<ui64>());
+        cacheBypass.Activate(nodeId1, commitId2, TByteRange::MaxEnd(0, 4_KB));
 
         TMaybe<IIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
@@ -252,53 +251,80 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         cacheBypass.SetUnconfirmedRecoveryReady(true);
 
         // write at [1000, 2000)
-        cacheBypass.Activate(nodeId1, commitId2, 1000, 2000);
+        cacheBypass.Activate(nodeId1, commitId2, TByteRange(1000, 1000, 4_KB));
 
         // other nodes are not affected
-        UNIT_ASSERT(
-            !cacheBypass.ShouldBypassRead(nodeId2, commitId2, 0, Max<ui64>()));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId2,
+            commitId2,
+            TByteRange::MaxEnd(0, 4_KB)));
 
         // reads that do not intersect the write range
-        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(nodeId1, commitId2, 0, 1000));
-        UNIT_ASSERT(
-            !cacheBypass.ShouldBypassRead(nodeId1, commitId2, 2000, 3000));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId2,
+            TByteRange(0, 1000, 4_KB)));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId2,
+            TByteRange(2000, 1000, 4_KB)));
 
         // reads that intersect the write range
-        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId2, 0, 1001));
-        UNIT_ASSERT(
-            cacheBypass.ShouldBypassRead(nodeId1, commitId2, 1999, 3000));
-        UNIT_ASSERT(
-            cacheBypass.ShouldBypassRead(nodeId1, commitId2, 1200, 1300));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId2,
+            TByteRange(0, 1001, 4_KB)));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId2,
+            TByteRange(1999, 1001, 4_KB)));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId2,
+            TByteRange(1200, 100, 4_KB)));
 
         // the write is not visible to an older read snapshot
-        UNIT_ASSERT(
-            !cacheBypass.ShouldBypassRead(nodeId1, commitId1, 1200, 1300));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId1,
+            TByteRange(1200, 100, 4_KB)));
 
         // reads without a byte range intersect any write
         UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId2));
 
         // a size-changing write at [5000, +inf)
-        cacheBypass.Activate(nodeId1, commitId3, 5000, Max<ui64>());
+        cacheBypass.Activate(nodeId1, commitId3, TByteRange::MaxEnd(5000, 4_KB));
 
-        UNIT_ASSERT(
-            !cacheBypass.ShouldBypassRead(nodeId1, commitId2, 5000, 6000));
-        UNIT_ASSERT(
-            cacheBypass.ShouldBypassRead(nodeId1, commitId3, 5000, 6000));
-        UNIT_ASSERT(
-            cacheBypass
-                .ShouldBypassRead(nodeId1, commitId3, 1'000'000, 1'000'001));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId2,
+            TByteRange(5000, 1000, 4_KB)));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId3,
+            TByteRange(5000, 1000, 4_KB)));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId3,
+            TByteRange(1'000'000, 1, 4_KB)));
 
         cacheBypass.Deactivate(nodeId1, commitId2);
 
-        UNIT_ASSERT(
-            !cacheBypass.ShouldBypassRead(nodeId1, commitId3, 1200, 1300));
-        UNIT_ASSERT(
-            cacheBypass.ShouldBypassRead(nodeId1, commitId3, 5000, 6000));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId3,
+            TByteRange(1200, 100, 4_KB)));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId3,
+            TByteRange(5000, 1000, 4_KB)));
 
         cacheBypass.Deactivate(nodeId1, commitId3);
 
-        UNIT_ASSERT(
-            !cacheBypass.ShouldBypassRead(nodeId1, commitId3, 5000, 6000));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId3,
+            TByteRange(5000, 1000, 4_KB)));
     }
 
     Y_UNIT_TEST(ShouldCountBypassedReads)
@@ -311,7 +337,10 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedNodeReadCount());
         UNIT_ASSERT_VALUES_EQUAL(0, cacheBypass.GetBypassedRangeReadCount());
 
-        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId1, 0, 100));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId1,
+            TByteRange(0, 100, 4_KB)));
         UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedNodeReadCount());
         UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedRangeReadCount());
 
@@ -320,13 +349,18 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(!cacheBypass.ShouldBypassRead(nodeId1, commitId1));
         UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedNodeReadCount());
 
-        cacheBypass.Activate(nodeId1, commitId1, 0, 100);
+        cacheBypass.Activate(nodeId1, commitId1, TByteRange(0, 100, 4_KB));
 
-        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId1, 50, 150));
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId1,
+            TByteRange(50, 100, 4_KB)));
         UNIT_ASSERT_VALUES_EQUAL(2, cacheBypass.GetBypassedRangeReadCount());
 
-        UNIT_ASSERT(
-            !cacheBypass.ShouldBypassRead(nodeId1, commitId1, 100, 200));
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(
+            nodeId1,
+            commitId1,
+            TByteRange(100, 100, 4_KB)));
         UNIT_ASSERT_VALUES_EQUAL(2, cacheBypass.GetBypassedRangeReadCount());
 
         UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId1));
@@ -396,7 +430,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
             .NodeAttrsRow = {commitId1, attrValue1, attrVersion1},
         }});
 
-        cacheBypass.Activate(nodeId1, commitId1, 0, Max<ui64>());
+        cacheBypass.Activate(nodeId1, commitId1, TByteRange::MaxEnd(0, 4_KB));
 
         TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -172,7 +172,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
         UNIT_ASSERT(node.Defined());
 
-        cacheBypass.Activate(nodeId1, commitId2);
+        // ReadNode is not bound to a byte range, so it should be bypassed by
+        // an active write to any range of the node.
+        cacheBypass.Activate(nodeId1, commitId2, 1000, 2000);
 
         node.Clear();
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
@@ -190,7 +192,9 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
         cacheBypass.Activate(
             nodeId1,
-            InvalidCommitId);
+            InvalidCommitId,
+            0,
+            Max<ui64>());
 
         node.Clear();
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId1, node));
@@ -221,7 +225,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                 .Node = nodeAttrs1,
             }}});
 
-        cacheBypass.Activate(nodeId1, commitId2);
+        cacheBypass.Activate(nodeId1, commitId2, 0, Max<ui64>());
 
         TMaybe<IIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
@@ -238,6 +242,98 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         node.Clear();
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId2, node));
         UNIT_ASSERT(node.Defined());
+    }
+
+    Y_UNIT_TEST(ShouldBypassCacheReadsByRange)
+    {
+        const ui64 commitId3 = 3;
+
+        TCacheReadBypass cacheBypass;
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
+
+        // write at [1000, 2000)
+        cacheBypass.Activate(nodeId1, commitId2, 1000, 2000);
+
+        // other nodes are not affected
+        UNIT_ASSERT(
+            !cacheBypass.ShouldBypassRead(nodeId2, commitId2, 0, Max<ui64>()));
+
+        // reads that do not intersect the write range
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(nodeId1, commitId2, 0, 1000));
+        UNIT_ASSERT(
+            !cacheBypass.ShouldBypassRead(nodeId1, commitId2, 2000, 3000));
+
+        // reads that intersect the write range
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId2, 0, 1001));
+        UNIT_ASSERT(
+            cacheBypass.ShouldBypassRead(nodeId1, commitId2, 1999, 3000));
+        UNIT_ASSERT(
+            cacheBypass.ShouldBypassRead(nodeId1, commitId2, 1200, 1300));
+
+        // the write is not visible to an older read snapshot
+        UNIT_ASSERT(
+            !cacheBypass.ShouldBypassRead(nodeId1, commitId1, 1200, 1300));
+
+        // reads without a byte range intersect any write
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId2));
+
+        // a size-changing write at [5000, +inf)
+        cacheBypass.Activate(nodeId1, commitId3, 5000, Max<ui64>());
+
+        UNIT_ASSERT(
+            !cacheBypass.ShouldBypassRead(nodeId1, commitId2, 5000, 6000));
+        UNIT_ASSERT(
+            cacheBypass.ShouldBypassRead(nodeId1, commitId3, 5000, 6000));
+        UNIT_ASSERT(
+            cacheBypass
+                .ShouldBypassRead(nodeId1, commitId3, 1'000'000, 1'000'001));
+
+        cacheBypass.Deactivate(nodeId1, commitId2);
+
+        UNIT_ASSERT(
+            !cacheBypass.ShouldBypassRead(nodeId1, commitId3, 1200, 1300));
+        UNIT_ASSERT(
+            cacheBypass.ShouldBypassRead(nodeId1, commitId3, 5000, 6000));
+
+        cacheBypass.Deactivate(nodeId1, commitId3);
+
+        UNIT_ASSERT(
+            !cacheBypass.ShouldBypassRead(nodeId1, commitId3, 5000, 6000));
+    }
+
+    Y_UNIT_TEST(ShouldCountBypassedReads)
+    {
+        TCacheReadBypass cacheBypass;
+
+        // recovery is not ready yet, all reads bypass the cache and are
+        // counted by the overload that was called
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId1));
+        UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedNodeReadCount());
+        UNIT_ASSERT_VALUES_EQUAL(0, cacheBypass.GetBypassedRangeReadCount());
+
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId1, 0, 100));
+        UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedNodeReadCount());
+        UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedRangeReadCount());
+
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
+
+        UNIT_ASSERT(!cacheBypass.ShouldBypassRead(nodeId1, commitId1));
+        UNIT_ASSERT_VALUES_EQUAL(1, cacheBypass.GetBypassedNodeReadCount());
+
+        cacheBypass.Activate(nodeId1, commitId1, 0, 100);
+
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId1, 50, 150));
+        UNIT_ASSERT_VALUES_EQUAL(2, cacheBypass.GetBypassedRangeReadCount());
+
+        UNIT_ASSERT(
+            !cacheBypass.ShouldBypassRead(nodeId1, commitId1, 100, 200));
+        UNIT_ASSERT_VALUES_EQUAL(2, cacheBypass.GetBypassedRangeReadCount());
+
+        UNIT_ASSERT(cacheBypass.ShouldBypassRead(nodeId1, commitId1));
+        UNIT_ASSERT_VALUES_EQUAL(2, cacheBypass.GetBypassedNodeReadCount());
+        UNIT_ASSERT_VALUES_EQUAL(2, cacheBypass.GetBypassedRangeReadCount());
+
+        cacheBypass.Deactivate(nodeId1, commitId1);
     }
 
     const TString attrName1 = "name1";
@@ -287,6 +383,26 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         attr = {};
         UNIT_ASSERT(state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));
         UNIT_ASSERT(attr.Empty());
+    }
+
+    Y_UNIT_TEST(ShouldNotBypassNodeAttrsCacheReads)
+    {
+        TCacheReadBypass cacheBypass;
+        TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 1, 0, 0);
+        cacheBypass.SetUnconfirmedRecoveryReady(true);
+
+        state.UpdateState({IInMemoryIndexState::TWriteNodeAttrsRequest{
+            .NodeAttrsKey = {nodeId1, attrName1},
+            .NodeAttrsRow = {commitId1, attrValue1, attrVersion1},
+        }});
+
+        cacheBypass.Activate(nodeId1, commitId1, 0, Max<ui64>());
+
+        TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
+        UNIT_ASSERT(state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));
+        UNIT_ASSERT(attr.Defined());
+
+        cacheBypass.Deactivate(nodeId1, commitId1);
     }
 
     Y_UNIT_TEST(ShouldEvictNodeAttrs)

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -397,7 +397,10 @@ message TDescribeDataResponse
     repeated TFreshDataRange FreshDataRanges = 2;
     repeated TBlobPiece BlobPieces = 3;
 
-    // File size.
+    // File size. When the response is served from the read-ahead cache, the
+    // actual file size may already be bigger (e.g. an unconfirmed write is
+    // extending the file). Suitable only for clamping the read range, not as
+    // the actual file size.
     uint64 FileSize = 4;
 
     // This constitutes a “fake” response, meaning it is not related to real

--- a/cloud/storage/core/libs/common/byte_range.h
+++ b/cloud/storage/core/libs/common/byte_range.h
@@ -163,6 +163,11 @@ struct TByteRange
         return {0, 0, blockSize};
     }
 
+    static TByteRange MaxEnd(ui64 offset, ui32 blockSize)
+    {
+        return {offset, ::Max<ui64>() - offset, blockSize};
+    }
+
     static TByteRange BlockRange(ui64 blockIndex, ui32 blockSize)
     {
         return {blockIndex * blockSize, blockSize, blockSize};

--- a/cloud/storage/core/libs/common/byte_range_ut.cpp
+++ b/cloud/storage/core/libs/common/byte_range_ut.cpp
@@ -95,6 +95,25 @@ Y_UNIT_TEST_SUITE(TByteRangeTest)
 
         UNIT_ASSERT(!range.Overlaps({0, 0, 4_KB}));
     }
+
+    Y_UNIT_TEST(MaxRange)
+    {
+        TByteRange range = TByteRange::MaxEnd(0, 4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(range.Offset, 0);
+        UNIT_ASSERT_VALUES_EQUAL(range.End(), Max<ui64>());
+
+        UNIT_ASSERT(range.Overlaps({0, 100, 4_KB}));
+        UNIT_ASSERT(range.Overlaps({Max<ui64>() - 100, 100, 4_KB}));
+        UNIT_ASSERT(!range.Overlaps({100, 0, 4_KB}));
+
+        range = TByteRange::MaxEnd(16_KB, 4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(range.Offset, 16_KB);
+        UNIT_ASSERT_VALUES_EQUAL(range.End(), Max<ui64>());
+
+        UNIT_ASSERT(!range.Overlaps({0, 16_KB, 4_KB}));
+        UNIT_ASSERT(range.Overlaps({0, 16_KB + 1, 4_KB}));
+        UNIT_ASSERT(range.Overlaps({Max<ui64>() - 100, 100, 4_KB}));
+    }
 }
 
 }   // namespace NCloud


### PR DESCRIPTION
### Notes
Added metrics for cache bypass during unconfirmed writes
Narrowed cache bypass for ReadAheadCache to overlapping range
Remove ReadXAttr from cache bypass participation
Added ut

### Issue
#2293
