### PR TITLE
issue-6518: fix "address already in use" errors in nemesis tests caused by port collisions

### DIFF
--- a/cloud/blockstore/tests/python/lib/disk_agent_runner.py
+++ b/cloud/blockstore/tests/python/lib/disk_agent_runner.py
@@ -12,6 +12,7 @@ from cloud.blockstore.config.storage_pb2 import TStorageServiceConfig
 from cloud.blockstore.config.server_pb2 import TServerAppConfig, TKikimrServiceConfig, TServerConfig, TLocation
 from cloud.storage.core.config.features_pb2 import TFeaturesConfig
 from cloud.storage.core.tools.common.python.core_pattern import core_pattern
+from cloud.storage.core.tools.common.python.port_reservation import PortManager
 from cloud.storage.core.tools.testing.access_service.lib import AccessService
 from contrib.ydb.core.protos.auth_pb2 import TAuthConfig
 from contrib.ydb.core.protos.config_pb2 import TActorSystemConfig
@@ -61,11 +62,11 @@ class LocalDiskAgent(Daemon):
                 dict(name="dynamic_storage_pool:2", kind="ssd")]
 
         self.__service_type = LocalDiskAgent.__get_service_type(server_app_config)
-        self.__port_manager = yatest_common.PortManager()
+        self.__port_manager = PortManager()
         self.__grpc_port = grpc_port
         self.__grpc_trace = grpc_trace
-        self.__ic_port = self.__port_manager.get_port()
-        self.__mon_port = self.__port_manager.get_port()
+        self.__ic_port = self.__port_manager.reserve_port()
+        self.__mon_port = self.__port_manager.reserve_port()
         self.__temporary_agent = temporary_agent
         if disk_agent_binary_path is not None:
             self.__binary_path = disk_agent_binary_path
@@ -131,8 +132,8 @@ class LocalDiskAgent(Daemon):
         self.__access_service = None
         if enable_access_service:
             host = "localhost"
-            port = self.__port_manager.get_port()
-            control_server_port = self.__port_manager.get_port()
+            port = self.__port_manager.reserve_port()
+            control_server_port = self.__port_manager.reserve_port()
             self.__access_service = AccessService(host, port, control_server_port)
             self.__proto_configs["auth.txt"] = self.__generate_auth_txt(port)
 
@@ -557,6 +558,17 @@ ModifyScheme {
             command = [
                 launcher_path,
             ] + self.__unstable_process_args
+
+            # All ports allocated by this agent (ic, mon, access-service,
+            # ...) are reserved by PortManager (flocked under PORT_SYNC_PATH)
+            # only while the allocating process lives.
+            #
+            # Pass the reserved ports to the launcher so it re-takes and holds
+            # those flocks across every restart.
+            #
+            # See issue #6518 for details
+            for reserved_port in self.__port_manager.list_reserved_ports():
+                command += ["--reserve-port", str(reserved_port)]
 
             for cmd in commands:
                 command += [

--- a/cloud/filestore/tests/python/lib/daemon_config.py
+++ b/cloud/filestore/tests/python/lib/daemon_config.py
@@ -21,6 +21,7 @@ from cloud.filestore.config.storage_pb2 import TStorageConfig
 
 from cloud.storage.core.protos.media_pb2 import STORAGE_MEDIA_HDD
 from cloud.storage.core.tools.testing.access_service.lib import AccessService
+from cloud.storage.core.tools.common.python.port_reservation import PortManager
 
 logger = logging.getLogger(__name__)
 
@@ -81,17 +82,17 @@ class FilestoreDaemonConfigGenerator:
         self.__restart_interval = restart_interval
         self.__restart_flag = restart_flag
 
-        self._port_manager = yatest_common.PortManager()
-        self.__port = self._port_manager.get_port()
-        self.__mon_port = self._port_manager.get_port()
-        self.__ic_port = self._port_manager.get_port() if ic_port is None else ic_port
+        self._port_manager = PortManager()
+        self.__port = self._port_manager.reserve_port()
+        self.__mon_port = self._port_manager.reserve_port()
+        self.__ic_port = self._port_manager.reserve_port() if ic_port is None else ic_port
         self.__access_service_type = access_service_type
         self.__access_service_port = access_service_port
 
         self.__use_secure_registration = use_secure_registration
 
         if secure:
-            self.__secure_port = self._port_manager.get_port()
+            self.__secure_port = self._port_manager.reserve_port()
             self.__app_config.ServerConfig.SecurePort = self.__secure_port
 
         with open(self.__app_config_file_path, "w") as config_file:
@@ -366,7 +367,21 @@ class FilestoreDaemonConfigGenerator:
                 str(self.__restart_interval),
                 "--cmdline",
                 " ".join(command),
-            ] + (["--allow-restart-flag", self.__restart_flag] if self.__restart_flag else [])
+            ]
+
+            if self.__restart_flag:
+                command += ["--allow-restart-flag", self.__restart_flag]
+
+            # All ports allocated by the PortManager (server, mon, ic, secure,
+            # local-service, ...) are reserved (flocked under PORT_SYNC_PATH)
+            # only until the recipe process exits.
+            #
+            # Pass the full set to the launcher so it re-takes and holds those
+            # flocks across every restart.
+            #
+            # See issue #6518 for details
+            for reserved_port in self._port_manager.list_reserved_ports():
+                command += ["--reserve-port", str(reserved_port)]
 
         return command
 
@@ -464,7 +479,7 @@ class FilestoreVhostConfigGenerator(FilestoreDaemonConfigGenerator):
             trace_sampling_rate=trace_sampling_rate,
         )
 
-        self.__local_service_port = self._port_manager.get_port()
+        self.__local_service_port = self._port_manager.reserve_port()
 
     def generate_aux_params(self):
         return ["--local-service-port", str(self.__local_service_port)]

--- a/cloud/filestore/tests/python/lib/ya.make
+++ b/cloud/filestore/tests/python/lib/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
 
     cloud/storage/core/protos
     cloud/storage/core/tests/common
+    cloud/storage/core/tools/common/python
     cloud/storage/core/tools/testing/access_service_new/lib
     cloud/storage/core/tools/testing/access_service/lib
 

--- a/cloud/storage/core/tools/common/python/port_reservation.py
+++ b/cloud/storage/core/tools/common/python/port_reservation.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 
 import library.python.filelock
 import yatest.common.network as ya_network
@@ -56,14 +57,24 @@ class PortReservation:
     with any PortManager sharing PORT_SYNC_PATH is preserved - and keeps them
     until the holding process exits.
 
-    reserve_ports() is called synchronously right before every terminate/kill,
-    it does all its work once, before the first restart, so the sockets are
-    never freed while the ports are unreserved.
+    reserve_ports() is called synchronously right before every terminate/kill.
+    A single non-blocking flock attempt is not enough there: a concurrent
+    PortManager takes the flock for a moment while it bind-checks the port
+    (the check fails while our child is alive, so the flock comes right
+    back), and if our only attempt happens to land in that moment we would
+    free the sockets with the port unreserved - exactly the race we are
+    fixing. So each call retries in short steps for up to grace_seconds.
+
+    A holder that does not go away within the grace period is not transient -
+    it is the allocating process itself, still alive and still holding the
+    flock. In that case the port is protected by that process for as long as
+    it lives, so it is safe to proceed with the restart - the next
+    reserve_ports() call retries and picks the flock up.
 
     Introduced to fix a race with unreserved ports (see issue #6518 for details)
     """
 
-    def __init__(self, ports, grace_seconds=60):
+    def __init__(self, ports, grace_seconds=2, retry_step_seconds=0.001):
         self._sync_dir = os.environ.get('PORT_SYNC_PATH')
         assert self._sync_dir
 
@@ -72,35 +83,46 @@ class PortReservation:
 
         self._locks = {}
         self._grace_seconds = grace_seconds
+        self._retry_step_seconds = retry_step_seconds
         self._reserve_done = False
 
     def reserve_ports(self):
-        # One-shot by design: all acquisition happens on the first call (right
-        # before the first restart) and later calls return immediately.
+        # All acquisition normally happens on the first call (right before
+        # the first restart), ports whose flocks are still held by a
+        # long-lived process (see the class docstring) are retried on every
+        # subsequent call until acquired
 
         if self._reserve_done:
             return
 
-        pending = set(self._ports)
-        for port in sorted(pending):
-            lock = library.python.filelock.FileLock(
-                os.path.join(self._sync_dir, str(port)))
-            if lock.acquire(blocking=False):
-                # Keep the fd open -> lock stays held until we exit
-                self._locks[port] = lock
-                pending.discard(port)
-                logging.info('reserved port %d (%s)', port, lock.path)
-            else:
-                # Port reservation is best effort. There may be legitimate port
-                # holders, such as test code
-                logging.info(
-                    'failed to reserve port %d (%s), someone else is holding it',
-                    port,
-                    lock.path,
-                )
+        pending = set(self._ports) - set(self._locks)
+        deadline = time.monotonic() + self._grace_seconds
+        while True:
+            for port in sorted(pending):
+                lock = library.python.filelock.FileLock(
+                    os.path.join(self._sync_dir, str(port)))
+                if lock.acquire(blocking=False):
+                    # Keep the fd open -> lock stays held until we exit
+                    self._locks[port] = lock
+                    pending.discard(port)
+                    logging.info('reserved port %d (%s)', port, lock.path)
 
-        if not pending:
-            self._reserve_done = True
+            if not pending:
+                self._reserve_done = True
+                break
+
+            if time.monotonic() >= deadline:
+                # Not transient: the flocks are held by a long-lived process
+                # (normally the allocating one, which itself keeps the ports
+                # protected).
+                #
+                # Proceed and retry on the next call
+                logging.info(
+                    'ports %s are still flocked by another process; '
+                    'will retry before the next restart', sorted(pending))
+                break
+
+            time.sleep(self._retry_step_seconds)
 
     def release(self):
         while self._locks:

--- a/cloud/storage/core/tools/common/python/port_reservation.py
+++ b/cloud/storage/core/tools/common/python/port_reservation.py
@@ -1,0 +1,108 @@
+import logging
+import os
+
+import library.python.filelock
+import yatest.common.network as ya_network
+
+
+class PortManager:
+    """Wrapper over a yatest PortManager that memorizes allocated ports.
+
+    yatest PortManager reserves a port by holding an flock on
+    <PORT_SYNC_PATH>/<port>, but that flock only lives as long as the
+    allocating process (where PortManager is locatedf). When the process
+    that binds the port is wrapped in a restarting launcher (unstable-process),
+    the ports must stay reserved for the launcher's whole lifetime instead:
+    every restart briefly frees the sockets, and during that gap a concurrent
+    suite's PortManager could otherwise grab the same ports.
+
+    Code that allocates such ports should do it via reserve_port() and pass
+    list_reserved_ports() to the unstable-process via --reserve-port option, which re-takes
+    and holds the flocks via PortReservation below.
+
+    Introduced to fix a race with unreserved ports (see issue #6518 for details)
+    """
+
+    def __init__(self):
+        # the underlying PortManager picks up the sync dir from the
+        # PORT_SYNC_PATH environment variable
+        self._port_manager = ya_network.PortManager()
+        self._reserved_ports = []
+
+    def reserve_port(self):
+        port = self._port_manager.get_port()
+        self._reserved_ports.append(port)
+        return port
+
+    def list_reserved_ports(self):
+        return list(self._reserved_ports)
+
+    def release_port(self, port):
+        # a released port is no longer reserved
+        if port in self._reserved_ports:
+            self._reserved_ports.remove(port)
+        self._port_manager.release_port(port)
+
+    def release(self):
+        self._reserved_ports = []
+        self._port_manager.release()
+
+
+class PortReservation:
+    """Re-holds port flocks before the launched process's sockets are freed.
+
+    Re-takes the same flocks the allocating PortManager held - same path
+    convention and same library.python.filelock.FileLock, so mutual exclusion
+    with any PortManager sharing PORT_SYNC_PATH is preserved - and keeps them
+    until the holding process exits.
+
+    reserve_ports() is called synchronously right before every terminate/kill,
+    it does all its work once, before the first restart, so the sockets are
+    never freed while the ports are unreserved.
+
+    Introduced to fix a race with unreserved ports (see issue #6518 for details)
+    """
+
+    def __init__(self, ports, grace_seconds=60):
+        self._sync_dir = os.environ.get('PORT_SYNC_PATH')
+        assert self._sync_dir
+
+        assert ports
+        self._ports = sorted(set(ports))
+
+        self._locks = {}
+        self._grace_seconds = grace_seconds
+        self._reserve_done = False
+
+    def reserve_ports(self):
+        # One-shot by design: all acquisition happens on the first call (right
+        # before the first restart) and later calls return immediately.
+
+        if self._reserve_done:
+            return
+
+        pending = set(self._ports)
+        for port in sorted(pending):
+            lock = library.python.filelock.FileLock(
+                os.path.join(self._sync_dir, str(port)))
+            if lock.acquire(blocking=False):
+                # Keep the fd open -> lock stays held until we exit
+                self._locks[port] = lock
+                pending.discard(port)
+                logging.info('reserved port %d (%s)', port, lock.path)
+            else:
+                # Port reservation is best effort. There may be legitimate port
+                # holders, such as test code
+                logging.info(
+                    'failed to reserve port %d (%s), someone else is holding it',
+                    port,
+                    lock.path,
+                )
+
+        if not pending:
+            self._reserve_done = True
+
+    def release(self):
+        while self._locks:
+            _, lock = self._locks.popitem()
+            lock.release()

--- a/cloud/storage/core/tools/common/python/ut/port_reservation_ut.py
+++ b/cloud/storage/core/tools/common/python/ut/port_reservation_ut.py
@@ -1,0 +1,68 @@
+import os
+
+import library.python.filelock
+import yatest.common as yc
+
+from cloud.storage.core.tools.common.python.port_reservation import (
+    PortManager,
+    PortReservation,
+)
+
+
+def setup_sync_dir():
+    sync_dir = yc.output_path("port_sync_dir")
+    os.makedirs(sync_dir, exist_ok=True)
+    os.environ["PORT_SYNC_PATH"] = sync_dir
+    return sync_dir
+
+
+def get_lock_file_path(sync_dir, port):
+    return os.path.join(sync_dir, str(port))
+
+
+def assert_lock_failure(sync_dir, port):
+    lock_file_path = get_lock_file_path(sync_dir, port)
+    assert os.path.exists(lock_file_path)
+
+    lock = library.python.filelock.FileLock(lock_file_path)
+    assert not lock.acquire(blocking=False)
+
+
+def assert_lock_success(sync_dir, port):
+    lock_file_path = get_lock_file_path(sync_dir, port)
+
+    lock = library.python.filelock.FileLock(lock_file_path)
+    assert lock.acquire(blocking=False)
+    lock.release()
+
+
+def test_port_manager():
+    sync_dir = setup_sync_dir()
+    pm = PortManager()
+
+    ports = [pm.reserve_port() for _ in range(3)]
+
+    # Ports should be reserved by the underlying PortManager
+    for port in ports:
+        assert_lock_failure(sync_dir, port)
+
+    assert pm.list_reserved_ports() == ports
+
+    # a released port is no longer reserved and can be reserved again
+    pm.release_port(ports[1])
+    assert pm.list_reserved_ports() == [ports[0], ports[2]]
+    assert_lock_success(sync_dir, ports[1])
+
+
+def test_port_reservation_and_release():
+    sync_dir = setup_sync_dir()
+    pm = PortManager()
+    port = pm.reserve_port()
+    pm.release_port(port)
+
+    reservation = PortReservation([port])
+    reservation.reserve_ports()
+    assert_lock_failure(sync_dir, port)
+
+    reservation.release()
+    assert_lock_success(sync_dir, port)

--- a/cloud/storage/core/tools/common/python/ut/ya.make
+++ b/cloud/storage/core/tools/common/python/ut/ya.make
@@ -4,10 +4,14 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 
 TEST_SRCS(
     core_pattern_ut.py
+    port_reservation_ut.py
 )
 
 PEERDIR(
     cloud/storage/core/tools/common/python
+
+    library/python/filelock
+    library/python/testing/yatest_common
 )
 
 END()

--- a/cloud/storage/core/tools/common/python/ya.make
+++ b/cloud/storage/core/tools/common/python/ya.make
@@ -3,10 +3,18 @@ PY3_LIBRARY()
 PY_SRCS(
     core_pattern.py
     daemon.py
+    port_reservation.py
 )
 
 PEERDIR(
     contrib/python/requests/py3
+
+    library/python/filelock
+    library/python/testing/yatest_common
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/cloud/storage/core/tools/testing/unstable-process/__main__.py
+++ b/cloud/storage/core/tools/testing/unstable-process/__main__.py
@@ -9,8 +9,11 @@ import subprocess
 import sys
 import time
 
+from cloud.storage.core.tools.common.python.port_reservation import PortReservation
+
 
 process = None
+reservation = None
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +21,9 @@ logger = logging.getLogger(__name__)
 def sighandler(sig, frame):
     if process is not None:
         process.terminate()
+
+    if reservation is not None:
+        reservation.release()
 
     sys.exit(0)
 
@@ -77,6 +83,14 @@ def main():
     parser.add_argument('--ping-path', help='part of ping endpoint', type=str, default='')
     parser.add_argument('--ping-success-codes', help='', nargs='*')
     parser.add_argument('--allow-restart-flag', help='file to look for before restart', type=str, default=None)
+    parser.add_argument(
+        '--reserve-port',
+        help='re-take the PortManager flock (under $PORT_SYNC_PATH) for this port '
+             'and hold it for the whole lifetime of this launcher; repeat for '
+             'each port',
+        type=int,
+        action='append',
+        default=[])
     parser.add_argument('-v', '--verbose', help='verbose mode', default=0, action='count')
     parser.add_argument('--terminate-check-timeout', help='the timeout in seconds between wait attempts for terminated process', type=int, default=60)
 
@@ -97,6 +111,10 @@ def main():
     interval = datetime.timedelta(seconds=args.restart_interval)
 
     global process
+    global reservation
+
+    if len(args.reserve_port) != 0:
+        reservation = PortReservation(args.reserve_port)
 
     while True:
         now = datetime.datetime.now()
@@ -107,6 +125,13 @@ def main():
                     logging.debug("waiting for the allow restart flag")
                     time.sleep(1)
                     continue
+
+                # Hold the port flocks *before* the child's sockets are freed,
+                # so the ports are never observable as both unlocked and unbound.
+                #
+                # Needed to fix a race with unreserved ports (see issue #6518 for details)
+                if reservation is not None:
+                    reservation.reserve_ports()
 
                 if should_kill_process():
                     logging.info(f'killing process {cmdline}')

--- a/cloud/storage/core/tools/testing/unstable-process/__main__.py
+++ b/cloud/storage/core/tools/testing/unstable-process/__main__.py
@@ -19,10 +19,10 @@ logger = logging.getLogger(__name__)
 
 
 def sighandler(sig, frame):
-    if process is not None:
+    if process:
         process.terminate()
 
-    if reservation is not None:
+    if reservation:
         reservation.release()
 
     sys.exit(0)
@@ -113,14 +113,14 @@ def main():
     global process
     global reservation
 
-    if len(args.reserve_port) != 0:
+    if args.reserve_port:
         reservation = PortReservation(args.reserve_port)
 
     while True:
         now = datetime.datetime.now()
         deadline = start_ts + interval if start_ts is not None else None
         if deadline is None or now >= deadline:
-            if process is not None:
+            if process:
                 while args.allow_restart_flag is not None and not os.path.exists(args.allow_restart_flag):
                     logging.debug("waiting for the allow restart flag")
                     time.sleep(1)
@@ -130,7 +130,7 @@ def main():
                 # so the ports are never observable as both unlocked and unbound.
                 #
                 # Needed to fix a race with unreserved ports (see issue #6518 for details)
-                if reservation is not None:
+                if reservation:
                     reservation.reserve_ports()
 
                 if should_kill_process():
@@ -147,7 +147,7 @@ def main():
                                             check_timeout=args.terminate_check_timeout)
 
             def start_process():
-                if process is not None and args.downtime > 0:
+                if process and args.downtime > 0:
                     logging.info(f'waiting {args.downtime} seconds before starting process')
                     time.sleep(args.downtime)
 

--- a/cloud/storage/core/tools/testing/unstable-process/__main__.py
+++ b/cloud/storage/core/tools/testing/unstable-process/__main__.py
@@ -136,6 +136,10 @@ def main():
                 if should_kill_process():
                     logging.info(f'killing process {cmdline}')
                     process.kill()
+                    # Reap the killed process before starting the next one:
+                    # its sockets are only guaranteed to be freed once it is
+                    # gone, and the new instance binds the same ports.
+                    process.wait()
                 else:
                     logging.info(f'terminating process {cmdline}')
                     process.terminate()

--- a/cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon/__main__.py
+++ b/cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon/__main__.py
@@ -1,0 +1,23 @@
+import argparse
+import socket
+import time
+
+
+def main():
+    # A minimal stand-in for a real daemon managed by unstable-process
+    # (launcher): binds the port the same way PortManager's is_port_free()
+    # probes it (AF_INET6, '::') and idles until the launcher restarts it.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--port', type=int, required=True)
+    args = parser.parse_args()
+
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    sock.bind(('::', args.port))
+    sock.listen(1)
+
+    while True:
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon/ya.make
+++ b/cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon/ya.make
@@ -1,0 +1,7 @@
+PY3_PROGRAM(dummy-daemon)
+
+PY_SRCS(
+    __main__.py
+)
+
+END()

--- a/cloud/storage/core/tools/testing/unstable-process/tests/test.py
+++ b/cloud/storage/core/tools/testing/unstable-process/tests/test.py
@@ -1,0 +1,213 @@
+import errno
+import os
+import socket
+import threading
+import time
+
+import yatest.common as yc
+
+import library.python.filelock
+
+from cloud.storage.core.tools.common.python.daemon import Daemon, DaemonError
+from cloud.storage.core.tools.common.python.port_reservation import PortManager
+
+
+RESTART_INTERVAL = 1
+
+
+def launcher_command():
+    return [yc.binary_path(
+        "cloud/storage/core/tools/testing/unstable-process/storage-unstable-process")]
+
+
+def dummy_daemon_command():
+    return [yc.binary_path(
+        "cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon/dummy-daemon")]
+
+
+class PortStealer(threading.Thread):
+    """Mimic of a concurrent suite capturing the port.
+
+    Non-blocking flock on <sync>/<port> (as PortManager does), then an attempt
+    to bind the port - the same check PortManager's is_port_free() performs,
+    except the socket is kept: a successful bind means the port was both
+    unlocked and unbound, and the stealer holds the flock and the socket
+    (as the concurrent suite's PortManager + daemon would) and sets `stolen`.
+    If the port is in use, the flock is released and the attempt is retried in
+    a tight loop to reproduce the race as aggressively as possible.
+
+    """
+
+    def __init__(self, port, sync_dir):
+        super().__init__(daemon=True)
+        self._port = port
+        self._lock_path = os.path.join(sync_dir, str(port))
+        self._should_stop = threading.Event()
+        self.stolen = threading.Event()
+
+    def stop(self):
+        self._should_stop.set()
+        self.join()
+
+    def run(self):
+        while not self._should_stop.is_set():
+            lock = library.python.filelock.FileLock(self._lock_path)
+            if not lock.acquire(blocking=False):
+                # flock is held (steady state once the launcher reserved it):
+                # back off slightly so spinning stealers don't starve slow
+                # runners, while the free-port path below stays as tight as
+                # possible
+                time.sleep(0.001)
+                continue
+
+            sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            try:
+                sock.bind(('::', self._port))
+            except OSError as e:
+                sock.close()
+                lock.release()
+                if e.errno != errno.EADDRINUSE:
+                    raise
+                continue
+
+            # port was both unlocked and unbound: captured exactly like a
+            # foreign PortManager + daemon would
+            sock.listen(1)
+            self.stolen.set()
+
+            self._should_stop.wait()
+
+            sock.close()
+            lock.release()
+            return
+
+
+class Env:
+    def __init__(self):
+        # everything lands under the test output dir, so the launcher's
+        # captured std streams and the lock files survive as test artifacts
+        self.dir = yc.output_path("unstable_process_test")
+        self.sync_dir = os.path.join(self.dir, "port_sync_dir")
+        os.makedirs(self.sync_dir, exist_ok=True)
+        # inherited by the launcher process (and read by PortReservation and
+        # any PortManager constructed without an explicit sync_dir)
+        os.environ["PORT_SYNC_PATH"] = self.sync_dir
+        self._launchers = []
+        self._stealers = []
+
+    def start_launcher(self, port, reserve):
+        command = launcher_command() + [
+            "--restart-interval", str(RESTART_INTERVAL),
+            "--cmdline", " ".join(dummy_daemon_command() + ["--port", str(port)]),
+        ]
+        if reserve:
+            command += ["--reserve-port", str(port)]
+
+        launcher = Daemon(
+            commands=[command], cwd=self.dir, service_name="launcher")
+        launcher.start()
+        self._launchers.append(launcher)
+
+        return launcher
+
+    def start_stealers(self, port, count=4):
+        for _ in range(count):
+            stealer = PortStealer(port, self.sync_dir)
+            stealer.start()
+            self._stealers.append(stealer)
+
+    def stolen(self):
+        return any(stealer.stolen.is_set() for stealer in self._stealers)
+
+    def cleanup(self):
+        for launcher in self._launchers:
+            try:
+                if launcher.is_alive():
+                    launcher.stop()
+            except DaemonError:
+                pass
+
+        for stealer in self._stealers:
+            stealer.stop()
+
+
+def port_bound(port):
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        sock.bind(("::", port))
+    except OSError as e:
+        if e.errno == errno.EADDRINUSE:
+            return True
+        raise
+    finally:
+        sock.close()
+    return False
+
+
+def wait_for(predicate, timeout=60, step=0.1):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(step)
+    return predicate()
+
+
+# See issue #6518 for details
+def test_cannot_steal_reserved_port():
+    env = Env()
+    try:
+        pm = PortManager()
+        port = pm.reserve_port()
+
+        # maximum pressure: stealers hammer the flock before the launcher
+        # even starts
+        env.start_stealers(port)
+
+        assert not env.stolen(), \
+            "port stealer captured the port before launcer is started"
+
+        launcher = env.start_launcher(port, reserve=True)
+        assert wait_for(lambda: port_bound(port))
+        assert launcher.is_alive(), \
+            "launcher died shortly after start"
+
+        # corresponds to recipe finished its start
+        pm.release_port(port)
+
+        # let several restart gaps happen under attack
+        time.sleep(RESTART_INTERVAL * 5)
+
+        assert not env.stolen(), \
+            "port stealer captured the port after despite the reservation"
+        assert launcher.is_alive(), \
+            "launcher died; the daemon likely failed to rebind its port"
+    finally:
+        env.cleanup()
+
+
+def test_steals_port_without_reservation():
+    # Proves the stealer (and therefore the test above) can actually reproduce
+    # the original race. Without --reserve-port the first restart gap is
+    # unprotected: the stealer takes the flock, finds the port free, binds it.
+    # The daemon then fails to rebind (EADDRINUSE) and exits, and the launcher
+    # terminates with exit code 3 ('subprocess unexpectedly exited').
+    #
+    # See issue #6518 for details
+    env = Env()
+    try:
+        pm = PortManager()
+        port = pm.reserve_port()
+
+        env.start_stealers(port)
+
+        launcher = env.start_launcher(port, reserve=False)
+        assert wait_for(lambda: port_bound(port))
+        pm.release_port(port)
+
+        assert wait_for(env.stolen), \
+            "port stealer failed to reproduce the race with unreserved ports"
+        assert wait_for(lambda: not launcher.is_alive())
+        assert launcher.returncode == 3
+    finally:
+        env.cleanup()

--- a/cloud/storage/core/tools/testing/unstable-process/tests/ya.make
+++ b/cloud/storage/core/tools/testing/unstable-process/tests/ya.make
@@ -1,0 +1,19 @@
+PY3TEST()
+
+TEST_SRCS(test.py)
+
+DEPENDS(
+    cloud/storage/core/tools/testing/unstable-process
+    cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon
+)
+
+PEERDIR(
+    cloud/storage/core/tools/common/python
+
+    library/python/filelock
+    library/python/testing/yatest_common
+)
+
+SIZE(MEDIUM)
+
+END()

--- a/cloud/storage/core/tools/testing/unstable-process/ya.make
+++ b/cloud/storage/core/tools/testing/unstable-process/ya.make
@@ -2,6 +2,8 @@ PY3_PROGRAM(storage-unstable-process)
 
 PEERDIR(
     contrib/python/requests/py3
+
+    cloud/storage/core/tools/common/python
 )
 
 PY_SRCS(
@@ -9,3 +11,7 @@ PY_SRCS(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    tests
+)


### PR DESCRIPTION
### Problem

Nemesis tests (daemons wrapped in the `unstable-process` launcher) sporadically fail with
"address already in use": after a restart the daemon cannot re-bind its own ports because a
concurrently running test suite has grabbed them.

The root cause is a lifetime mismatch. yatest `PortManager` reserves a port by holding a
flock on `<PORT_SYNC_PATH>/<port>`, but that flock only lives as long as the *allocating*
process (e.g. a recipe), while the port itself is used for the whole lifetime of the
launcher. Once the allocator exits, every restart gap - the moment between the child's
sockets being freed and the new instance binding them - leaves the port both unlocked and
unbound. A concurrent suite's `PortManager` (which takes the flock first and bind-checks
second) can then legitimately capture it.

### Fix

Keep the flocks held for the launcher's whole lifetime by handing them over from the
allocator to the launcher:

* **`port_reservation.py` - `PortManager`**: a wrapper over yatest `PortManager` that
  memorizes allocated ports (`reserve_port()` / `list_reserved_ports()`), so runners can
  tell the launcher which ports to protect.
* **`port_reservation.py` - `PortReservation`**: used inside `unstable-process`; re-takes
  the same flocks (same path convention, same `library.python.filelock.FileLock`) and holds
  them until the launcher exits. Requires `PORT_SYNC_PATH` (asserts otherwise).
* **`unstable-process --reserve-port`** (repeatable): before every terminate/kill — i.e.
  before the child's sockets are freed - the launcher calls `reserve_ports()`, so the port
  is never observable as both unlocked and unbound.
* **Integration**: `disk_agent_runner.py` (blockstore) and `daemon_config.py` (filestore)
  allocate ports through the wrapper and pass the reserved set to the launcher.

Acquisition is **non-blocking and best-effort with a short grace period** (retry in 1 ms
steps, up to 2 s per call). A single non-blocking attempt is not enough: a concurrent
`PortManager` holds the flock for a moment while it bind-checks the port (the check fails
while our child is alive, so the flock comes right back), and an attempt landing in that
window would otherwise free the sockets unprotected. A holder that survives the whole grace
period is not transient - it is the allocating process itself, which keeps the port
protected for as long as it lives, so the launcher proceeds and retries before the next
restart. At any moment at least one of the three holds the port: the allocator's flock, the
child's bound socket, or the launcher's flock.

Additionally, the kill path now reaps the killed child (`process.wait()`) before starting
the next instance: its sockets are only guaranteed to be freed once it is gone, and the new
instance binds the same ports.

### Testing

* `cloud/storage/core/tools/common/python/ut`: unit tests for the wrapper and for
  `PortReservation` acquire/release semantics.
* `cloud/storage/core/tools/testing/unstable-process/tests`: integration tests running the
  real launcher with a dummy daemon under attack from `PortStealer` threads that mimic a
  concurrent suite (flock, then bind, keep both on success):
  * `test_cannot_steal_reserved_port` - with `--reserve-port` the port survives multiple
    restart gaps under contention;
  * `test_steals_port_without_reservation` - without the option the stealer reproduces the
    original race (daemon dies with EADDRINUSE, launcher exits with code 3), proving the
    test setup actually exercises the bug.

### Issue
#6518

