### PR TITLE
issue-5894: fastshard naive storage group

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
@@ -1,5 +1,11 @@
 #include "storage_group.h"
 
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/logger.h>
+
 #include <util/generic/vector.h>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
@@ -8,10 +14,52 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TAcquireDevicesParams
+{
+    IStorageNodePtr Node;
+    NProto::TAcquireDevicesRequest* Request;
+    NProto::TAcquireDevicesResponse* Response;
+};
+
+int AcquireDevicesFiberMain(TAcquireDevicesParams* params) noexcept
+{
+    *params->Response = params->Node->AcquireDevices(*params->Request);
+    return 0;
+}
+
+struct TReleaseDevicesParams
+{
+    IStorageNodePtr Node;
+    NProto::TReleaseDevicesRequest* Request;
+    NProto::TReleaseDevicesResponse* Response;
+};
+
+int ReleaseDevicesFiberMain(TReleaseDevicesParams* params) noexcept
+{
+    *params->Response = params->Node->ReleaseDevices(*params->Request);
+    return 0;
+}
+
+struct TWriteLogRecordParams
+{
+    IStorageNodePtr Node;
+    NProto::TWriteLogRecordRequest* Request;
+    NProto::TWriteLogRecordResponse* Response;
+};
+
+int WriteLogRecordFiberMain(TWriteLogRecordParams* params) noexcept
+{
+    *params->Response = params->Node->WriteLogRecord(*params->Request);
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TStorageGroupImpl: public IStorageGroup
 {
 private:
     TVector<IStorageNodePtr> Nodes;
+    std::atomic<ui32> Selector{0};
 
 public:
     explicit TStorageGroupImpl(TVector<IStorageNodePtr> nodes)
@@ -22,29 +70,87 @@ public:
     NProto::TAcquireDevicesResponse AcquireDevices(
         NProto::TAcquireDevicesRequest request) override
     {
-        Y_UNUSED(request);
-        return {};
+        return MirrorRequest<
+            NProto::TAcquireDevicesRequest,
+            NProto::TAcquireDevicesResponse,
+            TAcquireDevicesParams
+        >(AcquireDevicesFiberMain, std::move(request));
     }
 
     NProto::TReleaseDevicesResponse ReleaseDevices(
         NProto::TReleaseDevicesRequest request) override
     {
-        Y_UNUSED(request);
-        return {};
+        return MirrorRequest<
+            NProto::TReleaseDevicesRequest,
+            NProto::TReleaseDevicesResponse,
+            TReleaseDevicesParams
+        >(ReleaseDevicesFiberMain, std::move(request));
     }
 
     NProto::TWriteLogRecordResponse WriteLogRecord(
         NProto::TWriteLogRecordRequest request) override
     {
-        Y_UNUSED(request);
-        return {};
+        return MirrorRequest<
+            NProto::TWriteLogRecordRequest,
+            NProto::TWriteLogRecordResponse,
+            TWriteLogRecordParams
+        >(WriteLogRecordFiberMain, std::move(request));
     }
 
     NProto::TReadPagesResponse ReadPages(
         NProto::TReadPagesRequest request) override
     {
-        Y_UNUSED(request);
-        return {};
+        const ui32 i =
+            Selector.fetch_add(1, std::memory_order_relaxed) % Nodes.size();
+        return Nodes[i]->ReadPages(request);
+    }
+
+private:
+    template <
+        typename TRequest,
+        typename TResponse,
+        typename TParams,
+        typename TFiberMain>
+    TResponse MirrorRequest(TFiberMain fiberMain, TRequest request)
+    {
+        TVector<silk::FiberFuture> futures(Nodes.size());
+        TVector<TResponse> responses(Nodes.size());
+        for (ui32 i = 0; i < Nodes.size(); ++i) {
+            int r = silk::FiberScheduler::run(
+                fiberMain,
+                TParams{
+                    .Node = Nodes[i],
+                    .Request = &request,
+                    .Response = &responses[i]},
+                &futures[i]);
+            Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
+        }
+
+        TResponse response;
+        for (ui32 i = 0; i < Nodes.size(); ++i) {
+            int r = futures[i].wait();
+            if (r) {
+                SILK_ERROR("future error: %s", ::strerror(r));
+                if (!HasError(response.GetError())) {
+                    *response.MutableError() = MakeError(MAKE_SYSTEM_ERROR(r));
+                }
+
+                continue;
+            }
+
+            auto& nodeResponse = responses[i];
+            if (HasError(nodeResponse.GetError())) {
+                SILK_ERROR(
+                    "node error: %s",
+                    FormatError(nodeResponse.GetError()).c_str());
+                if (!HasError(response.GetError())) {
+                    *response.MutableError() =
+                        std::move(*nodeResponse.MutableError());
+                }
+            }
+        }
+
+        return response;
     }
 };
 

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
@@ -1,0 +1,61 @@
+#include "storage_group.h"
+
+#include <util/generic/vector.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TStorageGroupImpl: public IStorageGroup
+{
+private:
+    TVector<IStorageNodePtr> Nodes;
+
+public:
+    explicit TStorageGroupImpl(TVector<IStorageNodePtr> nodes)
+        : Nodes(std::move(nodes))
+    {}
+
+public:
+    NProto::TAcquireDevicesResponse AcquireDevices(
+        NProto::TAcquireDevicesRequest request) override
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TReleaseDevicesResponse ReleaseDevices(
+        NProto::TReleaseDevicesRequest request) override
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TWriteLogRecordResponse WriteLogRecord(
+        NProto::TWriteLogRecordRequest request) override
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TReadPagesResponse ReadPages(
+        NProto::TReadPagesRequest request) override
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageGroupPtr CreateNaiveMirroredStorageGroup(
+    TVector<IStorageNodePtr> nodes)
+{
+    return std::make_shared<TStorageGroupImpl>(std::move(nodes));
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Storage group iface. Right now it's basically the same iface as IStorageNode
+ * but it's better to keep a separate declaration to highlight that these things
+ * are actually different entities. Storage groups are supposed to provide
+ * some extra non-functional features on top of multiple storage nodes - like
+ * redundancy or hedged requests.
+ *
+ * The interface is synchronous and is supposed to be used from a fiber.
+ */
+struct IStorageGroup
+{
+    virtual ~IStorageGroup() = default;
+
+#define SN_DECLARE_METHOD(name, ...)                                           \
+    virtual NProto::T##name##Response name(                                    \
+        NProto::T##name##Request request) = 0;                                 \
+// SN_DECLARE_METHOD
+
+    SN_METHODS(SN_DECLARE_METHOD)
+
+#undef SN_DECLARE_METHOD
+};
+
+using IStorageGroupPtr = std::shared_ptr<IStorageGroup>;
+
+/**
+ * Returns an IStorageGroup which mirrors each write into all storage nodes and
+ * reads from one of the nodes selecting it in a round-robin manner. The
+ * implementation is naive in the sense that it does no crash recovery and is
+ * basically a happy-path implementation intended for tests and prototyping. And
+ * there's also no real m/n write / k/n read quorum here - it's just always
+ * n/n for writes, 1/n for reads.
+ *
+ * @return - The constructed group.
+ */
+IStorageGroupPtr CreateNaiveMirroredStorageGroup(
+    TVector<IStorageNodePtr> nodes);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_stub.cpp
@@ -1,0 +1,44 @@
+#include "storage_group.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/generic/vector.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TStorageGroupStub: public IStorageGroup
+{
+public:
+#define SN_STUB_METHOD(name, ...)                                              \
+    NCloud::NProto::T##name##Response name(                                    \
+        NCloud::NProto::T##name##Request request) override                     \
+    {                                                                          \
+        Y_UNUSED(request);                                                     \
+        NProto::T##name##Response response;                                    \
+        *response.MutableError() = MakeError(E_NOT_IMPLEMENTED);               \
+        return response;                                                       \
+    }                                                                          \
+// SN_STUB_METHOD
+
+    SN_METHODS(SN_STUB_METHOD)
+
+#undef SN_STUB_METHOD
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IStorageGroupPtr CreateNaiveMirroredStorageGroup(
+    TVector<IStorageNodePtr> nodes)
+{
+    Y_UNUSED(nodes);
+
+    return std::make_shared<TStorageGroupStub>();
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
@@ -1,0 +1,204 @@
+#include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/protos/device.pb.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+
+#include <gtest/gtest.h>
+
+#include <util/generic/string.h>
+#include <util/string/builder.h>
+
+using namespace NCloud;
+using namespace NFileStore::NStorage::NFastShard;
+using silk::FiberScheduler;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+[[maybe_unused]] auto* const gEnv =
+    ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
+
+////////////////////////////////////////////////////////////////////////////////
+// Test fixture: builds a set of fake storage nodes. And that's it.
+
+struct TStorageFixture
+{
+    static constexpr ui32 NodeCount = 3;
+    TVector<std::shared_ptr<TFakeStorageNode>> StorageNodes;
+    IStorageGroupPtr Group;
+
+    TStorageFixture()
+        : StorageNodes(NodeCount)
+    {
+        TVector<IStorageNodePtr> nodes(NodeCount);
+        for (ui32 i = 0; i < NodeCount; ++i) {
+            StorageNodes[i] = std::make_shared<TFakeStorageNode>();
+            nodes[i] = StorageNodes[i];
+        }
+
+        Group = CreateNaiveMirroredStorageGroup(std::move(nodes));
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(NaiveGroupTest, MirrorsAcquireReleaseRequests)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TStorageFixture fx;
+
+            {
+                NProto::TAcquireDevicesRequest request;
+                request.AddDeviceUUIDs("dev-a");
+                request.AddDeviceUUIDs("dev-b");
+
+                auto response = fx.Group->AcquireDevices(request);
+                EXPECT_EQ(S_OK, response.GetError().GetCode())
+                    << response.GetError().GetMessage();
+            }
+
+            //
+            // We expect naive group impl to do dumb mirroring for acquire and
+            // release requests.
+            //
+
+            for (auto& sn: fx.StorageNodes) {
+                EXPECT_EQ(1U, sn->AcquireCalls.size());
+                EXPECT_EQ(2U, sn->AcquireCalls[0].DeviceUUIDsSize());
+                EXPECT_EQ("dev-a", sn->AcquireCalls[0].GetDeviceUUIDs(0));
+                EXPECT_EQ("dev-b", sn->AcquireCalls[0].GetDeviceUUIDs(1));
+            }
+
+            {
+                NProto::TReleaseDevicesRequest request;
+                request.AddDeviceUUIDs("dev-a");
+                request.AddDeviceUUIDs("dev-b");
+
+                auto response = fx.Group->ReleaseDevices(request);
+                EXPECT_EQ(S_OK, response.GetError().GetCode())
+                    << response.GetError().GetMessage();
+            }
+
+            //
+            // We expect naive group impl to do dumb mirroring for acquire and
+            // release requests.
+            //
+
+            for (auto& sn: fx.StorageNodes) {
+                EXPECT_EQ(1U, sn->ReleaseCalls.size());
+                EXPECT_EQ(2U, sn->ReleaseCalls[0].DeviceUUIDsSize());
+                EXPECT_EQ("dev-a", sn->ReleaseCalls[0].GetDeviceUUIDs(0));
+                EXPECT_EQ("dev-b", sn->ReleaseCalls[0].GetDeviceUUIDs(1));
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(NaiveGroupTest, MirrorsWrites)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TStorageFixture fx;
+
+            {
+                NProto::TWriteLogRecordRequest request;
+                request.SetDeviceUUID("dev");
+                auto* pg = request.AddPageGroups();
+                pg->AddContent("page1");
+                pg->AddContent("page2");
+                pg->SetFirstPageNo(111);
+
+                auto response = fx.Group->WriteLogRecord(request);
+                EXPECT_EQ(S_OK, response.GetError().GetCode())
+                    << response.GetError().GetMessage();
+            }
+
+            for (auto& sn: fx.StorageNodes) {
+                EXPECT_EQ(1U, sn->WriteCalls.size());
+                EXPECT_EQ("dev", sn->WriteCalls[0].GetDeviceUUID());
+                EXPECT_EQ(1U, sn->WriteCalls[0].PageGroupsSize());
+                const auto& pg = sn->WriteCalls[0].GetPageGroups(0);
+                EXPECT_EQ(111U, pg.GetFirstPageNo());
+                EXPECT_EQ(2U, pg.ContentSize());
+                EXPECT_EQ("page1", pg.GetContent(0));
+                EXPECT_EQ("page2", pg.GetContent(1));
+            }
+
+            {
+                NProto::TReleaseDevicesRequest request;
+                request.AddDeviceUUIDs("dev-a");
+                request.AddDeviceUUIDs("dev-b");
+
+                auto response = fx.Group->ReleaseDevices(request);
+                EXPECT_EQ(S_OK, response.GetError().GetCode())
+                    << response.GetError().GetMessage();
+            }
+
+            //
+            // We expect naive group impl to do dumb mirroring for acquire and
+            // release requests.
+            //
+
+            for (auto& sn: fx.StorageNodes) {
+                EXPECT_EQ(1U, sn->ReleaseCalls.size());
+                EXPECT_EQ(2U, sn->ReleaseCalls[0].DeviceUUIDsSize());
+                EXPECT_EQ("dev-a", sn->ReleaseCalls[0].GetDeviceUUIDs(0));
+                EXPECT_EQ("dev-b", sn->ReleaseCalls[0].GetDeviceUUIDs(1));
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}
+
+TEST(NaiveGroupTest, RoundRobinsRead)
+{
+    const int r = FiberScheduler::run(
+        +[](int*) noexcept -> int {
+            TStorageFixture fx;
+
+            for (ui32 i = 0; i < 10 * TStorageFixture::NodeCount; ++i) {
+                {
+                    NProto::TReadPagesRequest request;
+                    request.SetDeviceUUID("dev");
+
+                    auto* pg = request.AddPageGroupRefs();
+                    pg->SetPageSize(4_KB);
+                    pg->SetPageCount(100);
+                    pg->SetFirstPageNo(111);
+
+                    auto response = fx.Group->ReadPages(request);
+                    EXPECT_EQ(S_OK, response.GetError().GetCode())
+                        << response.GetError().GetMessage();
+                }
+
+                auto& sn = fx.StorageNodes[i % TStorageFixture::NodeCount];
+                const ui32 cnt = 1 + i / TStorageFixture::NodeCount;
+                EXPECT_EQ(cnt, sn->ReadCalls.size());
+                EXPECT_EQ("dev", sn->ReadCalls[cnt - 1].GetDeviceUUID());
+                EXPECT_EQ(1U, sn->ReadCalls[cnt - 1].PageGroupRefsSize());
+                const auto& pg = sn->ReadCalls[cnt - 1].GetPageGroupRefs(0);
+                EXPECT_EQ(4_KB, pg.GetPageSize());
+                EXPECT_EQ(100U, pg.GetPageCount());
+                EXPECT_EQ(111U, pg.GetFirstPageNo());
+            }
+
+            return 0;
+        },
+        0);
+    EXPECT_EQ(0, r);
+}

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
@@ -171,7 +171,18 @@ TEST(NaiveGroupTest, RoundRobinsRead)
         +[](int*) noexcept -> int {
             TStorageFixture fx;
 
+            TVector<NProto::TReadPagesResponse> readResponses(
+                TStorageFixture::NodeCount);
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                auto* pg = readResponses[i].AddPageGroups();
+                pg->SetFirstPageNo(111);
+                pg->AddContent(TStringBuilder() << "aaa" << i);
+                fx.StorageNodes[i]->ReadResp = readResponses[i];
+            }
+
             for (ui32 i = 0; i < 10 * TStorageFixture::NodeCount; ++i) {
+                const ui32 snIndex = i % TStorageFixture::NodeCount;
+
                 {
                     NProto::TReadPagesRequest request;
                     request.SetDeviceUUID("dev");
@@ -184,9 +195,12 @@ TEST(NaiveGroupTest, RoundRobinsRead)
                     auto response = fx.Group->ReadPages(request);
                     EXPECT_EQ(S_OK, response.GetError().GetCode())
                         << response.GetError().GetMessage();
+                    EXPECT_STREQ(
+                        readResponses[snIndex].ShortUtf8DebugString().c_str(),
+                        response.ShortUtf8DebugString().c_str());
                 }
 
-                auto& sn = fx.StorageNodes[i % TStorageFixture::NodeCount];
+                auto& sn = fx.StorageNodes[snIndex];
                 const ui32 cnt = 1 + i / TStorageFixture::NodeCount;
                 EXPECT_EQ(cnt, sn->ReadCalls.size());
                 EXPECT_EQ("dev", sn->ReadCalls[cnt - 1].GetDeviceUUID());

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/ut/ya.make
@@ -1,0 +1,20 @@
+GTEST()
+
+SRCS(
+    ../storage_group_ut.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/sn/iface
+    cloud/filestore/libs/storage/fastshard/sn/quorum
+    cloud/filestore/libs/storage/fastshard/testlib
+
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+
+    contrib/libs/silk/src/fibers
+
+    contrib/restricted/googletest/googletest
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/ya.make
@@ -1,0 +1,31 @@
+LIBRARY()
+
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    SRCS(
+        storage_group.cpp
+    )
+
+    PEERDIR(
+        contrib/libs/silk/src/fibers
+    )
+ELSE()
+    SRCS(
+        storage_group_stub.cpp
+    )
+ENDIF()
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/sn/iface
+
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+)
+
+END()
+
+# TODO(#5895): fix silk bootstrap/shutdown under msan
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB AND SANITIZER_TYPE != "memory")
+    RECURSE_FOR_TESTS(
+        ut
+    )
+ENDIF()

--- a/cloud/filestore/libs/storage/fastshard/sn/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/sn/ya.make
@@ -1,5 +1,6 @@
 RECURSE(
     client
     iface
+    quorum
     server
 )


### PR DESCRIPTION
### Notes
This group implementation just does mirroring for acquire/release/write requests and round-robin for read requests. The main purpose is to do the required number of requests to be able to measure end2end latencies. And to work correctly in happy-path scenarios.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
