### PR TITLE
 add silk_env_stub for testlib

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/testlib/silk_env.cpp
+++ b/cloud/filestore/libs/storage/fastshard/testlib/silk_env.cpp
@@ -3,6 +3,8 @@
 #include <silk/fibers/fiber.h>
 #include <silk/util/init.h>
 
+#include <gtest/gtest.h>
+
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
 namespace {

--- a/cloud/filestore/libs/storage/fastshard/testlib/silk_env.h
+++ b/cloud/filestore/libs/storage/fastshard/testlib/silk_env.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <gtest/gtest.h>
+namespace testing {
+
+class Environment;
+
+}   // namespace testing
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
@@ -17,6 +21,7 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
  *         ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
  *
  * @return - Owning pointer, hand to ::testing::AddGlobalTestEnvironment.
+ *           In stub builds this returns nullptr, which gtest ignores.
  */
 ::testing::Environment* MakeSilkTestEnv();
 

--- a/cloud/filestore/libs/storage/fastshard/testlib/silk_env_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/testlib/silk_env_stub.cpp
@@ -1,0 +1,12 @@
+#include "silk_env.h"
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+::testing::Environment* MakeSilkTestEnv()
+{
+    return nullptr;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/testlib/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/testlib/ya.make
@@ -2,17 +2,30 @@ LIBRARY()
 
 SRCS(
     fake_storage_node.cpp
-    silk_env.cpp
 )
+
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    SRCS(
+        silk_env.cpp
+    )
+ELSE()
+    SRCS(
+        silk_env_stub.cpp
+    )
+ENDIF()
 
 PEERDIR(
     cloud/filestore/libs/storage/fastshard/sn/iface
 
     cloud/storage/core/protos
-
-    contrib/libs/silk/src/fibers
-
-    contrib/restricted/googletest/googletest
 )
+
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    PEERDIR(
+        contrib/libs/silk/src/fibers
+
+        contrib/restricted/googletest/googletest
+    )
+ENDIF()
 
 END()


### PR DESCRIPTION
### Notes
Notes
This PR adds stub-mode support for `cloud/filestore/libs/storage/fastshard/testlib`.
When `FORCE_FASTSHARD_IPC_STUB` is enabled, testlib now builds a no-op `MakeSilkTestEnv()` implementation instead of the real silk-based environment, and no longer links `contrib/libs/silk/src/fibers`


### Issue
Build failed in Arcadia without cotnrib/silk library
```
PEERDIR from $S/cloud/filestore/libs/storage/fastshard/testlib to $S/contrib/restricted/googletest/googletest is prohibited by peerdir policy and skipped.
See https://docs.yandex-team.ru/ya-make/manual/common/peerdir_rules#policy for details

PEERDIR to missing directory: $S/contrib/libs/silk/src/fibers

could not resolve include file: gtest/gtest.h included from here: $S/cloud/filestore/libs/storage/fastshard/testlib/silk_env.h

could not resolve include file: silk/fibers/fiber.h included from here: $S/cloud/filestore/libs/storage/fastshard/testlib/silk_env.cpp

could not resolve include file: silk/util/init.h included from here: $S/cloud/filestore/libs/storage/fastshard/testlib/silk_env.cpp
```
