### PR TITLE
issue-6508: [Filestore] loadtest: reset latency histograms each report period

### DIFF
--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -51,7 +51,10 @@ struct TTestStats
     struct TStats
     {
         ui64 Requests = 0;
+        // Whole-run distribution, reported in the final results
         TLatencyHistogram Hist;
+        // Reset after each progress report, reported in progress reports
+        TLatencyHistogram IntervalHist;
     };
 
     TString Name;
@@ -693,6 +696,7 @@ private:
             auto& stats = TestStats.ActionStats[request->Action];
             ++stats.Requests;
             stats.Hist.RecordValue(request->Elapsed);
+            stats.IntervalHist.RecordValue(request->Elapsed);
         }
     }
 
@@ -704,7 +708,7 @@ private:
         if (elapsed > ReportInterval) {
             const auto requestsCompleted = RequestsCompleted - LastRequestsCompleted;
 
-            auto stats = GetStats();
+            auto stats = GetStats(true);
             STORAGE_INFO("%s current rate: %ld r/s; stats:\n%s",
                 MakeTestTag().c_str(),
                 (ui64)(requestsCompleted / elapsed.Seconds()),
@@ -715,18 +719,25 @@ private:
         }
     }
 
-    NProto::TTestStats GetStats()
+    // With sinceLastReport latencies cover only the requests completed after
+    // the previous progress report; otherwise they cover the whole run.
+    NProto::TTestStats GetStats(bool sinceLastReport = false)
     {
         NProto::TTestStats results;
         results.SetName(Config.GetName());
         results.SetSuccess(TestStats.Success);
 
         auto* stats = results.MutableStats();
-        for (const auto& pair: TestStats.ActionStats) {
+        for (auto& pair: TestStats.ActionStats) {
             auto* action = stats->Add();
             action->SetAction(NProto::EAction_Name(pair.first));
             action->SetCount(pair.second.Requests);
-            FillLatency(pair.second.Hist, *action->MutableLatency());
+            if (sinceLastReport) {
+                FillLatency(pair.second.IntervalHist, *action->MutableLatency());
+                pair.second.IntervalHist.Reset();
+            } else {
+                FillLatency(pair.second.Hist, *action->MutableLatency());
+            }
         }
 
         // TODO report some stats for the files generated during the shooting


### PR DESCRIPTION
Addresses point 2 of #6508.

Latency histograms were never reset, so the percentiles in the periodic progress report were computed since test start — a recent latency degradation was diluted by old samples and practically invisible in a long run.

Keep a second per-action histogram that is reset after each progress report: progress reports now show the latency distribution of the last report interval (~5s, matching the windowed request rate), while the final test results still report the whole-run distribution.

Note: touches the same lines as #6509 (point 1 of the issue); whichever lands second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)