### PR TITLE
issue-5894: fastshard IStorageNode iface + a tcp server which can forward requests to this storage node (intended for testing purposes)

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.cpp
@@ -1,0 +1,39 @@
+#include "storage_node.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TStorageNodeStub: public IStorageNode
+{
+public:
+#define SN_STUB_METHOD(name, ...)                                              \
+    NThreading::TFuture<NCloud::NProto::T##name##Response> name(               \
+        NCloud::NProto::T##name##Request request) override                     \
+    {                                                                          \
+        Y_UNUSED(request);                                                     \
+        NProto::T##name##Response response;                                    \
+        *response.MutableError() = MakeError(E_NOT_IMPLEMENTED);               \
+        return NThreading::MakeFuture(std::move(response));                    \
+    }                                                                          \
+// SN_STUB_METHOD
+
+    SN_METHODS(SN_STUB_METHOD)
+
+#undef SN_STUB_METHOD
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageNodePtr CreateStorageNodeStub()
+{
+    return std::make_shared<TStorageNodeStub>();
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <library/cpp/threading/future/future.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define SN_METHODS(xxx, ...)                                                   \
+    xxx(AcquireDevices,   __VA_ARGS__)                                         \
+    xxx(ReleaseDevices,   __VA_ARGS__)                                         \
+    xxx(ReadPages,        __VA_ARGS__)                                         \
+    xxx(WriteLogRecord,   __VA_ARGS__)                                         \
+// SN_METHODS
+
+struct IStorageNode
+{
+    virtual ~IStorageNode() = default;
+
+#define SN_DECLARE_METHOD(name, ...)                                           \
+    virtual NThreading::TFuture<NCloud::NProto::T##name##Response> name(       \
+        NCloud::NProto::T##name##Request request) = 0;                         \
+// SN_DECLARE_METHOD
+
+    SN_METHODS(SN_DECLARE_METHOD)
+
+#undef SN_DECLARE_METHOD
+};
+
+using IStorageNodePtr = std::shared_ptr<IStorageNode>;
+
+// A stub IStorageNode that returns default (S_OK) responses.
+IStorageNodePtr CreateStorageNodeStub();
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
@@ -17,6 +17,16 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
     xxx(WriteLogRecord,   __VA_ARGS__)                                         \
 // SN_METHODS
 
+/**
+ * Storage node backend that handles TDeviceProtocolRequest messages
+ * decoded off the wire by the sn server. One method per case of the
+ * TDeviceProtocolRequest.Request oneof — see SN_METHODS above.
+ *
+ * All methods take a concrete request proto and return a future for the
+ * matching response proto. The server invokes them from a silk fiber
+ * that WaitFiber-blocks on the returned future, so implementations may
+ * finish synchronously (return MakeFuture(...)) or asynchronously.
+ */
 struct IStorageNode
 {
     virtual ~IStorageNode() = default;
@@ -33,7 +43,14 @@ struct IStorageNode
 
 using IStorageNodePtr = std::shared_ptr<IStorageNode>;
 
-// A stub IStorageNode that returns default (S_OK) responses.
+/**
+ * Returns an IStorageNode whose every method resolves to a default-
+ * constructed response with Error.Code = E_NOT_IMPLEMENTED. Intended
+ * for tests, stub bootstraps and the not-yet-wired path in production
+ * builds.
+ *
+ * @return - Shared owner of the stub instance.
+ */
 IStorageNodePtr CreateStorageNodeStub();
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/iface/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/ya.make
@@ -1,0 +1,14 @@
+LIBRARY()
+
+SRCS(
+    storage_node.cpp
+)
+
+PEERDIR(
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+
+    library/cpp/threading/future
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
@@ -8,11 +8,15 @@
 #include <silk/fibers/future.h>
 #include <silk/util/logger.h>
 
+#include <util/generic/deque.h>
 #include <util/generic/size_literals.h>
 #include <util/generic/string.h>
+#include <util/generic/yexception.h>
+#include <util/system/spinlock.h>
 
 #include <cerrno>
 #include <cstring>
+#include <memory>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -39,6 +43,118 @@ constexpr ui64 MaxMessageSize = 64_MB;
 constexpr int SocketBacklog = 128;
 
 ////////////////////////////////////////////////////////////////////////////////
+// Handler bookkeeping.
+//
+// Every accepted connection is represented by a THandler which owns the
+// accepted fd and the FiberFuture the ConnFiberMain fiber signals on
+// completion. THandlerRegistry keeps them so Stop() can shut every live
+// connection down and wait for its fiber to actually exit before returning.
+
+struct THandler
+{
+    int Fd;
+    FiberFuture Future;
+
+    explicit THandler(int fd)
+        : Fd(fd)
+    {}
+
+    ~THandler()
+    {
+        if (Fd >= 0) {
+            ::close(Fd);
+        }
+    }
+
+    // FiberFuture holds an atomic, so THandler cannot be copied or moved.
+    // The registry stores it via std::unique_ptr, giving it a stable
+    // address for the whole ConnFiberMain lifetime.
+    THandler(const THandler&) = delete;
+    THandler& operator=(const THandler&) = delete;
+};
+
+class THandlerRegistry
+{
+public:
+    // Consume the handler on success; return it back if the registry is
+    // shutting down. The caller then lets the returned handler's dtor
+    // close the fd (see the Register() call site for the shutdown/wait
+    // logic that keeps the already-spawned fiber from touching a
+    // destroyed future).
+    std::unique_ptr<THandler> Register(std::unique_ptr<THandler> h)
+    {
+        with_lock (Lock) {
+            if (Stopping) {
+                return h;
+            }
+            Handlers.push_back(std::move(h));
+        }
+        return nullptr;
+    }
+
+    // Drop any entries whose fiber has already finished. Called from the
+    // accept loop so the deque doesn't grow without bound while the server
+    // is running.
+    void Prune()
+    {
+        with_lock (Lock) {
+            for (auto it = Handlers.begin(); it != Handlers.end();) {
+                int err = 0;
+                if ((*it)->Future.isSet(&err)) {
+                    if (err) {
+                        SILK_WARN(
+                            "conn fd=%d: error: %s",
+                            (*it)->Fd,
+                            ::strerror(err));
+                    }
+
+                    // ~THandler closes the fd.
+                    it = Handlers.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+    }
+
+    // Shut down every still-open connection and wait for its fiber to
+    // finish. After this returns no ConnFiberMain fiber is still running
+    // and no future Register() call will succeed.
+    void Stop()
+    {
+        TDeque<std::unique_ptr<THandler>> local;
+        with_lock (Lock) {
+            Stopping = true;
+            std::swap(local, Handlers);
+        }
+
+        // Half-close each fd so any recv/send inside the handler wakes
+        // with EOF/EPIPE; the fd itself stays owned by THandler until
+        // wait() returns and we let the unique_ptr fall out of scope.
+        for (const auto& h: local) {
+            int err = 0;
+            if (h->Future.isSet(&err)) {
+                continue;
+            }
+            ::shutdown(h->Fd, SHUT_RDWR);
+        }
+
+        for (auto& h: local) {
+            h->Future.wait();
+        }
+        // local goes out of scope: unique_ptr dtors close each fd exactly
+        // once, after we know no fiber can still reference it.
+    }
+
+private:
+    TAdaptiveLock Lock;
+    TDeque<std::unique_ptr<THandler>> Handlers;
+    bool Stopping = false;
+};
+
+using THandlerRegistryPtr = std::shared_ptr<THandlerRegistry>;
+
+////////////////////////////////////////////////////////////////////////////////
 // Bridge NThreading::TFuture to silk FiberFuture.
 
 template <typename T>
@@ -49,7 +165,11 @@ T WaitFiber(const NThreading::TFuture<T>& future)
         fiberFuture.set(0);
     });
     fiberFuture.wait();
-    return future.GetValue();
+    try {
+        return future.GetValue();
+    } catch (...) {
+        Y_ABORT("unexpected: %s", CurrentExceptionMessage().c_str());
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -97,13 +217,16 @@ static_assert(sizeof(TConnParams) <= silk::FIBER_PARAMETERS_SIZE);
 
 int ConnFiberMain(TConnParams* params) noexcept
 {
+    //
+    // The fd is owned by THandler in the server's registry, not by this
+    // fiber. We just use it and return; the server closes it after our
+    // future is set (via ~THandler in Prune() or Stop()).
+    //
+
     int fd = params->Fd;
     auto storage = params->Storage.lock();
     if (!storage) {
-        SILK_WARN(
-            "conn fd=%d: storage gone before handshake, dropping",
-            fd);
-        ::close(fd);
+        SILK_WARN("conn fd=%d: storage gone before handshake, dropping", fd);
         return ECANCELED;
     }
 
@@ -112,13 +235,14 @@ int ConnFiberMain(TConnParams* params) noexcept
         ui32 lenBe = 0;
         if (int r = RecvAll(fd, &lenBe, sizeof(lenBe)); r) {
             if (r != EIO) {
-                SILK_WARN(
-                    "conn fd=%d: recv length: %s",
-                    fd,
-                    ::strerror(r));
+                SILK_WARN("conn fd=%d: recv length: %s", fd, ::strerror(r));
             }
-            ::close(fd);
-            // EIO means the client closed the connection cleanly.
+
+            //
+            // EIO means the client closed the connection cleanly, or
+            // the server half-closed us from Stop().
+            //
+
             return r == EIO ? 0 : r;
         }
         ui32 len = ntohl(lenBe);
@@ -128,7 +252,6 @@ int ConnFiberMain(TConnParams* params) noexcept
                 fd,
                 len,
                 MaxMessageSize);
-            ::close(fd);
             return EMSGSIZE;
         }
 
@@ -140,7 +263,6 @@ int ConnFiberMain(TConnParams* params) noexcept
                 "conn fd=%d: recv body: %s",
                 fd,
                 ::strerror(r));
-            ::close(fd);
             return r;
         }
 
@@ -150,7 +272,6 @@ int ConnFiberMain(TConnParams* params) noexcept
                 "conn fd=%d: parse request failed, len=%u",
                 fd,
                 len);
-            ::close(fd);
             return EBADMSG;
         }
 
@@ -175,7 +296,6 @@ int ConnFiberMain(TConnParams* params) noexcept
                 "conn fd=%d: send resp length: %s",
                 fd,
                 ::strerror(r));
-            ::close(fd);
             return r;
         }
         if (int r = SendAll(fd, respBuf.data(), respBuf.size()); r) {
@@ -183,7 +303,6 @@ int ConnFiberMain(TConnParams* params) noexcept
                 "conn fd=%d: send resp body: %s",
                 fd,
                 ::strerror(r));
-            ::close(fd);
             return r;
         }
     }
@@ -197,20 +316,77 @@ struct TAcceptParams
     int ListenFd;
     int ShutdownFd;
     std::weak_ptr<IStorageNode> Storage;
+    std::weak_ptr<THandlerRegistry> Handlers;
 };
 static_assert(sizeof(TAcceptParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+void RegisterHandler(
+    int cfd,
+    THandlerRegistry& handlers,
+    std::weak_ptr<IStorageNode> storage) noexcept
+{
+    int one = 1;
+    ::setsockopt(cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+    //
+    // Package the fd + a future the spawned fiber will signal on
+    // exit. THandler owns the fd (its dtor closes it) once we
+    // hand it to the registry, so we do not ::close(cfd) on any
+    // path below — the registry's Prune()/Stop() will.
+    //
+
+    auto handler = std::make_unique<THandler>(cfd);
+    FiberFuture* fut = &handler->Future;
+
+    int r = FiberScheduler::run(
+        ConnFiberMain,
+        TConnParams{.Fd = cfd, .Storage = std::move(storage)},
+        fut);
+    if (r) {
+        SILK_ERROR("spawn handler fiber: %s", ::strerror(r));
+
+        //
+        // Fiber wasn't scheduled; the runtime won't touch the
+        // future, and no one will read from cfd. Handler dtor
+        // closes cfd on scope exit.
+        //
+
+        return;
+    }
+
+    //
+    // Spawn succeeded — the fiber holds a pointer to
+    // handler->Future. If the registry is already shutting down
+    // we cannot destroy `handler` (that would free the future
+    // while the fiber may still write to it): shutdown the fd so
+    // the fiber wakes with EOF/EPIPE, wait for it, then let
+    // ~THandler close the fd.
+    //
+
+    if (auto rejected = handlers.Register(std::move(handler))) {
+        SILK_INFO(
+            "registry stopping; waking spawned handler fd=%d",
+            rejected->Fd);
+        ::shutdown(rejected->Fd, SHUT_RDWR);
+        rejected->Future.wait();
+    }
+}
 
 int AcceptFiberMain(TAcceptParams* params) noexcept
 {
     int lfd = params->ListenFd;
     int sfd = params->ShutdownFd;
     auto storage = params->Storage.lock();
-    if (!storage) {
-        SILK_WARN("accept fiber: storage gone before startup, exiting");
+    auto handlers = params->Handlers.lock();
+    if (!storage || !handlers) {
+        SILK_WARN("accept fiber: server gone before startup, exiting");
         return ECANCELED;
     }
 
     for (;;) {
+        // Reap completed handlers so the registry deque doesn't grow.
+        handlers->Prune();
+
         sockaddr_in addr{};
         socklen_t addrLen = sizeof(addr);
         int cfd = ::accept4(
@@ -219,23 +395,13 @@ int AcceptFiberMain(TAcceptParams* params) noexcept
             &addrLen,
             SOCK_NONBLOCK | SOCK_CLOEXEC);
         if (cfd >= 0) {
-            int one = 1;
-            ::setsockopt(cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
-
-            int r = FiberScheduler::run(
-                ConnFiberMain,
-                TConnParams{.Fd = cfd, .Storage = storage},
-                nullptr /* future */);
-            if (r) {
-                SILK_ERROR("spawn handler fiber: %s", ::strerror(r));
-                ::close(cfd);
-            }
-            continue;
+            RegisterHandler(cfd, *handlers, storage);
         }
 
         if (errno == EINTR || errno == ECONNABORTED) {
             continue;
         }
+
         if (errno != EAGAIN && errno != EWOULDBLOCK) {
             const int savedErrno = errno;
             SILK_ERROR(
@@ -273,6 +439,7 @@ public:
     TServer(ui16 port, IStorageNodePtr storage)
         : Port(port)
         , Storage(std::move(storage))
+        , Handlers(std::make_shared<THandlerRegistry>())
     {}
 
     ~TServer() override
@@ -307,9 +474,11 @@ public:
                 .ListenFd = ListenFd,
                 .ShutdownFd = ShutdownFd,
                 .Storage = Storage,
+                .Handlers = Handlers,
             },
             &AcceptFuture);
         Y_ENSURE(r == 0, "failed to spawn accept fiber: " << ::strerror(r));
+        AcceptFiberSpawned = true;
     }
 
     void Stop() override
@@ -321,16 +490,34 @@ public:
             }
         }
 
-        // Wait for the accept fiber to exit; surface its exit code so that
-        // an unclean shutdown (e.g. accept4 failure) is visible in logs.
-        const int r = AcceptFuture.wait();
-        if (r) {
-            SILK_WARN(
-                "accept fiber exited with error: %s",
-                ::strerror(r));
-        } else {
-            SILK_INFO("sn server stopped");
+        //
+        // Wait for the accept fiber to exit; surface its exit code so
+        // that an unclean shutdown (e.g. accept4 failure) is visible in
+        // logs. AcceptFuture is only set after AcceptFiberMain returns,
+        // so once this returns we know no new handlers can be
+        // registered.
+        //
+        // Skip the wait if Start() bailed before scheduling the fiber
+        // (eventfd/socket/bind/listen failure): AcceptFuture stays
+        // unset and .wait() would block forever.
+        //
+
+        if (AcceptFiberSpawned) {
+            const int r = AcceptFuture.wait();
+            if (r) {
+                SILK_WARN("accept fiber exited with error: %s", ::strerror(r));
+            }
         }
+
+        //
+        // Half-close every still-live connection and wait for its
+        // handler fiber to finish. After this returns there are no
+        // ConnFiberMain fibers left running against this server.
+        //
+
+        Handlers->Stop();
+
+        SILK_INFO("sn server stopped");
     }
 
 private:
@@ -371,8 +558,10 @@ private:
 
     ui16 Port;
     IStorageNodePtr Storage;
+    THandlerRegistryPtr Handlers;
     int ListenFd = -1;
     int ShutdownFd = -1;
+    bool AcceptFiberSpawned = false;
     FiberFuture AcceptFuture;
 };
 

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
@@ -1,0 +1,388 @@
+#include "server.h"
+
+#include <cloud/filestore/libs/storage/fastshard/ipc/ipc.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/logger.h>
+
+#include <util/generic/size_literals.h>
+#include <util/generic/string.h>
+
+#include <cerrno>
+#include <cstring>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+using silk::FiberFuture;
+using silk::FiberScheduler;
+
+using NCloud::NProto::TDeviceProtocolRequest;
+using NCloud::NProto::TDeviceProtocolResponse;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// Constants.
+
+constexpr ui64 MaxMessageSize = 64_MB;
+constexpr int SocketBacklog = 128;
+
+////////////////////////////////////////////////////////////////////////////////
+// Bridge NThreading::TFuture to silk FiberFuture.
+
+template <typename T>
+T WaitFiber(const NThreading::TFuture<T>& future)
+{
+    FiberFuture fiberFuture;
+    future.Subscribe([&fiberFuture](const auto&) {
+        fiberFuture.set(0);
+    });
+    fiberFuture.wait();
+    return future.GetValue();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Request dispatch.
+
+TDeviceProtocolResponse Dispatch(
+    IStorageNode& storage,
+    const TDeviceProtocolRequest& req)
+{
+    TDeviceProtocolResponse resp;
+
+    switch (req.GetRequestCase()) {
+#define DISPATCH_REQUEST(name, ...)                                            \
+        case TDeviceProtocolRequest::k##name: {                                \
+            auto result = WaitFiber(storage.name(req.Get##name()));            \
+            *resp.Mutable##name() = std::move(result);                         \
+            break;                                                             \
+        }                                                                      \
+// DISPATCH_REQUEST
+
+    SN_METHODS(DISPATCH_REQUEST)
+
+#undef DISPATCH_REQUEST
+
+        case TDeviceProtocolRequest::REQUEST_NOT_SET: {
+            auto* err = resp.MutableProtocolError();
+            err->SetCode(E_ARGUMENT);
+            err->SetMessage("empty device protocol request");
+            break;
+        }
+    }
+
+    return resp;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Per-connection handler fiber.
+
+struct TConnParams
+{
+    int Fd;
+    std::weak_ptr<IStorageNode> Storage;
+};
+static_assert(sizeof(TConnParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int ConnFiberMain(TConnParams* params) noexcept
+{
+    int fd = params->Fd;
+    auto storage = params->Storage.lock();
+    if (!storage) {
+        SILK_WARN(
+            "conn fd=%d: storage gone before handshake, dropping",
+            fd);
+        ::close(fd);
+        return ECANCELED;
+    }
+
+    for (;;) {
+        // Read length prefix.
+        ui32 lenBe = 0;
+        if (int r = RecvAll(fd, &lenBe, sizeof(lenBe)); r) {
+            if (r != EIO) {
+                SILK_WARN(
+                    "conn fd=%d: recv length: %s",
+                    fd,
+                    ::strerror(r));
+            }
+            ::close(fd);
+            // EIO means the client closed the connection cleanly.
+            return r == EIO ? 0 : r;
+        }
+        ui32 len = ntohl(lenBe);
+        if (len > MaxMessageSize) {
+            SILK_WARN(
+                "conn fd=%d: oversized message: len=%u, limit=%lu",
+                fd,
+                len,
+                MaxMessageSize);
+            ::close(fd);
+            return EMSGSIZE;
+        }
+
+        // Read request body.
+        TString reqBuf;
+        reqBuf.ReserveAndResize(len);
+        if (int r = RecvAll(fd, reqBuf.begin(), len); r) {
+            SILK_WARN(
+                "conn fd=%d: recv body: %s",
+                fd,
+                ::strerror(r));
+            ::close(fd);
+            return r;
+        }
+
+        TDeviceProtocolRequest req;
+        if (!req.ParseFromString(reqBuf)) {
+            SILK_WARN(
+                "conn fd=%d: parse request failed, len=%u",
+                fd,
+                len);
+            ::close(fd);
+            return EBADMSG;
+        }
+
+        // Dispatch.
+        TDeviceProtocolResponse resp = Dispatch(*storage, req);
+
+        // Echo the outer request id so the client can correlate.
+        resp.SetRequestId(req.GetRequestId());
+
+        // Send response.
+        TString respBuf;
+        const bool serialized = resp.SerializeToString(&respBuf);
+        if (!serialized) {
+            SILK_ERROR(
+                "conn fd=%d: failed to serialize response",
+                fd);
+        }
+
+        ui32 respLenBe = htonl(static_cast<ui32>(respBuf.size()));
+        if (int r = SendAll(fd, &respLenBe, sizeof(respLenBe)); r) {
+            SILK_WARN(
+                "conn fd=%d: send resp length: %s",
+                fd,
+                ::strerror(r));
+            ::close(fd);
+            return r;
+        }
+        if (int r = SendAll(fd, respBuf.data(), respBuf.size()); r) {
+            SILK_WARN(
+                "conn fd=%d: send resp body: %s",
+                fd,
+                ::strerror(r));
+            ::close(fd);
+            return r;
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Accept loop fiber.
+
+struct TAcceptParams
+{
+    int ListenFd;
+    int ShutdownFd;
+    std::weak_ptr<IStorageNode> Storage;
+};
+static_assert(sizeof(TAcceptParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+int AcceptFiberMain(TAcceptParams* params) noexcept
+{
+    int lfd = params->ListenFd;
+    int sfd = params->ShutdownFd;
+    auto storage = params->Storage.lock();
+    if (!storage) {
+        SILK_WARN("accept fiber: storage gone before startup, exiting");
+        return ECANCELED;
+    }
+
+    for (;;) {
+        sockaddr_in addr{};
+        socklen_t addrLen = sizeof(addr);
+        int cfd = ::accept4(
+            lfd,
+            reinterpret_cast<sockaddr*>(&addr),
+            &addrLen,
+            SOCK_NONBLOCK | SOCK_CLOEXEC);
+        if (cfd >= 0) {
+            int one = 1;
+            ::setsockopt(cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+            int r = FiberScheduler::run(
+                ConnFiberMain,
+                TConnParams{.Fd = cfd, .Storage = storage},
+                nullptr /* future */);
+            if (r) {
+                SILK_ERROR("spawn handler fiber: %s", ::strerror(r));
+                ::close(cfd);
+            }
+            continue;
+        }
+
+        if (errno == EINTR || errno == ECONNABORTED) {
+            continue;
+        }
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            const int savedErrno = errno;
+            SILK_ERROR(
+                "accept fiber: accept4: %s, exiting",
+                ::strerror(savedErrno));
+            return savedErrno;
+        }
+
+        // Wait for connection or shutdown.
+        FiberScheduler::IoFuture acceptFuture;
+        FiberScheduler::IoFuture shutdownFuture;
+        FiberScheduler::poll(lfd, POLLIN, nullptr, &acceptFuture);
+        FiberScheduler::poll(sfd, POLLIN, nullptr, &shutdownFuture);
+
+        FiberFuture* futures[] = {&acceptFuture, &shutdownFuture};
+        uint64_t which =
+            FiberFuture::waitForMultiple(futures, std::size(futures));
+
+        if (which == 1) {
+            acceptFuture.cancel();
+            acceptFuture.wait();
+            return 0;
+        }
+
+        shutdownFuture.cancel();
+        shutdownFuture.wait();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TServer: public IServer
+{
+public:
+    TServer(ui16 port, IStorageNodePtr storage)
+        : Port(port)
+        , Storage(std::move(storage))
+    {}
+
+    ~TServer() override
+    {
+        if (ShutdownFd >= 0) {
+            ::close(ShutdownFd);
+        }
+        if (ListenFd >= 0) {
+            ::close(ListenFd);
+        }
+    }
+
+    void Start() override
+    {
+        ShutdownFd = ::eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+        if (ShutdownFd < 0) {
+            SILK_ERROR("eventfd: %s", ::strerror(errno));
+            return;
+        }
+
+        ListenFd = MakeListenSocket();
+        if (ListenFd < 0) {
+            return;
+        }
+
+        SILK_INFO("sn server listening on port %u", Port);
+
+        // Spawn the accept loop as a background fiber.
+        int r = FiberScheduler::run(
+            AcceptFiberMain,
+            TAcceptParams{
+                .ListenFd = ListenFd,
+                .ShutdownFd = ShutdownFd,
+                .Storage = Storage,
+            },
+            &AcceptFuture);
+        Y_ENSURE(r == 0, "failed to spawn accept fiber: " << ::strerror(r));
+    }
+
+    void Stop() override
+    {
+        if (ShutdownFd >= 0) {
+            uint64_t one = 1;
+            if (::write(ShutdownFd, &one, sizeof(one)) < 0) {
+                SILK_ERROR("shutdown write: %s", ::strerror(errno));
+            }
+        }
+
+        // Wait for the accept fiber to exit; surface its exit code so that
+        // an unclean shutdown (e.g. accept4 failure) is visible in logs.
+        const int r = AcceptFuture.wait();
+        if (r) {
+            SILK_WARN(
+                "accept fiber exited with error: %s",
+                ::strerror(r));
+        } else {
+            SILK_INFO("sn server stopped");
+        }
+    }
+
+private:
+    int MakeListenSocket()
+    {
+        int fd = ::socket(
+            AF_INET,
+            SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC,
+            0);
+        if (fd < 0) {
+            SILK_ERROR("socket: %s", ::strerror(errno));
+            return -1;
+        }
+
+        int one = 1;
+        ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(Port);
+        addr.sin_addr.s_addr = INADDR_ANY;
+
+        if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr))
+            < 0)
+        {
+            SILK_ERROR("bind: %s", ::strerror(errno));
+            ::close(fd);
+            return -1;
+        }
+
+        if (::listen(fd, SocketBacklog) < 0) {
+            SILK_ERROR("listen: %s", ::strerror(errno));
+            ::close(fd);
+            return -1;
+        }
+        return fd;
+    }
+
+    ui16 Port;
+    IStorageNodePtr Storage;
+    int ListenFd = -1;
+    int ShutdownFd = -1;
+    FiberFuture AcceptFuture;
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IServerPtr CreateServer(ui16 port, IStorageNodePtr storage)
+{
+    return std::make_shared<TServer>(port, std::move(storage));
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+
+#include <cloud/storage/core/libs/common/startable.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IServer: public IStartable
+{
+};
+
+using IServerPtr = std::shared_ptr<IServer>;
+
+// Creates a silk-based TCP server that reads TDeviceProtocolRequest
+// frames from the wire, dispatches them to `storage`, and writes back
+// TDeviceProtocolResponse frames.
+IServerPtr CreateServer(ui16 port, IStorageNodePtr storage);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server.h
@@ -10,15 +10,28 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * TCP server that decodes TDeviceProtocolRequest frames and dispatches
+ * them to a single IStorageNode. Extends IStartable — Start() begins
+ * accepting; Stop() shuts the accept loop down, half-closes every open
+ * connection and waits for every handler fiber before returning.
+ */
 struct IServer: public IStartable
 {
 };
 
 using IServerPtr = std::shared_ptr<IServer>;
 
-// Creates a silk-based TCP server that reads TDeviceProtocolRequest
-// frames from the wire, dispatches them to `storage`, and writes back
-// TDeviceProtocolResponse frames.
+/**
+ * Constructs a silk-based TCP server that reads length-prefixed
+ * TDeviceProtocolRequest frames from the wire, dispatches each to
+ * `storage`, and writes the matching TDeviceProtocolResponse frame back.
+ *
+ * @param port - TCP port to listen on (bound at Start()).
+ * @param storage - Backend that services the four request cases.
+ *
+ * @return - Server instance; call Start() to begin accepting.
+ */
 IServerPtr CreateServer(ui16 port, IStorageNodePtr storage);
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server_stub.cpp
@@ -1,0 +1,36 @@
+#include "server.h"
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TServer: public IServer
+{
+public:
+    TServer(ui16 port, IStorageNodePtr storage)
+    {
+        Y_UNUSED(port);
+        Y_UNUSED(storage);
+    }
+
+    void Start() override
+    {
+    }
+
+    void Stop() override
+    {
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IServerPtr CreateServer(ui16 port, IStorageNodePtr storage)
+{
+    return std::make_unique<TServer>(port, std::move(storage));
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server_ut.cpp
@@ -429,3 +429,39 @@ TEST(ServerTest, HandlesMultipleRequestsPerConnection)
         0);
     EXPECT_EQ(0, r);
 }
+
+TEST(ServerTest, StopClosesIdleConnection)
+{
+    // A client opens a connection but never sends a request. The handler
+    // fiber ends up parked in RecvAll on the length prefix. When the
+    // fixture is torn down, Server->Stop() must half-close that fd so the
+    // handler can wake, exit, and be waited on -- otherwise the fiber
+    // outlives the server and FiberScheduler::destroy() would be running
+    // with a live fiber against a freed IStorageNode.
+    //
+    // Regression guard: without the THandlerRegistry / Stop path this
+    // test hangs (RecvAll on the client side never gets EOF because the
+    // server never shuts down cfd).
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            int fd;
+            {
+                TServerFixture fx;
+                fd = ConnectTo(fx.Port);
+                EXPECT_GE(fd, 0);
+                // Do not send anything. Fixture goes out of scope,
+                // Server->Stop() runs, and the handler must be woken.
+            }
+
+            // After Stop() the server has half-closed our socket, so the
+            // next recv on our side must return EOF (RecvAll translates
+            // that into EIO).
+            char buf = 0;
+            const int recvR = RecvAll(fd, &buf, sizeof(buf));
+            EXPECT_EQ(EIO, recvR);
+            ::close(fd);
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server_ut.cpp
@@ -1,0 +1,431 @@
+#include <cloud/filestore/libs/storage/fastshard/ipc/ipc.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/server/server.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/init.h>
+
+#include <gtest/gtest.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/string/builder.h>
+#include <util/system/spinlock.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace NCloud::NFileStore::NStorage::NFastShard;
+using NCloud::NProto::TDeviceProtocolRequest;
+using NCloud::NProto::TDeviceProtocolResponse;
+using silk::FiberScheduler;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// Silk test environment.
+
+class TSilkEnv: public ::testing::Environment
+{
+public:
+    void SetUp() override
+    {
+        silk::initialize();
+        FiberScheduler::initialize();
+    }
+
+    void TearDown() override
+    {
+        FiberScheduler::destroy();
+        silk::destroy();
+    }
+};
+
+[[maybe_unused]] auto* const gEnv =
+    ::testing::AddGlobalTestEnvironment(new TSilkEnv);
+
+////////////////////////////////////////////////////////////////////////////////
+// Pick a free port on loopback.
+
+ui16 GetFreePort()
+{
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    ::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+    socklen_t len = sizeof(addr);
+    ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len);
+    ui16 port = ntohs(addr.sin_port);
+    ::close(fd);
+    return port;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// A fake storage node that records every call and returns preconfigured
+// responses.
+
+struct TFakeStorageNode: public IStorageNode
+{
+    TAdaptiveLock Lock;
+
+    TVector<NCloud::NProto::TAcquireDevicesRequest> AcquireCalls;
+    TVector<NCloud::NProto::TReleaseDevicesRequest> ReleaseCalls;
+    TVector<NCloud::NProto::TReadPagesRequest> ReadCalls;
+    TVector<NCloud::NProto::TWriteLogRecordRequest> WriteCalls;
+
+    NCloud::NProto::TAcquireDevicesResponse AcquireResp;
+    NCloud::NProto::TReleaseDevicesResponse ReleaseResp;
+    NCloud::NProto::TReadPagesResponse ReadResp;
+    NCloud::NProto::TWriteLogRecordResponse WriteResp;
+
+    NThreading::TFuture<NCloud::NProto::TAcquireDevicesResponse> AcquireDevices(
+        NCloud::NProto::TAcquireDevicesRequest request) override
+    {
+        with_lock (Lock) {
+            AcquireCalls.push_back(std::move(request));
+        }
+        return NThreading::MakeFuture(AcquireResp);
+    }
+
+    NThreading::TFuture<NCloud::NProto::TReleaseDevicesResponse> ReleaseDevices(
+        NCloud::NProto::TReleaseDevicesRequest request) override
+    {
+        with_lock (Lock) {
+            ReleaseCalls.push_back(std::move(request));
+        }
+        return NThreading::MakeFuture(ReleaseResp);
+    }
+
+    NThreading::TFuture<NCloud::NProto::TReadPagesResponse> ReadPages(
+        NCloud::NProto::TReadPagesRequest request) override
+    {
+        with_lock (Lock) {
+            ReadCalls.push_back(std::move(request));
+        }
+        return NThreading::MakeFuture(ReadResp);
+    }
+
+    NThreading::TFuture<NCloud::NProto::TWriteLogRecordResponse> WriteLogRecord(
+        NCloud::NProto::TWriteLogRecordRequest request) override
+    {
+        with_lock (Lock) {
+            WriteCalls.push_back(std::move(request));
+        }
+        return NThreading::MakeFuture(WriteResp);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Fiber-friendly non-blocking connect to loopback.
+
+int ConnectTo(ui16 port)
+{
+    int fd =
+        ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    int r = ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+    if (r < 0 && errno != EINPROGRESS) {
+        ::close(fd);
+        return -1;
+    }
+    if (r < 0) {
+        if (FiberScheduler::poll(fd, POLLOUT)) {
+            ::close(fd);
+            return -1;
+        }
+        int err = 0;
+        socklen_t errLen = sizeof(err);
+        ::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errLen);
+        if (err) {
+            ::close(fd);
+            return -1;
+        }
+    }
+    int one = 1;
+    ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+    return fd;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Send a framed request and read a framed response on the same connection.
+
+TDeviceProtocolResponse SendRecv(int fd, const TDeviceProtocolRequest& req)
+{
+    TString buf;
+    Y_PROTOBUF_SUPPRESS_NODISCARD req.SerializeToString(&buf);
+    ui32 lenBe = htonl(static_cast<ui32>(buf.size()));
+    EXPECT_EQ(0, SendAll(fd, &lenBe, sizeof(lenBe)));
+    EXPECT_EQ(0, SendAll(fd, buf.data(), buf.size()));
+
+    ui32 respLenBe = 0;
+    EXPECT_EQ(0, RecvAll(fd, &respLenBe, sizeof(respLenBe)));
+    ui32 respLen = ntohl(respLenBe);
+    TString respBuf;
+    respBuf.ReserveAndResize(respLen);
+    EXPECT_EQ(0, RecvAll(fd, respBuf.begin(), respLen));
+
+    TDeviceProtocolResponse resp;
+    EXPECT_TRUE(resp.ParseFromString(respBuf));
+    return resp;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Test fixture: builds a fake storage, starts the server on a free port.
+//
+// IServer::Start() runs synchronously through bind() + listen() and only then
+// spawns the accept fiber, so once the constructor returns the listen socket
+// is already accepting connections — no timing dependency.
+
+struct TServerFixture
+{
+    std::shared_ptr<TFakeStorageNode> Storage;
+    ui16 Port;
+    IServerPtr Server;
+
+    TServerFixture()
+        : Storage(std::make_shared<TFakeStorageNode>())
+        , Port(GetFreePort())
+        , Server(CreateServer(Port, Storage))
+    {
+        Server->Start();
+    }
+
+    ~TServerFixture()
+    {
+        Server->Stop();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(ServerTest, RoundTripsAcquireDevices)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TServerFixture fx;
+
+            int fd = ConnectTo(fx.Port);
+            EXPECT_GE(fd, 0);
+
+            TDeviceProtocolRequest req;
+            req.SetRequestId(7);
+            auto* body = req.MutableAcquireDevices();
+            body->AddDeviceUUIDs("dev-a");
+            body->AddDeviceUUIDs("dev-b");
+            const auto resp = SendRecv(fd, req);
+            ::close(fd);
+
+            EXPECT_EQ(7u, resp.GetRequestId());
+            EXPECT_TRUE(resp.HasAcquireDevices());
+            EXPECT_FALSE(resp.HasProtocolError());
+            EXPECT_EQ(1u, fx.Storage->AcquireCalls.size());
+            EXPECT_EQ(2u, fx.Storage->AcquireCalls[0].DeviceUUIDsSize());
+            EXPECT_EQ("dev-a", fx.Storage->AcquireCalls[0].GetDeviceUUIDs(0));
+            EXPECT_EQ("dev-b", fx.Storage->AcquireCalls[0].GetDeviceUUIDs(1));
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ServerTest, RoundTripsReleaseDevices)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TServerFixture fx;
+
+            int fd = ConnectTo(fx.Port);
+            EXPECT_GE(fd, 0);
+
+            TDeviceProtocolRequest req;
+            req.SetRequestId(11);
+            req.MutableReleaseDevices()->AddDeviceUUIDs("dev-x");
+            const auto resp = SendRecv(fd, req);
+            ::close(fd);
+
+            EXPECT_EQ(11u, resp.GetRequestId());
+            EXPECT_TRUE(resp.HasReleaseDevices());
+            EXPECT_EQ(1u, fx.Storage->ReleaseCalls.size());
+            EXPECT_EQ(1u, fx.Storage->ReleaseCalls[0].DeviceUUIDsSize());
+            EXPECT_EQ("dev-x", fx.Storage->ReleaseCalls[0].GetDeviceUUIDs(0));
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ServerTest, RoundTripsReadPages)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TServerFixture fx;
+
+            // Preload the canned response with a distinguishable payload.
+            // Safe to configure post-Start: no client has connected yet so
+            // the fake storage is not being read.
+            auto* pg = fx.Storage->ReadResp.AddPageGroups();
+            pg->SetFirstPageNo(5);
+            pg->AddContent("page-content");
+
+            int fd = ConnectTo(fx.Port);
+            EXPECT_GE(fd, 0);
+
+            TDeviceProtocolRequest req;
+            req.SetRequestId(42);
+            auto* body = req.MutableReadPages();
+            body->SetDeviceUUID("dev-42");
+            auto* ref = body->AddPageGroupRefs();
+            ref->SetFirstPageNo(5);
+            ref->SetPageCount(2);
+            ref->SetPageSize(4096);
+            const auto resp = SendRecv(fd, req);
+            ::close(fd);
+
+            EXPECT_EQ(42u, resp.GetRequestId());
+            EXPECT_TRUE(resp.HasReadPages());
+            EXPECT_EQ(1u, resp.GetReadPages().PageGroupsSize());
+            EXPECT_EQ(
+                5u,
+                resp.GetReadPages().GetPageGroups(0).GetFirstPageNo());
+            EXPECT_EQ(
+                "page-content",
+                resp.GetReadPages().GetPageGroups(0).GetContent(0));
+
+            EXPECT_EQ(1u, fx.Storage->ReadCalls.size());
+            EXPECT_EQ("dev-42", fx.Storage->ReadCalls[0].GetDeviceUUID());
+            EXPECT_EQ(1u, fx.Storage->ReadCalls[0].PageGroupRefsSize());
+            EXPECT_EQ(
+                5u,
+                fx.Storage->ReadCalls[0].GetPageGroupRefs(0).GetFirstPageNo());
+            EXPECT_EQ(
+                2u,
+                fx.Storage->ReadCalls[0].GetPageGroupRefs(0).GetPageCount());
+            EXPECT_EQ(
+                4096u,
+                fx.Storage->ReadCalls[0].GetPageGroupRefs(0).GetPageSize());
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ServerTest, RoundTripsWriteLogRecord)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TServerFixture fx;
+
+            int fd = ConnectTo(fx.Port);
+            EXPECT_GE(fd, 0);
+
+            TDeviceProtocolRequest req;
+            req.SetRequestId(99);
+            auto* body = req.MutableWriteLogRecord();
+            body->SetDeviceUUID("dev-99");
+            body->SetLogSequenceNumber(1234);
+            auto* pg = body->AddPageGroups();
+            pg->SetFirstPageNo(0);
+            pg->AddContent("payload");
+            const auto resp = SendRecv(fd, req);
+            ::close(fd);
+
+            EXPECT_EQ(99u, resp.GetRequestId());
+            EXPECT_TRUE(resp.HasWriteLogRecord());
+            EXPECT_EQ(1u, fx.Storage->WriteCalls.size());
+            EXPECT_EQ("dev-99", fx.Storage->WriteCalls[0].GetDeviceUUID());
+            EXPECT_EQ(
+                1234u,
+                fx.Storage->WriteCalls[0].GetLogSequenceNumber());
+            EXPECT_EQ(1u, fx.Storage->WriteCalls[0].PageGroupsSize());
+            EXPECT_EQ(
+                "payload",
+                fx.Storage->WriteCalls[0].GetPageGroups(0).GetContent(0));
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ServerTest, ReturnsProtocolErrorForEmptyRequest)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TServerFixture fx;
+
+            int fd = ConnectTo(fx.Port);
+            EXPECT_GE(fd, 0);
+
+            TDeviceProtocolRequest req;
+            req.SetRequestId(3);
+            // No oneof set → server should reply with ProtocolError.
+            const auto resp = SendRecv(fd, req);
+            ::close(fd);
+
+            EXPECT_EQ(3u, resp.GetRequestId());
+            EXPECT_TRUE(resp.HasProtocolError());
+            EXPECT_EQ(
+                static_cast<ui32>(NCloud::E_ARGUMENT),
+                resp.GetProtocolError().GetCode());
+            EXPECT_EQ(0u, fx.Storage->AcquireCalls.size());
+            EXPECT_EQ(0u, fx.Storage->ReleaseCalls.size());
+            EXPECT_EQ(0u, fx.Storage->ReadCalls.size());
+            EXPECT_EQ(0u, fx.Storage->WriteCalls.size());
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ServerTest, HandlesMultipleRequestsPerConnection)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TServerFixture fx;
+
+            int fd = ConnectTo(fx.Port);
+            EXPECT_GE(fd, 0);
+
+            for (ui64 i = 1; i <= 3; ++i) {
+                TDeviceProtocolRequest req;
+                req.SetRequestId(i);
+                req.MutableAcquireDevices()->AddDeviceUUIDs(
+                    TStringBuilder() << "dev-" << i);
+                const auto resp = SendRecv(fd, req);
+                EXPECT_EQ(i, resp.GetRequestId());
+                EXPECT_TRUE(resp.HasAcquireDevices());
+            }
+            ::close(fd);
+
+            EXPECT_EQ(3u, fx.Storage->AcquireCalls.size());
+            EXPECT_EQ("dev-1", fx.Storage->AcquireCalls[0].GetDeviceUUIDs(0));
+            EXPECT_EQ("dev-2", fx.Storage->AcquireCalls[1].GetDeviceUUIDs(0));
+            EXPECT_EQ("dev-3", fx.Storage->AcquireCalls[2].GetDeviceUUIDs(0));
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}

--- a/cloud/filestore/libs/storage/fastshard/sn/server/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/ut/ya.make
@@ -1,0 +1,20 @@
+GTEST()
+
+SRCS(
+    ../server_ut.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/ipc
+    cloud/filestore/libs/storage/fastshard/sn/iface
+    cloud/filestore/libs/storage/fastshard/sn/server
+
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+
+    contrib/libs/silk/src/fibers
+
+    contrib/restricted/googletest/googletest
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/sn/server/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/ya.make
@@ -1,0 +1,34 @@
+LIBRARY()
+
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    SRCS(
+        server.cpp
+    )
+
+    PEERDIR(
+        cloud/filestore/libs/storage/fastshard/ipc
+
+        contrib/libs/silk/src/fibers
+    )
+ELSE()
+    SRCS(
+        server_stub.cpp
+    )
+ENDIF()
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/sn/iface
+
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+
+    library/cpp/threading/future
+)
+
+END()
+
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    RECURSE_FOR_TESTS(
+        ut
+    )
+ENDIF()

--- a/cloud/filestore/libs/storage/fastshard/sn/server/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/ya.make
@@ -27,7 +27,8 @@ PEERDIR(
 
 END()
 
-IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+# TODO(#5895): fix silk bootstrap/shutdown under msan
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB AND SANITIZER_TYPE != "memory")
     RECURSE_FOR_TESTS(
         ut
     )

--- a/cloud/filestore/libs/storage/fastshard/sn/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/ya.make
@@ -1,0 +1,4 @@
+RECURSE(
+    iface
+    server
+)

--- a/cloud/filestore/libs/storage/fastshard/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/ya.make
@@ -5,4 +5,5 @@ RECURSE(
     impl
     ipc
     server
+    sn
 )


### PR DESCRIPTION
### Notes
Will use this storage node interface + sn server as a lightweight alternative to blockstore-disk-agent intended for testing purposes and faster prototyping

Storage API was merged here: https://github.com/ydb-platform/nbs/pull/6441

### Issue
https://github.com/ydb-platform/nbs/issues/5894