### PR TITLE
[Filestore] Introduce full IIndexTabletDatabase interface

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_database.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database.h
@@ -26,34 +26,6 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define FILESTORE_FILESYSTEM_STATS(xxx, ...)                                   \
-    xxx(LastNodeId,             __VA_ARGS__)                                   \
-    xxx(LastLockId,             __VA_ARGS__)                                   \
-    xxx(LastCollectCommitId,    __VA_ARGS__)                                   \
-    xxx(LastXAttr,              __VA_ARGS__)                                   \
-    xxx(HasXAttrs,              __VA_ARGS__)                                   \
-                                                                               \
-    xxx(UsedNodesCount,         __VA_ARGS__)                                   \
-    xxx(UsedSessionsCount,      __VA_ARGS__)                                   \
-    xxx(UsedHandlesCount,       __VA_ARGS__)                                   \
-    xxx(UsedLocksCount,         __VA_ARGS__)                                   \
-    xxx(UsedBlocksCount,        __VA_ARGS__)                                   \
-                                                                               \
-    xxx(FreshBlocksCount,           __VA_ARGS__)                               \
-    xxx(MixedBlocksCount,           __VA_ARGS__)                               \
-    xxx(MixedBlobsCount,            __VA_ARGS__)                               \
-    xxx(DeletionMarkersCount,       __VA_ARGS__)                               \
-    xxx(GarbageQueueSize,           __VA_ARGS__)                               \
-    xxx(GarbageBlocksCount,         __VA_ARGS__)                               \
-    xxx(CheckpointNodesCount,       __VA_ARGS__)                               \
-    xxx(CheckpointBlocksCount,      __VA_ARGS__)                               \
-    xxx(CheckpointBlobsCount,       __VA_ARGS__)                               \
-    xxx(FreshBytesCount,            __VA_ARGS__)                               \
-    xxx(AttrsUsedBytesCount,        __VA_ARGS__)                               \
-    xxx(DeletedFreshBytesCount,     __VA_ARGS__)                               \
-    xxx(LargeDeletionMarkersCount,  __VA_ARGS__)                               \
-// FILESTORE_FILESYSTEM_STATS
-
 #define FILESTORE_DUPCACHE_REQUESTS(xxx, ...)                                  \
     xxx(CreateHandle,   __VA_ARGS__)                                           \
     xxx(CreateNode,     __VA_ARGS__)                                           \
@@ -64,7 +36,7 @@ namespace NCloud::NFileStore::NStorage {
 ////////////////////////////////////////////////////////////////////////////////
 
 class TIndexTabletDatabase
-    : public INodeIndexTabletDatabase
+    : public IIndexTabletDatabase
     , public NKikimr::NIceDb::TNiceDb
 {
 public:
@@ -72,21 +44,22 @@ public:
         : NKikimr::NIceDb::TNiceDb(database)
     {}
 
-    void InitSchema();
+    void InitSchema() override;
 
     //
     // FileSystem
     //
 
-    void WriteFileSystem(const NProto::TFileSystem& fileSystem);
-    bool ReadFileSystem(NProto::TFileSystem& fileSystem);
-    bool ReadFileSystemStats(NProto::TFileSystemStats& stats);
+    void WriteFileSystem(const NProto::TFileSystem& fileSystem) override;
+    bool ReadFileSystem(NProto::TFileSystem& fileSystem) override;
+    bool ReadFileSystemStats(NProto::TFileSystemStats& stats) override;
 
-    void WriteStorageConfig(const NProto::TStorageConfig& storageConfig);
-    bool ReadStorageConfig(TMaybe<NProto::TStorageConfig>& storageConfig);
+    void WriteStorageConfig(
+        const NProto::TStorageConfig& storageConfig) override;
+    bool ReadStorageConfig(TMaybe<NProto::TStorageConfig>& storageConfig) override;
 
 #define FILESTORE_DECLARE_STATS(name, ...)                                     \
-    void Write##name(ui64 value);                                              \
+    void Write##name(ui64 value) override;                                     \
 // FILESTORE_DECLARE_STATS
 
 FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
@@ -94,19 +67,19 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
 #undef FILESTORE_DECLARE_STATS
 
     bool ReadTabletStorageInfo(
-        NCloud::NProto::TTabletStorageInfo& tabletStorageInfo);
+        NCloud::NProto::TTabletStorageInfo& tabletStorageInfo) override;
     void WriteTabletStorageInfo(
-        const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo);
+        const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo) override;
 
     //
     // Nodes
     //
 
-    virtual void WriteNode(
+    void WriteNode(
         ui64 nodeId,
         ui64 commitId,
-        const NProto::TNode& attrs);
-    virtual void DeleteNode(ui64 nodeId);
+        const NProto::TNode& attrs) override;
+    void DeleteNode(ui64 nodeId) override;
     bool ReadNode(
         ui64 nodeId,
         ui64 commitId,
@@ -121,13 +94,13 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // Nodes_Ver
     //
 
-    virtual void WriteNodeVer(
+    void WriteNodeVer(
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
-        const NProto::TNode& attrs);
+        const NProto::TNode& attrs) override;
 
-    virtual void DeleteNodeVer(ui64 nodeId, ui64 commitId);
+    void DeleteNodeVer(ui64 nodeId, ui64 commitId) override;
 
     bool ReadNodeVer(
         ui64 nodeId,
@@ -138,14 +111,14 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // NodeAttrs
     //
 
-    virtual void WriteNodeAttr(
+    void WriteNodeAttr(
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         const TString& value,
-        ui64 version);
+        ui64 version) override;
 
-    virtual void DeleteNodeAttr(ui64 nodeId, const TString& name);
+    void DeleteNodeAttr(ui64 nodeId, const TString& name) override;
 
     bool ReadNodeAttr(
         ui64 nodeId,
@@ -162,18 +135,18 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // NodeAttrs_Ver
     //
 
-    virtual void WriteNodeAttrVer(
+    void WriteNodeAttrVer(
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
         const TString& name,
         const TString& value,
-        ui64 version);
+        ui64 version) override;
 
-    virtual void DeleteNodeAttrVer(
+    void DeleteNodeAttrVer(
         ui64 nodeId,
         ui64 commitId,
-        const TString& name);
+        const TString& name) override;
 
     bool ReadNodeAttrVer(
         ui64 nodeId,
@@ -190,11 +163,11 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
     // NodeRefs
     //
 
-    virtual void WriteNodeRef(
+    void WriteNodeRef(
         const TNodeRef& nodeRef,
-        bool markExhaustive);
+        bool markExhaustive) override;
 
-    virtual void DeleteNodeRef(ui64 nodeId, const TString& name);
+    void DeleteNodeRef(ui64 nodeId, const TString& name) override;
 
     bool ReadNodeRef(
         ui64 nodeId,
@@ -244,19 +217,19 @@ public:
     // NodeRefs_Ver
     //
 
-    virtual void WriteNodeRefVer(
+    void WriteNodeRefVer(
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
         const TString& name,
         ui64 childNode,
         const TString& shardId,
-        const TString& shardNodeName);
+        const TString& shardNodeName) override;
 
-    virtual void DeleteNodeRefVer(
+    void DeleteNodeRefVer(
         ui64 nodeId,
         ui64 commitId,
-        const TString& name);
+        const TString& name) override;
 
     bool ReadNodeRefVer(
         ui64 nodeId,
@@ -273,58 +246,62 @@ public:
     // TruncateQueue
     //
 
-    void WriteTruncateQueueEntry(ui64 nodeId, TByteRange range);
-    void DeleteTruncateQueueEntry(ui64 id);
-    bool ReadTruncateQueue(TVector<NProto::TTruncateEntry>& entries);
+    void WriteTruncateQueueEntry(ui64 nodeId, TByteRange range) override;
+    void DeleteTruncateQueueEntry(ui64 id) override;
+    bool ReadTruncateQueue(TVector<NProto::TTruncateEntry>& entries) override;
 
     //
     // Sessions
     //
 
-    void WriteSession(const NProto::TSession& session);
-    void DeleteSession(const TString& sessionId);
-    bool ReadSessions(TVector<NProto::TSession>& sessions);
+    void WriteSession(const NProto::TSession& session) override;
+    void DeleteSession(const TString& sessionId) override;
+    bool ReadSessions(TVector<NProto::TSession>& sessions) override;
 
     //
     // SessionHandles
     //
 
-    void WriteSessionHandle(const NProto::TSessionHandle& handle);
-    void DeleteSessionHandle(const TString& sessionId, ui64 handle);
-    bool ReadSessionHandles(TVector<NProto::TSessionHandle>& handles);
+    void WriteSessionHandle(const NProto::TSessionHandle& handle) override;
+    void DeleteSessionHandle(const TString& sessionId, ui64 handle) override;
+    bool ReadSessionHandles(TVector<NProto::TSessionHandle>& handles) override;
 
     bool ReadSessionHandles(
         const TString& sessionId,
-        TVector<NProto::TSessionHandle>& handles);
+        TVector<NProto::TSessionHandle>& handles) override;
 
     //
     // SessionLocks
     //
 
-    void WriteSessionLock(const NProto::TSessionLock& lock);
-    void DeleteSessionLock(const TString& sessionId, ui64 lockId);
-    bool ReadSessionLocks(TVector<NProto::TSessionLock>& locks);
+    void WriteSessionLock(const NProto::TSessionLock& lock) override;
+    void DeleteSessionLock(const TString& sessionId, ui64 lockId) override;
+    bool ReadSessionLocks(TVector<NProto::TSessionLock>& locks) override;
 
     bool ReadSessionLocks(
         const TString& sessionId,
-        TVector<NProto::TSessionLock>& locks);
+        TVector<NProto::TSessionLock>& locks) override;
 
     //
     // SessionDuplicateCache
     //
 
-    void WriteSessionDupCacheEntry(const NProto::TDupCacheEntry& entry);
-    void DeleteSessionDupCacheEntry(const TString& sessionId, ui64 entryId);
-    bool ReadSessionDupCacheEntries(TVector<NProto::TDupCacheEntry>& entries);
+    void WriteSessionDupCacheEntry(
+        const NProto::TDupCacheEntry& entry) override;
+    void DeleteSessionDupCacheEntry(
+        const TString& sessionId,
+        ui64 entryId) override;
+    bool ReadSessionDupCacheEntries(TVector<NProto::TDupCacheEntry>& entries) override;
 
 
     //
     // SessionHistory
     //
 
-    void WriteSessionHistoryEntry(const NProto::TSessionHistoryEntry& entry);
-    void DeleteSessionHistoryEntry(ui64 entryId);
-    bool ReadSessionHistoryEntries(TVector<NProto::TSessionHistoryEntry>& entries);
+    void WriteSessionHistoryEntry(
+        const NProto::TSessionHistoryEntry& entry) override;
+    void DeleteSessionHistoryEntry(ui64 entryId) override;
+    bool ReadSessionHistoryEntries(TVector<NProto::TSessionHistoryEntry>& entries) override;
 
 
     //
@@ -335,26 +312,20 @@ public:
         ui64 nodeId,
         ui64 commitId,
         ui64 offset,
-        TStringBuf data);
+        TStringBuf data) override;
 
     void WriteFreshBytesDeletionMarker(
         ui64 nodeId,
         ui64 commitId,
         ui64 offset,
-        ui64 len);
+        ui64 len) override;
 
-    void DeleteFreshBytes(ui64 nodeId, ui64 commitId, ui64 offset);
+    void DeleteFreshBytes(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 offset) override;
 
-    struct TFreshBytesEntry
-    {
-        ui64 NodeId;
-        ui64 MinCommitId;
-        ui64 Offset;
-        TString Data;
-        ui64 Len;
-    };
-
-    bool ReadFreshBytes(TVector<TFreshBytesEntry>& bytes);
+    bool ReadFreshBytes(TVector<TFreshBytesEntry>& bytes) override;
 
     //
     // FreshBlocks
@@ -364,26 +335,20 @@ public:
         ui64 nodeId,
         ui64 commitId,
         ui32 blockIndex,
-        TStringBuf blockData);
+        TStringBuf blockData) override;
 
     void MarkFreshBlockDeleted(
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
-        ui32 blockIndex);
+        ui32 blockIndex) override;
 
-    void DeleteFreshBlock(ui64 nodeId, ui64 commitId, ui32 blockIndex);
+    void DeleteFreshBlock(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex) override;
 
-    struct TFreshBlock
-    {
-        ui64 NodeId;
-        ui32 BlockIndex;
-        ui64 MinCommitId;
-        ui64 MaxCommitId;
-        TString BlockData;
-    };
-
-    bool ReadFreshBlocks(TVector<TFreshBlock>& blocks);
+    bool ReadFreshBlocks(TVector<TFreshBlock>& blocks) override;
 
     //
     // MixedBlocks
@@ -394,15 +359,17 @@ public:
         const TPartialBlobId& blobId,
         const TBlockList& blockList,
         ui32 garbageBlocks,
-        ui32 checkpointBlocks);
+        ui32 checkpointBlocks) override;
 
-    void DeleteMixedBlocks(ui32 rangeId, const TPartialBlobId& blobId);
+    void DeleteMixedBlocks(
+        ui32 rangeId,
+        const TPartialBlobId& blobId) override;
 
     bool ReadMixedBlocks(
         ui32 rangeId,
         const TPartialBlobId& blobId,
         TMaybe<TMixedBlob>& blob,
-        IAllocator* alloc);
+        IAllocator* alloc) override;
 
     bool ReadMixedBlocks(
         ui32 rangeId,
@@ -418,13 +385,13 @@ public:
         ui64 nodeId,
         ui64 commitId,
         ui32 blockIndex,
-        ui32 blocksCount);
+        ui32 blocksCount) override;
 
     void DeleteDeletionMarker(
         ui32 rangeId,
         ui64 nodeId,
         ui64 commitId,
-        ui32 blockIndex);
+        ui32 blockIndex) override;
 
     bool ReadDeletionMarkers(
         ui32 rangeId,
@@ -438,53 +405,53 @@ public:
         ui64 nodeId,
         ui64 commitId,
         ui32 blockIndex,
-        ui32 blocksCount);
+        ui32 blocksCount) override;
 
     void DeleteLargeDeletionMarker(
         ui64 nodeId,
         ui64 commitId,
-        ui32 blockIndex);
+        ui32 blockIndex) override;
 
-    bool ReadLargeDeletionMarkers(TVector<TDeletionMarker>& deletionMarkers);
+    bool ReadLargeDeletionMarkers(TVector<TDeletionMarker>& deletionMarkers) override;
 
     //
     // OrphanNodes
     //
 
-    void WriteOrphanNode(ui64 nodeId);
-    void DeleteOrphanNode(ui64 nodeId);
-    bool ReadOrphanNodes(TVector<ui64>& nodeIds);
+    void WriteOrphanNode(ui64 nodeId) override;
+    void DeleteOrphanNode(ui64 nodeId) override;
+    bool ReadOrphanNodes(TVector<ui64>& nodeIds) override;
 
     //
     // NewBlobs
     //
 
-    void WriteNewBlob(const TPartialBlobId& blobId);
-    void DeleteNewBlob(const TPartialBlobId& blobId);
-    bool ReadNewBlobs(TVector<TPartialBlobId>& blobIds);
+    void WriteNewBlob(const TPartialBlobId& blobId) override;
+    void DeleteNewBlob(const TPartialBlobId& blobId) override;
+    bool ReadNewBlobs(TVector<TPartialBlobId>& blobIds) override;
 
     //
     // GarbageBlobs
     //
 
-    void WriteGarbageBlob(const TPartialBlobId& blobId);
-    void DeleteGarbageBlob(const TPartialBlobId& blobId);
-    bool ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds);
+    void WriteGarbageBlob(const TPartialBlobId& blobId) override;
+    void DeleteGarbageBlob(const TPartialBlobId& blobId) override;
+    bool ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds) override;
 
     //
     // Checkpoints
     //
 
-    void WriteCheckpoint(const NProto::TCheckpoint& checkpoint);
-    void DeleteCheckpoint(const TString& checkpointId);
-    bool ReadCheckpoints(TVector<NProto::TCheckpoint>& checkpoints);
+    void WriteCheckpoint(const NProto::TCheckpoint& checkpoint) override;
+    void DeleteCheckpoint(const TString& checkpointId) override;
+    bool ReadCheckpoints(TVector<NProto::TCheckpoint>& checkpoints) override;
 
     //
     // CheckpointNodes
     //
 
-    void WriteCheckpointNode(ui64 checkpointId, ui64 nodeId);
-    void DeleteCheckpointNode(ui64 checkpointId, ui64 nodeId);
+    void WriteCheckpointNode(ui64 checkpointId, ui64 nodeId) override;
+    void DeleteCheckpointNode(ui64 checkpointId, ui64 nodeId) override;
 
     bool ReadCheckpointNodes(
         ui64 checkpointId,
@@ -498,23 +465,17 @@ public:
     void WriteCheckpointBlob(
         ui64 checkpointId,
         ui32 rangeId,
-        const TPartialBlobId& blobId);
+        const TPartialBlobId& blobId) override;
 
     void DeleteCheckpointBlob(
         ui64 checkpointId,
         ui32 rangeId,
-        const TPartialBlobId& blobId);
-
-    struct TCheckpointBlob
-    {
-        ui32 RangeId = 0;
-        TPartialBlobId BlobId;
-    };
+        const TPartialBlobId& blobId) override;
 
     bool ReadCheckpointBlobs(
         ui64 checkpointId,
         TVector<TCheckpointBlob>& blobs,
-        size_t maxCount = 100);
+        size_t maxCount) override;
 
     //
     // CompactionMap
@@ -524,58 +485,56 @@ public:
         ui32 rangeId,
         ui32 blobsCount,
         ui32 deletionsCount,
-        ui32 garbageBlocksCount);
+        ui32 garbageBlocksCount) override;
     void WriteCompactionMap(
         ui32 rangeId,
         ui32 blobsCount,
         ui32 deletionsCount,
-        ui32 garbageBlocksCount);
-    bool ReadCompactionMap(TVector<TCompactionRangeInfo>& compactionMap);
+        ui32 garbageBlocksCount) override;
+    bool ReadCompactionMap(TVector<TCompactionRangeInfo>& compactionMap) override;
+
     bool ReadCompactionMap(
         TVector<TCompactionRangeInfo>& compactionMap,
         ui32 firstRangeId,
         ui32 rangeCount,
-        bool prechargeAll);
+        bool prechargeAll) override;
 
     //
     // OpLog
     //
 
-    void WriteOpLogEntry(const NProto::TOpLogEntry& entry);
-    void DeleteOpLogEntry(ui64 entryId);
-    bool ReadOpLogEntry(ui64 entryId, TMaybe<NProto::TOpLogEntry>& entry);
-    bool ReadOpLog(TVector<NProto::TOpLogEntry>& opLog);
+    void WriteOpLogEntry(const NProto::TOpLogEntry& entry) override;
+    void DeleteOpLogEntry(ui64 entryId) override;
+    bool ReadOpLogEntry(ui64 entryId, TMaybe<NProto::TOpLogEntry>& entry) override;
+    bool ReadOpLog(TVector<NProto::TOpLogEntry>& opLog) override;
 
     //
     // ResponseLog
     //
 
-    void WriteResponseLogEntry(const NProtoPrivate::TResponseLogEntry& entry);
-    void DeleteResponseLogEntry(ui64 clientTabletId, ui64 requestId);
+    void WriteResponseLogEntry(
+        const NProtoPrivate::TResponseLogEntry& entry) override;
+    void DeleteResponseLogEntry(
+        ui64 clientTabletId,
+        ui64 requestId) override;
     bool ReadResponseLogEntry(
         ui64 clientTabletId,
         ui64 requestId,
-        TMaybe<NProtoPrivate::TResponseLogEntry>& entry);
+        TMaybe<NProtoPrivate::TResponseLogEntry>& entry) override;
     bool ReadResponseLog(
-        TVector<NProtoPrivate::TResponseLogEntry>& responseLog);
+        TVector<NProtoPrivate::TResponseLogEntry>& responseLog) override;
 
     //
     // UnconfirmedData
     //
 
-    struct TUnconfirmedDataEntry
-    {
-        ui64 CommitId = 0;
-        NProto::TUnconfirmedData Data;
-    };
-
     void WriteUnconfirmedData(
         ui64 commitId,
-        const NProto::TUnconfirmedData& data);
+        const NProto::TUnconfirmedData& data) override;
 
-    void DeleteUnconfirmedData(ui64 commitId);
+    void DeleteUnconfirmedData(ui64 commitId) override;
 
-    bool ReadUnconfirmedData(TVector<TUnconfirmedDataEntry>& entries);
+    bool ReadUnconfirmedData(TVector<TUnconfirmedDataEntry>& entries) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_iface.h
@@ -1,11 +1,48 @@
 #pragma once
 
 #include <cloud/filestore/libs/storage/tablet/model/block_list.h>
+#include <cloud/filestore/libs/storage/tablet/model/compaction_map.h>
 #include <cloud/filestore/libs/storage/tablet/model/deletion_markers.h>
 #include <cloud/filestore/libs/storage/tablet/protos/tablet.pb.h>
 #include <cloud/filestore/public/api/protos/node.pb.h>
 
+namespace NCloud::NProto {
+
+class TTabletStorageInfo;
+
+} // namespace NCloud::NProto
+
 namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define FILESTORE_FILESYSTEM_STATS(xxx, ...)                                   \
+    xxx(LastNodeId,             __VA_ARGS__)                                   \
+    xxx(LastLockId,             __VA_ARGS__)                                   \
+    xxx(LastCollectCommitId,    __VA_ARGS__)                                   \
+    xxx(LastXAttr,              __VA_ARGS__)                                   \
+    xxx(HasXAttrs,              __VA_ARGS__)                                   \
+                                                                               \
+    xxx(UsedNodesCount,         __VA_ARGS__)                                   \
+    xxx(UsedSessionsCount,      __VA_ARGS__)                                   \
+    xxx(UsedHandlesCount,       __VA_ARGS__)                                   \
+    xxx(UsedLocksCount,         __VA_ARGS__)                                   \
+    xxx(UsedBlocksCount,        __VA_ARGS__)                                   \
+                                                                               \
+    xxx(FreshBlocksCount,           __VA_ARGS__)                               \
+    xxx(MixedBlocksCount,           __VA_ARGS__)                               \
+    xxx(MixedBlobsCount,            __VA_ARGS__)                               \
+    xxx(DeletionMarkersCount,       __VA_ARGS__)                               \
+    xxx(GarbageQueueSize,           __VA_ARGS__)                               \
+    xxx(GarbageBlocksCount,         __VA_ARGS__)                               \
+    xxx(CheckpointNodesCount,       __VA_ARGS__)                               \
+    xxx(CheckpointBlocksCount,      __VA_ARGS__)                               \
+    xxx(CheckpointBlobsCount,       __VA_ARGS__)                               \
+    xxx(FreshBytesCount,            __VA_ARGS__)                               \
+    xxx(AttrsUsedBytesCount,        __VA_ARGS__)                               \
+    xxx(DeletedFreshBytesCount,     __VA_ARGS__)                               \
+    xxx(LargeDeletionMarkersCount,  __VA_ARGS__)                               \
+// FILESTORE_FILESYSTEM_STATS
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -216,6 +253,405 @@ public:
     virtual bool ReadDeletionMarkers(
         ui32 rangeId,
         TVector<TDeletionMarker>& deletionMarkers) = 0;
+};
+
+/**
+ * @brief This interface exposes all operations supported by the index db.
+ */
+class IIndexTabletDatabase: public INodeIndexTabletDatabase
+{
+public:
+    virtual void InitSchema() = 0;
+
+    //
+    // FileSystem
+    //
+
+    virtual void WriteFileSystem(const NProto::TFileSystem& fileSystem) = 0;
+    virtual bool ReadFileSystem(NProto::TFileSystem& fileSystem) = 0;
+    virtual bool ReadFileSystemStats(NProto::TFileSystemStats& stats) = 0;
+
+#define FILESTORE_DECLARE_STATS(name, ...)    \
+    virtual void Write##name(ui64 value) = 0; \
+    // FILESTORE_DECLARE_STATS
+
+    FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
+
+#undef FILESTORE_DECLARE_STATS
+
+    virtual void WriteStorageConfig(
+        const NProto::TStorageConfig& storageConfig) = 0;
+    virtual bool ReadStorageConfig(
+        TMaybe<NProto::TStorageConfig>& storageConfig) = 0;
+
+    virtual bool ReadTabletStorageInfo(
+        NCloud::NProto::TTabletStorageInfo& tabletStorageInfo) = 0;
+    virtual void WriteTabletStorageInfo(
+        const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo) = 0;
+
+    //
+    // Nodes
+    //
+
+    virtual void
+    WriteNode(ui64 nodeId, ui64 commitId, const NProto::TNode& attrs) = 0;
+    virtual void DeleteNode(ui64 nodeId) = 0;
+
+    //
+    // Nodes_Ver
+    //
+
+    virtual void WriteNodeVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const NProto::TNode& attrs) = 0;
+    virtual void DeleteNodeVer(ui64 nodeId, ui64 commitId) = 0;
+
+    //
+    // NodeAttrs
+    //
+
+    virtual void WriteNodeAttr(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        const TString& value,
+        ui64 version) = 0;
+    virtual void DeleteNodeAttr(ui64 nodeId, const TString& name) = 0;
+
+    //
+    // NodeAttrs_Ver
+    //
+
+    virtual void WriteNodeAttrVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const TString& name,
+        const TString& value,
+        ui64 version) = 0;
+    virtual void
+    DeleteNodeAttrVer(ui64 nodeId, ui64 commitId, const TString& name) = 0;
+
+    //
+    // NodeRefs
+    //
+
+    virtual void WriteNodeRef(const TNodeRef& nodeRef, bool markExhaustive) = 0;
+    virtual void DeleteNodeRef(ui64 nodeId, const TString& name) = 0;
+
+    //
+    // NodeRefs_Ver
+    //
+
+    virtual void WriteNodeRefVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const TString& name,
+        ui64 childNode,
+        const TString& shardId,
+        const TString& shardNodeName) = 0;
+    virtual void
+    DeleteNodeRefVer(ui64 nodeId, ui64 commitId, const TString& name) = 0;
+
+    //
+    // TruncateQueue
+    //
+
+    virtual void WriteTruncateQueueEntry(ui64 nodeId, TByteRange range) = 0;
+    virtual void DeleteTruncateQueueEntry(ui64 id) = 0;
+    virtual bool ReadTruncateQueue(
+        TVector<NProto::TTruncateEntry>& entries) = 0;
+
+    //
+    // Sessions
+    //
+
+    virtual void WriteSession(const NProto::TSession& session) = 0;
+    virtual void DeleteSession(const TString& sessionId) = 0;
+    virtual bool ReadSessions(TVector<NProto::TSession>& sessions) = 0;
+
+    //
+    // SessionHandles
+    //
+
+    virtual void WriteSessionHandle(const NProto::TSessionHandle& handle) = 0;
+    virtual void DeleteSessionHandle(const TString& sessionId, ui64 handle) = 0;
+    virtual bool ReadSessionHandles(
+        TVector<NProto::TSessionHandle>& handles) = 0;
+
+    virtual bool ReadSessionHandles(
+        const TString& sessionId,
+        TVector<NProto::TSessionHandle>& handles) = 0;
+
+    //
+    // SessionLocks
+    //
+
+    virtual void WriteSessionLock(const NProto::TSessionLock& lock) = 0;
+    virtual void DeleteSessionLock(const TString& sessionId, ui64 lockId) = 0;
+    virtual bool ReadSessionLocks(TVector<NProto::TSessionLock>& locks) = 0;
+
+    virtual bool ReadSessionLocks(
+        const TString& sessionId,
+        TVector<NProto::TSessionLock>& locks) = 0;
+
+    //
+    // SessionDuplicateCache
+    //
+
+    virtual void WriteSessionDupCacheEntry(
+        const NProto::TDupCacheEntry& entry) = 0;
+    virtual void DeleteSessionDupCacheEntry(
+        const TString& sessionId,
+        ui64 entryId) = 0;
+    virtual bool ReadSessionDupCacheEntries(
+        TVector<NProto::TDupCacheEntry>& entries) = 0;
+
+    //
+    // SessionHistory
+    //
+
+    virtual void WriteSessionHistoryEntry(
+        const NProto::TSessionHistoryEntry& entry) = 0;
+    virtual void DeleteSessionHistoryEntry(ui64 entryId) = 0;
+    virtual bool ReadSessionHistoryEntries(
+        TVector<NProto::TSessionHistoryEntry>& entries) = 0;
+
+    //
+    // FreshBytes
+    //
+
+    struct TFreshBytesEntry
+    {
+        ui64 NodeId;
+        ui64 MinCommitId;
+        ui64 Offset;
+        TString Data;
+        ui64 Len;
+    };
+
+    virtual void WriteFreshBytes(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 offset,
+        TStringBuf data) = 0;
+    virtual void WriteFreshBytesDeletionMarker(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 offset,
+        ui64 len) = 0;
+    virtual void DeleteFreshBytes(ui64 nodeId, ui64 commitId, ui64 offset) = 0;
+    virtual bool ReadFreshBytes(TVector<TFreshBytesEntry>& bytes) = 0;
+
+    //
+    // FreshBlocks
+    //
+
+    struct TFreshBlock
+    {
+        ui64 NodeId;
+        ui32 BlockIndex;
+        ui64 MinCommitId;
+        ui64 MaxCommitId;
+        TString BlockData;
+    };
+
+    virtual void WriteFreshBlock(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        TStringBuf blockData) = 0;
+    virtual void MarkFreshBlockDeleted(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        ui32 blockIndex) = 0;
+    virtual void
+    DeleteFreshBlock(ui64 nodeId, ui64 commitId, ui32 blockIndex) = 0;
+    virtual bool ReadFreshBlocks(TVector<TFreshBlock>& blocks) = 0;
+
+    //
+    // MixedBlocks
+    //
+
+    virtual void WriteMixedBlocks(
+        ui32 rangeId,
+        const TPartialBlobId& blobId,
+        const TBlockList& blockList,
+        ui32 garbageBlocks,
+        ui32 checkpointBlocks) = 0;
+    virtual void DeleteMixedBlocks(
+        ui32 rangeId,
+        const TPartialBlobId& blobId) = 0;
+    virtual bool ReadMixedBlocks(
+        ui32 rangeId,
+        const TPartialBlobId& blobId,
+        TMaybe<TMixedBlob>& blob,
+        IAllocator* alloc) = 0;
+    using INodeIndexTabletDatabase::ReadMixedBlocks;
+
+    //
+    // DeletionMarkers
+    //
+
+    virtual void WriteDeletionMarkers(
+        ui32 rangeId,
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount) = 0;
+    virtual void DeleteDeletionMarker(
+        ui32 rangeId,
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex) = 0;
+
+    //
+    // LargeDeletionMarkers
+    //
+
+    virtual void WriteLargeDeletionMarkers(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount) = 0;
+    virtual void
+    DeleteLargeDeletionMarker(ui64 nodeId, ui64 commitId, ui32 blockIndex) = 0;
+    virtual bool ReadLargeDeletionMarkers(
+        TVector<TDeletionMarker>& deletionMarkers) = 0;
+
+    //
+    // OrphanNodes
+    //
+
+    virtual void WriteOrphanNode(ui64 nodeId) = 0;
+    virtual void DeleteOrphanNode(ui64 nodeId) = 0;
+    virtual bool ReadOrphanNodes(TVector<ui64>& nodeIds) = 0;
+
+    //
+    // NewBlobs
+    //
+
+    virtual void WriteNewBlob(const TPartialBlobId& blobId) = 0;
+    virtual void DeleteNewBlob(const TPartialBlobId& blobId) = 0;
+    virtual bool ReadNewBlobs(TVector<TPartialBlobId>& blobIds) = 0;
+
+    //
+    // GarbageBlobs
+    //
+
+    virtual void WriteGarbageBlob(const TPartialBlobId& blobId) = 0;
+    virtual void DeleteGarbageBlob(const TPartialBlobId& blobId) = 0;
+    virtual bool ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds) = 0;
+
+    //
+    // Checkpoints
+    //
+
+    virtual void WriteCheckpoint(const NProto::TCheckpoint& checkpoint) = 0;
+    virtual void DeleteCheckpoint(const TString& checkpointId) = 0;
+    virtual bool ReadCheckpoints(TVector<NProto::TCheckpoint>& checkpoints) = 0;
+
+    //
+    // CheckpointNodes
+    //
+
+    virtual void WriteCheckpointNode(ui64 checkpointId, ui64 nodeId) = 0;
+    virtual void DeleteCheckpointNode(ui64 checkpointId, ui64 nodeId) = 0;
+
+    //
+    // CheckpointBlobs
+    //
+
+    struct TCheckpointBlob
+    {
+        ui32 RangeId = 0;
+        TPartialBlobId BlobId;
+    };
+
+    virtual void WriteCheckpointBlob(
+        ui64 checkpointId,
+        ui32 rangeId,
+        const TPartialBlobId& blobId) = 0;
+    virtual void DeleteCheckpointBlob(
+        ui64 checkpointId,
+        ui32 rangeId,
+        const TPartialBlobId& blobId) = 0;
+    virtual bool ReadCheckpointBlobs(
+        ui64 checkpointId,
+        TVector<TCheckpointBlob>& blobs,
+        size_t maxCount) = 0;
+
+    //
+    // CompactionMap
+    //
+
+    virtual void ForceWriteCompactionMap(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount) = 0;
+    virtual void WriteCompactionMap(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount) = 0;
+    virtual bool ReadCompactionMap(
+        TVector<TCompactionRangeInfo>& compactionMap) = 0;
+
+    virtual bool ReadCompactionMap(
+        TVector<TCompactionRangeInfo>& compactionMap,
+        ui32 firstRangeId,
+        ui32 rangeCount,
+        bool prechargeAll) = 0;
+
+    //
+    // OpLog
+    //
+
+    virtual void WriteOpLogEntry(const NProto::TOpLogEntry& entry) = 0;
+    virtual void DeleteOpLogEntry(ui64 entryId) = 0;
+    virtual bool ReadOpLogEntry(
+        ui64 entryId,
+        TMaybe<NProto::TOpLogEntry>& entry) = 0;
+    virtual bool ReadOpLog(TVector<NProto::TOpLogEntry>& opLog) = 0;
+
+    //
+    // ResponseLog
+    //
+
+    virtual void WriteResponseLogEntry(
+        const NProtoPrivate::TResponseLogEntry& entry) = 0;
+    virtual void DeleteResponseLogEntry(
+        ui64 clientTabletId,
+        ui64 requestId) = 0;
+    virtual bool ReadResponseLogEntry(
+        ui64 clientTabletId,
+        ui64 requestId,
+        TMaybe<NProtoPrivate::TResponseLogEntry>& entry) = 0;
+
+    virtual bool ReadResponseLog(
+        TVector<NProtoPrivate::TResponseLogEntry>& responseLog) = 0;
+
+    //
+    // UnconfirmedData
+    //
+
+    struct TUnconfirmedDataEntry
+    {
+        ui64 CommitId = 0;
+        NProto::TUnconfirmedData Data;
+    };
+
+    virtual void WriteUnconfirmedData(
+        ui64 commitId,
+        const NProto::TUnconfirmedData& data) = 0;
+    virtual void DeleteUnconfirmedData(ui64 commitId) = 0;
+    virtual bool ReadUnconfirmedData(
+        TVector<TUnconfirmedDataEntry>& entries) = 0;
 };
 
 }   // namespace NCloud::NFileStore::NStorage


### PR DESCRIPTION
### Notes
This is a preliminary step required for fixes requested on review of the https://github.com/ydb-platform/nbs/pull/6423. Idea is to later provide another implementation of that interface that would randomly fail read operations.

This PR is part **2** of the following chain:

- Rename IIndexTabletDatabase to INodeIndexTabletDatabase
- Introduce a new IIndexTabletDatabase containing every public method from TIndexTabletDatabase and makes TIndexTabletDatabase implement that interface.  <<< **We are here**
- Create TIndexTabletDatabase in tablet_actor_* via factory functions instead of creating the objects on stack.

### Issue
https://github.com/ydb-platform/nbs/issues/6467
