### PR TITLE
[IC] Suppress repeated hold-by-error messages

### DIFF
--- a/contrib/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/contrib/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -757,7 +757,11 @@ namespace NActors {
     void TInterconnectProxyTCP::TransitToErrorState(TString explanation, bool updateErrorLog) {
         ICPROXY_PROFILED;
 
-        LOG_NOTICE_IC("ICP32", "transit to hold-by-error state Explanation# %s", explanation.data());
+        const auto holdByErrorLogPriority = HoldByErrorWakeupDuration != TDuration::Zero()
+            ? NLog::PRI_DEBUG
+            : NLog::PRI_NOTICE;
+        LOG_LOG_IC(NActorsServices::INTERCONNECT, "ICP32", holdByErrorLogPriority,
+            "transit to hold-by-error state Explanation# %s", explanation.data());
         LOG_INFO(*TlsActivationContext, NActorsServices::INTERCONNECT_STATUS, "[%u] error state: %s", PeerNodeId, explanation.data());
 
         if (updateErrorLog) {

--- a/contrib/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/contrib/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -15,6 +15,8 @@ namespace {
 struct THandshakeFailureLogCounters {
     std::atomic<ui32> Notice = 0;
     std::atomic<ui32> Debug = 0;
+    std::atomic<ui32> HoldByErrorNotice = 0;
+    std::atomic<ui32> HoldByErrorDebug = 0;
 };
 
 class TCountingLogBackend : public TLogBackend {
@@ -26,11 +28,9 @@ public:
     void WriteData(const TLogRecord& rec) override {
         const TStringBuf line(rec.Data, rec.Len);
         if (line.Contains("ICP25") && line.Contains("outgoing handshake failed")) {
-            if (rec.Priority == TLOG_NOTICE) {
-                OutgoingHandshakeFailures->Notice.fetch_add(1, std::memory_order_relaxed);
-            } else if (rec.Priority == TLOG_DEBUG) {
-                OutgoingHandshakeFailures->Debug.fetch_add(1, std::memory_order_relaxed);
-            }
+            CountPriority(rec, OutgoingHandshakeFailures->Notice, OutgoingHandshakeFailures->Debug);
+        } else if (line.Contains("ICP32") && line.Contains("transit to hold-by-error state")) {
+            CountPriority(rec, OutgoingHandshakeFailures->HoldByErrorNotice, OutgoingHandshakeFailures->HoldByErrorDebug);
         }
     }
 
@@ -38,6 +38,14 @@ public:
     }
 
 private:
+    static void CountPriority(const TLogRecord& rec, std::atomic<ui32>& notice, std::atomic<ui32>& debug) {
+        if (rec.Priority == TLOG_NOTICE) {
+            notice.fetch_add(1, std::memory_order_relaxed);
+        } else if (rec.Priority == TLOG_DEBUG) {
+            debug.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
     std::shared_ptr<THandshakeFailureLogCounters> OutgoingHandshakeFailures;
 };
 
@@ -264,7 +272,8 @@ Y_UNIT_TEST_SUITE(Interconnect) {
 
         outgoingHandshakeFailures->Notice.store(0, std::memory_order_relaxed);
         outgoingHandshakeFailures->Debug.store(0, std::memory_order_relaxed);
-        cluster.StopNode(1);
+        outgoingHandshakeFailures->HoldByErrorNotice.store(0, std::memory_order_relaxed);
+        outgoingHandshakeFailures->HoldByErrorDebug.store(0, std::memory_order_relaxed);        cluster.StopNode(1);
         Sleep(TDuration::Seconds(10));
 
         const ui32 noticeLogCount = outgoingHandshakeFailures->Notice.load(std::memory_order_relaxed);
@@ -274,6 +283,13 @@ Y_UNIT_TEST_SUITE(Interconnect) {
                 << noticeLogCount);
         UNIT_ASSERT_C(debugLogCount > 0,
             "expected repeated ICP25 outgoing handshake failure log records to be demoted to debug");
-    }
+
+        const ui32 holdByErrorNoticeLogCount = outgoingHandshakeFailures->HoldByErrorNotice.load(std::memory_order_relaxed);
+        const ui32 holdByErrorDebugLogCount = outgoingHandshakeFailures->HoldByErrorDebug.load(std::memory_order_relaxed);
+        UNIT_ASSERT_C(holdByErrorNoticeLogCount == 1 || holdByErrorNoticeLogCount == 2,
+            TStringBuilder() << "expected one or two notice-level ICP32 hold-by-error transition log records in 10 seconds, got "
+                << holdByErrorNoticeLogCount);
+        UNIT_ASSERT_C(holdByErrorDebugLogCount > 0,
+            "expected repeated ICP32 hold-by-error transition log records to be demoted to debug");    }
 
 }

--- a/contrib/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/contrib/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -273,7 +273,8 @@ Y_UNIT_TEST_SUITE(Interconnect) {
         outgoingHandshakeFailures->Notice.store(0, std::memory_order_relaxed);
         outgoingHandshakeFailures->Debug.store(0, std::memory_order_relaxed);
         outgoingHandshakeFailures->HoldByErrorNotice.store(0, std::memory_order_relaxed);
-        outgoingHandshakeFailures->HoldByErrorDebug.store(0, std::memory_order_relaxed);        cluster.StopNode(1);
+        outgoingHandshakeFailures->HoldByErrorDebug.store(0, std::memory_order_relaxed);
+        cluster.StopNode(1);
         Sleep(TDuration::Seconds(10));
 
         const ui32 noticeLogCount = outgoingHandshakeFailures->Notice.load(std::memory_order_relaxed);
@@ -290,6 +291,7 @@ Y_UNIT_TEST_SUITE(Interconnect) {
             TStringBuilder() << "expected one or two notice-level ICP32 hold-by-error transition log records in 10 seconds, got "
                 << holdByErrorNoticeLogCount);
         UNIT_ASSERT_C(holdByErrorDebugLogCount > 0,
-            "expected repeated ICP32 hold-by-error transition log records to be demoted to debug");    }
+            "expected repeated ICP32 hold-by-error transition log records to be demoted to debug");
+    }
 
 }


### PR DESCRIPTION
### Notes
It's a cherry pick of 
https://github.com/ydb-platform/ydb/commit/81ba20f4bda887e55954397cdab2008df987cbf3#diff-3645dcdad5c41ca7e40dc2be401c669ced736fdad89070a916a0367a0b6c4add

When a node has a connectivity issue, other nodes report "hold-by-error" log messages once a second and overwhelm logs.
This commit suppresses repeated "hold-by-error" log messages, a message is sent just once.

