### PR TITLE
filestore: replace TString PascalCase Size() with size() in tests

### DIFF
--- a/cloud/filestore/libs/storage/model/block_buffer_ut.cpp
+++ b/cloud/filestore/libs/storage/model/block_buffer_ut.cpp
@@ -27,7 +27,7 @@ Y_UNIT_TEST_SUITE(TBlockBufferTest)
             , AlignedRange(Range.AlignedSuperRange())
         {
             Data.ReserveAndResize(AlignedRange.Length);
-            for (ui32 i = 0; i < Data.Size(); ++i) {
+            for (ui32 i = 0; i < Data.size(); ++i) {
                 Data[i] = 'a' + RandomNumber<ui32>('z' - 'a' + 1);
             }
             BlockBuffer = CreateBlockBuffer(AlignedRange, Data);

--- a/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut_randomized.cpp
+++ b/cloud/filestore/libs/storage/tablet/model/fresh_bytes_ut_randomized.cpp
@@ -304,7 +304,7 @@ struct TFreshBytesVisitor final
             << " " << bytes.Length << Endl;
 
         auto& content = NodeId2Content[bytes.NodeId];
-        if (content.Size() < bytes.Offset + bytes.Length) {
+        if (content.size() < bytes.Offset + bytes.Length) {
             content.resize(bytes.Offset + bytes.Length, 0);
         }
         UNIT_ASSERT_VALUES_EQUAL(bytes.Length, data.size());


### PR DESCRIPTION
Fix Arcadia sync: newer contrib removed deleted PascalCase TString methods (Size, Data, Empty) from util/generic/string.h.

### Notes
- Replace `Size()` with `size()` in `block_buffer_ut.cpp` and `fresh_bytes_ut_randomized.cpp`

### Issue
Fixes Arcadia sync: newer contrib removed deleted PascalCase `TString` methods (`Size`, `Data`, `Empty`) from `util/generic/string.h`
