### PR TITLE
[NBS] should not send reject if "child.kind" could not converted

### DIFF
--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -268,18 +268,16 @@ void TDescribeSchemeActor::HandleDescribeSchemeResult(
     }
     if (entry.ListNodeEntry) {
         for (const auto& child: entry.ListNodeEntry->Children) {
-            NKikimrSchemeOp::TDirEntry* entry =
-                pathDescription.MutableChildren()->Add();
             auto pathType = ConvertSchemeCacheKind(child.Kind);
             if (!pathType) {
-                HandleError(
-                    ctx,
-                    MakeError(
-                        E_REJECTED,
-                        TStringBuilder()
-                            << "Unknown child path kind: " << child.Kind));
-                return;
+                LOG_WARN(ctx, TBlockStoreComponents::SS_PROXY,
+                    "Skipping child with unknown kind: %d, name: %s",
+                    static_cast<int>(child.Kind),
+                    child.Name.c_str());
+                continue;
             }
+
+            auto* entry = pathDescription.MutableChildren()->Add();
             entry->SetPathType(*pathType);
             entry->SetName(child.Name);
             entry->SetPathId(child.PathId.LocalPathId);

--- a/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_ut.cpp
+++ b/cloud/blockstore/libs/storage/ss_proxy/ss_proxy_ut.cpp
@@ -2074,6 +2074,89 @@ Y_UNIT_TEST_SUITE(TSSProxyTest)
             "NavigateKeySet undelivered",
             response->GetErrorReason());
     }
+
+    Y_UNIT_TEST(ShouldSkipUnknownChildKindsWithSchemeCache)
+    {
+        TTestEnv env;
+        auto& runtime = env.GetRuntime();
+        auto config = CreateStorageConfig(
+            []()
+            {
+                NProto::TStorageServiceConfig config;
+                config.SetUseSchemeCache(true);
+                return config;
+            }());
+        SetupTestEnv(env, config);
+
+        CreateVolume(runtime, "volume0");
+
+        runtime.SetEventFilter(
+            [&](auto&, TAutoPtr<IEventHandle>& event)
+            {
+                if (event->GetTypeRewrite() ==
+                    TEvTxProxySchemeCache::EvNavigateKeySetResult)
+                {
+                    auto* msg = event->Get<
+                        TEvTxProxySchemeCache::TEvNavigateKeySetResult>();
+                    auto* record = msg->Request.Get();
+                    if (!record || record->ResultSet.size() != 1) {
+                        return false;
+                    }
+
+                    auto& entry = record->ResultSet.front();
+                    if (!entry.ListNodeEntry) {
+                        return false;
+                    }
+
+                    auto newListNode = MakeIntrusive<
+                        NSchemeCache::TSchemeCacheNavigate::TListNodeEntry>();
+                    newListNode->Kind = entry.ListNodeEntry->Kind;
+                    for (const auto& child: entry.ListNodeEntry->Children) {
+                        newListNode->Children.emplace_back(
+                            child.Name,
+                            child.PathId,
+                            child.Kind,
+                            child.SchemaVersion);
+                    }
+
+                    newListNode->Children.emplace_back(
+                        "fake-table",
+                        TPathId(1, 999),
+                        NSchemeCache::TSchemeCacheNavigate::KindTable);
+                    newListNode->Children.emplace_back(
+                        "fake-topic",
+                        TPathId(1, 998),
+                        NSchemeCache::TSchemeCacheNavigate::KindTopic);
+
+                    entry.ListNodeEntry = std::move(newListNode);
+                }
+                return false;
+            });
+
+        const auto response = DescribePath(runtime, config);
+        const auto& pathDescription = response->Get()->PathDescription;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimrSchemeOp::EPathTypeSubDomain,
+            pathDescription.GetSelf().GetPathType());
+
+        for (const auto& child: pathDescription.GetChildren()) {
+            UNIT_ASSERT_C(
+                child.GetName() != "fake-table" &&
+                    child.GetName() != "fake-topic",
+                TStringBuilder()
+                    << "Unknown child kind should have been skipped: "
+                    << child.GetName());
+
+            auto pathType = child.GetPathType();
+            UNIT_ASSERT_C(
+                pathType == NKikimrSchemeOp::EPathTypeDir ||
+                    pathType == NKikimrSchemeOp::EPathTypeBlockStoreVolume ||
+                    pathType == NKikimrSchemeOp::EPathTypeSubDomain,
+                TStringBuilder()
+                    << "Unexpected path type: " << static_cast<int>(pathType));
+        }
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_describescheme.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_actor_describescheme.cpp
@@ -261,18 +261,16 @@ void TDescribeSchemeActor::HandleDescribeSchemeResult(
 
     if (entry.ListNodeEntry) {
         for (const auto& child: entry.ListNodeEntry->Children) {
-            auto* childEntry = pathDescription.MutableChildren()->Add();
-
             auto pathType = ConvertSchemeCacheKind(child.Kind);
-
             if (!pathType) {
-                const TString message = TStringBuilder()
-                    << "Unknown child path kind: " << child.Kind;
-                ReportSchemeCacheError(message);
-                HandleError(ctx, MakeError(E_REJECTED, message));
-                return;
+                LOG_WARN(ctx, LogComponent,
+                    "Skipping child with unknown kind: %d, name: %s",
+                    static_cast<int>(child.Kind),
+                    child.Name.c_str());
+                continue;
             }
 
+            auto* childEntry = pathDescription.MutableChildren()->Add();
             childEntry->SetPathType(*pathType);
             childEntry->SetName(child.Name);
             childEntry->SetPathId(child.PathId.LocalPathId);

--- a/cloud/storage/core/libs/ss_proxy/ss_proxy_ut.cpp
+++ b/cloud/storage/core/libs/ss_proxy/ss_proxy_ut.cpp
@@ -14,6 +14,7 @@
 #include <contrib/ydb/core/testlib/fake_coordinator.h>
 #include <contrib/ydb/core/testlib/tablet_helpers.h>
 #include <contrib/ydb/core/testlib/test_client.h>
+#include <contrib/ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <contrib/ydb/core/tx/schemeshard/schemeshard.h>
 #include <contrib/ydb/core/tx/schemeshard/schemeshard_identificators.h>
 #include <contrib/ydb/core/tx/tx_allocator/txallocator.h>
@@ -1171,6 +1172,96 @@ void TestShouldCreateDirectoryIdempotently(bool useSchemeCache)
     }
 }
 
+void TestShouldSkipUnknownChildKinds()
+{
+    TTestBasicRuntime runtime;
+    TTestEnv env(runtime);
+
+    ui64 txId = 100;
+
+    TestMkDir(runtime, ++txId, "/MyRoot", "nbs");
+    env.TestWaitNotification(runtime, txId);
+
+    auto ssProxyId = SetupSSProxy(runtime, true);
+
+    CreateFileStore(runtime, ssProxyId, "fs");
+    CreateBlockStoreVolume(runtime, ssProxyId, "volume");
+
+    using TSchemeCacheNavigate = NKikimr::NSchemeCache::TSchemeCacheNavigate;
+
+    runtime.SetEventFilter(
+        [&](auto&, TAutoPtr<IEventHandle>& event)
+        {
+            if (event->GetTypeRewrite() ==
+                TEvTxProxySchemeCache::EvNavigateKeySetResult)
+            {
+                auto* msg =
+                    event
+                        ->Get<TEvTxProxySchemeCache::TEvNavigateKeySetResult>();
+                auto* record = msg->Request.Get();
+                if (!record || record->ResultSet.size() != 1) {
+                    return false;
+                }
+
+                auto& entry = record->ResultSet.front();
+                if (!entry.ListNodeEntry) {
+                    return false;
+                }
+
+                auto newListNode =
+                    MakeIntrusive<TSchemeCacheNavigate::TListNodeEntry>();
+                newListNode->Kind = entry.ListNodeEntry->Kind;
+                for (const auto& child: entry.ListNodeEntry->Children) {
+                    newListNode->Children.emplace_back(
+                        child.Name,
+                        child.PathId,
+                        child.Kind,
+                        child.SchemaVersion);
+                }
+
+                newListNode->Children.emplace_back(
+                    "fake-table",
+                    TPathId(1, 999),
+                    TSchemeCacheNavigate::KindTable);
+                newListNode->Children.emplace_back(
+                    "fake-topic",
+                    TPathId(1, 998),
+                    TSchemeCacheNavigate::KindTopic);
+
+                entry.ListNodeEntry = std::move(newListNode);
+            }
+            return false;
+        });
+
+    const auto response = DescribePath(runtime, ssProxyId, "/MyRoot/nbs");
+    const auto& pathDescription = response->Get()->PathDescription;
+
+    bool foundFileStore = false;
+    bool foundBlockStoreVolume = false;
+
+    for (const auto& child: pathDescription.GetChildren()) {
+        UNIT_ASSERT_C(
+            child.GetName() != "fake-table" && child.GetName() != "fake-topic",
+            TStringBuilder() << "Unknown child kind should have been skipped: "
+                             << child.GetName());
+
+        if (child.GetName() == "fs") {
+            UNIT_ASSERT_VALUES_EQUAL(
+                NKikimrSchemeOp::EPathTypeFileStore,
+                child.GetPathType());
+            foundFileStore = true;
+        } else if (child.GetName() == "volume") {
+            UNIT_ASSERT_VALUES_EQUAL(
+                NKikimrSchemeOp::EPathTypeBlockStoreVolume,
+                child.GetPathType());
+            foundBlockStoreVolume = true;
+        }
+    }
+
+    UNIT_ASSERT(foundFileStore);
+    UNIT_ASSERT(foundBlockStoreVolume);
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1235,6 +1326,11 @@ Y_UNIT_TEST_SUITE(TSSProxyTest)
     Y_UNIT_TEST(ShouldCreateAndDropBlockStoreVolumeWithoutSchemeCache)
     {
         TestShouldCreateAndDropBlockStoreVolume(false);
+    }
+
+    Y_UNIT_TEST(ShouldSkipUnknownChildKindsWithSchemeCache)
+    {
+        TestShouldSkipUnknownChildKinds();
     }
 }
 


### PR DESCRIPTION
We started receive error for ListVolumes command
`2026-07-14T04:13:03.972806Z :BLOCKSTORE_CLIENT WARN: cloud/blockstore/libs/client/durable.cpp:297: [c:c5cddfbb-ad87260d-51e67e67-d6833fed] ListVolumes #10048137230457655649 retry request (retries: 1, timeout: 500.000ms, error: E_REJECTED Unknown child path kind: KindSysView)
`
