### PR TITLE
issue-1751: [Filestore] Do not limit flush batches by barriers in WriteBackCache

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.cpp
@@ -184,13 +184,10 @@ ui64 TNodeCache::GetMaxFlushedSequenceId() const
 }
 
 void TNodeCache::VisitUnflushedRequests(
-    TCachedWriteDataRequestVisitor visitor, ui64 maxSequenceId) const
+    TCachedWriteDataRequestVisitor visitor) const
 {
     for (const auto& e: UnflushedRequests) {
         auto* cachedWriteDataRequest = e.get();
-        if (cachedWriteDataRequest->GetSequenceId() > maxSequenceId) {
-            break;
-        }
         const bool shouldContinue = visitor(cachedWriteDataRequest);
         if (!shouldContinue) {
             break;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache.h
@@ -88,9 +88,7 @@ public:
     ui64 GetMinFlushedSequenceId() const;
     ui64 GetMaxFlushedSequenceId() const;
 
-    void VisitUnflushedRequests(
-        TCachedWriteDataRequestVisitor visitor,
-        ui64 maxSequenceId) const;
+    void VisitUnflushedRequests(TCachedWriteDataRequestVisitor visitor) const;
 
     TCachedData GetCachedData(
         ui64 offset,

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_cache_ut.cpp
@@ -167,8 +167,7 @@ struct TBootstrap
                 }
                 out << request->GetOffset() << ":" << request->GetBuffer();
                 return true;
-            },
-            Max<ui64>());
+            });
         return out;
     }
 };

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/node_state.h
@@ -134,7 +134,16 @@ struct TNodeState
     // Handles that have THandleState::ReleaseHandleRequest initialized
     THashSet<ui64> HandlesWithReleaseRequests;
 
-    // Requests with SequenceId > BarrierId are prevented from being flushed
+    // Barriers are used to execute operations that should not interfere with
+    // cache. Pending or acquired barrier prohibits scheduling flush for a node
+    // when all unflushed requests have SequenceId > BarrierId.
+    //
+    // Pending barrier becomes acquired when the following conditions are met:
+    // - there are no unflushed requests with SequenceId < BarrierId;
+    // - all flushed requests are evicted.
+    //
+    // When building a flush batch, barriers are not taken into account - it is
+    // allowed to reorder concurrent pending requests.
     TMap<ui64, std::unique_ptr<TBarrier>> Barriers;
 
     bool CanBeDeleted() const
@@ -165,8 +174,8 @@ struct TNodeState
         if (!Barriers.empty()) {
             // Having a barrier means that there is an operation that wants
             // the data prior to barrier acquisition to be flushed and evicted.
-            // Therefore, flush should be scheduled if there is such data.
-            // Also, barrier prevents newer data from being flushed.
+            // If a barrier cannot be acquired due to unflushed data, flush
+            // is scheduled. Otherwise, flush is prohibited.
             return minUnflushedSequenceId < Barriers.cbegin()->first
                        ? ENodeFlushStatus::FlushRequested
                        : ENodeFlushStatus::NothingToFlush;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.h
@@ -204,25 +204,35 @@ public:
         ui64 nodeId,
         ui64 handle);
 
-    /* Read directly from the underlying storage.
-     * All prior cached WriteData requests are flushed and evicted.
-     * No new WriteData requests will be flushed until the direct read is
-     * completed.
+    /* Read directly from the underlying storage under a barrier.
+     * An acquired barrier ensures that operation will not interfere with cache:
+     * - All cached WriteData requests prior to barrier acquisition are flushed
+     *   and evicted.
+     * - No flush may take place until the barrier is released.
+     * Note: the sequence point is barrier acquisition, not the request itself.
+     * It means that newer WriteData requests may be reordered and flushed while
+     * the barrier is in pending state.
      */
     NThreading::TFuture<NProto::TReadDataResponse> ReadDataDirect(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TReadDataRequest> request);
 
-    /* Write directly to the underlying storage.
-     * All prior cached WriteData requests are flushed and evicted.
-     * No new WriteData requests will be flushed until the direct write is
-     * completed.
+    /* Write directly to the underlying storage under a barrier.
+     * An acquired barrier ensures that operation will not interfere with cache:
+     * - All cached WriteData requests prior to barrier acquisition are flushed
+     *   and evicted.
+     * - No flush may take place until the barrier is released.
+     * Note: the sequence point is barrier acquisition, not the request itself.
+     * It means that newer WriteData requests may be reordered and flushed while
+     * the barrier is in pending state.
      */
     NThreading::TFuture<NProto::TWriteDataResponse> WriteDataDirect(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TWriteDataRequest> request);
 
-    // Execute SetNodeAttr with taking awareness of changing node size
+    /* Execute SetNodeAttr with taking awareness of changing node size under a
+     * barrier.
+     */
     NThreading::TFuture<NProto::TSetNodeAttrResponse> SetNodeAttr(
         TCallContextPtr callContext,
         std::shared_ptr<NProto::TSetNodeAttrRequest> request);

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.cpp
@@ -282,11 +282,18 @@ void TWriteBackCacheState::VisitUnflushedRequests(
         return;
     }
 
-    const ui64 maxSequenceId = nodeState->Barriers.empty()
-                                   ? Max<ui64>()
-                                   : nodeState->Barriers.cbegin()->first;
+    if (!nodeState->Cache.HasUnflushedRequests()) {
+        return;
+    }
 
-    nodeState->Cache.VisitUnflushedRequests(visitor, maxSequenceId);
+    if (!nodeState->Barriers.empty()) {
+        const ui64 minBarrierId = nodeState->Barriers.cbegin()->first;
+        if (minBarrierId < nodeState->Cache.GetMinUnflushedSequenceId()) {
+            return;
+        }
+    }
+
+    nodeState->Cache.VisitUnflushedRequests(visitor);
 }
 
 ui64 TWriteBackCacheState::GetLiveHandle(ui64 nodeId) const

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state.h
@@ -148,6 +148,7 @@ public:
     void UnpinNodeStates(TNodeStatePin pinId);
 
     // Visit unflushed cached requests in the increasing order of SequenceId
+    // Returns no requests if a barrier prevents from flushing
     void VisitUnflushedRequests(
         ui64 nodeId,
         const TEntryVisitor& visitor) const;

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_state_ut.cpp
@@ -638,7 +638,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
 
             UNIT_ASSERT_VALUES_EQUAL("1", b.DumpEvents());
             UNIT_ASSERT_VALUES_EQUAL(
-                "1:abc",
+                "1:abc, 4:def",
                 b.VisitUnflushedCachedRequests(1));
 
             b.State->FlushFailed(1, MakeError(E_FAIL, "Flush failed"));
@@ -667,7 +667,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
             UNIT_ASSERT(b.Add(1, 101, 7, "ghi").GetValue());
             UNIT_ASSERT_VALUES_EQUAL("1", b.DumpEvents());
             UNIT_ASSERT_VALUES_EQUAL(
-                "1:abc, 4:def",
+                "1:abc, 4:def, 7:ghi",
                 b.VisitUnflushedCachedRequests(1));
 
             UNIT_ASSERT(!flush.HasValue());
@@ -683,7 +683,7 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheStateTest)
             // Flush is requested because of AcquireBarrier
             UNIT_ASSERT_VALUES_EQUAL("1", b.DumpEvents());
             UNIT_ASSERT_VALUES_EQUAL(
-                "4:def",
+                "4:def, 7:ghi",
                 b.VisitUnflushedCachedRequests(1));
 
             // flushed: abc def

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache_ut.cpp
@@ -2632,6 +2632,47 @@ Y_UNIT_TEST_SUITE(TWriteBackCacheTest)
             UNIT_ASSERT_VALUES_EQUAL("abc", readResult.GetBuffer());
         }
     }
+
+    Y_UNIT_TEST(AllowReorderingOnBarrierAcquisition)
+    {
+        TBootstrap b({
+            // Direct writes bypass cache - validation will fail
+            .DoNotCheckWriteDataRequestBuffer = true,
+            // Control flush batches
+            .FlushWritesInParallelEnabled = false,
+        });
+
+        // Prevent write requests initiated by Flush from completing immediately
+        TManualProceedHandlers writeRequests(b.Session->WriteDataHandler);
+
+        UNIT_ASSERT(b.WriteToCache(1, 0, "abc").HasValue());
+        UNIT_ASSERT(b.WriteToCache(1, 10, "def").HasValue());
+
+        auto request = std::make_shared<NProto::TWriteDataRequest>();
+        request->SetNodeId(1);
+        request->SetHandle(102);
+        request->SetOffset(12);
+        request->SetBuffer("+++");
+
+        auto directWriteFuture =
+            b.Cache.WriteDataDirect(b.CallContext, std::move(request));
+
+        UNIT_ASSERT(b.WriteToCache(1, 10, "ghi").HasValue());
+        UNIT_ASSERT(b.WriteToCache(1, 14, "jkl").HasValue());
+        UNIT_ASSERT(!directWriteFuture.HasValue());
+
+        // "def" and "ghi" are expected to go to the same flush batch
+        // then direct flush is executed
+        writeRequests.ProceedAll();
+
+        UNIT_ASSERT(directWriteFuture.HasValue());
+
+        auto readResponse = b.ReadFromCache(1, 10, 7).GetValue();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "gh++jkl",
+            readResponse.GetBuffer().substr(readResponse.GetBufferOffset()));
+    }
 }
 
 }   // namespace NCloud::NFileStore::NFuse


### PR DESCRIPTION
### Notes
Barriers in WriteBackCache ensure the absence of side effects of cached WriteData requests.

Current implementation: 
- Each barrier acquisition request is assigned a `SequenceId`;
- All WriteData requests with lower `SequenceId` should be flushed and evicted;
- All WriteData requests with higher `SequenceId` should not be flushed;
- Barrier is acquired once all WriteData requests with lower `SequenceId` are flushed and evicted.

When flush is triggered, barrier acquisition requests truncate flush batches.

Actually, this truncation is not necessary because the barrier condition should be enforced when it is acquired instead of when it is requested but is not in effect yet.

Proposed implementation:
- Each barrier acquisition request is assigned a `SequenceId`;
- Flush should be executed when and only when there exist unflushed WriteData requests with lower `SequenceId`;
- Flush is not restricted in taking the requests from the unflushed queue;
- Barrier is acquired once all WriteData requests with lower `SequenceId` are flushed and evicted.

Requests from the same flush batch are processed at once and barrier acquisition conditions are checked after the entire flush batch is processed.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
