### PR TITLE
[Filestore] Fix test TFileSystemTest::ShouldNotCacheRequestsOnWriteBackCacheFlushBatchBackpressure failure under sanitizers

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -5654,6 +5654,11 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         // will consist of a single WriteData request
         features.SetServerWriteBackCacheFlushWritesInParallelEnabled(false);
 
+        auto firstWriteDataPromise = NewPromise<NProto::TWriteDataResponse>();
+        auto secondWriteDataPromise = NewPromise<NProto::TWriteDataResponse>();
+        auto restWriteDataPromise = NewPromise<NProto::TWriteDataResponse>();
+        std::atomic<int> writeDataCalled = 0;
+
         TBootstrap bootstrap(
             CreateWallClockTimer(),
             CreateScheduler(),
@@ -5666,11 +5671,6 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
         {
             bootstrap.Stop();
         };
-
-        auto firstWriteDataPromise = NewPromise<NProto::TWriteDataResponse>();
-        auto secondWriteDataPromise = NewPromise<NProto::TWriteDataResponse>();
-        auto restWriteDataPromise = NewPromise<NProto::TWriteDataResponse>();
-        std::atomic<int> writeDataCalled = 0;
 
         bootstrap.Service->WriteDataHandler = [&](auto, auto)
         {


### PR DESCRIPTION
Resolve test failure due to wrong initialization order
```
[crashed] TFileSystemTest::ShouldNotCacheRequestsOnWriteBackCacheFlushBatchBackpressure [default-linux-x86_64-relwithdebinfo-FORCE_STATIC_LINKING=yes-asan] (0.00s)
Test crashed (return code: 100)
==1171682==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fea77f56ce0 at pc 0x000002b434ea bp 0x7fea71ddde70 sp 0x7fea71ddde68
WRITE of size 4 at 0x7fea77f56ce0 thread T6 (cloud-fi.Timer)
warning: address range table at offset 0x0 has a premature terminator entry at offset 0x10
warning: address range table at offset 0x30 has a premature terminator entry at offset 0x40
warning: address range table at offset 0x990 has a premature terminator entry at offset 0x9a0
warning: address range table at offset 0x9c0 has a premature terminator entry at offset 0x9d0
warning: address range table at offset 0x9f0 has a premature terminator entry at offset 0xa00
warning: address range table at offset 0xa20 has a premature terminator entry at offset 0xa30
warning: address range table at offset 0xa50 has a premature terminator entry at offset 0xa60
warning: address range table at offset 0xa80 has a premature terminator entry at offset 0xa90
warning: address range table at offset 0xab0 has a premature terminator entry at offset 0xac0
warning: address range table at offset 0xae0 has a premature terminator entry at offset 0xaf0
warning: address range table at offset 0xb10 has a premature terminator entry at offset 0xb20
warning: address range table at offset 0xb40 has a premature terminator entry at offset 0xb50
warning: address range table at offset 0xb70 has a premature terminator entry at offset 0xb80
warning: address range table at offset 0xba0 has a premature terminator entry at offset 0xbb0
warning: address range table at offset 0xbd0 has a premature terminator entry at offset 0xbe0
warning: address range table at offset 0xc00 has a premature terminator entry at offset 0xc10
warning: address range table at offset 0xc30 has a premature terminator entry at offset 0xc40
warning: address range table at offset 0xc60 has a premature terminator entry at offset 0xc70
warning: address range table at offset 0xc90 has a premature terminator entry at offset 0xca0
warning: address range table at offset 0xcc0 has a premature terminator entry at offset 0xcd0
warning: address range table at offset 0x12a0 has a premature terminator entry at offset 0x12b0
    #0 0x2b434e9 in int std::__y1::__cxx_atomic_fetch_add[abi:v180000]<int>(std::__y1::__cxx_atomic_base_impl<int>*, int, std::__y1::memory_order) /home/nasonov/repos/nbs/contrib/libs/cxxsupp/libcxx/
..[snippet truncated]..
ut.cpp:5664:19
    #6 0x293d319 in NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute()::'lambda'()::operator()() const /home/nasonov/repos/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:421:1
    #7 0x305ad8e in std::__y1::__function::__value_func<void ()>::operator()[abi:v180000]() const /home/nasonov/repos/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16
    #8 0x305ad8e in std::__y1::function<void ()>::operator()() const /home/nasonov/repos/nbs/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12
    #9 0x305ad8e in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /home/nasonov/repos/nbs/library/cpp/testing/unittest/utmain.cpp:525:20
    #10 0x301df25 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /home/nasonov/repos/nbs/library/cpp/testing/unittest/registar.cpp:374:18
    #11 0x293c1f3 in NCloud::NFileStore::NFuse::NTestSuiteTFileSystemTest::TCurrentTest::Execute() /home/nasonov/repos/nbs/cloud/filestore/libs/vfs_fuse/fs_ut.cpp:421:1
    #12 0x301fd05 in NUnitTest::TTestFactory::Execute() /home/nasonov/repos/nbs/library/cpp/testing/unittest/registar.cpp:495:19
    #13 0x305202c in NUnitTest::RunMain(int, char**) /home/nasonov/repos/nbs/library/cpp/testing/unittest/utmain.cpp:872:44
    #14 0x7fea79ba5d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
==1171682==ABORTING
```