### PR TITLE
issue-5894: fastshard storage node client implementation + got rid of futures in IStorageNode + extracted common test code into testlib

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server_ut.cpp
@@ -3,6 +3,9 @@
 #include <cloud/filestore/libs/storage/fastshard/server/server.h>
 #include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
 #include <cloud/filestore/libs/storage/fastshard/impl/mem/memshard.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
+
+#include <library/cpp/testing/common/network.h>
 
 #include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
@@ -11,14 +14,8 @@
 
 #include <silk/fibers/fiber.h>
 #include <silk/fibers/future.h>
-#include <silk/util/init.h>
 
 #include <gtest/gtest.h>
-
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <unistd.h>
 
 using namespace NCloud::NFileStore::NStorage::NFastShard;
 using namespace NCloud::NFileStore::NStorage::NFastShard::NProtoSrv;
@@ -31,56 +28,20 @@ namespace {
 
 constexpr TDuration WaitTimeout = TDuration::Seconds(5);
 
-////////////////////////////////////////////////////////////////////////////////
-// Silk test environment.
-
-class TSilkEnv : public ::testing::Environment
-{
-public:
-    void SetUp() override
-    {
-        silk::initialize();
-        FiberScheduler::initialize();
-    }
-    void TearDown() override
-    {
-        FiberScheduler::destroy();
-        silk::destroy();
-    }
-};
-
 [[maybe_unused]] auto* const gEnv =
-    ::testing::AddGlobalTestEnvironment(new TSilkEnv);
-
-////////////////////////////////////////////////////////////////////////////////
-// Pick a free port.
-
-ui16 GetFreePort()
-{
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    addr.sin_port = 0;
-    ::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
-    socklen_t len = sizeof(addr);
-    ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len);
-    ui16 port = ntohs(addr.sin_port);
-    ::close(fd);
-    return port;
-}
+    ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
 
 ////////////////////////////////////////////////////////////////////////////////
 // Test fixture that runs the server in a fiber.
 
 struct TServerFixture
 {
-    ui16 Port;
+    NTesting::TPortHolder Port;
     IServerPtr Server;
     FiberFuture ServerFuture;
 
     TServerFixture()
-        : Port(GetFreePort())
+        : Port(NTesting::GetFreePort())
         , Server(CreateServer(Port))
     {}
 

--- a/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/server/ut/ya.make
@@ -9,8 +9,11 @@ PEERDIR(
     cloud/filestore/libs/storage/fastshard/server
     cloud/filestore/libs/storage/fastshard/server/protos
     cloud/filestore/libs/storage/fastshard/impl/mem
+    cloud/filestore/libs/storage/fastshard/testlib
 
     cloud/filestore/private/api/unsafe_protos
+
+    library/cpp/testing/common
 
     contrib/libs/silk/src/fibers
 

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client.cpp
@@ -1,0 +1,245 @@
+#include "client.h"
+
+#include <cloud/filestore/libs/storage/fastshard/ipc/ipc.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/mutex.h>
+#include <silk/util/logger.h>
+
+#include <util/generic/scope.h>
+#include <util/generic/string.h>
+#include <util/string/builder.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <mutex>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+using silk::FiberMutex;
+using silk::FiberScheduler;
+
+using NCloud::NProto::TDeviceProtocolRequest;
+using NCloud::NProto::TDeviceProtocolResponse;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+// TCP connect from within a fiber. Returns fd on success, -1 on failure.
+
+int OpenTcp(const TString& host, ui16 port)
+{
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    char portStr[6];
+    ui32 printed = snprintf(portStr, sizeof(portStr), "%d", port);
+    if (printed >= sizeof(portStr)) {
+        return -1;
+    }
+
+    addrinfo* res = nullptr;
+    if (::getaddrinfo(host.c_str(), portStr, &hints, &res) != 0) {
+        return -1;
+    }
+    Y_DEFER {
+        ::freeaddrinfo(res);
+    };
+
+    for (addrinfo* ai = res; ai != nullptr; ai = ai->ai_next) {
+        int fd = ::socket(
+            ai->ai_family,
+            ai->ai_socktype | SOCK_NONBLOCK | SOCK_CLOEXEC,
+            ai->ai_protocol);
+        if (fd < 0) {
+            continue;
+        }
+
+        int ret = ::connect(fd, ai->ai_addr, ai->ai_addrlen);
+        if (ret < 0 && errno != EINPROGRESS) {
+            ::close(fd);
+            continue;
+        }
+        if (ret < 0) {
+            if (FiberScheduler::poll(fd, POLLOUT)) {
+                ::close(fd);
+                continue;
+            }
+            int err = 0;
+            socklen_t errLen = sizeof(err);
+            ::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errLen);
+            if (err) {
+                ::close(fd);
+                continue;
+            }
+        }
+
+        int one = 1;
+        ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+        return fd;
+    }
+    return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// IStorageNode over a single TCP connection to an sn server.
+
+class TStorageNodeClient: public IStorageNode
+{
+public:
+    TStorageNodeClient(TString host, ui16 port)
+        : Host(std::move(host))
+        , Port(port)
+    {}
+
+    ~TStorageNodeClient() override
+    {
+        if (Fd >= 0) {
+            ::close(Fd);
+        }
+    }
+
+#define SN_CLIENT_METHOD(name, ...)                                            \
+    NCloud::NProto::T##name##Response name(                                    \
+        NCloud::NProto::T##name##Request request) override                     \
+    {                                                                          \
+        TDeviceProtocolRequest wire;                                           \
+        wire.SetRequestId(NextRequestId.fetch_add(1));                         \
+        *wire.Mutable##name() = std::move(request);                            \
+                                                                               \
+        TDeviceProtocolResponse resp = Exchange(wire);                         \
+                                                                               \
+        NCloud::NProto::T##name##Response out;                                 \
+        if (resp.HasProtocolError()) {                                         \
+            *out.MutableError() = std::move(                                   \
+                *resp.MutableProtocolError());                                 \
+        } else if (resp.Has##name()) {                                         \
+            out = std::move(*resp.Mutable##name());                            \
+        } else {                                                               \
+            *out.MutableError() = MakeError(                                   \
+                E_REJECTED,                                                    \
+                "sn client: response missing " #name " case");                 \
+        }                                                                      \
+        return out;                                                            \
+    }                                                                          \
+// SN_CLIENT_METHOD
+
+    SN_METHODS(SN_CLIENT_METHOD)
+
+#undef SN_CLIENT_METHOD
+
+private:
+    TDeviceProtocolResponse Exchange(const TDeviceProtocolRequest& req)
+    {
+        std::lock_guard g(ConnMutex);
+
+        //
+        // Open the socket lazily and reopen it after any I/O error.
+        // Every failure path below closes Fd and sets it to -1 so the
+        // next call retries the connect.
+        //
+
+        if (Fd < 0) {
+            Fd = OpenTcp(Host, Port);
+            if (Fd < 0) {
+                return MakeErrorResponse(
+                    req.GetRequestId(),
+                    E_REJECTED,
+                    TStringBuilder() << "sn client: connect to "
+                        << Host << ":" << Port << " failed");
+            }
+        }
+
+        TString buf;
+        Y_PROTOBUF_SUPPRESS_NODISCARD req.SerializeToString(&buf);
+
+        ui32 lenBe = htonl(static_cast<ui32>(buf.size()));
+        if (int r = SendAll(Fd, &lenBe, sizeof(lenBe)); r) {
+            return CloseAndError(req.GetRequestId(), r, "send length");
+        }
+        if (int r = SendAll(Fd, buf.data(), buf.size()); r) {
+            return CloseAndError(req.GetRequestId(), r, "send body");
+        }
+
+        ui32 respLenBe = 0;
+        if (int r = RecvAll(Fd, &respLenBe, sizeof(respLenBe)); r) {
+            return CloseAndError(req.GetRequestId(), r, "recv length");
+        }
+        ui32 respLen = ntohl(respLenBe);
+
+        TString respBuf;
+        respBuf.ReserveAndResize(respLen);
+        if (int r = RecvAll(Fd, respBuf.begin(), respLen); r) {
+            return CloseAndError(req.GetRequestId(), r, "recv body");
+        }
+
+        TDeviceProtocolResponse resp;
+        if (!resp.ParseFromString(respBuf)) {
+            return CloseAndError(
+                req.GetRequestId(), EBADMSG, "parse response");
+        }
+        return resp;
+    }
+
+    TDeviceProtocolResponse CloseAndError(
+        ui64 requestId,
+        int err,
+        const char* op)
+    {
+        SILK_WARN(
+            "sn client fd=%d: %s: %s", Fd, op, ::strerror(err));
+        ::close(Fd);
+        Fd = -1;
+        return MakeErrorResponse(
+            requestId,
+            E_REJECTED,
+            TStringBuilder() << "sn client: " << op << ": "
+                << ::strerror(err));
+    }
+
+    static TDeviceProtocolResponse MakeErrorResponse(
+        ui64 requestId,
+        ui32 code,
+        const TString& msg)
+    {
+        TDeviceProtocolResponse resp;
+        resp.SetRequestId(requestId);
+        auto* err = resp.MutableProtocolError();
+        err->SetCode(code);
+        err->SetMessage(msg);
+        return resp;
+    }
+
+private:
+    const TString Host;
+    const ui16 Port;
+    FiberMutex ConnMutex;
+    int Fd = -1;
+    std::atomic<ui64> NextRequestId{1};
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageNodePtr CreateStorageNodeClient(TString host, ui16 port)
+{
+    return std::make_shared<TStorageNodeClient>(std::move(host), port);
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+
+#include <util/generic/string.h>
+#include <util/system/types.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns an IStorageNode that forwards every call over a single TCP
+ * connection to an sn server at `host:port`. Each call is wrapped in a
+ * TDeviceProtocolRequest, sent length-prefixed, and its
+ * TDeviceProtocolResponse is unpacked into the matching concrete
+ * response.
+ *
+ * Concurrency: methods on the returned client may be called from any
+ * silk fiber; concurrent calls are serialized on a single shared
+ * connection.
+ *
+ * Errors:
+ *   - I/O failures (connect / send / recv / parse) surface as a
+ *     response whose Error field is set to E_REJECTED. The connection
+ *     is closed and reopened on the next call.
+ *   - A TDeviceProtocolResponse.ProtocolError from the server is
+ *     copied into the concrete response's Error field.
+ *
+ * Must be called from a silk fiber context.
+ *
+ * @param host - Server hostname or IP.
+ * @param port - Server TCP port.
+ *
+ * @return - Shared owner of the client instance.
+ */
+IStorageNodePtr CreateStorageNodeClient(TString host, ui16 port);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client_stub.cpp
@@ -1,0 +1,14 @@
+#include "client.h"
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageNodePtr CreateStorageNodeClient(TString host, ui16 port)
+{
+    Y_UNUSED(host);
+    Y_UNUSED(port);
+    return CreateStorageNodeStub();
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/client/client_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/client_ut.cpp
@@ -1,0 +1,281 @@
+#include <cloud/filestore/libs/storage/fastshard/sn/client/client.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/server/server.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
+
+#include <library/cpp/testing/common/network.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <silk/fibers/fiber.h>
+
+#include <gtest/gtest.h>
+
+#include <util/generic/string.h>
+#include <util/string/cast.h>
+
+using namespace NCloud::NFileStore::NStorage::NFastShard;
+using silk::FiberScheduler;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+[[maybe_unused]] auto* const gEnv =
+    ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
+
+////////////////////////////////////////////////////////////////////////////////
+// Test fixture: builds a fake storage, starts the sn server on a free
+// port, and constructs an IStorageNode client pointing at it.
+
+struct TFixture
+{
+    std::shared_ptr<TFakeStorageNode> Storage;
+    NTesting::TPortHolder Port;
+    IServerPtr Server;
+    IStorageNodePtr Client;
+
+    TFixture()
+        : Storage(std::make_shared<TFakeStorageNode>())
+        , Port(NTesting::GetFreePort())
+        , Server(CreateServer(Port, Storage))
+        , Client(CreateStorageNodeClient("localhost", Port))
+    {
+        Server->Start();
+    }
+
+    ~TFixture()
+    {
+        Server->Stop();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Fixture for a client pointing at a definitely-unreachable port. Used
+// by the connect-failure test.
+
+struct TUnreachableFixture
+{
+    NTesting::TPortHolder Port;
+    IStorageNodePtr Client;
+
+    TUnreachableFixture()
+        : Port(NTesting::GetFreePort())
+        , Client(CreateStorageNodeClient("localhost", Port))
+    {
+        //
+        // NTesting::GetFreePort returns a port it briefly bound and
+        // released — the returned TPortHolder only carries the
+        // cross-process file lock, so no socket is listening. connect()
+        // will get ECONNREFUSED.
+        //
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(ClientTest, AcquireDevicesRoundTrip)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TFixture fx;
+
+            NCloud::NProto::TAcquireDevicesRequest req;
+            req.AddDeviceUUIDs("dev-a");
+            req.AddDeviceUUIDs("dev-b");
+            auto resp = fx.Client->AcquireDevices(std::move(req));
+
+            EXPECT_FALSE(resp.HasError() && resp.GetError().GetCode())
+                << resp.GetError().GetMessage();
+            EXPECT_EQ(1u, fx.Storage->AcquireCalls.size());
+            EXPECT_EQ(2u, fx.Storage->AcquireCalls[0].DeviceUUIDsSize());
+            EXPECT_EQ("dev-a", fx.Storage->AcquireCalls[0].GetDeviceUUIDs(0));
+            EXPECT_EQ("dev-b", fx.Storage->AcquireCalls[0].GetDeviceUUIDs(1));
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, ReleaseDevicesRoundTrip)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TFixture fx;
+
+            NCloud::NProto::TReleaseDevicesRequest req;
+            req.AddDeviceUUIDs("dev-x");
+            auto resp = fx.Client->ReleaseDevices(std::move(req));
+
+            EXPECT_EQ(0u, resp.GetError().GetCode());
+            EXPECT_EQ(1u, fx.Storage->ReleaseCalls.size());
+            EXPECT_EQ(1u, fx.Storage->ReleaseCalls[0].DeviceUUIDsSize());
+            EXPECT_EQ("dev-x", fx.Storage->ReleaseCalls[0].GetDeviceUUIDs(0));
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, ReadPagesRoundTrip)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TFixture fx;
+
+            //
+            // Preload the canned response before the client connects so
+            // the server-side dispatch returns exactly what the client
+            // should see back.
+            //
+
+            auto* pg = fx.Storage->ReadResp.AddPageGroups();
+            pg->SetFirstPageNo(5);
+            pg->AddContent("page-content");
+
+            NCloud::NProto::TReadPagesRequest req;
+            req.SetDeviceUUID("dev-42");
+            auto* ref = req.AddPageGroupRefs();
+            ref->SetFirstPageNo(5);
+            ref->SetPageCount(2);
+            ref->SetPageSize(4096);
+
+            auto resp = fx.Client->ReadPages(std::move(req));
+
+            EXPECT_EQ(0u, resp.GetError().GetCode());
+            EXPECT_EQ(1u, resp.PageGroupsSize());
+            EXPECT_EQ(5u, resp.GetPageGroups(0).GetFirstPageNo());
+            EXPECT_EQ("page-content", resp.GetPageGroups(0).GetContent(0));
+
+            EXPECT_EQ(1u, fx.Storage->ReadCalls.size());
+            EXPECT_EQ("dev-42", fx.Storage->ReadCalls[0].GetDeviceUUID());
+            EXPECT_EQ(1u, fx.Storage->ReadCalls[0].PageGroupRefsSize());
+            EXPECT_EQ(
+                5u,
+                fx.Storage->ReadCalls[0].GetPageGroupRefs(0).GetFirstPageNo());
+            EXPECT_EQ(
+                2u,
+                fx.Storage->ReadCalls[0].GetPageGroupRefs(0).GetPageCount());
+            EXPECT_EQ(
+                4096u,
+                fx.Storage->ReadCalls[0].GetPageGroupRefs(0).GetPageSize());
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, WriteLogRecordRoundTrip)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TFixture fx;
+
+            NCloud::NProto::TWriteLogRecordRequest req;
+            req.SetDeviceUUID("dev-99");
+            req.SetLogSequenceNumber(1234);
+            auto* pg = req.AddPageGroups();
+            pg->SetFirstPageNo(0);
+            pg->AddContent("payload");
+
+            auto resp =
+                fx.Client->WriteLogRecord(std::move(req));
+
+            EXPECT_EQ(0u, resp.GetError().GetCode());
+            EXPECT_EQ(1u, fx.Storage->WriteCalls.size());
+            EXPECT_EQ("dev-99", fx.Storage->WriteCalls[0].GetDeviceUUID());
+            EXPECT_EQ(
+                1234u,
+                fx.Storage->WriteCalls[0].GetLogSequenceNumber());
+            EXPECT_EQ(1u, fx.Storage->WriteCalls[0].PageGroupsSize());
+            EXPECT_EQ(
+                "payload",
+                fx.Storage->WriteCalls[0].GetPageGroups(0).GetContent(0));
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, StorageErrorPassesThrough)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TFixture fx;
+
+            //
+            // Storage returns a non-OK response. The client must relay
+            // the Error field verbatim on the concrete response type.
+            //
+
+            *fx.Storage->AcquireResp.MutableError() = NCloud::MakeError(
+                NCloud::E_FS_IO, "disk on fire");
+
+            NCloud::NProto::TAcquireDevicesRequest req;
+            req.AddDeviceUUIDs("dev-a");
+            auto resp = fx.Client->AcquireDevices(std::move(req));
+
+            EXPECT_EQ(
+                static_cast<ui32>(NCloud::E_FS_IO),
+                resp.GetError().GetCode());
+            EXPECT_EQ("disk on fire", resp.GetError().GetMessage());
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, ConnectFailureReturnsRejected)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TUnreachableFixture fx;
+
+            NCloud::NProto::TAcquireDevicesRequest req;
+            req.AddDeviceUUIDs("dev-a");
+            auto resp = fx.Client->AcquireDevices(std::move(req));
+
+            EXPECT_EQ(
+                static_cast<ui32>(NCloud::E_REJECTED),
+                resp.GetError().GetCode());
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(ClientTest, ReusesConnectionAcrossSequentialCalls)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TFixture fx;
+
+            //
+            // Three sequential AcquireDevices calls on the same client
+            // must all succeed. If the client tore the fd down between
+            // calls (e.g. on a spurious error path) the second or third
+            // call would still work — but the fake will show us the
+            // full sequence.
+            //
+
+            for (ui32 i = 1; i <= 3; ++i) {
+                NCloud::NProto::TAcquireDevicesRequest req;
+                req.AddDeviceUUIDs(TString("dev-") + ToString(i));
+                auto resp =
+                    fx.Client->AcquireDevices(std::move(req));
+                EXPECT_EQ(0u, resp.GetError().GetCode());
+            }
+
+            EXPECT_EQ(3u, fx.Storage->AcquireCalls.size());
+            EXPECT_EQ("dev-1", fx.Storage->AcquireCalls[0].GetDeviceUUIDs(0));
+            EXPECT_EQ("dev-2", fx.Storage->AcquireCalls[1].GetDeviceUUIDs(0));
+            EXPECT_EQ("dev-3", fx.Storage->AcquireCalls[2].GetDeviceUUIDs(0));
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}

--- a/cloud/filestore/libs/storage/fastshard/sn/client/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/ut/ya.make
@@ -1,11 +1,11 @@
 GTEST()
 
 SRCS(
-    ../server_ut.cpp
+    ../client_ut.cpp
 )
 
 PEERDIR(
-    cloud/filestore/libs/storage/fastshard/ipc
+    cloud/filestore/libs/storage/fastshard/sn/client
     cloud/filestore/libs/storage/fastshard/sn/iface
     cloud/filestore/libs/storage/fastshard/sn/server
     cloud/filestore/libs/storage/fastshard/testlib

--- a/cloud/filestore/libs/storage/fastshard/sn/client/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/client/ya.make
@@ -2,7 +2,7 @@ LIBRARY()
 
 IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     SRCS(
-        server.cpp
+        client.cpp
     )
 
     PEERDIR(
@@ -12,7 +12,7 @@ IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     )
 ELSE()
     SRCS(
-        server_stub.cpp
+        client_stub.cpp
     )
 ENDIF()
 

--- a/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.cpp
@@ -12,13 +12,13 @@ class TStorageNodeStub: public IStorageNode
 {
 public:
 #define SN_STUB_METHOD(name, ...)                                              \
-    NThreading::TFuture<NCloud::NProto::T##name##Response> name(               \
+    NCloud::NProto::T##name##Response name(                                    \
         NCloud::NProto::T##name##Request request) override                     \
     {                                                                          \
         Y_UNUSED(request);                                                     \
         NProto::T##name##Response response;                                    \
         *response.MutableError() = MakeError(E_NOT_IMPLEMENTED);               \
-        return NThreading::MakeFuture(std::move(response));                    \
+        return response;                                                       \
     }                                                                          \
 // SN_STUB_METHOD
 

--- a/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h
@@ -2,8 +2,6 @@
 
 #include <cloud/storage/core/protos/device.pb.h>
 
-#include <library/cpp/threading/future/future.h>
-
 #include <memory>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
@@ -22,17 +20,18 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
  * decoded off the wire by the sn server. One method per case of the
  * TDeviceProtocolRequest.Request oneof — see SN_METHODS above.
  *
- * All methods take a concrete request proto and return a future for the
- * matching response proto. The server invokes them from a silk fiber
- * that WaitFiber-blocks on the returned future, so implementations may
- * finish synchronously (return MakeFuture(...)) or asynchronously.
+ * All methods are synchronous: the caller (server dispatch, or the
+ * client's Exchange path) always runs inside a silk fiber, so a slow
+ * implementation just cooperatively suspends the fiber.
+ * Implementations that need to wait on external I/O should do so via
+ * silk primitives (FiberFuture::wait, FiberScheduler::poll, etc.).
  */
 struct IStorageNode
 {
     virtual ~IStorageNode() = default;
 
 #define SN_DECLARE_METHOD(name, ...)                                           \
-    virtual NThreading::TFuture<NCloud::NProto::T##name##Response> name(       \
+    virtual NCloud::NProto::T##name##Response name(                            \
         NCloud::NProto::T##name##Request request) = 0;                         \
 // SN_DECLARE_METHOD
 

--- a/cloud/filestore/libs/storage/fastshard/sn/iface/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/iface/ya.make
@@ -7,8 +7,6 @@ SRCS(
 PEERDIR(
     cloud/storage/core/libs/common
     cloud/storage/core/protos
-
-    library/cpp/threading/future
 )
 
 END()

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
@@ -155,24 +155,6 @@ private:
 using THandlerRegistryPtr = std::shared_ptr<THandlerRegistry>;
 
 ////////////////////////////////////////////////////////////////////////////////
-// Bridge NThreading::TFuture to silk FiberFuture.
-
-template <typename T>
-T WaitFiber(const NThreading::TFuture<T>& future)
-{
-    FiberFuture fiberFuture;
-    future.Subscribe([&fiberFuture](const auto&) {
-        fiberFuture.set(0);
-    });
-    fiberFuture.wait();
-    try {
-        return future.GetValue();
-    } catch (...) {
-        Y_ABORT("unexpected: %s", CurrentExceptionMessage().c_str());
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Request dispatch.
 
 TDeviceProtocolResponse Dispatch(
@@ -184,8 +166,7 @@ TDeviceProtocolResponse Dispatch(
     switch (req.GetRequestCase()) {
 #define DISPATCH_REQUEST(name, ...)                                            \
         case TDeviceProtocolRequest::k##name: {                                \
-            auto result = WaitFiber(storage.name(req.Get##name()));            \
-            *resp.Mutable##name() = std::move(result);                         \
+            *resp.Mutable##name() = storage.name(req.Get##name());             \
             break;                                                             \
         }                                                                      \
 // DISPATCH_REQUEST

--- a/cloud/filestore/libs/storage/fastshard/sn/server/server_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server_ut.cpp
@@ -1,20 +1,21 @@
 #include <cloud/filestore/libs/storage/fastshard/ipc/ipc.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
 #include <cloud/filestore/libs/storage/fastshard/sn/server/server.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
+
+#include <library/cpp/testing/common/network.h>
 
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/protos/device.pb.h>
 
 #include <silk/fibers/fiber.h>
 #include <silk/fibers/future.h>
-#include <silk/util/init.h>
 
 #include <gtest/gtest.h>
 
 #include <util/generic/string.h>
-#include <util/generic/vector.h>
 #include <util/string/builder.h>
-#include <util/system/spinlock.h>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -31,99 +32,9 @@ using silk::FiberScheduler;
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
-// Silk test environment.
-
-class TSilkEnv: public ::testing::Environment
-{
-public:
-    void SetUp() override
-    {
-        silk::initialize();
-        FiberScheduler::initialize();
-    }
-
-    void TearDown() override
-    {
-        FiberScheduler::destroy();
-        silk::destroy();
-    }
-};
 
 [[maybe_unused]] auto* const gEnv =
-    ::testing::AddGlobalTestEnvironment(new TSilkEnv);
-
-////////////////////////////////////////////////////////////////////////////////
-// Pick a free port on loopback.
-
-ui16 GetFreePort()
-{
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    addr.sin_port = 0;
-    ::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
-    socklen_t len = sizeof(addr);
-    ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len);
-    ui16 port = ntohs(addr.sin_port);
-    ::close(fd);
-    return port;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// A fake storage node that records every call and returns preconfigured
-// responses.
-
-struct TFakeStorageNode: public IStorageNode
-{
-    TAdaptiveLock Lock;
-
-    TVector<NCloud::NProto::TAcquireDevicesRequest> AcquireCalls;
-    TVector<NCloud::NProto::TReleaseDevicesRequest> ReleaseCalls;
-    TVector<NCloud::NProto::TReadPagesRequest> ReadCalls;
-    TVector<NCloud::NProto::TWriteLogRecordRequest> WriteCalls;
-
-    NCloud::NProto::TAcquireDevicesResponse AcquireResp;
-    NCloud::NProto::TReleaseDevicesResponse ReleaseResp;
-    NCloud::NProto::TReadPagesResponse ReadResp;
-    NCloud::NProto::TWriteLogRecordResponse WriteResp;
-
-    NThreading::TFuture<NCloud::NProto::TAcquireDevicesResponse> AcquireDevices(
-        NCloud::NProto::TAcquireDevicesRequest request) override
-    {
-        with_lock (Lock) {
-            AcquireCalls.push_back(std::move(request));
-        }
-        return NThreading::MakeFuture(AcquireResp);
-    }
-
-    NThreading::TFuture<NCloud::NProto::TReleaseDevicesResponse> ReleaseDevices(
-        NCloud::NProto::TReleaseDevicesRequest request) override
-    {
-        with_lock (Lock) {
-            ReleaseCalls.push_back(std::move(request));
-        }
-        return NThreading::MakeFuture(ReleaseResp);
-    }
-
-    NThreading::TFuture<NCloud::NProto::TReadPagesResponse> ReadPages(
-        NCloud::NProto::TReadPagesRequest request) override
-    {
-        with_lock (Lock) {
-            ReadCalls.push_back(std::move(request));
-        }
-        return NThreading::MakeFuture(ReadResp);
-    }
-
-    NThreading::TFuture<NCloud::NProto::TWriteLogRecordResponse> WriteLogRecord(
-        NCloud::NProto::TWriteLogRecordRequest request) override
-    {
-        with_lock (Lock) {
-            WriteCalls.push_back(std::move(request));
-        }
-        return NThreading::MakeFuture(WriteResp);
-    }
-};
+    ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
 
 ////////////////////////////////////////////////////////////////////////////////
 // Fiber-friendly non-blocking connect to loopback.
@@ -195,12 +106,12 @@ TDeviceProtocolResponse SendRecv(int fd, const TDeviceProtocolRequest& req)
 struct TServerFixture
 {
     std::shared_ptr<TFakeStorageNode> Storage;
-    ui16 Port;
+    NTesting::TPortHolder Port;
     IServerPtr Server;
 
     TServerFixture()
         : Storage(std::make_shared<TFakeStorageNode>())
-        , Port(GetFreePort())
+        , Port(NTesting::GetFreePort())
         , Server(CreateServer(Port, Storage))
     {
         Server->Start();

--- a/cloud/filestore/libs/storage/fastshard/sn/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/ya.make
@@ -1,4 +1,5 @@
 RECURSE(
+    client
     iface
     server
 )

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.cpp
@@ -1,0 +1,43 @@
+#include "fake_storage_node.h"
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NCloud::NProto::TAcquireDevicesResponse TFakeStorageNode::AcquireDevices(
+    NCloud::NProto::TAcquireDevicesRequest request)
+{
+    with_lock (Lock) {
+        AcquireCalls.push_back(std::move(request));
+    }
+    return AcquireResp;
+}
+
+NCloud::NProto::TReleaseDevicesResponse TFakeStorageNode::ReleaseDevices(
+    NCloud::NProto::TReleaseDevicesRequest request)
+{
+    with_lock (Lock) {
+        ReleaseCalls.push_back(std::move(request));
+    }
+    return ReleaseResp;
+}
+
+NCloud::NProto::TReadPagesResponse TFakeStorageNode::ReadPages(
+    NCloud::NProto::TReadPagesRequest request)
+{
+    with_lock (Lock) {
+        ReadCalls.push_back(std::move(request));
+    }
+    return ReadResp;
+}
+
+NCloud::NProto::TWriteLogRecordResponse TFakeStorageNode::WriteLogRecord(
+    NCloud::NProto::TWriteLogRecordRequest request)
+{
+    with_lock (Lock) {
+        WriteCalls.push_back(std::move(request));
+    }
+    return WriteResp;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
+++ b/cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <util/generic/vector.h>
+#include <util/system/spinlock.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * IStorageNode used from tests. Records every incoming request in a
+ * TAdaptiveLock-guarded TVector per method, and returns the
+ * corresponding preconfigured response (also per method).
+ *
+ * Typical use: construct, edit the *Resp members to set up canned
+ * output, register the fake with an sn server, drive it through the
+ * client, then inspect the *Calls vectors to check what the server
+ * dispatched.
+ */
+struct TFakeStorageNode: public IStorageNode
+{
+    TAdaptiveLock Lock;
+
+    TVector<NCloud::NProto::TAcquireDevicesRequest> AcquireCalls;
+    TVector<NCloud::NProto::TReleaseDevicesRequest> ReleaseCalls;
+    TVector<NCloud::NProto::TReadPagesRequest> ReadCalls;
+    TVector<NCloud::NProto::TWriteLogRecordRequest> WriteCalls;
+
+    NCloud::NProto::TAcquireDevicesResponse AcquireResp;
+    NCloud::NProto::TReleaseDevicesResponse ReleaseResp;
+    NCloud::NProto::TReadPagesResponse ReadResp;
+    NCloud::NProto::TWriteLogRecordResponse WriteResp;
+
+    NCloud::NProto::TAcquireDevicesResponse AcquireDevices(
+        NCloud::NProto::TAcquireDevicesRequest request) override;
+
+    NCloud::NProto::TReleaseDevicesResponse ReleaseDevices(
+        NCloud::NProto::TReleaseDevicesRequest request) override;
+
+    NCloud::NProto::TReadPagesResponse ReadPages(
+        NCloud::NProto::TReadPagesRequest request) override;
+
+    NCloud::NProto::TWriteLogRecordResponse WriteLogRecord(
+        NCloud::NProto::TWriteLogRecordRequest request) override;
+};
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/testlib/silk_env.cpp
+++ b/cloud/filestore/libs/storage/fastshard/testlib/silk_env.cpp
@@ -1,0 +1,37 @@
+#include "silk_env.h"
+
+#include <silk/fibers/fiber.h>
+#include <silk/util/init.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSilkEnv: public ::testing::Environment
+{
+public:
+    void SetUp() override
+    {
+        silk::initialize();
+        silk::FiberScheduler::initialize();
+    }
+
+    void TearDown() override
+    {
+        silk::FiberScheduler::destroy();
+        silk::destroy();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+::testing::Environment* MakeSilkTestEnv()
+{
+    return new TSilkEnv;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/testlib/silk_env.h
+++ b/cloud/filestore/libs/storage/fastshard/testlib/silk_env.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns a gtest environment that calls silk::initialize() +
+ * FiberScheduler::initialize() in SetUp and destroys both in TearDown.
+ *
+ * Every ut binary that runs test bodies inside FiberScheduler::run
+ * should register exactly one instance at file scope:
+ *
+ *     [[maybe_unused]] auto* const gEnv =
+ *         ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
+ *
+ * @return - Owning pointer, hand to ::testing::AddGlobalTestEnvironment.
+ */
+::testing::Environment* MakeSilkTestEnv();
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/testlib/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/testlib/ya.make
@@ -1,0 +1,18 @@
+LIBRARY()
+
+SRCS(
+    fake_storage_node.cpp
+    silk_env.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/sn/iface
+
+    cloud/storage/core/protos
+
+    contrib/libs/silk/src/fibers
+
+    contrib/restricted/googletest/googletest
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/ya.make
@@ -6,4 +6,5 @@ RECURSE(
     ipc
     server
     sn
+    testlib
 )


### PR DESCRIPTION
### Notes
Continuing the work started in https://github.com/ydb-platform/nbs/pull/6446:
* got rid of futures in `IStorageNode` - no need for them, those methods are supposed to be called from fibers, they can have non-async sigs
* extracted common code used in fastshard unit tests into fastshard/testlib
* added storage node client and unit tests for it
* got rid of custom `GetFreePort()` func in favor of `NTesting::GetFreePort()`

### Issue
https://github.com/ydb-platform/nbs/issues/5894
