### PR TITLE
Fix missing return statement in HandleChangeVolumeBindingRequest

### DIFF
--- a/cloud/blockstore/libs/storage/service/volume_session_actor_binding.cpp
+++ b/cloud/blockstore/libs/storage/service/volume_session_actor_binding.cpp
@@ -69,6 +69,7 @@ void TVolumeSessionActor::HandleChangeVolumeBindingRequest(
         if (VolumeInfo->BindingType == NProto::BINDING_LOCAL) {
             replyError(
                 MakeError(S_ALREADY, "Volume is already running at host"));
+            return;
         }
         bindingType = NProto::BINDING_LOCAL;
     }


### PR DESCRIPTION
Fix missing return statement in HandleChangeVolumeBindingRequest in no-action-required check.
Could potentially cause redundant remounts
