### PR TITLE
[NBS] Local NVMe service: expose NVMe disk serial number and firmware version in metrics

### DIFF
--- a/cloud/blockstore/config/local_nvme.proto
+++ b/cloud/blockstore/config/local_nvme.proto
@@ -16,4 +16,7 @@ message TLocalNVMeConfig {
 
     // How often to poll the device provider while no NVMe devices are available (in milliseconds).
     optional uint32 UpdateDevicesInterval = 3;
+
+    // Update counters interval (in milliseconds).
+    optional uint32 UpdateCountersInterval = 4;
 }

--- a/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp
@@ -815,6 +815,7 @@ void TBootstrapYdb::InitKikimrService()
         LocalNVMeService = CreateLocalNVMeService(
             Configs->LocalNVMeConfig,
             logging,
+            Monitoring,
             LocalNVMeDeviceProvider,
             NvmeManager,
             Executor,

--- a/cloud/blockstore/libs/local_nvme/config.cpp
+++ b/cloud/blockstore/libs/local_nvme/config.cpp
@@ -18,6 +18,7 @@ namespace {
     xxx(DevicesSourceUri,                TString,          ""                 )\
     xxx(StateCacheFilePath,              TString,          ""                 )\
     xxx(UpdateDevicesInterval,           TDuration,        1min               )\
+    xxx(UpdateCountersInterval,           TDuration,        15s               )\
 // BLOCKSTORE_LOCAL_NVME_CONFIG
 
 #define BLOCKSTORE_LOCAL_NVME_DECLARE_CONFIG(name, type, value)                \

--- a/cloud/blockstore/libs/local_nvme/config.h
+++ b/cloud/blockstore/libs/local_nvme/config.h
@@ -27,6 +27,7 @@ public:
     [[nodiscard]] TString GetDevicesSourceUri() const;
     [[nodiscard]] TString GetStateCacheFilePath() const;
     [[nodiscard]] TDuration GetUpdateDevicesInterval() const;
+    [[nodiscard]] TDuration GetUpdateCountersInterval() const;
 
     void Dump(IOutputStream& out) const;
     void DumpHtml(IOutputStream& out) const;

--- a/cloud/blockstore/libs/local_nvme/protos/local_nvme.proto
+++ b/cloud/blockstore/libs/local_nvme/protos/local_nvme.proto
@@ -31,6 +31,9 @@ message TNVMeDevice
 
     // NUMA node.
     optional uint32 NumaNode = 8;
+
+    // Firmware revision of NVMe.
+    string FirmwareRev = 9;
 }
 
 // List of NVMe devices.

--- a/cloud/blockstore/libs/local_nvme/service.h
+++ b/cloud/blockstore/libs/local_nvme/service.h
@@ -41,6 +41,7 @@ ILocalNVMeServicePtr CreateLocalNVMeServiceStub();
 ILocalNVMeServicePtr CreateLocalNVMeService(
     TLocalNVMeConfigPtr config,
     ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,

--- a/cloud/blockstore/libs/local_nvme/service_generic.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_generic.cpp
@@ -7,6 +7,7 @@ namespace NCloud::NBlockStore {
 ILocalNVMeServicePtr CreateLocalNVMeService(
     TLocalNVMeConfigPtr config,
     ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,
@@ -15,6 +16,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     Y_UNUSED(
         config,
         logging,
+        monitoring,
         deviceProvider,
         nvmeManager,
         executor,

--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -9,7 +9,9 @@
 #include <cloud/storage/core/libs/common/proto_helpers.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/protobuf/util/pb_io.h>
 #include <library/cpp/threading/future/future.h>
 
@@ -134,6 +136,7 @@ class TLocalNVMeService final
 private:
     const TLocalNVMeConfigPtr Config;
     const ILoggingServicePtr Logging;
+    const IMonitoringServicePtr Monitoring;
     const ILocalNVMeDeviceProviderPtr DeviceProvider;
     const NNvme::INvmeManagerPtr NVMeManager;
     const TExecutorPtr Executor;
@@ -145,8 +148,12 @@ private:
     TLog Log;
     bool IsVfioDevSupported = false;
 
-    TFuture<void> Ready;
-    TCont* StartCont = nullptr;
+    NMonitoring::TDynamicCountersPtr Counters;
+
+    TFuture<void> Started;
+
+    TCont* InitDevicesCont = nullptr;
+    TCont* UpdateCountersCont = nullptr;
 
     THashMap<TSerialNumber, NProto::TNVMeDevice> Devices;
     THashSet<TSerialNumber> AcquiredDevices;
@@ -156,6 +163,7 @@ public:
     TLocalNVMeService(
         TLocalNVMeConfigPtr config,
         ILoggingServicePtr logging,
+        IMonitoringServicePtr monitoring,
         ILocalNVMeDeviceProviderPtr deviceProvider,
         NNvme::INvmeManagerPtr nvmeManager,
         TExecutorPtr executor,
@@ -190,19 +198,24 @@ private:
         const TSerialNumber& serialNumber,
         const TString& idempotenceId) -> TFuture<NProto::TError>;
 
-    auto AcquireDeviceImpl(NProto::TNVMeDevice device) -> TAcquireResult;
-    auto ReleaseDeviceImpl(const NProto::TNVMeDevice& device) -> NProto::TError;
+    auto AcquireDeviceImpl(const TSerialNumber& serialNumber) -> TAcquireResult;
+    auto ReleaseDeviceImpl(const TSerialNumber& serialNumber) -> NProto::TError;
 
     static auto EnsureIsReady(
         const std::weak_ptr<TLocalNVMeService>& weakService)
         -> TResultOrError<std::shared_ptr<TLocalNVMeService>>;
 
-    void StartImpl();
-    auto Initialize() -> NProto::TError;
+    void InitCounters();
+    void UpdateCounters();
+    void UpdateCountersLoop();
+    void InitDevices();
+    auto InitDevicesImpl() -> NProto::TError;
     auto FetchDevices() const -> TResultOrError<TVector<NProto::TNVMeDevice>>;
     auto PrepareDevice(
         const TSerialNumber& serialNumber,
         const TString& pciAddr) const -> TResultOrError<NProto::TNVMeDevice>;
+    auto RefreshDevice(const TSerialNumber& serialNumber)
+        -> TResultOrError<NProto::TNVMeDevice>;
     auto UpdateDevices() -> NProto::TError;
     bool TryRestoreStateFromCache();
     void UpdateStateCache();
@@ -217,6 +230,8 @@ private:
         const TString& driverName) -> NProto::TError;
     auto GetVfioDevName(const TString& pciAddress) const
         -> TResultOrError<TString>;
+    auto GetDevice(const TSerialNumber& serialNumber)
+        -> std::optional<NProto::TNVMeDevice>;
 
     auto StopImpl() -> TFuture<void>;
 
@@ -239,6 +254,7 @@ private:
 TLocalNVMeService::TLocalNVMeService(
     TLocalNVMeConfigPtr config,
     ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,
@@ -246,6 +262,7 @@ TLocalNVMeService::TLocalNVMeService(
     ISysFsPtr sysFs)
     : Config(std::move(config))
     , Logging(std::move(logging))
+    , Monitoring(std::move(monitoring))
     , DeviceProvider(std::move(deviceProvider))
     , NVMeManager(std::move(nvmeManager))
     , Executor(std::move(executor))
@@ -253,18 +270,18 @@ TLocalNVMeService::TLocalNVMeService(
     , SysFs(std::move(sysFs))
 {}
 
-void TLocalNVMeService::StartImpl()
+void TLocalNVMeService::InitDevices()
 {
-    // Save the StartImpl continuation so Stop() can interrupt startup.
-    StartCont = RunningCont();
-    Y_DEBUG_ABORT_UNLESS(StartCont);
+    // Save the InitDevices continuation so Stop() can interrupt it.
+    InitDevicesCont = RunningCont();
+    Y_DEBUG_ABORT_UNLESS(InitDevicesCont);
 
     Y_DEFER
     {
-        StartCont = nullptr;
+        InitDevicesCont = nullptr;
     };
 
-    if (auto error = Initialize(); HasError(error)) {
+    if (auto error = InitDevicesImpl(); HasError(error)) {
         STORAGE_ERROR(
             "Failed to initialize Local NVMe service: " << FormatError(error));
         return;
@@ -292,7 +309,34 @@ void TLocalNVMeService::StartImpl()
     }
 }
 
-auto TLocalNVMeService::Initialize() -> NProto::TError
+void TLocalNVMeService::UpdateCounters()
+{
+    for (auto& [sn, device]: Devices) {
+        auto deviceGroup = Counters->GetSubgroup("device", sn);
+        auto fwGroup =
+            deviceGroup->GetSubgroup("firmware", device.GetFirmwareRev());
+        auto revisionCounter = fwGroup->GetCounter("revision", false);
+        *revisionCounter = 1;
+    }
+}
+
+void TLocalNVMeService::UpdateCountersLoop()
+{
+    // Save the UpdateCountersLoop continuation so Stop() can interrupt it.
+    UpdateCountersCont = RunningCont();
+    Y_DEBUG_ABORT_UNLESS(UpdateCountersCont);
+
+    Y_DEFER
+    {
+        UpdateCountersCont = nullptr;
+    };
+
+    while (SleepCont(Config->GetUpdateCountersInterval())) {
+        UpdateCounters();
+    }
+}
+
+auto TLocalNVMeService::InitDevicesImpl() -> NProto::TError
 {
     if (TryRestoreStateFromCache()) {
         return {};
@@ -332,6 +376,8 @@ void TLocalNVMeService::Start()
 
     STORAGE_INFO("Starting Local NVMe service");
 
+    InitCounters();
+
     auto [supported, error] = SafeExecute<TResultOrError<bool>>(
         [&] { return SysFs->IsVfioDevSupported(); });
     if (HasError(error)) {
@@ -341,13 +387,31 @@ void TLocalNVMeService::Start()
         IsVfioDevSupported = supported;
     }
 
-    Ready = Executor->Execute(
+    auto initDevices = Executor->Execute(
         [weakSelf = weak_from_this()]
         {
             if (auto self = weakSelf.lock()) {
-                self->StartImpl();
+                self->InitDevices();
             }
         });
+
+    auto updateCounters = Executor->Execute(
+        [weakSelf = weak_from_this()]
+        {
+            if (auto self = weakSelf.lock()) {
+                self->UpdateCountersLoop();
+            }
+        });
+
+    Started = WaitAll(initDevices, updateCounters);
+}
+
+void TLocalNVMeService::InitCounters()
+{
+    auto rootGroup =
+        Monitoring->GetCounters()->GetSubgroup("counters", "blockstore");
+
+    Counters = rootGroup->GetSubgroup("component", "local_nvme");
 }
 
 auto TLocalNVMeService::StopImpl() -> TFuture<void>
@@ -357,9 +421,14 @@ auto TLocalNVMeService::StopImpl() -> TFuture<void>
     TVector<TFuture<void>> futures;
     futures.reserve(Operations.size() + 1);
 
-    futures.push_back(Ready);
-    if (StartCont) {
-        StartCont->Cancel();
+    futures.push_back(Started);
+
+    if (InitDevicesCont) {
+        InitDevicesCont->Cancel();
+    }
+
+    if (UpdateCountersCont) {
+        UpdateCountersCont->Cancel();
     }
 
     for (const auto& [_, op]: Operations) {
@@ -498,6 +567,29 @@ auto TLocalNVMeService::UpdateDevices() -> NProto::TError
     return {};
 }
 
+auto TLocalNVMeService::RefreshDevice(const TSerialNumber& serialNumber)
+    -> TResultOrError<NProto::TNVMeDevice>
+{
+    auto* device = Devices.FindPtr(serialNumber);
+    if (!device) {
+        return MakeError(
+            E_NOT_FOUND,
+            TStringBuilder()
+                << "Device " << serialNumber.Quote() << " not found");
+    }
+
+    auto [newDevice, error] =
+        PrepareDevice(serialNumber, device->GetPCIAddress());
+
+    if (HasError(error)) {
+        return error;
+    }
+
+    *device = newDevice;
+
+    return newDevice;
+}
+
 auto TLocalNVMeService::PrepareDevice(
     const TSerialNumber& serialNumber,
     const TString& pciAddr) const -> TResultOrError<NProto::TNVMeDevice>
@@ -602,21 +694,25 @@ void TLocalNVMeService::UpdateStateCache()
 
         NFs::Rename(tmpPath, Config->GetStateCacheFilePath());
 
-        STORAGE_INFO("Service state stored in cache successfully");
+        STORAGE_INFO("Service state cache updated successfully");
     } catch (...) {
         STORAGE_ERROR(
-            "Failed to store the service state from the cache: "
+            "Failed to update service state cache: "
             << CurrentExceptionMessage());
     }
 }
 
 bool TLocalNVMeService::TryRestoreStateFromCache()
 {
-    if (!Config->GetStateCacheFilePath() ||
-        !NFs::Exists(Config->GetStateCacheFilePath()))
-    {
-        STORAGE_DEBUG("Cache not configured");
+    const auto& cachePath = Config->GetStateCacheFilePath();
 
+    if (!cachePath) {
+        STORAGE_DEBUG("Service state cache is not configured");
+        return false;
+    }
+
+    if (!NFs::Exists(cachePath)) {
+        STORAGE_DEBUG("Service state cache file does not exist");
         return false;
     }
 
@@ -625,18 +721,18 @@ bool TLocalNVMeService::TryRestoreStateFromCache()
         ParseProtoTextFromFile(Config->GetStateCacheFilePath(), proto);
     } catch (...) {
         STORAGE_ERROR(
-            "Failed to restore the service state from the cache: "
+            "Failed to restore service state from cache: "
             << CurrentExceptionMessage());
         return false;
     }
 
     if (!proto.DevicesSize()) {
-        STORAGE_INFO("No NVMe devices in the cache");
+        STORAGE_INFO("Service state cache contains no NVMe devices");
         return false;
     }
 
     STORAGE_INFO(
-        "Found in cache NVMe devices ("
+        "Restored NVMe devices from service state cache ("
         << proto.DevicesSize() << "): " << Join(", ", proto.GetDevices())
         << "; acquired devices: " << Join(", ", proto.GetAcquiredDevices())
         << ";");
@@ -723,9 +819,7 @@ auto TLocalNVMeService::StartOperation(
     const TSerialNumber& serialNumber,
     const TString& idempotenceId) -> TFuture<TFnResult>
 {
-    const auto* device = Devices.FindPtr(serialNumber);
-
-    if (!device) {
+    if (Devices.FindPtr(serialNumber) == nullptr) {
         return MakeFuture<TFnResult>(MakeError(
             E_NOT_FOUND,
             TStringBuilder()
@@ -757,13 +851,13 @@ auto TLocalNVMeService::StartOperation(
     auto weakSelf = weak_from_this();
 
     auto future = Executor->Execute(
-        [op, weakSelf, fn, device = *device]() mutable
+        [op, weakSelf, fn, serialNumber]() mutable
         {
             op->Cont = RunningCont();
 
             auto self = weakSelf.lock();
-            TFnResult r =
-                self ? std::invoke(fn, self, device) : ServiceDestroyedError;
+            TFnResult r = self ? std::invoke(fn, self, serialNumber)
+                               : ServiceDestroyedError;
 
             op->FinishTime = Now();
             op->Cont = nullptr;
@@ -807,10 +901,17 @@ auto TLocalNVMeService::AcquireDevice(
         MakeError(E_TRY_AGAIN, "Acquire in progress"));
 }
 
-auto TLocalNVMeService::AcquireDeviceImpl(NProto::TNVMeDevice device)
+auto TLocalNVMeService::AcquireDeviceImpl(const TSerialNumber& serialNumber)
     -> TResultOrError<NProto::TNVMeDevice>
 {
-    const auto& serialNumber = device.GetSerialNumber();
+    std::optional device = GetDevice(serialNumber);
+
+    if (!device) {
+        return MakeError(
+            E_NOT_FOUND,
+            TStringBuilder()
+                << "Device " << serialNumber.Quote() << " not found");
+    }
 
     auto [_, ok] = AcquiredDevices.insert(serialNumber);
     if (!ok) {
@@ -822,24 +923,24 @@ auto TLocalNVMeService::AcquireDeviceImpl(NProto::TNVMeDevice device)
 
     UpdateStateCache();
 
-    if (auto error = BindDeviceToDriver(device, "vfio-pci"); HasError(error)) {
+    if (auto error = BindDeviceToDriver(*device, "vfio-pci"); HasError(error)) {
         return error;
     }
 
     if (!IsVfioDevSupported) {
-        return device;
+        return std::move(device).value();
     }
 
-    auto [vfioDev, error] = GetVfioDevName(device.GetPCIAddress());
+    auto [vfioDev, error] = GetVfioDevName(device->GetPCIAddress());
     if (HasError(error)) {
         STORAGE_ERROR(
-            "Failed to get vfio device for " << device << ": "
+            "Failed to get vfio device for " << *device << ": "
                                              << FormatError(error));
     } else {
-        device.SetVfioDevName(std::move(vfioDev));
+        device->SetVfioDevName(std::move(vfioDev));
     }
 
-    return device;
+    return std::move(device).value();
 }
 
 auto TLocalNVMeService::GetVfioDevName(const TString& pciAddress) const
@@ -985,22 +1086,49 @@ auto TLocalNVMeService::ReleaseDevice(
         MakeError(E_TRY_AGAIN, "Release in progress"));
 }
 
-auto TLocalNVMeService::ReleaseDeviceImpl(const NProto::TNVMeDevice& device)
+auto TLocalNVMeService::GetDevice(const TSerialNumber& serialNumber)
+    -> std::optional<NProto::TNVMeDevice>
+{
+    const auto* device = Devices.FindPtr(serialNumber);
+    if (!device) {
+        return std::nullopt;
+    }
+    return *device;
+}
+
+auto TLocalNVMeService::ReleaseDeviceImpl(const TSerialNumber& serialNumber)
     -> NProto::TError
 {
-    if (auto error = BindDeviceToDriver(device, "nvme"); HasError(error)) {
+    std::optional device = GetDevice(serialNumber);
+    if (!device) {
+        return MakeError(
+            E_NOT_FOUND,
+            TStringBuilder()
+                << "Device " << serialNumber.Quote() << " not found");
+    }
+
+    if (auto error = BindDeviceToDriver(*device, "nvme"); HasError(error)) {
         return error;
     }
 
-    if (auto error = SanitizeNVMeDevice(device); HasError(error)) {
+    {
+        auto [newDevice, error] = RefreshDevice(serialNumber);
+        if (HasError(error)) {
+            return error;
+        }
+
+        device = newDevice;
+    }
+
+    if (auto error = SanitizeNVMeDevice(*device); HasError(error)) {
         return error;
     }
 
-    if (auto error = ResetToSingleNamespace(device); HasError(error)) {
+    if (auto error = ResetToSingleNamespace(*device); HasError(error)) {
         return error;
     }
 
-    AcquiredDevices.erase(device.GetSerialNumber());
+    AcquiredDevices.erase(serialNumber);
 
     UpdateStateCache();
 
@@ -1028,6 +1156,7 @@ auto TLocalNVMeService::ListDevices() const -> TVector<NProto::TNVMeDevice>
 ILocalNVMeServicePtr CreateLocalNVMeService(
     TLocalNVMeConfigPtr config,
     ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,
@@ -1037,6 +1166,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     return std::make_shared<TLocalNVMeService>(
         std::move(config),
         std::move(logging),
+        std::move(monitoring),
         std::move(deviceProvider),
         std::move(nvmeManager),
         std::move(executor),
@@ -1047,6 +1177,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
 ILocalNVMeServicePtr CreateLocalNVMeService(
     TLocalNVMeConfigPtr config,
     ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,
@@ -1055,6 +1186,7 @@ ILocalNVMeServicePtr CreateLocalNVMeService(
     return CreateLocalNVMeService(
         std::move(config),
         std::move(logging),
+        std::move(monitoring),
         std::move(deviceProvider),
         std::move(nvmeManager),
         std::move(executor),

--- a/cloud/blockstore/libs/local_nvme/service_linux.h
+++ b/cloud/blockstore/libs/local_nvme/service_linux.h
@@ -12,6 +12,7 @@ namespace NCloud::NBlockStore {
 ILocalNVMeServicePtr CreateLocalNVMeService(
     TLocalNVMeConfigPtr config,
     ILoggingServicePtr logging,
+    IMonitoringServicePtr monitoring,
     ILocalNVMeDeviceProviderPtr deviceProvider,
     NNvme::INvmeManagerPtr nvmeManager,
     TExecutorPtr executor,

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -12,7 +12,9 @@
 #include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
+#include <cloud/storage/core/libs/diagnostics/monitoring.h>
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/protobuf/util/pb_io.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/future.h>
@@ -247,6 +249,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
 
     TLocalNVMeConfigPtr Config;
     ILoggingServicePtr Logging;
+    IMonitoringServicePtr Monitoring;
     std::shared_ptr<TTestNVMeManager> NVMeManager;
     TExecutorPtr Executor;
     ITaskQueuePtr BackgroundThreadPool;
@@ -265,6 +268,9 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
             CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
         Logging->Start();
 
+        Monitoring = CreateMonitoringServiceStub();
+        Monitoring->Start();
+
         NVMeManager = std::make_shared<TTestNVMeManager>();
 
         BackgroundThreadPool = CreateLongRunningTaskExecutor("BG");
@@ -279,6 +285,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
         Service->Stop();
         Executor->Stop();
         BackgroundThreadPool->Stop();
+        Monitoring->Stop();
         Logging->Stop();
 
         if (StateCacheFile) {
@@ -292,6 +299,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
         return CreateLocalNVMeService(
             Config,
             Logging,
+            Monitoring,
             std::move(deviceProvider),
             std::static_pointer_cast<INvmeManager>(NVMeManager),
             Executor,
@@ -311,6 +319,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
                 VendorId: 0x100
                 DeviceId: 0x200
                 Model: "Test NVMe 1"
+                FirmwareRev: "FW4242"
             }
             Devices {
                 SerialNumber: "NVME_1"
@@ -319,6 +328,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
                 VendorId: 0x300
                 DeviceId: 0x400
                 Model: "Test NVMe 2"
+                FirmwareRev: "FW4243"
             }
             Devices {
                 SerialNumber: "NVME_2"
@@ -327,6 +337,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
                 VendorId: 0x100
                 DeviceId: 0x200
                 Model: "Test NVMe 1"
+                FirmwareRev: "FW4242"
             }
             Devices {
                 SerialNumber: "NVME_3"
@@ -335,6 +346,7 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
                 VendorId: 0x100
                 DeviceId: 0x200
                 Model: "Test NVMe 1"
+                FirmwareRev: "FW4242"
             }
         )",
             list);
@@ -361,7 +373,8 @@ struct TFixtureBase: public NUnitTest::TBaseFixture
 
         NProto::TLocalNVMeConfig proto;
         proto.SetStateCacheFilePath(StateCacheFile);
-        proto.SetUpdateDevicesInterval(TDuration::Seconds(1).MilliSeconds());
+        proto.SetUpdateDevicesInterval(TDuration(1s).MilliSeconds());
+        proto.SetUpdateCountersInterval(TDuration(100ms).MilliSeconds());
 
         Config = std::make_shared<TLocalNVMeConfig>(proto);
     }
@@ -459,6 +472,18 @@ struct TFixture: public TFixtureBase
     {
         DeviceProvider->ListNVMeDevicesImpl.SetValue(
             [&] { return MakeFuture(CreateDeviceList()); });
+    }
+
+    void WaitCountersUpdate()
+    {
+        Executor
+            ->Execute(
+                [&]
+                {
+                    RunningCont()->SleepT(
+                        Config->GetUpdateCountersInterval() * 2);
+                })
+            .Wait();
     }
 };
 
@@ -1573,6 +1598,121 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
         UNIT_ASSERT_VALUES_EQUAL(lastAttempt, attempts.load());
 
         Service->Stop();
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldUpdateNvmeFirmwareRevisionMetricWhenDiskFirmwareRevisionChanges,
+        TFixture)
+    {
+        SetProviderReady();
+
+        {
+            auto [devices, error] = ListNVMeDevices();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        WaitCountersUpdate();
+
+        auto rootGroup =
+            Monitoring->GetCounters()->FindSubgroup("counters", "blockstore");
+        UNIT_ASSERT(rootGroup);
+
+        auto counters = rootGroup->FindSubgroup("component", "local_nvme");
+        UNIT_ASSERT(counters);
+
+        for (const auto& d: Devices) {
+            auto deviceGroup =
+                counters->FindSubgroup("device", d.GetSerialNumber());
+            UNIT_ASSERT(deviceGroup);
+            auto fwGroup =
+                deviceGroup->FindSubgroup("firmware", d.GetFirmwareRev());
+            UNIT_ASSERT(fwGroup);
+            auto revisionCounter = fwGroup->FindCounter("revision");
+            UNIT_ASSERT(revisionCounter);
+            UNIT_ASSERT_VALUES_EQUAL(1, revisionCounter->Val());
+        }
+
+        auto& device = Devices[1];
+        const TString sn = device.GetSerialNumber();
+
+        {
+            auto future = Service->AcquireNVMeDevice(sn, EmptyIdempotenceId);
+
+            const auto& [_, error] = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        const TString ctrlPath = "/dev/nvme1";
+        const TString oldFwRev = Devices[1].GetFirmwareRev();
+        const TString newFwRev = "new-fw";
+
+        // Simulate a firmware revision change while the NVMe device is detached
+        // from the nvme driver. The service should not observe this change yet
+        SysFs->AddrToDevice[Devices[1].GetPCIAddress()].SetFirmwareRev(
+            newFwRev);
+
+        WaitCountersUpdate();
+
+        // The firmware revision metric should remain unchanged while the device
+        // is acquired and detached from the nvme driver
+        {
+            auto deviceGroup = counters->FindSubgroup("device", sn);
+            UNIT_ASSERT(deviceGroup);
+
+            UNIT_ASSERT(!deviceGroup->FindSubgroup("firmware", newFwRev));
+
+            auto fwGroup = deviceGroup->FindSubgroup("firmware", oldFwRev);
+            UNIT_ASSERT(fwGroup);
+            auto revisionCounter = fwGroup->FindCounter("revision");
+            UNIT_ASSERT(revisionCounter);
+            UNIT_ASSERT_VALUES_EQUAL(1, revisionCounter->Val());
+        }
+
+        // Release the NVMe device back to the nvme driver so the service can
+        // observe the updated firmware revision
+        {
+            auto future = Service->ReleaseNVMeDevice(sn, EmptyIdempotenceId);
+
+            NVMeManager->WaitSanitizeRequested();
+            NVMeManager->UpdateSanitizeStatus(ctrlPath, MakeError(S_OK), 100.0);
+
+            const auto& error = future.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        WaitCountersUpdate();
+
+        // After the device is released, the metric should expose the new
+        // firmware revision while keeping the old revision series present
+        {
+            auto deviceGroup = counters->FindSubgroup("device", sn);
+            UNIT_ASSERT(deviceGroup);
+
+            auto newFwGroup = deviceGroup->FindSubgroup("firmware", newFwRev);
+            {
+                UNIT_ASSERT(newFwGroup);
+                auto revisionCounter = newFwGroup->FindCounter("revision");
+                UNIT_ASSERT(revisionCounter);
+                UNIT_ASSERT_VALUES_EQUAL(1, revisionCounter->Val());
+            }
+
+            auto oldFwGroup = deviceGroup->FindSubgroup("firmware", oldFwRev);
+            {
+                UNIT_ASSERT(oldFwGroup);
+                auto revisionCounter = oldFwGroup->FindCounter("revision");
+                UNIT_ASSERT(revisionCounter);
+                UNIT_ASSERT_VALUES_EQUAL(1, revisionCounter->Val());
+            }
+        }
     }
 
     Y_UNIT_TEST_F(ShouldGetDevicesFromInfra, TFixtureInfra)

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers.cpp
@@ -175,6 +175,10 @@ public:
 
             device.SetSerialNumber(ReadFile(nvme / "serial"));
             device.SetModel(ReadFile(nvme / "model"));
+
+            if (auto fwRev = nvme / "firmware_rev"; NFs::Exists(fwRev)) {
+                device.SetFirmwareRev(ReadFile(fwRev));
+            }
         }
 
         if (auto group = GetIOMMUGroup(pciDevicePath)) {

--- a/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/sysfs_helpers_ut.cpp
@@ -94,6 +94,8 @@ struct TFixture: public NUnitTest::TBaseFixture
 
             TFileOutput(ctrlPath / "serial").Write(device.GetSerialNumber());
             TFileOutput(ctrlPath / "model").Write(device.GetModel());
+            TFileOutput(ctrlPath / "firmware_rev")
+                .Write(device.GetFirmwareRev());
         }
 
         // NVME_1 bound to the vfio-pci driver
@@ -153,6 +155,7 @@ struct TFixture: public NUnitTest::TBaseFixture
                 DeviceId: 0x200
                 Model: "Test NVMe 1"
                 NumaNode: 0
+                FirmwareRev: "FW4242"
             }
             Devices {
                 SerialNumber: "NVME_1"

--- a/cloud/blockstore/tests/local_nvme/test.py
+++ b/cloud/blockstore/tests/local_nvme/test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+import time
 
 from google.protobuf.text_format import MessageToString
 
@@ -27,6 +28,7 @@ LOCAL_NVME_DEVICES = [
         VendorId=0x100,
         DeviceId=0x200,
         Model="Test NVMe 1",
+        FirmwareRev="FW4242",
     ),
     TNVMeDevice(
         SerialNumber="NVME_1",
@@ -35,6 +37,7 @@ LOCAL_NVME_DEVICES = [
         VendorId=0x100,
         DeviceId=0x300,
         Model="Test NVMe 2",
+        FirmwareRev="FW4243",
     ),
     TNVMeDevice(
         SerialNumber="NVME_2",
@@ -43,6 +46,7 @@ LOCAL_NVME_DEVICES = [
         VendorId=0x100,
         DeviceId=0x300,
         Model="Test NVMe 2",
+        FirmwareRev="FW4243",
     ),
     TNVMeDevice(
         SerialNumber="NVME_3",
@@ -51,6 +55,7 @@ LOCAL_NVME_DEVICES = [
         VendorId=0x100,
         DeviceId=0x200,
         Model="Test NVMe 1",
+        FirmwareRev="FW4242",
     ),
 ]
 
@@ -86,7 +91,9 @@ def create_local_nvme_config():
 
     return TLocalNVMeConfig(
         DevicesSourceUri=f"file://{devicesPath}",
-        StateCacheFilePath=cacheFilePath)
+        StateCacheFilePath=cacheFilePath,
+        UpdateCountersInterval=1000,    # 1s
+    )
 
 
 @pytest.fixture(name='nbs_socket')
@@ -111,7 +118,7 @@ def start_nbs_daemon(ydb, local_nvme_config, nbs_socket):
 
 
 @pytest.mark.parametrize("transport", ["http", "uds"])
-def test_list_nvme_devices(nbs, nbs_socket, transport):
+def test_list_nvme_devices(nbs, nbs_socket, local_nvme_config, transport):
 
     endpoint = f"localhost:{nbs.port}"
     if transport == "uds":
@@ -141,3 +148,21 @@ def test_list_nvme_devices(nbs, nbs_socket, transport):
         assert lhs.SerialNumber == rhs['SerialNumber']
         assert lhs.PCIAddress == rhs['PCIAddress']
         assert lhs.IOMMUGroup == rhs['IOMMUGroup']
+
+    time.sleep(local_nvme_config.UpdateCountersInterval / 1000)
+
+    counters = {}
+    for c in nbs.counters.find_all({'component': 'local_nvme'}):
+        sn = c['labels'].get('device')
+        if not sn:
+            continue
+        counters[sn] = c
+
+    assert len(counters) == len(LOCAL_NVME_DEVICES)
+
+    for sn, c in counters.items():
+        d = next((d for d in LOCAL_NVME_DEVICES if d.SerialNumber == sn), None)
+
+        assert d, sn
+        assert c['labels']['firmware'] == d.FirmwareRev
+        assert c['value'] == 1

--- a/cloud/blockstore/tests/python/lib/daemon.py
+++ b/cloud/blockstore/tests/python/lib/daemon.py
@@ -42,14 +42,11 @@ class _Counters:
 
         return None
 
-    def find_all(self, queries):
+    def find_all(self, query):
         r = []
         for s in self.__data["sensors"]:
-            for query in queries:
-                if _match(s.get("labels", {}), query):
-                    r.append(s)
-                    break
-
+            if _match(s.get("labels", {}), query):
+                r.append(s)
         return r
 
     def __rep__(self):


### PR DESCRIPTION
Expose NVMe disk serial number and firmware revision in Local NVMe service metrics.

The change also refreshes NVMe disk configuration after the disk is returned back to the NVMe driver, adds a configurable counters update interval, and extends tests for the new metadata collection logic.
