### PR TITLE
fix empty in-flight reconnect race

### DIFF
--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -1025,6 +1025,7 @@ void TClientEndpoint::AbortRequests() noexcept
     while (QueuedRequests) {
         auto req = QueuedRequests.Dequeue();
         Y_ABORT_UNLESS(req);
+        RDMA_DEBUG("abort request " << req->ReqId);
         Counters->RequestDequeued();
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -867,18 +867,17 @@ ui64 TClientEndpoint::SendRequest(
     req->CallContext = std::move(callContext);
 
     auto clientReqId = GetNewReqId();
-
-    LWTRACK(
-        RequestEnqueued,
-        req->CallContext->LWOrbit,
-        req->CallContext->RequestId);
+    req->ClientReqId = clientReqId;
 
     if (!CheckState(EEndpointState::Connected)) {
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
         return clientReqId;
     }
 
-    req->ClientReqId = clientReqId;
+    LWTRACK(
+        RequestEnqueued,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
 
     Counters->RequestEnqueued();
     InputRequests.Enqueue(std::move(req));
@@ -886,6 +885,7 @@ ui64 TClientEndpoint::SendRequest(
     if (WaitMode == EWaitMode::Poll) {
         RequestEvent.Set();
     }
+
     return clientReqId;
 }
 
@@ -907,22 +907,27 @@ bool TClientEndpoint::HandleInputRequests() noexcept
 
 void TClientEndpoint::HandleQueuedRequests() noexcept
 {
-    if (!CheckState(EEndpointState::Connected)) {
-        return;
-    }
-
     while (QueuedRequests) {
-        auto* send = SendQueue.Pop();
-        if (!send) {
-            // no more WRs available
-            break;
+        if (CheckState(EEndpointState::Connected)) {
+            auto* send = SendQueue.Pop();
+            if (!send) {
+                // no more WRs available
+                break;
+            }
+
+            auto req = QueuedRequests.Dequeue();
+            Y_ABORT_UNLESS(req);
+
+            Counters->RequestDequeued();
+            SendRequest(std::move(req), send);
         }
+        else {
+            auto req = QueuedRequests.Dequeue();
+            Y_ABORT_UNLESS(req);
 
-        auto req = QueuedRequests.Dequeue();
-        Y_ABORT_UNLESS(req);
-
-        Counters->RequestDequeued();
-        SendRequest(std::move(req), send);
+            Counters->RequestDequeued();
+            AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
+        }
     }
 }
 
@@ -1008,6 +1013,10 @@ void TClientEndpoint::AbortRequests() noexcept
         AbortRequestsEvent.Clear();
     }
 
+    if (!CheckState(EEndpointState::Disconnecting)) {
+        return;
+    }
+
     auto requests = InputRequests.DequeueAll();
     if (requests) {
         QueuedRequests.Append(std::move(requests));
@@ -1016,13 +1025,12 @@ void TClientEndpoint::AbortRequests() noexcept
     while (QueuedRequests) {
         auto req = QueuedRequests.Dequeue();
         Y_ABORT_UNLESS(req);
-        RDMA_DEBUG("abort request " << req->ReqId);
         Counters->RequestDequeued();
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }
 
     while (auto req = ActiveRequests.Pop()) {
-        RDMA_DEBUG("request " << req->ReqId << " aborted");
+        RDMA_DEBUG("abort request " << req->ReqId);
         Counters->RequestAborted();
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }


### PR DESCRIPTION
In poll mode events can get through in any state, so we need to handle this explicitly

- `AbortRequests` can be ignored in all states except Disconnecting
- `HandleCancelRequests` is safe to execute in any state
- `HandleInputRequests` is safe to execute in any state
- `HandleQueuedRequests` must cancel requests in all states except `Connected`, otherwise `HandleInputEvent` might get lost

Offending test is `TRdmaClientTest::ShouldReconnect`
```
2026-07-10T16:42:41.019422Z :RDMA_TEST INFO: start client
2026-07-10T16:42:41.019628Z :RDMA_TEST INFO: [5690230191690045565] start endpoint [host=:: send_magic=4EF7C236 recv_magic=11E3587D]
2026-07-10T16:42:41.019840Z :RDMA_TEST DEBUG: [5690230191690045565] Disconnected -> ResolvingAddress
2026-07-10T16:42:41.019846Z :RDMA_TEST DEBUG: [5690230191690045565] resolve address
2026-07-10T16:42:41.035095Z :RDMA_TEST INFO: [5690230191690045565] RDMA_CM_EVENT_ADDR_RESOLVED received
2026-07-10T16:42:41.035112Z :RDMA_TEST DEBUG: [5690230191690045565] resolve route
2026-07-10T16:42:41.035117Z :RDMA_TEST DEBUG: [5690230191690045565] ResolvingAddress -> ResolvingRoute
2026-07-10T16:42:41.035124Z :RDMA_TEST INFO: [5690230191690045565] RDMA_CM_EVENT_ROUTE_RESOLVED received
2026-07-10T16:42:41.035127Z :RDMA_TEST INFO: [5690230191690045565] connect to ::
2026-07-10T16:42:41.035130Z :RDMA_TEST DEBUG: [5690230191690045565] ResolvingRoute -> Connecting
2026-07-10T16:42:41.035167Z :RDMA_TEST INFO: [5690230191690045565] RDMA_CM_EVENT_ESTABLISHED received
2026-07-10T16:42:41.035169Z :RDMA_TEST DEBUG: [5690230191690045565] validate accept message
2026-07-10T16:42:41.035173Z :RDMA_TEST DEBUG: [5690230191690045565] Connecting -> Connected
2026-07-10T16:42:41.035198Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.9 posted
2026-07-10T16:42:41.035202Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.8 posted
2026-07-10T16:42:41.035205Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.7 posted
2026-07-10T16:42:41.035207Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.6 posted
2026-07-10T16:42:41.035210Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.5 posted
2026-07-10T16:42:41.035213Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.4 posted
2026-07-10T16:42:41.035216Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.3 posted
2026-07-10T16:42:41.035218Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.2 posted
2026-07-10T16:42:41.035221Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.1 posted
2026-07-10T16:42:41.035224Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.0 posted
2026-07-10T16:42:41.035227Z :RDMA_TEST INFO: [5690230191690045565] connected
2026-07-10T16:42:41.035326Z :RDMA_TEST INFO: [5690230191690045565] RDMA_CM_EVENT_DISCONNECTED received
2026-07-10T16:42:41.035337Z :RDMA_TEST INFO: [5690230191690045565] disconnect from ::
2026-07-10T16:42:41.035340Z :RDMA_TEST DEBUG: [5690230191690045565] Connected -> Disconnecting
2026-07-10T16:42:41.035344Z :RDMA_TEST DEBUG: [5690230191690045565] flush queues
2026-07-10T16:42:41.035418Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.9 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035433Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.8 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035437Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.7 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035442Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.6 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035445Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.5 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035449Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.4 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035452Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.3 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035455Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.2 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035458Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.1 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035462Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.0.0 IBV_WC_WR_FLUSH_ERR
2026-07-10T16:42:41.035480Z :RDMA_TEST DEBUG: [5690230191690045565] Disconnecting -> Disconnected
2026-07-10T16:42:41.035483Z :RDMA_TEST INFO: [5690230191690045565] disconnected
2026-07-10T16:42:41.047421Z :RDMA_TEST DEBUG: [5690230191690045565] reconnect timer hit in Disconnected state
2026-07-10T16:42:41.047446Z :RDMA_TEST WARN: [5690230191690045565] reconnect
2026-07-10T16:42:41.047961Z :RDMA_TEST DEBUG: [5690230191690045565] Disconnected -> ResolvingAddress
2026-07-10T16:42:41.047968Z :RDMA_TEST DEBUG: [5690230191690045565] resolve address
2026-07-10T16:42:41.047977Z :RDMA_TEST INFO: [5690230191690045565] RDMA_CM_EVENT_ADDR_RESOLVED received
2026-07-10T16:42:41.047980Z :RDMA_TEST DEBUG: [5690230191690045565] resolve route
2026-07-10T16:42:41.047982Z :RDMA_TEST DEBUG: [5690230191690045565] ResolvingAddress -> ResolvingRoute
2026-07-10T16:42:41.047985Z :RDMA_TEST INFO: [5690230191690045565] RDMA_CM_EVENT_ROUTE_RESOLVED received
2026-07-10T16:42:41.047987Z :RDMA_TEST INFO: [5690230191690045565] connect to ::
2026-07-10T16:42:41.047989Z :RDMA_TEST DEBUG: [5690230191690045565] ResolvingRoute -> Connecting
2026-07-10T16:42:41.048036Z :RDMA_TEST INFO: [5690230191690045565] RDMA_CM_EVENT_ESTABLISHED received
2026-07-10T16:42:41.048038Z :RDMA_TEST DEBUG: [5690230191690045565] validate accept message
2026-07-10T16:42:41.048040Z :RDMA_TEST DEBUG: [5690230191690045565] Connecting -> Connected
2026-07-10T16:42:41.048050Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.9 posted
2026-07-10T16:42:41.048052Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.8 posted
2026-07-10T16:42:41.048055Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.7 posted
2026-07-10T16:42:41.048057Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.6 posted
2026-07-10T16:42:41.048059Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.5 posted
2026-07-10T16:42:41.048061Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.4 posted
2026-07-10T16:42:41.048063Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.3 posted
2026-07-10T16:42:41.048065Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.2 posted
2026-07-10T16:42:41.048067Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.1 posted
2026-07-10T16:42:41.048070Z :RDMA_TEST TRACE: [5690230191690045565] RECV 11E3587D.1.0 posted
2026-07-10T16:42:41.048072Z :RDMA_TEST INFO: [5690230191690045565] connected
2026-07-10T16:42:41.048562Z :RDMA_TEST DEBUG: [5690230191690045565] abort request 0
```