### PR TITLE
issue-6508: [Filestore] periodically reset request latencies reported by the filestore/tools/testing/loadtest

### DIFF
--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -53,7 +53,9 @@ struct TTestStats
     {
         ui64 Requests = 0;
         ui64 RequestBytes = 0;
-        // Reported in the final results
+        // Resets after each progress report
+        ui64 IntervalRequests = 0;
+        // Whole-run distribution, reported in the final results
         TLatencyHistogram Hist;
         // Reset after each progress report, reported in progress reports
         TLatencyHistogram IntervalHist;
@@ -700,6 +702,7 @@ private:
 
             auto& stats = TestStats.ActionStats[request->Action];
             ++stats.Requests;
+            ++stats.IntervalRequests;
             stats.RequestBytes += request->RequestBytes;
             RequestBytes += request->RequestBytes;
             stats.Hist.RecordValue(request->Elapsed);
@@ -733,7 +736,7 @@ private:
     }
 
     // With sinceLastReport latencies cover only the requests completed after
-    // the previous progress report; otherwise they cover the whole run.
+    // the previous progress report; otherwise they cover the whole run
     NProto::TTestStats GetStats(bool sinceLastReport)
     {
         NProto::TTestStats results;
@@ -742,15 +745,20 @@ private:
 
         auto* stats = results.MutableStats();
         for (auto& pair: TestStats.ActionStats) {
+            if (sinceLastReport && pair.second.IntervalRequests == 0) {
+                // Skip reporting latencies for actions that have not been
+                // executed since the last report
+                continue;
+            }
+
             auto* action = stats->Add();
             action->SetAction(NProto::EAction_Name(pair.first));
             action->SetCount(pair.second.Requests);
             action->SetRequestBytes(pair.second.RequestBytes);
             if (sinceLastReport) {
-                FillLatency(
-                    pair.second.IntervalHist,
-                    *action->MutableLatency());
+                FillLatency(pair.second.IntervalHist, *action->MutableLatency());
                 pair.second.IntervalHist.Reset();
+                pair.second.IntervalRequests = 0;
             } else {
                 FillLatency(pair.second.Hist, *action->MutableLatency());
             }

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -489,7 +489,7 @@ public:
             // prevent race between this thread and main thread
             // destroying test instance right after setvalue()
             auto result = Result;
-            result.SetValue(GetStats(false));
+            result.SetValue(GetStats(false /* sinceLastReport */));
         } catch(...) {
             STORAGE_ERROR("%s test has failed: %s",
                 MakeTestTag().c_str(), CurrentExceptionMessage().c_str());
@@ -719,7 +719,7 @@ private:
             const auto requestsCompleted = RequestsCompleted - LastRequestsCompleted;
             const auto requestBytes = RequestBytes - LastRequestBytes;
 
-            auto stats = GetStats(true);
+            auto stats = GetStats(true /* sinceLastReport */);
             STORAGE_INFO(
                 "%s current rate: %ld r/s, bandwidth: %s/s; stats:\n%s",
                 MakeTestTag().c_str(),

--- a/cloud/filestore/tools/testing/loadtest/lib/test.cpp
+++ b/cloud/filestore/tools/testing/loadtest/lib/test.cpp
@@ -53,7 +53,10 @@ struct TTestStats
     {
         ui64 Requests = 0;
         ui64 RequestBytes = 0;
+        // Reported in the final results
         TLatencyHistogram Hist;
+        // Reset after each progress report, reported in progress reports
+        TLatencyHistogram IntervalHist;
     };
 
     TString Name;
@@ -484,7 +487,7 @@ public:
             // prevent race between this thread and main thread
             // destroying test instance right after setvalue()
             auto result = Result;
-            result.SetValue(GetStats());
+            result.SetValue(GetStats(false));
         } catch(...) {
             STORAGE_ERROR("%s test has failed: %s",
                 MakeTestTag().c_str(), CurrentExceptionMessage().c_str());
@@ -700,6 +703,7 @@ private:
             stats.RequestBytes += request->RequestBytes;
             RequestBytes += request->RequestBytes;
             stats.Hist.RecordValue(request->Elapsed);
+            stats.IntervalHist.RecordValue(request->Elapsed);
         }
     }
 
@@ -712,7 +716,7 @@ private:
             const auto requestsCompleted = RequestsCompleted - LastRequestsCompleted;
             const auto requestBytes = RequestBytes - LastRequestBytes;
 
-            auto stats = GetStats();
+            auto stats = GetStats(true);
             STORAGE_INFO(
                 "%s current rate: %ld r/s, bandwidth: %s/s; stats:\n%s",
                 MakeTestTag().c_str(),
@@ -728,19 +732,28 @@ private:
         }
     }
 
-    NProto::TTestStats GetStats()
+    // With sinceLastReport latencies cover only the requests completed after
+    // the previous progress report; otherwise they cover the whole run.
+    NProto::TTestStats GetStats(bool sinceLastReport)
     {
         NProto::TTestStats results;
         results.SetName(Config.GetName());
         results.SetSuccess(TestStats.Success);
 
         auto* stats = results.MutableStats();
-        for (const auto& pair: TestStats.ActionStats) {
+        for (auto& pair: TestStats.ActionStats) {
             auto* action = stats->Add();
             action->SetAction(NProto::EAction_Name(pair.first));
             action->SetCount(pair.second.Requests);
             action->SetRequestBytes(pair.second.RequestBytes);
-            FillLatency(pair.second.Hist, *action->MutableLatency());
+            if (sinceLastReport) {
+                FillLatency(
+                    pair.second.IntervalHist,
+                    *action->MutableLatency());
+                pair.second.IntervalHist.Reset();
+            } else {
+                FillLatency(pair.second.Hist, *action->MutableLatency());
+            }
         }
 
         // TODO report some stats for the files generated during the shooting


### PR DESCRIPTION
### Notes
Second part of #6508:
> 2. Latency histograms are never reset ([test.cpp#L54](https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/tools/testing/loadtest/lib/test.cpp#L54)), so the percentiles in the periodic progress report ([test.cpp#L699-L716](https://github.com/ydb-platform/nbs/blob/main/cloud/filestore/tools/testing/loadtest/lib/test.cpp#L699-L716)) are computed since test start. A recent latency degradation is diluted by old samples and practically invisible in the long run.

### Issue
#6508