### PR TITLE
Allow GentlePreemption for rebind action

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1621,4 +1621,8 @@ message TStorageServiceConfig
 
     // Use read or recreated compaction blob metas during cleanup.
     optional bool UseRecreatedBlobMetasOnCleanup = 513;
+
+    // If false (default), UseGentlePreemption param
+    // for RebindVolumes action is ignored
+    optional bool AllowGentlePreemptionForRebindVolumesAction = 514;
 }

--- a/cloud/blockstore/libs/storage/api/service.h
+++ b/cloud/blockstore/libs/storage/api/service.h
@@ -41,6 +41,7 @@ struct TEvService
         const TString DiskId;
         const EChangeBindingOp Action;
         const NProto::EPreemptionSource Source;
+        const bool UseGentlePreemption = false;
 
         TChangeVolumeBindingRequest(
                 TString diskId,
@@ -49,6 +50,17 @@ struct TEvService
             : DiskId(std::move(diskId))
             , Action(action)
             , Source(source)
+        {}
+
+        TChangeVolumeBindingRequest(
+            TString diskId,
+            EChangeBindingOp action,
+            NProto::EPreemptionSource source,
+            bool useGentlePreemption)
+            : DiskId(std::move(diskId))
+            , Action(action)
+            , Source(source)
+            , UseGentlePreemption(useGentlePreemption)
         {}
     };
 

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -715,6 +715,8 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(SplitByCompactionRangeMaxBlobCount,         ui64,       0             )\
     xxx(VerifyRecreatedBlobMetasOnCleanup,          bool,       false         )\
     xxx(UseRecreatedBlobMetasOnCleanup,             bool,       false         )\
+                                                                               \
+    xxx(AllowGentlePreemptionForRebindVolumesAction,    bool,   false         )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -853,6 +853,8 @@ public:
     [[nodiscard]] bool GetVerifyRecreatedBlobMetasOnCleanup() const;
 
     [[nodiscard]] bool GetUseRecreatedBlobMetasOnCleanup() const;
+
+    [[nodiscard]] bool GetAllowGentlePreemptionForRebindVolumesAction() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_rebind_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_rebind_volumes.cpp
@@ -33,6 +33,7 @@ private:
     const TRequestInfoPtr RequestInfo;
     const NPrivateProto::TRebindVolumesRequest RebindRequest;
     const TVector<TString> DiskIds;
+    const bool UseGentlePreemption;
     ui32 Responses = 0;
 
     NProto::TError Error;
@@ -41,7 +42,8 @@ public:
     TRebindVolumesActor(
         TRequestInfoPtr requestInfo,
         NPrivateProto::TRebindVolumesRequest rebindRequest,
-        TVector<TString> diskIds);
+        TVector<TString> diskIds,
+        bool useGentlePreemption);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -61,10 +63,12 @@ private:
 TRebindVolumesActor::TRebindVolumesActor(
         TRequestInfoPtr requestInfo,
         NPrivateProto::TRebindVolumesRequest rebindRequest,
-        TVector<TString> diskIds)
+        TVector<TString> diskIds,
+        const bool useGentlePreemption)
     : RequestInfo(std::move(requestInfo))
     , RebindRequest(std::move(rebindRequest))
     , DiskIds(std::move(diskIds))
+    , UseGentlePreemption(useGentlePreemption)
 {}
 
 void TRebindVolumesActor::Bootstrap(const TActorContext& ctx)
@@ -87,11 +91,12 @@ void TRebindVolumesActor::Bootstrap(const TActorContext& ctx)
             op = TRequest::EChangeBindingOp::RELEASE_TO_HIVE;
         }
 
-        auto request = std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
-            diskId,
-            op,
+        auto request =
+            std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
+                diskId,
+                op,
                 NProto::SOURCE_MANUAL,
-                RebindRequest.GetUseGentlePreemption());
+                UseGentlePreemption);
 
         NCloud::Send(ctx, MakeStorageServiceId(), std::move(request));
     }
@@ -210,10 +215,15 @@ TResultOrError<IActorPtr> TServiceActor::CreateRebindVolumesActionActor(
     State.SetIsManuallyPreemptedVolumesTrackingDisabled(
         binding == NProto::BINDING_REMOTE);
 
+    const auto useGentlePreemption =
+        rebindRequest.GetUseGentlePreemption() &&
+        Config->GetAllowGentlePreemptionForRebindVolumesAction();
+
     return {std::make_unique<TRebindVolumesActor>(
         std::move(requestInfo),
         std::move(rebindRequest),
-        std::move(localDiskIds))};
+        std::move(localDiskIds),
+        useGentlePreemption)};
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_rebind_volumes.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_rebind_volumes.cpp
@@ -90,8 +90,8 @@ void TRebindVolumesActor::Bootstrap(const TActorContext& ctx)
         auto request = std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
             diskId,
             op,
-            NProto::SOURCE_MANUAL
-        );
+                NProto::SOURCE_MANUAL,
+                RebindRequest.GetUseGentlePreemption());
 
         NCloud::Send(ctx, MakeStorageServiceId(), std::move(request));
     }

--- a/cloud/blockstore/libs/storage/service/service_actor_volume_binding.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_volume_binding.cpp
@@ -34,6 +34,7 @@ private:
     const TString DiskId;
     const EChangeBindingOp Action;
     const NProto::EPreemptionSource Source;
+    const bool UseGentlePreemption;
 
 public:
     TDelayChangeBindingActor(
@@ -42,15 +43,16 @@ public:
             TDuration delay,
             TString diskId,
             EChangeBindingOp action,
-            NProto::EPreemptionSource source)
+        NProto::EPreemptionSource source,
+        const bool useGentlePreemption)
         : RequestInfo(std::move(requestInfo))
         , SessionActor(sessionActor)
         , Delay(delay)
         , DiskId(std::move(diskId))
         , Action(action)
         , Source(source)
-    {
-    }
+        , UseGentlePreemption(useGentlePreemption)
+    {}
 
     void Bootstrap(const TActorContext& ctx)
     {
@@ -70,7 +72,8 @@ private:
                 std::move(RequestInfo->CallContext),
                 DiskId,
                 Action,
-                Source);
+                Source,
+                UseGentlePreemption);
 
         NCloud::SendWithUndeliveryTracking(
             ctx,
@@ -218,7 +221,8 @@ void TServiceActor::HandleChangeVolumeBinding(
         delayInterval,
         std::move(msg->DiskId),
         msg->Action,
-        msg->Source);
+        msg->Source,
+        msg->UseGentlePreemption);
 
     volume->RebindingIsInflight = true;
 }

--- a/cloud/blockstore/libs/storage/service/service_actor_volume_binding.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_volume_binding.cpp
@@ -43,8 +43,8 @@ public:
             TDuration delay,
             TString diskId,
             EChangeBindingOp action,
-        NProto::EPreemptionSource source,
-        const bool useGentlePreemption)
+            NProto::EPreemptionSource source,
+            const bool useGentlePreemption)
         : RequestInfo(std::move(requestInfo))
         , SessionActor(sessionActor)
         , Delay(delay)

--- a/cloud/blockstore/libs/storage/service/service_events_private.h
+++ b/cloud/blockstore/libs/storage/service/service_events_private.h
@@ -217,6 +217,7 @@ struct TEvServicePrivate
         NProto::TMountVolumeRequest Record;
         NProto::EVolumeBinding BindingType = NProto::BINDING_NOT_SET;
         NProto::EPreemptionSource PreemptionSource = NProto::SOURCE_NONE;
+        bool UseGentlePreemption = false;
 
         TInternalMountVolumeRequest() = default;
 

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -617,6 +617,7 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
     {
         TTestEnv env;
         NProto::TStorageServiceConfig config;
+        config.SetAllowGentlePreemptionForRebindVolumesAction(true);
         ui32 nodeIdx = SetupTestEnv(env, std::move(config));
 
         TServiceClient service(env.GetRuntime(), nodeIdx);

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -613,6 +613,64 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
         UNIT_ASSERT_VALUES_EQUAL(diskIds.count("vol1"), 1);
     }
 
+    Y_UNIT_TEST(ShouldRebindLocalVolumesWithGentlePreemption)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateVolume("vol0");   // local
+        service.CreateVolume("vol1");   // local
+        service.CreateVolume("vol2");   // remote
+        service.CreateVolume("vol3");   // not mounted
+
+        service.MountVolume("vol0");
+        service.MountVolume("vol1");
+        service.MountVolume(
+            "vol2",
+            TString(),   // instanceId
+            TString(),   // token
+            NProto::IPC_GRPC,
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_REMOTE);
+
+        TSet<TString> diskIds;
+
+        env.GetRuntime().SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvService::EvChangeVolumeBindingRequest: {
+                        auto* msg = event->Get<
+                            TEvService::TEvChangeVolumeBindingRequest>();
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            static_cast<ui32>(
+                                TEvService::TChangeVolumeBindingRequest::
+                                    EChangeBindingOp::RELEASE_TO_HIVE),
+                            static_cast<ui32>(msg->Action));
+                        UNIT_ASSERT(msg->UseGentlePreemption);
+
+                        diskIds.insert(msg->DiskId);
+                    }
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        NPrivateProto::TRebindVolumesRequest request;
+        request.SetBinding(2);   // REMOTE
+        request.SetUseGentlePreemption(true);
+
+        TString buf;
+        google::protobuf::util::MessageToJsonString(request, &buf);
+
+        service.ExecuteAction("rebindvolumes", buf);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, diskIds.size());
+        UNIT_ASSERT_VALUES_EQUAL(diskIds.count("vol0"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(diskIds.count("vol1"), 1);
+    }
+
     Y_UNIT_TEST(ShouldDrainNode)
     {
         TTestEnv env;

--- a/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_mount.cpp
@@ -5900,7 +5900,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         NProto::TStorageServiceConfig config;
         config.SetBalancerActionDelayInterval(0);
-        config.SetVolumeBalancerGentlePreemptionEnabled(true);
 
         ui32 nodeIdx1 = SetupTestEnv(env, config);
         auto& runtime = env.GetRuntime();
@@ -5978,7 +5977,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
                     DefaultDiskId,
                     EChangeBindingOp::RELEASE_TO_HIVE,
-                    NProto::EPreemptionSource::SOURCE_BALANCER);
+                    NProto::EPreemptionSource::SOURCE_BALANCER,
+                    true);
             service.SendRequest(MakeStorageServiceId(), std::move(request));
         }
 
@@ -6022,7 +6022,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         NProto::TStorageServiceConfig config;
         config.SetBalancerActionDelayInterval(0);
-        config.SetVolumeBalancerGentlePreemptionEnabled(true);
 
         ui32 nodeIdx1 = SetupTestEnv(env, config);
         auto& runtime = env.GetRuntime();
@@ -6107,7 +6106,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
                     DefaultDiskId,
                     EChangeBindingOp::ACQUIRE_FROM_HIVE,
-                    NProto::EPreemptionSource::SOURCE_BALANCER);
+                    NProto::EPreemptionSource::SOURCE_BALANCER,
+                    true);
             service.SendRequest(MakeStorageServiceId(), std::move(request));
 
             runtime.DispatchEvents({}, TDuration::Seconds(5));
@@ -6153,7 +6153,6 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
 
         NProto::TStorageServiceConfig config;
         config.SetBalancerActionDelayInterval(0);
-        config.SetVolumeBalancerGentlePreemptionEnabled(true);
 
         ui32 nodeIdx = SetupTestEnv(env, config);
         TServiceClient service(env.GetRuntime(), nodeIdx);
@@ -6173,7 +6172,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
                     DefaultDiskId,
                     EChangeBindingOp::RELEASE_TO_HIVE,
-                    NProto::EPreemptionSource::SOURCE_BALANCER);
+                    NProto::EPreemptionSource::SOURCE_BALANCER,
+                    true);
             service.SendRequest(MakeStorageServiceId(), std::move(request));
             auto response =
                 service
@@ -6188,7 +6188,8 @@ Y_UNIT_TEST_SUITE(TServiceMountVolumeTest)
                 std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
                     DefaultDiskId,
                     EChangeBindingOp::ACQUIRE_FROM_HIVE,
-                    NProto::EPreemptionSource::SOURCE_BALANCER);
+                    NProto::EPreemptionSource::SOURCE_BALANCER,
+                    true);
             service.SendRequest(MakeStorageServiceId(), std::move(request));
             auto response =
                 service

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_binding.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_binding.cpp
@@ -88,6 +88,7 @@ void TVolumeSessionActor::HandleChangeVolumeBindingRequest(
     }
     request->BindingType = bindingType;
     request->PreemptionSource = msg->Source;
+    request->UseGentlePreemption = msg->UseGentlePreemption;
     request->CallContext = std::move(msg->CallContext);
 
     using TEventType =

--- a/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_mount.cpp
@@ -391,6 +391,8 @@ struct TMountRequestParams
     NProto::EVolumeBinding BindingType = NProto::BINDING_REMOTE;
     NProto::EPreemptionSource PreemptionSource = NProto::SOURCE_NONE;
 
+    bool UseGentlePreemption = false;
+
     bool IsLocalMounter = false;
     bool RejectOnAddClientTimeout = false;
 
@@ -453,8 +455,6 @@ private:
 
     void GentlyReleaseVolume(const TActorContext& ctx);
     void GentlyPullVolume(const TActorContext& ctx);
-
-    bool GentlePreemptionAllowed() const;
 
 private:
     STFUNC(StateWork);
@@ -902,12 +902,6 @@ void TMountRequestActor::GentlyPullVolume(const TActorContext& ctx)
         Config->GetVolumeBalancerGentlePreemptionTimeout());
 }
 
-bool TMountRequestActor::GentlePreemptionAllowed() const
-{
-    return Config->GetVolumeBalancerGentlePreemptionEnabled() &&
-           Params.PreemptionSource == NProto::SOURCE_BALANCER;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void TMountRequestActor::NotifyAndDie(const TActorContext& ctx)
@@ -962,7 +956,7 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
         }
 
         if (!VolumeStarted && MountMode == NProto::VOLUME_MOUNT_LOCAL) {
-            if (GentlePreemptionAllowed()) {
+            if (Params.UseGentlePreemption) {
                 GentlyPullVolume(ctx);
             } else {
                 RequestVolumeStart(ctx);
@@ -991,7 +985,7 @@ void TMountRequestActor::HandleVolumeAddClientResponse(
         const bool mayStopVolume = Params.IsLocalMounter || VolumeStarted;
 
         if (mayStopVolume && MountMode == NProto::VOLUME_MOUNT_REMOTE) {
-            if (GentlePreemptionAllowed()) {
+            if (Params.UseGentlePreemption) {
                 GentlyReleaseVolume(ctx);
             } else {
                 RequestVolumeStop(ctx);
@@ -1472,6 +1466,7 @@ void TVolumeSessionActor::HandleInternalMountVolume(
         .StartVolumeActor = StartVolumeActor,
         .BindingType = bindingType,
         .PreemptionSource = msg->PreemptionSource,
+        .UseGentlePreemption = msg->UseGentlePreemption,
         .IsLocalMounter = clientInfo &&
             clientInfo->VolumeMountMode == NProto::VOLUME_MOUNT_LOCAL,
         .RejectOnAddClientTimeout = Config->GetRejectMountOnAddClientTimeout(),

--- a/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume_balancer/volume_balancer_actor.cpp
@@ -209,10 +209,13 @@ void TVolumeBalancerActor::PullVolumeFromHive(
         "Pull volume %s from hive",
         volume.data());
 
-    auto pullRequest = std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
-        volume,
-        TEvService::TEvChangeVolumeBindingRequest::EChangeBindingOp::ACQUIRE_FROM_HIVE,
-        NProto::EPreemptionSource::SOURCE_BALANCER);
+    auto pullRequest =
+        std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
+            volume,
+            TEvService::TEvChangeVolumeBindingRequest::EChangeBindingOp::
+                ACQUIRE_FROM_HIVE,
+            NProto::EPreemptionSource::SOURCE_BALANCER,
+            StorageConfig->GetVolumeBalancerGentlePreemptionEnabled());
     NCloud::Send(ctx, ServiceActorId, std::move(pullRequest));
 
     PullCount->Add(1);
@@ -228,10 +231,13 @@ void TVolumeBalancerActor::SendVolumeToHive(
         "Push volume %s to hive",
         volume.data());
 
-    auto pushRequest = std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
-        volume,
-        TEvService::TEvChangeVolumeBindingRequest::EChangeBindingOp::RELEASE_TO_HIVE,
-        NProto::EPreemptionSource::SOURCE_BALANCER);
+    auto pushRequest =
+        std::make_unique<TEvService::TEvChangeVolumeBindingRequest>(
+            volume,
+            TEvService::TEvChangeVolumeBindingRequest::EChangeBindingOp::
+                RELEASE_TO_HIVE,
+            NProto::EPreemptionSource::SOURCE_BALANCER,
+            StorageConfig->GetVolumeBalancerGentlePreemptionEnabled());
     NCloud::Send(ctx, ServiceActorId, std::move(pushRequest));
 
     PushCount->Add(1);

--- a/cloud/blockstore/private/api/protos/volume.proto
+++ b/cloud/blockstore/private/api/protos/volume.proto
@@ -158,6 +158,9 @@ message TRebindVolumesRequest
 {
     // EVolumeBinding, see libs/storage/service/service_state.h
     uint32 Binding = 1;
+
+    // If true, no direct volume kill happens during rebind
+    bool UseGentlePreemption = 2;
 };
 
 message TRebindVolumesResponse


### PR DESCRIPTION
This PR adds option to perform RebindVolumes service action with GentlePreemption.

This feature is expected to reduce volume downtime during mass RebindVolumes / Hive overload.