### PR TITLE
issue-5894: fastshard server - waiting for conn fibers before shutting down

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/server/server.cpp
+++ b/cloud/filestore/libs/storage/fastshard/server/server.cpp
@@ -10,14 +10,17 @@
 #include <silk/fibers/future.h>
 #include <silk/util/logger.h>
 
+#include <util/generic/deque.h>
 #include <util/generic/hash.h>
 #include <util/generic/size_literals.h>
 #include <util/generic/string.h>
+#include <util/generic/yexception.h>
 #include <util/string/builder.h>
 #include <util/system/spinlock.h>
 
 #include <cerrno>
 #include <cstring>
+#include <memory>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -40,6 +43,118 @@ namespace {
 
 constexpr ui64 MaxMessageSize = 64_MB;
 constexpr int SocketBacklog = 128;
+
+////////////////////////////////////////////////////////////////////////////////
+// Handler bookkeeping.
+//
+// Every accepted connection is represented by a THandler which owns the
+// accepted fd and the FiberFuture the ConnFiberMain fiber signals on
+// completion. THandlerRegistry keeps them so Stop() can shut every live
+// connection down and wait for its fiber to actually exit before returning.
+
+struct THandler
+{
+    int Fd;
+    FiberFuture Future;
+
+    explicit THandler(int fd)
+        : Fd(fd)
+    {}
+
+    ~THandler()
+    {
+        if (Fd >= 0) {
+            ::close(Fd);
+        }
+    }
+
+    // FiberFuture holds an atomic, so THandler cannot be copied or moved.
+    // The registry stores it via std::unique_ptr, giving it a stable
+    // address for the whole ConnFiberMain lifetime.
+    THandler(const THandler&) = delete;
+    THandler& operator=(const THandler&) = delete;
+};
+
+class THandlerRegistry
+{
+public:
+    // Consume the handler on success; return it back if the registry is
+    // shutting down. The caller then lets the returned handler's dtor
+    // close the fd (see the Register() call site for the shutdown/wait
+    // logic that keeps the already-spawned fiber from touching a
+    // destroyed future).
+    std::unique_ptr<THandler> Register(std::unique_ptr<THandler> h)
+    {
+        with_lock (Lock) {
+            if (Stopping) {
+                return h;
+            }
+            Handlers.push_back(std::move(h));
+        }
+        return nullptr;
+    }
+
+    // Drop any entries whose fiber has already finished. Called from the
+    // accept loop so the deque doesn't grow without bound while the server
+    // is running.
+    void Prune()
+    {
+        with_lock (Lock) {
+            for (auto it = Handlers.begin(); it != Handlers.end();) {
+                int err = 0;
+                if ((*it)->Future.isSet(&err)) {
+                    if (err) {
+                        SILK_WARN(
+                            "conn fd=%d: error: %s",
+                            (*it)->Fd,
+                            ::strerror(err));
+                    }
+
+                    // ~THandler closes the fd.
+                    it = Handlers.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+    }
+
+    // Shut down every still-open connection and wait for its fiber to
+    // finish. After this returns no ConnFiberMain fiber is still running
+    // and no future Register() call will succeed.
+    void Stop()
+    {
+        TDeque<std::unique_ptr<THandler>> local;
+        with_lock (Lock) {
+            Stopping = true;
+            std::swap(local, Handlers);
+        }
+
+        // Half-close each fd so any recv/send inside the handler wakes
+        // with EOF/EPIPE; the fd itself stays owned by THandler until
+        // wait() returns and we let the unique_ptr fall out of scope.
+        for (const auto& h: local) {
+            int err = 0;
+            if (h->Future.isSet(&err)) {
+                continue;
+            }
+            ::shutdown(h->Fd, SHUT_RDWR);
+        }
+
+        for (auto& h: local) {
+            h->Future.wait();
+        }
+        // local goes out of scope: unique_ptr dtors close each fd exactly
+        // once, after we know no fiber can still reference it.
+    }
+
+private:
+    TAdaptiveLock Lock;
+    TDeque<std::unique_ptr<THandler>> Handlers;
+    bool Stopping = false;
+};
+
+using THandlerRegistryPtr = std::shared_ptr<THandlerRegistry>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Bridge NThreading::TFuture to silk FiberFuture.
@@ -126,6 +241,12 @@ static_assert(sizeof(TConnParams) <= silk::FIBER_PARAMETERS_SIZE);
 
 int ConnFiberMain(TConnParams* params) noexcept
 {
+    //
+    // The fd is owned by THandler in the server's registry, not by this
+    // fiber. We just use it and return; the server closes it after our
+    // future is set (via ~THandler in Prune() or Stop()).
+    //
+
     int fd = params->Fd;
     auto registry = params->Registry.lock();
     if (!registry) {
@@ -136,13 +257,15 @@ int ConnFiberMain(TConnParams* params) noexcept
         // Read length prefix.
         ui32 lenBe = 0;
         if (int r = RecvAll(fd, &lenBe, sizeof(lenBe)); r) {
-            ::close(fd);
-            // EIO means the client closed the connection cleanly.
+            //
+            // EIO means the client closed the connection cleanly, or
+            // the server half-closed us from Stop().
+            //
+
             return r == EIO ? 0 : r;
         }
         ui32 len = ntohl(lenBe);
         if (len > MaxMessageSize) {
-            ::close(fd);
             return EMSGSIZE;
         }
 
@@ -150,13 +273,11 @@ int ConnFiberMain(TConnParams* params) noexcept
         TString reqBuf;
         reqBuf.ReserveAndResize(len);
         if (int r = RecvAll(fd, reqBuf.begin(), len); r) {
-            ::close(fd);
             return r;
         }
 
         TRequest req;
         if (!req.ParseFromString(reqBuf)) {
-            ::close(fd);
             return EBADMSG;
         }
 
@@ -186,12 +307,10 @@ int ConnFiberMain(TConnParams* params) noexcept
         ui32 respLenBe = htonl(static_cast<ui32>(respBuf.size()));
         if (int r = SendAll(fd, &respLenBe, sizeof(respLenBe)); r) {
             SILK_WARN("send resp length: %s", ::strerror(r));
-            ::close(fd);
             return r;
         }
         if (int r = SendAll(fd, respBuf.data(), respBuf.size()); r) {
             SILK_WARN("send resp body: %s", ::strerror(r));
-            ::close(fd);
             return r;
         }
     }
@@ -205,19 +324,77 @@ struct TAcceptParams
     int ListenFd;
     int ShutdownFd;
     std::weak_ptr<TShardRegistry> Registry;
+    std::weak_ptr<THandlerRegistry> Handlers;
 };
 static_assert(sizeof(TAcceptParams) <= silk::FIBER_PARAMETERS_SIZE);
+
+void RegisterHandler(
+    int cfd,
+    THandlerRegistry& handlers,
+    std::weak_ptr<TShardRegistry> registry) noexcept
+{
+    int one = 1;
+    ::setsockopt(cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+    //
+    // Package the fd + a future the spawned fiber will signal on
+    // exit. THandler owns the fd (its dtor closes it) once we
+    // hand it to the registry, so we do not ::close(cfd) on any
+    // path below — the registry's Prune()/Stop() will.
+    //
+
+    auto handler = std::make_unique<THandler>(cfd);
+    FiberFuture* fut = &handler->Future;
+
+    int r = FiberScheduler::run(
+        ConnFiberMain,
+        TConnParams{.Fd = cfd, .Registry = std::move(registry)},
+        fut);
+    if (r) {
+        SILK_ERROR("spawn handler fiber: %s", ::strerror(r));
+
+        //
+        // Fiber wasn't scheduled; the runtime won't touch the
+        // future, and no one will read from cfd. Handler dtor
+        // closes cfd on scope exit.
+        //
+
+        return;
+    }
+
+    //
+    // Spawn succeeded — the fiber holds a pointer to
+    // handler->Future. If the registry is already shutting down
+    // we cannot destroy `handler` (that would free the future
+    // while the fiber may still write to it): shutdown the fd so
+    // the fiber wakes with EOF/EPIPE, wait for it, then let
+    // ~THandler close the fd.
+    //
+
+    if (auto rejected = handlers.Register(std::move(handler))) {
+        SILK_INFO(
+            "registry stopping; waking spawned handler fd=%d",
+            rejected->Fd);
+        ::shutdown(rejected->Fd, SHUT_RDWR);
+        rejected->Future.wait();
+    }
+}
 
 int AcceptFiberMain(TAcceptParams* params) noexcept
 {
     int lfd = params->ListenFd;
     int sfd = params->ShutdownFd;
     auto registry = params->Registry.lock();
-    if (!registry) {
+    auto handlers = params->Handlers.lock();
+    if (!registry || !handlers) {
+        SILK_WARN("accept fiber: server gone before startup, exiting");
         return ECANCELED;
     }
 
     for (;;) {
+        // Reap completed handlers so the registry deque doesn't grow.
+        handlers->Prune();
+
         sockaddr_in addr{};
         socklen_t addrLen = sizeof(addr);
         int cfd = ::accept4(
@@ -226,20 +403,7 @@ int AcceptFiberMain(TAcceptParams* params) noexcept
             &addrLen,
             SOCK_NONBLOCK | SOCK_CLOEXEC);
         if (cfd >= 0) {
-            int one = 1;
-            ::setsockopt(
-                cfd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
-
-            int r = FiberScheduler::run(
-                ConnFiberMain,
-                TConnParams{.Fd = cfd, .Registry = registry},
-                nullptr);
-            if (r) {
-                SILK_ERROR(
-                    "spawn handler fiber: %s",
-                    ::strerror(r));
-                ::close(cfd);
-            }
+            RegisterHandler(cfd, *handlers, registry);
             continue;
         }
 
@@ -279,6 +443,7 @@ public:
     explicit TServer(ui16 port)
         : Port(port)
         , Registry(std::make_shared<TShardRegistry>())
+        , Handlers(std::make_shared<THandlerRegistry>())
     {}
 
     ~TServer() override
@@ -313,12 +478,14 @@ public:
                 .ListenFd = ListenFd,
                 .ShutdownFd = ShutdownFd,
                 .Registry = Registry,
+                .Handlers = Handlers,
             },
             &AcceptFuture);
         Y_ENSURE(
             r == 0,
             "failed to spawn accept fiber: "
                 << ::strerror(r));
+        AcceptFiberSpawned = true;
     }
 
     void Stop() override
@@ -332,8 +499,26 @@ public:
             }
         }
 
-        // Wait for the accept fiber to exit.
-        AcceptFuture.wait();
+        //
+        // Wait for the accept fiber to exit. AcceptFuture is only set
+        // once AcceptFiberMain returns, so once this returns no new
+        // handlers can be registered.
+        //
+        // Skip the wait if Start() bailed before scheduling the fiber
+        // (eventfd/socket/bind/listen failure): AcceptFuture stays
+        // unset and .wait() would block forever.
+        //
+
+        if (AcceptFiberSpawned) {
+            AcceptFuture.wait();
+        }
+
+        //
+        // Half-close every still-live connection and wait for its
+        // handler fiber to finish.
+        //
+
+        Handlers->Stop();
     }
 
     void RegisterShard(
@@ -388,6 +573,8 @@ private:
     int ListenFd = -1;
     int ShutdownFd = -1;
     std::shared_ptr<TShardRegistry> Registry;
+    THandlerRegistryPtr Handlers;
+    bool AcceptFiberSpawned = false;
     FiberFuture AcceptFuture;
 };
 


### PR DESCRIPTION
### Notes
There was a race between conn fiber shutdown and server shutdown because server shutdown logic didn't wait for those fibers to complete. Fixing this. Probably I'll be able to reenable msan builds for fastshard tests after this. But I don't want to do it right now - want to merge this fix first, then I'll merge this https://github.com/ydb-platform/nbs/pull/6516 and then, if everything's stable, will reenable msan for fastshard. 

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895
