### PR TITLE
ListVolumes: sequential schemeshard traversal instead of parallel

### DIFF
--- a/cloud/blockstore/apps/client/lib/list_volumes.cpp
+++ b/cloud/blockstore/apps/client/lib/list_volumes.cpp
@@ -25,7 +25,7 @@ public:
     {
         Opts.AddLongOption(
                 "max-concurrency",
-                "max concurrent schemeshard requests (0 = sequential)")
+                "max concurrent schemeshard requests (0 = server default)")
             .OptionalArgument("NUM")
             .StoreResult(&MaxConcurrency);
     }

--- a/cloud/blockstore/apps/client/lib/list_volumes.cpp
+++ b/cloud/blockstore/apps/client/lib/list_volumes.cpp
@@ -16,21 +16,34 @@ namespace {
 class TListVolumesCommand final
     : public TCommand
 {
+private:
+    ui32 MaxConcurrency = 0;
+
 public:
     TListVolumesCommand(IBlockStorePtr client)
         : TCommand(std::move(client))
-    {}
+    {
+        Opts.AddLongOption(
+                "max-concurrency",
+                "max concurrent schemeshard requests (0 = sequential)")
+            .OptionalArgument("NUM")
+            .StoreResult(&MaxConcurrency);
+    }
 
 protected:
     bool DoExecute() override
     {
         auto& output = GetOutputStream();
 
+        auto request = std::make_shared<NProto::TListVolumesRequest>();
+        if (MaxConcurrency > 0) {
+            request->SetMaxConcurrency(MaxConcurrency);
+        }
+
         STORAGE_DEBUG("Sending ListVolumes request");
         auto result = WaitFor(ClientEndpoint->ListVolumes(
             MakeIntrusive<TCallContext>(),
-            std::make_shared<NProto::TListVolumesRequest>()
-        ));
+            std::move(request)));
 
         STORAGE_DEBUG("Received ListVolumes response");
         if (Proto) {

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1625,9 +1625,4 @@ message TStorageServiceConfig
     // If false (default), UseGentlePreemption param
     // for RebindVolumes action is ignored
     optional bool AllowGentlePreemptionForRebindVolumesAction = 514;
-
-    // Maximum number of concurrent DescribeScheme requests issued by
-    // TDescribeActor during ListVolumes traversal. Prevents flooding
-    // schemeshard while still allowing bounded parallelism.
-    optional uint32 ListVolumesConcurrency = 515;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1625,4 +1625,9 @@ message TStorageServiceConfig
     // If false (default), UseGentlePreemption param
     // for RebindVolumes action is ignored
     optional bool AllowGentlePreemptionForRebindVolumesAction = 514;
+
+    // Maximum number of concurrent DescribeScheme requests issued by
+    // TDescribeActor during ListVolumes traversal. Prevents flooding
+    // schemeshard while still allowing bounded parallelism.
+    optional uint32 ListVolumesConcurrency = 515;
 }

--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1625,4 +1625,8 @@ message TStorageServiceConfig
     // If false (default), UseGentlePreemption param
     // for RebindVolumes action is ignored
     optional bool AllowGentlePreemptionForRebindVolumesAction = 514;
+
+    // Maximum number of concurrent DescribeScheme requests during ListVolumes
+    // traversal. 0 means use this default.
+    optional uint32 ListVolumesConcurrency = 515;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -85,6 +85,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
 // clang-format off
 #define BLOCKSTORE_STORAGE_CONFIG_RO(xxx)                                      \
     xxx(SchemeShardDir,                TString,   "/Root"                     )\
+    xxx(ListVolumesConcurrency,        ui32,      100                         )\
     xxx(DisableLocalService,           bool,      false                       )\
     xxx(ServiceVersionInfo,            TString,   ""                          )\
     xxx(FolderId,                      TString,   ""                          )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -85,6 +85,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
 // clang-format off
 #define BLOCKSTORE_STORAGE_CONFIG_RO(xxx)                                      \
     xxx(SchemeShardDir,                TString,   "/Root"                     )\
+    xxx(ListVolumesConcurrency,        ui32,      8                           )\
     xxx(DisableLocalService,           bool,      false                       )\
     xxx(ServiceVersionInfo,            TString,   ""                          )\
     xxx(FolderId,                      TString,   ""                          )\

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -85,7 +85,6 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
 // clang-format off
 #define BLOCKSTORE_STORAGE_CONFIG_RO(xxx)                                      \
     xxx(SchemeShardDir,                TString,   "/Root"                     )\
-    xxx(ListVolumesConcurrency,        ui32,      8                           )\
     xxx(DisableLocalService,           bool,      false                       )\
     xxx(ServiceVersionInfo,            TString,   ""                          )\
     xxx(FolderId,                      TString,   ""                          )\

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -79,6 +79,7 @@ public:
     [[nodiscard]] NProto::TStorageServiceConfig GetStorageConfigProto() const;
 
     TString GetSchemeShardDir() const;
+    [[nodiscard]] ui32 GetListVolumesConcurrency() const;
     ui32 GetWriteBlobThreshold() const;
     ui32 GetWriteBlobThresholdSSD() const;
     [[nodiscard]] ui32 GetWriteMixedBlobThresholdHDD() const;

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -79,7 +79,6 @@ public:
     [[nodiscard]] NProto::TStorageServiceConfig GetStorageConfigProto() const;
 
     TString GetSchemeShardDir() const;
-    [[nodiscard]] ui32 GetListVolumesConcurrency() const;
     ui32 GetWriteBlobThreshold() const;
     ui32 GetWriteBlobThresholdSSD() const;
     [[nodiscard]] ui32 GetWriteMixedBlobThresholdHDD() const;

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -184,8 +184,9 @@ void TServiceActor::HandleListVolumes(
     auto requestInfo =
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
-    const size_t maxConcurrency =
-        request.GetMaxConcurrency() > 0 ? request.GetMaxConcurrency() : 100;
+    const size_t maxConcurrency = request.GetMaxConcurrency() > 0
+                                      ? request.GetMaxConcurrency()
+                                      : Config->GetListVolumesConcurrency();
 
     LOG_DEBUG(
         ctx,

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -36,8 +36,8 @@ public:
     void Bootstrap(const TActorContext& ctx);
 
 private:
-    void DescribePath(const TActorContext& ctx, const TString& path);
     void ContinueDescribing(const TActorContext& ctx);
+    void DescribePath(const TActorContext& ctx, const TString& path);
 
     void ReplyAndDie(
         const TActorContext& ctx,

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -181,15 +181,15 @@ void TServiceActor::HandleListVolumes(
     const auto* msg = ev->Get();
     const auto& request = msg->Record;
 
-    auto requestInfo = CreateRequestInfo(
-        ev->Sender,
-        ev->Cookie,
-        msg->CallContext);
+    auto requestInfo =
+        CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
     const size_t maxConcurrency =
         request.GetMaxConcurrency() > 0 ? request.GetMaxConcurrency() : 1;
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
         "Listing volumes: %s",
         Config->GetSchemeShardDir().Quote().data());
 

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -97,6 +97,14 @@ void TDescribeActor::DescribePath(const TActorContext& ctx, const TString& path)
         RequestInfo->Cookie);
 }
 
+void TDescribeActor::DispatchPending(const TActorContext& ctx)
+{
+    while (RequestsInFlight < MaxConcurrency && !PendingPaths.empty()) {
+        DescribePath(ctx, PendingPaths.front());
+        PendingPaths.pop_front();
+    }
+}
+
 void TDescribeActor::ReplyAndDie(
     const TActorContext& ctx,
     std::unique_ptr<TEvService::TEvListVolumesResponse> response)

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -97,14 +97,6 @@ void TDescribeActor::DescribePath(const TActorContext& ctx, const TString& path)
         RequestInfo->Cookie);
 }
 
-void TDescribeActor::DispatchPending(const TActorContext& ctx)
-{
-    while (RequestsInFlight < MaxConcurrency && !PendingPaths.empty()) {
-        DescribePath(ctx, PendingPaths.front());
-        PendingPaths.pop_front();
-    }
-}
-
 void TDescribeActor::ReplyAndDie(
     const TActorContext& ctx,
     std::unique_ptr<TEvService::TEvListVolumesResponse> response)
@@ -193,7 +185,7 @@ void TServiceActor::HandleListVolumes(
         CreateRequestInfo(ev->Sender, ev->Cookie, msg->CallContext);
 
     const size_t maxConcurrency =
-        request.GetMaxConcurrency() > 0 ? request.GetMaxConcurrency() : 1;
+        request.GetMaxConcurrency() > 0 ? request.GetMaxConcurrency() : 100;
 
     LOG_DEBUG(
         ctx,

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -21,6 +21,7 @@ class TDescribeActor final
 {
 private:
     const TRequestInfoPtr RequestInfo;
+    const size_t MaxConcurrency;
     TVector<TString> Volumes;
     TDeque<TString> PendingPaths;
     size_t RequestsInFlight = 0;
@@ -28,7 +29,8 @@ private:
 public:
     TDescribeActor(
         TRequestInfoPtr requestInfo,
-        TString rootPath);
+        TString rootPath,
+        size_t maxConcurrency);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -49,17 +51,23 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TDescribeActor::TDescribeActor(TRequestInfoPtr requestInfo, TString rootPath)
+TDescribeActor::TDescribeActor(
+    TRequestInfoPtr requestInfo,
+    TString rootPath,
+    size_t maxConcurrency)
     : RequestInfo(std::move(requestInfo))
+    , MaxConcurrency(maxConcurrency)
 {
     PendingPaths.emplace_back(std::move(rootPath));
 }
 
 void TDescribeActor::Bootstrap(const TActorContext& ctx)
 {
-    TString root = std::move(PendingPaths.front());
-    PendingPaths.pop_front();
-    DescribePath(ctx, root);
+    while (!PendingPaths.empty() && RequestsInFlight < MaxConcurrency) {
+        TString path = std::move(PendingPaths.front());
+        PendingPaths.pop_front();
+        DescribePath(ctx, path);
+    }
     Become(&TThis::StateWork);
 }
 
@@ -143,19 +151,18 @@ void TDescribeActor::HandleDescribeResponse(
         }
     }
 
-    if (RequestsInFlight == 0 && PendingPaths.empty()) {
+    while (RequestsInFlight < MaxConcurrency && !PendingPaths.empty()) {
+        TString next = std::move(PendingPaths.front());
+        PendingPaths.pop_front();
+        DescribePath(ctx, next);
+    }
+
+    if (RequestsInFlight == 0) {
         auto response = std::make_unique<TEvService::TEvListVolumesResponse>();
         for (const auto& volume: Volumes) {
             *response->Record.MutableVolumes()->Add() = volume;
         }
         ReplyAndDie(ctx, std::move(response));
-        return;
-    }
-
-    if (RequestsInFlight == 0 && !PendingPaths.empty()) {
-        TString next = std::move(PendingPaths.front());
-        PendingPaths.pop_front();
-        DescribePath(ctx, next);
     }
 }
 
@@ -185,7 +192,8 @@ void TServiceActor::HandleListVolumes(
     NCloud::Register<TDescribeActor>(
         ctx,
         std::move(requestInfo),
-        Config->GetSchemeShardDir());
+        Config->GetSchemeShardDir(),
+        Config->GetListVolumesConcurrency());
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -25,6 +25,7 @@ private:
     TVector<TString> Volumes;
     TDeque<TString> PendingPaths;
     size_t RequestsInFlight = 0;
+    size_t TotalRequestsScheduled = 0;
 
 public:
     TDescribeActor(
@@ -36,6 +37,7 @@ public:
 
 private:
     void DescribePath(const TActorContext& ctx, const TString& path);
+    void ContinueDescribing(const TActorContext& ctx);
 
     void ReplyAndDie(
         const TActorContext& ctx,
@@ -63,20 +65,26 @@ TDescribeActor::TDescribeActor(
 
 void TDescribeActor::Bootstrap(const TActorContext& ctx)
 {
-    while (!PendingPaths.empty() && RequestsInFlight < MaxConcurrency) {
-        TString path = std::move(PendingPaths.front());
-        PendingPaths.pop_front();
-        DescribePath(ctx, path);
-    }
+    ContinueDescribing(ctx);
     Become(&TThis::StateWork);
+}
+
+void TDescribeActor::ContinueDescribing(const TActorContext& ctx)
+{
+    while (RequestsInFlight < MaxConcurrency && !PendingPaths.empty()) {
+        DescribePath(ctx, PendingPaths.front());
+        PendingPaths.pop_front();
+    }
 }
 
 void TDescribeActor::DescribePath(const TActorContext& ctx, const TString& path)
 {
-    LOG_DEBUG(
+    ++TotalRequestsScheduled;
+    LOG_INFO(
         ctx,
         TBlockStoreComponents::SERVICE,
-        "Sending describe request for path %s",
+        "Sending describe request #%zu for path %s",
+        TotalRequestsScheduled,
         path.Quote().data());
 
     auto request = std::make_unique<TEvSSProxy::TEvDescribeSchemeRequest>(path);
@@ -123,7 +131,7 @@ void TDescribeActor::HandleDescribeResponse(
 
     const auto& error = msg->GetError();
     if (FAILED(error.GetCode())) {
-        LOG_DEBUG(
+        LOG_ERROR(
             ctx,
             TBlockStoreComponents::SERVICE,
             "Path %s: describe failed: %s",
@@ -151,11 +159,7 @@ void TDescribeActor::HandleDescribeResponse(
         }
     }
 
-    while (RequestsInFlight < MaxConcurrency && !PendingPaths.empty()) {
-        TString next = std::move(PendingPaths.front());
-        PendingPaths.pop_front();
-        DescribePath(ctx, next);
-    }
+    ContinueDescribing(ctx);
 
     if (RequestsInFlight == 0) {
         auto response = std::make_unique<TEvService::TEvListVolumesResponse>();
@@ -182,8 +186,8 @@ void TServiceActor::HandleListVolumes(
         ev->Cookie,
         msg->CallContext);
 
-    // TODO: filter?
-    Y_UNUSED(request);
+    const size_t maxConcurrency =
+        request.GetMaxConcurrency() > 0 ? request.GetMaxConcurrency() : 1;
 
     LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
         "Listing volumes: %s",
@@ -193,7 +197,7 @@ void TServiceActor::HandleListVolumes(
         ctx,
         std::move(requestInfo),
         Config->GetSchemeShardDir(),
-        Config->GetListVolumesConcurrency());
+        maxConcurrency);
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_list.cpp
@@ -21,15 +21,14 @@ class TDescribeActor final
 {
 private:
     const TRequestInfoPtr RequestInfo;
-    const TString Path;
     TVector<TString> Volumes;
-    size_t RequestsCompleted = 0;
-    size_t RequestsScheduled = 0;
+    TDeque<TString> PendingPaths;
+    size_t RequestsInFlight = 0;
 
 public:
     TDescribeActor(
         TRequestInfoPtr requestInfo,
-        TString path);
+        TString rootPath);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -50,27 +49,30 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TDescribeActor::TDescribeActor(
-        TRequestInfoPtr requestInfo,
-        TString path)
+TDescribeActor::TDescribeActor(TRequestInfoPtr requestInfo, TString rootPath)
     : RequestInfo(std::move(requestInfo))
-    , Path(std::move(path))
-{}
+{
+    PendingPaths.emplace_back(std::move(rootPath));
+}
 
 void TDescribeActor::Bootstrap(const TActorContext& ctx)
 {
-    DescribePath(ctx, Path);
+    TString root = std::move(PendingPaths.front());
+    PendingPaths.pop_front();
+    DescribePath(ctx, root);
     Become(&TThis::StateWork);
 }
 
 void TDescribeActor::DescribePath(const TActorContext& ctx, const TString& path)
 {
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
         "Sending describe request for path %s",
         path.Quote().data());
 
     auto request = std::make_unique<TEvSSProxy::TEvDescribeSchemeRequest>(path);
-    RequestsScheduled++;
+    ++RequestsInFlight;
 
     NCloud::Send(
         ctx,
@@ -107,15 +109,17 @@ void TDescribeActor::HandleDescribeResponse(
     const TEvSSProxy::TEvDescribeSchemeResponse::TPtr& ev,
     const TActorContext& ctx)
 {
-    RequestsCompleted++;
+    --RequestsInFlight;
 
     const auto* msg = ev->Get();
 
     const auto& error = msg->GetError();
     if (FAILED(error.GetCode())) {
-        LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+        LOG_DEBUG(
+            ctx,
+            TBlockStoreComponents::SERVICE,
             "Path %s: describe failed: %s",
-            Path.Quote().data(),
+            msg->Path.Quote().data(),
             FormatError(error).data());
 
         ReplyAndDie(
@@ -130,7 +134,7 @@ void TDescribeActor::HandleDescribeResponse(
         const auto& descr = pathDescription.GetChildren(i);
 
         if (descr.GetPathType() == NKikimrSchemeOp::EPathTypeDir) {
-            DescribePath(ctx, msg->Path + "/" + descr.GetName());
+            PendingPaths.emplace_back(msg->Path + "/" + descr.GetName());
             continue;
         }
 
@@ -139,18 +143,20 @@ void TDescribeActor::HandleDescribeResponse(
         }
     }
 
-    if (RequestsCompleted != RequestsScheduled) {
-        Y_DEBUG_ABORT_UNLESS(RequestsCompleted < RequestsScheduled);
+    if (RequestsInFlight == 0 && PendingPaths.empty()) {
+        auto response = std::make_unique<TEvService::TEvListVolumesResponse>();
+        for (const auto& volume: Volumes) {
+            *response->Record.MutableVolumes()->Add() = volume;
+        }
+        ReplyAndDie(ctx, std::move(response));
         return;
     }
 
-    auto response = std::make_unique<TEvService::TEvListVolumesResponse>();
-
-    for (const auto& volume : Volumes) {
-        *response->Record.MutableVolumes()->Add() = volume;
+    if (RequestsInFlight == 0 && !PendingPaths.empty()) {
+        TString next = std::move(PendingPaths.front());
+        PendingPaths.pop_front();
+        DescribePath(ctx, next);
     }
-
-    ReplyAndDie(ctx, std::move(response));
 }
 
 }   // namespace

--- a/cloud/blockstore/libs/storage/service/service_ut_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_list.cpp
@@ -36,6 +36,51 @@ Y_UNIT_TEST_SUITE(TServiceListVolumesTest)
         UNIT_ASSERT_VALUES_EQUAL(volumes, expected);
     }
 
+    Y_UNIT_TEST(ShouldListVolumesBoundedConcurrency)
+    {
+        constexpr size_t concurrency = 8;
+
+        NProto::TStorageServiceConfig config;
+        config.SetListVolumesConcurrency(concurrency);
+
+        TTestEnv env;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+
+        for (int i = 0; i < 20; ++i) {
+            service.CreateVolume("vol-seq-" + ToString(i));
+        }
+
+        size_t inFlight = 0;
+        size_t maxInFlight = 0;
+
+        runtime.SetObserverFunc(
+            [&inFlight, &maxInFlight](TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeSchemeRequest:
+                        maxInFlight = Max(maxInFlight, ++inFlight);
+                        break;
+                    case TEvSSProxy::EvDescribeSchemeResponse:
+                        inFlight -= (inFlight > 0);
+                        break;
+                }
+                return TTestActorRuntime::DefaultObserverFunc(event);
+            });
+
+        auto response = service.ListVolumes();
+
+        UNIT_ASSERT_C(
+            SUCCEEDED(response->GetStatus()),
+            response->GetErrorReason());
+        UNIT_ASSERT_C(
+            maxInFlight <= concurrency,
+            TStringBuilder() << "maxInFlight=" << maxInFlight
+                             << " exceeds ListVolumesConcurrency=" << concurrency);
+    }
+
     Y_UNIT_TEST(ShouldFailListVolumesIfDescribeSchemeFails)
     {
         TTestEnv env;

--- a/cloud/blockstore/libs/storage/service/service_ut_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_list.cpp
@@ -38,7 +38,7 @@ Y_UNIT_TEST_SUITE(TServiceListVolumesTest)
 
     Y_UNIT_TEST(ShouldListVolumesBoundedConcurrency)
     {
-        constexpr ui32 concurrency = 1;
+        constexpr ui32 concurrency = 4;
 
         TTestEnv env;
         ui32 nodeIdx = SetupTestEnv(env);

--- a/cloud/blockstore/libs/storage/service/service_ut_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_list.cpp
@@ -38,13 +38,10 @@ Y_UNIT_TEST_SUITE(TServiceListVolumesTest)
 
     Y_UNIT_TEST(ShouldListVolumesBoundedConcurrency)
     {
-        constexpr size_t concurrency = 8;
-
-        NProto::TStorageServiceConfig config;
-        config.SetListVolumesConcurrency(concurrency);
+        constexpr ui32 concurrency = 1;
 
         TTestEnv env;
-        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+        ui32 nodeIdx = SetupTestEnv(env);
 
         auto& runtime = env.GetRuntime();
         TServiceClient service(runtime, nodeIdx);
@@ -70,7 +67,10 @@ Y_UNIT_TEST_SUITE(TServiceListVolumesTest)
                 return TTestActorRuntime::DefaultObserverFunc(event);
             });
 
-        auto response = service.ListVolumes();
+        auto request = service.CreateListVolumesRequest();
+        request->Record.SetMaxConcurrency(concurrency);
+        service.SendListVolumesRequest(std::move(request));
+        auto response = service.RecvListVolumesResponse();
 
         UNIT_ASSERT_C(
             SUCCEEDED(response->GetStatus()),
@@ -78,7 +78,7 @@ Y_UNIT_TEST_SUITE(TServiceListVolumesTest)
         UNIT_ASSERT_C(
             maxInFlight <= concurrency,
             TStringBuilder() << "maxInFlight=" << maxInFlight
-                             << " exceeds ListVolumesConcurrency=" << concurrency);
+                             << " exceeds MaxConcurrency=" << concurrency);
     }
 
     Y_UNIT_TEST(ShouldFailListVolumesIfDescribeSchemeFails)

--- a/cloud/blockstore/libs/storage/service/service_ut_list.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_list.cpp
@@ -69,7 +69,7 @@ Y_UNIT_TEST_SUITE(TServiceListVolumesTest)
 
         auto request = service.CreateListVolumesRequest();
         request->Record.SetMaxConcurrency(concurrency);
-        service.SendListVolumesRequest(std::move(request));
+        service.SendRequest(MakeStorageServiceId(), std::move(request));
         auto response = service.RecvListVolumesResponse();
 
         UNIT_ASSERT_C(

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -648,6 +648,10 @@ message TListVolumesRequest
 {
     // Optional request headers.
     THeaders Headers = 1;
+
+    // Maximum number of concurrent DescribeScheme requests during traversal.
+    // 0 means sequential (default).
+    uint32 MaxConcurrency = 2;
 }
 
 message TListVolumesResponse

--- a/cloud/blockstore/public/api/protos/volume.proto
+++ b/cloud/blockstore/public/api/protos/volume.proto
@@ -650,7 +650,7 @@ message TListVolumesRequest
     THeaders Headers = 1;
 
     // Maximum number of concurrent DescribeScheme requests during traversal.
-    // 0 means sequential (default).
+    // 0 means use server default.
     uint32 MaxConcurrency = 2;
 }
 

--- a/cloud/blockstore/tests/client/test_with_client.py
+++ b/cloud/blockstore/tests/client/test_with_client.py
@@ -918,6 +918,23 @@ def test_createvolume_with_tags():
     tear_down(env)
 
 
+def test_list_volumes():
+    env, run = setup()
+
+    disk_ids = ["vol-list-0", "vol-list-1", "vol-list-2"]
+    for disk_id in disk_ids:
+        run("createvolume",
+            "--disk-id", disk_id,
+            "--blocks-count", str(BLOCKS_COUNT))
+
+    response = list_volumes(env, run)
+    for disk_id in disk_ids:
+        assert disk_id in response.Volumes, \
+            f"{disk_id} not found in ListVolumes response: {list(response.Volumes)}"
+
+    tear_down(env)
+
+
 def test_describe_volume_with_exact_disk_id_match():
     env, run = setup(with_nrd=True, nrd_device_count=2, rack='')
 


### PR DESCRIPTION
ListVolumes: traverse schemeshard directories sequentially to avoid flooding it with parallel requests