### PR TITLE
DiskRegistry Monitoring fix dirty device cleanup state time

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -91,7 +91,9 @@ private:
     bool UsersNotificationInProgress = false;
     bool DiskStatesPublicationInProgress = false;
     bool AutomaticallyReplacedDevicesDeletionInProgress = false;
+    THashSet<TString> SecureEraseScheduledPools;
     THashSet<TString> SecureEraseInProgressPerPool;
+    THashMap<TString, TInstant> DeviceCleanupStartTs;
     bool StartMigrationInProgress = false;
 
     TVector<TString> DisksBeingDestroyed;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -2491,26 +2491,31 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
     TVector<TDirtyDeviceEntry> broken;
     TVector<TDirtyDeviceEntry> blocked;
     for (const auto& device: dirtyDevices) {
+        const TString uuid = device.GetDeviceUUID();
+        TInstant stateTs;
+        if (const auto* ts = DeviceCleanupStartTs.FindPtr(uuid)) {
+            stateTs = *ts;
+        }
         TDirtyDeviceEntry entry{
-            .Uuid = device.GetDeviceUUID(),
-            .StateTs = TInstant::MicroSeconds(device.GetStateTs()),
+            .Uuid = uuid,
+            .StateTs = stateTs,
             .PoolName = device.GetPoolName(),
             .StateMessage = device.GetStateMessage(),
         };
-
+        const NProto::TAgentConfig* agent =
+            State->FindAgent(device.GetNodeId());
         if (device.GetState() == NProto::DEVICE_STATE_ERROR) {
+            if (agent) {
+                entry.AgentId = agent->GetAgentId();
+            }
             broken.push_back(std::move(entry));
             continue;
         }
-
         if (device.GetState() != NProto::DEVICE_STATE_ONLINE &&
             device.GetState() != NProto::DEVICE_STATE_WARNING)
         {
             continue;
         }
-
-        const NProto::TAgentConfig* agent =
-            State->FindAgent(device.GetNodeId());
         if (!agent) {
             waiting.push_back(std::move(entry));
         } else if (agent->GetState() == NProto::AGENT_STATE_UNAVAILABLE) {
@@ -2530,9 +2535,11 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
     }
 
     HTML (out) {
+        const auto now = TInstant::Now();
         auto renderTable = [&](const TString& title,
                                const TVector<TDirtyDeviceEntry>& rows,
-                               bool agentRed)
+                               bool agentRed,
+                               bool showCleanupTime)
         {
             TAG (TH3) {
                 out << title << " (" << rows.size() << ")";
@@ -2560,7 +2567,9 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
                             out << "In state since";
                         }
                         TABLEH () {
-                            out << "Time in state";
+                            out
+                                << (showCleanupTime ? "Time in cleanup"
+                                                    : "Time in state");
                         }
                     }
                 }
@@ -2587,23 +2596,39 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
                             out << e.StateMessage;
                         }
                         TABLED () {
-                            out << e.StateTs.FormatGmTime(
-                                "%Y-%m-%d %H:%M:%S UTC");
+                            if (e.StateTs) {
+                                out << e.StateTs.FormatGmTime(
+                                    "%Y-%m-%d %H:%M:%S UTC");
+                            } else {
+                                out << "N/A";
+                            }
                         }
                         TABLED () {
-                            out << FormatDuration(TInstant::Now() - e.StateTs);
+                            if (showCleanupTime) {
+                                const auto* cleanupTs =
+                                    DeviceCleanupStartTs.FindPtr(e.Uuid);
+                                if (cleanupTs) {
+                                    out << FormatDuration(now - *cleanupTs);
+                                } else {
+                                    out << "N/A";
+                                }
+                            } else if (e.StateTs) {
+                                out << FormatDuration(now - e.StateTs);
+                            } else {
+                                out << "N/A";
+                            }
                         }
                     }
                 }
             }
         };
 
-        renderTable("Clean up in progress", processing, false);
-        renderTable("Ready for cleanup", cleaning, false);
-        renderTable("Waiting for cleanup", waiting, false);
-        renderTable("Agent unavailable", agentDown, true);
-        renderTable("Cleanup blocked", blocked, false);
-        renderTable("Device broken", broken, false);
+        renderTable("Clean up in progress", processing, false, true);
+        renderTable("Ready for cleanup", cleaning, false, false);
+        renderTable("Waiting for cleanup", waiting, false, false);
+        renderTable("Agent unavailable", agentDown, true, false);
+        renderTable("Cleanup blocked", blocked, false, false);
+        renderTable("Device broken", broken, false, false);
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -342,6 +342,10 @@ void TDiskRegistryActor::CompleteCleanupDevices(
     for (const auto& diskId: args.SyncDeallocatedDisks) {
         ReplyToPendingDeallocations(ctx, diskId);
     }
+
+    for (const auto& uuid: args.Devices) {
+        DeviceCleanupStartTs.erase(uuid);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -349,6 +353,11 @@ void TDiskRegistryActor::CompleteCleanupDevices(
 void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
 {
     auto dirtyDevices = State->GetDirtyDevices();
+
+    for (const auto& device: dirtyDevices) {
+        DeviceCleanupStartTs.emplace(device.GetDeviceUUID(), ctx.Now());
+    }
+
     EraseIf(
         dirtyDevices,
         [this](auto& device) { return !State->CanSecureErase(device); });
@@ -389,11 +398,12 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
             [&poolName](const auto& device)
             { return poolName == device.GetPoolName(); });
 
-        auto [_, alreadyInProgress] =
-            SecureEraseInProgressPerPool.insert(poolName);
-        if (!alreadyInProgress) {
+        if (SecureEraseScheduledPools.contains(poolName) ||
+            SecureEraseInProgressPerPool.contains(poolName))
+        {
             continue;
         }
+        SecureEraseScheduledPools.insert(poolName);
 
         auto request =
             std::make_unique<TEvDiskRegistryPrivate::TEvSecureEraseRequest>(
@@ -452,6 +462,13 @@ void TDiskRegistryActor::HandleSecureErase(
         "%s Received SecureErase request. DirtyDevices: %s",
         LogTitle.GetWithTime().c_str(),
         MakeDevicesNamesString(msg->DirtyDevices).c_str());
+
+    SecureEraseScheduledPools.erase(msg->PoolName);
+    SecureEraseInProgressPerPool.insert(msg->PoolName);
+
+    for (const auto& device: msg->DirtyDevices) {
+        DeviceCleanupStartTs[device.GetDeviceUUID()] = ctx.Now();
+    }
 
     auto actor = NCloud::Register<TSecureEraseActor>(
         ctx,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -405,6 +405,10 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
         }
         SecureEraseScheduledPools.insert(poolName);
 
+        for (auto it2 = first; it2 != it; ++it2) {
+            DeviceCleanupStartTs[it2->GetDeviceUUID()] = ctx.Now();
+        }
+
         auto request =
             std::make_unique<TEvDiskRegistryPrivate::TEvSecureEraseRequest>(
                 poolName,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
@@ -104,7 +104,9 @@ void TDiskRegistryActor::CompleteWritableState(
     DisksNotificationInProgress = false;
     UsersNotificationInProgress = false;
     DiskStatesPublicationInProgress = false;
+    SecureEraseScheduledPools.clear();
     SecureEraseInProgressPerPool.clear();
+    DeviceCleanupStartTs.clear();
     StartMigrationInProgress = false;
 }
 


### PR DESCRIPTION
 In #6319, devices jumped directly to "Clean up in progress" skipping "Ready for cleanup", and timestamps were inaccurate. Fixed by tracking cleanup start time in DeviceCleanupStartTs and moving SecureEraseInProgressPerPool.insert() to HandleSecureErase() so it reflects actual erase start, not scheduling time


<img width="2284" height="920" alt="image" src="https://github.com/user-attachments/assets/b8d2eef3-4092-4f6e-92cc-00ee0982ae65" />

that TimeInCleanup shows how long the disk has been in the cleanup/erase process. However, if Disk Registry restarts, this time is calculated relative to the restart moment
