### PR TITLE
github ci: add PR check for TString PascalCase accessors

### DIFF
--- a/.github/scripts/check_tstring_pascal_methods.py
+++ b/.github/scripts/check_tstring_pascal_methods.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Reject PascalCase TString accessors removed from util/generic/string.h.
+
+Newer contrib deletes TString::Size(), Data(), and Empty(). Use size(), data(),
+and empty() instead. The check is limited to TString-family types so other
+classes that legitimately expose Size()/Data()/Empty() are not affected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+CPP_SUFFIXES = {".cpp", ".cc", ".cxx", ".h", ".hpp", ".hh", ".hxx"}
+
+STRING_TYPES = (
+    r"TString(?:Buf)?"
+    r"|TUtf16String(?:Buf)?"
+    r"|TWtringBuf"
+    r"|std::basic_string<[^>]+>"
+    r"|std::(?:u16|u32|w)?string"
+)
+
+BANNED_METHODS = {
+    "Size": "size",
+    "Data": "data",
+    "Empty": "empty",
+}
+
+DECL_RE = re.compile(
+    rf"\b(?:const\s+)?(?:volatile\s+)?(?:static\s+)?({STRING_TYPES})\s*"
+    rf"(?:const\s*)?(?:&|\*+)?\s*(\w+)\b"
+)
+
+POINTER_DECL_RE = re.compile(
+    rf"\b(?:const\s+)?(?:volatile\s+)?(?:static\s+)?({STRING_TYPES})\s*"
+    rf"(?:const\s*)?\*\s*(?:const\s*)?\s*(\w+)\b"
+)
+
+INLINE_RE = re.compile(
+    rf"\b({STRING_TYPES})\s*(?:\([^)]*\))?\s*\.(Size|Data|Empty)\s*\("
+)
+
+DOT_RE = re.compile(r"\b(\w+)\s*\.(Size|Data|Empty)\s*\(")
+ARROW_RE = re.compile(r"\b(\w+)\s*->(Size|Data|Empty)\s*\(")
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line_no: int
+    line: str
+    method: str
+    replacement: str
+
+
+def run_git(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to check. Defaults to staged C++ files when --cached is set.",
+    )
+    parser.add_argument(
+        "--cached",
+        action="store_true",
+        help="Check only staged changes (for .githooks/pre-commit).",
+    )
+    parser.add_argument("--from-ref", default="")
+    parser.add_argument("--to-ref", default="HEAD")
+    return parser.parse_args()
+
+
+def is_cpp_file(path: Path) -> bool:
+    return path.suffix in CPP_SUFFIXES
+
+
+def list_cached_cpp_files() -> list[Path]:
+    output = run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    return [Path(line) for line in output.splitlines() if is_cpp_file(Path(line))]
+
+
+def list_changed_cpp_files(diff_selector: str) -> list[Path]:
+    if diff_selector == "--cached":
+        cmd = ["diff", "--cached", "--name-only", "--diff-filter=ACMR"]
+    else:
+        cmd = ["diff", "--name-only", "--diff-filter=ACMR", diff_selector]
+    output = run_git(cmd)
+    return [Path(line) for line in output.splitlines() if is_cpp_file(Path(line))]
+
+
+def diff_range(args: argparse.Namespace) -> str:
+    if args.from_ref:
+        return f"{args.from_ref}...{args.to_ref}"
+    if args.cached:
+        return "--cached"
+    try:
+        merge_base = run_git(["merge-base", "origin/main", "HEAD"]).strip()
+        if merge_base:
+            return f"{merge_base}...HEAD"
+    except subprocess.CalledProcessError:
+        pass
+    return "--cached"
+
+
+def added_lines(path: Path, diff_selector: str) -> list[tuple[int, str]]:
+    try:
+        if diff_selector == "--cached":
+            diff = run_git(["diff", "--cached", "-U0", "--", str(path)])
+        else:
+            diff = run_git(["diff", "-U0", diff_selector, "--", str(path)])
+    except subprocess.CalledProcessError:
+        return []
+
+    added: list[tuple[int, str]] = []
+    current_line = 0
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("@@"):
+            match = re.search(r"\+(\d+)", raw_line)
+            if match:
+                current_line = int(match.group(1))
+            continue
+        if raw_line.startswith("+++") or raw_line.startswith("---"):
+            continue
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            added.append((current_line, raw_line[1:]))
+            current_line += 1
+        elif raw_line.startswith("-") and not raw_line.startswith("---"):
+            continue
+        elif raw_line.startswith(" "):
+            current_line += 1
+    return added
+
+
+def collect_string_identifiers(content: str) -> tuple[set[str], set[str]]:
+    values: set[str] = set()
+    pointers: set[str] = set()
+    for match in DECL_RE.finditer(content):
+        values.add(match.group(2))
+    for match in POINTER_DECL_RE.finditer(content):
+        pointers.add(match.group(2))
+    return values, pointers
+
+
+def find_violations(path: Path, content: str, added: list[tuple[int, str]]) -> list[Violation]:
+    values, pointers = collect_string_identifiers(content)
+    violations: list[Violation] = []
+
+    for line_no, line in added:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+
+        for match in INLINE_RE.finditer(line):
+            method = match.group(2)
+            violations.append(
+                Violation(path, line_no, line, method, BANNED_METHODS[method])
+            )
+            continue
+
+        for match in DOT_RE.finditer(line):
+            ident, method = match.group(1), match.group(2)
+            if ident in values:
+                violations.append(
+                    Violation(path, line_no, line, method, BANNED_METHODS[method])
+                )
+
+        for match in ARROW_RE.finditer(line):
+            ident, method = match.group(1), match.group(2)
+            if ident in pointers:
+                violations.append(
+                    Violation(path, line_no, line, method, BANNED_METHODS[method])
+                )
+
+    return violations
+
+
+def check_file(path: Path, diff_selector: str) -> list[Violation]:
+    if not path.is_file():
+        return []
+    content = path.read_text(encoding="utf-8", errors="replace")
+    return find_violations(path, content, added_lines(path, diff_selector))
+
+
+def main() -> int:
+    args = parse_args()
+    diff_selector = diff_range(args)
+
+    if args.files:
+        files = [Path(f) for f in args.files if is_cpp_file(Path(f))]
+    elif args.cached:
+        files = list_cached_cpp_files()
+    else:
+        files = list_changed_cpp_files(diff_selector)
+
+    violations: list[Violation] = []
+    for path in files:
+        violations.extend(check_file(path, diff_selector))
+
+    if not violations:
+        return 0
+
+    print(
+        "Found PascalCase TString accessors. "
+        "Use lowercase size()/data()/empty() from util/generic/string.h:",
+        file=sys.stderr,
+    )
+    for violation in violations:
+        print(
+            f"{violation.path}:{violation.line_no}: "
+            f"use .{violation.replacement}() instead of .{violation.method}()",
+            file=sys.stderr,
+        )
+        print(f"  {violation.line.rstrip()}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_tstring_pascal_methods/README.md
+++ b/.github/scripts/check_tstring_pascal_methods/README.md
@@ -1,0 +1,88 @@
+# TString PascalCase Methods Check
+
+Проверка запрещает PascalCase-методы `Size()`, `Data()` и `Empty()` у строковых
+типов из `util/generic/string.h` (`TString`, `TStringBuf`, `TUtf16String*`,
+`TWtringBuf`, `std::string` и т.п.).
+
+В новых версиях contrib эти методы у `TString` удалены — нужно использовать
+`size()`, `data()` и `empty()`.
+
+Скрипт смотрит только на **добавленные строки** в diff. Вызовы вроде
+`range.Size()` у других типов не трогаются.
+
+Скрипт: `.github/scripts/check_tstring_pascal_methods.py`  
+Тесты: `.github/scripts/tests/check_tstring_pascal_methods_test.py`  
+CI: workflow `.github/workflows/check-tstring-pascal-methods.yaml` (на PR в `main`)
+
+## Юнит-тесты
+
+Из корня репозитория:
+
+```bash
+python3 .github/scripts/tests/check_tstring_pascal_methods_test.py -v
+```
+
+## Проверка как в CI
+
+То же, что делает GitHub Actions на pull request — diff от `main` до текущего
+`HEAD`:
+
+```bash
+git fetch origin main
+
+python3 .github/scripts/check_tstring_pascal_methods.py \
+  --from-ref origin/main \
+  --to-ref HEAD
+```
+
+Код выхода `0` — нарушений нет, `1` — найдены PascalCase-вызовы на строках.
+
+## Проверка staged-изменений
+
+Перед коммитом, только по файлам в индексе:
+
+```bash
+git add path/to/file.cpp
+
+python3 .github/scripts/check_tstring_pascal_methods.py --cached
+```
+
+## Проверка конкретных файлов
+
+```bash
+python3 .github/scripts/check_tstring_pascal_methods.py \
+  --from-ref origin/main \
+  --to-ref HEAD \
+  cloud/filestore/libs/storage/model/block_buffer_ut.cpp
+```
+
+## Ручная проверка «должно упасть»
+
+```bash
+sed -i 's/Data\.size()/Data.Size()/' cloud/filestore/libs/storage/model/block_buffer_ut.cpp
+git add cloud/filestore/libs/storage/model/block_buffer_ut.cpp
+
+python3 .github/scripts/check_tstring_pascal_methods.py --cached
+
+# откат
+git restore --staged cloud/filestore/libs/storage/model/block_buffer_ut.cpp
+git restore cloud/filestore/libs/storage/model/block_buffer_ut.cpp
+```
+
+Ожидаемый вывод:
+
+```text
+use .size() instead of .Size()
+```
+
+## Что проверяется / что нет
+
+| Пример | Результат |
+|--------|-----------|
+| `TString s; s.Size()` в новой строке | fail |
+| `TStringBuf buf; buf.Data()` в новой строке | fail |
+| `TRange range; range.Size()` | ok |
+| Старый код без изменений в diff | ok |
+
+Ограничение: `auto s = GetString(); s.Size()` не поймается, если `s` не
+объявлен явно как строковый тип в том же файле.

--- a/.github/scripts/tests/check_tstring_pascal_methods_test.py
+++ b/.github/scripts/tests/check_tstring_pascal_methods_test.py
@@ -1,0 +1,65 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_tstring_pascal_methods.py"
+
+
+class CheckTStringPascalMethodsTest(unittest.TestCase):
+    def run_script(self, content: str, added_line: str) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.check_call(["git", "init", "-q"], cwd=repo)
+            subprocess.check_call(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=repo,
+            )
+            subprocess.check_call(
+                ["git", "config", "user.name", "Test User"],
+                cwd=repo,
+            )
+
+            path = repo / "sample.cpp"
+            path.write_text(content, encoding="utf-8")
+            subprocess.check_call(["git", "add", "sample.cpp"], cwd=repo)
+            subprocess.check_call(["git", "commit", "-qm", "base"], cwd=repo)
+
+            updated = content + added_line
+            path.write_text(updated, encoding="utf-8")
+            subprocess.check_call(["git", "add", "sample.cpp"], cwd=repo)
+
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), "--cached", "sample.cpp"],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_flags_tstring_size_on_added_line(self):
+        result = self.run_script(
+            "TString Data;\n",
+            "    for (ui32 i = 0; i < Data.Size(); ++i) {}\n",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("use .size() instead of .Size()", result.stderr)
+
+    def test_ignores_non_string_size(self):
+        result = self.run_script(
+            "struct TRange { ui64 Size() const; };\nTRange range;\n",
+            "    auto n = range.Size();\n",
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_flags_tstring_data(self):
+        result = self.run_script(
+            "TStringBuf buf;\n",
+            "    const char* ptr = buf.Data();\n",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("use .data() instead of .Data()", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/check-tstring-pascal-methods.yaml
+++ b/.github/workflows/check-tstring-pascal-methods.yaml
@@ -1,0 +1,42 @@
+name: check-tstring-pascal-methods
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.cpp"
+      - "**/*.cc"
+      - "**/*.cxx"
+      - "**/*.h"
+      - "**/*.hpp"
+      - "**/*.hh"
+      - "**/*.hxx"
+      - ".github/scripts/check_tstring_pascal_methods.py"
+      - ".github/workflows/check-tstring-pascal-methods.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-tstring-pascal-methods:
+    runs-on: [self-hosted, "self-hosted", "runner_light"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: fetch base branch
+        run: git fetch origin "${{ github.base_ref }}"
+
+      - name: check TString PascalCase methods
+        run: |
+          python3 .github/scripts/check_tstring_pascal_methods.py \
+            --from-ref "origin/${{ github.base_ref }}" \
+            --to-ref HEAD


### PR DESCRIPTION
### Notes

Add a lightweight script and GitHub Actions workflow that reject new uses of Size()/Data()/Empty() on TString-family types. Newer contrib removes these PascalCase methods from util/generic/string.h.

- Add `check_tstring_pascal_methods.py` to reject new uses of `Size()`, `Data()`, and `Empty()` on TString-family types (`TString`, `TStringBuf`, `TUtf16String*`, `TWtringBuf`, `std::string`, etc.)
- Add a lightweight GitHub Actions workflow that runs on every pull request to `main` (no `ok-to-test` label required)
- Add unit tests and a README with local usage instructions

### Issue
This helps prevent Arcadia sync breakages: newer contrib removes the deleted PascalCase `TString` accessors from `util/generic/string.h` in favor of `size()`, `data()`, and `empty()`.
The check only inspects **added lines** in the PR diff and only flags variables declared as string types, so legitimate calls like `range.Size()` on other classes are not affected.
