### PR TITLE
issue-1559: [Disk Manager] Stabilize filesystem snapshot task nemesis test

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
@@ -123,10 +123,11 @@ func scanFilesystemSnapshotState(res persistence.Result) (state filesystemSnapsh
 
 func scanFilesystemSnapshotStates(ctx context.Context, res persistence.Result) ([]filesystemSnapshotState, error) {
 	var states []filesystemSnapshotState
-	// TODO: NextResultSet(ctx) drops the error returned by NextResultSetErr(ctx).
+	// NOTE: YDB SDK's NextResultSet(ctx) drops the error returned by NextResultSetErr(ctx).
 	// If ctx is cancelled during iteration, the YDB SDK can return ctx.Err()
-	// without storing it in res.Err(), so this scanner may incorrectly observe
-	// an empty result. See:
+	// without storing it in res.Err(), so we must check ctx.Err() after iteration
+	// to avoid incorrectly treating the result as empty.
+	// See:
 	// https://github.com/ydb-platform/ydb-go-sdk/blob/v3.54.3/internal/table/scanner/result.go#L149-L205
 	// https://github.com/ydb-platform/ydb-go-sdk/blob/v3.54.3/internal/table/scanner/scanner.go#L219-L235
 	for res.NextResultSet(ctx) {

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/common.go
@@ -123,6 +123,12 @@ func scanFilesystemSnapshotState(res persistence.Result) (state filesystemSnapsh
 
 func scanFilesystemSnapshotStates(ctx context.Context, res persistence.Result) ([]filesystemSnapshotState, error) {
 	var states []filesystemSnapshotState
+	// TODO: NextResultSet(ctx) drops the error returned by NextResultSetErr(ctx).
+	// If ctx is cancelled during iteration, the YDB SDK can return ctx.Err()
+	// without storing it in res.Err(), so this scanner may incorrectly observe
+	// an empty result. See:
+	// https://github.com/ydb-platform/ydb-go-sdk/blob/v3.54.3/internal/table/scanner/result.go#L149-L205
+	// https://github.com/ydb-platform/ydb-go-sdk/blob/v3.54.3/internal/table/scanner/scanner.go#L219-L235
 	for res.NextResultSet(ctx) {
 		for res.NextRow() {
 			state, err := scanFilesystemSnapshotState(res)
@@ -137,6 +143,10 @@ func scanFilesystemSnapshotStates(ctx context.Context, res persistence.Result) (
 	// NOTE: always check query result after iteration.
 	if res.Err() != nil {
 		return nil, errors.NewRetriableError(res.Err())
+	}
+
+	if ctx.Err() != nil {
+		return nil, errors.NewRetriableError(ctx.Err())
 	}
 
 	return states, nil

--- a/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/filesystem/snapshot/storage/storage_ydb_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -346,6 +347,69 @@ func TestCheckFilesystemSnapshotReady(t *testing.T) {
 	err = f.storage.CheckFilesystemSnapshotReady(f.ctx, "snapshot")
 	require.Error(t, err)
 	require.ErrorIs(t, err, errors.NewEmptyNonRetriableError())
+}
+
+func TestCheckFilesystemSnapshotReadyWithCancellationDoesNotReturnNonRetriableError(
+	t *testing.T,
+) {
+	f := createFixture(t)
+	defer f.teardown()
+
+	snapshotID := "snapshot"
+	created, err := f.storage.CreateFilesystemSnapshot(
+		f.ctx,
+		FilesystemSnapshotMeta{
+			ID:           snapshotID,
+			CreateTaskID: "create",
+			Filesystem: &types.Filesystem{
+				ZoneId:       "zone",
+				FilesystemId: "fs",
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.False(t, created.Ready)
+
+	err = f.storage.FilesystemSnapshotCreated(f.ctx, snapshotID, 100, 200, 5)
+	require.NoError(t, err)
+
+	err = f.storage.CheckFilesystemSnapshotReady(f.ctx, snapshotID)
+	require.NoError(t, err)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 200; i++ {
+		runCtx, cancel := context.WithCancel(f.ctx)
+		delay := time.Duration(rng.Intn(50)+1) * time.Millisecond
+		timer := time.AfterFunc(delay, cancel)
+
+		err = f.storage.CheckFilesystemSnapshotReady(runCtx, snapshotID)
+
+		timer.Stop()
+		cancel()
+
+		if err == nil {
+			continue
+		}
+
+		require.False(
+			t,
+			errors.Is(err, errors.NewEmptyNonRetriableError()),
+			"iteration %v returned non-retriable error after cancelling after %v: %v",
+			i,
+			delay,
+			err,
+		)
+		require.True(
+			t,
+			errors.Is(err, context.Canceled) ||
+				errors.Is(err, errors.NewEmptyRetriableError()),
+			"iteration %v returned unexpected error after cancelling after %v: %v",
+			i,
+			delay,
+			err,
+		)
+	}
 }
 
 func TestLockUnlockFilesystemSnapshot(t *testing.T) {


### PR DESCRIPTION
### Notes
NextResultSet(ctx) drops the error returned by NextResultSetErr(ctx).
If ctx is cancelled during iteration, the YDB SDK can return ctx.Err()
 without storing it in res.Err(), so this scanner may incorrectly observe
 an empty result. In that case,  CheckSnapshotReady returns NonRetriableError.

 See:
 https://github.com/ydb-platform/ydb-go-sdk/blob/v3.54.3/internal/table/scanner/result.go#L149-L205
 https://github.com/ydb-platform/ydb-go-sdk/blob/v3.54.3/internal/table/scanner/scanner.go#L219-L235

### Issue
#1559