### PR TITLE
[Filestore local] fix xattr cache invalidation on inode reuse

### DIFF
--- a/cloud/filestore/config/filesystem.proto
+++ b/cloud/filestore/config/filesystem.proto
@@ -116,4 +116,9 @@ message TFileSystemConfig
     // may observe the effects of newer writes before older ones.
     // With parallel writes off, only sequential writes will be optimized.
     optional bool ServerWriteBackCacheFlushWritesInParallelEnabled = 34;
+
+    // Invalidate the xattr cache when a create path returns a newly created
+    // inode. Needed only for backends that may reuse inode ids (local
+    // filestore); not needed for the ydb-based backend.
+    optional bool XAttrCacheInvalidateOnCreateEnabled = 35;
 }

--- a/cloud/filestore/libs/service_local/fs_session.cpp
+++ b/cloud/filestore/libs/service_local/fs_session.cpp
@@ -72,6 +72,11 @@ NProto::TCreateSessionResponse TLocalFileSystem::CreateSession(
         features->SetXAttrCacheTimeout(
             Config->GetXAttrCacheTimeout(cloudId, folderId, fsId)
                 .MilliSeconds());
+        // The local service may reuse inode ids, so the FUSE xattr cache must
+        // be invalidated when a create path returns a newly created inode.
+        // The ydb-based backend never reuses ids and leaves this disabled.
+        features->SetXAttrCacheInvalidateOnCreateEnabled(
+            !features->GetExtendedAttributesDisabled());
         const bool directoryHandleStorageEnabled =
             Config->GetDirectoryHandlesStorageEnabled(cloudId, folderId, fsId);
         features->SetDirectoryHandlesStorageEnabled(

--- a/cloud/filestore/libs/vfs_fuse/config.cpp
+++ b/cloud/filestore/libs/vfs_fuse/config.cpp
@@ -23,6 +23,7 @@ namespace {
                                                                                \
     xxx(XAttrCacheLimit,        ui32,           512                           )\
     xxx(XAttrCacheTimeout,      TDuration,      TDuration::Seconds(15)        )\
+    xxx(XAttrCacheInvalidateOnCreateEnabled,    bool, false                   )\
                                                                                \
     xxx(MaxBufferSize,          ui32,           4_MB                          )\
                                                                                \

--- a/cloud/filestore/libs/vfs_fuse/config.h
+++ b/cloud/filestore/libs/vfs_fuse/config.h
@@ -33,6 +33,7 @@ public:
 
     ui32 GetXAttrCacheLimit() const;
     TDuration GetXAttrCacheTimeout() const;
+    bool GetXAttrCacheInvalidateOnCreateEnabled() const;
 
     ui32 GetMaxBufferSize() const;
     ui32 GetPreferredBlockSize() const;

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -214,6 +214,12 @@ void TFileSystem::InvalidateDirectoryEntryInCache(
     DirectoryEntryVersionCache->AdvanceVersion(parent, name, version);
 }
 
+void TFileSystem::InvalidateXAttrCache(ui64 ino)
+{
+    TGuard g{XAttrCacheLock};
+    XAttrCache.Invalidate(ino);
+}
+
 void TFileSystem::UpdateXAttrCache(
     ui64 ino,
     const TString& name,
@@ -238,7 +244,8 @@ void TFileSystem::ReplyCreateWithCache(
     fuse_req_t req,
     ui64 handle,
     const NProto::TNodeAttr& attrs,
-    ui64 version)
+    ui64 version,
+    bool newNodeCreated)
 {
     STORAGE_TRACE("inserting node: "
         << ProtoMessagePrinter.ToString(attrs)
@@ -247,6 +254,12 @@ void TFileSystem::ReplyCreateWithCache(
     if (attrs.GetId() == InvalidNodeId) {
         ReplyError(callContext, MakeError(E_FS_IO), req, EIO);
         return;
+    }
+
+    if (Config->GetXAttrCacheInvalidateOnCreateEnabled() && newNodeCreated &&
+        !HasError(error))
+    {
+        InvalidateXAttrCache(attrs.GetId());
     }
 
     fuse_entry_param entry = {};
@@ -267,7 +280,8 @@ void TFileSystem::ReplyEntryWithCache(
     const NCloud::NProto::TError& error,
     fuse_req_t req,
     const NProto::TNodeAttr& attrs,
-    ui64 version)
+    ui64 version,
+    bool newNodeCreated)
 {
     STORAGE_TRACE("inserting node: "
         << ProtoMessagePrinter.ToString(attrs)
@@ -276,6 +290,12 @@ void TFileSystem::ReplyEntryWithCache(
     if (attrs.GetId() == InvalidNodeId) {
         ReplyError(callContext, MakeError(E_FS_IO), req, EIO);
         return;
+    }
+
+    if (Config->GetXAttrCacheInvalidateOnCreateEnabled() && newNodeCreated &&
+        !HasError(error))
+    {
+        InvalidateXAttrCache(attrs.GetId());
     }
 
     fuse_entry_param entry = {};

--- a/cloud/filestore/libs/vfs_fuse/fs_impl.h
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.h
@@ -425,6 +425,7 @@ private:
     void InvalidateDirectoryEntryInCache(
         fuse_ino_t parent,
         const TString& name);
+    void InvalidateXAttrCache(ui64 ino);
 
     void UpdateXAttrCache(
         ui64 ino,
@@ -439,13 +440,15 @@ private:
         fuse_req_t req,
         ui64 handle,
         const NProto::TNodeAttr& attrs,
-        ui64 version);
+        ui64 version,
+        bool newNodeCreated);
     void ReplyEntryWithCache(
         TCallContext& callContext,
         const NCloud::NProto::TError& error,
         fuse_req_t req,
         const NProto::TNodeAttr& attrs,
-        ui64 version);
+        ui64 version,
+        bool newNodeCreated);
     void ReplyXAttrInt(
         TCallContext& callContext,
         const NCloud::NProto::TError& error,

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -176,7 +176,10 @@ void TFileSystem::Create(
                     req,
                     response.GetHandle(),
                     response.GetNodeAttr(),
-                    version);
+                    version,
+                    HasFlag(
+                        flags,
+                        NProto::TCreateHandleRequest::E_CREATE));
             }
         });
 }

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_node.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_node.cpp
@@ -52,7 +52,8 @@ void TFileSystem::Lookup(
                         error,
                         req,
                         response.GetNode(),
-                        version);
+                        version,
+                        false /* newNodeCreated */);
                 } else if (error.GetCode() == E_FS_NAMETOOLONG) {
                     self->ReplyError(*callContext, error, req, ENAMETOOLONG);
                 } else {
@@ -135,7 +136,8 @@ void TFileSystem::MkDir(
                     error,
                     req,
                     response.GetNode(),
-                    1 /* version */);
+                    1 /* version */,
+                    true /* newNodeCreated */);
             }
         });
 }
@@ -240,7 +242,8 @@ void TFileSystem::MkNode(
                     error,
                     req,
                     response.GetNode(),
-                    1 /* version */);
+                    1 /* version */,
+                    true /* newNodeCreated */);
             }
         });
 }
@@ -369,7 +372,8 @@ void TFileSystem::SymLink(
                     error,
                     req,
                     response.GetNode(),
-                    1 /* version */);
+                    1 /* version */,
+                    true /* newNodeCreated */);
             }
         });
 }
@@ -413,7 +417,8 @@ void TFileSystem::Link(
                     error,
                     req,
                     response.GetNode(),
-                    1 /* version */);
+                    1 /* version */,
+                    false /* newNodeCreated */);
             }
         });
 }

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -414,6 +414,67 @@ struct TBootstrap
     }
 };
 
+NProto::TNodeAttr MakeNodeAttr(ui64 nodeId, ui32 nodeType)
+{
+    NProto::TNodeAttr attrs;
+    attrs.SetId(nodeId);
+    attrs.SetType(nodeType);
+    attrs.SetMode(0644);
+    return attrs;
+}
+
+template <typename TSetupCreateHandler, typename TSendCreateRequest>
+void DoShouldInvalidateXAttrCacheAfterSuccessfulCreate(
+    TSetupCreateHandler setupCreateHandler,
+    TSendCreateRequest sendCreateRequest)
+{
+    constexpr ui64 recycledNodeId = 6;
+
+    NProto::TFileStoreFeatures features;
+    features.SetXAttrCacheInvalidateOnCreateEnabled(true);
+
+    auto timer = std::make_shared<TTestTimer>();
+    TBootstrap bootstrap{timer, CreateScheduler(), features};
+    bootstrap.Start();
+    Y_DEFER {
+        bootstrap.Stop();
+    };
+
+    std::atomic<int> xattrCallCount = 0;
+    bootstrap.Service->SetHandlerGetNodeXAttr(
+        [&] (auto callContext, auto request) {
+            Y_UNUSED(request);
+            UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+            const auto call = ++xattrCallCount;
+            NProto::TGetNodeXAttrResponse response;
+            response.SetValue(call == 1 ? "old-value" : "new-value");
+            response.SetVersion(call);
+            return MakeFuture(response);
+        });
+
+    setupCreateHandler(bootstrap, recycledNodeId);
+
+    {
+        auto xattr = bootstrap.Fuse->SendRequest<TGetXAttrValueRequest>(
+            "name",
+            recycledNodeId);
+        UNIT_ASSERT(xattr.Wait(WaitTimeout));
+        UNIT_ASSERT_STRINGS_EQUAL("old-value", xattr.GetValue());
+    }
+
+    sendCreateRequest(bootstrap, recycledNodeId);
+
+    {
+        auto xattr = bootstrap.Fuse->SendRequest<TGetXAttrValueRequest>(
+            "name",
+            recycledNodeId);
+        UNIT_ASSERT(xattr.Wait(WaitTimeout));
+        UNIT_ASSERT_STRINGS_EQUAL("new-value", xattr.GetValue());
+        UNIT_ASSERT_VALUES_EQUAL(2, xattrCallCount.load());
+    }
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2336,6 +2397,294 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                 yexception,
                 "-61"); // NODATA error code
             UNIT_ASSERT_VALUES_EQUAL(1, callCount.load());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldInvalidateXAttrCacheAfterMkDirReusesNodeId)
+    {
+        DoShouldInvalidateXAttrCacheAfterSuccessfulCreate(
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                bootstrap.Service->SetHandlerCreateNode(
+                    [=] (auto callContext, auto request) {
+                        Y_UNUSED(request);
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            FileSystemId,
+                            callContext->FileSystemId);
+
+                        NProto::TCreateNodeResponse response;
+                        *response.MutableNode() = MakeNodeAttr(
+                            recycledNodeId,
+                            NProto::E_DIRECTORY_NODE);
+                        return MakeFuture(response);
+                    });
+            },
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                Y_UNUSED(recycledNodeId);
+                auto create = bootstrap.Fuse->SendRequest<TMkDirRequest>(
+                    "dir",
+                    RootNodeId);
+                UNIT_ASSERT(create.Wait(WaitTimeout));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldInvalidateXAttrCacheAfterMkNodeReusesNodeId)
+    {
+        DoShouldInvalidateXAttrCacheAfterSuccessfulCreate(
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                bootstrap.Service->SetHandlerCreateNode(
+                    [=] (auto callContext, auto request) {
+                        Y_UNUSED(request);
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            FileSystemId,
+                            callContext->FileSystemId);
+
+                        NProto::TCreateNodeResponse response;
+                        *response.MutableNode() = MakeNodeAttr(
+                            recycledNodeId,
+                            NProto::E_REGULAR_NODE);
+                        return MakeFuture(response);
+                    });
+            },
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                Y_UNUSED(recycledNodeId);
+                auto create = bootstrap.Fuse->SendRequest<TMkNodeRequest>(
+                    "file",
+                    RootNodeId);
+                UNIT_ASSERT(create.Wait(WaitTimeout));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldInvalidateXAttrCacheAfterSymLinkReusesNodeId)
+    {
+        DoShouldInvalidateXAttrCacheAfterSuccessfulCreate(
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                bootstrap.Service->SetHandlerCreateNode(
+                    [=] (auto callContext, auto request) {
+                        Y_UNUSED(request);
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            FileSystemId,
+                            callContext->FileSystemId);
+
+                        NProto::TCreateNodeResponse response;
+                        *response.MutableNode() = MakeNodeAttr(
+                            recycledNodeId,
+                            NProto::E_LINK_NODE);
+                        return MakeFuture(response);
+                    });
+            },
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                Y_UNUSED(recycledNodeId);
+                auto create = bootstrap.Fuse->SendRequest<TSymLinkRequest>(
+                    "link",
+                    "target",
+                    RootNodeId);
+                UNIT_ASSERT(create.Wait(WaitTimeout));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldInvalidateXAttrCacheAfterCreateHandleReusesNodeId)
+    {
+        DoShouldInvalidateXAttrCacheAfterSuccessfulCreate(
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                bootstrap.Service->SetHandlerCreateHandle(
+                    [=] (auto callContext, auto request) {
+                        Y_UNUSED(request);
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            FileSystemId,
+                            callContext->FileSystemId);
+
+                        NProto::TCreateHandleResponse response;
+                        response.SetHandle(42);
+                        *response.MutableNodeAttr() = MakeNodeAttr(
+                            recycledNodeId,
+                            NProto::E_REGULAR_NODE);
+                        return MakeFuture(response);
+                    });
+            },
+            [] (TBootstrap& bootstrap, ui64 recycledNodeId) {
+                Y_UNUSED(recycledNodeId);
+                auto request = std::make_shared<TCreateHandleRequest>(
+                    "file",
+                    RootNodeId);
+                request->In->Body.flags = O_CREAT | O_RDWR;
+                request->In->Body.mode = 0644;
+
+                auto create = bootstrap.Fuse->SendRequest(request);
+                UNIT_ASSERT(create.Wait(WaitTimeout));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldNotInvalidateXAttrCacheAfterFailedCreate)
+    {
+        constexpr ui64 recycledNodeId = 6;
+
+        NProto::TFileStoreFeatures features;
+        features.SetXAttrCacheInvalidateOnCreateEnabled(true);
+
+        auto timer = std::make_shared<TTestTimer>();
+        TBootstrap bootstrap{timer, CreateScheduler(), features};
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        std::atomic<int> xattrCallCount = 0;
+        bootstrap.Service->SetHandlerGetNodeXAttr(
+            [&] (auto callContext, auto request) {
+                Y_UNUSED(request);
+                UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+                ++xattrCallCount;
+                NProto::TGetNodeXAttrResponse response;
+                response.SetValue("old-value");
+                response.SetVersion(xattrCallCount.load());
+                return MakeFuture(response);
+            });
+
+        bootstrap.Service->SetHandlerCreateNode(
+            [] (auto callContext, auto request) {
+                Y_UNUSED(request);
+                UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+                NProto::TCreateNodeResponse response;
+                response.MutableError()->SetCode(MAKE_FILESTORE_ERROR(
+                    NProto::E_FS_IO));
+                return MakeFuture(response);
+            });
+
+        {
+            auto xattr = bootstrap.Fuse->SendRequest<TGetXAttrValueRequest>(
+                "name",
+                recycledNodeId);
+            UNIT_ASSERT(xattr.Wait(WaitTimeout));
+            UNIT_ASSERT_STRINGS_EQUAL("old-value", xattr.GetValue());
+        }
+
+        {
+            auto create = bootstrap.Fuse->SendRequest<TMkNodeRequest>(
+                "file",
+                RootNodeId);
+            UNIT_ASSERT(create.Wait(WaitTimeout));
+            UNIT_ASSERT_EXCEPTION(create.GetValue(), yexception);
+        }
+
+        {
+            auto xattr = bootstrap.Fuse->SendRequest<TGetXAttrValueRequest>(
+                "name",
+                recycledNodeId);
+            UNIT_ASSERT(xattr.Wait(WaitTimeout));
+            UNIT_ASSERT_STRINGS_EQUAL("old-value", xattr.GetValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, xattrCallCount.load());
+        }
+    }
+
+    Y_UNIT_TEST(ShouldNotInvalidateXAttrCacheAfterLookupLinkOrOpenExisting)
+    {
+        constexpr ui64 nodeId = 6;
+
+        NProto::TFileStoreFeatures features;
+        features.SetXAttrCacheInvalidateOnCreateEnabled(true);
+
+        auto timer = std::make_shared<TTestTimer>();
+        TBootstrap bootstrap{timer, CreateScheduler(), features};
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+
+        std::atomic<int> xattrCallCount = 0;
+        bootstrap.Service->SetHandlerGetNodeXAttr(
+            [&] (auto callContext, auto request) {
+                Y_UNUSED(request);
+                UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+                ++xattrCallCount;
+                NProto::TGetNodeXAttrResponse response;
+                response.SetValue("old-value");
+                response.SetVersion(xattrCallCount.load());
+                return MakeFuture(response);
+            });
+
+        bootstrap.Service->SetHandlerGetNodeAttr(
+            [=] (auto callContext, auto request) {
+                Y_UNUSED(request);
+                UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+                NProto::TGetNodeAttrResponse response;
+                *response.MutableNode() = MakeNodeAttr(
+                    nodeId,
+                    NProto::E_REGULAR_NODE);
+                return MakeFuture(response);
+            });
+
+        bootstrap.Service->SetHandlerCreateNode(
+            [=] (auto callContext, auto request) {
+                Y_UNUSED(request);
+                UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+                NProto::TCreateNodeResponse response;
+                *response.MutableNode() = MakeNodeAttr(
+                    nodeId,
+                    NProto::E_REGULAR_NODE);
+                return MakeFuture(response);
+            });
+
+        bootstrap.Service->SetHandlerCreateHandle(
+            [=] (auto callContext, auto request) {
+                Y_UNUSED(request);
+                UNIT_ASSERT_VALUES_EQUAL(FileSystemId, callContext->FileSystemId);
+
+                NProto::TCreateHandleResponse response;
+                response.SetHandle(42);
+                *response.MutableNodeAttr() = MakeNodeAttr(
+                    nodeId,
+                    NProto::E_REGULAR_NODE);
+                return MakeFuture(response);
+            });
+
+        auto assertCachedXAttr = [&] {
+            auto xattr = bootstrap.Fuse->SendRequest<TGetXAttrValueRequest>(
+                "name",
+                nodeId);
+            UNIT_ASSERT(xattr.Wait(WaitTimeout));
+            UNIT_ASSERT_STRINGS_EQUAL("old-value", xattr.GetValue());
+            UNIT_ASSERT_VALUES_EQUAL(1, xattrCallCount.load());
+        };
+
+        {
+            auto xattr = bootstrap.Fuse->SendRequest<TGetXAttrValueRequest>(
+                "name",
+                nodeId);
+            UNIT_ASSERT(xattr.Wait(WaitTimeout));
+            UNIT_ASSERT_STRINGS_EQUAL("old-value", xattr.GetValue());
+        }
+
+        {
+            auto lookup = bootstrap.Fuse->SendRequest<TLookupRequest>(
+                "file",
+                RootNodeId);
+            UNIT_ASSERT(lookup.Wait(WaitTimeout));
+            assertCachedXAttr();
+        }
+
+        {
+            auto link = bootstrap.Fuse->SendRequest<TLinkRequest>(
+                "hardlink",
+                nodeId,
+                RootNodeId);
+            UNIT_ASSERT(link.Wait(WaitTimeout));
+            assertCachedXAttr();
+        }
+
+        {
+            auto request = std::make_shared<TCreateHandleRequest>(
+                "file",
+                RootNodeId);
+            request->In->Body.flags = O_RDWR;
+
+            auto create = bootstrap.Fuse->SendRequest(request);
+            UNIT_ASSERT(create.Wait(WaitTimeout));
+            assertCachedXAttr();
         }
     }
 

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -1277,6 +1277,8 @@ private:
         if (features.GetXAttrCacheTimeout()) {
             config.SetXAttrCacheTimeout(features.GetXAttrCacheTimeout());
         }
+        config.SetXAttrCacheInvalidateOnCreateEnabled(
+            features.GetXAttrCacheInvalidateOnCreateEnabled());
         config.SetAsyncDestroyHandleEnabled(
             features.GetAsyncDestroyHandleEnabled());
         config.SetAsyncHandleOperationPeriod(

--- a/cloud/filestore/libs/vfs_fuse/node_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/node_cache.cpp
@@ -123,12 +123,35 @@ void TXAttrCache::AddAbsent(ui64 ino, const TString& name)
 
 const TXAttr* TXAttrCache::Get(ui64 ino, const TString& name)
 {
+    const auto now = Timer->Now();
+
     auto it = Cache.Find({ino, name});
-    if (it != Cache.End() && (Timer->Now() - it.Value().UpdateTime) < Timeout) {
-        return &it.Value();
+    if (it == Cache.End() || (now - it.Value().UpdateTime) >= Timeout) {
+        return nullptr;
     }
 
-    return nullptr;
+    auto invalidation = Cache.Find(TKey{ino, TString{}});
+    if (invalidation != Cache.End() &&
+        (now - invalidation.Value().UpdateTime) < Timeout &&
+        it.Value().UpdateTime <= invalidation.Value().UpdateTime)
+    {
+        return nullptr;
+    }
+
+    return &it.Value();
+}
+
+void TXAttrCache::Invalidate(ui64 ino)
+{
+    Cache.Update(
+        TKey{ino, TString{}},
+        TXAttr{
+            .Name = TString{},
+            .Value = Nothing(),
+            .Version = 0,
+            .UpdateTime = Timer->Now()
+        }
+    );
 }
 
 void TXAttrCache::Forget(ui64 ino, const TString& name)

--- a/cloud/filestore/libs/vfs_fuse/node_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/node_cache.h
@@ -187,6 +187,7 @@ public:
         ui64 version);
     void AddAbsent(ui64 ino, const TString& name);
     const TXAttr* Get(ui64 ino, const TString& name);
+    void Invalidate(ui64 ino);
     void Forget(ui64 ino, const TString& name);
 };
 

--- a/cloud/filestore/libs/vhost/request.h
+++ b/cloud/filestore/libs/vhost/request.h
@@ -7,6 +7,8 @@
 #include <util/generic/string.h>
 #include <util/string/builder.h>
 
+#include <sys/stat.h>
+
 namespace NCloud::NFileStore::NVhost {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -224,6 +226,90 @@ struct TLookupRequest
         In->Header.opcode = FUSE_LOOKUP;
         In->Header.nodeid = nodeId;
         strcpy(In->Body, name.c_str());
+    }
+
+    void SetResult() override
+    {
+        Result.SetValue(Out->Body.nodeid);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TMkDirRequest
+    : public TRequestBase<fuse_mkdir_in, fuse_entry_out, ui64>
+{
+    TMkDirRequest(const TString& name, ui64 parentNodeId, ui32 mode = 0755)
+    {
+        In = TIn::Create(name.size() + 1);
+        In->Header.opcode = FUSE_MKDIR;
+        In->Header.nodeid = parentNodeId;
+        In->Body.mode = mode;
+        strcpy((char*)In->Data(), name.c_str());
+    }
+
+    void SetResult() override
+    {
+        Result.SetValue(Out->Body.nodeid);
+    }
+};
+
+struct TMkNodeRequest
+    : public TRequestBase<fuse_mknod_in, fuse_entry_out, ui64>
+{
+    TMkNodeRequest(
+            const TString& name,
+            ui64 parentNodeId,
+            ui32 mode = S_IFREG | 0644,
+            ui32 rdev = 0)
+    {
+        In = TIn::Create(name.size() + 1);
+        In->Header.opcode = FUSE_MKNOD;
+        In->Header.nodeid = parentNodeId;
+        In->Body.mode = mode;
+        In->Body.rdev = rdev;
+        strcpy((char*)In->Data(), name.c_str());
+    }
+
+    void SetResult() override
+    {
+        Result.SetValue(Out->Body.nodeid);
+    }
+};
+
+struct TSymLinkRequest
+    : public TRequestBase<void, fuse_entry_out, ui64>
+{
+    TSymLinkRequest(
+            const TString& name,
+            const TString& target,
+            ui64 parentNodeId)
+    {
+        In = TIn::Create(name.size() + target.size() + 2);
+        In->Header.opcode = FUSE_SYMLINK;
+        In->Header.nodeid = parentNodeId;
+
+        char* data = static_cast<char*>(In->Data());
+        strcpy(data, name.c_str());
+        strcpy(data + name.size() + 1, target.c_str());
+    }
+
+    void SetResult() override
+    {
+        Result.SetValue(Out->Body.nodeid);
+    }
+};
+
+struct TLinkRequest
+    : public TRequestBase<fuse_link_in, fuse_entry_out, ui64>
+{
+    TLinkRequest(const TString& name, ui64 nodeId, ui64 parentNodeId)
+    {
+        In = TIn::Create(name.size() + 1);
+        In->Header.opcode = FUSE_LINK;
+        In->Header.nodeid = parentNodeId;
+        In->Body.oldnodeid = nodeId;
+        strcpy((char*)In->Data(), name.c_str());
     }
 
     void SetResult() override

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -60,6 +60,7 @@ message TFileStoreFeatures
     uint32 StatFileStoreCacheTTL = 45; // in ms
     bool ExternalReadDataPayload = 46;
     optional bool TabletDirectRdmaEnabled = 47;
+    bool XAttrCacheInvalidateOnCreateEnabled = 48;
 }
 
 message TFileStore


### PR DESCRIPTION
Invalidate cached xattrs on successful create paths that return a newly created
inode. The xattr cache stores a bounded per-inode sentinel entry and treats
xattr values older than or equal to that sentinel as cache misses. This prevents
stale xattrs from being returned when local filestore reuses an inode id.

Enable xattr cache invalidation only for local filestore mounts with extended
attributes enabled, since YDB-backed filestore allocate inode ids monotonically
and do not need this cache-side inode reuse handling.