### PR TITLE
[Filestore] Rename IIndexTabletDatabase to INodeIndexTabletDatabase

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -844,7 +844,7 @@ private:
         FILESTORE_IMPLEMENT_RO_TRANSACTION,
         TTxIndexTablet,
         TIndexTabletDatabaseProxy,
-        IIndexTabletDatabase);
+        INodeIndexTabletDatabase);
 
     STFUNC(StateBoot);
     STFUNC(StateInit);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_accessnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_accessnode.cpp
@@ -79,7 +79,7 @@ bool TIndexTabletActor::ValidateTx_AccessNode(
 
 bool TIndexTabletActor::PrepareTx_AccessNode(
     const NActors::TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TAccessNode& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -497,7 +497,7 @@ bool TIndexTabletActor::PrepareTx_AddBlob(
 
     bool ready = true;
     for (auto [id, maxOffset]: args.WriteRanges) {
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         if (!ReadNode(db, id, args.CommitId, node)) {
             ready = false;
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -634,7 +634,7 @@ bool TIndexTabletActor::PrepareTx_Compaction(
 
     bool ready = true;
     for (auto nodeId: nodes) {
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         if (!ReadNode(db, nodeId, args.CommitId, node)) {
             ready = false;
             continue;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -248,7 +248,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
         }
 
         // check whether child node exists
-        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
         if (!ReadNodeRef(db, args.NodeId, args.ReadCommitId, args.Name, ref)) {
             return false;   // not ready
         }
@@ -383,7 +383,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
                 args.WriteCommitId,
                 attrs);
 
-            args.TargetNode = IIndexTabletDatabase::TNode {
+            args.TargetNode = INodeIndexTabletDatabase::TNode {
                 args.TargetNodeId,
                 attrs,
                 args.WriteCommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -654,7 +654,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
         // If the filesystem is configured to check for nodeRefs
 
         // validate target node doesn't exist
-        TMaybe<IIndexTabletDatabase::TNodeRef> childRef;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> childRef;
 
         if (!ReadNodeRef(
                 db,
@@ -750,7 +750,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
                 args.CommitId,
                 args.Attrs);
 
-            args.ChildNode = IIndexTabletDatabase::TNode {
+            args.ChildNode = INodeIndexTabletDatabase::TNode {
                 args.ChildNodeId,
                 args.Attrs,
                 args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -86,7 +86,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
 
             if (ready) {
                 for (ui64 nodeId: args.NodeIds) {
-                    TMaybe<IIndexTabletDatabase::TNode> node;
+                    TMaybe<INodeIndexTabletDatabase::TNode> node;
                     if (!db.ReadNodeVer(nodeId, args.CommitId, node)) {
                         ready = false;
                     }
@@ -123,7 +123,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
                         }
                     }
 
-                    TMaybe<IIndexTabletDatabase::TMixedBlob> mixedBlob;
+                    TMaybe<INodeIndexTabletDatabase::TMixedBlob> mixedBlob;
                     if (!db.ReadMixedBlocks(
                             blob.RangeId,
                             blob.BlobId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -115,7 +115,7 @@ bool TIndexTabletActor::PrepareTx_DestroySession(
             continue;
         }
 
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         if (!ReadNode(db, handle.GetNodeId(), commitId, node)) {
             ready = false;
         } else {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
@@ -66,7 +66,7 @@ bool TIndexTabletActor::PrepareTx_FilterAliveNodes(
     TIndexTabletDatabase db(tx.DB);
 
     args.CommitId = GetCurrentCommitId();
-    TMaybe<IIndexTabletDatabase::TNode> node;
+    TMaybe<INodeIndexTabletDatabase::TNode> node;
 
     bool ready = true;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodeattr.cpp
@@ -115,7 +115,7 @@ bool TIndexTabletActor::ValidateTx_GetNodeAttr(
 
 bool TIndexTabletActor::PrepareTx_GetNodeAttr(
     const NActors::TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TGetNodeAttr& args)
 {
     Y_UNUSED(ctx);
@@ -138,7 +138,7 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttr(
         TABLET_VERIFY(args.ParentNode);
 
         // validate target node exists
-        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
         if (!ReadNodeRef(db, args.NodeId, args.CommitId, args.Name, ref)) {
             return false;   // not ready
         }
@@ -275,7 +275,7 @@ bool TIndexTabletActor::ValidateTx_GetNodeAttrBatch(
 
 bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
     const NActors::TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TGetNodeAttrBatch& args)
 {
     Y_UNUSED(ctx);
@@ -292,7 +292,7 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
         return true;
     }
 
-    TVector<TMaybe<IIndexTabletDatabase::TNodeRef>> refs(
+    TVector<TMaybe<INodeIndexTabletDatabase::TNodeRef>> refs(
         args.Request.NamesSize());
     ui32 foundRefs = 0;
     for (ui32 i = 0; i < args.Request.NamesSize(); ++i) {
@@ -314,7 +314,7 @@ bool TIndexTabletActor::PrepareTx_GetNodeAttrBatch(
         return false;   // not ready
     }
 
-    TVector<TMaybe<IIndexTabletDatabase::TNode>> nodes(
+    TVector<TMaybe<INodeIndexTabletDatabase::TNode>> nodes(
         args.Request.NamesSize());
     bool ready = true;
     for (ui32 i = 0; i < args.Request.NamesSize(); ++i) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_getnodexattr.cpp
@@ -82,7 +82,7 @@ bool TIndexTabletActor::ValidateTx_GetNodeXAttr(
 
 bool TIndexTabletActor::PrepareTx_GetNodeXAttr(
     const TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TGetNodeXAttr& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodes.cpp
@@ -174,7 +174,7 @@ bool TIndexTabletActor::ValidateTx_ListNodes(
 
 bool TIndexTabletActor::PrepareTx_ListNodes(
     const NActors::TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TListNodes& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_listnodexattr.cpp
@@ -78,7 +78,7 @@ bool TIndexTabletActor::ValidateTx_ListNodeXAttr(
 
 bool TIndexTabletActor::PrepareTx_ListNodeXAttr(
     const TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TListNodeXAttr& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_noderefs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_noderefs.cpp
@@ -23,7 +23,7 @@ bool TIndexTabletActor::ValidateTx_LoadNodeRefs(
 
 bool TIndexTabletActor::PrepareTx_LoadNodeRefs(
     const TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TLoadNodeRefs& args)
 {
     TVector<TIndexTabletDatabase::TNodeRef> nodeRefs;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate_nodes.cpp
@@ -22,7 +22,7 @@ bool TIndexTabletActor::ValidateTx_LoadNodes(
 
 bool TIndexTabletActor::PrepareTx_LoadNodes(
     const TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TLoadNodes& args)
 {
     Y_UNUSED(ctx, db, args);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -916,7 +916,7 @@ bool TIndexTabletActor::ValidateTx_ReadData(
 
 bool TIndexTabletActor::PrepareTx_ReadData(
     const TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TReadData& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readlink.cpp
@@ -72,7 +72,7 @@ bool TIndexTabletActor::ValidateTx_ReadLink(
 
 bool TIndexTabletActor::PrepareTx_ReadLink(
     const NActors::TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TReadLink& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readnoderefs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readnoderefs.cpp
@@ -23,7 +23,7 @@ bool TIndexTabletActor::ValidateTx_ReadNodeRefs(
 
 bool TIndexTabletActor::PrepareTx_ReadNodeRefs(
     const TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TReadNodeRefs& args)
 {
     bool ready = ReadNodeRefs(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -467,7 +467,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
                 args.NewChildNode->Attrs.GetType() == NProto::E_DIRECTORY_NODE;
             if (newChildIsDir) {
                 // 1 entry is enough to prevent rename
-                TVector<IIndexTabletDatabase::TNodeRef> refs;
+                TVector<INodeIndexTabletDatabase::TNodeRef> refs;
                 if (!ReadNodeRefs(
                         db,
                         args.NewChildNode->NodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -100,7 +100,7 @@ bool TIndexTabletActor::PrepareTx_ResetSession(
             continue;
         }
 
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         if (!ReadNode(db, handle.GetNodeId(), commitId, node)) {
             ready = false;
         } else {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resolvepath.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resolvepath.cpp
@@ -67,7 +67,7 @@ bool TIndexTabletActor::ValidateTx_ResolvePath(
 
 bool TIndexTabletActor::PrepareTx_ResolvePath(
     const TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TResolvePath& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -442,7 +442,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
     }
 
     if (args.ChildNode->Attrs.GetType() == NProto::E_DIRECTORY_NODE) {
-        TVector<IIndexTabletDatabase::TNodeRef> refs;
+        TVector<INodeIndexTabletDatabase::TNodeRef> refs;
         // 1 entry is enough to prevent deletion
         if (!ReadNodeRefs(db, childNodeId, args.CommitId, {}, refs, 1)) {
             return false;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
@@ -79,7 +79,7 @@ bool TIndexTabletActor::PrepareTx_PrepareUnlinkDirectoryNode(
         return true;
     }
 
-    TVector<IIndexTabletDatabase::TNodeRef> refs;
+    TVector<INodeIndexTabletDatabase::TNodeRef> refs;
     // 1 entry is enough to prevent deletion
     ready = ReadNodeRefs(
         db,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
@@ -330,7 +330,7 @@ bool TIndexTabletActor::ValidateTx_UnsafeGetNode(
 
 bool TIndexTabletActor::PrepareTx_UnsafeGetNode(
     const NActors::TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TUnsafeGetNode& args)
 {
     Y_UNUSED(ctx);
@@ -717,7 +717,7 @@ bool TIndexTabletActor::ValidateTx_UnsafeGetNodeRef(
 
 bool TIndexTabletActor::PrepareTx_UnsafeGetNodeRef(
     const NActors::TActorContext& ctx,
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     TTxIndexTablet::TUnsafeGetNodeRef& args)
 {
     Y_UNUSED(ctx);

--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -64,7 +64,7 @@ namespace NCloud::NFileStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 class TIndexTabletDatabase
-    : public IIndexTabletDatabase
+    : public INodeIndexTabletDatabase
     , public NKikimr::NIceDb::TNiceDb
 {
 public:

--- a/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_ut.cpp
@@ -75,15 +75,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
         });
 
         executor.ReadTx([&] (TIndexTabletDatabase db) {
-            TMaybe<IIndexTabletDatabase::TNode> node1;
+            TMaybe<INodeIndexTabletDatabase::TNode> node1;
             UNIT_ASSERT(db.ReadNode(nodeId1, commitId, node1));
             UNIT_ASSERT(node1);
 
-            TMaybe<IIndexTabletDatabase::TNode> node2;
+            TMaybe<INodeIndexTabletDatabase::TNode> node2;
             UNIT_ASSERT(db.ReadNode(nodeId2, commitId, node2));
             UNIT_ASSERT(node2);
 
-            TMaybe<IIndexTabletDatabase::TNode> node3;
+            TMaybe<INodeIndexTabletDatabase::TNode> node3;
             UNIT_ASSERT(db.ReadNode(12345, commitId, node3));
             UNIT_ASSERT(!node3);
         });
@@ -139,7 +139,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
             db.WriteNode(childNodeId1, commitId, attrs);
             db.WriteNode(childNodeId2, commitId, attrs);
             db.WriteNodeRef(
-                IIndexTabletDatabase::TNodeRef{
+                INodeIndexTabletDatabase::TNodeRef{
                     .NodeId = nodeId,
                     .Name = "child1",
                     .ChildNodeId = childNodeId1,
@@ -149,7 +149,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
                     .MaxCommitId = InvalidCommitId},
                 false);
             db.WriteNodeRef(
-                IIndexTabletDatabase::TNodeRef{
+                INodeIndexTabletDatabase::TNodeRef{
                     .NodeId = nodeId,
                     .Name = "child2",
                     .ChildNodeId = childNodeId2,
@@ -161,19 +161,19 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
         });
 
         executor.ReadTx([&] (TIndexTabletDatabase db) {
-            TMaybe<IIndexTabletDatabase::TNodeRef> ref1;
+            TMaybe<INodeIndexTabletDatabase::TNodeRef> ref1;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child1", ref1));
             UNIT_ASSERT_EQUAL(ref1->ChildNodeId, childNodeId1);
             UNIT_ASSERT_EQUAL(ref1->ShardId, "");
             UNIT_ASSERT_EQUAL(ref1->ShardNodeName, "");
 
-            TMaybe<IIndexTabletDatabase::TNodeRef> ref2;
+            TMaybe<INodeIndexTabletDatabase::TNodeRef> ref2;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child2", ref2));
             UNIT_ASSERT_EQUAL(ref2->ChildNodeId, childNodeId2);
             UNIT_ASSERT_EQUAL(ref2->ShardId, "shard");
             UNIT_ASSERT_EQUAL(ref2->ShardNodeName, "name");
 
-            TMaybe<IIndexTabletDatabase::TNodeRef> ref3;
+            TMaybe<INodeIndexTabletDatabase::TNodeRef> ref3;
             UNIT_ASSERT(db.ReadNodeRef(nodeId, commitId, "child3", ref3));
             UNIT_ASSERT(!ref3);
         });
@@ -585,7 +585,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
                 db.WriteNode(childNodeId1, commitId, attrs);
                 db.WriteNode(childNodeId2, commitId, attrs);
                 db.WriteNodeRef(
-                    IIndexTabletDatabase::TNodeRef{
+                    INodeIndexTabletDatabase::TNodeRef{
                         .NodeId = nodeId,
                         .Name = "child1",
                         .ChildNodeId = childNodeId1,
@@ -595,7 +595,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
                         .MaxCommitId = InvalidCommitId},
                     false);
                 db.WriteNodeRef(
-                    IIndexTabletDatabase::TNodeRef{
+                    INodeIndexTabletDatabase::TNodeRef{
                         .NodeId = nodeId,
                         .Name = "child2",
                         .ChildNodeId = childNodeId2,
@@ -609,7 +609,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
         executor.ReadTx(
             [&](TIndexTabletDatabase db)
             {
-                TVector<IIndexTabletDatabase::TNodeRef> refs;
+                TVector<INodeIndexTabletDatabase::TNodeRef> refs;
                 UNIT_ASSERT(db.ReadNodeRefs(
                     nodeId,
                     commitId,
@@ -626,7 +626,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletDatabaseTest)
         executor.ReadTx(
             [&](TIndexTabletDatabase db)
             {
-                TVector<IIndexTabletDatabase::TNodeRef> refs;
+                TVector<INodeIndexTabletDatabase::TNodeRef> refs;
                 UNIT_ASSERT(db.ReadNodeRefs(
                     nodeId,
                     commitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -557,7 +557,7 @@ public:
 
     [[nodiscard]] NProto::TError RemoveNode(
         TIndexTabletDatabase& db,
-        const IIndexTabletDatabase::TNode& node,
+        const INodeIndexTabletDatabase::TNode& node,
         ui64 minCommitId,
         ui64 maxCommitId);
 
@@ -565,7 +565,7 @@ public:
         TIndexTabletDatabase& db,
         ui64 parentNodeId,
         const TString& name,
-        const IIndexTabletDatabase::TNode& node,
+        const INodeIndexTabletDatabase::TNode& node,
         ui64 minCommitId,
         ui64 maxCommitId,
         bool removeNodeRef);
@@ -580,10 +580,10 @@ public:
         ui64 maxCommitId);
 
     bool ReadNode(
-        IIndexTabletDatabase& db,
+        INodeIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
-        TMaybe<IIndexTabletDatabase::TNode>& node);
+        TMaybe<INodeIndexTabletDatabase::TNode>& node);
 
     void RewriteNode(
         TIndexTabletDatabase& db,
@@ -626,7 +626,7 @@ public:
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
-        const IIndexTabletDatabase::TNodeAttr& attr,
+        const INodeIndexTabletDatabase::TNodeAttr& attr,
         const TString& newValue);
 
     void RemoveNodeAttr(
@@ -634,27 +634,27 @@ public:
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
-        const IIndexTabletDatabase::TNodeAttr& attr);
+        const INodeIndexTabletDatabase::TNodeAttr& attr);
 
     bool ReadNodeAttr(
-        IIndexTabletDatabase& db,
+        INodeIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<IIndexTabletDatabase::TNodeAttr>& attr);
+        TMaybe<INodeIndexTabletDatabase::TNodeAttr>& attr);
 
     bool ReadNodeAttrs(
-        IIndexTabletDatabase& db,
+        INodeIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
-        TVector<IIndexTabletDatabase::TNodeAttr>& attrs);
+        TVector<INodeIndexTabletDatabase::TNodeAttr>& attrs);
 
     void RewriteNodeAttr(
         TIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
-        const IIndexTabletDatabase::TNodeAttr& attr);
+        const INodeIndexTabletDatabase::TNodeAttr& attr);
 
 
     //
@@ -696,34 +696,34 @@ public:
         const TString& shardNodeName);
 
     bool ReadNodeRef(
-        IIndexTabletDatabase& db,
+        INodeIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<IIndexTabletDatabase::TNodeRef>& ref);
+        TMaybe<INodeIndexTabletDatabase::TNodeRef>& ref);
 
     bool ReadNodeRefs(
-        IIndexTabletDatabase& db,
+        INodeIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& cookie,
-        TVector<IIndexTabletDatabase::TNodeRef>& refs,
+        TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
         ui32 maxBytes,
         TString* next = nullptr,
         bool noAutoPrecharge = false,
         NProto::EListNodesSizeMode sizeMode = NProto::LNSM_NAME_ONLY);
 
     bool ReadNodeRefs(
-        IIndexTabletDatabase& db,
+        INodeIndexTabletDatabase& db,
         ui64 startNodeId,
         const TString& startCookie,
         ui64 maxCount,
-        TVector<IIndexTabletDatabase::TNodeRef>& refs,
+        TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
         ui64& nextNodeId,
         TString& nextCookie);
 
     bool PrechargeNodeRefs(
-        IIndexTabletDatabase& db,
+        INodeIndexTabletDatabase& db,
         ui64 nodeId,
         const TString& cookie,
         ui64 rowsToPrecharge,
@@ -1118,7 +1118,7 @@ public:
     //
 
 public:
-    bool LoadMixedBlocks(IIndexTabletDatabase& db, ui32 rangeId);
+    bool LoadMixedBlocks(INodeIndexTabletDatabase& db, ui32 rangeId);
     void ReleaseMixedBlocks(ui32 rangeId);
     void ReleaseMixedBlocks(const TSet<ui32>& ranges);
 
@@ -1581,7 +1581,7 @@ public:
     // In-memory index state.
     //
 
-    IIndexTabletDatabase* AccessInMemoryIndexState();
+    INodeIndexTabletDatabase* AccessInMemoryIndexState();
     void UpdateInMemoryIndexState(
         const TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
     void MarkNodeRefsLoadComplete();

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.cpp
@@ -359,7 +359,7 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadNodeRefs(
     ui64 startNodeId,
     const TString& startCookie,
     ui64 maxCount,
-    TVector<IIndexTabletDatabase::TNodeRef>& refs,
+    TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
     ui64& nextNodeId,
     TString& nextCookie)
 {
@@ -468,7 +468,7 @@ bool TInMemoryIndexState<TNodeRefsImpl>::ReadCheckpointNodes(
 template <typename TNodeRefsImpl>
 bool TInMemoryIndexState<TNodeRefsImpl>::ReadMixedBlocks(
     ui32 rangeId,
-    TVector<IIndexTabletDatabase::TMixedBlob>& blobs,
+    TVector<INodeIndexTabletDatabase::TMixedBlob>& blobs,
     IAllocator* alloc)
 {
     Y_UNUSED(rangeId, blobs, alloc);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_cache.h
@@ -31,7 +31,7 @@ struct TInMemoryIndexStateStats
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class IInMemoryIndexState : public IIndexTabletDatabase
+class IInMemoryIndexState : public INodeIndexTabletDatabase
 {
 public:
     virtual void LoadNodeRefs(const TVector<TNodeRef>& nodeRefs) = 0;
@@ -144,13 +144,13 @@ public:
     bool ReadNode(
         ui64 nodeId,
         ui64 commitId,
-        TMaybe<IIndexTabletDatabase::TNode>& node) override;
+        TMaybe<INodeIndexTabletDatabase::TNode>& node) override;
 
     bool ReadNodes(
         ui64 startNodeId,
         ui64 maxNodes,
         ui64& nextNodeId,
-        TVector<IIndexTabletDatabase::TNode>& nodes) override;
+        TVector<INodeIndexTabletDatabase::TNode>& nodes) override;
 
 private:
     void WriteNode(
@@ -168,7 +168,7 @@ public:
     bool ReadNodeVer(
         ui64 nodeId,
         ui64 commitId,
-        TMaybe<IIndexTabletDatabase::TNode>& node) override;
+        TMaybe<INodeIndexTabletDatabase::TNode>& node) override;
 
     //
     // NodeAttrs
@@ -178,12 +178,12 @@ public:
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<IIndexTabletDatabase::TNodeAttr>& attr) override;
+        TMaybe<INodeIndexTabletDatabase::TNodeAttr>& attr) override;
 
     bool ReadNodeAttrs(
         ui64 nodeId,
         ui64 commitId,
-        TVector<IIndexTabletDatabase::TNodeAttr>& attrs) override;
+        TVector<INodeIndexTabletDatabase::TNodeAttr>& attrs) override;
 
 private:
     void WriteNodeAttr(
@@ -204,12 +204,12 @@ public:
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<IIndexTabletDatabase::TNodeAttr>& attr) override;
+        TMaybe<INodeIndexTabletDatabase::TNodeAttr>& attr) override;
 
     bool ReadNodeAttrVers(
         ui64 nodeId,
         ui64 commitId,
-        TVector<IIndexTabletDatabase::TNodeAttr>& attrs) override;
+        TVector<INodeIndexTabletDatabase::TNodeAttr>& attrs) override;
 
     //
     // NodeRefs
@@ -219,13 +219,13 @@ public:
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<IIndexTabletDatabase::TNodeRef>& ref) override;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef>& ref) override;
 
     bool ReadNodeRefs(
         ui64 nodeId,
         ui64 commitId,
         const TString& cookie,
-        TVector<IIndexTabletDatabase::TNodeRef>& refs,
+        TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
         ui32 maxBytes,
         TString* next,
         ui32* skippedRefs,
@@ -236,7 +236,7 @@ public:
         ui64 startNodeId,
         const TString& startCookie,
         ui64 maxCount,
-        TVector<IIndexTabletDatabase::TNodeRef>& refs,
+        TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
         ui64& nextNodeId,
         TString& nextCookie) override;
 
@@ -266,12 +266,12 @@ public:
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
-        TMaybe<IIndexTabletDatabase::TNodeRef>& ref) override;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef>& ref) override;
 
     bool ReadNodeRefVers(
         ui64 nodeId,
         ui64 commitId,
-        TVector<IIndexTabletDatabase::TNodeRef>& refs) override;
+        TVector<INodeIndexTabletDatabase::TNodeRef>& refs) override;
 
     //
     // CheckpointNodes
@@ -288,7 +288,7 @@ public:
 
     bool ReadMixedBlocks(
         ui32 rangeId,
-        TVector<IIndexTabletDatabase::TMixedBlob>& blobs,
+        TVector<INodeIndexTabletDatabase::TMixedBlob>& blobs,
         IAllocator* alloc) override;
 
     bool ReadDeletionMarkers(

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -674,14 +674,14 @@ void TIndexTabletState::DeleteFreshBlocks(
 ////////////////////////////////////////////////////////////////////////////////
 // MixedBlocks
 
-bool TIndexTabletState::LoadMixedBlocks(IIndexTabletDatabase& db, ui32 rangeId)
+bool TIndexTabletState::LoadMixedBlocks(INodeIndexTabletDatabase& db, ui32 rangeId)
 {
     if (Impl->MixedBlocks.IsLoaded(rangeId)) {
         Impl->MixedBlocks.RefRange(rangeId);
         return true;
     }
 
-    TVector<TIndexTabletDatabase::IIndexTabletDatabase::TMixedBlob> blobs;
+    TVector<INodeIndexTabletDatabase::TMixedBlob> blobs;
     TVector<TDeletionMarker> deletionMarkers;
 
     if (!db.ReadMixedBlocks(rangeId, blobs, AllocatorRegistry.GetAllocator(EAllocatorTag::BlockList)) ||

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.cpp
@@ -24,7 +24,7 @@ static_assert(sizeof(TGUID::dw) == 16);
 
 }   // namespace
 
-bool IIndexTabletDatabase::TNodeRef::TryToEncodeShardId(const TString& mainFsId)
+bool INodeIndexTabletDatabase::TNodeRef::TryToEncodeShardId(const TString& mainFsId)
 {
     if (ShardId.empty() || IsFilesystemIdEncoded(ShardId)) {
         return true;
@@ -69,7 +69,7 @@ bool IIndexTabletDatabase::TNodeRef::TryToEncodeShardId(const TString& mainFsId)
     return true;
 }
 
-bool IIndexTabletDatabase::TNodeRef::TryToDecodeShardId(const TString& mainFsId)
+bool INodeIndexTabletDatabase::TNodeRef::TryToDecodeShardId(const TString& mainFsId)
 {
     if (!IsFilesystemIdEncoded(ShardId)) {
         return true;

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
@@ -25,7 +25,7 @@ namespace NCloud::NFileStore::NStorage {
  * and ReadDeletionMarkers which are not supposed to be used in the inode index.
  * But they are needed for the ReadData operation.
  */
-class IIndexTabletDatabase
+class INodeIndexTabletDatabase
 {
 public:
     struct TNode
@@ -78,7 +78,7 @@ public:
         ui64 Version;
     };
 
-    virtual ~IIndexTabletDatabase() = default;
+    virtual ~INodeIndexTabletDatabase() = default;
 
     //
     // Nodes
@@ -162,7 +162,7 @@ public:
         ui64 startNodeId,
         const TString& startCookie,
         ui64 maxCount,
-        TVector<IIndexTabletDatabase::TNodeRef>& refs,
+        TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
         ui64& nextNodeId,
         TString& nextCookie) = 0;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface_ut.cpp
@@ -22,8 +22,8 @@ Y_UNIT_TEST_SUITE(IIndexTabletDatabaseTest)
             "_s",
             "nfs_shared"};
 
-        auto cmpNodeRefs = [](const IIndexTabletDatabase::TNodeRef& ref1,
-                              const IIndexTabletDatabase::TNodeRef& ref2)
+        auto cmpNodeRefs = [](const INodeIndexTabletDatabase::TNodeRef& ref1,
+                              const INodeIndexTabletDatabase::TNodeRef& ref2)
         {
             UNIT_ASSERT_EQUAL(ref1.ShardId, ref2.ShardId);
             UNIT_ASSERT_EQUAL(ref1.ShardNodeName, ref2.ShardNodeName);
@@ -37,7 +37,7 @@ Y_UNIT_TEST_SUITE(IIndexTabletDatabaseTest)
                 mainFsId + "_s32",
                 mainFsId + "_s475"};
             for (const auto& shardId: shardIds) {
-                IIndexTabletDatabase::TNodeRef ref = {
+                INodeIndexTabletDatabase::TNodeRef ref = {
                     .NodeId = nodeId,
                     .Name = "some_name",
                     .ChildNodeId = childNodeId,
@@ -47,7 +47,7 @@ Y_UNIT_TEST_SUITE(IIndexTabletDatabaseTest)
                     .MaxCommitId = InvalidCommitId
                 };
 
-                IIndexTabletDatabase::TNodeRef refCopy(ref);
+                INodeIndexTabletDatabase::TNodeRef refCopy(ref);
                 UNIT_ASSERT(refCopy.TryToEncodeShardId(mainFsId));
                 UNIT_ASSERT(refCopy.TryToDecodeShardId(mainFsId));
                 cmpNodeRefs(ref, refCopy);
@@ -64,7 +64,7 @@ Y_UNIT_TEST_SUITE(IIndexTabletDatabaseTest)
                 {"abcd_s123", "not a guid"}};
 
             for (const auto& shardId: malformedShardIds) {
-                IIndexTabletDatabase::TNodeRef ref = {
+                INodeIndexTabletDatabase::TNodeRef ref = {
                     .NodeId = nodeId,
                     .Name = "some_name",
                     .ChildNodeId = childNodeId,
@@ -88,7 +88,7 @@ Y_UNIT_TEST_SUITE(IIndexTabletDatabaseTest)
                 {"\x01\x01\x02", malformedGuid}};
 
             for (const auto& shardId: malformedShardIds) {
-                IIndexTabletDatabase::TNodeRef ref = {
+                INodeIndexTabletDatabase::TNodeRef ref = {
                     .NodeId = nodeId,
                     .Name = "some_name",
                     .ChildNodeId = childNodeId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -88,7 +88,7 @@ void TIndexTabletState::UpdateNode(
 
 NProto::TError TIndexTabletState::RemoveNode(
     TIndexTabletDatabase& db,
-    const IIndexTabletDatabase::TNode& node,
+    const INodeIndexTabletDatabase::TNode& node,
     ui64 minCommitId,
     ui64 maxCommitId)
 {
@@ -126,7 +126,7 @@ NProto::TError TIndexTabletState::UnlinkNode(
     TIndexTabletDatabase& db,
     ui64 parentNodeId,
     const TString& name,
-    const IIndexTabletDatabase::TNode& node,
+    const INodeIndexTabletDatabase::TNode& node,
     ui64 minCommitId,
     ui64 maxCommitId,
     bool removeNodeRef)
@@ -191,10 +191,10 @@ void TIndexTabletState::UnlinkExternalNode(
 }
 
 bool TIndexTabletState::ReadNode(
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
-    TMaybe<IIndexTabletDatabase::TNode>& node)
+    TMaybe<INodeIndexTabletDatabase::TNode>& node)
 {
     bool ready = db.ReadNode(nodeId, commitId, node);
 
@@ -339,7 +339,7 @@ void TIndexTabletState::RemoveNodeAttr(
 }
 
 bool TIndexTabletState::ReadNodeAttr(
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -364,7 +364,7 @@ bool TIndexTabletState::ReadNodeAttr(
 }
 
 bool TIndexTabletState::ReadNodeAttrs(
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     TVector<TIndexTabletDatabase::TNodeAttr>& attrs)
@@ -424,7 +424,7 @@ namespace {
 
 inline void TryToEncodeShardId(
     const TString& mainFsId,
-    IIndexTabletDatabase::TNodeRef& nodeRef)
+    INodeIndexTabletDatabase::TNodeRef& nodeRef)
 {
     if (!nodeRef.TryToEncodeShardId(mainFsId)) {
         ReportMalformedShardNodeRef(
@@ -436,7 +436,7 @@ inline void TryToEncodeShardId(
 
 inline bool TryToDecodeShardId(
     const TString& mainFsId,
-    IIndexTabletDatabase::TNodeRef& nodeRef)
+    INodeIndexTabletDatabase::TNodeRef& nodeRef)
 {
     if (!nodeRef.TryToDecodeShardId(mainFsId)) {
         // This is a kind of impossible situation meaning that data in
@@ -468,7 +468,7 @@ void TIndexTabletState::CreateNodeRef(
     const TString& shardNodeName,
     bool markExhaustive)
 {
-    IIndexTabletDatabase::TNodeRef nodeRef {
+    INodeIndexTabletDatabase::TNodeRef nodeRef {
         .NodeId = nodeId,
         .Name = childName,
         .ChildNodeId = childNodeId,
@@ -514,11 +514,11 @@ void TIndexTabletState::RemoveNodeRef(
 }
 
 bool TIndexTabletState::ReadNodeRef(
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
-    TMaybe<IIndexTabletDatabase::TNodeRef>& ref)
+    TMaybe<INodeIndexTabletDatabase::TNodeRef>& ref)
 {
     bool ready = db.ReadNodeRef(nodeId, commitId, name, ref);
 
@@ -543,11 +543,11 @@ bool TIndexTabletState::ReadNodeRef(
 }
 
 bool TIndexTabletState::ReadNodeRefs(
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& cookie,
-    TVector<IIndexTabletDatabase::TNodeRef>& refs,
+    TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
     ui32 maxBytes,
     TString* next,
     bool noAutoPrecharge,
@@ -566,7 +566,7 @@ bool TIndexTabletState::ReadNodeRefs(
 
     std::erase_if(
         refs,
-        [this](IIndexTabletDatabase::TNodeRef& ref)
+        [this](INodeIndexTabletDatabase::TNodeRef& ref)
         { return !TryToDecodeShardId(GetMainFileSystemId(), ref); });
 
     ui64 checkpointId = Impl->Checkpoints.FindCheckpoint(nodeId, commitId);
@@ -581,11 +581,11 @@ bool TIndexTabletState::ReadNodeRefs(
 }
 
 bool TIndexTabletState::ReadNodeRefs(
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     ui64 startNodeId,
     const TString& startCookie,
     ui64 maxCount,
-    TVector<IIndexTabletDatabase::TNodeRef>& refs,
+    TVector<INodeIndexTabletDatabase::TNodeRef>& refs,
     ui64& nextNodeId,
     TString& nextCookie)
 {
@@ -599,14 +599,14 @@ bool TIndexTabletState::ReadNodeRefs(
 
     std::erase_if(
         refs,
-        [this](IIndexTabletDatabase::TNodeRef& ref)
+        [this](INodeIndexTabletDatabase::TNodeRef& ref)
         { return !TryToDecodeShardId(GetMainFileSystemId(), ref); });
 
     return ready;
 }
 
 bool TIndexTabletState::PrechargeNodeRefs(
-    IIndexTabletDatabase& db,
+    INodeIndexTabletDatabase& db,
     ui64 nodeId,
     const TString& cookie,
     ui64 rowsToPrecharge,
@@ -673,7 +673,7 @@ void TIndexTabletState::VisitNodeRefLocks(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IIndexTabletDatabase* TIndexTabletState::AccessInMemoryIndexState()
+INodeIndexTabletDatabase* TIndexTabletState::AccessInMemoryIndexState()
 {
     return Impl->InMemoryIndexState.get();
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -284,7 +284,7 @@ struct TNodeOps
         return value;
     }
 
-    static auto GetNodeId(const IIndexTabletDatabase::TNode& node)
+    static auto GetNodeId(const INodeIndexTabletDatabase::TNode& node)
     {
         return node.NodeId;
     }
@@ -309,7 +309,7 @@ struct TNodeOps
 };
 
 using TNodeSet = THashSet<
-    IIndexTabletDatabase::TNode,
+    INodeIndexTabletDatabase::TNode,
     TNodeOps::TNodeSetHash,
     TNodeOps::TNodeSetEqual>;
 
@@ -348,7 +348,7 @@ struct TTxIndexTablet
         NProto::TFileSystem FileSystem;
         NProto::TFileSystemStats FileSystemStats;
         NCloud::NProto::TTabletStorageInfo TabletStorageInfo;
-        TMaybe<IIndexTabletDatabase::TNode> RootNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> RootNode;
         TVector<NProto::TSession> Sessions;
         TVector<NProto::TSessionHandle> Handles;
         TVector<NProto::TSessionLock> Locks;
@@ -653,12 +653,12 @@ struct TTxIndexTablet
         ui64 CommitId = InvalidCommitId;
 
         TVector<ui64> NodeIds;
-        TVector<IIndexTabletDatabase::TNode> Nodes;
+        TVector<INodeIndexTabletDatabase::TNode> Nodes;
         TVector<TIndexTabletDatabase::TNodeAttr> NodeAttrs;
-        TVector<IIndexTabletDatabase::TNodeRef> NodeRefs;
+        TVector<INodeIndexTabletDatabase::TNodeRef> NodeRefs;
 
         TVector<TIndexTabletDatabase::TCheckpointBlob> Blobs;
-        TVector<TIndexTabletDatabase::IIndexTabletDatabase::TMixedBlob> MixedBlobs;
+        TVector<INodeIndexTabletDatabase::TMixedBlob> MixedBlobs;
 
         // NOTE: should persist state across tx restarts
         TSet<ui32> MixedBlocksRanges;
@@ -747,9 +747,9 @@ struct TTxIndexTablet
         NProto::TCreateNodeRequest Request;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
         ui64 ChildNodeId = InvalidNodeId;
-        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ChildNode;
 
         NProto::TOpLogEntry OpLogEntry;
 
@@ -810,9 +810,9 @@ struct TTxIndexTablet
         const TString Name;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
-        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
-        TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ChildRef;
 
         NProto::TOpLogEntry OpLogEntry;
 
@@ -863,9 +863,9 @@ struct TTxIndexTablet
         const bool IsExplicitRequest;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
-        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
-        TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ChildRef;
 
         NProto::TOpLogEntry OpLogEntry;
 
@@ -919,7 +919,7 @@ struct TTxIndexTablet
         NProtoPrivate::TPrepareUnlinkDirectoryNodeInShardResponse Response;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TPrepareUnlinkDirectoryNode(
                 TRequestInfoPtr requestInfo,
@@ -960,7 +960,7 @@ struct TTxIndexTablet
         NProtoPrivate::TAbortUnlinkDirectoryNodeInShardResponse Response;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TAbortUnlinkDirectoryNode(
                 TRequestInfoPtr requestInfo,
@@ -1008,13 +1008,13 @@ struct TTxIndexTablet
         const ui64 AbortUnlinkOpLogEntryId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
-        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
-        TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ChildRef;
 
-        TMaybe<IIndexTabletDatabase::TNode> NewParentNode;
-        TMaybe<IIndexTabletDatabase::TNode> NewChildNode;
-        TMaybe<IIndexTabletDatabase::TNodeRef> NewChildRef;
+        TMaybe<INodeIndexTabletDatabase::TNode> NewParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> NewChildNode;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> NewChildRef;
 
         NProto::TOpLogEntry OpLogEntry;
 
@@ -1109,9 +1109,9 @@ struct TTxIndexTablet
         const bool IsExplicitRequest;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
-        TMaybe<IIndexTabletDatabase::TNode> ChildNode;
-        TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ChildNode;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ChildRef;
 
         NProto::TOpLogEntry OpLogEntry;
 
@@ -1169,8 +1169,8 @@ struct TTxIndexTablet
         const ui64 AbortUnlinkOpLogEntryId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> NewParentNode;
-        TMaybe<IIndexTabletDatabase::TNodeRef> NewChildRef;
+        TMaybe<INodeIndexTabletDatabase::TNode> NewParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> NewChildRef;
 
         NProto::TOpLogEntry OpLogEntry;
         NProtoPrivate::TResponseLogEntry ResponseLogEntry;
@@ -1260,7 +1260,7 @@ struct TTxIndexTablet
         const bool IsExplicitRequest;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNodeRef> ChildRef;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ChildRef;
 
         TCommitRenameNodeInSource(
                 TRequestInfoPtr requestInfo,
@@ -1378,7 +1378,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TAccessNode(
                 TRequestInfoPtr requestInfo,
@@ -1414,7 +1414,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TReadLink(
                 TRequestInfoPtr requestInfo,
@@ -1453,9 +1453,9 @@ struct TTxIndexTablet
         const bool ReplyInternal;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
-        TVector<IIndexTabletDatabase::TNodeRef> ChildRefs;
-        TVector<IIndexTabletDatabase::TNode> ChildNodes;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
+        TVector<INodeIndexTabletDatabase::TNodeRef> ChildRefs;
+        TVector<INodeIndexTabletDatabase::TNode> ChildNodes;
         TString Next;
 
         ui32 BytesToPrecharge = 0;
@@ -1515,7 +1515,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TSetNodeAttr(
                 TRequestInfoPtr requestInfo,
@@ -1553,9 +1553,9 @@ struct TTxIndexTablet
         TTabletRequestMetrics& RequestMetrics;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
         ui64 TargetNodeId = InvalidNodeId;
-        TMaybe<IIndexTabletDatabase::TNode> TargetNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> TargetNode;
         TString ShardId;
         TString ShardNodeName;
 
@@ -1605,7 +1605,7 @@ struct TTxIndexTablet
         NProtoPrivate::TGetNodeAttrBatchResponse Response;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
 
         TGetNodeAttrBatch(
                 TRequestInfoPtr requestInfo,
@@ -1650,7 +1650,7 @@ struct TTxIndexTablet
 
         ui64 Version = 0;
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
         TMaybe<TIndexTabletDatabase::TNodeAttr> Attr;
 
         TSetNodeXAttr(
@@ -1692,7 +1692,7 @@ struct TTxIndexTablet
         const TString Name;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
         TMaybe<TIndexTabletDatabase::TNodeAttr> Attr;
 
         TGetNodeXAttr(
@@ -1731,7 +1731,7 @@ struct TTxIndexTablet
         const ui64 NodeId;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
         TVector<TIndexTabletDatabase::TNodeAttr> Attrs;
 
         TListNodeXAttr(
@@ -1770,7 +1770,7 @@ struct TTxIndexTablet
         const TString Name;
 
         ui64 CommitId = InvalidCommitId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
         TMaybe<TIndexTabletDatabase::TNodeAttr> Attr;
 
         TRemoveNodeXAttr(
@@ -1852,8 +1852,8 @@ struct TTxIndexTablet
         TString ShardNodeName;
         bool IsNewShardNode = false;
         const bool IsNodeRefLocked;
-        TMaybe<IIndexTabletDatabase::TNode> TargetNode;
-        TMaybe<IIndexTabletDatabase::TNode> ParentNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> TargetNode;
+        TMaybe<INodeIndexTabletDatabase::TNode> ParentNode;
         TVector<ui64> UpdatedNodes;
 
         NProto::TOpLogEntry OpLogEntry;
@@ -1918,7 +1918,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProto::TDestroyHandleRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
         bool Completed = false;
 
         TDestroyHandle(
@@ -2049,7 +2049,7 @@ struct TTxIndexTablet
         ui64 CommitId = InvalidCommitId;
         ui64 NodeId = InvalidNodeId;
         TMaybe<TByteRange> ReadAheadRange;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
         TVector<TBlockDataRef> Blocks;
         TVector<TBlockBytes> Bytes;
 
@@ -2124,7 +2124,7 @@ struct TTxIndexTablet
 
         ui64 CommitId = InvalidCommitId;
         ui64 NodeId = InvalidNodeId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TWriteData(
                 TRequestInfoPtr requestInfo,
@@ -2181,7 +2181,7 @@ struct TTxIndexTablet
         const ui64 ExplicitNodeId = InvalidNodeId;
 
         ui64 NodeId = InvalidNodeId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         template <typename TRequest>
         TAddDataBase(
@@ -2301,7 +2301,7 @@ struct TTxIndexTablet
 
         ui64 CommitId = InvalidCommitId;
         ui64 NodeId = InvalidNodeId;
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TAllocateData(
                 TRequestInfoPtr requestInfo,
@@ -2887,7 +2887,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeCreateNodeRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TUnsafeCreateNode(
                 TRequestInfoPtr requestInfo,
@@ -2912,7 +2912,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeDeleteNodeRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TUnsafeDeleteNode(
                 TRequestInfoPtr requestInfo,
@@ -2938,7 +2938,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeUpdateNodeRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TUnsafeUpdateNode(
                 TRequestInfoPtr requestInfo,
@@ -2962,7 +2962,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeGetNodeRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNode> Node;
+        TMaybe<INodeIndexTabletDatabase::TNode> Node;
 
         TUnsafeGetNode(
                 TRequestInfoPtr requestInfo,
@@ -2986,7 +2986,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeCreateNodeRefRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> NodeRef;
 
         TUnsafeCreateNodeRef(
                 TRequestInfoPtr requestInfo,
@@ -3012,7 +3012,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeDeleteNodeRefRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> NodeRef;
 
         TUnsafeDeleteNodeRef(
                 TRequestInfoPtr requestInfo,
@@ -3038,7 +3038,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeUpdateNodeRefRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> NodeRef;
 
         TUnsafeUpdateNodeRef(
                 TRequestInfoPtr requestInfo,
@@ -3063,7 +3063,7 @@ struct TTxIndexTablet
         const TRequestInfoPtr RequestInfo;
         const NProtoPrivate::TUnsafeGetNodeRefRequest Request;
 
-        TMaybe<IIndexTabletDatabase::TNodeRef> NodeRef;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> NodeRef;
 
         TUnsafeGetNodeRef(
                 TRequestInfoPtr requestInfo,
@@ -3205,7 +3205,7 @@ struct TTxIndexTablet
         const TString Cookie;
         const ui64 Limit;
 
-        TVector<IIndexTabletDatabase::TNodeRef> Refs;
+        TVector<INodeIndexTabletDatabase::TNodeRef> Refs;
         ui64 NextNodeId = 0;
         TString NextCookie;
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_state_cache.cpp
@@ -16,7 +16,7 @@ auto* Alloc()
 
 void CheckNodeRef(
     const IInMemoryIndexState::TWriteNodeRefsRequest& request,
-    IIndexTabletDatabase::TNodeRef& ref)
+    INodeIndexTabletDatabase::TNodeRef& ref)
 {
     UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsKey.NodeId, ref.NodeId);
     UNIT_ASSERT_VALUES_EQUAL(request.NodeRefsKey.Name, ref.Name);
@@ -33,7 +33,7 @@ void ReadAndCheckNodeRef(
     IInMemoryIndexState& state,
     const IInMemoryIndexState::TWriteNodeRefsRequest& request)
 {
-    TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+    TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
     UNIT_ASSERT(state.ReadNodeRef(
         request.NodeRefsKey.NodeId,
         request.NodeRefsRow.CommitId,
@@ -76,7 +76,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         TStandardInMemoryIndexState state(Alloc(), cacheBypass, 1, 0, 0, 0);
         cacheBypass.SetUnconfirmedRecoveryReady(true);
 
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
 
         NProto::TNode realNode = nodeAttrs1;
@@ -125,7 +125,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                      .Node = nodeAttrs2,
                  }}});
 
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
 
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId1, node));
     }
@@ -143,7 +143,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                 .Node = nodeAttrs1,
             }}});
 
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
         UNIT_ASSERT(node.Defined());
 
@@ -168,7 +168,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                 .Node = nodeAttrs1,
             }}});
 
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(state.ReadNode(nodeId1, commitId1, node));
         UNIT_ASSERT(node.Defined());
 
@@ -226,7 +226,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
         cacheBypass.Activate(nodeId1, commitId2, TByteRange::MaxEnd(0, 4_KB));
 
-        TMaybe<IIndexTabletDatabase::TNode> node;
+        TMaybe<INodeIndexTabletDatabase::TNode> node;
         UNIT_ASSERT(!state.ReadNode(nodeId1, commitId2, node));
         UNIT_ASSERT(node.Empty());
 
@@ -388,7 +388,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         TStandardInMemoryIndexState state(Alloc(), cacheBypass, 0, 1, 0, 0);
         cacheBypass.SetUnconfirmedRecoveryReady(true);
 
-        TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
+        TMaybe<INodeIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId2, attrName1, attr));
 
         state.UpdateState({IInMemoryIndexState::TWriteNodeAttrsRequest{
@@ -432,7 +432,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
         cacheBypass.Activate(nodeId1, commitId1, TByteRange::MaxEnd(0, 4_KB));
 
-        TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
+        TMaybe<INodeIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));
         UNIT_ASSERT(attr.Defined());
 
@@ -455,7 +455,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
                  .NodeAttrsRow = {commitId1, attrValue2, attrVersion2},
              }});
 
-        TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
+        TMaybe<INodeIndexTabletDatabase::TNodeAttr> attr;
 
         UNIT_ASSERT(!state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));
     }
@@ -471,7 +471,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
             .NodeAttrsRow = {commitId1, attrValue1, attrVersion1},
         }});
 
-        TMaybe<IIndexTabletDatabase::TNodeAttr> attr;
+        TMaybe<INodeIndexTabletDatabase::TNodeAttr> attr;
         UNIT_ASSERT(state.ReadNodeAttr(nodeId1, commitId1, attrName1, attr));
         UNIT_ASSERT(attr.Defined());
 
@@ -508,7 +508,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         TStateImpl state(Alloc(), cacheBypass, 0, 0, 1, 0);
         cacheBypass.SetUnconfirmedRecoveryReady(true);
 
-        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
         UNIT_ASSERT(
             !state.ReadNodeRef(rootNodeIds[0], commitId1, nodeNames[0], ref));
 
@@ -527,7 +527,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
         // The cache is preemptive, so the listing should not be possible for
         // now
-        TVector<IIndexTabletDatabase::TNodeRef> refs;
+        TVector<INodeIndexTabletDatabase::TNodeRef> refs;
         TString next;
         UNIT_ASSERT(!state.ReadNodeRefs(
             rootNodeIds[0],
@@ -606,7 +606,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         state.MarkNodeRefsLoadComplete();
 
         // read two first refs
-        TVector<IIndexTabletDatabase::TNodeRef> refs;
+        TVector<INodeIndexTabletDatabase::TNodeRef> refs;
         TString nextName;
 
         UNIT_ASSERT(state.ReadNodeRefs(
@@ -622,7 +622,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(nextName.empty());
 
         // all three refs should be in cache
-        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
         for (const auto& request: requests) {
             ReadAndCheckNodeRef(state, request);
         }
@@ -719,7 +719,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         state.MarkNodeRefsLoadComplete();
 
         // read two first refs
-        TVector<IIndexTabletDatabase::TNodeRef> refs;
+        TVector<INodeIndexTabletDatabase::TNodeRef> refs;
         TString nextName;
 
         UNIT_ASSERT(state.ReadNodeRefs(
@@ -735,7 +735,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
         UNIT_ASSERT(nextName.empty());
 
         // all three refs should be in cache
-        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
         for (const auto& request: requests) {
             ReadAndCheckNodeRef(state, request);
         }
@@ -804,7 +804,7 @@ Y_UNIT_TEST_SUITE(TInMemoryIndexStateTest)
 
         state.UpdateState({request});
 
-        TMaybe<IIndexTabletDatabase::TNodeRef> ref;
+        TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
         UNIT_ASSERT(state.ReadNodeRef(
             request.NodeRefsKey.NodeId,
             request.NodeRefsRow.CommitId,


### PR DESCRIPTION
### Notes
This is a preliminary step required for fixes requested on review of the https://github.com/ydb-platform/nbs/pull/6423. Idea is to later provide another implementation of that interface that would randomly fail read operations.

This PR is part **1** of the following chain:
- Rename IIndexTabletDatabase to INodeIndexTabletDatabase <<< **We are here**
Idea is that this name better reflects limited amount of methods exposed by the inteface.
- Introduce a new IIndexTabletDatabase containing every public method from TIndexTabletDatabase and makes TIndexTabletDatabase implement that interface.
- Create TIndexTabletDatabase in tablet_actor_* via factory functions instead of creating the objects on stack.

### Issue
https://github.com/ydb-platform/nbs/issues/6467
