### PR TITLE
[Filestore] add direct RDMA flag

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -838,4 +838,8 @@ message TStorageConfig
     // If enabled, tablet overload is ignored when deciding whether to use
     // the unconfirmed data flow.
     optional bool AllowTabletOverload = 523;
+
+    // Enables the RDMA side channel for tablet-proxied requests in
+    // filestore-server and filestore-vhost.
+    optional bool TabletDirectRdmaEnabled = 524;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -29,6 +29,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(PipeClientMinRetryTime,        TDuration, TDuration::Seconds(1)       )\
     xxx(PipeClientMaxRetryTime,        TDuration, TDuration::Seconds(4)       )\
                                                                                \
+    xxx(TabletDirectRdmaEnabled,       bool,      false                       )\
+                                                                               \
     xxx(EstablishSessionTimeout,       TDuration, TDuration::Seconds(30)      )\
     xxx(IdleSessionTimeout,            TDuration, TDuration::Hours(1)         )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -76,6 +76,8 @@ public:
     TDuration GetPipeClientMinRetryTime() const;
     TDuration GetPipeClientMaxRetryTime() const;
 
+    bool GetTabletDirectRdmaEnabled() const;
+
     TDuration GetEstablishSessionTimeout() const;
     TDuration GetIdleSessionTimeout() const;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -97,6 +97,8 @@ void FillFeatures(
     features->SetGuestHandleKillPrivV2Enabled(
         config.GetGuestHandleKillPrivV2Enabled());
 
+    features->SetTabletDirectRdmaEnabled(config.GetTabletDirectRdmaEnabled());
+
     // TODO(#5670) posix acl is not yet fully supported in tablet based
     // filestore
     features->SetGuestPosixAclEnabled(false);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_sessions.cpp
@@ -808,6 +808,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
             TDuration::MilliSeconds(50).MilliSeconds());
         features.SetHasXAttrs(true);
         features.SetMaxFuseLoopThreads(1);
+        features.SetTabletDirectRdmaEnabled(false);
 
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
 
@@ -840,6 +841,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         config.SetWriteBlobDisabled(true);
         config.SetUseCustomReadDataResponseParser(true);
         config.SetExternalReadDataPayload(true);
+        config.SetTabletDirectRdmaEnabled(true);
 
         features.SetTwoStageReadEnabled(true);
         features.SetTwoStageReadThreshold(64_KB);
@@ -870,6 +872,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Sessions)
         features.SetWriteBlobDisabled(true);
         features.SetUseCustomReadDataResponseParser(true);
         features.SetExternalReadDataPayload(true);
+        features.SetTabletDirectRdmaEnabled(true);
 
         DoTestShouldReturnFeaturesInCreateSessionResponse(config, features);
     }

--- a/cloud/filestore/public/api/protos/fs.proto
+++ b/cloud/filestore/public/api/protos/fs.proto
@@ -59,6 +59,7 @@ message TFileStoreFeatures
     bool ServerWriteBackCacheFlushWritesInParallelEnabled = 44;
     uint32 StatFileStoreCacheTTL = 45; // in ms
     bool ExternalReadDataPayload = 46;
+    optional bool TabletDirectRdmaEnabled = 47;
 }
 
 message TFileStore

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_enable_directory_creation_in_shards/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_enable_directory_creation_in_shards/results.txt
@@ -15,6 +15,7 @@ FileStore {
     AsyncHandleOperationPeriod: 50
     HasXAttrs: true
     MaxFuseLoopThreads: 1
+    TabletDirectRdmaEnabled: false
   }
   ShardFileSystemIds: "fs0_s1"
 }

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_enable_strict/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_enable_strict/results.txt
@@ -15,6 +15,7 @@ FileStore {
     AsyncHandleOperationPeriod: 50
     HasXAttrs: true
     MaxFuseLoopThreads: 1
+    TabletDirectRdmaEnabled: false
   }
   ShardFileSystemIds: "fs0_s1"
 }


### PR DESCRIPTION
### Notes
Added flag for enabling direct RDMA between vhost and server. This flag will be used for RDMA direct connection between vhost and filestore-server

### Issue
#5388