### PR TITLE
issue-5894: fastshard sn server - forgot to do 'continue' after handler registration

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/server/server.cpp
@@ -396,6 +396,7 @@ int AcceptFiberMain(TAcceptParams* params) noexcept
             SOCK_NONBLOCK | SOCK_CLOEXEC);
         if (cfd >= 0) {
             RegisterHandler(cfd, *handlers, storage);
+            continue;
         }
 
         if (errno == EINTR || errno == ECONNABORTED) {


### PR DESCRIPTION
### Notes
Just adding a forgotten `continue` - otherwise we sometimes see `errno`s from non-`accept` syscalls but then treat them as if they come from `accept`

### Issue
https://github.com/ydb-platform/nbs/issues/5894