### PR TITLE
[Filestore] Send WriteData buffer as an external payload

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -840,5 +840,5 @@ message TStorageConfig
     optional bool AllowTabletOverload = 523;
 
     // Pass data buffer to the tablet as a message payload
-    optional bool ExternalWriteDataPayload = 524;
+    optional bool ExternalWriteDataPayloadEnabled = 524;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -838,4 +838,7 @@ message TStorageConfig
     // If enabled, tablet overload is ignored when deciding whether to use
     // the unconfirmed data flow.
     optional bool AllowTabletOverload = 523;
+
+    // Pass data buffer to the tablet as a message payload
+    optional bool ExternalWriteDataPayload = 524;
 }

--- a/cloud/filestore/libs/diagnostics/critical_events.h
+++ b/cloud/filestore/libs/diagnostics/critical_events.h
@@ -94,6 +94,7 @@ namespace NCloud::NFileStore{
     xxx(InvalidCommitIdInUnconfirmedAddBlobSafePoint)                          \
     xxx(ListNodesInternalFailedToAddNodeRef)                                   \
     xxx(InMemoryIndexStateNotInitialized)                                      \
+    xxx(WriteDataRequestWithBufferAndPayload)                                  \
 // FILESTORE_IMPOSSIBLE_EVENTS
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -377,6 +377,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(SoftBackpressureMaxReadBandwidth,              ui32,    30 * 1024     )\
     xxx(SoftBackpressureMaxWriteIops,                  ui32,    10'000        )\
     xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
+                                                                               \
+    xxx(ExternalWriteDataPayload,               bool,   false                 )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -378,7 +378,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(SoftBackpressureMaxWriteIops,                  ui32,    10'000        )\
     xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
                                                                                \
-    xxx(ExternalWriteDataPayload,               bool,   false                 )\
+    xxx(ExternalWriteDataPayloadEnabled,               bool,    false         )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -434,6 +434,8 @@ public:
     ui32 GetSoftBackpressureMaxReadBandwidth() const;
     ui32 GetSoftBackpressureMaxWriteIops() const;
     ui32 GetSoftBackpressureMaxReadIops() const;
+
+    [[nodiscard]] bool GetExternalWriteDataPayload() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -435,7 +435,7 @@ public:
     ui32 GetSoftBackpressureMaxWriteIops() const;
     ui32 GetSoftBackpressureMaxReadIops() const;
 
-    [[nodiscard]] bool GetExternalWriteDataPayload() const;
+    [[nodiscard]] bool GetExternalWriteDataPayloadEnabled() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -173,7 +173,7 @@ private:
     TRope Rope;
 
     const bool UseThreeStageWrite = false;
-    const bool ExternalWriteDataPayload = false;
+    const bool ExternalWriteDataPayloadEnabled = false;
 
 public:
     TWriteDataActor(
@@ -188,7 +188,7 @@ public:
         ITraceSerializerPtr traceSerializer,
         NCloud::NProto::EStorageMediaKind mediaKind,
         bool useThreeStageWrite,
-        bool externalWriteDataPayload)
+        bool externalWriteDataPayloadEnabled)
         : WriteRequest(std::move(request))
         , Range(range)
         , BlobRange(Range.AlignedSubRange())
@@ -201,7 +201,7 @@ public:
         , TraceSerializer(std::move(traceSerializer))
         , MediaKind(mediaKind)
         , UseThreeStageWrite(useThreeStageWrite)
-        , ExternalWriteDataPayload(externalWriteDataPayload)
+        , ExternalWriteDataPayloadEnabled(externalWriteDataPayloadEnabled)
     {}
 
     void Bootstrap(const TActorContext& ctx)
@@ -875,7 +875,9 @@ private:
 
         auto request = std::make_unique<TEvService::TEvWriteDataRequest>();
         request->Record = std::move(WriteRequest);
-        PrepareWriteDataRequestPayload(*request, ExternalWriteDataPayload);
+        PrepareWriteDataRequestPayload(
+            *request,
+            ExternalWriteDataPayloadEnabled);
         if (isFallback) {
             request->Record.MutableHeaders()->SetThrottlingDisabled(true);
         }
@@ -1092,7 +1094,7 @@ void TStorageServiceActor::HandleWriteData(
         TraceSerializer,
         session->MediaKind,
         threeStageWriteEnabled,
-        filestore.GetFeatures().GetExternalWriteDataPayload());
+        filestore.GetFeatures().GetExternalWriteDataPayloadEnabled());
     NCloud::Register(ctx, std::move(actor));
 }
 

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -106,7 +106,7 @@ void PrepareWriteDataRequestPayload(
 
     auto rope = CreateRope(record.GetIovecs());
     TString buffer;
-    const auto bytesToCopy = NFileStore::CalculateByteCount(request);
+    const auto bytesToCopy = NFileStore::CalculateByteCount(record);
     buffer.ReserveAndResize(bytesToCopy);
     auto bytesCopied =
         TRopeUtils::SafeMemcpy(buffer.begin(), rope.Begin(), bytesToCopy);

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -83,38 +83,40 @@ ui64 CopyBufferFromRope(
  *
  * If the request payload is represented by iovecs, this function copies the
  * required data slice from the iovecs into the request buffer, or into the
- * request payload when @p externalPayload is set. The iovecs are then cleared
- * from the request.
+ * request payload when @p useExternalPayload is set. The iovecs are then
+ * cleared from the request.
  *
  * @param request The write request containing iovecs used as the data source.
- * @param externalPayload If true, stores the copied data as an external payload;
- *                        otherwise, stores it in the request buffer.
+ * @param useExternalPayload If true, stores the copied data as an external
+ * payload; otherwise, stores it in the request buffer.
  */
-void PrepareWriteDataRequestPayload(auto* msg, bool externalPayload)
+void PrepareWriteDataRequestPayload(
+    TEvService::TEvWriteDataRequest& request,
+    bool useExternalPayload)
 {
-    auto& request = msg->Record;
-    if (request.GetIovecs().empty()) {
-        if (externalPayload) {
-            auto& buffer = *request.MutableBuffer();
-            msg->AddPayload(TRope(std::move(buffer)));
+    auto& record = request.Record;
+    if (record.GetIovecs().empty()) {
+        if (useExternalPayload) {
+            auto& buffer = *record.MutableBuffer();
+            request.AddPayload(TRope(std::move(buffer)));
             buffer.clear();
         }
         return;
     }
 
-    auto rope = CreateRope(request.GetIovecs());
+    auto rope = CreateRope(record.GetIovecs());
     TString buffer;
     const auto bytesToCopy = NFileStore::CalculateByteCount(request);
     buffer.ReserveAndResize(bytesToCopy);
     auto bytesCopied =
         TRopeUtils::SafeMemcpy(buffer.begin(), rope.Begin(), bytesToCopy);
-    request.MutableIovecs()->Clear();
+    record.MutableIovecs()->Clear();
     Y_ABORT_UNLESS(bytesCopied == bytesToCopy);
 
-    if (externalPayload) {
-        msg->AddPayload(TRope(std::move(buffer)));
+    if (useExternalPayload) {
+        request.AddPayload(TRope(std::move(buffer)));
     } else {
-        request.SetBuffer(std::move(buffer));
+        record.SetBuffer(std::move(buffer));
     }
 }
 
@@ -873,7 +875,7 @@ private:
 
         auto request = std::make_unique<TEvService::TEvWriteDataRequest>();
         request->Record = std::move(WriteRequest);
-        PrepareWriteDataRequestPayload(request.get(), ExternalWriteDataPayload);
+        PrepareWriteDataRequestPayload(*request, ExternalWriteDataPayload);
         if (isFallback) {
             request->Record.MutableHeaders()->SetThrottlingDisabled(true);
         }

--- a/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_writedata.cpp
@@ -79,25 +79,43 @@ ui64 CopyBufferFromRope(
 }
 
 /**
- * @brief Copies a slice of data from the iovecs in the request into the buffer
- *        in the same request and cleanup iovecs.
+ * @brief Prepares a WriteData request to be sent to the tablet.
  *
- * @param request The write request containing iovecs as the source of data
+ * If the request payload is represented by iovecs, this function copies the
+ * required data slice from the iovecs into the request buffer, or into the
+ * request payload when @p externalPayload is set. The iovecs are then cleared
+ * from the request.
+ *
+ * @param request The write request containing iovecs used as the data source.
+ * @param externalPayload If true, stores the copied data as an external payload;
+ *                        otherwise, stores it in the request buffer.
  */
-void MoveIovecsToBuffer(NProto::TWriteDataRequest& request)
+void PrepareWriteDataRequestPayload(auto* msg, bool externalPayload)
 {
+    auto& request = msg->Record;
     if (request.GetIovecs().empty()) {
+        if (externalPayload) {
+            auto& buffer = *request.MutableBuffer();
+            msg->AddPayload(TRope(std::move(buffer)));
+            buffer.clear();
+        }
         return;
     }
 
     auto rope = CreateRope(request.GetIovecs());
-    auto* buffer = request.MutableBuffer();
+    TString buffer;
     const auto bytesToCopy = NFileStore::CalculateByteCount(request);
-    buffer->ReserveAndResize(bytesToCopy);
+    buffer.ReserveAndResize(bytesToCopy);
     auto bytesCopied =
-        TRopeUtils::SafeMemcpy(&(*buffer)[0], rope.Begin(), bytesToCopy);
+        TRopeUtils::SafeMemcpy(buffer.begin(), rope.Begin(), bytesToCopy);
     request.MutableIovecs()->Clear();
     Y_ABORT_UNLESS(bytesCopied == bytesToCopy);
+
+    if (externalPayload) {
+        msg->AddPayload(TRope(std::move(buffer)));
+    } else {
+        request.SetBuffer(std::move(buffer));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -153,6 +171,7 @@ private:
     TRope Rope;
 
     const bool UseThreeStageWrite = false;
+    const bool ExternalWriteDataPayload = false;
 
 public:
     TWriteDataActor(
@@ -166,7 +185,8 @@ public:
         IProfileLogPtr profileLog,
         ITraceSerializerPtr traceSerializer,
         NCloud::NProto::EStorageMediaKind mediaKind,
-        bool useThreeStageWrite)
+        bool useThreeStageWrite,
+        bool externalWriteDataPayload)
         : WriteRequest(std::move(request))
         , Range(range)
         , BlobRange(Range.AlignedSubRange())
@@ -179,6 +199,7 @@ public:
         , TraceSerializer(std::move(traceSerializer))
         , MediaKind(mediaKind)
         , UseThreeStageWrite(useThreeStageWrite)
+        , ExternalWriteDataPayload(externalWriteDataPayload)
     {}
 
     void Bootstrap(const TActorContext& ctx)
@@ -850,9 +871,9 @@ private:
             RequestInfo->CallContext,
             "WriteData");
 
-        MoveIovecsToBuffer(WriteRequest);
         auto request = std::make_unique<TEvService::TEvWriteDataRequest>();
         request->Record = std::move(WriteRequest);
+        PrepareWriteDataRequestPayload(request.get(), ExternalWriteDataPayload);
         if (isFallback) {
             request->Record.MutableHeaders()->SetThrottlingDisabled(true);
         }
@@ -1068,7 +1089,8 @@ void TStorageServiceActor::HandleWriteData(
         ProfileLog,
         TraceSerializer,
         session->MediaKind,
-        threeStageWriteEnabled);
+        threeStageWriteEnabled,
+        filestore.GetFeatures().GetExternalWriteDataPayload());
     NCloud::Register(ctx, std::move(actor));
 }
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4830,6 +4830,28 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         TestZeroCopyWrite(config, 0, iovecSizes);
     }
 
+    Y_UNIT_TEST(TestAlignedZeroCopyWriteFallbackWithExternalPayload)
+    {
+        NProto::TStorageConfig config;
+        config.SetThreeStageWriteEnabled(false);
+        config.SetUnalignedThreeStageWriteEnabled(false);
+        config.SetZeroCopyWriteEnabled(true);
+        config.SetExternalWriteDataPayload(true);
+        config.SetExternalReadDataPayload(true);
+        TestZeroCopyWrite(config, 4_KB, std::vector<ui64>(64, 4_KB));
+    }
+
+    Y_UNIT_TEST(TestUnalignedZeroCopyWriteFallbackWithExternalPayload)
+    {
+        NProto::TStorageConfig config;
+        config.SetThreeStageWriteEnabled(true);
+        config.SetUnalignedThreeStageWriteEnabled(false);
+        config.SetZeroCopyWriteEnabled(true);
+        config.SetExternalWriteDataPayload(true);
+        config.SetExternalReadDataPayload(true);
+        TestZeroCopyWrite(config, 111, std::vector<ui64>(64, 4_KB));
+    }
+
     Y_UNIT_TEST(TestZeroCopyWriteWithEmptyIovecs)
     {
         NProto::TStorageConfig config;
@@ -5178,6 +5200,48 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     {
         DoShouldHitNodesCountLimit(false);
         DoShouldHitNodesCountLimit(true);
+    }
+
+    Y_UNIT_TEST(TestWriteWithExternalPayload)
+    {
+        NProto::TStorageConfig config;
+        config.SetExternalWriteDataPayload(true);
+        TTestEnv env({}, std::move(config));
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        const TString fs = "test";
+        service.CreateFileStore(
+            fs,
+            1000,
+            DefaultBlockSize,
+            NProto::EStorageMediaKind::STORAGE_MEDIA_SSD);
+        auto headers = service.InitSession(fs, "client");
+        ui64 nodeId =
+            service
+                .CreateNode(headers, TCreateNodeArgs::File(RootNodeId, "file"))
+                ->Record.GetNode()
+                .GetId();
+
+        ui64 handle =
+            service
+                .CreateHandle(headers, fs, nodeId, "", TCreateHandleArgs::RDWR)
+                ->Record.GetHandle();
+
+        auto data = GenerateValidateData(64_KB);
+        service.WriteData(headers, fs, nodeId, handle, 0, data);
+        auto readDataResult = service.ReadData(
+            headers,
+            fs,
+            nodeId,
+            handle,
+            0,
+            data.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            data.size(),
+            readDataResult->Record.GetBuffer().size());
+        UNIT_ASSERT_VALUES_EQUAL(data, readDataResult->Record.GetBuffer());
     }
 }
 

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -4836,7 +4836,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         config.SetThreeStageWriteEnabled(false);
         config.SetUnalignedThreeStageWriteEnabled(false);
         config.SetZeroCopyWriteEnabled(true);
-        config.SetExternalWriteDataPayload(true);
+        config.SetExternalWriteDataPayloadEnabled(true);
         config.SetExternalReadDataPayload(true);
         TestZeroCopyWrite(config, 4_KB, std::vector<ui64>(64, 4_KB));
     }
@@ -4847,7 +4847,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         config.SetThreeStageWriteEnabled(true);
         config.SetUnalignedThreeStageWriteEnabled(false);
         config.SetZeroCopyWriteEnabled(true);
-        config.SetExternalWriteDataPayload(true);
+        config.SetExternalWriteDataPayloadEnabled(true);
         config.SetExternalReadDataPayload(true);
         TestZeroCopyWrite(config, 111, std::vector<ui64>(64, 4_KB));
     }
@@ -5205,7 +5205,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
     Y_UNIT_TEST(TestWriteWithExternalPayload)
     {
         NProto::TStorageConfig config;
-        config.SetExternalWriteDataPayload(true);
+        config.SetExternalWriteDataPayloadEnabled(true);
         TTestEnv env({}, std::move(config));
 
         ui32 nodeIdx = env.AddDynamicNode();

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -453,6 +453,7 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
 {
     auto error = ValidateRange(range, Config->GetMaxFileBlocks());
     if (HasError(error)) {
+        std::cerr << "MYAGKOV: validate write request failed" << std::endl;
         return error;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -453,7 +453,6 @@ NProto::TError TIndexTabletActor::ValidateWriteRequest(
 {
     auto error = ValidateRange(range, Config->GetMaxFileBlocks());
     if (HasError(error)) {
-        std::cerr << "MYAGKOV: validate write request failed" << std::endl;
         return error;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -121,6 +121,7 @@ void FillFeatures(
         config.GetStatFileStoreCacheTTL().MilliSeconds());
 
     features->SetExternalReadDataPayload(config.GetExternalReadDataPayload());
+    features->SetExternalWriteDataPayload(config.GetExternalWriteDataPayload());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -202,6 +203,12 @@ void ProcessAdapterModeFeatures(NProto::TFileStoreFeatures& f)
 
     f.SetTwoStageReadEnabled(false);
     f.SetThreeStageWriteEnabled(false);
+
+    // Adapter mode doesn't support external read/write data payloads yet.
+    // Disabling external read/write data payloads for the whole FS for
+    // simplicity if at least one shard is configured in adapter mode.
+    f.SetExternalReadDataPayload(false);
+    f.SetExternalWriteDataPayload(false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -121,7 +121,8 @@ void FillFeatures(
         config.GetStatFileStoreCacheTTL().MilliSeconds());
 
     features->SetExternalReadDataPayload(config.GetExternalReadDataPayload());
-    features->SetExternalWriteDataPayload(config.GetExternalWriteDataPayload());
+    features->SetExternalWriteDataPayloadEnabled(
+        config.GetExternalWriteDataPayloadEnabled());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -208,7 +209,7 @@ void ProcessAdapterModeFeatures(NProto::TFileStoreFeatures& f)
     // Disabling external read/write data payloads for the whole FS for
     // simplicity if at least one shard is configured in adapter mode.
     f.SetExternalReadDataPayload(false);
-    f.SetExternalWriteDataPayload(false);
+    f.SetExternalWriteDataPayloadEnabled(false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -26,6 +26,17 @@ void TIndexTabletActor::HandleWriteData(
 {
     auto* msg = ev->Get();
 
+    if (msg->Record.GetBuffer().empty() && msg->GetPayloadCount() > 0 &&
+        msg->GetPayload(0).size() != 0)
+    {
+        auto& payload = msg->GetPayload(0);
+        msg->Record.MutableBuffer()->ReserveAndResize(payload.size());
+        TRopeUtils::Memcpy(
+            msg->Record.MutableBuffer()->begin(),
+            payload.begin(),
+            payload.size());
+    }
+
     NProto::TProfileLogRequestInfo profileLogRequest;
     InitTabletProfileLogRequestInfo(
         profileLogRequest,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -44,6 +44,7 @@ void TIndexTabletActor::HandleWriteData(
                 msg->Record.MutableBuffer()->begin(),
                 payload.begin(),
                 payload.size());
+            msg->StripPayload();
         }
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -26,15 +26,25 @@ void TIndexTabletActor::HandleWriteData(
 {
     auto* msg = ev->Get();
 
-    if (msg->Record.GetBuffer().empty() && msg->GetPayloadCount() > 0 &&
-        msg->GetPayload(0).size() != 0)
-    {
-        auto& payload = msg->GetPayload(0);
-        msg->Record.MutableBuffer()->ReserveAndResize(payload.size());
-        TRopeUtils::Memcpy(
-            msg->Record.MutableBuffer()->begin(),
-            payload.begin(),
-            payload.size());
+    if (msg->GetPayloadCount() > 0 && msg->GetPayload(0).size() != 0) {
+        if (!msg->Record.GetBuffer().empty()) {
+            TStringStream error;
+            error << "WriteData request has both buffer and payload. "
+                  << "FileSystemId: " << msg->Record.GetFileSystemId()
+                  << ", Handle: " << msg->Record.GetHandle()
+                  << ", NodeId: " << msg->Record.GetNodeId()
+                  << ", Offset: " << msg->Record.GetOffset()
+                  << ", Buffer size: " << msg->Record.GetBuffer().size()
+                  << ", Payload size: " << msg->GetPayload(0).size();
+            ReportWriteDataRequestWithBufferAndPayload(error.Str());
+        } else {
+            auto& payload = msg->GetPayload(0);
+            msg->Record.MutableBuffer()->ReserveAndResize(payload.size());
+            TRopeUtils::Memcpy(
+                msg->Record.MutableBuffer()->begin(),
+                payload.begin(),
+                payload.size());
+        }
     }
 
     NProto::TProfileLogRequestInfo profileLogRequest;

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -9065,10 +9065,11 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
                 << rebootTracker.GetGenerationCount());
     }
 
-    TABLET_TEST(ShouldPassReadDataAsPayload)
+    TABLET_TEST(ShouldPassDataAsPayload)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetExternalReadDataPayload(true);
+        storageConfig.SetExternalWriteDataPayload(true);
 
         TTestEnv env({} /* config */, std::move(storageConfig));
 
@@ -9079,7 +9080,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             env.GetRuntime(),
             nodeIdx,
             tabletId,
-            tabletConfig);
+            tabletConfig,
+            true,
+            storageConfig);
         tablet.InitSession("client", "session");
 
         auto id = CreateNode(tablet, TCreateNodeArgs::File(RootNodeId, "test"));

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -9069,7 +9069,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetExternalReadDataPayload(true);
-        storageConfig.SetExternalWriteDataPayload(true);
+        storageConfig.SetExternalWriteDataPayloadEnabled(true);
 
         TTestEnv env({} /* config */, storageConfig);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -9071,7 +9071,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetExternalReadDataPayload(true);
         storageConfig.SetExternalWriteDataPayload(true);
 
-        TTestEnv env({} /* config */, std::move(storageConfig));
+        TTestEnv env({} /* config */, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -9081,7 +9081,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             nodeIdx,
             tabletId,
             tabletConfig,
-            true,
+            true /*updateConfig*/,
             storageConfig);
         tablet.InitSession("client", "session");
 

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -109,16 +109,20 @@ private:
 
     ui64 AutoRequestId = 0;
 
+    TStorageConfig StorageConfig;
+
 public:
     TIndexTabletClient(
             NKikimr::TTestActorRuntime& runtime,
             ui32 nodeIdx,
             ui64 tabletId,
             const TFileSystemConfig& config = {},
-            bool updateConfig = true)
+            bool updateConfig = true,
+            const TStorageConfig& storageConfig = {})
         : Runtime(runtime)
         , NodeIdx(nodeIdx)
         , TabletId(tabletId)
+        , StorageConfig(storageConfig)
     {
         Sender = Runtime.AllocateEdgeActor(NodeIdx);
 
@@ -885,7 +889,12 @@ public:
         auto request = CreateSessionRequest<TEvService::TEvWriteDataRequest>();
         request->Record.SetHandle(handle);
         request->Record.SetOffset(offset);
-        request->Record.SetBuffer(CreateBuffer(len, fill));
+        TString buffer = CreateBuffer(len, fill);
+        if (StorageConfig.GetExternalWriteDataPayload()) {
+            request->AddPayload(TRope(std::move(buffer)));
+        } else {
+            request->Record.SetBuffer(std::move(buffer));
+        }
         if (node != InvalidNodeId) {
             request->Record.SetNodeId(node);
         }
@@ -902,7 +911,12 @@ public:
         auto request = CreateSessionRequest<TEvService::TEvWriteDataRequest>();
         request->Record.SetHandle(handle);
         request->Record.SetOffset(offset);
-        request->Record.MutableBuffer()->assign(data, len);
+        TString buffer(data, len);
+        if (StorageConfig.GetExternalWriteDataPayload()) {
+            request->AddPayload(TRope(std::move(buffer)));
+        } else {
+            request->Record.SetBuffer(std::move(buffer));
+        }
         if (node != InvalidNodeId) {
             request->Record.SetNodeId(node);
         }

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -890,7 +890,7 @@ public:
         request->Record.SetHandle(handle);
         request->Record.SetOffset(offset);
         TString buffer = CreateBuffer(len, fill);
-        if (StorageConfig.GetExternalWriteDataPayload()) {
+        if (StorageConfig.GetExternalWriteDataPayloadEnabled()) {
             request->AddPayload(TRope(std::move(buffer)));
         } else {
             request->Record.SetBuffer(std::move(buffer));
@@ -912,7 +912,7 @@ public:
         request->Record.SetHandle(handle);
         request->Record.SetOffset(offset);
         TString buffer(data, len);
-        if (StorageConfig.GetExternalWriteDataPayload()) {
+        if (StorageConfig.GetExternalWriteDataPayloadEnabled()) {
             request->AddPayload(TRope(std::move(buffer)));
         } else {
             request->Record.SetBuffer(std::move(buffer));

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -59,6 +59,7 @@ message TFileStoreFeatures
     bool ServerWriteBackCacheFlushWritesInParallelEnabled = 44;
     uint32 StatFileStoreCacheTTL = 45; // in ms
     bool ExternalReadDataPayload = 46;
+    bool ExternalWriteDataPayload = 47;
 }
 
 message TFileStore

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -59,7 +59,7 @@ message TFileStoreFeatures
     bool ServerWriteBackCacheFlushWritesInParallelEnabled = 44;
     uint32 StatFileStoreCacheTTL = 45; // in ms
     bool ExternalReadDataPayload = 46;
-    bool ExternalWriteDataPayload = 47;
+    bool ExternalWriteDataPayloadEnabled = 47;
 }
 
 message TFileStore

--- a/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/nfs-patch.txt
@@ -1,1 +1,2 @@
 ExternalReadDataPayload: true
+ExternalWriteDataPayload: true

--- a/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-external-payload-test/nfs-patch.txt
@@ -1,2 +1,2 @@
 ExternalReadDataPayload: true
-ExternalWriteDataPayload: true
+ExternalWriteDataPayloadEnabled: true

--- a/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-fallback-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-fallback-test/nfs-patch.txt
@@ -2,3 +2,4 @@ ZeroCopyWriteEnabled: true
 ZeroCopyReadEnabled: true
 UseCustomReadDataResponseParser: true
 ExternalReadDataPayload: true
+ExternalWriteDataPayload: true

--- a/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-fallback-test/nfs-patch.txt
+++ b/cloud/filestore/tests/fio/qemu-kikimr-zero-copy-fallback-test/nfs-patch.txt
@@ -2,4 +2,4 @@ ZeroCopyWriteEnabled: true
 ZeroCopyReadEnabled: true
 UseCustomReadDataResponseParser: true
 ExternalReadDataPayload: true
-ExternalWriteDataPayload: true
+ExternalWriteDataPayloadEnabled: true


### PR DESCRIPTION
issue: https://github.com/ydb-platform/nbs/issues/6334

Pass WriteData as an external payload to eliminate Protobuf parsing/serialization overhead and enable transmitting the WriteData payload over XDC/RDMA.

The 1 MiB FIO tests showed a significant improvement in write bandwidth with disabled three-stage write, increasing from 7.3 GiB/s to 9 GiB/s.
