### PR TITLE
[Disk Manager] Add disk-manager-export-snapshot tool

### DIFF
--- a/cloud/disk_manager/cmd/disk-manager-export-snapshot/README.md
+++ b/cloud/disk_manager/cmd/disk-manager-export-snapshot/README.md
@@ -1,0 +1,78 @@
+# disk-manager-export-snapshot
+
+Standalone tool that reads a ready snapshot (or image) directly from the
+dataplane storage — chunk map in YDB, chunk data in S3 or YDB — and assembles
+it into a local raw disk image, without going through the Disk Manager service.
+
+Typical use cases: recovering data from a snapshot when the regular path
+(create disk from snapshot, attach, copy) is unavailable, or inspecting
+snapshot/image content offline.
+
+## Requirements
+
+* A host with network access to the dataplane YDB database and to S3 — usually
+  a host where the Disk Manager dataplane is deployed.
+* The regular Disk Manager server config (`--config`, default
+  `/etc/disk-manager/server-config.txt`). The tool only uses:
+  * `DataplaneConfig.SnapshotConfig` — dataplane YDB endpoint/database and the
+    S3 endpoint/credentials/bucket (`PersistenceConfig` and its `S3Config`),
+    plus the storage folder and the S3 key prefix;
+  * `AuthConfig` — credentials, same as the service uses.
+* The access may be read-only: the tool only reads the `snapshots`,
+  `chunk_map` and `chunk_blobs` tables and only gets objects from the S3
+  bucket.
+* Free disk space for the output file. Zero chunks are skipped, so the actual
+  disk usage is proportional to the number of data chunks (4 MiB each), not to
+  the snapshot virtual size.
+
+## Build
+
+```
+ya make cloud/disk_manager/cmd/disk-manager-export-snapshot
+```
+
+Plain `go build` does not work: the generated proto packages are not committed
+to the repository.
+
+## Run
+
+```
+disk-manager-export-snapshot \
+    --config /etc/disk-manager/server-config.txt \
+    --snapshot-id <snapshot or image ID> \
+    --output /path/to/image.raw
+```
+
+* `--snapshot-id` accepts both snapshot and image IDs: images are stored in
+  the same dataplane snapshot storage.
+* Incremental snapshots are exported the same way as full ones: their chunk
+  map is complete, unchanged chunks are shallow copies of the base snapshot
+  chunks.
+* `--worker-count` (default 32) is the number of chunks fetched concurrently;
+  each worker holds a 4 MiB buffer.
+* Progress is logged every 1024 chunks (4 GiB of data). `-v` additionally logs
+  every chunk read.
+
+## Result
+
+The output is a raw disk image truncated to the snapshot virtual size. The
+checksum of every chunk is verified during the export; a mismatch fails the
+whole export. Zero chunks are not written, so the file is sparse where
+possible (compare `du -h` with `du -h --apparent-size`).
+
+The image can be verified and converted with qemu-img:
+
+```
+qemu-img info image.raw
+qemu-img convert -f raw -O qcow2 image.raw image.qcow2
+```
+
+## Limitations
+
+* The snapshot must be ready (fully created and not being deleted).
+* Snapshots of encrypted disks are exported as stored, i.e. encrypted (the
+  tool prints a warning).
+* The legacy snapshot storage (`LegacyStorageFolder`) is not supported.
+* The output must be a regular file, not a block device: the tool truncates
+  it to the snapshot virtual size and relies on skipped ranges reading back
+  as zeroes.

--- a/cloud/disk_manager/cmd/disk-manager-export-snapshot/main.go
+++ b/cloud/disk_manager/cmd/disk-manager-export-snapshot/main.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/auth"
+	server_config "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/configs/server/config"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/export"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/monitoring/metrics"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/util"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
+	"github.com/ydb-platform/nbs/cloud/tasks/persistence"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func exportSnapshot(
+	ctx context.Context,
+	config *server_config.ServerConfig,
+	snapshotID string,
+	outputFilePath string,
+	workerCount int,
+) error {
+
+	snapshotConfig := config.GetDataplaneConfig().GetSnapshotConfig()
+	if snapshotConfig == nil {
+		return fmt.Errorf("dataplane snapshot config is missing in the config file")
+	}
+
+	creds := auth.NewCredentials(ctx, config.GetAuthConfig())
+
+	db, err := persistence.NewYDBClient(
+		ctx,
+		snapshotConfig.GetPersistenceConfig(),
+		metrics.NewEmptyRegistry(),
+		persistence.WithCredentials(creds),
+	)
+	if err != nil {
+		return err
+	}
+	defer db.Close(ctx)
+
+	s3Config := snapshotConfig.GetPersistenceConfig().GetS3Config()
+	var s3 *persistence.S3Client
+	if s3Config != nil {
+		s3, err = persistence.NewS3ClientFromConfig(
+			s3Config,
+			metrics.NewEmptyRegistry(),
+			nil, // availabilityMonitoring
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	snapshotStorage, err := storage.NewStorage(
+		snapshotConfig,
+		metrics.NewEmptyRegistry(),
+		db,
+		s3,
+	)
+	if err != nil {
+		return err
+	}
+
+	// os.Create truncates an existing file, so zero chunks that Export skips
+	// are guaranteed to read back as zeroes.
+	file, err := os.Create(outputFilePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	stats, err := export.Export(
+		ctx,
+		snapshotStorage,
+		snapshotID,
+		file,
+		workerCount,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = file.Sync()
+	if err != nil {
+		return err
+	}
+
+	logging.Info(
+		ctx,
+		"exported snapshot %v to %v: size %v bytes, %v data chunks, %v zero chunks",
+		snapshotID,
+		outputFilePath,
+		stats.Size,
+		stats.DataChunkCount,
+		stats.ZeroChunkCount,
+	)
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func main() {
+	var configFilePath string
+	var snapshotID string
+	var outputFilePath string
+	var workerCount int
+	var verbose bool
+	config := &server_config.ServerConfig{}
+
+	rootCmd := &cobra.Command{
+		Use:   "disk-manager-export-snapshot",
+		Short: "Exports a snapshot (or an image) from the dataplane storage into a local raw image file",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return util.ParseProto(configFilePath, config)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			level := logging.InfoLevel
+			if verbose {
+				level = logging.DebugLevel
+			}
+
+			ctx := logging.SetLogger(
+				context.Background(),
+				logging.NewStderrLogger(level),
+			)
+			return exportSnapshot(
+				ctx,
+				config,
+				snapshotID,
+				outputFilePath,
+				workerCount,
+			)
+		},
+	}
+
+	rootCmd.Flags().StringVar(
+		&configFilePath,
+		"config",
+		"/etc/disk-manager/server-config.txt",
+		"Path to the config file",
+	)
+	rootCmd.Flags().StringVar(
+		&snapshotID,
+		"snapshot-id",
+		"",
+		"ID of the snapshot (or image) to export",
+	)
+	rootCmd.Flags().StringVar(
+		&outputFilePath,
+		"output",
+		"",
+		"Path to the output raw image file",
+	)
+	rootCmd.Flags().IntVar(
+		&workerCount,
+		"worker-count",
+		32,
+		"Number of chunks to read concurrently",
+	)
+	rootCmd.Flags().BoolVarP(
+		&verbose,
+		"verbose",
+		"v",
+		false,
+		"Enable verbose logging",
+	)
+
+	for _, flagName := range []string{"snapshot-id", "output"} {
+		err := rootCmd.MarkFlagRequired(flagName)
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+}

--- a/cloud/disk_manager/cmd/disk-manager-export-snapshot/ya.make
+++ b/cloud/disk_manager/cmd/disk-manager-export-snapshot/ya.make
@@ -1,0 +1,7 @@
+GO_PROGRAM()
+
+SRCS(
+    main.go
+)
+
+END()

--- a/cloud/disk_manager/cmd/ya.make
+++ b/cloud/disk_manager/cmd/ya.make
@@ -1,5 +1,6 @@
 RECURSE(
     disk-manager
     disk-manager-admin
+    disk-manager-export-snapshot
     disk-manager-init-db
 )

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/export.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/export.go
@@ -1,0 +1,183 @@
+package export
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+
+	dataplane_common "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/common"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/types"
+	task_errors "github.com/ydb-platform/nbs/cloud/tasks/errors"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
+	"golang.org/x/sync/errgroup"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Must be equal to chunkSize used by dataplane tasks that create snapshots
+// (see internal/pkg/dataplane/consts.go). ReadChunk verifies the checksum of
+// the whole chunk, so a mismatch results in an error, not in corrupted output.
+const chunkSize = 4 * 1024 * 1024
+
+// Progress is logged after each logProgressChunkCount processed chunks.
+const logProgressChunkCount = 1024
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Destination receives the exported snapshot data, e.g. *os.File.
+// It should not contain any data before the export: zero chunks are skipped,
+// not written, so the destination is expected to read back as zeroes there.
+type Destination interface {
+	io.WriterAt
+	Truncate(size int64) error
+}
+
+type Stats struct {
+	// Snapshot virtual size in bytes, the destination is truncated to it.
+	Size uint64
+	// Number of chunks read from the storage.
+	DataChunkCount uint32
+	// Number of zero chunks (they are never stored, only listed in chunk map).
+	ZeroChunkCount uint32
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Export reads all chunks of the snapshot (or image) snapshotID from
+// snapshotStorage, verifies their checksums and writes them to dst at
+// chunkIndex*chunkSize offsets. In the end dst is truncated to the snapshot
+// virtual size. The result is a raw disk image. Incremental snapshots don't
+// need any special handling: their chunk map is complete, unchanged chunks
+// are shallow copies of the base snapshot chunks.
+func Export(
+	ctx context.Context,
+	snapshotStorage storage.Storage,
+	snapshotID string,
+	dst Destination,
+	workerCount int,
+) (Stats, error) {
+
+	if workerCount <= 0 {
+		return Stats{}, task_errors.NewNonRetriableErrorf(
+			"workerCount must be positive, got %v",
+			workerCount,
+		)
+	}
+
+	meta, err := snapshotStorage.CheckSnapshotReady(ctx, snapshotID)
+	if err != nil {
+		return Stats{}, err
+	}
+
+	if meta.Encryption.GetMode() != types.EncryptionMode_NO_ENCRYPTION {
+		logging.Warn(
+			ctx,
+			"snapshot %v is encrypted, the exported data is encrypted as well",
+			snapshotID,
+		)
+	}
+
+	logging.Info(
+		ctx,
+		"exporting snapshot %v: size %v bytes, %v chunks",
+		snapshotID,
+		meta.Size,
+		meta.ChunkCount,
+	)
+
+	var dataChunkCount, zeroChunkCount, processedChunkCount atomic.Uint32
+
+	errGroup, groupCtx := errgroup.WithContext(ctx)
+
+	entries, entriesErrors := snapshotStorage.ReadChunkMap(
+		groupCtx,
+		snapshotID,
+		0, // milestoneChunkIndex
+	)
+
+	for i := 0; i < workerCount; i++ {
+		errGroup.Go(func() error {
+			data := make([]byte, chunkSize)
+
+			for entry := range entries {
+				if len(entry.ChunkID) == 0 {
+					// Zero chunks have no data and are skipped.
+					zeroChunkCount.Add(1)
+				} else {
+					err := exportChunk(
+						groupCtx,
+						snapshotStorage,
+						entry,
+						data,
+						dst,
+					)
+					if err != nil {
+						return err
+					}
+
+					dataChunkCount.Add(1)
+				}
+
+				processed := processedChunkCount.Add(1)
+				if processed%logProgressChunkCount == 0 {
+					logging.Info(
+						ctx,
+						"exported %v/%v chunks",
+						processed,
+						meta.ChunkCount,
+					)
+				}
+			}
+
+			return nil
+		})
+	}
+
+	err = errGroup.Wait()
+	if err != nil {
+		return Stats{}, err
+	}
+
+	err = <-entriesErrors
+	if err != nil {
+		return Stats{}, err
+	}
+
+	err = dst.Truncate(int64(meta.Size))
+	if err != nil {
+		return Stats{}, err
+	}
+
+	return Stats{
+		Size:           meta.Size,
+		DataChunkCount: dataChunkCount.Load(),
+		ZeroChunkCount: zeroChunkCount.Load(),
+	}, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func exportChunk(
+	ctx context.Context,
+	snapshotStorage storage.Storage,
+	entry storage.ChunkMapEntry,
+	data []byte,
+	dst Destination,
+) error {
+
+	chunk := dataplane_common.Chunk{
+		ID:         entry.ChunkID,
+		Index:      entry.ChunkIndex,
+		StoredInS3: entry.StoredInS3,
+		Data:       data,
+	}
+
+	err := snapshotStorage.ReadChunk(ctx, &chunk)
+	if err != nil {
+		return err
+	}
+
+	_, err = dst.WriteAt(data, int64(entry.ChunkIndex)*chunkSize)
+	return err
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/export_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/export_test.go
@@ -1,0 +1,231 @@
+package export
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	dataplane_common "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/common"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/mocks"
+	"github.com/ydb-platform/nbs/cloud/tasks/logging"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+const testWorkerCount = 3
+
+func newContext() context.Context {
+	return logging.SetLogger(
+		context.Background(),
+		logging.NewStderrLogger(logging.InfoLevel),
+	)
+}
+
+func chunkDataByte(chunkIndex uint32) byte {
+	return byte(chunkIndex) + 1
+}
+
+func newChunkMapChannels(
+	entries []storage.ChunkMapEntry,
+	err error,
+) (<-chan storage.ChunkMapEntry, <-chan error) {
+
+	entryChannel := make(chan storage.ChunkMapEntry, len(entries))
+	for _, entry := range entries {
+		entryChannel <- entry
+	}
+	close(entryChannel)
+
+	errorChannel := make(chan error, 1)
+	if err != nil {
+		errorChannel <- err
+	}
+	close(errorChannel)
+
+	return entryChannel, errorChannel
+}
+
+func fillChunkOnRead(args mock.Arguments) {
+	chunk := args.Get(1).(*dataplane_common.Chunk)
+	for i := range chunk.Data {
+		chunk.Data[i] = chunkDataByte(chunk.Index)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// In-memory Destination for tests.
+type memDestination struct {
+	mutex         sync.Mutex
+	data          []byte
+	truncatedSize int64
+}
+
+func newMemDestination(size uint64) *memDestination {
+	return &memDestination{data: make([]byte, size)}
+}
+
+func (d *memDestination) WriteAt(p []byte, off int64) (int, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	if off < 0 || int(off)+len(p) > len(d.data) {
+		return 0, fmt.Errorf("write out of range: off %v, len %v", off, len(p))
+	}
+
+	copy(d.data[off:], p)
+	return len(p), nil
+}
+
+func (d *memDestination) Truncate(size int64) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	d.truncatedSize = size
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestExportWritesChunksAtTheirOffsets(t *testing.T) {
+	ctx := newContext()
+
+	entries := []storage.ChunkMapEntry{
+		{ChunkIndex: 0, ChunkID: "chunk-0", StoredInS3: true},
+		{ChunkIndex: 1, ChunkID: ""}, // Zero chunk.
+		{ChunkIndex: 2, ChunkID: "chunk-2"},
+	}
+
+	snapshotStorage := mocks.NewStorageMock()
+	snapshotStorage.On("CheckSnapshotReady", mock.Anything, "snapshot").Return(
+		storage.SnapshotMeta{Size: 3 * chunkSize, ChunkCount: 3},
+		nil,
+	)
+	entryChannel, errorChannel := newChunkMapChannels(entries, nil)
+	snapshotStorage.On("ReadChunkMap", mock.Anything, "snapshot", uint32(0)).Return(
+		entryChannel,
+		errorChannel,
+	)
+	snapshotStorage.On("ReadChunk", mock.Anything, mock.Anything).Run(
+		fillChunkOnRead,
+	).Return(nil)
+
+	dst := newMemDestination(3 * chunkSize)
+
+	stats, err := Export(ctx, snapshotStorage, "snapshot", dst, testWorkerCount)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(3*chunkSize), stats.Size)
+	require.Equal(t, uint32(2), stats.DataChunkCount)
+	require.Equal(t, uint32(1), stats.ZeroChunkCount)
+	require.Equal(t, int64(3*chunkSize), dst.truncatedSize)
+
+	expected := make([]byte, 3*chunkSize)
+	for i := 0; i < chunkSize; i++ {
+		expected[i] = chunkDataByte(0)
+	}
+	for i := 2 * chunkSize; i < 3*chunkSize; i++ {
+		expected[i] = chunkDataByte(2)
+	}
+	require.True(t, bytes.Equal(expected, dst.data))
+
+	// Zero chunk should not be read from the storage.
+	snapshotStorage.AssertNumberOfCalls(t, "ReadChunk", 2)
+}
+
+func TestExportFailsOnChunkReadError(t *testing.T) {
+	ctx := newContext()
+
+	entries := []storage.ChunkMapEntry{
+		{ChunkIndex: 0, ChunkID: "chunk-0"},
+	}
+
+	snapshotStorage := mocks.NewStorageMock()
+	snapshotStorage.On("CheckSnapshotReady", mock.Anything, "snapshot").Return(
+		storage.SnapshotMeta{Size: chunkSize, ChunkCount: 1},
+		nil,
+	)
+	entryChannel, errorChannel := newChunkMapChannels(entries, nil)
+	snapshotStorage.On("ReadChunkMap", mock.Anything, "snapshot", uint32(0)).Return(
+		entryChannel,
+		errorChannel,
+	)
+	snapshotStorage.On("ReadChunk", mock.Anything, mock.Anything).Return(
+		fmt.Errorf("chunk read failed"),
+	)
+
+	dst := newMemDestination(chunkSize)
+
+	_, err := Export(ctx, snapshotStorage, "snapshot", dst, testWorkerCount)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chunk read failed")
+
+	// Destination should not be truncated after a failed export.
+	require.Equal(t, int64(0), dst.truncatedSize)
+}
+
+func TestExportFailsOnChunkMapError(t *testing.T) {
+	ctx := newContext()
+
+	entries := []storage.ChunkMapEntry{
+		{ChunkIndex: 0, ChunkID: "chunk-0"},
+	}
+
+	snapshotStorage := mocks.NewStorageMock()
+	snapshotStorage.On("CheckSnapshotReady", mock.Anything, "snapshot").Return(
+		storage.SnapshotMeta{Size: 2 * chunkSize, ChunkCount: 2},
+		nil,
+	)
+	entryChannel, errorChannel := newChunkMapChannels(
+		entries,
+		fmt.Errorf("chunk map read failed"),
+	)
+	snapshotStorage.On("ReadChunkMap", mock.Anything, "snapshot", uint32(0)).Return(
+		entryChannel,
+		errorChannel,
+	)
+	snapshotStorage.On("ReadChunk", mock.Anything, mock.Anything).Run(
+		fillChunkOnRead,
+	).Return(nil)
+
+	dst := newMemDestination(2 * chunkSize)
+
+	_, err := Export(ctx, snapshotStorage, "snapshot", dst, testWorkerCount)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chunk map read failed")
+	require.Equal(t, int64(0), dst.truncatedSize)
+}
+
+func TestExportFailsOnNonPositiveWorkerCount(t *testing.T) {
+	ctx := newContext()
+
+	snapshotStorage := mocks.NewStorageMock()
+	dst := newMemDestination(chunkSize)
+
+	_, err := Export(ctx, snapshotStorage, "snapshot", dst, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "workerCount must be positive")
+}
+
+func TestExportFailsWhenSnapshotIsNotReady(t *testing.T) {
+	ctx := newContext()
+
+	snapshotStorage := mocks.NewStorageMock()
+	snapshotStorage.On("CheckSnapshotReady", mock.Anything, "snapshot").Return(
+		storage.SnapshotMeta{},
+		fmt.Errorf("snapshot is not ready"),
+	)
+
+	dst := newMemDestination(chunkSize)
+
+	_, err := Export(ctx, snapshotStorage, "snapshot", dst, testWorkerCount)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "snapshot is not ready")
+
+	snapshotStorage.AssertNumberOfCalls(t, "ReadChunkMap", 0)
+}

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/tests/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/tests/ya.make
@@ -1,0 +1,3 @@
+GO_TEST_FOR(cloud/disk_manager/internal/pkg/dataplane/snapshot/export)
+
+END()

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/export/ya.make
@@ -1,0 +1,15 @@
+GO_LIBRARY()
+
+SRCS(
+    export.go
+)
+
+GO_TEST_SRCS(
+    export_test.go
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    tests
+)

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/ya.make
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/ya.make
@@ -10,5 +10,6 @@ END()
 
 RECURSE(
     config
+    export
     storage
 )


### PR DESCRIPTION
## Problem

Sometimes an operator needs to extract snapshot or image data from the dataplane storage directly — e.g. to recover data or to inspect snapshot content — without going through the Disk Manager service (create disk from snapshot, attach, dd).

## Solution

Add `disk-manager-export-snapshot` — a standalone tool that reads all chunks of a ready snapshot (or image) directly from the dataplane storage (chunk map in YDB, chunk data in S3 or YDB) and assembles them into a local raw image file:

* reads the chunk map via `storage.ReadChunkMap` and fetches chunks concurrently (`--worker-count`);
* chunk checksums are verified by `storage.ReadChunk`;
* zero chunks are skipped, so the output file is sparse where the snapshot has no data; in the end the file is truncated to the snapshot virtual size;
* incremental snapshots need no special handling: their chunk map is complete, unchanged chunks are shallow copies of the base snapshot chunks;
* uses the regular Disk Manager server config (`--config`) to construct YDB/S3 clients and the snapshot storage, same as `disk-manager-init-db`;
* warns if the snapshot is encrypted (the data is exported as stored, i.e. encrypted).

The export logic lives in `internal/pkg/dataplane/snapshot/export` and is covered by unit tests on top of the existing storage mock. Usage instructions: `cloud/disk_manager/cmd/disk-manager-export-snapshot/README.md`.

Usage:
```
disk-manager-export-snapshot --config /etc/disk-manager/server-config.txt --snapshot-id <id> --output /path/to/image.raw
```