### PR TITLE
[NBS] Remove  from blockstore-client in e2e-tests-vhost

### DIFF
--- a/cloud/blockstore/tests/e2e-tests-vhost/test.py
+++ b/cloud/blockstore/tests/e2e-tests-vhost/test.py
@@ -61,7 +61,6 @@ def init(stored_endpoints_path=None):
     def run(*args, **kwargs):
         args = [BLOCKSTORE_CLIENT_PATH,
                 *args,
-                "--grpc-trace",
                 "--config",
                 str(client_config_path)]
         script_input = kwargs.get("input")


### PR DESCRIPTION
Remove `--grpc-trace` from `blockstore-client` in the `e2e-tests-vhost` test to avoid a shutdown crash caused by gRPC logging after the logger has been destroyed.

#6500