### PR TITLE
[Filestore] take into acount tablet overloading for unconfirmed writes

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -834,4 +834,8 @@ message TStorageConfig
     // Sets the minimum shard count that each filesystem would have regardless
     // of its size.
     optional uint32 MinShardCount = 522;
+
+    // If enabled, tablet overload is ignored when deciding whether to use
+    // the unconfirmed data flow.
+    optional bool AllowTabletOverload = 523;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -326,6 +326,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
                                                                                \
     xxx(CpuLackOverloadThreshold,               ui32,      101                )\
     xxx(TabletActorCpuUsageOverloadThreshold,   ui32,      101                )\
+    xxx(AllowTabletOverload,                    bool,      false              )\
                                                                                \
     xxx(MaxTabletStep,                     ui32,      Max<ui32>()             )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -391,6 +391,7 @@ public:
 
     ui32 GetCpuLackOverloadThreshold() const;
     ui32 GetTabletActorCpuUsageOverloadThreshold() const;
+    [[nodiscard]] bool GetAllowTabletOverload() const;
 
     ui32 GetMaxTabletStep() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -577,6 +577,15 @@ bool TIndexTabletActor::CanUseUnconfirmedData() const
     return true;
 }
 
+bool TIndexTabletActor::IsTabletConsideredOverloaded() const
+{
+    if (Config->GetAllowTabletOverload()) {
+        return false;
+    }
+
+    return IsTabletOverloaded(*Config, *SystemCounters, Metrics.CPUUsageRate);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 ui32 TIndexTabletActor::ScaleCompactionThreshold(ui32 t) const

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -62,9 +62,9 @@ inline bool IsTabletOverloaded(
     ui32 tabletActorCpuUsageRate)
 {
     const ui64 cl = systemCounters.CpuLack.load(std::memory_order_relaxed);
-    return tabletActorCpuUsageRate
-            >= config.GetTabletActorCpuUsageOverloadThreshold()
-        || cl >= config.GetCpuLackOverloadThreshold();
+    return tabletActorCpuUsageRate >=
+               config.GetTabletActorCpuUsageOverloadThreshold() ||
+           cl >= config.GetCpuLackOverloadThreshold();
 }
 
 inline void BuildBackendInfo(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -56,6 +56,17 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+inline bool IsTabletOverloaded(
+    const TStorageConfig& config,
+    const TSystemCounters& systemCounters,
+    ui32 tabletActorCpuUsageRate)
+{
+    const ui64 cl = systemCounters.CpuLack.load(std::memory_order_relaxed);
+    return tabletActorCpuUsageRate
+            >= config.GetTabletActorCpuUsageOverloadThreshold()
+        || cl >= config.GetCpuLackOverloadThreshold();
+}
+
 inline void BuildBackendInfo(
     const TStorageConfig& config,
     const TSystemCounters& systemCounters,
@@ -63,11 +74,8 @@ inline void BuildBackendInfo(
     ui32 tabletActorCpuUsageRate,
     NProto::TBackendInfo* backendInfo)
 {
-    const ui64 cl = systemCounters.CpuLack.load(std::memory_order_relaxed);
     backendInfo->SetIsOverloaded(
-        tabletActorCpuUsageRate
-            >= config.GetTabletActorCpuUsageOverloadThreshold()
-        || cl >= config.GetCpuLackOverloadThreshold());
+        IsTabletOverloaded(config, systemCounters, tabletActorCpuUsageRate));
 
     const ui32 fastShardPort = config.GetFastShardServerPort();
     if (fastShardPort) {
@@ -591,6 +599,7 @@ private:
 
     NProto::TError IsDataOperationAllowed() const;
     bool CanUseUnconfirmedData() const;
+    bool IsTabletConsideredOverloaded() const;
 
     ui32 ScaleCompactionThreshold(ui32 t) const;
     TCompactionInfo GetCompactionInfo() const;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -337,9 +337,9 @@ void TIndexTabletActor::HandleGenerateBlobIds(
         return ScheduleRebootTabletOnCommitIdOverflow(ctx, "GenerateBlobIds");
     }
 
-    // TODO (#5468) consider take into account isOverloaded
     const bool canUseUnconfirmed =
-        msg->Record.GetUnconfirmedFlowRequested() && CanUseUnconfirmedData();
+        msg->Record.GetUnconfirmedFlowRequested() && CanUseUnconfirmedData() &&
+        !IsTabletConsideredOverloaded();
 
     auto validator = [&](const NProtoPrivate::TGenerateBlobIdsRequest& request)
     {

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -307,6 +307,85 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
         AssertStorageStats(tablet, 0, 0);
     }
 
+    Y_UNIT_TEST(ShouldNotEnableUnconfirmedFlowWhenTabletIsOverloaded)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetCpuLackOverloadThreshold(50);
+
+        TTestEnv env({}, std::move(storageConfig));
+        auto systemCounters = env.GetSystemCounters();
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        systemCounters->CpuLack.store(60);
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        UNIT_ASSERT(!gbi->Record.GetUnconfirmedFlowEnabled());
+        AssertStorageStats(tablet, 0, 0);
+
+        systemCounters->CpuLack.store(30);
+        gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        UNIT_ASSERT(gbi->Record.GetUnconfirmedFlowEnabled());
+        GenerateBlobIdsPutBlobAndConfirm(
+            env,
+            tablet,
+            *gbi,
+            TString(block, 'a'));
+
+        UNIT_ASSERT_BUFFER_CONTENTS_EQUAL(
+            ReadData(tablet, handle, block, 0),
+            block,
+            'a');
+    }
+
+    Y_UNIT_TEST(ShouldEnableUnconfirmedFlowOnOverloadIfTabletOverloadAllowed)
+    {
+        constexpr ui32 block = 4_KB;
+
+        NProto::TStorageConfig storageConfig;
+        storageConfig.SetWriteBlobThreshold(1);
+        storageConfig.SetAddingUnconfirmedDataEnabled(true);
+        storageConfig.SetUnconfirmedDataCountHardLimit(10);
+        storageConfig.SetCpuLackOverloadThreshold(50);
+        storageConfig.SetAllowTabletOverload(true);
+
+        TTestEnv env({}, std::move(storageConfig));
+        env.GetSystemCounters()->CpuLack.store(60);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+        tablet.InitSession("client", "session");
+
+        auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));
+        ui64 handle = CreateHandle(tablet, id);
+
+        auto gbi = tablet.GenerateBlobIds(id, handle, 0, block);
+        UNIT_ASSERT(gbi->Record.GetUnconfirmedFlowEnabled());
+        GenerateBlobIdsPutBlobAndConfirm(
+            env,
+            tablet,
+            *gbi,
+            TString(block, 'a'));
+
+        UNIT_ASSERT_BUFFER_CONTENTS_EQUAL(
+            ReadData(tablet, handle, block, 0),
+            block,
+            'a');
+    }
+
     Y_UNIT_TEST(ShouldConfirmUnalignedHeadAndTailData)
     {
         constexpr ui32 block = 4_KB;


### PR DESCRIPTION
### Notes
Take into account if tablet is overloaded and do not use unconfirmed writes in that case
Added uts
Added special flag to disable this behaviour. This will be needed for further improvements and tests

### Issue
#2293
