### PR TITLE
issue-5894: journalled device request/response schema

### DIFF
--- a/cloud/storage/core/protos/device.proto
+++ b/cloud/storage/core/protos/device.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+
+import "cloud/storage/core/protos/error.proto";
+
+package NCloud.NProto;
+
+option go_package = "github.com/ydb-platform/nbs/cloud/storage/core/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+// Headers.
+
+message TDeviceRequestHeaders
+{
+    // Client identifier for client detection.
+    string ClientId = 1;
+
+    // Request identifier.
+    uint64 RequestId = 2;
+
+    // Request timeout (in milliseconds).
+    uint32 RequestTimeout = 3;
+}
+
+message TDeviceResponseHeaders
+{
+    // Request identifier.
+    uint64 RequestId = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Read request/response.
+
+message TDevicePageGroupRef
+{
+    // The number of the first page in the response relative to the start of
+    // the device, starts from 0.
+    uint64 FirstPageNo = 1;
+
+    // The number of consecutive pages.
+    uint64 PageCount = 2;
+
+    // Logical page size.
+    uint32 PageSize = 3;
+}
+
+message TReadPagesRequest
+{
+    // Request headers.
+    TDeviceRequestHeaders Headers = 1;
+
+    // UUID of the device to read from.
+    string DeviceUUID = 2;
+
+    // Requested pages.
+    repeated TDevicePageGroupRef PageGroupRefs = 3;
+}
+
+message TDevicePageGroup
+{
+    // The number of the first page in the response relative to the start of
+    // the device, starts from 0.
+    uint64 FirstPageNo = 1;
+
+    // Page data for each of the response pages.
+    repeated bytes Content = 2;
+}
+
+message TReadPagesResponse
+{
+    // Response headers.
+    TDeviceResponseHeaders Headers = 1;
+
+    // Optional error, set only if error happened.
+    TError Error = 2;
+
+    // Requested pages.
+    repeated TDevicePageGroup PageGroups = 3;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Write request/response.
+
+message TWriteLogRecordRequest
+{
+    // Request headers.
+    TDeviceRequestHeaders Headers = 1;
+
+    // UUID of device to write to.
+    string DeviceUUID = 2;
+
+    // Pages to write.
+    repeated TDevicePageGroup PageGroups = 3;
+
+    // Log sequence number used to order the writes.
+    uint64 LogSequenceNumber = 4;
+}
+
+message TWriteLogRecordResponse
+{
+    // Response headers.
+    TDeviceResponseHeaders Headers = 1;
+
+    // Optional error, set only if error happened.
+    TError Error = 2;
+}

--- a/cloud/storage/core/protos/device.proto
+++ b/cloud/storage/core/protos/device.proto
@@ -14,17 +14,58 @@ message TDeviceRequestHeaders
     // Client identifier for client detection.
     string ClientId = 1;
 
-    // Request identifier.
-    uint64 RequestId = 2;
-
     // Request timeout (in milliseconds).
-    uint32 RequestTimeout = 3;
+    uint32 RequestTimeout = 2;
 }
 
 message TDeviceResponseHeaders
 {
-    // Request identifier.
-    uint64 RequestId = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Acquire request/response.
+
+message TAcquireDevicesRequest
+{
+    // Headers.
+    TDeviceRequestHeaders Headers = 1;
+
+    // List of device UUIDs to acquire.
+    repeated string DeviceUUIDs = 2;
+
+    // Access mode.
+    // Let's just assume r/w access for now.
+    // EAccessMode AccessMode = 2;
+}
+
+message TAcquireDevicesResponse
+{
+    // Headers.
+    TDeviceResponseHeaders Headers = 1;
+
+    // Optional error, set only if error happened.
+    TError Error = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Release request/response.
+
+message TReleaseDevicesRequest
+{
+    // Headers.
+    TDeviceRequestHeaders Headers = 1;
+
+    // List of device UUIDs to release.
+    repeated string DeviceUUIDs = 2;
+}
+
+message TReleaseDevicesResponse
+{
+    // Headers.
+    TDeviceResponseHeaders Headers = 1;
+
+    // Optional error, set only if error happened.
+    TError Error = 2;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -45,7 +86,7 @@ message TDevicePageGroupRef
 
 message TReadPagesRequest
 {
-    // Request headers.
+    // Headers.
     TDeviceRequestHeaders Headers = 1;
 
     // UUID of the device to read from.
@@ -67,7 +108,7 @@ message TDevicePageGroup
 
 message TReadPagesResponse
 {
-    // Response headers.
+    // Headers.
     TDeviceResponseHeaders Headers = 1;
 
     // Optional error, set only if error happened.
@@ -82,7 +123,7 @@ message TReadPagesResponse
 
 message TWriteLogRecordRequest
 {
-    // Request headers.
+    // Headers.
     TDeviceRequestHeaders Headers = 1;
 
     // UUID of device to write to.
@@ -97,9 +138,40 @@ message TWriteLogRecordRequest
 
 message TWriteLogRecordResponse
 {
-    // Response headers.
+    // Headers.
     TDeviceResponseHeaders Headers = 1;
 
     // Optional error, set only if error happened.
     TError Error = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Device protocol request/response wrappers.
+
+message TDeviceProtocolRequest
+{
+    // Request identifier.
+    uint64 RequestId = 1;
+
+    oneof Request {
+        TAcquireDevicesRequest AcquireDevices = 2;
+        TReleaseDevicesRequest ReleaseDevices = 3;
+        TReadPagesRequest ReadPages = 4;
+        TWriteLogRecordRequest WriteLogRecord = 5;
+    }
+}
+
+message TDeviceProtocolResponse
+{
+    // Request identifier - used to match this response with its request.
+    uint64 RequestId = 1;
+
+    oneof Response {
+        NCloud.NProto.TError ProtocolError = 2;
+
+        TAcquireDevicesResponse AcquireDevices = 3;
+        TReleaseDevicesResponse ReleaseDevices = 4;
+        TReadPagesResponse ReadPages = 5;
+        TWriteLogRecordResponse WriteLogRecord = 6;
+    }
 }

--- a/cloud/storage/core/protos/ya.make
+++ b/cloud/storage/core/protos/ya.make
@@ -11,6 +11,7 @@ SRCS(
     authorization_mode.proto
     certificate.proto
     config_dispatcher_settings.proto
+    device.proto
     diagnostics.proto
     endpoints.proto
     error.proto


### PR DESCRIPTION
### Notes
Unfortunately directly using blockstore `T{Read,Write}DeviceBlocks{Request,Response}` is inconvenient even for the prototype because they depend on too many blockstore specifics. So initially I decided to make "forks" of those requests/responses but eventually decided to introduce proper APIs even for the prototype stage.

The API basically consists of 2 new requests:
* a batch read request which lets the caller read multiple page ranges (basically block ranges) in a single request - very useful for reading file data and metadata in one go
* a WAL write request which also has a batch of page ranges (will be used to tell the device to atomically update the pages corresponding to file inode, index and data) and an LSN which will be used to enforce proper write ordering

And 2 forked and simplified versions of acquire/release requests as well

At the prototype stage we won't need journal implementation and thus won't have atomicity guarantees for the writes - it's fine. We also can just disregard LSN at the prototype stage. The implementation at this stage can just handle each of these batch read/write requests as multiple independent `T{Read,Write}DeviceBlocksRequests`

The `RequestId` passed in the request headers is supposed to be returned in the response headers to be able to match requests and responses at the client side

### Issue
https://github.com/ydb-platform/nbs/issues/5894
