### PR TITLE
issue-6508: [Filestore] Add RequestBytes tracking to filestore/tools/testing/loadtest

### DIFF
--- a/cloud/filestore/libs/service/request.cpp
+++ b/cloud/filestore/libs/service/request.cpp
@@ -128,6 +128,17 @@ ui64 CalculateByteCount<NProto::TWriteDataRequest>(
     return byteCount;
 }
 
+template <>
+ui64 CalculateByteCount<NProto::TReadDataResponse>(
+    const NProto::TReadDataResponse& response)
+{
+    if (!response.GetBuffer().empty()) {
+        return response.GetBuffer().size() - response.GetBufferOffset();
+    }
+
+    return response.GetLength();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #define FILESTORE_DECLARE_REQUEST(name, ...) #name,

--- a/cloud/filestore/libs/service/request_i.h
+++ b/cloud/filestore/libs/service/request_i.h
@@ -185,6 +185,10 @@ template <>
 ui64 CalculateByteCount<NProto::TWriteDataRequest>(
     const NProto::TWriteDataRequest& request);
 
+template <>
+ui64 CalculateByteCount<NProto::TReadDataResponse>(
+    const NProto::TReadDataResponse& response);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr bool IsDataChannel(NCloud::NProto::ERequestSource source)

--- a/cloud/filestore/libs/service/ut/request_ut.cpp
+++ b/cloud/filestore/libs/service/ut/request_ut.cpp
@@ -64,6 +64,30 @@ Y_UNIT_TEST_SUITE(TCalculateByteCountTest)
 
         UNIT_ASSERT_VALUES_EQUAL(0, CalculateByteCount(request));
     }
+
+    Y_UNIT_TEST(ShouldReturnBufferSizeMinusOffsetForReadDataResponse)
+    {
+        NProto::TReadDataResponse response;
+        response.SetBuffer("xxhello");
+        response.SetBufferOffset(2);
+
+        UNIT_ASSERT_VALUES_EQUAL(5, CalculateByteCount(response));
+    }
+
+    Y_UNIT_TEST(ShouldReturnLengthForReadDataResponseWithoutBuffer)
+    {
+        NProto::TReadDataResponse response;
+        response.SetLength(4096);
+
+        UNIT_ASSERT_VALUES_EQUAL(4096, CalculateByteCount(response));
+    }
+
+    Y_UNIT_TEST(ShouldReturnZeroForEmptyReadDataResponse)
+    {
+        NProto::TReadDataResponse response;
+
+        UNIT_ASSERT_VALUES_EQUAL(0, CalculateByteCount(response));
+    }
 }
 
 }   // namespace NCloud::NFileStore

--- a/cloud/filestore/tools/testing/loadtest/lib/request.h
+++ b/cloud/filestore/tools/testing/loadtest/lib/request.h
@@ -24,13 +24,19 @@ struct TCompletedRequest
 {
     NProto::EAction Action{};
     TDuration Elapsed;
+    ui64 RequestBytes = 0;
     NProto::TError Error;
 
     TCompletedRequest() = default;
 
-    TCompletedRequest(NProto::EAction action, TInstant start, NProto::TError error) noexcept
+    TCompletedRequest(
+            NProto::EAction action,
+            TInstant start,
+            NProto::TError error,
+            ui64 requestBytes = 0) noexcept
         : Action(action)
         , Elapsed(TInstant::Now() - start)
+        , RequestBytes(requestBytes)
         , Error(std::move(error))
     {}
 };

--- a/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
@@ -404,8 +404,6 @@ private:
         request->SetOffset(byteOffset);
         request->SetLength(ReadBytes);
 
-        const auto requestBytes = CalculateByteCount(*request);
-
         auto self = weak_from_this();
         return Session->ReadData(CreateCallContext(), std::move(request)).Apply(
             [=] (const TFuture<NProto::TReadDataResponse>& future){
@@ -414,8 +412,7 @@ private:
                         future,
                         handleInfo,
                         started,
-                        byteOffset,
-                        requestBytes);
+                        byteOffset);
                 }
 
                 return TCompletedRequest{
@@ -429,8 +426,7 @@ private:
         const TFuture<NProto::TReadDataResponse>& future,
         THandleInfo handleInfo,
         TInstant started,
-        ui64 byteOffset,
-        ui64 requestBytes)
+        ui64 byteOffset)
     {
         try {
             const auto& response = future.GetValue();
@@ -443,6 +439,8 @@ private:
             } else {
                 Y_ABORT_UNLESS(bufferOffset < buffer.size());
             }
+
+            const ui64 bytesRead = CalculateByteCount(response);
 
             ui64 segmentId = byteOffset / SEGMENT_SIZE;
             for (ui64 offset = 0; offset < ReadBytes; offset += SEGMENT_SIZE) {
@@ -472,7 +470,7 @@ private:
                 NProto::ACTION_READ,
                 started,
                 response.GetError(),
-                requestBytes};
+                bytesRead};
         } catch (const TServiceError& e)  {
             auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
             STORAGE_ERROR("read for %s has failed: %s",

--- a/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_data.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/filestore/libs/client/session.h>
 #include <cloud/filestore/libs/service/context.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/public/api/protos/data.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
@@ -403,6 +404,8 @@ private:
         request->SetOffset(byteOffset);
         request->SetLength(ReadBytes);
 
+        const auto requestBytes = CalculateByteCount(*request);
+
         auto self = weak_from_this();
         return Session->ReadData(CreateCallContext(), std::move(request)).Apply(
             [=] (const TFuture<NProto::TReadDataResponse>& future){
@@ -411,8 +414,8 @@ private:
                         future,
                         handleInfo,
                         started,
-                        byteOffset
-                    );
+                        byteOffset,
+                        requestBytes);
                 }
 
                 return TCompletedRequest{
@@ -426,7 +429,8 @@ private:
         const TFuture<NProto::TReadDataResponse>& future,
         THandleInfo handleInfo,
         TInstant started,
-        ui64 byteOffset)
+        ui64 byteOffset,
+        ui64 requestBytes)
     {
         try {
             const auto& response = future.GetValue();
@@ -464,7 +468,11 @@ private:
                 HandleInfos.emplace_back(std::move(handleInfo));
             }
 
-            return {NProto::ACTION_READ, started, response.GetError()};
+            return {
+                NProto::ACTION_READ,
+                started,
+                response.GetError(),
+                requestBytes};
         } catch (const TServiceError& e)  {
             auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
             STORAGE_ERROR("read for %s has failed: %s",
@@ -527,11 +535,17 @@ private:
         }
         *request->MutableBuffer() = std::move(buffer);
 
+        const auto requestBytes = CalculateByteCount(*request);
+
         auto self = weak_from_this();
         return Session->WriteData(CreateCallContext(), std::move(request)).Apply(
             [=] (const TFuture<NProto::TWriteDataResponse>& future){
                 if (auto ptr = self.lock()) {
-                    return ptr->HandleWrite(future, handleInfo, started);
+                    return ptr->HandleWrite(
+                        future,
+                        handleInfo,
+                        started,
+                        requestBytes);
                 }
 
                 return TCompletedRequest{
@@ -545,7 +559,8 @@ private:
     TCompletedRequest HandleWrite(
         const TFuture<NProto::TWriteDataResponse>& future,
         THandleInfo handleInfo,
-        TInstant started)
+        TInstant started,
+        ui64 requestBytes)
     {
         try {
             const auto& response = future.GetValue();
@@ -555,7 +570,11 @@ private:
                 HandleInfos.emplace_back(std::move(handleInfo));
             }
 
-            return {NProto::ACTION_WRITE, started, response.GetError()};
+            return {
+                NProto::ACTION_WRITE,
+                started,
+                response.GetError(),
+                requestBytes};
         } catch (const TServiceError& e)  {
             auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
             STORAGE_ERROR("write on %s has failed: %s",

--- a/cloud/filestore/tools/testing/loadtest/lib/request_datashard_like.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_datashard_like.cpp
@@ -295,8 +295,6 @@ private:
         char* shmLocalPtr =
             DataClient ? DataClient->PrepareRead(*request, shmOffset) : nullptr;
 
-        const auto requestBytes = CalculateByteCount(*request);
-
         auto self = weak_from_this();
         return Session->ReadData(CreateCallContext(), std::move(request))
             .Apply(
@@ -308,8 +306,7 @@ private:
                             nodeInfo,
                             started,
                             shmLocalPtr,
-                            shmOffset,
-                            requestBytes);
+                            shmOffset);
                     }
 
                     return TCompletedRequest{
@@ -324,8 +321,7 @@ private:
         TNodeInfo nodeInfo,
         TInstant started,
         char* shmLocalPtr,
-        ui64 shmOffset,
-        ui64 requestBytes)
+        ui64 shmOffset)
     {
         Y_DEFER
         {
@@ -351,7 +347,7 @@ private:
                 NProto::ACTION_READ,
                 started,
                 response.GetError(),
-                requestBytes};
+                CalculateByteCount(response)};
         } catch (const TServiceError& e) {
             auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
             STORAGE_ERROR(

--- a/cloud/filestore/tools/testing/loadtest/lib/request_datashard_like.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_datashard_like.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/client/session.h>
 #include <cloud/filestore/libs/service/context.h>
 #include <cloud/filestore/libs/service/filestore.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/public/api/protos/data.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
@@ -294,6 +295,8 @@ private:
         char* shmLocalPtr =
             DataClient ? DataClient->PrepareRead(*request, shmOffset) : nullptr;
 
+        const auto requestBytes = CalculateByteCount(*request);
+
         auto self = weak_from_this();
         return Session->ReadData(CreateCallContext(), std::move(request))
             .Apply(
@@ -305,7 +308,8 @@ private:
                             nodeInfo,
                             started,
                             shmLocalPtr,
-                            shmOffset);
+                            shmOffset,
+                            requestBytes);
                     }
 
                     return TCompletedRequest{
@@ -320,7 +324,8 @@ private:
         TNodeInfo nodeInfo,
         TInstant started,
         char* shmLocalPtr,
-        ui64 shmOffset)
+        ui64 shmOffset,
+        ui64 requestBytes)
     {
         Y_DEFER
         {
@@ -342,7 +347,11 @@ private:
                 NodeInfos.emplace_back(std::move(nodeInfo));
             }
 
-            return {NProto::ACTION_READ, started, response.GetError()};
+            return {
+                NProto::ACTION_READ,
+                started,
+                response.GetError(),
+                requestBytes};
         } catch (const TServiceError& e) {
             auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
             STORAGE_ERROR(
@@ -381,14 +390,20 @@ private:
         ui64 shmOffset =
             DataClient ? DataClient->PrepareWrite(*request) : Max<ui64>();
 
+        const auto requestBytes = CalculateByteCount(*request);
+
         auto self = weak_from_this();
         return Session->WriteData(CreateCallContext(), std::move(request))
             .Apply(
                 [=](const TFuture<NProto::TWriteDataResponse>& future)
                 {
                     if (auto ptr = self.lock()) {
-                        return ptr
-                            ->HandleWrite(future, nodeInfo, started, shmOffset);
+                        return ptr->HandleWrite(
+                            future,
+                            nodeInfo,
+                            started,
+                            shmOffset,
+                            requestBytes);
                     }
 
                     return TCompletedRequest{
@@ -402,7 +417,8 @@ private:
         const TFuture<NProto::TWriteDataResponse>& future,
         TNodeInfo nodeInfo,
         TInstant started,
-        ui64 shmOffset)
+        ui64 shmOffset,
+        ui64 requestBytes)
     {
         Y_DEFER
         {
@@ -418,7 +434,11 @@ private:
                 NodeInfos.emplace_back(std::move(nodeInfo));
             }
 
-            return {NProto::ACTION_WRITE, started, response.GetError()};
+            return {
+                NProto::ACTION_WRITE,
+                started,
+                response.GetError(),
+                requestBytes};
         } catch (const TServiceError& e) {
             auto error = MakeError(e.GetCode(), TString{e.GetMessage()});
             STORAGE_ERROR(

--- a/cloud/filestore/tools/testing/loadtest/lib/request_fastshard.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_fastshard.cpp
@@ -282,6 +282,8 @@ private:
 
         if (HasError(err)) {
             requestBytes = 0;
+        } else if (resp.HasReadData()) {
+            requestBytes = CalculateByteCount(resp.GetReadData());
         }
         s->Promise.SetValue(
             {s->Action, s->Started, std::move(err), requestBytes});

--- a/cloud/filestore/tools/testing/loadtest/lib/request_fastshard.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_fastshard.cpp
@@ -3,6 +3,7 @@
 #include <cloud/filestore/libs/storage/fastshard/client/client.h>
 #include <cloud/filestore/libs/storage/fastshard/server/protos/fastshard.pb.h>
 #include <cloud/filestore/libs/service/filestore.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
 #include <cloud/storage/core/libs/common/error.h>
@@ -243,6 +244,7 @@ private:
         TRequest req;
         req.SetFileSystemId(s->ShardFileSystemId);
 
+        ui64 requestBytes = 0;
         if (s->Action == NProto::ACTION_READ) {
             const ui64 slotCount = s->File.Size / s->ReadBytes;
             const ui64 offset = RandomNumber(slotCount) * s->ReadBytes;
@@ -250,6 +252,7 @@ private:
             body->SetHandle(s->File.Handle);
             body->SetOffset(offset);
             body->SetLength(s->ReadBytes);
+            requestBytes = CalculateByteCount(*body);
         } else {
             const ui64 offset = s->File.Size;
             s->File.Size += s->WriteBytes;
@@ -257,6 +260,7 @@ private:
             body->SetHandle(s->File.Handle);
             body->SetOffset(offset);
             body->SetBuffer(TString(s->WriteBytes, '\0'));
+            requestBytes = CalculateByteCount(*body);
         }
 
         auto resp = e->Send(req);
@@ -275,7 +279,12 @@ private:
         }
 
         releaseEndpoint();
-        s->Promise.SetValue({s->Action, s->Started, std::move(err)});
+
+        if (HasError(err)) {
+            requestBytes = 0;
+        }
+        s->Promise.SetValue(
+            {s->Action, s->Started, std::move(err), requestBytes});
     }
 
     TFuture<TCompletedRequest> DoRead()

--- a/cloud/filestore/tools/testing/loadtest/lib/request_replay_fs.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_replay_fs.cpp
@@ -556,7 +556,11 @@ private:
                     (TInstant::Now() - started).MicroSeconds());
 
                 if (value) {
-                    return TCompletedRequest(NProto::ACTION_READ, started, {});
+                    return TCompletedRequest(
+                        NProto::ACTION_READ,
+                        started,
+                        {},
+                        static_cast<ui64>(value));
                 }
                 return TCompletedRequest(
                     NProto::ACTION_READ,
@@ -662,7 +666,11 @@ private:
                     (TInstant::Now() - started).MicroSeconds());
 
                 if (value) {
-                    return TCompletedRequest(NProto::ACTION_WRITE, started, {});
+                    return TCompletedRequest(
+                        NProto::ACTION_WRITE,
+                        started,
+                        {},
+                        static_cast<ui64>(value));
                 }
                 return TCompletedRequest(
                     NProto::ACTION_WRITE,

--- a/cloud/filestore/tools/testing/loadtest/lib/request_replay_grpc.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_replay_grpc.cpp
@@ -13,6 +13,7 @@ compare the profile log and the actual result ( S_OK E_FS_NOENT ...)
 #include <cloud/filestore/libs/client/session.h>
 #include <cloud/filestore/libs/diagnostics/events/profile_events.ev.pb.h>
 #include <cloud/filestore/libs/service/context.h>
+#include <cloud/filestore/libs/service/request.h>
 #include <cloud/filestore/public/api/protos/data.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 #include <cloud/filestore/tools/analytics/libs/event-log/dump.h>
@@ -139,6 +140,7 @@ private:
         ssize_t EventMessageNumber = 0;
         const NCloud::NFileStore::NProto::TProfileLogRequestInfo LogRequest;
         TString Description;
+        ui64 RequestBytes = 0;
     };
 
     TFuture<TCompletedRequest> DoAccessNode(
@@ -376,7 +378,8 @@ private:
             .Started = Started,
             .EventMessageNumber = EventMessageNumber,
             .LogRequest = logRequest,
-            .Description = ToString(handle)};
+            .Description = ToString(handle),
+            .RequestBytes = CalculateByteCount(*request)};
 
         auto self = weak_from_this();
         return Session->ReadData(CreateCallContext(), std::move(request))
@@ -402,7 +405,11 @@ private:
             const auto& response = future.GetValue();
             CompareResponse(info, response.GetError().GetCode());
             CheckResponse(response);
-            return {NProto::ACTION_READ, info.Started, response.GetError()};
+            return {
+                NProto::ACTION_READ,
+                info.Started,
+                response.GetError(),
+                info.RequestBytes};
         } catch (const TServiceError& e) {
             CompareResponse(info, e.GetCode());
             return {
@@ -477,7 +484,8 @@ private:
             .Started = Started,
             .EventMessageNumber = EventMessageNumber,
             .LogRequest = logRequest,
-            .Description = ToString(handleLog)};
+            .Description = ToString(handleLog),
+            .RequestBytes = CalculateByteCount(*request)};
 
         const auto self = weak_from_this();
         return Session->WriteData(CreateCallContext(), std::move(request))
@@ -503,7 +511,11 @@ private:
             const auto& response = future.GetValue();
             CompareResponse(info, response.GetError().GetCode());
             CheckResponse(response);
-            return {NProto::ACTION_WRITE, info.Started, response.GetError()};
+            return {
+                NProto::ACTION_WRITE,
+                info.Started,
+                response.GetError(),
+                info.RequestBytes};
         } catch (const TServiceError& e) {
             CompareResponse(info, e.GetCode());
             return {

--- a/cloud/filestore/tools/testing/loadtest/lib/request_replay_grpc.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/request_replay_grpc.cpp
@@ -378,8 +378,7 @@ private:
             .Started = Started,
             .EventMessageNumber = EventMessageNumber,
             .LogRequest = logRequest,
-            .Description = ToString(handle),
-            .RequestBytes = CalculateByteCount(*request)};
+            .Description = ToString(handle)};
 
         auto self = weak_from_this();
         return Session->ReadData(CreateCallContext(), std::move(request))
@@ -409,7 +408,7 @@ private:
                 NProto::ACTION_READ,
                 info.Started,
                 response.GetError(),
-                info.RequestBytes};
+                CalculateByteCount(response)};
         } catch (const TServiceError& e) {
             CompareResponse(info, e.GetCode());
             return {

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -278,8 +278,8 @@ private:
     TInstant LastReportTs;
     ui64 LastRequestsCompleted = 0;
 
-    ui64 BytesTransferred = 0;
-    ui64 LastBytesTransferred = 0;
+    ui64 RequestBytes = 0;
+    ui64 LastRequestBytes = 0;
 
     IRequestGeneratorPtr RequestGenerator;
     TRequestsCompletionQueue CompletionQueue;
@@ -697,7 +697,7 @@ private:
             auto& stats = TestStats.ActionStats[request->Action];
             ++stats.Requests;
             stats.RequestBytes += request->RequestBytes;
-            BytesTransferred += request->RequestBytes;
+            RequestBytes += request->RequestBytes;
             stats.Hist.RecordValue(request->Elapsed);
         }
     }
@@ -709,18 +709,18 @@ private:
 
         if (elapsed > ReportInterval) {
             const auto requestsCompleted = RequestsCompleted - LastRequestsCompleted;
-            const auto bytesTransferred = BytesTransferred - LastBytesTransferred;
+            const auto requestBytes = RequestBytes - LastRequestBytes;
 
             auto stats = GetStats();
             STORAGE_INFO("%s current rate: %ld r/s, bandwidth: %ld bytes/s; stats:\n%s",
                 MakeTestTag().c_str(),
                 (ui64)(requestsCompleted / elapsed.Seconds()),
-                (ui64)(bytesTransferred / elapsed.SecondsFloat()),
+                (ui64)(requestBytes / elapsed.SecondsFloat()),
                 NProtobufJson::Proto2Json(stats, {.FormatOutput = true}).c_str());
 
             LastReportTs = now;
             LastRequestsCompleted = RequestsCompleted;
-            LastBytesTransferred = BytesTransferred;
+            LastRequestBytes = RequestBytes;
         }
     }
 

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -51,6 +51,7 @@ struct TTestStats
     struct TStats
     {
         ui64 Requests = 0;
+        ui64 RequestBytes = 0;
         TLatencyHistogram Hist;
     };
 
@@ -276,6 +277,9 @@ private:
 
     TInstant LastReportTs;
     ui64 LastRequestsCompleted = 0;
+
+    ui64 BytesTransferred = 0;
+    ui64 LastBytesTransferred = 0;
 
     IRequestGeneratorPtr RequestGenerator;
     TRequestsCompletionQueue CompletionQueue;
@@ -692,6 +696,8 @@ private:
 
             auto& stats = TestStats.ActionStats[request->Action];
             ++stats.Requests;
+            stats.RequestBytes += request->RequestBytes;
+            BytesTransferred += request->RequestBytes;
             stats.Hist.RecordValue(request->Elapsed);
         }
     }
@@ -703,15 +709,18 @@ private:
 
         if (elapsed > ReportInterval) {
             const auto requestsCompleted = RequestsCompleted - LastRequestsCompleted;
+            const auto bytesTransferred = BytesTransferred - LastBytesTransferred;
 
             auto stats = GetStats();
-            STORAGE_INFO("%s current rate: %ld r/s; stats:\n%s",
+            STORAGE_INFO("%s current rate: %ld r/s, bandwidth: %ld bytes/s; stats:\n%s",
                 MakeTestTag().c_str(),
                 (ui64)(requestsCompleted / elapsed.Seconds()),
+                (ui64)(bytesTransferred / elapsed.SecondsFloat()),
                 NProtobufJson::Proto2Json(stats, {.FormatOutput = true}).c_str());
 
             LastReportTs = now;
             LastRequestsCompleted = RequestsCompleted;
+            LastBytesTransferred = BytesTransferred;
         }
     }
 
@@ -726,6 +735,7 @@ private:
             auto* action = stats->Add();
             action->SetAction(NProto::EAction_Name(pair.first));
             action->SetCount(pair.second.Requests);
+            action->SetRequestBytes(pair.second.RequestBytes);
             FillLatency(pair.second.Hist, *action->MutableLatency());
         }
 

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -714,7 +714,7 @@ private:
             auto stats = GetStats();
             STORAGE_INFO("%s current rate: %ld r/s, bandwidth: %ld bytes/s; stats:\n%s",
                 MakeTestTag().c_str(),
-                (ui64)(requestsCompleted / elapsed.Seconds()),
+                (ui64)(requestsCompleted / elapsed.SecondsFloat()),
                 (ui64)(requestBytes / elapsed.SecondsFloat()),
                 NProtobufJson::Proto2Json(stats, {.FormatOutput = true}).c_str());
 

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -12,6 +12,7 @@
 #include <cloud/filestore/libs/service/request.h>
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/common/timer.h>
@@ -712,11 +713,14 @@ private:
             const auto requestBytes = RequestBytes - LastRequestBytes;
 
             auto stats = GetStats();
-            STORAGE_INFO("%s current rate: %ld r/s, bandwidth: %ld bytes/s; stats:\n%s",
+            STORAGE_INFO(
+                "%s current rate: %ld r/s, bandwidth: %s/s; stats:\n%s",
                 MakeTestTag().c_str(),
                 (ui64)(requestsCompleted / elapsed.SecondsFloat()),
-                (ui64)(requestBytes / elapsed.SecondsFloat()),
-                NProtobufJson::Proto2Json(stats, {.FormatOutput = true}).c_str());
+                FormatByteSize((ui64)(requestBytes / elapsed.SecondsFloat()))
+                    .c_str(),
+                NProtobufJson::Proto2Json(stats, {.FormatOutput = true})
+                    .c_str());
 
             LastReportTs = now;
             LastRequestsCompleted = RequestsCompleted;

--- a/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
+++ b/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto
@@ -234,6 +234,7 @@ message TTestStats
         string Action = 1;
         uint64 Count = 2;
         TLatency Latency = 3;
+        uint64 RequestBytes = 4;
     }
 
     string Name = 1;


### PR DESCRIPTION
### Notes
First part of #6508:

> 1. Per-action stats in `filestore-loadtest` only report request `Count` and latencies
   ([loadtest.proto#L232-L237](https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/tools/testing/loadtest/protos/loadtest.proto#L232-L237)). READ/WRITE bytes are not tracked, so there is no way to see the actual bandwidth achieved.

Example of it working:

```
2026-07-14T17:24:27.906355Z :RUNNER INFO: cloud/filestore/tools/testing/loadtest/lib/test.cpp:721: [bandwidth-smoke] current rate: 125 r/s, bandwidth: 125.96 MiB/s; stats:
{
  "Name":"bandwidth-smoke",
  "Success":true,
  "Stats":
    [
      {
        "Action":"ACTION_CREATE_HANDLE",
        "Count":32,
        "Latency":
          {
            "P50":42783,
            "P95":70335,
            "P90":68351,
            "P99":74367,
            "P999":74367,
            "Min":12992,
            "Max":74367,
            "Mean":43590,
            "StdDeviation":18386.35274
          }
      },
      {
        "Action":"ACTION_WRITE",
        "Count":1477,
        "Latency":
          {
            "P50":188159,
            "P95":515583,
            "P90":431871,
            "P99":2103295,
            "P999":2336767,
            "Min":35200,
            "Max":2336767,
            "Mean":256275.8023,
            "StdDeviation":271043.1787
          },
        "RequestBytes":1548746752
      },
      {
        "Action":"ACTION_READ",
        "Count":1509,
        "Latency":
          {
            "P50":147839,
            "P95":303871,
            "P90":265471,
            "P99":411391,
            "P999":1607679,
            "Min":39328,
            "Max":1677311,
            "Mean":172144.562,
            "StdDeviation":121115.8395
          },
        "RequestBytes":1582301184
      }
    ]
}
```

### Issue
#6508