### PR TITLE
fix: qemu start issues and coredumps setup as soon as ssh becomes available

### DIFF
--- a/cloud/storage/core/tools/testing/qemu/lib/backtrace.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/backtrace.py
@@ -182,4 +182,10 @@ def setup_coredumps(ssh):
 
 def process_coredumps(ssh):
     """Run guest-side core dump backtrace collection."""
-    ssh('sudo /process_coredumps.sh')
+    ssh(
+        'if sudo test -x /process_coredumps.sh; then '
+        'sudo /process_coredumps.sh; '
+        'else '
+        "echo 'Skipping coredump processing: /process_coredumps.sh is not installed'; "
+        'fi'
+    )

--- a/cloud/storage/core/tools/testing/qemu/lib/qemu.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qemu.py
@@ -342,7 +342,22 @@ class Qemu:
             **daemon_log_files(prefix="qemu-bin", id=0, cwd=yatest.common.output_path()))
         self.qemu_bin.start()
 
-        self.qmp = QmpClient(self.qmp_socket)
+        try:
+            self.qmp = QmpClient(
+                self.qmp_socket,
+                vm_proc=self.qemu_bin.daemon.process,
+            )
+        except Exception:
+            logger.exception("Failed to initialize QMP; killing qemu")
+            try:
+                self.qemu_bin.kill()
+            except Exception:
+                logger.exception("Failed to kill qemu after QMP initialization failure")
+            finally:
+                # A failed start must not make a later call return the pid of a
+                # dead or only partially initialized process.
+                self.qemu_bin = None
+            raise
 
         return self.qemu_bin.daemon.process.pid
 

--- a/cloud/storage/core/tools/testing/qemu/lib/qmp.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/qmp.py
@@ -23,27 +23,31 @@ class QmpClient:
         self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._sock.settimeout(self.timeout)
 
-        time_end = time.time() + self.timeout
-        while True:
-            try:
-                self._sock.connect(sock_path)
-                break
-            except (FileNotFoundError, ConnectionRefusedError) as e:
-                if time.time() > time_end:
-                    logger.debug("%s: timed out", sock_path)
-                    raise
+        try:
+            time_end = time.time() + self.timeout
+            while True:
+                try:
+                    self._sock.connect(sock_path)
+                    break
+                except (FileNotFoundError, ConnectionRefusedError) as e:
+                    if time.time() > time_end:
+                        logger.debug("%s: timed out", sock_path)
+                        raise
 
-                if vm_proc is not None:
-                    res = vm_proc.poll()
-                    if res is not None:
-                        raise Exception('VM process exited with result: {}'.format(res))
+                    if vm_proc is not None:
+                        res = vm_proc.poll()
+                        if res is not None:
+                            raise Exception('VM process exited with result: {}'.format(res))
 
-                logger.debug("%s: %s: retrying", sock_path, e)
-                time.sleep(1)
+                    logger.debug("%s: %s: retrying", sock_path, e)
+                    time.sleep(1)
 
-        logger.info("init for socket {}".format(sock_path))
+            logger.info("init for socket {}".format(sock_path))
 
-        self.command("qmp_capabilities")
+            self.command("qmp_capabilities")
+        except Exception:
+            self.close()
+            raise
 
     def get_socket_path(self):
         return self.sock_path

--- a/cloud/storage/core/tools/testing/qemu/lib/recipe.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/recipe.py
@@ -76,6 +76,10 @@ def start(argv):
 
 
 def start_instance(args, inst_index):
+    # The recipe can retry startup in the same process. Do not let cleanup for
+    # the current attempt use a forwarding port left by an earlier attempt.
+    recipe_set_env("QEMU_FORWARDING_PORT", "", inst_index)
+
     virtio = _get_vm_virtio(args)
     mount_paths = get_mount_paths(inst_index=inst_index)
 
@@ -121,6 +125,9 @@ def start_instance(args, inst_index):
     recipe_set_env("QEMU_FORWARDING_PORT", str(ssh.port), inst_index)
 
     _wait_ssh(qemu, ssh)
+    # Install coredump handling as soon as SSH is available. Any later setup
+    # step may fail and trigger cleanup, including mounting shared filesystems.
+    setup_coredumps(ssh)
 
     for tag, path, _ in mount_paths:
         ssh("sudo mkdir -p {path}".format(path=path))
@@ -162,7 +169,18 @@ def _process_coredumps(args):
     for instance in range(args.instance_count):
         try:
             qemu_fwd_port = env_with_guest_index("QEMU_FORWARDING_PORT", instance)
-            port = int(os.getenv(qemu_fwd_port, 22))
+            port = os.getenv(qemu_fwd_port)
+            key = os.getenv("QEMU_SSH_KEY")
+
+            if not port or not key:
+                logger.info(
+                    "Skipping coredump processing for instance #%d: "
+                    "guest SSH connection is not initialized",
+                    instance,
+                )
+                continue
+
+            port = int(port)
 
             logger.info(
                 "Processing coredumps for instance #%d via SSH port %d",
@@ -173,7 +191,7 @@ def _process_coredumps(args):
             _process_instance_coredumps(
                 user=_get_ssh_user(args),
                 port=port,
-                key=os.getenv("QEMU_SSH_KEY"))
+                key=key)
 
             logger.info("Finished processing coredumps for instance #%d", instance)
         except Exception:
@@ -183,6 +201,8 @@ def _process_coredumps(args):
 def stop(argv):
     args = _parse_args(argv)
     _process_coredumps(args)
+    for instance in range(args.instance_count):
+        recipe_set_env("QEMU_FORWARDING_PORT", "", instance)
 
     with open(PID_FILE, "r") as f:
         pids = f.read().strip().splitlines()
@@ -389,7 +409,7 @@ def _get_ssh_key(args):
     new_ssh_key = yatest.common.work_path(os.path.basename(ssh_key))
     fs.copy_file(ssh_key, new_ssh_key)
     os.chmod(new_ssh_key, 0o0600)
-    library.python.testing.recipe.set_env("QEMU_SSH_KEY", new_ssh_key)
+    recipe_set_env("QEMU_SSH_KEY", new_ssh_key)
     return new_ssh_key
 
 
@@ -450,8 +470,6 @@ def _prepare_test_environment(ssh, virtio):
     else:
         raise QemuKvmRecipeException("Invalid virtio type")
 
-    setup_coredumps(ssh)
-
     library.python.testing.recipe.set_env(
         "TEST_ENV_WRAPPER", vm_env['TEST_ENV_WRAPPER'])
 
@@ -511,7 +529,10 @@ def _wait_ssh(daemon, ssh):
 
 
 def recipe_set_env(key, val, guest_index=0):
-    library.python.testing.recipe.set_env(env_with_guest_index(key, guest_index), val)
+    key = env_with_guest_index(key, guest_index)
+    val = str(val)
+    os.environ[key] = val
+    library.python.testing.recipe.set_env(key, val)
 
 
 def recipe_get_env(key, guest_index=0):

--- a/cloud/storage/core/tools/testing/qemu/lib/ut/backtrace_ut.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/ut/backtrace_ut.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+from cloud.storage.core.tools.testing.qemu.lib import backtrace
+
+
+def test_process_coredumps_skips_an_uninstalled_guest_script():
+    ssh = mock.Mock()
+
+    backtrace.process_coredumps(ssh)
+
+    command = ssh.call_args.args[0]
+    assert "if sudo test -x /process_coredumps.sh" in command
+    assert "sudo /process_coredumps.sh" in command
+    assert "is not installed" in command

--- a/cloud/storage/core/tools/testing/qemu/lib/ut/qemu_ut.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/ut/qemu_ut.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from cloud.storage.core.tools.testing.qemu.lib import qemu as qemu_module
+
+
+def test_start_kills_qemu_when_qmp_initialization_fails():
+    qemu = object.__new__(qemu_module.Qemu)
+    qemu.qemu_bin = None
+    qemu.enable_kvm = False
+    qemu.rootfs = "/test/rootfs"
+    qemu.backup_rootfs = False
+    qemu.qmp_socket = "/tmp/test-qmp"
+
+    process = mock.Mock()
+    daemon = mock.Mock()
+    daemon.daemon = SimpleNamespace(process=process)
+
+    with mock.patch.object(
+        qemu_module,
+        "prepare_root_image",
+        return_value="/test/rootfs",
+    ), mock.patch.object(
+        qemu,
+        "_create_cmd",
+        return_value=["qemu"],
+    ), mock.patch.object(
+        qemu_module,
+        "daemon_log_files",
+        return_value={},
+    ), mock.patch.object(
+        qemu_module.yatest.common,
+        "output_path",
+        return_value="/test/output",
+    ), mock.patch.object(
+        qemu_module.yatest.common,
+        "work_path",
+        return_value="/test/work",
+    ), mock.patch.object(
+        qemu_module,
+        "Daemon",
+        return_value=daemon,
+    ), mock.patch.object(
+        qemu_module,
+        "QmpClient",
+        side_effect=TimeoutError("QMP timed out"),
+    ) as qmp_client:
+        with pytest.raises(TimeoutError, match="QMP timed out"):
+            qemu.start()
+
+    daemon.start.assert_called_once_with()
+    qmp_client.assert_called_once_with("/tmp/test-qmp", vm_proc=process)
+    daemon.kill.assert_called_once_with()
+    assert qemu.qemu_bin is None

--- a/cloud/storage/core/tools/testing/qemu/lib/ut/qmp_ut.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/ut/qmp_ut.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+
+from cloud.storage.core.tools.testing.qemu.lib import qmp
+
+
+def test_init_closes_socket_when_capability_initialization_fails():
+    sock = mock.Mock()
+
+    with mock.patch.object(qmp.socket, "socket", return_value=sock), \
+            mock.patch.object(
+                qmp.QmpClient,
+                "command",
+                side_effect=TimeoutError("QMP timed out"),
+            ):
+        with pytest.raises(TimeoutError, match="QMP timed out"):
+            qmp.QmpClient("/tmp/test-qmp")
+
+    sock.connect.assert_called_once_with("/tmp/test-qmp")
+    sock.close.assert_called_once_with()

--- a/cloud/storage/core/tools/testing/qemu/lib/ut/recipe_ut.py
+++ b/cloud/storage/core/tools/testing/qemu/lib/ut/recipe_ut.py
@@ -1,0 +1,123 @@
+import os
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest import mock
+
+from cloud.storage.core.tools.testing.qemu.lib import recipe
+
+
+def test_recipe_set_env_updates_current_process_and_recipe_env():
+    env_name = "QEMU_TEST_VALUE__2"
+
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(env_name, None)
+        with mock.patch.object(
+            recipe.library.python.testing.recipe,
+            "set_env",
+        ) as persist_env:
+            recipe.recipe_set_env("QEMU_TEST_VALUE", 123, guest_index=2)
+
+        assert os.environ[env_name] == "123"
+        persist_env.assert_called_once_with(env_name, "123")
+
+
+def test_process_coredumps_does_not_fallback_to_port_22():
+    args = SimpleNamespace(instance_count=1, ssh_user="qemu")
+
+    with mock.patch.dict(
+        os.environ,
+        {"QEMU_SSH_KEY": "/test/id_rsa"},
+        clear=False,
+    ):
+        os.environ.pop("QEMU_FORWARDING_PORT", None)
+        with mock.patch.object(
+            recipe,
+            "_process_instance_coredumps",
+        ) as process_instance_coredumps:
+            recipe._process_coredumps(args)
+
+    process_instance_coredumps.assert_not_called()
+
+
+def test_process_coredumps_uses_same_process_recipe_env():
+    args = SimpleNamespace(instance_count=1, ssh_user="qemu")
+
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("QEMU_FORWARDING_PORT", None)
+        os.environ.pop("QEMU_SSH_KEY", None)
+        with mock.patch.object(
+            recipe.library.python.testing.recipe,
+            "set_env",
+        ):
+            recipe.recipe_set_env("QEMU_FORWARDING_PORT", "45757")
+            recipe.recipe_set_env("QEMU_SSH_KEY", "/test/id_rsa")
+
+        with mock.patch.object(
+            recipe,
+            "_process_instance_coredumps",
+        ) as process_instance_coredumps:
+            recipe._process_coredumps(args)
+
+    process_instance_coredumps.assert_called_once_with(
+        user="qemu",
+        port=45757,
+        key="/test/id_rsa",
+    )
+
+
+def test_start_instance_sets_up_coredumps_immediately_after_ssh():
+    args = SimpleNamespace(shared_nic_port=0, invoke_test=False)
+    events = []
+
+    qemu = mock.Mock()
+    qemu.qemu_bin.stderr_file_name = "/test/qemu.err"
+    qemu.qemu_bin.daemon.process.pid = 123
+    qemu.get_ssh_port.return_value = 45757
+
+    patches = [
+        mock.patch.object(recipe, "recipe_set_env"),
+        mock.patch.object(recipe, "_get_vm_virtio", return_value="none"),
+        mock.patch.object(recipe, "get_mount_paths", return_value=[]),
+        mock.patch.object(recipe, "_get_vm_use_virtiofs_server", return_value=False),
+        mock.patch.object(recipe, "_get_qemu_kvm", return_value="qemu"),
+        mock.patch.object(recipe, "_get_qemu_firmware", return_value="firmware"),
+        mock.patch.object(recipe, "get_qemu_bios", return_value=None),
+        mock.patch.object(recipe, "_get_rootfs", return_value="rootfs"),
+        mock.patch.object(recipe, "_get_kernel", return_value=None),
+        mock.patch.object(recipe, "_get_kcmdline", return_value=None),
+        mock.patch.object(recipe, "_get_initrd", return_value=None),
+        mock.patch.object(recipe, "_get_vm_mem", return_value="1G"),
+        mock.patch.object(recipe, "_get_vm_proc", return_value="1"),
+        mock.patch.object(recipe, "_get_qemu_options", return_value=[]),
+        mock.patch.object(recipe, "_get_vm_enable_kvm", return_value=False),
+        mock.patch.object(recipe, "_get_num_request_queues", return_value=1),
+        mock.patch.object(recipe, "Qemu", return_value=qemu),
+        mock.patch.object(recipe, "append_recipe_err_files"),
+        mock.patch.object(recipe, "_get_ssh_user", return_value="qemu"),
+        mock.patch.object(recipe, "_get_ssh_key", return_value="/test/id_rsa"),
+        mock.patch.object(recipe, "SshToGuest"),
+        mock.patch.object(
+            recipe,
+            "_wait_ssh",
+            side_effect=lambda *_: events.append("ssh-ready"),
+        ),
+        mock.patch.object(
+            recipe,
+            "setup_coredumps",
+            side_effect=lambda *_: events.append("coredumps"),
+        ),
+        mock.patch.object(
+            recipe,
+            "_prepare_test_environment",
+            side_effect=lambda *_: events.append("guest-setup"),
+        ),
+        mock.patch.object(recipe, "recipe_get_env", return_value=None),
+        mock.patch("builtins.open", mock.mock_open()),
+    ]
+
+    with ExitStack() as stack:
+        for patch in patches:
+            stack.enter_context(patch)
+        recipe.start_instance(args, 0)
+
+    assert events == ["ssh-ready", "coredumps", "guest-setup"]

--- a/cloud/storage/core/tools/testing/qemu/lib/ut/ya.make
+++ b/cloud/storage/core/tools/testing/qemu/lib/ut/ya.make
@@ -1,0 +1,16 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
+
+TEST_SRCS(
+    backtrace_ut.py
+    qemu_ut.py
+    qmp_ut.py
+    recipe_ut.py
+)
+
+PEERDIR(
+    cloud/storage/core/tools/testing/qemu/lib
+)
+
+END()

--- a/cloud/storage/core/tools/testing/qemu/lib/ya.make
+++ b/cloud/storage/core/tools/testing/qemu/lib/ya.make
@@ -22,3 +22,5 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(ut)


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/actions/runs/29310073358/job/87012299709 here we encountered error where test failed by timeout and we failed to setup_coredumps and it looped processing of coredumps indefinetely. And said coredumps processing were failing because ssh was not set up correctly because it missed setting up environment variables. 

```
  File "cloud/storage/core/tools/testing/qemu/lib/common.py", line 65, in get_command
    logger.info("ssh execute command: '{}'".format(" ".join(cmd)))
                                                   ^^^^^^^^^^^^^
TypeError: sequence item 17: expected str instance, NoneType found
```

So technically there are separate issues that cumulatively caused all this:
1. _prepare_test_environment failed on `touch /mnt/fs0/.test` due to crash in filestore-vhost 
2. Setting up environment file didn't set envvars inside the running recipe process. This lead to NoneType (which was referencing QEMU_SSH_KEY) which lead to ssh failing infinitely.
3. Qemu started but QMP client failed and recipe didn't have pid file to stop it. This lead to leaking of qemu processes (this is kind of side issue)
