### PR TITLE
issue-6439: disable AllowOverlappingSharedMemoryPages in datashard-like e2e test

### DIFF
--- a/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/datashard-like-read-write-with-page-size.txt
+++ b/cloud/filestore/tests/loadtest/service-kikimr-datashard-like-test/datashard-like-read-write-with-page-size.txt
@@ -24,7 +24,6 @@ Tests {
             SharedMemoryFilePath: "shm-loadtest.bin"
             SharedMemorySizeBytes: 33554432
             SharedMemoryPageSize: 4096
-            AllowOverlappingSharedMemoryPages: true
         }
         IODepth: 4
         TestDuration: 30


### PR DESCRIPTION
issue: #6439

test with enabled AllowOverlappingSharedMemoryPages is failing with sanitizers as an loadtest implementation is incorrect.


I'm disabling AllowOverlappingSharedMemoryPages for now and reimplement it in another pr as part of #6439
