### PR TITLE
issue-6438: add per-volume cumulative availability counters

### DIFF
--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -257,6 +257,14 @@ private:
     TRequestCounters RequestCounters;
     TDynamicCounters::TCounterPtr HasDowntimeCounter;
 
+    // Cumulative per-volume availability counters (derivative/RATE, seconds).
+    // Nested: ObservedSeconds >= AvailableSeconds >= HealthySeconds. Consumers
+    // compute availability = Available/Observed and quality = Healthy/Observed
+    // over a window. Advance only while the volume is served.
+    TDynamicCounters::TCounterPtr ObservedSecondsCounter;
+    TDynamicCounters::TCounterPtr AvailableSecondsCounter;
+    TDynamicCounters::TCounterPtr HealthySecondsCounter;
+
     TInstant LastRemountTime;
 
     // Number of pins on the object.
@@ -545,6 +553,11 @@ private:
     >;
     TDownDisksCounters DownDisksCounters;
     TDynamicCounters::TCounterPtr TotalDownDisksCounter;
+
+    // Wall-clock time of the last finished update interval, used to measure the
+    // real elapsed duration for the cumulative availability counters. Accessed
+    // only from UpdateStats (single periodic updater).
+    TInstant LastUpdateStatsTime;
 
 public:
     TVolumeStats(
@@ -884,6 +897,18 @@ public:
         ui32 totalDownDisks = 0;
         std::array<ui32, NProto::EStorageMediaKind_ARRAYSIZE> downDisksCounters{};
 
+        // Real duration of the finished update interval, used to advance the
+        // cumulative availability counters. Zero on the very first interval
+        // (no prior timestamp), which is fine for RATE metrics.
+        ui64 intervalSeconds = 0;
+        if (updateIntervalFinished) {
+            const auto now = Timer->Now();
+            if (LastUpdateStatsTime != TInstant::Zero()) {
+                intervalSeconds = (now - LastUpdateStatsTime).Seconds();
+            }
+            LastUpdateStatsTime = now;
+        }
+
         for (auto& [logicalDiskId, holder]: Volumes) {
             TVolumeInfoBase& volumeBase = *holder.VolumeBase;
 
@@ -905,12 +930,30 @@ public:
                     : EDowntimeStateChange::UP);
             }
 
+            const bool isSufferingCritically =
+                volumeBase.PerfCalc.IsSufferingCritically();
+            const bool isAvailable = !hasDowntime;
+            const bool isHealthy = isAvailable && !isSufferingCritically;
+
             for (auto& [key, instance]: holder.VolumeInfos) {
                 instance->RequestCounters.UpdateStats(updateIntervalFinished);
                 if (updateIntervalFinished) {
                     Y_DEBUG_ABORT_UNLESS(instance->HasDowntimeCounter);
                     if (instance->HasDowntimeCounter) {
                         *instance->HasDowntimeCounter = hasDowntime;
+                    }
+
+                    if (intervalSeconds) {
+                        if (instance->ObservedSecondsCounter) {
+                            *instance->ObservedSecondsCounter += intervalSeconds;
+                        }
+                        if (isAvailable && instance->AvailableSecondsCounter) {
+                            *instance->AvailableSecondsCounter +=
+                                intervalSeconds;
+                        }
+                        if (isHealthy && instance->HealthySecondsCounter) {
+                            *instance->HealthySecondsCounter += intervalSeconds;
+                        }
                     }
                 }
             }
@@ -1075,6 +1118,12 @@ private:
                 ->GetSubgroup("folder", volumeConfig.GetFolderId());
         info->RequestCounters.Register(*countersGroup);
         info->HasDowntimeCounter = countersGroup->GetCounter("HasDowntime");
+        info->ObservedSecondsCounter =
+            countersGroup->GetCounter("ObservedSeconds", true);
+        info->AvailableSecondsCounter =
+            countersGroup->GetCounter("AvailableSeconds", true);
+        info->HealthySecondsCounter =
+            countersGroup->GetCounter("HealthySeconds", true);
 
         auto reportZeroBlocksMetrics =
             !DiagnosticsConfig

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -542,6 +542,14 @@ private:
         DiagnosticsConfig->GetExecutionTimeSizeClasses();
 
     TDynamicCountersPtr Counters;
+    // Separate, narrow counters tree (component=sli_volume) for the
+    // cumulative availability counters (ObservedSeconds/AvailableSeconds/
+    // HealthySeconds) only. component=server_volume also carries ~200-280
+    // other per-volume perf counters, so a UA scrape of the whole subtree
+    // just to reach our ~3 sensors is wasteful; this sibling group lets UA
+    // pull only what SLI needs. Only populated for EServerStats - client-side
+    // stats keep the previous (nested) placement, see RegisterInstance().
+    TDynamicCountersPtr SliCounters;
     std::shared_ptr<NUserCounter::IUserCounterSupplier> UserCounters;
     std::unique_ptr<TSufferCounters> SufferCounters;
     std::unique_ptr<TSufferCounters> SmoothSufferCounters;
@@ -1126,12 +1134,24 @@ private:
                 ->GetSubgroup("folder", volumeConfig.GetFolderId());
         info->RequestCounters.Register(*countersGroup);
         info->HasDowntimeCounter = countersGroup->GetCounter("HasDowntime");
+
+        // component=sli_volume for server-side stats (see SliCounters
+        // comment); client-side stats keep the old nested placement.
+        auto sliCountersGroup = SliCounters
+            ? SliCounters
+                  ->GetSubgroup("volume", volumeConfig.GetDiskId())
+                  ->GetSubgroup(
+                      "instance",
+                      realInstanceId.GetRealInstanceId())
+                  ->GetSubgroup("cloud", volumeConfig.GetCloudId())
+                  ->GetSubgroup("folder", volumeConfig.GetFolderId())
+            : countersGroup;
         info->ObservedSecondsCounter =
-            countersGroup->GetCounter("ObservedSeconds", true);
+            sliCountersGroup->GetCounter("ObservedSeconds", true);
         info->AvailableSecondsCounter =
-            countersGroup->GetCounter("AvailableSeconds", true);
+            sliCountersGroup->GetCounter("AvailableSeconds", true);
         info->HealthySecondsCounter =
-            countersGroup->GetCounter("HealthySeconds", true);
+            sliCountersGroup->GetCounter("HealthySeconds", true);
 
         auto reportZeroBlocksMetrics =
             !DiagnosticsConfig
@@ -1161,6 +1181,11 @@ private:
         Counters->GetSubgroup("volume", volumeBase->Volume.GetDiskId())->
             RemoveSubgroup("instance", realInstanceId.GetRealInstanceId());
 
+        if (SliCounters) {
+            SliCounters->GetSubgroup("volume", volumeBase->Volume.GetDiskId())->
+                RemoveSubgroup("instance", realInstanceId.GetRealInstanceId());
+        }
+
         NUserCounter::UnregisterServerVolumeInstance(
             *UserCounters,
             volumeBase->Volume.GetCloudId(),
@@ -1176,6 +1201,10 @@ private:
         }
 
         Counters->RemoveSubgroup("volume", volumeBase->Volume.GetDiskId());
+
+        if (SliCounters) {
+            SliCounters->RemoveSubgroup("volume", volumeBase->Volume.GetDiskId());
+        }
     }
 
     void InitCounters()
@@ -1216,6 +1245,10 @@ private:
                             ->GetCounter("DownDisks");
                     ++mk;
                 }
+
+                SliCounters = Counters
+                    ->GetSubgroup("component", "sli_volume")
+                    ->GetSubgroup("host", "cluster");
 
                 Counters = Counters->GetSubgroup("component", "server_volume");
                 break;

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -545,10 +545,11 @@ private:
     // Separate, narrow counters tree (component=sli_volume) for the
     // cumulative availability counters (ObservedSeconds/AvailableSeconds/
     // HealthySeconds) only. component=server_volume also carries ~200-280
-    // other per-volume perf counters, so a UA scrape of the whole subtree
-    // just to reach our ~3 sensors is wasteful; this sibling group lets UA
-    // pull only what SLI needs. Only populated for EServerStats - client-side
-    // stats keep the previous (nested) placement, see RegisterInstance().
+    // other per-volume perf counters, so scraping the whole subtree just to
+    // reach our ~3 sensors is wasteful; this sibling group lets a monitoring
+    // agent pull only these specific counters. Only populated for
+    // EServerStats - client-side stats keep the previous (nested)
+    // placement, see RegisterInstance().
     TDynamicCountersPtr SliCounters;
     std::shared_ptr<NUserCounter::IUserCounterSupplier> UserCounters;
     std::unique_ptr<TSufferCounters> SufferCounters;
@@ -1137,6 +1138,13 @@ private:
 
         // component=sli_volume for server-side stats (see SliCounters
         // comment); client-side stats keep the old nested placement.
+        // "type" uses MediaKindToComputeType (not MediaKindToStatsString, the
+        // convention used by the DownDisks aggregate below) to produce the
+        // same disk-type spelling ("network-ssd", ...) this helper already
+        // produces elsewhere in the codebase.
+        // StorageMediaKind is immutable for the lifetime of a volume (unlike
+        // cloud/folder, which AlterVolume can change), so this extra level
+        // needs no re-registration/aliasing handling.
         auto sliCountersGroup = SliCounters
             ? SliCounters
                   ->GetSubgroup("volume", volumeConfig.GetDiskId())
@@ -1145,6 +1153,9 @@ private:
                       realInstanceId.GetRealInstanceId())
                   ->GetSubgroup("cloud", volumeConfig.GetCloudId())
                   ->GetSubgroup("folder", volumeConfig.GetFolderId())
+                  ->GetSubgroup(
+                      "type",
+                      MediaKindToComputeType(volumeConfig.GetStorageMediaKind()))
             : countersGroup;
         info->ObservedSecondsCounter =
             sliCountersGroup->GetCounter("ObservedSeconds", true);

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -265,6 +265,11 @@ private:
     TDynamicCounters::TCounterPtr AvailableSecondsCounter;
     TDynamicCounters::TCounterPtr HealthySecondsCounter;
 
+    // Wall-clock time up to which the availability counters have been credited
+    // for this instance. Seeded at construction (mount time) so that time
+    // before the volume was served is never counted.
+    TInstant AvailabilityLastUpdateTime;
+
     TInstant LastRemountTime;
 
     // Number of pins on the object.
@@ -301,6 +306,7 @@ public:
               GetRequestCountersOptions(*VolumeBase),
               histogramCounterOptions,
               executionTimeSizeClasses))
+        , AvailabilityLastUpdateTime(VolumeBase->Timer->Now())
     {}
 
     bool IsPinned() const noexcept
@@ -553,11 +559,6 @@ private:
     >;
     TDownDisksCounters DownDisksCounters;
     TDynamicCounters::TCounterPtr TotalDownDisksCounter;
-
-    // Wall-clock time of the last finished update interval, used to measure the
-    // real elapsed duration for the cumulative availability counters. Accessed
-    // only from UpdateStats (single periodic updater).
-    TInstant LastUpdateStatsTime;
 
 public:
     TVolumeStats(
@@ -897,17 +898,11 @@ public:
         ui32 totalDownDisks = 0;
         std::array<ui32, NProto::EStorageMediaKind_ARRAYSIZE> downDisksCounters{};
 
-        // Real duration of the finished update interval, used to advance the
-        // cumulative availability counters. Zero on the very first interval
-        // (no prior timestamp), which is fine for RATE metrics.
-        ui64 intervalSeconds = 0;
-        if (updateIntervalFinished) {
-            const auto now = Timer->Now();
-            if (LastUpdateStatsTime != TInstant::Zero()) {
-                intervalSeconds = (now - LastUpdateStatsTime).Seconds();
-            }
-            LastUpdateStatsTime = now;
-        }
+        // Wall-clock time of this stats tick. The cumulative availability
+        // counters advance on every tick (not only on the publish tick) by the
+        // real per-volume elapsed time, so state changes are sampled at tick
+        // resolution and newly mounted volumes are not over-credited.
+        const auto now = Timer->Now();
 
         for (auto& [logicalDiskId, holder]: Volumes) {
             TVolumeInfoBase& volumeBase = *holder.VolumeBase;
@@ -924,7 +919,7 @@ public:
 
             if (updateIntervalFinished) {
                 volumeBase.DowntimeHistory.PushBack(
-                    Timer->Now(),
+                    now,
                     hasDowntime
                     ? EDowntimeStateChange::DOWN
                     : EDowntimeStateChange::UP);
@@ -942,18 +937,31 @@ public:
                     if (instance->HasDowntimeCounter) {
                         *instance->HasDowntimeCounter = hasDowntime;
                     }
+                }
 
-                    if (intervalSeconds) {
-                        if (instance->ObservedSecondsCounter) {
-                            *instance->ObservedSecondsCounter += intervalSeconds;
-                        }
+                // Advance the cumulative availability counters by the real time
+                // this instance has been served since the last accounted tick.
+                // Sampling every tick (not only on the publish tick) tracks the
+                // downtime/suffering signal at tick resolution; the per-instance
+                // timestamp (seeded at mount) avoids crediting time before the
+                // volume was served; advancing the timestamp only by the whole
+                // seconds credited keeps the sub-second remainder and avoids
+                // drift.
+                if (instance->ObservedSecondsCounter &&
+                    now > instance->AvailabilityLastUpdateTime)
+                {
+                    const ui64 seconds =
+                        (now - instance->AvailabilityLastUpdateTime).Seconds();
+                    if (seconds) {
+                        *instance->ObservedSecondsCounter += seconds;
                         if (isAvailable && instance->AvailableSecondsCounter) {
-                            *instance->AvailableSecondsCounter +=
-                                intervalSeconds;
+                            *instance->AvailableSecondsCounter += seconds;
                         }
                         if (isHealthy && instance->HealthySecondsCounter) {
-                            *instance->HealthySecondsCounter += intervalSeconds;
+                            *instance->HealthySecondsCounter += seconds;
                         }
+                        instance->AvailabilityLastUpdateTime +=
+                            TDuration::Seconds(seconds);
                     }
                 }
             }

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -552,7 +552,7 @@ private:
     // only these specific counters. Populated for both EServerStats and
     // EClientStats in InitCounters; see RegisterInstance() for the per-volume
     // subgroup layout.
-    TDynamicCountersPtr SliCounters;
+    TDynamicCountersPtr AvailabilityCounters;
     std::shared_ptr<NUserCounter::IUserCounterSupplier> UserCounters;
     std::unique_ptr<TSufferCounters> SufferCounters;
     std::unique_ptr<TSufferCounters> SmoothSufferCounters;
@@ -1149,9 +1149,8 @@ private:
         info->RequestCounters.Register(*countersGroup);
         info->HasDowntimeCounter = countersGroup->GetCounter("HasDowntime");
 
-        // When the narrow component=sli_volume tree is available (see
-        // SliCounters comment) register the cumulative counters there;
-        // otherwise fall back to the nested per-volume group.
+        // Register the cumulative counters in the narrow component=sli_volume
+        // tree (see AvailabilityCounters comment).
         // "type" uses MediaKindToComputeType (not MediaKindToStatsString, the
         // convention used by the DownDisks aggregate below) to produce the
         // same disk-type spelling ("network-ssd", ...) this helper already
@@ -1159,24 +1158,21 @@ private:
         // StorageMediaKind is immutable for the lifetime of a volume (unlike
         // cloud/folder, which AlterVolume can change), so this extra level
         // needs no re-registration/aliasing handling.
-        auto sliCountersGroup = SliCounters
-            ? SliCounters
-                  ->GetSubgroup("volume", volumeConfig.GetDiskId())
-                  ->GetSubgroup(
-                      "instance",
-                      realInstanceId.GetRealInstanceId())
-                  ->GetSubgroup("cloud", volumeConfig.GetCloudId())
-                  ->GetSubgroup("folder", volumeConfig.GetFolderId())
-                  ->GetSubgroup(
-                      "type",
-                      MediaKindToComputeType(volumeConfig.GetStorageMediaKind()))
-            : countersGroup;
+        auto availabilityCountersGroup =
+            AvailabilityCounters
+                ->GetSubgroup("volume", volumeConfig.GetDiskId())
+                ->GetSubgroup("instance", realInstanceId.GetRealInstanceId())
+                ->GetSubgroup("cloud", volumeConfig.GetCloudId())
+                ->GetSubgroup("folder", volumeConfig.GetFolderId())
+                ->GetSubgroup(
+                    "type",
+                    MediaKindToComputeType(volumeConfig.GetStorageMediaKind()));
         info->ObservedSecondsCounter =
-            sliCountersGroup->GetCounter("ObservedSeconds", true);
+            availabilityCountersGroup->GetCounter("ObservedSeconds", true);
         info->AvailableSecondsCounter =
-            sliCountersGroup->GetCounter("AvailableSeconds", true);
+            availabilityCountersGroup->GetCounter("AvailableSeconds", true);
         info->HealthySecondsCounter =
-            sliCountersGroup->GetCounter("HealthySeconds", true);
+            availabilityCountersGroup->GetCounter("HealthySeconds", true);
 
         auto reportZeroBlocksMetrics =
             !DiagnosticsConfig
@@ -1206,10 +1202,9 @@ private:
         Counters->GetSubgroup("volume", volumeBase->Volume.GetDiskId())->
             RemoveSubgroup("instance", realInstanceId.GetRealInstanceId());
 
-        if (SliCounters) {
-            SliCounters->GetSubgroup("volume", volumeBase->Volume.GetDiskId())->
-                RemoveSubgroup("instance", realInstanceId.GetRealInstanceId());
-        }
+        AvailabilityCounters
+            ->GetSubgroup("volume", volumeBase->Volume.GetDiskId())
+            ->RemoveSubgroup("instance", realInstanceId.GetRealInstanceId());
 
         NUserCounter::UnregisterServerVolumeInstance(
             *UserCounters,
@@ -1227,9 +1222,9 @@ private:
 
         Counters->RemoveSubgroup("volume", volumeBase->Volume.GetDiskId());
 
-        if (SliCounters) {
-            SliCounters->RemoveSubgroup("volume", volumeBase->Volume.GetDiskId());
-        }
+        AvailabilityCounters->RemoveSubgroup(
+            "volume",
+            volumeBase->Volume.GetDiskId());
     }
 
     void InitCounters()
@@ -1271,7 +1266,7 @@ private:
                     ++mk;
                 }
 
-                SliCounters = Counters
+                AvailabilityCounters = Counters
                     ->GetSubgroup("component", "sli_volume")
                     ->GetSubgroup("host", "cluster");
 
@@ -1279,7 +1274,7 @@ private:
                 break;
             }
             case EVolumeStatsType::EClientStats: {
-                SliCounters = Counters
+                AvailabilityCounters = Counters
                     ->GetSubgroup("component", "sli_volume")
                     ->GetSubgroup("host", "cluster");
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -260,7 +260,8 @@ private:
     // Cumulative per-volume availability counters (derivative/RATE, seconds).
     // Nested: ObservedSeconds >= AvailableSeconds >= HealthySeconds. Consumers
     // compute availability = Available/Observed and quality = Healthy/Observed
-    // over a window. Advance only while the volume is served.
+    // over a window. Advance only while the volume is being served, 
+    // until the counters are trimmed.
     TDynamicCounters::TCounterPtr ObservedSecondsCounter;
     TDynamicCounters::TCounterPtr AvailableSecondsCounter;
     TDynamicCounters::TCounterPtr HealthySecondsCounter;
@@ -960,18 +961,29 @@ public:
                 if (instance->ObservedSecondsCounter &&
                     now > instance->AvailabilityLastUpdateTime)
                 {
-                    const ui64 seconds =
-                        (now - instance->AvailabilityLastUpdateTime).Seconds();
-                    if (seconds) {
-                        *instance->ObservedSecondsCounter += seconds;
-                        if (isAvailable && instance->AvailableSecondsCounter) {
-                            *instance->AvailableSecondsCounter += seconds;
+                    const auto elapsed =
+                        now - instance->AvailabilityLastUpdateTime;
+                    if (elapsed > UpdateCountersInterval) {
+                        // A forward gap larger than the publish interval means
+                        // stats were not updated for a long time (thread
+                        // starvation, a suspended process, or a wall-clock
+                        // jump). Crediting the whole gap would count that
+                        // "stall" time as availability, so drop this increment
+                        // and just resync the timestamp.
+                        instance->AvailabilityLastUpdateTime = now;
+                    } else {
+                        const ui64 seconds = elapsed.Seconds();
+                        if (seconds) {
+                            *instance->ObservedSecondsCounter += seconds;
+                            if (isAvailable && instance->AvailableSecondsCounter) {
+                                *instance->AvailableSecondsCounter += seconds;
+                            }
+                            if (isHealthy && instance->HealthySecondsCounter) {
+                                *instance->HealthySecondsCounter += seconds;
+                            }
+                            instance->AvailabilityLastUpdateTime +=
+                                TDuration::Seconds(seconds);
                         }
-                        if (isHealthy && instance->HealthySecondsCounter) {
-                            *instance->HealthySecondsCounter += seconds;
-                        }
-                        instance->AvailabilityLastUpdateTime +=
-                            TDuration::Seconds(seconds);
                     }
                 }
             }

--- a/cloud/blockstore/libs/diagnostics/volume_stats.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats.cpp
@@ -544,12 +544,13 @@ private:
     TDynamicCountersPtr Counters;
     // Separate, narrow counters tree (component=sli_volume) for the
     // cumulative availability counters (ObservedSeconds/AvailableSeconds/
-    // HealthySeconds) only. component=server_volume also carries ~200-280
-    // other per-volume perf counters, so scraping the whole subtree just to
-    // reach our ~3 sensors is wasteful; this sibling group lets a monitoring
-    // agent pull only these specific counters. Only populated for
-    // EServerStats - client-side stats keep the previous (nested)
-    // placement, see RegisterInstance().
+    // HealthySeconds) only. The main per-volume tree (component=
+    // server_volume / client_volume) also carries ~200-280 other per-volume
+    // perf counters, so scraping the whole subtree just to reach our ~3
+    // sensors is wasteful; this sibling group lets a monitoring agent pull
+    // only these specific counters. Populated for both EServerStats and
+    // EClientStats in InitCounters; see RegisterInstance() for the per-volume
+    // subgroup layout.
     TDynamicCountersPtr SliCounters;
     std::shared_ptr<NUserCounter::IUserCounterSupplier> UserCounters;
     std::unique_ptr<TSufferCounters> SufferCounters;
@@ -1136,8 +1137,9 @@ private:
         info->RequestCounters.Register(*countersGroup);
         info->HasDowntimeCounter = countersGroup->GetCounter("HasDowntime");
 
-        // component=sli_volume for server-side stats (see SliCounters
-        // comment); client-side stats keep the old nested placement.
+        // When the narrow component=sli_volume tree is available (see
+        // SliCounters comment) register the cumulative counters there;
+        // otherwise fall back to the nested per-volume group.
         // "type" uses MediaKindToComputeType (not MediaKindToStatsString, the
         // convention used by the DownDisks aggregate below) to produce the
         // same disk-type spelling ("network-ssd", ...) this helper already
@@ -1265,6 +1267,10 @@ private:
                 break;
             }
             case EVolumeStatsType::EClientStats: {
+                SliCounters = Counters
+                    ->GetSubgroup("component", "sli_volume")
+                    ->GetSubgroup("host", "cluster");
+
                 Counters = Counters->GetSubgroup("component", "client_volume");
                 break;
             }

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1508,6 +1508,66 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
     }
 
+    Y_UNIT_TEST(ShouldTrackClientAvailabilityCountersInSliVolume)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        const auto config =
+            std::make_shared<TDiagnosticsConfig>(NProto::TDiagnosticsConfig());
+
+        auto monitoring = CreateMonitoringServiceStub();
+
+        // Client-side stats must place the cumulative availability counters in
+        // the same narrow component=sli_volume tree as the server, so a
+        // monitoring agent on the compute host can scrape only these sensors.
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EClientStats,
+            timer);
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        auto sliCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+
+        auto observed = sliCounters->GetCounter("ObservedSeconds");
+        auto available = sliCounters->GetCounter("AvailableSeconds");
+        auto healthy = sliCounters->GetCounter("HealthySeconds");
+
+        // A healthy, served volume advances all three counters by the real
+        // time elapsed since it was mounted, exactly like the server path.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+
+        // The counters must live in the narrow sli_volume tree, not nested in
+        // the wide component=client_volume per-volume group.
+        auto clientVolume = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "client_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId);
+        UNIT_ASSERT(!clientVolume->FindCounter("ObservedSeconds"));
+    }
+
     Y_UNIT_TEST(ShouldAlterVolume)
     {
         auto inactivityTimeout = TDuration::MilliSeconds(10);

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1229,37 +1229,76 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         auto available = volumeCounters->GetCounter("AvailableSeconds");
         auto healthy = volumeCounters->GetCounter("HealthySeconds");
 
-        // The first finished interval has no prior timestamp, so nothing is
-        // accumulated.
-        timer->AdvanceTime(TDuration::Seconds(15));
-        volumeStats->UpdateStats(true);
-        UNIT_ASSERT_VALUES_EQUAL(0, observed->Val());
-        UNIT_ASSERT_VALUES_EQUAL(0, available->Val());
-        UNIT_ASSERT_VALUES_EQUAL(0, healthy->Val());
-
-        // A healthy, served volume advances all three counters by the elapsed
-        // interval.
+        // A healthy, served volume advances all three counters by the real time
+        // elapsed since it was mounted (seeded at mount time).
         timer->AdvanceTime(TDuration::Seconds(15));
         volumeStats->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
         UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
         UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
 
-        // updateIntervalFinished == false must not advance the counters and
-        // must not shift the interval baseline.
-        timer->AdvanceTime(TDuration::Seconds(15));
+        // Accumulation happens on every tick, not only on the publish tick, so
+        // updateIntervalFinished == false must still advance the counters.
+        timer->AdvanceTime(TDuration::Seconds(1));
         volumeStats->UpdateStats(false);
-        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
-        UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
-        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+        UNIT_ASSERT_VALUES_EQUAL(16, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(16, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(16, healthy->Val());
 
-        // The next finished interval accounts for the whole time elapsed since
-        // the previous finished interval (30s), including the skipped tick.
-        timer->AdvanceTime(TDuration::Seconds(15));
+        // A tick with no elapsed time credits nothing.
         volumeStats->UpdateStats(true);
-        UNIT_ASSERT_VALUES_EQUAL(45, observed->Val());
-        UNIT_ASSERT_VALUES_EQUAL(45, available->Val());
-        UNIT_ASSERT_VALUES_EQUAL(45, healthy->Val());
+        UNIT_ASSERT_VALUES_EQUAL(16, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(16, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(16, healthy->Val());
+
+        timer->AdvanceTime(TDuration::Seconds(14));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(30, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(30, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(30, healthy->Val());
+    }
+
+    Y_UNIT_TEST(ShouldCreditAvailabilityFromMountTime)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        const auto config =
+            std::make_shared<TDiagnosticsConfig>(NProto::TDiagnosticsConfig());
+
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            timer);
+
+        Mount(volumeStats, "test1", "client1", "instance1",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        // The service has already ticked for a while on the first volume.
+        timer->AdvanceTime(TDuration::Seconds(10));
+        volumeStats->UpdateStats(true);
+
+        // A second volume is mounted mid-interval, well after the previous tick.
+        Mount(volumeStats, "test2", "client2", "instance2",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        auto observed2 = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test2")
+            ->GetSubgroup("instance", "instance2")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetCounter("ObservedSeconds");
+
+        // Five seconds later the new volume must be credited only for the 5s it
+        // was actually served, not for the whole tick interval.
+        timer->AdvanceTime(TDuration::Seconds(5));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(5, observed2->Val());
     }
 
     Y_UNIT_TEST(ShouldNotAdvanceAvailableSecondsDuringDowntime)
@@ -1298,11 +1337,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         auto available = volumeCounters->GetCounter("AvailableSeconds");
         auto healthy = volumeCounters->GetCounter("HealthySeconds");
 
-        // Baseline.
-        timer->AdvanceTime(TDuration::Seconds(15));
-        volumeStats->UpdateStats(true);
-
-        // Healthy interval: everything advances.
+        // One healthy interval: everything advances.
         timer->AdvanceTime(TDuration::Seconds(15));
         volumeStats->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
@@ -1374,11 +1409,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         auto available = volumeCounters->GetCounter("AvailableSeconds");
         auto healthy = volumeCounters->GetCounter("HealthySeconds");
 
-        // Baseline.
-        timer->AdvanceTime(TDuration::Seconds(15));
-        volumeStats->UpdateStats(true);
-
-        // Healthy interval: everything advances.
+        // One healthy interval: everything advances.
         timer->AdvanceTime(TDuration::Seconds(15));
         volumeStats->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
@@ -1416,7 +1447,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
     }
 
-    Y_UNIT_TEST(ShouldNotAdvanceAvailabilityCountersForUnservedVolume)
+    Y_UNIT_TEST(ShouldStopAccruingAvailabilityAfterVolumeTrimmed)
     {
         auto timer = std::make_shared<TTestTimer>();
         const auto config =
@@ -1424,10 +1455,15 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
 
         auto monitoring = CreateMonitoringServiceStub();
 
+        // Finite inactivity timeout so that TrimVolumes() actually removes the
+        // instance. NOTE: UnmountVolume() is intentionally a no-op for this
+        // class (an instance may back several endpoints / live migration), so a
+        // volume keeps accruing during the grace period until it is trimmed —
+        // this mirrors the existing HasDowntime/RequestCounters behaviour.
         auto volumeStats = CreateVolumeStats(
             monitoring,
             config,
-            TDuration::Max(),
+            TDuration::Seconds(10),
             EVolumeStatsType::EServerStats,
             timer);
 
@@ -1449,16 +1485,19 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
 
         auto observed = volumeCounters->GetCounter("ObservedSeconds");
 
-        // Baseline + one accounted interval while served.
-        timer->AdvanceTime(TDuration::Seconds(15));
-        volumeStats->UpdateStats(true);
+        // One accounted interval while served.
         timer->AdvanceTime(TDuration::Seconds(15));
         volumeStats->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
 
-        // Once unmounted the volume is no longer iterated, so the counter must
-        // stop advancing.
+        // Unmount is a no-op; the instance is only removed by TrimVolumes once
+        // it has been inactive longer than the timeout (now - LastRemountTime
+        // = 15s > 10s).
         volumeStats->UnmountVolume("test1", "client1");
+        volumeStats->TrimVolumes();
+
+        // After the instance is trimmed it is no longer iterated, so the
+        // counter must stop advancing.
         timer->AdvanceTime(TDuration::Seconds(15));
         volumeStats->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1303,6 +1303,53 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         UNIT_ASSERT_VALUES_EQUAL(5, observed2->Val());
     }
 
+    Y_UNIT_TEST(ShouldNotCreditLargeGapAsAvailability)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        const auto config =
+            std::make_shared<TDiagnosticsConfig>(NProto::TDiagnosticsConfig());
+
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            timer);
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        auto sliCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "sli_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
+
+        auto observed = sliCounters->GetCounter("ObservedSeconds");
+
+        // A gap larger than the publish interval (e.g. stats were not updated
+        // for a long time / the clock jumped forward) must not be credited as
+        // availability: the increment is dropped and the timestamp resynced.
+        timer->AdvanceTime(TDuration::Seconds(60));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(0, observed->Val());
+
+        // A normal tick after the resync is accounted as usual.
+        timer->AdvanceTime(TDuration::Seconds(10));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(10, observed->Val());
+    }
+
     Y_UNIT_TEST(ShouldNotAdvanceAvailableSecondsDuringDowntime)
     {
         auto timer = std::make_shared<TTestTimer>();
@@ -1495,17 +1542,22 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         volumeStats->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
 
-        // Unmount is a no-op; the instance is only removed by TrimVolumes once
-        // it has been inactive longer than the timeout (now - LastRemountTime
-        // = 15s > 10s).
+        // Unmount alone is a no-op for this class: the instance (and therefore
+        // its counter) is not removed until TrimVolumes fires, so it must
+        // still be present and still accrue on the next tick.
         volumeStats->UnmountVolume("test1", "client1");
-        volumeStats->TrimVolumes();
-
-        // After the instance is trimmed it is no longer iterated, so the
-        // counter must stop advancing.
         timer->AdvanceTime(TDuration::Seconds(15));
         volumeStats->UpdateStats(true);
-        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+        UNIT_ASSERT(sliCounters->FindCounter("ObservedSeconds"));
+        UNIT_ASSERT_VALUES_EQUAL(30, observed->Val());
+
+        // The instance has now been inactive longer than the timeout
+        // (now - LastRemountTime = 30s > 10s), so TrimVolumes removes it and
+        // the counter stops advancing.
+        volumeStats->TrimVolumes();
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(30, observed->Val());
     }
 
     Y_UNIT_TEST(ShouldTrackClientAvailabilityCountersInSliVolume)

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1223,7 +1223,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
-            ->GetSubgroup("folder", DefaultFolderId);
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
 
         auto observed = sliCounters->GetCounter("ObservedSeconds");
         auto available = sliCounters->GetCounter("AvailableSeconds");
@@ -1292,6 +1293,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("instance", "instance2")
             ->GetSubgroup("cloud", DefaultCloudId)
             ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd")
             ->GetCounter("ObservedSeconds");
 
         // Five seconds later the new volume must be credited only for the 5s it
@@ -1331,7 +1333,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
-            ->GetSubgroup("folder", DefaultFolderId);
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
 
         auto observed = sliCounters->GetCounter("ObservedSeconds");
         auto available = sliCounters->GetCounter("AvailableSeconds");
@@ -1403,7 +1406,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
-            ->GetSubgroup("folder", DefaultFolderId);
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
 
         auto observed = sliCounters->GetCounter("ObservedSeconds");
         auto available = sliCounters->GetCounter("AvailableSeconds");
@@ -1481,7 +1485,8 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
-            ->GetSubgroup("folder", DefaultFolderId);
+            ->GetSubgroup("folder", DefaultFolderId)
+            ->GetSubgroup("type", "network-ssd");
 
         auto observed = sliCounters->GetCounter("ObservedSeconds");
 

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1194,6 +1194,276 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
                 ->GetCounter("DownDisks")->Val());
     }
 
+    Y_UNIT_TEST(ShouldTrackAvailabilityCounters)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        const auto config =
+            std::make_shared<TDiagnosticsConfig>(NProto::TDiagnosticsConfig());
+
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            timer);
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        auto volumeCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId);
+
+        auto observed = volumeCounters->GetCounter("ObservedSeconds");
+        auto available = volumeCounters->GetCounter("AvailableSeconds");
+        auto healthy = volumeCounters->GetCounter("HealthySeconds");
+
+        // The first finished interval has no prior timestamp, so nothing is
+        // accumulated.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(0, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(0, healthy->Val());
+
+        // A healthy, served volume advances all three counters by the elapsed
+        // interval.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+
+        // updateIntervalFinished == false must not advance the counters and
+        // must not shift the interval baseline.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(false);
+        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+
+        // The next finished interval accounts for the whole time elapsed since
+        // the previous finished interval (30s), including the skipped tick.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(45, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(45, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(45, healthy->Val());
+    }
+
+    Y_UNIT_TEST(ShouldNotAdvanceAvailableSecondsDuringDowntime)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        const auto config =
+            std::make_shared<TDiagnosticsConfig>(NProto::TDiagnosticsConfig());
+
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            timer);
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volumeInfo = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto volumeCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId);
+
+        auto observed = volumeCounters->GetCounter("ObservedSeconds");
+        auto available = volumeCounters->GetCounter("AvailableSeconds");
+        auto healthy = volumeCounters->GetCounter("HealthySeconds");
+
+        // Baseline.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+
+        // Healthy interval: everything advances.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+
+        // Force downtime: a completed request whose measured duration exceeds
+        // the downtime threshold (requestStarted set far in the past in cycle
+        // terms), same trick as the DownDisks tests above.
+        volumeInfo->RequestCompleted(
+            EBlockStoreRequest::WriteBlocks,
+            timer->Now().MicroSeconds(),
+            TDuration::Zero(),   // postponedTime
+            TDuration::Zero(),   // backoffTime
+            TDuration::Zero(),   // shapingTime
+            1024,
+            {},
+            NCloud::NProto::EF_NONE,
+            false,
+            0);
+
+        // During downtime observed still advances, but available and healthy
+        // freeze.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(30, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+    }
+
+    Y_UNIT_TEST(ShouldFreezeHealthySecondsDuringCriticalSuffering)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+
+        NProto::TDiagnosticsConfig cfg;
+        cfg.MutableSsdPerfSettings()->MutableWrite()->SetIops(4200);
+        cfg.MutableSsdPerfSettings()->MutableWrite()->SetBandwidth(342000000);
+        cfg.MutableSsdPerfSettings()->MutableRead()->SetIops(4200);
+        cfg.MutableSsdPerfSettings()->MutableRead()->SetBandwidth(342000000);
+        auto config = std::make_shared<TDiagnosticsConfig>(std::move(cfg));
+
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            timer);
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+        auto volumeInfo = volumeStats->GetVolumeInfo("test1", "client1");
+
+        auto volumeCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId);
+
+        auto observed = volumeCounters->GetCounter("ObservedSeconds");
+        auto available = volumeCounters->GetCounter("AvailableSeconds");
+        auto healthy = volumeCounters->GetCounter("HealthySeconds");
+
+        // Baseline.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+
+        // Healthy interval: everything advances.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+
+        // A single, heavily over-latency write drives critical suffering (but
+        // stays well below the 5s SSD downtime threshold, so the volume is
+        // still "available").
+        auto requestDuration = TDuration::MilliSeconds(400) +
+            config->GetExpectedIoParallelism() * CostPerIO(
+                config->GetSsdPerfSettings().Write.Iops,
+                config->GetSsdPerfSettings().Write.Bandwidth,
+                1_MB);
+        auto durationInCycles = DurationToCyclesSafe(requestDuration);
+        auto now = GetCycleCount();
+        volumeInfo->RequestCompleted(
+            EBlockStoreRequest::WriteBlocks,
+            now - Min(now, durationInCycles),
+            TDuration::Zero(),   // postponedTime
+            TDuration::Zero(),   // backoffTime
+            TDuration::Zero(),   // shapingTime
+            1_MB,
+            {},
+            NCloud::NProto::EF_NONE,
+            false,
+            0);
+
+        // During critical suffering observed and available advance, but
+        // healthy freezes.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(30, observed->Val());
+        UNIT_ASSERT_VALUES_EQUAL(30, available->Val());
+        UNIT_ASSERT_VALUES_EQUAL(15, healthy->Val());
+    }
+
+    Y_UNIT_TEST(ShouldNotAdvanceAvailabilityCountersForUnservedVolume)
+    {
+        auto timer = std::make_shared<TTestTimer>();
+        const auto config =
+            std::make_shared<TDiagnosticsConfig>(NProto::TDiagnosticsConfig());
+
+        auto monitoring = CreateMonitoringServiceStub();
+
+        auto volumeStats = CreateVolumeStats(
+            monitoring,
+            config,
+            TDuration::Max(),
+            EVolumeStatsType::EServerStats,
+            timer);
+
+        Mount(
+            volumeStats,
+            "test1",
+            "client1",
+            "instance",
+            NCloud::NProto::STORAGE_MEDIA_SSD);
+
+        auto volumeCounters = monitoring->GetCounters()
+            ->GetSubgroup("counters", "blockstore")
+            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("host", "cluster")
+            ->GetSubgroup("volume", "test1")
+            ->GetSubgroup("instance", "instance")
+            ->GetSubgroup("cloud", DefaultCloudId)
+            ->GetSubgroup("folder", DefaultFolderId);
+
+        auto observed = volumeCounters->GetCounter("ObservedSeconds");
+
+        // Baseline + one accounted interval while served.
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+
+        // Once unmounted the volume is no longer iterated, so the counter must
+        // stop advancing.
+        volumeStats->UnmountVolume("test1", "client1");
+        timer->AdvanceTime(TDuration::Seconds(15));
+        volumeStats->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(15, observed->Val());
+    }
+
     Y_UNIT_TEST(ShouldAlterVolume)
     {
         auto inactivityTimeout = TDuration::MilliSeconds(10);

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1216,7 +1216,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             "instance",
             NCloud::NProto::STORAGE_MEDIA_SSD);
 
-        auto sliCounters = monitoring->GetCounters()
+        auto availabilityCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
@@ -1226,9 +1226,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("folder", DefaultFolderId)
             ->GetSubgroup("type", "network-ssd");
 
-        auto observed = sliCounters->GetCounter("ObservedSeconds");
-        auto available = sliCounters->GetCounter("AvailableSeconds");
-        auto healthy = sliCounters->GetCounter("HealthySeconds");
+        auto observed = availabilityCounters->GetCounter("ObservedSeconds");
+        auto available = availabilityCounters->GetCounter("AvailableSeconds");
+        auto healthy = availabilityCounters->GetCounter("HealthySeconds");
 
         // A healthy, served volume advances all three counters by the real time
         // elapsed since it was mounted (seeded at mount time).
@@ -1325,7 +1325,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             "instance",
             NCloud::NProto::STORAGE_MEDIA_SSD);
 
-        auto sliCounters = monitoring->GetCounters()
+        auto availabilityCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
@@ -1335,7 +1335,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("folder", DefaultFolderId)
             ->GetSubgroup("type", "network-ssd");
 
-        auto observed = sliCounters->GetCounter("ObservedSeconds");
+        auto observed = availabilityCounters->GetCounter("ObservedSeconds");
 
         // A gap larger than the publish interval (e.g. stats were not updated
         // for a long time / the clock jumped forward) must not be credited as
@@ -1373,7 +1373,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             NCloud::NProto::STORAGE_MEDIA_SSD);
         auto volumeInfo = volumeStats->GetVolumeInfo("test1", "client1");
 
-        auto sliCounters = monitoring->GetCounters()
+        auto availabilityCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
@@ -1383,9 +1383,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("folder", DefaultFolderId)
             ->GetSubgroup("type", "network-ssd");
 
-        auto observed = sliCounters->GetCounter("ObservedSeconds");
-        auto available = sliCounters->GetCounter("AvailableSeconds");
-        auto healthy = sliCounters->GetCounter("HealthySeconds");
+        auto observed = availabilityCounters->GetCounter("ObservedSeconds");
+        auto available = availabilityCounters->GetCounter("AvailableSeconds");
+        auto healthy = availabilityCounters->GetCounter("HealthySeconds");
 
         // One healthy interval: everything advances.
         timer->AdvanceTime(TDuration::Seconds(15));
@@ -1446,7 +1446,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             NCloud::NProto::STORAGE_MEDIA_SSD);
         auto volumeInfo = volumeStats->GetVolumeInfo("test1", "client1");
 
-        auto sliCounters = monitoring->GetCounters()
+        auto availabilityCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
@@ -1456,9 +1456,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("folder", DefaultFolderId)
             ->GetSubgroup("type", "network-ssd");
 
-        auto observed = sliCounters->GetCounter("ObservedSeconds");
-        auto available = sliCounters->GetCounter("AvailableSeconds");
-        auto healthy = sliCounters->GetCounter("HealthySeconds");
+        auto observed = availabilityCounters->GetCounter("ObservedSeconds");
+        auto available = availabilityCounters->GetCounter("AvailableSeconds");
+        auto healthy = availabilityCounters->GetCounter("HealthySeconds");
 
         // One healthy interval: everything advances.
         timer->AdvanceTime(TDuration::Seconds(15));
@@ -1525,7 +1525,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             "instance",
             NCloud::NProto::STORAGE_MEDIA_SSD);
 
-        auto sliCounters = monitoring->GetCounters()
+        auto availabilityCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
@@ -1535,7 +1535,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("folder", DefaultFolderId)
             ->GetSubgroup("type", "network-ssd");
 
-        auto observed = sliCounters->GetCounter("ObservedSeconds");
+        auto observed = availabilityCounters->GetCounter("ObservedSeconds");
 
         // One accounted interval while served.
         timer->AdvanceTime(TDuration::Seconds(15));
@@ -1548,7 +1548,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         volumeStats->UnmountVolume("test1", "client1");
         timer->AdvanceTime(TDuration::Seconds(15));
         volumeStats->UpdateStats(true);
-        UNIT_ASSERT(sliCounters->FindCounter("ObservedSeconds"));
+        UNIT_ASSERT(availabilityCounters->FindCounter("ObservedSeconds"));
         UNIT_ASSERT_VALUES_EQUAL(30, observed->Val());
 
         // The instance has now been inactive longer than the timeout
@@ -1585,7 +1585,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             "instance",
             NCloud::NProto::STORAGE_MEDIA_SSD);
 
-        auto sliCounters = monitoring->GetCounters()
+        auto availabilityCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
             ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
@@ -1595,9 +1595,9 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             ->GetSubgroup("folder", DefaultFolderId)
             ->GetSubgroup("type", "network-ssd");
 
-        auto observed = sliCounters->GetCounter("ObservedSeconds");
-        auto available = sliCounters->GetCounter("AvailableSeconds");
-        auto healthy = sliCounters->GetCounter("HealthySeconds");
+        auto observed = availabilityCounters->GetCounter("ObservedSeconds");
+        auto available = availabilityCounters->GetCounter("AvailableSeconds");
+        auto healthy = availabilityCounters->GetCounter("HealthySeconds");
 
         // A healthy, served volume advances all three counters by the real
         // time elapsed since it was mounted, exactly like the server path.

--- a/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/volume_stats_ut.cpp
@@ -1216,18 +1216,18 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             "instance",
             NCloud::NProto::STORAGE_MEDIA_SSD);
 
-        auto volumeCounters = monitoring->GetCounters()
+        auto sliCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
             ->GetSubgroup("folder", DefaultFolderId);
 
-        auto observed = volumeCounters->GetCounter("ObservedSeconds");
-        auto available = volumeCounters->GetCounter("AvailableSeconds");
-        auto healthy = volumeCounters->GetCounter("HealthySeconds");
+        auto observed = sliCounters->GetCounter("ObservedSeconds");
+        auto available = sliCounters->GetCounter("AvailableSeconds");
+        auto healthy = sliCounters->GetCounter("HealthySeconds");
 
         // A healthy, served volume advances all three counters by the real time
         // elapsed since it was mounted (seeded at mount time).
@@ -1286,7 +1286,7 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
 
         auto observed2 = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
             ->GetSubgroup("volume", "test2")
             ->GetSubgroup("instance", "instance2")
@@ -1324,18 +1324,18 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             NCloud::NProto::STORAGE_MEDIA_SSD);
         auto volumeInfo = volumeStats->GetVolumeInfo("test1", "client1");
 
-        auto volumeCounters = monitoring->GetCounters()
+        auto sliCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
             ->GetSubgroup("folder", DefaultFolderId);
 
-        auto observed = volumeCounters->GetCounter("ObservedSeconds");
-        auto available = volumeCounters->GetCounter("AvailableSeconds");
-        auto healthy = volumeCounters->GetCounter("HealthySeconds");
+        auto observed = sliCounters->GetCounter("ObservedSeconds");
+        auto available = sliCounters->GetCounter("AvailableSeconds");
+        auto healthy = sliCounters->GetCounter("HealthySeconds");
 
         // One healthy interval: everything advances.
         timer->AdvanceTime(TDuration::Seconds(15));
@@ -1396,18 +1396,18 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             NCloud::NProto::STORAGE_MEDIA_SSD);
         auto volumeInfo = volumeStats->GetVolumeInfo("test1", "client1");
 
-        auto volumeCounters = monitoring->GetCounters()
+        auto sliCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
             ->GetSubgroup("folder", DefaultFolderId);
 
-        auto observed = volumeCounters->GetCounter("ObservedSeconds");
-        auto available = volumeCounters->GetCounter("AvailableSeconds");
-        auto healthy = volumeCounters->GetCounter("HealthySeconds");
+        auto observed = sliCounters->GetCounter("ObservedSeconds");
+        auto available = sliCounters->GetCounter("AvailableSeconds");
+        auto healthy = sliCounters->GetCounter("HealthySeconds");
 
         // One healthy interval: everything advances.
         timer->AdvanceTime(TDuration::Seconds(15));
@@ -1474,16 +1474,16 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
             "instance",
             NCloud::NProto::STORAGE_MEDIA_SSD);
 
-        auto volumeCounters = monitoring->GetCounters()
+        auto sliCounters = monitoring->GetCounters()
             ->GetSubgroup("counters", "blockstore")
-            ->GetSubgroup("component", "server_volume")
+            ->GetSubgroup("component", "sli_volume")
             ->GetSubgroup("host", "cluster")
             ->GetSubgroup("volume", "test1")
             ->GetSubgroup("instance", "instance")
             ->GetSubgroup("cloud", DefaultCloudId)
             ->GetSubgroup("folder", DefaultFolderId);
 
-        auto observed = volumeCounters->GetCounter("ObservedSeconds");
+        auto observed = sliCounters->GetCounter("ObservedSeconds");
 
         // One accounted interval while served.
         timer->AdvanceTime(TDuration::Seconds(15));


### PR DESCRIPTION
### Notes
Add three monotonic derivative counters to TVolumeInfo in volume_stats.cpp: ObservedSeconds, AvailableSeconds, HealthySeconds. They advance once per finished update interval and are nested (observed >= available >= healthy), reflecting downtime (HasDowntime) and critical suffering (PerfCalc.IsSufferingCritically()) state at the time of each tick. Interval duration is measured via Timer->Now() to avoid assuming a fixed tick period. Add unit tests covering the basic accumulation, downtime, critical-suffering, and unmounted-volume cases.

### Issue
https://github.com/ydb-platform/nbs/issues/6438
