### PR TITLE
[NBS] Add grace period before stopping partitions after GC

### DIFF
--- a/cloud/blockstore/config/storage.proto
+++ b/cloud/blockstore/config/storage.proto
@@ -1621,4 +1621,10 @@ message TStorageServiceConfig
 
     // Use read or recreated compaction blob metas during cleanup.
     optional bool UseRecreatedBlobMetasOnCleanup = 513;
+
+    // Grace period (in milliseconds) before stopping partitions after GC
+    // completion when the volume has no active clients. If a client connects
+    // during this period, partitions stay up and are upgraded to STARTED_FOR_USE
+    // without a costly reboot. 0 means disabled (stop immediately, old behavior).
+    optional uint32 StopPartitionsAfterGcGracePeriod = 514;
 }

--- a/cloud/blockstore/libs/storage/core/config.cpp
+++ b/cloud/blockstore/libs/storage/core/config.cpp
@@ -715,6 +715,7 @@ NProto::TLinkedDiskFillBandwidth GetBandwidth(
     xxx(SplitByCompactionRangeMaxBlobCount,         ui64,       0             )\
     xxx(VerifyRecreatedBlobMetasOnCleanup,          bool,       false         )\
     xxx(UseRecreatedBlobMetasOnCleanup,             bool,       false         )\
+    xxx(StopPartitionsAfterGcGracePeriod,           ui32,       0             )\
 
 // BLOCKSTORE_STORAGE_CONFIG_RW
 // clang-format on

--- a/cloud/blockstore/libs/storage/core/config.h
+++ b/cloud/blockstore/libs/storage/core/config.h
@@ -853,6 +853,8 @@ public:
     [[nodiscard]] bool GetVerifyRecreatedBlobMetasOnCleanup() const;
 
     [[nodiscard]] bool GetUseRecreatedBlobMetasOnCleanup() const;
+
+    [[nodiscard]] ui32 GetStopPartitionsAfterGcGracePeriod() const;
 };
 
 ui64 GetAllocationUnit(

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -1167,6 +1167,7 @@ STFUNC(TVolumeActor::StateWork)
             HandleWaitReadyResponse);
         HFunc(TEvPartition::TEvBackpressureReport, HandleBackpressureReport);
         HFunc(TEvPartition::TEvGarbageCollectorCompleted, HandleGarbageCollectorCompleted);
+        HFunc(TEvVolumePrivate::TEvStopPartitionsAfterGc, HandleStopPartitionsAfterGc);
 
         HFunc(TEvVolume::TEvPreparePartitionMigrationRequest, HandlePreparePartitionMigration);
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -412,6 +412,7 @@ private:
     ui64 PartitionRestartCounter = 0;
 
     TVector<ui64> GCCompletedPartitions;
+    bool StopPartitionsAfterGcScheduled = false;
 
     std::optional<TOutdatedLeaderDestruction> OutdatedLeaderDestruction;
 
@@ -1086,6 +1087,10 @@ private:
 
     void HandleGarbageCollectorCompleted(
         const NPartition::TEvPartition::TEvGarbageCollectorCompleted::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleStopPartitionsAfterGc(
+        const TEvVolumePrivate::TEvStopPartitionsAfterGc::TPtr& ev,
         const NActors::TActorContext& ctx);
 
     void HandleWakeup(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -189,6 +189,7 @@ void TVolumeActor::StartPartitionsIfNeeded(const TActorContext& ctx)
             }
             case EPartitionsStartedReason::STARTED_FOR_GC: {
                 PartitionsStartedReason = EPartitionsStartedReason::STARTED_FOR_USE;
+                StopPartitionsAfterGcScheduled = false;
                 return;
             }
             case EPartitionsStartedReason::STARTED_FOR_USE: {

--- a/cloud/blockstore/libs/storage/volume/volume_actor_updatestartpartitionsneeded.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_updatestartpartitionsneeded.cpp
@@ -4,6 +4,8 @@
 
 #include <cloud/blockstore/libs/storage/core/probes.h>
 #include <cloud/blockstore/libs/storage/core/proto_helpers.h>
+
+#include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/verify.h>
 
 namespace NCloud::NBlockStore::NStorage {
@@ -45,15 +47,33 @@ void TVolumeActor::ExecuteResetStartPartitionsNeeded(
                 GCCompletedPartitions.push_back(args.PartitionTabletId);
                 return;
             }
-            LOG_INFO(
-                ctx,
-                TBlockStoreComponents::VOLUME,
-                "%s Stopping partitions after gc finished",
-                LogTitle.GetWithTime().c_str());
 
-            StopPartitions(ctx, {});
-            State->Reset();
-            PartitionsStartedReason = EPartitionsStartedReason::NOT_STARTED;
+            const auto gracePeriod = TDuration::MilliSeconds(
+                Config->GetStopPartitionsAfterGcGracePeriod());
+
+            if (gracePeriod != TDuration::Zero()) {
+                LOG_INFO(
+                    ctx,
+                    TBlockStoreComponents::VOLUME,
+                    "%s Scheduling partition stop after %s grace period",
+                    LogTitle.GetWithTime().c_str(),
+                    FormatDuration(gracePeriod).c_str());
+
+                StopPartitionsAfterGcScheduled = true;
+                ctx.Schedule(
+                    gracePeriod,
+                    new TEvVolumePrivate::TEvStopPartitionsAfterGc());
+            } else {
+                LOG_INFO(
+                    ctx,
+                    TBlockStoreComponents::VOLUME,
+                    "%s Stopping partitions after gc finished",
+                    LogTitle.GetWithTime().c_str());
+
+                StopPartitions(ctx, {});
+                State->Reset();
+                PartitionsStartedReason = EPartitionsStartedReason::NOT_STARTED;
+            }
         }
         TVolumeDatabase db(tx.DB);
         State->SetStartPartitionsNeeded(false);
@@ -91,6 +111,50 @@ void TVolumeActor::HandleGarbageCollectorCompleted(
         ExecuteTx(ctx, CreateTx<TResetStartPartitionsNeeded>(
             requestInfo, partitionTabletId));
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TVolumeActor::HandleStopPartitionsAfterGc(
+    const TEvVolumePrivate::TEvStopPartitionsAfterGc::TPtr& ev,
+    const TActorContext& ctx)
+{
+    Y_UNUSED(ev);
+
+    StopPartitionsAfterGcScheduled = false;
+
+    if (PartitionsStartedReason != EPartitionsStartedReason::STARTED_FOR_GC) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "%s Grace period expired but partitions are no longer in gc mode "
+            "(reason: %d), skipping stop",
+            LogTitle.GetWithTime().c_str(),
+            static_cast<int>(PartitionsStartedReason));
+        return;
+    }
+
+    if (State && State->HasActiveClients(ctx.Now())) {
+        LOG_INFO(
+            ctx,
+            TBlockStoreComponents::VOLUME,
+            "%s Grace period expired but a client has connected, skipping stop",
+            LogTitle.GetWithTime().c_str());
+        PartitionsStartedReason = EPartitionsStartedReason::STARTED_FOR_USE;
+        return;
+    }
+
+    LOG_INFO(
+        ctx,
+        TBlockStoreComponents::VOLUME,
+        "%s Grace period expired, stopping partitions after gc",
+        LogTitle.GetWithTime().c_str());
+
+    StopPartitions(ctx, {});
+    if (State) {
+        State->Reset();
+    }
+    PartitionsStartedReason = EPartitionsStartedReason::NOT_STARTED;
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_events_private.h
+++ b/cloud/blockstore/libs/storage/volume/volume_events_private.h
@@ -547,6 +547,7 @@ struct TEvVolumePrivate
         EvCreateLinkFinished,
         EvDiskRegistryDeviceOperationStarted,
         EvDiskRegistryDeviceOperationFinished,
+        EvStopPartitionsAfterGc,
 
         EvEnd
     };
@@ -651,6 +652,9 @@ struct TEvVolumePrivate
     using TEvDiskRegistryDeviceOperationFinished = TRequestEvent<
         TDiskRegistryDeviceOperationFinished,
         EvDiskRegistryDeviceOperationFinished>;
+
+    using TEvStopPartitionsAfterGc =
+        TRequestEvent<TEmpty, EvStopPartitionsAfterGc>;
 };
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/volume/volume_ut.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut.cpp
@@ -11377,6 +11377,147 @@ Y_UNIT_TEST_SUITE(TVolumeTest)
 
         UNIT_ASSERT(deadActors.contains(firstFollower));
     }
+
+    Y_UNIT_TEST(ShouldDeferStopPartitionsAfterGcWhenGracePeriodSet)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetStopPartitionsAfterGcGracePeriod(5000);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TVolumeClient volume(*runtime);
+
+        bool externalBootHappened = false;
+        bool garbageCollectorCompleted = false;
+        bool partitionsStopped = false;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartition::EvWaitReadyResponse: {
+                        externalBootHappened = true;
+                        break;
+                    }
+                    case TEvPartition::EvGarbageCollectorCompleted: {
+                        garbageCollectorCompleted = true;
+                        break;
+                    }
+                    case TEvBootstrapper::EvStop: {
+                        partitionsStopped = true;
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        volume.UpdateVolumeConfig();
+        volume.RebootTablet();
+
+        UNIT_ASSERT(externalBootHappened);
+        UNIT_ASSERT(garbageCollectorCompleted);
+        UNIT_ASSERT(partitionsStopped);
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            false);
+
+        volume.AddClient(clientInfo);
+        volume.RemoveClient(clientInfo.GetClientId());
+
+        externalBootHappened = false;
+        garbageCollectorCompleted = false;
+        partitionsStopped = false;
+
+        volume.RebootTablet();
+
+        // Partitions started for GC
+        UNIT_ASSERT(externalBootHappened);
+        UNIT_ASSERT(garbageCollectorCompleted);
+        // Partitions should NOT be stopped yet — grace period active
+        UNIT_ASSERT(!partitionsStopped);
+
+        // Advance time past the grace period
+        runtime->AdvanceCurrentTime(TDuration::Seconds(6));
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(TEvBootstrapper::EvStop);
+        runtime->DispatchEvents(options, TDuration::MilliSeconds(100));
+
+        // Now partitions should be stopped
+        UNIT_ASSERT(partitionsStopped);
+    }
+
+    Y_UNIT_TEST(ShouldNotStopPartitionsIfClientConnectsDuringGracePeriod)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetStopPartitionsAfterGcGracePeriod(5000);
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TVolumeClient volume(*runtime);
+
+        bool externalBootHappened = false;
+        bool garbageCollectorCompleted = false;
+        bool partitionsStopped = false;
+
+        runtime->SetEventFilter(
+            [&] (TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event) {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartition::EvWaitReadyResponse: {
+                        externalBootHappened = true;
+                        break;
+                    }
+                    case TEvPartition::EvGarbageCollectorCompleted: {
+                        garbageCollectorCompleted = true;
+                        break;
+                    }
+                    case TEvBootstrapper::EvStop: {
+                        partitionsStopped = true;
+                        break;
+                    }
+                }
+                return false;
+            }
+        );
+
+        volume.UpdateVolumeConfig();
+        volume.RebootTablet();
+
+        auto clientInfo = CreateVolumeClientInfo(
+            NProto::VOLUME_ACCESS_READ_WRITE,
+            NProto::VOLUME_MOUNT_LOCAL,
+            false);
+
+        volume.AddClient(clientInfo);
+        volume.RemoveClient(clientInfo.GetClientId());
+
+        externalBootHappened = false;
+        garbageCollectorCompleted = false;
+        partitionsStopped = false;
+
+        volume.RebootTablet();
+
+        // Partitions started for GC
+        UNIT_ASSERT(externalBootHappened);
+        UNIT_ASSERT(garbageCollectorCompleted);
+        // Partitions should NOT be stopped — grace period active
+        UNIT_ASSERT(!partitionsStopped);
+
+        // Client connects during grace period — AddClient triggers
+        // StartPartitionsIfNeeded which upgrades STARTED_FOR_GC to
+        // STARTED_FOR_USE and clears StopPartitionsAfterGcScheduled
+        volume.AddClient(clientInfo);
+
+        // Advance time past the grace period
+        runtime->AdvanceCurrentTime(TDuration::Seconds(6));
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(TEvBootstrapper::EvStop);
+        runtime->DispatchEvents(options, TDuration::MilliSeconds(100));
+
+        // Partitions must NOT be stopped because they were upgraded to USE
+        UNIT_ASSERT(!partitionsStopped);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
During mass NBS node restarts, volume tablets reboot and start partitions for garbage collection (GC). Once GC completes, partitions are stopped immediately. If a client attempts to mount the disk moments after GC finishes, it has to wait for partitions to boot again from scratch — adding latency and contributing to mount timeouts, especially for encrypted disks that depend on synchronous KMS/IAM/Compute calls.

Added a configurable grace period (`StopPartitionsAfterGcGracePeriod`, milliseconds, default 0 = disabled) that defers partition stop after all partitions report GC completion.