### PR TITLE
Create TIndexTabletDatabase in tablet_actor_* via factory functions

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -5,7 +5,6 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/registry.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttler_logger.h>
-
 #include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler_logger.h>
@@ -1813,6 +1812,22 @@ void TIndexTabletActor::HandleRunRegularTasks(
     Y_UNUSED(ev);
 
     RunRegularTasks(ctx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Factories
+
+std::unique_ptr<IIndexTabletDatabase> TIndexTabletActor::CreateIndexTabletDatabase(
+    NKikimr::NTable::TDatabase& database)
+{
+    return std::make_unique<TIndexTabletDatabase>(database);
+}
+
+std::unique_ptr<IIndexTabletDatabase> TIndexTabletActor::CreateIndexTabletDatabaseProxy(
+    NKikimr::NTable::TDatabase& database,
+    TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates)
+{
+    return std::make_unique<TIndexTabletDatabaseProxy>(database, nodeUpdates);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -861,6 +861,13 @@ private:
     bool HasBlocksLeft(ui64 blocksRequired) const;
     bool HasSpaceLeft(ui64 prevSize, ui64 newSize) const;
     bool HasNodesLeft() const;
+
+    std::unique_ptr<IIndexTabletDatabase> CreateIndexTabletDatabase(
+        NKikimr::NTable::TDatabase& database);
+
+    std::unique_ptr<IIndexTabletDatabase> CreateIndexTabletDatabaseProxy(
+        NKikimr::NTable::TDatabase& database,
+        TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates);
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_acquirelock.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_acquirelock.cpp
@@ -101,8 +101,8 @@ void TIndexTabletActor::ExecuteTx_AcquireLock(
 
     auto result = TestLock(session, handle, range);
     if (result.Succeeded()) {
-        TIndexTabletDatabase db(tx.DB);
-        result = AcquireLock(db, session, handle->GetHandle(), range);
+        auto db = CreateIndexTabletDatabase(tx.DB);
+        result = AcquireLock(*db, session, handle->GetHandle(), range);
     }
     args.Error = std::move(result.Error);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_addblob.cpp
@@ -42,11 +42,9 @@ public:
 public:
     void Execute(
         const TActorContext& ctx,
-        TTransactionContext& tx,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
-        TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
-
         switch (args.Mode) {
             case EAddBlobMode::Write:
                 args.CommitIdOverflowMessage = "AddBlobWrite";
@@ -82,7 +80,7 @@ public:
 private:
     void Execute_AddBlob_Write(
         const TActorContext& ctx,
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
         Y_UNUSED(ctx);
@@ -213,7 +211,7 @@ private:
 
     void Execute_AddBlob_WriteUnconfirmed(
         const TActorContext& ctx,
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
         // TODO(#5353) Support immediate response before Tx
@@ -246,7 +244,7 @@ private:
     }
 
     void Execute_AddBlob_Flush(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
         TABLET_VERIFY(!args.SrcBlobs);
@@ -284,7 +282,7 @@ private:
     }
 
     void Execute_AddBlob_FlushBytes(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
         TABLET_VERIFY(!args.MergedBlobs);
@@ -324,7 +322,7 @@ private:
     }
 
     void Execute_AddBlob_Compaction(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
         TABLET_VERIFY(!args.MergedBlobs);
@@ -380,7 +378,7 @@ private:
     }
 
     void UpdateCompactionMap(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
         for (const auto& [rangeId, updatedStats]: RangeId2CompactionStats) {
@@ -408,7 +406,7 @@ private:
     }
 
     void UpdateNodeAttrs(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TTxIndexTablet::TAddBlob& args)
     {
         for (auto [id, maxOffset]: args.WriteRanges) {
@@ -491,14 +489,14 @@ bool TIndexTabletActor::PrepareTx_AddBlob(
 {
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     bool ready = true;
     for (auto [id, maxOffset]: args.WriteRanges) {
         TMaybe<INodeIndexTabletDatabase::TNode> node;
-        if (!ReadNode(db, id, args.CommitId, node)) {
+        if (!ReadNode(*db, id, args.CommitId, node)) {
             ready = false;
         }
 
@@ -522,8 +520,9 @@ void TIndexTabletActor::ExecuteTx_AddBlob(
     TTransactionContext& tx,
     TTxIndexTablet::TAddBlob& args)
 {
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
     TAddBlobsExecutor executor(LogTag, *this);
-    executor.Execute(ctx, tx, args);
+    executor.Execute(ctx, *db, args);
 }
 
 void TIndexTabletActor::CompleteTx_AddBlob(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata.cpp
@@ -133,9 +133,9 @@ bool TIndexTabletActor::ValidateAddDataRequest(
     }
     ui64 commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
-    if (!ReadNode(db, args.NodeId, commitId, args.Node)) {
+    if (!ReadNode(*db, args.NodeId, commitId, args.Node)) {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_adddata_unconfirmed.cpp
@@ -56,14 +56,14 @@ void TIndexTabletActor::ExecuteTx_AddDataUnconfirmed(
         return;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     auto& data = UnconfirmedDataInProgress[args.CommitId].Data;
 
     data.SetNodeId(args.NodeId);
 
     // Write serialized proto to DB for crash recovery
-    db.WriteUnconfirmedData(args.CommitId, data);
+    db->WriteUnconfirmedData(args.CommitId, data);
 
     LOG_DEBUG(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_allocatedata.cpp
@@ -129,9 +129,9 @@ bool TIndexTabletActor::PrepareTx_AllocateData(
     args.NodeId = handle->GetNodeId();
     args.CommitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
-    if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
+    if (!ReadNode(*db, args.NodeId, args.CommitId, args.Node)) {
         return false;
     }
 
@@ -187,7 +187,7 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
     const bool needExtend = args.Node->Attrs.GetSize() < size &&
         !HasFlag(args.Flags, NProto::TAllocateDataRequest::F_KEEP_SIZE);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     // Here we should not check F_KEEP_SIZE OR'ed with F_PUNCH_HOLE, because
     // we did it in validation stage.
@@ -204,7 +204,7 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
             return;
         }
         auto e = ZeroRange(
-            db,
+            *db,
             args.NodeId,
             args.CommitId,
             TByteRange(args.Offset, minBorder - args.Offset, GetBlockSize()));
@@ -233,7 +233,7 @@ void TIndexTabletActor::ExecuteTx_AllocateData(
     attrs.SetSize(size);
 
     UpdateNode(
-        db,
+        *db,
         args.NodeId,
         args.Node->MinCommitId,
         args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_change_storage_config.cpp
@@ -15,9 +15,9 @@ bool TIndexTabletActor::PrepareTx_ChangeStorageConfig(
     TTransactionContext& tx,
     TTxIndexTablet::TChangeStorageConfig& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
     if (args.MergeWithStorageConfigFromTabletDB) {
-        return db.ReadStorageConfig(args.StorageConfigFromDB);
+        return db->ReadStorageConfig(args.StorageConfigFromDB);
     }
     return true;
 }
@@ -27,16 +27,16 @@ void TIndexTabletActor::ExecuteTx_ChangeStorageConfig(
     TTransactionContext& tx,
     TTxIndexTablet::TChangeStorageConfig& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
     if (args.StorageConfigFromDB.Defined()) {
         auto* config = args.StorageConfigFromDB.Get();
         config->MergeFrom(args.StorageConfigNew);
-        db.WriteStorageConfig(*config);
+        db->WriteStorageConfig(*config);
         args.ResultStorageConfig = std::move(*config);
         return;
     }
     args.ResultStorageConfig = args.StorageConfigNew;
-    db.WriteStorageConfig(args.StorageConfigNew);
+    db->WriteStorageConfig(args.StorageConfigNew);
 }
 
 void TIndexTabletActor::CompleteTx_ChangeStorageConfig(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_cleanup.cpp
@@ -94,11 +94,11 @@ bool TIndexTabletActor::PrepareTx_Cleanup(
 {
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     args.CommitId = GetCurrentCommitId();
 
-    return LoadMixedBlocks(db, args.RangeId);
+    return LoadMixedBlocks(*db, args.RangeId);
 }
 
 void TIndexTabletActor::ExecuteTx_Cleanup(
@@ -112,10 +112,10 @@ void TIndexTabletActor::ExecuteTx_Cleanup(
     // before this tx completes
     AcquireCollectBarrier(args.CollectBarrier);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     args.ProcessedDeletionMarkerCount =
-        CleanupBlockDeletions(db, args.RangeId, args.ProfileLogRequest);
+        CleanupBlockDeletions(*db, args.RangeId, args.ProfileLogRequest);
 }
 
 void TIndexTabletActor::CompleteTx_Cleanup(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_compaction.cpp
@@ -607,13 +607,13 @@ bool TIndexTabletActor::PrepareTx_Compaction(
 {
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     args.CommitId = GetCurrentCommitId();
 
     // should not ref mixed range on tx restart due to nodes validation
     if (!args.RangeLoaded) {
-        if (!LoadMixedBlocks(db, args.RangeId)) {
+        if (!LoadMixedBlocks(*db, args.RangeId)) {
             return false;
         }
     }
@@ -635,7 +635,7 @@ bool TIndexTabletActor::PrepareTx_Compaction(
     bool ready = true;
     for (auto nodeId: nodes) {
         TMaybe<INodeIndexTabletDatabase::TNode> node;
-        if (!ReadNode(db, nodeId, args.CommitId, node)) {
+        if (!ReadNode(*db, nodeId, args.CommitId, node)) {
             ready = false;
             continue;
         }
@@ -664,9 +664,9 @@ void TIndexTabletActor::ExecuteTx_Compaction(
     const auto stats = GetCompactionStats(args.RangeId);
 
     if (!args.CompactionBlobs) {
-        TIndexTabletDatabase db(tx.DB);
+        auto db = CreateIndexTabletDatabase(tx.DB);
         UpdateCompactionMap(args.RangeId, 0, stats.DeletionsCount, 0, true);
-        db.WriteCompactionMap(args.RangeId, 0, stats.DeletionsCount, 0);
+        db->WriteCompactionMap(args.RangeId, 0, stats.DeletionsCount, 0);
         args.SkipRangeRewrite = true;
     } else if (garbageThreshold && blobSizeThreshold) {
         ui32 storedBlocks = 0;

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_confirmadddata.cpp
@@ -532,10 +532,10 @@ void TIndexTabletActor::ExecuteTx_DeleteUnconfirmedData(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     for (ui64 commitId: args.CommitIds) {
-        db.DeleteUnconfirmedData(commitId);
+        db->DeleteUnconfirmedData(commitId);
         UnconfirmedData.erase(commitId);
         const bool released = TryReleaseCollectBarrier(commitId);
         TABLET_VERIFY(released);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createcheckpoint.cpp
@@ -62,7 +62,7 @@ void TIndexTabletActor::ExecuteTx_CreateCheckpoint(
 
     FILESTORE_VALIDATE_TX_ERROR(CreateCheckpoint, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -71,7 +71,7 @@ void TIndexTabletActor::ExecuteTx_CreateCheckpoint(
     }
 
     auto* checkpoint = CreateCheckpoint(
-        db,
+        *db,
         args.CheckpointId,
         args.NodeId,
         args.CommitId);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createhandle.cpp
@@ -219,7 +219,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
         return true;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     // There could be two cases:
     // * access by parentId/name
@@ -227,7 +227,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
     if (args.Name) {
         // check that parent exists and is the directory;
         // TODO: what if symlink?
-        if (!ReadNode(db, args.NodeId, args.ReadCommitId, args.ParentNode)) {
+        if (!ReadNode(*db, args.NodeId, args.ReadCommitId, args.ParentNode)) {
             return false;
         }
 
@@ -249,7 +249,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
 
         // check whether child node exists
         TMaybe<INodeIndexTabletDatabase::TNodeRef> ref;
-        if (!ReadNodeRef(db, args.NodeId, args.ReadCommitId, args.Name, ref)) {
+        if (!ReadNodeRef(*db, args.NodeId, args.ReadCommitId, args.Name, ref)) {
             return false;   // not ready
         }
 
@@ -311,7 +311,7 @@ bool TIndexTabletActor::PrepareTx_CreateHandle(
     }
 
     if (args.TargetNodeId != InvalidNodeId) {
-        if (!ReadNode(db, args.TargetNodeId, args.ReadCommitId, args.TargetNode)) {
+        if (!ReadNode(*db, args.TargetNodeId, args.ReadCommitId, args.TargetNode)) {
             return false;   // not ready
         }
 
@@ -356,7 +356,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     if (args.TargetNodeId == InvalidNodeId
             && (args.ShardId.empty() || args.IsNewShardNode))
@@ -379,7 +379,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
             NProto::TNode attrs =
                 CreateRegularAttrs(args.Mode, args.Uid, args.Gid);
             args.TargetNodeId = CreateNode(
-                db,
+                *db,
                 args.WriteCommitId,
                 attrs);
 
@@ -393,7 +393,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
 
         // TODO: support for O_TMPFILE
         CreateNodeRef(
-            db,
+            *db,
             args.NodeId,
             args.WriteCommitId,
             args.Name,
@@ -404,7 +404,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         // update parent cmtime as we created a new entry
         auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
         UpdateNode(
-            db,
+            *db,
             args.ParentNode->NodeId,
             args.ParentNode->MinCommitId,
             args.WriteCommitId,
@@ -416,7 +416,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         && HasFlag(args.Flags, NProto::TCreateHandleRequest::E_TRUNCATE))
     {
         auto e = Truncate(
-            db,
+            *db,
             args.TargetNodeId,
             args.WriteCommitId,
             args.TargetNode->Attrs.GetSize(),
@@ -430,7 +430,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
         attrs.SetSize(0);
 
         UpdateNode(
-            db,
+            *db,
             args.TargetNodeId,
             args.TargetNode->MinCommitId,
             args.WriteCommitId,
@@ -441,7 +441,7 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
 
     if (args.ShardId.empty()) {
         auto* handle = CreateHandle(
-            db,
+            *db,
             session,
             args.TargetNodeId,
             session->GetCheckpointId() ? args.ReadCommitId : InvalidCommitId,
@@ -510,11 +510,11 @@ void TIndexTabletActor::ExecuteTx_CreateHandle(
                 << args.OpLogEntry.ShortUtf8DebugString().Quote());
         }
 
-        WriteOpLogEntry(db, args.OpLogEntry);
+        WriteOpLogEntry(*db, args.OpLogEntry);
     }
 
     AddDupCacheEntry(
-        db,
+        *db,
         session,
         args.RequestId,
         args.Response,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createnode.cpp
@@ -602,7 +602,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
         FILESTORE_VALIDATE_DUPTX_SESSION(CreateNode, args);
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
@@ -614,7 +614,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
     }
 
     // validate parent node exists
-    if (!ReadNode(db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
+    if (!ReadNode(*db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
         return false;   // not ready
     }
 
@@ -657,7 +657,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
         TMaybe<INodeIndexTabletDatabase::TNodeRef> childRef;
 
         if (!ReadNodeRef(
-                db,
+                *db,
                 args.ParentNodeId,
                 args.CommitId,
                 args.Name,
@@ -685,7 +685,7 @@ bool TIndexTabletActor::PrepareTx_CreateNode(
         //
         // Note: for the cases where the ShardId is set, the target node
         // already exists and its link count is updated, no need to validate it
-        if (!ReadNode(db, args.TargetNodeId, args.CommitId, args.ChildNode)) {
+        if (!ReadNode(*db, args.TargetNodeId, args.CommitId, args.ChildNode)) {
             return false;   // not ready
         }
 
@@ -736,7 +736,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
         }
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -746,7 +746,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
     if (args.TargetNodeId == InvalidNodeId) {
         if (args.ShardId.empty()) {
             args.ChildNodeId = CreateNode(
-                db,
+                *db,
                 args.CommitId,
                 args.Attrs);
 
@@ -788,7 +788,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
                     << args.OpLogEntry.ShortUtf8DebugString().Quote());
             }
 
-            WriteOpLogEntry(db, args.OpLogEntry);
+            WriteOpLogEntry(*db, args.OpLogEntry);
         }
     } else {
         // hard link
@@ -799,7 +799,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
             auto attrs =
                 CopyAttrs(args.ChildNode->Attrs, E_CM_CMTIME | E_CM_REF);
             UpdateNode(
-                db,
+                *db,
                 args.ChildNodeId,
                 args.ChildNode->MinCommitId,
                 args.CommitId,
@@ -813,7 +813,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
     // update parents cmtime
     auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
     UpdateNode(
-        db,
+        *db,
         args.ParentNode->NodeId,
         args.ParentNode->MinCommitId,
         args.CommitId,
@@ -826,7 +826,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
         // If this NodeRef is for a newly created directory, we can say that its
         // contents are exhaustively stored in the in-memory state
         CreateNodeRef(
-            db,
+            *db,
             args.ParentNodeId,
             args.CommitId,
             args.Name,
@@ -863,7 +863,7 @@ void TIndexTabletActor::ExecuteTx_CreateNode(
     //  dupcache
     if (!BehaveAsShard(args.Request.GetHeaders())) {
         AddDupCacheEntry(
-            db,
+            *db,
             session,
             args.RequestId,
             args.Response,
@@ -1082,13 +1082,13 @@ void TIndexTabletActor::ExecuteTx_CommitNodeCreationInShard(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
     PatchDupCacheEntry(
-        db,
+        *db,
         args.SessionId,
         args.RequestId,
         std::move(args.Response));
-    DeleteOpLogEntry(db, args.EntryId);
+    DeleteOpLogEntry(*db, args.EntryId);
 }
 
 void TIndexTabletActor::CompleteTx_CommitNodeCreationInShard(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_createsession.cpp
@@ -130,7 +130,7 @@ void FillFeatures(
 ////////////////////////////////////////////////////////////////////////////////
 
 TActorId DoRecoverSession(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TIndexTabletState& state,
     TSession* session,
     const TString& clientId,
@@ -321,7 +321,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
 
     const auto owner = args.RequestInfo->Sender;
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     // check if client reconnecting with known session id
     auto* session = FindSession(sessionId);
@@ -329,7 +329,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
         if (session->GetClientId() == clientId) {
             args.SessionId = session->GetSessionId();
             auto toKill = DoRecoverSession(
-                db,
+                *db,
                 *this,
                 session,
                 clientId,
@@ -389,7 +389,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
             args.SessionId = session->GetSessionId();
 
             DoRecoverSession(
-                db,
+                *db,
                 *this,
                 session,
                 clientId,
@@ -439,7 +439,7 @@ void TIndexTabletActor::ExecuteTx_CreateSession(
     auto sessionOptions = TSession::CreateSessionOptions(Config);
 
     auto* newSession = CreateSession(
-        db,
+        *db,
         clientId,
         args.SessionId,
         checkpointId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_delete_zero_compaction_ranges.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_delete_zero_compaction_ranges.cpp
@@ -48,7 +48,7 @@ void TIndexTabletActor::ExecuteTx_DeleteZeroCompactionRanges(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     TVector<ui32> ranges(
         Reserve(Config->GetMaxZeroCompactionRangesToDeletePerTx()));
@@ -58,7 +58,7 @@ void TIndexTabletActor::ExecuteTx_DeleteZeroCompactionRanges(
             i < Min<ui32>(args.StartIndex + rangesPerTx, rangeCount); ++i)
     {
         ui32 range = RangesWithEmptyCompactionScore[i];
-        db.WriteCompactionMap(
+        db->WriteCompactionMap(
             range,
             GetCompactionStats(range).BlobsCount,
             GetCompactionStats(range).DeletionsCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletecheckpoint.cpp
@@ -70,7 +70,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
 
     args.CommitId = checkpoint->GetCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     bool ready = true;
     switch (args.Mode) {
@@ -79,7 +79,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
             break;
 
         case EDeleteCheckpointMode::RemoveCheckpointNodes: {
-            ready = db.ReadCheckpointNodes(
+            ready = db->ReadCheckpointNodes(
                 args.CommitId,
                 args.NodeIds,
                 RemoveCheckpointNodesBatchSize);
@@ -87,7 +87,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
             if (ready) {
                 for (ui64 nodeId: args.NodeIds) {
                     TMaybe<INodeIndexTabletDatabase::TNode> node;
-                    if (!db.ReadNodeVer(nodeId, args.CommitId, node)) {
+                    if (!db->ReadNodeVer(nodeId, args.CommitId, node)) {
                         ready = false;
                     }
 
@@ -95,11 +95,11 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
                         args.Nodes.emplace_back(node.GetRef());
                     }
 
-                    if (!db.ReadNodeAttrVers(nodeId, args.CommitId, args.NodeAttrs)) {
+                    if (!db->ReadNodeAttrVers(nodeId, args.CommitId, args.NodeAttrs)) {
                         ready = false;
                     }
 
-                    if (!db.ReadNodeRefVers(nodeId, args.CommitId, args.NodeRefs)) {
+                    if (!db->ReadNodeRefVers(nodeId, args.CommitId, args.NodeRefs)) {
                         ready = false;
                     }
                 }
@@ -108,7 +108,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
         }
 
         case EDeleteCheckpointMode::RemoveCheckpointBlobs: {
-            ready = db.ReadCheckpointBlobs(
+            ready = db->ReadCheckpointBlobs(
                 args.CommitId,
                 args.Blobs,
                 RemoveCheckpointBlobsBatchSize);
@@ -116,7 +116,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
             if (ready) {
                 for (const auto& blob: args.Blobs) {
                     if (!args.MixedBlocksRanges.count(blob.RangeId)) {
-                        if (!LoadMixedBlocks(db, blob.RangeId)) {
+                        if (!LoadMixedBlocks(*db, blob.RangeId)) {
                             ready = false;
                         } else {
                             args.MixedBlocksRanges.insert(blob.RangeId);
@@ -124,7 +124,7 @@ bool TIndexTabletActor::PrepareTx_DeleteCheckpoint(
                     }
 
                     TMaybe<INodeIndexTabletDatabase::TMixedBlob> mixedBlob;
-                    if (!db.ReadMixedBlocks(
+                    if (!db->ReadMixedBlocks(
                             blob.RangeId,
                             blob.BlobId,
                             mixedBlob,
@@ -166,11 +166,11 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
     auto* checkpoint = FindCheckpoint(args.CheckpointId);
     TABLET_VERIFY(checkpoint);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     switch (args.Mode) {
         case EDeleteCheckpointMode::MarkCheckpointDeleted:
-            MarkCheckpointDeleted(db, checkpoint);
+            MarkCheckpointDeleted(*db, checkpoint);
             break;
 
         case EDeleteCheckpointMode::RemoveCheckpointNodes: {
@@ -181,7 +181,7 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
 
             for (const auto& node: args.Nodes) {
                 RewriteNode(
-                    db,
+                    *db,
                     node.NodeId,
                     node.MinCommitId,
                     node.MaxCommitId,
@@ -190,7 +190,7 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
 
             for (const auto& attr: args.NodeAttrs) {
                 RewriteNodeAttr(
-                    db,
+                    *db,
                     attr.NodeId,
                     attr.MinCommitId,
                     attr.MaxCommitId,
@@ -199,7 +199,7 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
 
             for (const auto& ref: args.NodeRefs) {
                 RewriteNodeRef(
-                    db,
+                    *db,
                     ref.NodeId,
                     ref.MinCommitId,
                     ref.MaxCommitId,
@@ -209,7 +209,7 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
                     ref.ShardNodeName);
             }
 
-            RemoveCheckpointNodes(db, checkpoint, args.NodeIds);
+            RemoveCheckpointNodes(*db, checkpoint, args.NodeIds);
             break;
         }
 
@@ -235,14 +235,14 @@ void TIndexTabletActor::ExecuteTx_DeleteCheckpoint(
                     args.MixedBlobs[i].CheckpointBlocks,
                 };
 
-                RewriteMixedBlocks(db, rangeId, blob, stats);
-                RemoveCheckpointBlob(db, checkpoint, rangeId, blob.BlobId);
+                RewriteMixedBlocks(*db, rangeId, blob, stats);
+                RemoveCheckpointBlob(*db, checkpoint, rangeId, blob.BlobId);
             }
             break;
         }
 
         case EDeleteCheckpointMode::RemoveCheckpoint:
-            RemoveCheckpoint(db, checkpoint);
+            RemoveCheckpoint(*db, checkpoint);
             break;
     }
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_deletegarbage.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_deletegarbage.cpp
@@ -82,7 +82,7 @@ void TIndexTabletActor::ExecuteTx_DeleteGarbage(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     const ui32 maxBlobsPerTx = Config->GetMaxDeleteGarbageBlobsPerTx();
     Crop(args.NewBlobs, args.RemainingNewBlobs, maxBlobsPerTx);
@@ -95,7 +95,7 @@ void TIndexTabletActor::ExecuteTx_DeleteGarbage(
         args.ProfileLogRequest);
 
     DeleteGarbage(
-        db,
+        *db,
         args.CollectCommitId,
         args.NewBlobs,
         args.GarbageBlobs);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroyhandle.cpp
@@ -74,8 +74,8 @@ bool TIndexTabletActor::PrepareTx_DestroyHandle(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
-    if (!ReadNode(db, handle->GetNodeId(), commitId, args.Node)) {
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+    if (!ReadNode(*db, handle->GetNodeId(), commitId, args.Node)) {
         return false;
     }
 
@@ -102,16 +102,16 @@ void TIndexTabletActor::ExecuteTx_DestroyHandle(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
-    DestroyHandle(db, handle);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+    DestroyHandle(*db, handle);
 
     if (args.Node->Attrs.GetLinks() == 0 && !HasOpenHandles(args.Node->NodeId))
     {
-        auto e = RemoveNode(db, *args.Node, args.Node->MinCommitId, commitId);
+        auto e = RemoveNode(*db, *args.Node, args.Node->MinCommitId, commitId);
 
         if (HasError(e)) {
             WriteOrphanNode(
-                db,
+                *db,
                 TStringBuilder() << "DestroyHandle: " << args.SessionId
                                  << ", Handle: " << args.Request.GetHandle()
                                  << ", RemoveNode: " << args.Node->NodeId

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_destroysession.cpp
@@ -105,7 +105,7 @@ bool TIndexTabletActor::PrepareTx_DestroySession(
         args.SessionId.c_str(),
         args.SessionSeqNo);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     bool ready = true;
     auto commitId = GetCurrentCommitId();
@@ -116,7 +116,7 @@ bool TIndexTabletActor::PrepareTx_DestroySession(
         }
 
         TMaybe<INodeIndexTabletDatabase::TNode> node;
-        if (!ReadNode(db, handle.GetNodeId(), commitId, node)) {
+        if (!ReadNode(*db, handle.GetNodeId(), commitId, node)) {
             ready = false;
         } else {
             TABLET_VERIFY(node);
@@ -135,7 +135,7 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
     TTransactionContext& tx,
     TTxIndexTablet::TDestroySession& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     auto* session = FindSession(args.SessionId);
     if (!session) {
@@ -145,7 +145,7 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
     if (!CheckSessionForDestroy(session, args.SessionSeqNo) &&
         session->DeleteSubSession(args.SessionSeqNo))
     {
-        db.WriteSession(*session);
+        db->WriteSession(*session);
         return;
     }
 
@@ -158,14 +158,14 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
     auto handle = session->Handles.begin();
     while (handle != session->Handles.end()) {
         auto nodeId = handle->GetNodeId();
-        DestroyHandle(db, &*(handle++));
+        DestroyHandle(*db, &*(handle++));
 
         auto it = args.Nodes.find(nodeId);
         if (it != args.Nodes.end() && !HasOpenHandles(nodeId)) {
-            auto e = RemoveNode(db, *it, it->MinCommitId, args.CommitId);
+            auto e = RemoveNode(*db, *it, it->MinCommitId, args.CommitId);
 
             if (HasError(e)) {
-                WriteOrphanNode(db, TStringBuilder()
+                WriteOrphanNode(*db, TStringBuilder()
                     << "DestroySession: " << args.SessionId
                     << ", RemoveNode: " << nodeId
                     << ", Error: " << FormatError(e), nodeId);
@@ -173,7 +173,7 @@ void TIndexTabletActor::ExecuteTx_DestroySession(
         }
     }
 
-    RemoveSession(db, args.SessionId);
+    RemoveSession(*db, args.SessionId);
 
     EnqueueTruncateIfNeeded(ctx);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_dumprange.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_dumprange.cpp
@@ -44,8 +44,8 @@ bool TIndexTabletActor::PrepareTx_DumpCompactionRange(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
-    if (!LoadMixedBlocks(db, args.RangeId)) {
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    if (!LoadMixedBlocks(*db, args.RangeId)) {
         return false;
     }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_filteralivenodes.cpp
@@ -63,7 +63,7 @@ bool TIndexTabletActor::PrepareTx_FilterAliveNodes(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     args.CommitId = GetCurrentCommitId();
     TMaybe<INodeIndexTabletDatabase::TNode> node;
@@ -71,7 +71,7 @@ bool TIndexTabletActor::PrepareTx_FilterAliveNodes(
     bool ready = true;
 
     for (const auto nodeId: args.Nodes) {
-        if (!ReadNode(db, nodeId, args.CommitId, node)) {
+        if (!ReadNode(*db, nodeId, args.CommitId, node)) {
             ready = false;
             continue;
         }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_flush_bytes.cpp
@@ -660,7 +660,7 @@ bool TIndexTabletActor::PrepareTx_FlushBytes(
     TTransactionContext& tx,
     TTxIndexTablet::TFlushBytes& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     InitTabletProfileLogRequestInfo(args.ProfileLogRequest, ctx.Now());
 
@@ -668,7 +668,7 @@ bool TIndexTabletActor::PrepareTx_FlushBytes(
     for (const auto& bytes: args.Bytes) {
         ui32 rangeId = GetMixedRangeIndex(bytes.NodeId, bytes.Offset / GetBlockSize());
         if (!args.MixedBlocksRanges.count(rangeId)) {
-            if (LoadMixedBlocks(db, rangeId)) {
+            if (LoadMixedBlocks(*db, rangeId)) {
                 args.MixedBlocksRanges.insert(rangeId);
             } else {
                 ready = false;
@@ -978,10 +978,10 @@ void TIndexTabletActor::ExecuteTx_TrimBytes(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     auto result = FinishFlushBytes(
-        db,
+        *db,
         Config->GetTrimBytesItemCount(),
         args.ChunkId,
         args.ProfileLogRequest);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_initschema.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_initschema.cpp
@@ -28,9 +28,9 @@ void TIndexTabletActor::ExecuteTx_InitSchema(
 {
     Y_UNUSED(ctx, args);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
-    db.InitSchema();
+    db->InitSchema();
 }
 
 void TIndexTabletActor::CompleteTx_InitSchema(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -95,30 +95,30 @@ bool TIndexTabletActor::PrepareTx_LoadState(
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Loading tablet state data");
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     std::initializer_list<bool> results = {
-        db.ReadFileSystem(args.FileSystem),
-        db.ReadFileSystemStats(args.FileSystemStats),
-        db.ReadTabletStorageInfo(args.TabletStorageInfo),
-        db.ReadNode(RootNodeId, 0, args.RootNode),
-        db.ReadSessions(args.Sessions),
-        db.ReadSessionHandles(args.Handles),
-        db.ReadSessionLocks(args.Locks),
-        db.ReadSessionDupCacheEntries(args.DupCache),
-        db.ReadFreshBytes(args.FreshBytes),
-        db.ReadFreshBlocks(args.FreshBlocks),
-        db.ReadNewBlobs(args.NewBlobs),
-        db.ReadGarbageBlobs(args.GarbageBlobs),
-        db.ReadCheckpoints(args.Checkpoints),
-        db.ReadTruncateQueue(args.TruncateQueue),
-        db.ReadStorageConfig(args.StorageConfig),
-        db.ReadSessionHistoryEntries(args.SessionHistory),
-        db.ReadOpLog(args.OpLog),
-        db.ReadResponseLog(args.ResponseLog),
-        db.ReadLargeDeletionMarkers(args.LargeDeletionMarkers),
-        db.ReadOrphanNodes(args.OrphanNodeIds),
-        db.ReadUnconfirmedData(args.UnconfirmedData),
+        db->ReadFileSystem(args.FileSystem),
+        db->ReadFileSystemStats(args.FileSystemStats),
+        db->ReadTabletStorageInfo(args.TabletStorageInfo),
+        db->ReadNode(RootNodeId, 0, args.RootNode),
+        db->ReadSessions(args.Sessions),
+        db->ReadSessionHandles(args.Handles),
+        db->ReadSessionLocks(args.Locks),
+        db->ReadSessionDupCacheEntries(args.DupCache),
+        db->ReadFreshBytes(args.FreshBytes),
+        db->ReadFreshBlocks(args.FreshBlocks),
+        db->ReadNewBlobs(args.NewBlobs),
+        db->ReadGarbageBlobs(args.GarbageBlobs),
+        db->ReadCheckpoints(args.Checkpoints),
+        db->ReadTruncateQueue(args.TruncateQueue),
+        db->ReadStorageConfig(args.StorageConfig),
+        db->ReadSessionHistoryEntries(args.SessionHistory),
+        db->ReadOpLog(args.OpLog),
+        db->ReadResponseLog(args.ResponseLog),
+        db->ReadLargeDeletionMarkers(args.LargeDeletionMarkers),
+        db->ReadOrphanNodes(args.OrphanNodeIds),
+        db->ReadUnconfirmedData(args.UnconfirmedData),
     };
 
     bool ready = std::accumulate(
@@ -143,12 +143,12 @@ void TIndexTabletActor::ExecuteTx_LoadState(
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Preparing tablet state");
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     if (!args.RootNode) {
         args.RootNode.ConstructInPlace();
         args.RootNode->Attrs = CreateDirectoryAttrs(0777, 0, 0);
-        db.WriteNode(RootNodeId, 0, args.RootNode->Attrs);
+        db->WriteNode(RootNodeId, 0, args.RootNode->Attrs);
     }
 
     const auto& oldTabletStorageInfo = args.TabletStorageInfo;
@@ -161,7 +161,7 @@ void TIndexTabletActor::ExecuteTx_LoadState(
 
         TABLET_VERIFY(newTabletStorageInfo.GetTabletId());
         args.TabletStorageInfo.CopyFrom(newTabletStorageInfo);
-        db.WriteTabletStorageInfo(newTabletStorageInfo);
+        db->WriteTabletStorageInfo(newTabletStorageInfo);
 
         // When a new file system is created, there are no XAttrs in it,
         // but if LazyXAttrsEnabled == false, we don't track XAttrs, and for
@@ -172,7 +172,7 @@ void TIndexTabletActor::ExecuteTx_LoadState(
         if (Config->GetLazyXAttrsEnabled()) {
             constexpr ui64 hasXAttrs = static_cast<ui64>(EHasXAttrs::False);
             args.FileSystemStats.SetHasXAttrs(hasXAttrs);
-            db.WriteHasXAttrs(hasXAttrs);
+            db->WriteHasXAttrs(hasXAttrs);
         }
 
         return;
@@ -194,7 +194,7 @@ void TIndexTabletActor::ExecuteTx_LoadState(
             LogTag << " Updating tablet storage info");
 
         args.TabletStorageInfo.CopyFrom(newTabletStorageInfo);
-        db.WriteTabletStorageInfo(newTabletStorageInfo);
+        db->WriteTabletStorageInfo(newTabletStorageInfo);
     }
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
@@ -671,9 +671,9 @@ bool TIndexTabletActor::PrepareTx_LoadCompactionMapChunk(
         LogTag << " Loading compaction map chunk "
             << args.FirstRangeId << ", " << args.RangeCount);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
-    bool ready = db.ReadCompactionMap(
+    bool ready = db->ReadCompactionMap(
         args.CompactionMap,
         args.FirstRangeId,
         args.RangeCount,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_oplog.cpp
@@ -228,8 +228,8 @@ void TIndexTabletActor::ExecuteTx_DeleteOpLogEntry(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
-    DeleteOpLogEntry(db, args.EntryId);
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    DeleteOpLogEntry(*db, args.EntryId);
 }
 
 void TIndexTabletActor::CompleteTx_DeleteOpLogEntry(
@@ -280,8 +280,8 @@ bool TIndexTabletActor::PrepareTx_GetOpLogEntry(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
-    return db.ReadOpLogEntry(args.EntryId, args.Entry);
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    return db->ReadOpLogEntry(args.EntryId, args.Entry);
 }
 
 void TIndexTabletActor::ExecuteTx_GetOpLogEntry(
@@ -342,8 +342,8 @@ bool TIndexTabletActor::PrepareTx_ListOpLogEntries(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
-    return db.ReadOpLog(args.Entries);
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    return db->ReadOpLog(args.Entries);
 }
 
 void TIndexTabletActor::ExecuteTx_ListOpLogEntries(
@@ -422,9 +422,9 @@ void TIndexTabletActor::ExecuteTx_WriteOpLogEntry(
         return;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
     args.Entry.SetEntryId(commitId);
-    WriteOpLogEntry(db, args.Entry);
+    WriteOpLogEntry(*db, args.Entry);
 }
 
 void TIndexTabletActor::CompleteTx_WriteOpLogEntry(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_releaselock.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_releaselock.cpp
@@ -71,9 +71,9 @@ void TIndexTabletActor::ExecuteTx_ReleaseLock(
 
     auto range = MakeLockRange(args.Request, handle->GetNodeId());
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
-    auto result = ReleaseLock(db, session, range);
+    auto result = ReleaseLock(*db, session, range);
 
     if (result.Failed()) {
         if (result.IncompatibleHolds<ELockOrigin>()) {

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_removenodexattr.cpp
@@ -66,12 +66,12 @@ bool TIndexTabletActor::PrepareTx_RemoveNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(RemoveNodeXAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // parse path
-    if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
+    if (!ReadNode(*db, args.NodeId, args.CommitId, args.Node)) {
         return false;   // not ready
     }
 
@@ -82,7 +82,7 @@ bool TIndexTabletActor::PrepareTx_RemoveNodeXAttr(
 
     // TODO: AccessCheck
     TABLET_VERIFY(args.Node);
-    if (!ReadNodeAttr(db, args.NodeId, args.CommitId, args.Name, args.Attr)) {
+    if (!ReadNodeAttr(*db, args.NodeId, args.CommitId, args.Name, args.Attr)) {
         return false;   // not ready
     }
 
@@ -103,7 +103,7 @@ void TIndexTabletActor::ExecuteTx_RemoveNodeXAttr(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -112,7 +112,7 @@ void TIndexTabletActor::ExecuteTx_RemoveNodeXAttr(
     }
 
     RemoveNodeAttr(
-        db,
+        *db,
         args.NodeId,
         args.Attr->MinCommitId,
         args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode.cpp
@@ -291,12 +291,12 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // validate parent node exists
-    if (!ReadNode(db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
+    if (!ReadNode(*db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
         return false;   // not ready
     }
 
@@ -309,7 +309,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     // validate old ref exists
     if (!ReadNodeRef(
-            db,
+            *db,
             args.ParentNodeId,
             args.CommitId,
             args.Name,
@@ -326,7 +326,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     if (!args.ChildRef->IsExternal()) {
         if (!ReadNode(
-                db,
+                *db,
                 args.ChildRef->ChildNodeId,
                 args.CommitId,
                 args.ChildNode))
@@ -346,7 +346,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     // validate new parent node exists
     if (!ReadNode(
-            db,
+            *db,
             args.NewParentNodeId,
             args.CommitId,
             args.NewParentNode))
@@ -368,7 +368,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
 
     // check if new ref exists
     if (!ReadNodeRef(
-            db,
+            *db,
             args.NewParentNodeId,
             args.CommitId,
             args.NewName,
@@ -386,7 +386,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
         if (!args.NewChildRef->IsExternal()) {
             // read new child node to unlink it
             if (!ReadNode(
-                    db,
+                    *db,
                     args.NewChildRef->ChildNodeId,
                     args.CommitId,
                     args.NewChildNode))
@@ -469,7 +469,7 @@ bool TIndexTabletActor::PrepareTx_RenameNode(
                 // 1 entry is enough to prevent rename
                 TVector<INodeIndexTabletDatabase::TNodeRef> refs;
                 if (!ReadNodeRefs(
-                        db,
+                        *db,
                         args.NewChildNode->NodeId,
                         args.CommitId,
                         {},
@@ -523,7 +523,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -533,7 +533,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
 
     // remove existing source ref
     RemoveNodeRef(
-        db,
+        *db,
         args.ParentNodeId,
         args.ChildRef->MinCommitId,
         args.CommitId,
@@ -546,7 +546,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
         if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
             // remove existing target ref
             RemoveNodeRef(
-                db,
+                *db,
                 args.NewParentNodeId,
                 args.NewChildRef->MinCommitId,
                 args.CommitId,
@@ -557,7 +557,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
 
             // create source ref to target node
             CreateNodeRef(
-                db,
+                *db,
                 args.ParentNodeId,
                 args.CommitId,
                 args.Name,
@@ -574,7 +574,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
 
             // remove target ref and unlink target node
             auto e = UnlinkNode(
-                db,
+                *db,
                 args.NewParentNode->NodeId,
                 args.NewName,
                 *args.NewChildNode,
@@ -584,7 +584,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
 
             if (HasError(e)) {
                 const auto nodeId = args.NewChildNode->NodeId;
-                WriteOrphanNode(db, TStringBuilder()
+                WriteOrphanNode(*db, TStringBuilder()
                     << "RenameNode: " << args.SessionId
                     << ", ParentNodeId: " << args.NewParentNode->NodeId
                     << ", NodeId: " << nodeId
@@ -592,12 +592,12 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
             }
         } else {
             if (args.AbortUnlinkOpLogEntryId) {
-                DeleteOpLogEntry(db, args.AbortUnlinkOpLogEntryId);
+                DeleteOpLogEntry(*db, args.AbortUnlinkOpLogEntryId);
             }
 
             // remove target ref
             UnlinkExternalNode(
-                db,
+                *db,
                 args.NewParentNode->NodeId,
                 args.NewName,
                 args.NewChildRef->ShardId,
@@ -619,14 +619,14 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
             shardRequest->SetUnlinkDirectory(
                 args.DestinationNodeAttr.GetType() == NProto::E_DIRECTORY_NODE);
 
-            WriteOpLogEntry(db, args.OpLogEntry);
+            WriteOpLogEntry(*db, args.OpLogEntry);
         }
     }
 
     // update old parent timestamps
     auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
     UpdateNode(
-        db,
+        *db,
         args.ParentNode->NodeId,
         args.ParentNode->MinCommitId,
         args.CommitId,
@@ -635,7 +635,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
 
     // create target ref to source node
     CreateNodeRef(
-        db,
+        *db,
         args.NewParentNodeId,
         args.CommitId,
         args.NewName,
@@ -645,7 +645,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
 
     auto newParent = CopyAttrs(args.NewParentNode->Attrs, E_CM_CMTIME);
     UpdateNode(
-        db,
+        *db,
         args.NewParentNode->NodeId,
         args.NewParentNode->MinCommitId,
         args.CommitId,
@@ -661,7 +661,7 @@ void TIndexTabletActor::ExecuteTx_RenameNode(
     }
 
     AddDupCacheEntry(
-        db,
+        *db,
         session,
         args.RequestId,
         NProto::TRenameNodeResponse{},

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_destination.cpp
@@ -505,13 +505,13 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // validate new parent node exists
     if (!ReadNode(
-            db,
+            *db,
             args.NewParentNodeId,
             args.CommitId,
             args.NewParentNode))
@@ -533,7 +533,7 @@ bool TIndexTabletActor::PrepareTx_RenameNodeInDestination(
 
     // check if new ref exists
     if (!ReadNodeRef(
-            db,
+            *db,
             args.NewParentNodeId,
             args.CommitId,
             args.NewName,
@@ -632,7 +632,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -644,7 +644,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
         if (HasFlag(args.Flags, NProto::TRenameNodeRequest::F_EXCHANGE)) {
             // remove existing target ref
             RemoveNodeRef(
-                db,
+                *db,
                 args.NewParentNodeId,
                 args.NewChildRef->MinCommitId,
                 args.CommitId,
@@ -666,12 +666,12 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
             return;
         } else {
             if (args.AbortUnlinkOpLogEntryId) {
-                DeleteOpLogEntry(db, args.AbortUnlinkOpLogEntryId);
+                DeleteOpLogEntry(*db, args.AbortUnlinkOpLogEntryId);
             }
 
             // remove target ref
             UnlinkExternalNode(
-                db,
+                *db,
                 args.NewParentNode->NodeId,
                 args.NewName,
                 args.NewChildRef->ShardId,
@@ -700,13 +700,13 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
                     << args.OpLogEntry.ShortUtf8DebugString().Quote());
             }
 
-            WriteOpLogEntry(db, args.OpLogEntry);
+            WriteOpLogEntry(*db, args.OpLogEntry);
         }
     }
 
     // create target ref to source node
     CreateNodeRef(
-        db,
+        *db,
         args.NewParentNodeId,
         args.CommitId,
         args.NewName,
@@ -716,7 +716,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
 
     auto newParent = CopyAttrs(args.NewParentNode->Attrs, E_CM_CMTIME);
     UpdateNode(
-        db,
+        *db,
         args.NewParentNode->NodeId,
         args.NewParentNode->MinCommitId,
         args.CommitId,
@@ -738,7 +738,7 @@ void TIndexTabletActor::ExecuteTx_RenameNodeInDestination(
     args.ResponseLogEntry.SetTimestampMs(ctx.Now().MilliSeconds());
     *args.ResponseLogEntry.MutableRenameNodeInDestinationResponse() =
         args.Response;
-    WriteResponseLogEntry(db, args.ResponseLogEntry);
+    WriteResponseLogEntry(*db, args.ResponseLogEntry);
 
     EnqueueTruncateIfNeeded(ctx);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_renamenode_source.cpp
@@ -426,12 +426,12 @@ bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
 
     FILESTORE_VALIDATE_DUPTX_SESSION(RenameNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // validate parent node exists
-    if (!ReadNode(db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
+    if (!ReadNode(*db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
         return false;   // not ready
     }
 
@@ -444,7 +444,7 @@ bool TIndexTabletActor::PrepareTx_PrepareRenameNodeInSource(
 
     // validate old ref exists
     if (!ReadNodeRef(
-            db,
+            *db,
             args.ParentNodeId,
             args.CommitId,
             args.Name,
@@ -483,7 +483,7 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
         return; // nothing to do
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -504,12 +504,12 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
             args.ChildRef->ShardNodeName,
             args.NewParentShardId);
 
-    WriteOpLogEntry(db, args.OpLogEntry);
+    WriteOpLogEntry(*db, args.OpLogEntry);
 
     // update old parent timestamps
     auto parent = CopyAttrs(args.ParentNode->Attrs, E_CM_CMTIME);
     UpdateNode(
-        db,
+        *db,
         args.ParentNode->NodeId,
         args.ParentNode->MinCommitId,
         args.CommitId,
@@ -525,7 +525,7 @@ void TIndexTabletActor::ExecuteTx_PrepareRenameNodeInSource(
     }
 
     AddDupCacheEntry(
-        db,
+        *db,
         session,
         args.RequestId,
         NProto::TRenameNodeResponse{},
@@ -698,13 +698,13 @@ bool TIndexTabletActor::PrepareTx_CommitRenameNodeInSource(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // validate old ref exists
     if (!ReadNodeRef(
-            db,
+            *db,
             args.Request.GetNodeId(),
             args.CommitId,
             args.Request.GetName(),
@@ -731,7 +731,7 @@ void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -745,14 +745,14 @@ void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
         NProto::TRenameNodeResponse response;
         *response.MutableError() = args.Response.GetError();
         PatchDupCacheEntry(
-            db,
+            *db,
             args.SessionId,
             args.RequestId,
             std::move(response));
         args.Error = args.Response.GetError();
     } else {
         RemoveNodeRef(
-            db,
+            *db,
             args.Request.GetNodeId(),
             args.ChildRef->MinCommitId,
             args.CommitId,
@@ -768,7 +768,7 @@ void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
         if (isExchange) {
             // create source ref to target node
             CreateNodeRef(
-                db,
+                *db,
                 args.Request.GetNodeId(),
                 args.CommitId,
                 args.Request.GetName(),
@@ -778,7 +778,7 @@ void TIndexTabletActor::ExecuteTx_CommitRenameNodeInSource(
         }
     }
 
-    DeleteOpLogEntry(db, args.OpLogEntryId);
+    DeleteOpLogEntry(*db, args.OpLogEntryId);
 }
 
 void TIndexTabletActor::CompleteTx_CommitRenameNodeInSource(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_resetsession.cpp
@@ -90,7 +90,7 @@ bool TIndexTabletActor::PrepareTx_ResetSession(
         args.SessionSeqNo,
         args.Request.GetSessionState().size());
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     bool ready = true;
     auto commitId = GetCurrentCommitId();
@@ -101,7 +101,7 @@ bool TIndexTabletActor::PrepareTx_ResetSession(
         }
 
         TMaybe<INodeIndexTabletDatabase::TNode> node;
-        if (!ReadNode(db, handle.GetNodeId(), commitId, node)) {
+        if (!ReadNode(*db, handle.GetNodeId(), commitId, node)) {
             ready = false;
         } else {
             TABLET_VERIFY(node);
@@ -120,7 +120,7 @@ void TIndexTabletActor::ExecuteTx_ResetSession(
     TTransactionContext& tx,
     TTxIndexTablet::TResetSession& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     auto* session = FindSession(args.SessionId);
     if (!session) {
@@ -140,7 +140,7 @@ void TIndexTabletActor::ExecuteTx_ResetSession(
     auto handle = session->Handles.begin();
     while (handle != session->Handles.end()) {
         auto nodeId = handle->GetNodeId();
-        DestroyHandle(db, &*(handle++));
+        DestroyHandle(*db, &*(handle++));
 
         LOG_INFO(ctx, TFileStoreComponents::TABLET,
             "%s Removing handle upon session reset s:%s n:%lu",
@@ -158,13 +158,13 @@ void TIndexTabletActor::ExecuteTx_ResetSession(
                 it->Attrs.GetSize());
 
             auto e = RemoveNode(
-                db,
+                *db,
                 *it,
                 it->MinCommitId,
                 commitId);
 
             if (HasError(e)) {
-                WriteOrphanNode(db, TStringBuilder()
+                WriteOrphanNode(*db, TStringBuilder()
                     << "DestroySession: " << args.SessionId
                     << ", RemoveNode: " << nodeId
                     << ", Error: " << FormatError(e), nodeId);
@@ -172,7 +172,7 @@ void TIndexTabletActor::ExecuteTx_ResetSession(
         }
     }
 
-    ResetSession(db, session, args.Request.GetSessionState());
+    ResetSession(*db, session, args.Request.GetSessionState());
 
     EnqueueTruncateIfNeeded(ctx);
 }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_responselog.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_responselog.cpp
@@ -53,9 +53,9 @@ void TIndexTabletActor::ExecuteTx_DeleteResponseLogEntries(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
     for (const auto& x: args.InternalRequestIds) {
-        DeleteResponseLogEntry(db, x.ClientTabletId, x.RequestId);
+        DeleteResponseLogEntry(*db, x.ClientTabletId, x.RequestId);
     }
 }
 
@@ -111,8 +111,8 @@ bool TIndexTabletActor::PrepareTx_GetResponseLogEntry(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
-    return db.ReadResponseLogEntry(
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    return db->ReadResponseLogEntry(
         args.ClientTabletId,
         args.RequestId,
         args.Entry);
@@ -194,8 +194,8 @@ void TIndexTabletActor::ExecuteTx_WriteResponseLogEntry(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
-    WriteResponseLogEntry(db, args.Entry);
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    WriteResponseLogEntry(*db, args.Entry);
 }
 
 void TIndexTabletActor::CompleteTx_WriteResponseLogEntry(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_set_has_xattrs.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_set_has_xattrs.cpp
@@ -39,11 +39,11 @@ void TIndexTabletActor::ExecuteTx_SetHasXAttrs(
     TTransactionContext& tx,
     TTxIndexTablet::TSetHasXAttrs& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     // Write only if the value is changed
     if (args.IsToBeChanged) {
-        WriteHasXAttrs(db, EHasXAttrsFromBool(args.Request.GetValue()));
+        WriteHasXAttrs(*db, EHasXAttrsFromBool(args.Request.GetValue()));
     }
     LOG_DEBUG(
         ctx,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodeattr.cpp
@@ -93,12 +93,12 @@ bool TIndexTabletActor::PrepareTx_SetNodeAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // validate target node exists
-    if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
+    if (!ReadNode(*db, args.NodeId, args.CommitId, args.Node)) {
         return false;   // not ready
     }
 
@@ -129,7 +129,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeAttr(
 {
     FILESTORE_VALIDATE_TX_ERROR(SetNodeAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -170,7 +170,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeAttr(
     }
     if (HasFlag(flags, NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE)) {
         auto e = Truncate(
-            db,
+            *db,
             args.NodeId,
             args.CommitId,
             attrs.GetSize(),
@@ -185,7 +185,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeAttr(
     }
 
     UpdateNode(
-        db,
+        *db,
         args.NodeId,
         args.Node->MinCommitId,
         args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_setnodexattr.cpp
@@ -72,12 +72,12 @@ bool TIndexTabletActor::PrepareTx_SetNodeXAttr(
 
     FILESTORE_VALIDATE_TX_SESSION(SetNodeXAttr, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // validate target node exists
-    if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
+    if (!ReadNode(*db, args.NodeId, args.CommitId, args.Node)) {
         return false;   // not ready
     }
 
@@ -89,7 +89,7 @@ bool TIndexTabletActor::PrepareTx_SetNodeXAttr(
     // TODO: AccessCheck
     TABLET_VERIFY(args.Node);
     // fetch previous version
-    if (!ReadNodeAttr(db, args.NodeId, args.CommitId, args.Name, args.Attr)) {
+    if (!ReadNodeAttr(*db, args.NodeId, args.CommitId, args.Name, args.Attr)) {
         return false;   // not ready
     }
 
@@ -115,7 +115,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeXAttr(
 
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -125,7 +125,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeXAttr(
 
     if (args.Attr) {
         args.Version = UpdateNodeAttr(
-            db,
+            *db,
             args.NodeId,
             args.Attr->MinCommitId,
             args.CommitId,
@@ -133,7 +133,7 @@ void TIndexTabletActor::ExecuteTx_SetNodeXAttr(
             args.Value);
     } else {
         args.Version = CreateNodeAttr(
-            db,
+            *db,
             args.NodeId,
             args.CommitId,
             args.Name,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_truncate.cpp
@@ -247,8 +247,8 @@ void TIndexTabletActor::ExecuteTx_TruncateCompleted(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
-    DeleteTruncate(db, args.NodeId);
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    DeleteTruncate(*db, args.NodeId);
 }
 
 void TIndexTabletActor::CompleteTx_TruncateCompleted(
@@ -314,7 +314,7 @@ void TIndexTabletActor::ExecuteTx_TruncateRange(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     ui64 commitId = GenerateCommitId();
     if (commitId == InvalidCommitId) {
@@ -327,7 +327,7 @@ void TIndexTabletActor::ExecuteTx_TruncateRange(
         args.Range.Length,
         args.ProfileLogRequest);
 
-    args.Error = TruncateRange(db, args.NodeId, commitId, args.Range);
+    args.Error = TruncateRange(*db, args.NodeId, commitId, args.Range);
 }
 
 void TIndexTabletActor::CompleteTx_TruncateRange(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode.cpp
@@ -382,12 +382,12 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
         FILESTORE_VALIDATE_DUPTX_SESSION(UnlinkNode, args);
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     // validate parent node exists
-    if (!ReadNode(db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
+    if (!ReadNode(*db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
         return false;   // not ready
     }
 
@@ -404,7 +404,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
     if (!Config->GetParentlessFilesOnly()) {
         // validate target node exists
         if (!ReadNodeRef(
-                db,
+                *db,
                 args.ParentNodeId,
                 args.CommitId,
                 args.Name,
@@ -424,7 +424,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
         childNodeId = args.ParentNodeId;
     }
 
-    if (!ReadNode(db, childNodeId, args.CommitId, args.ChildNode)) {
+    if (!ReadNode(*db, childNodeId, args.CommitId, args.ChildNode)) {
         return false;   // not ready
     }
 
@@ -444,7 +444,7 @@ bool TIndexTabletActor::PrepareTx_UnlinkNode(
     if (args.ChildNode->Attrs.GetType() == NProto::E_DIRECTORY_NODE) {
         TVector<INodeIndexTabletDatabase::TNodeRef> refs;
         // 1 entry is enough to prevent deletion
-        if (!ReadNodeRefs(db, childNodeId, args.CommitId, {}, refs, 1)) {
+        if (!ReadNodeRefs(*db, childNodeId, args.CommitId, {}, refs, 1)) {
             return false;
         }
 
@@ -474,7 +474,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
 {
     FILESTORE_VALIDATE_TX_ERROR(UnlinkNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -494,7 +494,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
 
         if (!GetFileSystem().GetDirectoryCreationInShardsEnabled()) {
             UnlinkExternalNode(
-                db,
+                *db,
                 args.ParentNodeId,
                 args.Name,
                 args.ChildRef->ShardId,
@@ -521,10 +521,10 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
                 << args.OpLogEntry.ShortUtf8DebugString().Quote());
         }
 
-        WriteOpLogEntry(db, args.OpLogEntry);
+        WriteOpLogEntry(*db, args.OpLogEntry);
     } else {
         auto e = UnlinkNode(
-            db,
+            *db,
             args.ParentNodeId,
             args.Name,
             *args.ChildNode,
@@ -548,7 +548,7 @@ void TIndexTabletActor::ExecuteTx_UnlinkNode(
         }
 
         AddDupCacheEntry(
-            db,
+            *db,
             session,
             args.RequestId,
             NProto::TUnlinkNodeResponse{},
@@ -669,13 +669,13 @@ bool TIndexTabletActor::PrepareTx_CompleteUnlinkNode(
 {
     Y_UNUSED(ctx, tx, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     // TODO(2674): we should pass commitId from the request, not generate it
     args.CommitId = GetCurrentCommitId();
 
     // validate parent node exists
-    if (!ReadNode(db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
+    if (!ReadNode(*db, args.ParentNodeId, args.CommitId, args.ParentNode)) {
         return false;   // not ready
     }
 
@@ -686,7 +686,7 @@ bool TIndexTabletActor::PrepareTx_CompleteUnlinkNode(
 
     // validate target node exists
     if (!ReadNodeRef(
-            db,
+            *db,
             args.ParentNodeId,
             args.CommitId,
             args.Name,
@@ -719,9 +719,9 @@ void TIndexTabletActor::ExecuteTx_CompleteUnlinkNode(
     TTransactionContext& tx,
     TTxIndexTablet::TCompleteUnlinkNode& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
-    DeleteOpLogEntry(db, args.OpLogEntryId);
+    DeleteOpLogEntry(*db, args.OpLogEntryId);
 
     // If the original response was an error or prepare stage failed, we don't
     // need to do anything
@@ -751,7 +751,7 @@ void TIndexTabletActor::ExecuteTx_CompleteUnlinkNode(
     }
 
     UnlinkExternalNode(
-        db,
+        *db,
         args.ParentNodeId,
         args.Name,
         args.ChildRef->ShardId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_abort.cpp
@@ -208,12 +208,12 @@ bool TIndexTabletActor::PrepareTx_AbortUnlinkDirectoryNode(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     bool ready = ReadNode(
-        db,
+        *db,
         args.Request.GetNodeId(),
         args.CommitId,
         args.Node);
@@ -281,7 +281,7 @@ void TIndexTabletActor::ExecuteTx_AbortUnlinkDirectoryNode(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -292,7 +292,7 @@ void TIndexTabletActor::ExecuteTx_AbortUnlinkDirectoryNode(
     NProto::TNode attrs = CopyAttrs(args.Node->Attrs, E_CM_CTIME);
     attrs.SetIsPreparedForUnlink(false);
     UpdateNode(
-        db,
+        *db,
         args.Request.GetNodeId(),
         args.Node->MinCommitId,
         args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unlinknode_prepare.cpp
@@ -50,12 +50,12 @@ bool TIndexTabletActor::PrepareTx_PrepareUnlinkDirectoryNode(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GetCurrentCommitId();
 
     bool ready = ReadNode(
-        db,
+        *db,
         args.Request.GetNodeId(),
         args.CommitId,
         args.Node);
@@ -82,7 +82,7 @@ bool TIndexTabletActor::PrepareTx_PrepareUnlinkDirectoryNode(
     TVector<INodeIndexTabletDatabase::TNodeRef> refs;
     // 1 entry is enough to prevent deletion
     ready = ReadNodeRefs(
-        db,
+        *db,
         args.Request.GetNodeId(),
         args.CommitId,
         {},
@@ -109,7 +109,7 @@ void TIndexTabletActor::ExecuteTx_PrepareUnlinkDirectoryNode(
 
     FILESTORE_VALIDATE_TX_ERROR(PrepareUnlinkDirectoryNode, args);
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -120,7 +120,7 @@ void TIndexTabletActor::ExecuteTx_PrepareUnlinkDirectoryNode(
     NProto::TNode attrs = CopyAttrs(args.Node->Attrs, E_CM_CTIME);
     attrs.SetIsPreparedForUnlink(true);
     UpdateNode(
-        db,
+        *db,
         args.Request.GetNodeId(),
         args.Node->MinCommitId,
         args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_unsafe_node_ops.cpp
@@ -47,8 +47,8 @@ bool TIndexTabletActor::PrepareTx_UnsafeCreateNode(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
-    return ReadNode(db, args.Request.GetNode().GetId(), commitId, args.Node);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+    return ReadNode(*db, args.Request.GetNode().GetId(), commitId, args.Node);
 }
 
 void TIndexTabletActor::ExecuteTx_UnsafeCreateNode(
@@ -56,7 +56,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeCreateNode(
     TTransactionContext& tx,
     TTxIndexTablet::TUnsafeCreateNode& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     if (args.Node) {
         LOG_WARN(ctx, TFileStoreComponents::TABLET,
@@ -76,7 +76,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeCreateNode(
     NProto::TNode node;
     ConvertAttrsToNode(args.Request.GetNode(), &node);
     node.SetSymLink(args.Request.GetSymLink());
-    CreateNodeWithId(db, args.Request.GetNode().GetId(), commitId, node);
+    CreateNodeWithId(*db, args.Request.GetNode().GetId(), commitId, node);
 }
 
 void TIndexTabletActor::CompleteTx_UnsafeCreateNode(
@@ -140,8 +140,8 @@ bool TIndexTabletActor::PrepareTx_UnsafeDeleteNode(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
-    return ReadNode(db, args.Request.GetId(), commitId, args.Node);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+    return ReadNode(*db, args.Request.GetId(), commitId, args.Node);
 }
 
 void TIndexTabletActor::ExecuteTx_UnsafeDeleteNode(
@@ -149,7 +149,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeDeleteNode(
     TTransactionContext& tx,
     TTxIndexTablet::TUnsafeDeleteNode& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     if (!args.Node) {
         LOG_WARN(ctx, TFileStoreComponents::TABLET,
@@ -166,7 +166,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeDeleteNode(
         return;
     }
 
-    args.Error = RemoveNode(db, *args.Node, args.Node->MinCommitId, commitId);
+    args.Error = RemoveNode(*db, *args.Node, args.Node->MinCommitId, commitId);
 }
 
 void TIndexTabletActor::CompleteTx_UnsafeDeleteNode(
@@ -226,8 +226,8 @@ bool TIndexTabletActor::PrepareTx_UnsafeUpdateNode(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
-    return ReadNode(db, args.Request.GetNode().GetId(), commitId, args.Node);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
+    return ReadNode(*db, args.Request.GetNode().GetId(), commitId, args.Node);
 }
 
 void TIndexTabletActor::ExecuteTx_UnsafeUpdateNode(
@@ -235,7 +235,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeUpdateNode(
     TTransactionContext& tx,
     TTxIndexTablet::TUnsafeUpdateNode& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     if (!args.Node) {
         LOG_WARN(ctx, TFileStoreComponents::TABLET,
@@ -259,7 +259,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeUpdateNode(
 
     ConvertAttrsToNode(args.Request.GetNode(), &node);
     UpdateNode(
-        db,
+        *db,
         args.Request.GetNode().GetId(),
         nodeCommitId,
         commitId,
@@ -407,9 +407,9 @@ bool TIndexTabletActor::PrepareTx_UnsafeCreateNodeRef(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
     return ReadNodeRef(
-        db,
+        *db,
         args.Request.GetParentId(),
         commitId,
         args.Request.GetName(),
@@ -421,7 +421,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeCreateNodeRef(
     TTransactionContext& tx,
     TTxIndexTablet::TUnsafeCreateNodeRef& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     if (args.NodeRef) {
         LOG_WARN(ctx, TFileStoreComponents::TABLET,
@@ -439,7 +439,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeCreateNodeRef(
     }
 
     CreateNodeRef(
-        db,
+        *db,
         args.Request.GetParentId(),
         commitId,
         args.Request.GetName(),
@@ -505,9 +505,9 @@ bool TIndexTabletActor::PrepareTx_UnsafeDeleteNodeRef(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
     return ReadNodeRef(
-        db,
+        *db,
         args.Request.GetParentId(),
         commitId,
         args.Request.GetName(),
@@ -519,7 +519,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeDeleteNodeRef(
     TTransactionContext& tx,
     TTxIndexTablet::TUnsafeDeleteNodeRef& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     if (!args.NodeRef) {
         LOG_WARN(ctx, TFileStoreComponents::TABLET,
@@ -539,7 +539,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeDeleteNodeRef(
     }
 
     RemoveNodeRef(
-        db,
+        *db,
         args.Request.GetParentId(),
         args.NodeRef->MinCommitId,
         commitId,
@@ -606,9 +606,9 @@ bool TIndexTabletActor::PrepareTx_UnsafeUpdateNodeRef(
 
     auto commitId = GetCurrentCommitId();
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
     return ReadNodeRef(
-        db,
+        *db,
         args.Request.GetParentId(),
         commitId,
         args.Request.GetName(),
@@ -620,7 +620,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeUpdateNodeRef(
     TTransactionContext& tx,
     TTxIndexTablet::TUnsafeUpdateNodeRef& args)
 {
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     if (!args.NodeRef) {
         LOG_WARN(ctx, TFileStoreComponents::TABLET,
@@ -640,7 +640,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeUpdateNodeRef(
     }
 
     RemoveNodeRef(
-        db,
+        *db,
         args.Request.GetParentId(),
         args.NodeRef->MinCommitId,
         commitId,
@@ -650,7 +650,7 @@ void TIndexTabletActor::ExecuteTx_UnsafeUpdateNodeRef(
         args.NodeRef->ShardNodeName);
 
     CreateNodeRef(
-        db,
+        *db,
         args.Request.GetParentId(),
         commitId,
         args.Request.GetName(),
@@ -815,10 +815,10 @@ void TIndexTabletActor::ExecuteTx_UnsafeCreateHandle(
         return;
     }
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     TSessionHandle* handle = UnsafeCreateHandle(
-        db,
+        *db,
         session,
         args.Request.GetHandle(),
         args.Request.GetNodeId(),
@@ -904,14 +904,14 @@ void TIndexTabletActor::ExecuteTx_UnsafeChangeTabletState(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     if (args.Request.HasCompressNodeRef()) {
-        SetCompressNodeRef(db, args.Request.GetCompressNodeRef());
+        SetCompressNodeRef(*db, args.Request.GetCompressNodeRef());
     }
 
     if (args.Request.HasFrozen()) {
-        SetFrozen(db, args.Request.GetFrozen());
+        SetFrozen(*db, args.Request.GetFrozen());
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_updateconfig.cpp
@@ -285,7 +285,7 @@ void TIndexTabletActor::ExecuteTx_UpdateConfig(
     TTransactionContext& tx,
     TTxIndexTablet::TUpdateConfig& args)
 {
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     ApplyStorageConfigOverrides(
         ctx,
@@ -297,7 +297,7 @@ void TIndexTabletActor::ExecuteTx_UpdateConfig(
         *Config,
         args.FileSystem.GetPerformanceProfile());
 
-    UpdateConfig(db, *Config, args.FileSystem, config);
+    UpdateConfig(*db, *Config, args.FileSystem, config);
 }
 
 void TIndexTabletActor::CompleteTx_UpdateConfig(
@@ -393,7 +393,7 @@ void TIndexTabletActor::ExecuteTx_ConfigureShards(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     auto config = GetFileSystem();
     *config.MutableShardFileSystemIds() =
@@ -414,7 +414,7 @@ void TIndexTabletActor::ExecuteTx_ConfigureShards(
         LogTag.c_str(),
         config.ShortDebugString().c_str());
 
-    UpdateConfig(db, *Config, config, GetThrottlingConfig());
+    UpdateConfig(*db, *Config, config, GetThrottlingConfig());
 }
 
 void TIndexTabletActor::CompleteTx_ConfigureShards(
@@ -515,7 +515,7 @@ void TIndexTabletActor::ExecuteTx_ConfigureAsShard(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     auto config = GetFileSystem();
     config.SetShardNo(args.Request.GetShardNo());
@@ -534,7 +534,7 @@ void TIndexTabletActor::ExecuteTx_ConfigureAsShard(
     *config.MutableFastShardConfig() =
         std::move(*args.Request.MutableFastShardConfig());
 
-    UpdateConfig(db, *Config, config, GetThrottlingConfig());
+    UpdateConfig(*db, *Config, config, GetThrottlingConfig());
 }
 
 void TIndexTabletActor::CompleteTx_ConfigureAsShard(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_write_compactionmap.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_write_compactionmap.cpp
@@ -54,9 +54,9 @@ void TIndexTabletActor::ExecuteTx_WriteCompactionMap(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
     for (const auto& range: args.Ranges) {
-        db.ForceWriteCompactionMap(
+        db->ForceWriteCompactionMap(
             range.GetRangeId(),
             range.GetBlobCount(),
             range.GetDeletionCount(),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_writedata.cpp
@@ -248,9 +248,9 @@ bool TIndexTabletActor::PrepareTx_WriteData(
         args.NodeId,
         args.ByteRange.Describe().c_str());
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
-    if (!ReadNode(db, args.NodeId, args.CommitId, args.Node)) {
+    if (!ReadNode(*db, args.NodeId, args.CommitId, args.Node)) {
         return false;
     }
 
@@ -291,7 +291,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
         return;
     }
 
-    TIndexTabletDatabaseProxy db(tx.DB, args.NodeUpdates);
+    auto db = CreateIndexTabletDatabaseProxy(tx.DB, args.NodeUpdates);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -300,7 +300,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
     }
 
     MarkFreshBlocksDeleted(
-        db,
+        *db,
         args.NodeId,
         args.CommitId,
         args.ByteRange.FirstAlignedBlock(),
@@ -312,7 +312,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
         BlockGroupSize,
         [&] (ui32 blockOffset, ui32 blocksCount) {
             MarkMixedBlocksDeleted(
-                db,
+                *db,
                 args.NodeId,
                 args.CommitId,
                 args.ByteRange.FirstAlignedBlock() + blockOffset,
@@ -324,7 +324,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
             ++b)
     {
         WriteFreshBlock(
-            db,
+            *db,
             args.NodeId,
             args.CommitId,
             b,
@@ -333,7 +333,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
 
     if (args.ByteRange.UnalignedHeadLength()) {
         WriteFreshBytes(
-            db,
+            *db,
             args.NodeId,
             args.CommitId,
             args.ByteRange.Offset,
@@ -345,26 +345,26 @@ void TIndexTabletActor::ExecuteTx_WriteData(
         if (args.Node->Attrs.GetSize() <= args.ByteRange.End()) {
             // it's safe to write at the end of file fresh block w 0s at the end
             MarkFreshBlocksDeleted(
-                db,
+                *db,
                 args.NodeId,
                 args.CommitId,
                 args.ByteRange.LastBlock(),
                 1);
             MarkMixedBlocksDeleted(
-                db,
+                *db,
                 args.NodeId,
                 args.CommitId,
                 args.ByteRange.LastBlock(),
                 1);
             WriteFreshBlock(
-                db,
+                *db,
                 args.NodeId,
                 args.CommitId,
                 args.ByteRange.LastBlock(),
                 args.Buffer->GetUnalignedTail());
         } else {
             WriteFreshBytes(
-                db,
+                *db,
                 args.NodeId,
                 args.CommitId,
                 args.ByteRange.UnalignedTailOffset(),
@@ -378,7 +378,7 @@ void TIndexTabletActor::ExecuteTx_WriteData(
     }
 
     UpdateNode(
-        db,
+        *db,
         args.NodeId,
         args.Node->MinCommitId,
         args.CommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_zerorange.cpp
@@ -74,7 +74,7 @@ void TIndexTabletActor::ExecuteTx_ZeroRange(
 {
     Y_UNUSED(ctx);
 
-    TIndexTabletDatabase db(tx.DB);
+    auto db = CreateIndexTabletDatabase(tx.DB);
 
     args.CommitId = GenerateCommitId();
     if (args.CommitId == InvalidCommitId) {
@@ -88,7 +88,7 @@ void TIndexTabletActor::ExecuteTx_ZeroRange(
         args.Range.Length,
         args.ProfileLogRequest);
 
-    args.Error = ZeroRange(db, args.NodeId, args.CommitId, args.Range);
+    args.Error = ZeroRange(*db, args.NodeId, args.CommitId, args.Range);
 }
 
 void TIndexTabletActor::CompleteTx_ZeroRange(

--- a/cloud/filestore/libs/storage/tablet/tablet_state.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.cpp
@@ -256,7 +256,7 @@ void TIndexTabletState::LoadState(
 }
 
 void TIndexTabletState::UpdateConfig(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TStorageConfig& config,
     const NProto::TFileSystem& fileSystem,
     const TThrottlerConfig& throttlerConfig)
@@ -272,14 +272,14 @@ void TIndexTabletState::UpdateConfig(
     InitShardBalancer(config);
 }
 
-void TIndexTabletState::SetFrozen(TIndexTabletDatabase& db, bool frozen)
+void TIndexTabletState::SetFrozen(IIndexTabletDatabase& db, bool frozen)
 {
     FileSystem.SetFrozen(frozen);
     db.WriteFileSystem(FileSystem);
 }
 
 void TIndexTabletState::SetCompressNodeRef(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     bool compressNodeRef)
 {
     FileSystem.SetCompressNodeRef(compressNodeRef);
@@ -349,14 +349,14 @@ ui64 TIndexTabletState::CalculateMinExpectedShardCount(
 ////////////////////////////////////////////////////////////////////////////////
 
 void TIndexTabletState::WriteOpLogEntry(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const NProto::TOpLogEntry& e)
 {
     db.WriteOpLogEntry(e);
     Impl->OpLogEntryIds.insert(e.GetEntryId());
 }
 
-void TIndexTabletState::DeleteOpLogEntry(TIndexTabletDatabase& db, ui64 entryId)
+void TIndexTabletState::DeleteOpLogEntry(IIndexTabletDatabase& db, ui64 entryId)
 {
     db.DeleteOpLogEntry(entryId);
     Impl->OpLogEntryIds.erase(entryId);
@@ -379,7 +379,7 @@ TIndexTabletState::LookupResponseLogEntry(
 }
 
 void TIndexTabletState::WriteResponseLogEntry(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const NProtoPrivate::TResponseLogEntry& e)
 {
     db.WriteResponseLogEntry(e);
@@ -408,7 +408,7 @@ void TIndexTabletState::CommitResponseLogEntry(
 }
 
 void TIndexTabletState::DeleteResponseLogEntry(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 clientTabletId,
     ui64 requestId)
 {

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -307,14 +307,14 @@ public:
     }
 
     void UpdateConfig(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TStorageConfig& config,
         const NProto::TFileSystem& fileSystem,
         const TThrottlerConfig& throttlerConfig);
 
-    void SetFrozen(TIndexTabletDatabase& db, bool frozen);
+    void SetFrozen(IIndexTabletDatabase& db, bool frozen);
 
-    void SetCompressNodeRef(TIndexTabletDatabase& db, bool compressNodeRef);
+    void SetCompressNodeRef(IIndexTabletDatabase& db, bool compressNodeRef);
 
     //
     // FileSystem
@@ -470,19 +470,19 @@ public:                                                                        \
         return FileSystemStats.Get##name();                                    \
     }                                                                          \
 private:                                                                       \
-    void Set##name(TIndexTabletDatabase& db, ui64 value)                       \
+    void Set##name(IIndexTabletDatabase& db, ui64 value)                       \
     {                                                                          \
         FileSystemStats.Set##name(value);                                      \
         db.Write##name(value);                                                 \
     }                                                                          \
-    ui64 Increment##name(TIndexTabletDatabase& db, size_t delta = 1)           \
+    ui64 Increment##name(IIndexTabletDatabase& db, size_t delta = 1)           \
     {                                                                          \
         ui64 value = SafeIncrement(FileSystemStats.Get##name(), delta);        \
         FileSystemStats.Set##name(value);                                      \
         db.Write##name(value);                                                 \
         return value;                                                          \
     }                                                                          \
-    ui64 Decrement##name(TIndexTabletDatabase& db, size_t delta = 1)           \
+    ui64 Decrement##name(IIndexTabletDatabase& db, size_t delta = 1)           \
     {                                                                          \
         ui64 value = SafeDecrement(FileSystemStats.Get##name(), delta);        \
         FileSystemStats.Set##name(value);                                      \
@@ -537,18 +537,18 @@ private:
 
 public:
     void CreateNodeWithId(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         const NProto::TNode& attrs);
 
     ui64 CreateNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 commitId,
         const NProto::TNode& attrs);
 
     void UpdateNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -556,13 +556,13 @@ public:
         const NProto::TNode& prevAttrs);
 
     [[nodiscard]] NProto::TError RemoveNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const INodeIndexTabletDatabase::TNode& node,
         ui64 minCommitId,
         ui64 maxCommitId);
 
     [[nodiscard]] NProto::TError UnlinkNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 parentNodeId,
         const TString& name,
         const INodeIndexTabletDatabase::TNode& node,
@@ -571,7 +571,7 @@ public:
         bool removeNodeRef);
 
     void UnlinkExternalNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 parentNodeId,
         const TString& name,
         const TString& shardId,
@@ -586,14 +586,14 @@ public:
         TMaybe<INodeIndexTabletDatabase::TNode>& node);
 
     void RewriteNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
         const NProto::TNode& attrs);
 
     void WriteOrphanNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TString& message,
         ui64 nodeId);
 
@@ -605,7 +605,7 @@ public:
 
 private:
     void UpdateUsedBlocksCount(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 currentSize,
         ui64 prevSize);
 
@@ -615,14 +615,14 @@ private:
 
 public:
     ui64 CreateNodeAttr(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& name,
         const TString& value);
 
     ui64 UpdateNodeAttr(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -630,7 +630,7 @@ public:
         const TString& newValue);
 
     void RemoveNodeAttr(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -650,7 +650,7 @@ public:
         TVector<INodeIndexTabletDatabase::TNodeAttr>& attrs);
 
     void RewriteNodeAttr(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -668,7 +668,7 @@ public:
         False = 2
     };
 
-    void WriteHasXAttrs(TIndexTabletDatabase& db, EHasXAttrs hasXAttrs);
+    void WriteHasXAttrs(IIndexTabletDatabase& db, EHasXAttrs hasXAttrs);
 
     //
     // NodeRefs
@@ -676,7 +676,7 @@ public:
 
 public:
     void CreateNodeRef(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         const TString& childName,
@@ -686,7 +686,7 @@ public:
         bool markExhaustive = false);
 
     void RemoveNodeRef(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -730,7 +730,7 @@ public:
         ui64 bytesToPrecharge);
 
     void RewriteNodeRef(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 minCommitId,
         ui64 maxCommitId,
@@ -760,7 +760,7 @@ public:
         const NProto::TSessionOptions& sessionOptions);
 
     TSession* CreateSession(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TString& clientId,
         const TString& sessionId,
         const TString& checkpointId,
@@ -771,7 +771,7 @@ public:
         const NProto::TSessionOptions& sessionOptions);
 
     void RemoveSession(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TString& sessionId);
 
     TSession* FindSession(const TString& sessionId) const;
@@ -794,7 +794,7 @@ public:
         const NActors::TActorId& pipeServer) const;
     void RemoveSessionByPipeServer(const NActors::TActorId& pipeServer);
     void OrphanSession(const NActors::TActorId& owner, TInstant inactivityDeadline);
-    void ResetSession(TIndexTabletDatabase& db, TSession* session, const TMaybe<TString>& state);
+    void ResetSession(IIndexTabletDatabase& db, TSession* session, const TMaybe<TString>& state);
 
     TVector<TSession*> GetTimedOutSessions(TInstant now) const;
     TVector<TSession*> GetSessionsToNotify(const NProto::TSessionEvent& event) const;
@@ -802,7 +802,7 @@ public:
 
     const TSessionHistoryList& GetSessionHistoryList() const;
     void AddSessionHistoryEntry(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TSessionHistoryEntry& entry, size_t maxEntryCount);
 
     using TCreateSessionRequests =
@@ -834,14 +834,14 @@ private:
 
 public:
     TSessionHandle* CreateHandle(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TSession* session,
         ui64 nodeId,
         ui64 commitId,
         ui32 flags);
 
     TSessionHandle* UnsafeCreateHandle(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TSession* session,
         ui64 handleId,
         ui64 nodeId,
@@ -849,7 +849,7 @@ public:
         ui32 flags);
 
     void DestroyHandle(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TSessionHandle* handle);
 
     TSessionHandle* FindHandle(ui64 handle) const;
@@ -871,13 +871,13 @@ private:
 
 public:
     TRangeLockOperationResult AcquireLock(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TSession* session,
         ui64 handle,
         const TLockRange& range);
 
     TRangeLockOperationResult ReleaseLock(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TSession* session,
         const TLockRange& range);
 
@@ -886,7 +886,7 @@ public:
         const TSessionHandle* handle,
         const TLockRange& range) const;
 
-    void ReleaseLocks(TIndexTabletDatabase& db, ui64 handle);
+    void ReleaseLocks(IIndexTabletDatabase& db, ui64 handle);
 
 private:
     TSessionLock* FindLock(ui64 lockId) const;
@@ -905,7 +905,7 @@ private:
 #define FILESTORE_DECLARE_DUPCACHE(name, ...)                                   \
 public:                                                                         \
     void AddDupCacheEntry(                                                      \
-        TIndexTabletDatabase& db,                                               \
+        IIndexTabletDatabase& db,                                               \
         TSession* session,                                                      \
         ui64 requestId,                                                         \
         const NProto::T##name##Response& response,                              \
@@ -921,13 +921,13 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_DECLARE_DUPCACHE)
 #undef FILESTORE_DECLARE_DUPCACHE
 
     void PatchDupCacheEntry(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TString& sessionId,
         ui64 requestId,
         NProto::TCreateNodeResponse response);
 
     void PatchDupCacheEntry(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TString& sessionId,
         ui64 requestId,
         NProto::TRenameNodeResponse response);
@@ -942,10 +942,10 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_DECLARE_DUPCACHE)
 
 public:
     void WriteOpLogEntry(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const NProto::TOpLogEntry& e);
 
-    void DeleteOpLogEntry(TIndexTabletDatabase& db, ui64 entryId);
+    void DeleteOpLogEntry(IIndexTabletDatabase& db, ui64 entryId);
 
     ui64 GetOpLogEntryCount() const;
 
@@ -959,13 +959,13 @@ public:
         ui64 requestId) const;
 
     void WriteResponseLogEntry(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const NProtoPrivate::TResponseLogEntry& e);
 
     void CommitResponseLogEntry(NProtoPrivate::TResponseLogEntry e);
 
     void DeleteResponseLogEntry(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 clientTabletId,
         ui64 requestId);
 
@@ -1007,7 +1007,7 @@ public:
     //
 
 public:
-    void ConfirmedDataAdded(TIndexTabletDatabase& db, ui64 commitId);
+    void ConfirmedDataAdded(IIndexTabletDatabase& db, ui64 commitId);
 
     void LoadUnconfirmedData(
         TVector<TIndexTabletDatabase::TUnconfirmedDataEntry> entries);
@@ -1046,14 +1046,14 @@ public:
         TStringBuf data) const;
 
     void WriteFreshBytes(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         ui64 offset,
         TStringBuf data);
 
     void WriteFreshBytesDeletionMarker(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         ui64 offset,
@@ -1063,7 +1063,7 @@ public:
         TVector<TBytes>* bytes,
         TVector<TBytes>* deletionMarkers);
     TFlushBytesStats FinishFlushBytes(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 itemLimit,
         ui64 chunkId,
         NProto::TProfileLogRequestInfo& profileLogRequest);
@@ -1096,21 +1096,21 @@ public:
         ui32 blockIndex) const;
 
     void WriteFreshBlock(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         ui32 blockIndex,
         TStringBuf blockData);
 
     void MarkFreshBlocksDeleted(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         ui32 blockIndex,
         ui32 blocksCount);
 
     void DeleteFreshBlocks(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TVector<TBlock>& blocks);
 
     //
@@ -1130,18 +1130,18 @@ public:
         ui32 blocksCount) const;
 
     void WriteMixedBlocks(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TPartialBlobId& blobId,
         const TBlock& block,
         ui32 blocksCount);
 
     TWriteMixedBlocksResult WriteMixedBlocks(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TPartialBlobId& blobId,
         /*const*/ TVector<TBlock>& blocks);
 
     void DeleteMixedBlocks(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TPartialBlobId& blobId,
         const TVector<TBlock>& blocks);
 
@@ -1150,7 +1150,7 @@ public:
     TMixedBlobMeta FindBlob(ui32 rangeId, TPartialBlobId blobId) const;
 
     void MarkMixedBlocksDeleted(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         ui32 blockIndex,
@@ -1158,16 +1158,16 @@ public:
 
     // returns processed deletion marker count
     ui32 CleanupBlockDeletions(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui32 rangeId,
         NProto::TProfileLogRequestInfo& profileLogRequest);
 
     bool UpdateBlockLists(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TMixedBlobMeta& blob);
 
     void RewriteMixedBlocks(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui32 rangeId,
         /*const*/ TMixedBlobMeta& blob,
         const TMixedBlobStats& blobStats);
@@ -1183,13 +1183,13 @@ public:
 
 private:
     TWriteMixedBlocksResult WriteMixedBlocks(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui32 rangeId,
         const TPartialBlobId& blobId,
         /*const*/ TVector<TBlock>& blocks);
 
     TDeleteMixedBlocksResult DeleteMixedBlocks(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui32 rangeId,
         const TPartialBlobId& blobId,
         const TVector<TBlock>& blocks);
@@ -1242,14 +1242,14 @@ public:
     TVector<TPartialBlobId> GetGarbageBlobs(ui64 collectCommitId) const;
 
     void DeleteGarbage(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 collectCommitId,
         const TVector<TPartialBlobId>& newBlobs,
         const TVector<TPartialBlobId>& garbageBlobs);
 
 private:
-    void AddNewBlob(TIndexTabletDatabase& db, const TPartialBlobId& blobId);
-    void AddGarbageBlob(TIndexTabletDatabase& db, const TPartialBlobId& blobId);
+    void AddNewBlob(IIndexTabletDatabase& db, const TPartialBlobId& blobId);
+    void AddGarbageBlob(IIndexTabletDatabase& db, const TPartialBlobId& blobId);
 
     //
     // Checkpoints
@@ -1265,38 +1265,38 @@ public:
     ui64 GetReadCommitId(const TString& checkpointId) const;
 
     TCheckpoint* CreateCheckpoint(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         const TString& checkpointId,
         ui64 nodeId,
         ui64 commitId);
 
     void MarkCheckpointDeleted(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TCheckpoint* checkpoint);
 
     void RemoveCheckpointNodes(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TCheckpoint* checkpoint,
         const TVector<ui64>& nodes);
 
     void RemoveCheckpointBlob(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TCheckpoint* checkpoint,
         ui32 rangeId,
         const TPartialBlobId& blobId);
 
     void RemoveCheckpoint(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         TCheckpoint* checkpoint);
 
 private:
     void AddCheckpointNode(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 checkpointId,
         ui64 nodeId);
 
     void AddCheckpointBlob(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 checkpointId,
         ui32 rangeId,
         const TPartialBlobId& blobId);
@@ -1510,11 +1510,11 @@ public:
     void CompleteTruncateOp(ui64 nodeId);
     bool HasActiveTruncateOp(ui64 nodeId) const;
 
-    void AddTruncate(TIndexTabletDatabase& db, ui64 nodeId, TByteRange range);
-    void DeleteTruncate(TIndexTabletDatabase& db, ui64 nodeId);
+    void AddTruncate(IIndexTabletDatabase& db, ui64 nodeId, TByteRange range);
+    void DeleteTruncate(IIndexTabletDatabase& db, ui64 nodeId);
 
     [[nodiscard]] NProto::TError Truncate(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         ui64 currentSize,
@@ -1527,7 +1527,7 @@ public:
     // - deletes all blocks in NEW range;
     // - writes fresh bytes (zeroes) on unaligned head, if range.Offset != 0.
     [[nodiscard]] NProto::TError TruncateRange(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         TByteRange range);
@@ -1537,14 +1537,14 @@ public:
     // - writes fresh bytes (zeroes) on unaligned head, if any;
     // - writes fresh bytes (zeroes) on unaligned tail, if any.
     [[nodiscard]] NProto::TError ZeroRange(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         TByteRange range);
 
 private:
     [[nodiscard]] NProto::TError DeleteRange(
-        TIndexTabletDatabase& db,
+        IIndexTabletDatabase& db,
         ui64 nodeId,
         ui64 commitId,
         const TByteRange& range);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_checkpoints.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_checkpoints.cpp
@@ -38,7 +38,7 @@ ui64 TIndexTabletState::GetReadCommitId(const TString& checkpointId) const
 }
 
 TCheckpoint* TIndexTabletState::CreateCheckpoint(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TString& checkpointId,
     ui64 nodeId,
     ui64 commitId)
@@ -59,7 +59,7 @@ TCheckpoint* TIndexTabletState::CreateCheckpoint(
 }
 
 void TIndexTabletState::MarkCheckpointDeleted(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TCheckpoint* checkpoint)
 {
     Impl->Checkpoints.MarkCheckpointDeleted(checkpoint);
@@ -68,7 +68,7 @@ void TIndexTabletState::MarkCheckpointDeleted(
 }
 
 void TIndexTabletState::RemoveCheckpointNodes(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TCheckpoint* checkpoint,
     const TVector<ui64>& nodes)
 {
@@ -81,7 +81,7 @@ void TIndexTabletState::RemoveCheckpointNodes(
 }
 
 void TIndexTabletState::RemoveCheckpointBlob(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TCheckpoint* checkpoint,
     ui32 rangeId,
     const TPartialBlobId& blobId)
@@ -91,7 +91,7 @@ void TIndexTabletState::RemoveCheckpointBlob(
 }
 
 void TIndexTabletState::RemoveCheckpoint(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TCheckpoint* checkpoint)
 {
     db.DeleteCheckpoint(checkpoint->GetCheckpointId());
@@ -100,7 +100,7 @@ void TIndexTabletState::RemoveCheckpoint(
 }
 
 void TIndexTabletState::AddCheckpointNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 checkpointId,
     ui64 nodeId)
 {
@@ -109,7 +109,7 @@ void TIndexTabletState::AddCheckpointNode(
 }
 
 void TIndexTabletState::AddCheckpointBlob(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 checkpointId,
     ui32 rangeId,
     const TPartialBlobId& blobId)

--- a/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_data.cpp
@@ -63,7 +63,7 @@ bool TIndexTabletState::GenerateBlobId(
 }
 
 NProto::TError TIndexTabletState::Truncate(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     ui64 currentSize,
@@ -84,7 +84,7 @@ NProto::TError TIndexTabletState::Truncate(
 }
 
 NProto::TError TIndexTabletState::TruncateRange(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     TByteRange range)
@@ -119,7 +119,7 @@ NProto::TError TIndexTabletState::TruncateRange(
 }
 
 NProto::TError TIndexTabletState::ZeroRange(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     TByteRange range)
@@ -161,7 +161,7 @@ NProto::TError TIndexTabletState::ZeroRange(
 }
 
 NProto::TError TIndexTabletState::DeleteRange(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     const TByteRange& range)
@@ -251,13 +251,13 @@ void TIndexTabletState::CompleteTruncateOp(ui64 nodeId)
     Impl->TruncateQueue.CompleteOperation(nodeId);
 }
 
-void TIndexTabletState::AddTruncate(TIndexTabletDatabase& db, ui64 nodeId, TByteRange range)
+void TIndexTabletState::AddTruncate(IIndexTabletDatabase& db, ui64 nodeId, TByteRange range)
 {
     EnqueueTruncateOp(nodeId, range);
     db.WriteTruncateQueueEntry(nodeId, range);
 }
 
-void TIndexTabletState::DeleteTruncate(TIndexTabletDatabase& db, ui64 nodeId)
+void TIndexTabletState::DeleteTruncate(IIndexTabletDatabase& db, ui64 nodeId)
 {
     db.DeleteTruncateQueueEntry(nodeId);
 }
@@ -354,7 +354,7 @@ void TIndexTabletState::FindFreshBytes(
 // UnconfirmedData
 
 void TIndexTabletState::ConfirmedDataAdded(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 commitId)
 {
     if (commitId == InvalidCommitId) {
@@ -454,7 +454,7 @@ NProto::TError TIndexTabletState::CheckFreshBytes(
 }
 
 void TIndexTabletState::WriteFreshBytes(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     ui64 offset,
@@ -479,7 +479,7 @@ void TIndexTabletState::WriteFreshBytes(
 }
 
 void TIndexTabletState::WriteFreshBytesDeletionMarker(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     ui64 offset,
@@ -513,7 +513,7 @@ TFlushBytesCleanupInfo TIndexTabletState::StartFlushBytes(
 }
 
 TFlushBytesStats TIndexTabletState::FinishFlushBytes(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 itemLimit,
     ui64 chunkId,
     NProto::TProfileLogRequestInfo& profileLogRequest)
@@ -607,7 +607,7 @@ TMaybe<TFreshBlock> TIndexTabletState::FindFreshBlock(
 }
 
 void TIndexTabletState::WriteFreshBlock(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     ui32 blockIndex,
@@ -629,7 +629,7 @@ void TIndexTabletState::WriteFreshBlock(
 }
 
 void TIndexTabletState::MarkFreshBlocksDeleted(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     ui32 blockIndex,
@@ -653,7 +653,7 @@ void TIndexTabletState::MarkFreshBlocksDeleted(
 }
 
 void TIndexTabletState::DeleteFreshBlocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TVector<TBlock>& blocks)
 {
     for (const auto& block: blocks) {
@@ -743,7 +743,7 @@ void TIndexTabletState::FindMixedBlocks(
 }
 
 void TIndexTabletState::WriteMixedBlocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TPartialBlobId& blobId,
     const TBlock& block,
     ui32 blocksCount)
@@ -773,7 +773,7 @@ void TIndexTabletState::WriteMixedBlocks(
 }
 
 TWriteMixedBlocksResult TIndexTabletState::WriteMixedBlocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TPartialBlobId& blobId,
     /*const*/ TVector<TBlock>& blocks)
 {
@@ -787,7 +787,7 @@ TWriteMixedBlocksResult TIndexTabletState::WriteMixedBlocks(
 }
 
 TWriteMixedBlocksResult TIndexTabletState::WriteMixedBlocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui32 rangeId,
     const TPartialBlobId& blobId,
     /*const*/ TVector<TBlock>& blocks)
@@ -852,7 +852,7 @@ TWriteMixedBlocksResult TIndexTabletState::WriteMixedBlocks(
 }
 
 void TIndexTabletState::DeleteMixedBlocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TPartialBlobId& blobId,
     const TVector<TBlock>& blocks)
 {
@@ -864,7 +864,7 @@ void TIndexTabletState::DeleteMixedBlocks(
 }
 
 TDeleteMixedBlocksResult TIndexTabletState::DeleteMixedBlocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui32 rangeId,
     const TPartialBlobId& blobId,
     const TVector<TBlock>& blocks)
@@ -924,7 +924,7 @@ TMixedBlobMeta TIndexTabletState::FindBlob(ui32 rangeId, TPartialBlobId blobId) 
 }
 
 void TIndexTabletState::MarkMixedBlocksDeleted(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     ui32 blockIndex,
@@ -965,7 +965,7 @@ void TIndexTabletState::MarkMixedBlocksDeleted(
 }
 
 bool TIndexTabletState::UpdateBlockLists(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TMixedBlobMeta& blob)
 {
     const auto rangeId = GetMixedRangeIndex(blob.Blocks);
@@ -974,7 +974,7 @@ bool TIndexTabletState::UpdateBlockLists(
 }
 
 ui32 TIndexTabletState::CleanupBlockDeletions(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui32 rangeId,
     NProto::TProfileLogRequestInfo& profileLogRequest)
 {
@@ -1102,7 +1102,7 @@ ui32 TIndexTabletState::CleanupBlockDeletions(
 }
 
 void TIndexTabletState::RewriteMixedBlocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui32 rangeId,
     /*const*/ TMixedBlobMeta& blob,
     const TMixedBlobStats& stats)
@@ -1275,7 +1275,7 @@ ui64 TIndexTabletState::GetCollectCommitId() const
 }
 
 void TIndexTabletState::AddNewBlob(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TPartialBlobId& blobId)
 {
     bool added = Impl->GarbageQueue.AddNewBlob(blobId);
@@ -1286,7 +1286,7 @@ void TIndexTabletState::AddNewBlob(
 }
 
 void TIndexTabletState::AddGarbageBlob(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TPartialBlobId& blobId)
 {
     bool added = Impl->GarbageQueue.AddGarbageBlob(blobId);
@@ -1307,7 +1307,7 @@ TVector<TPartialBlobId> TIndexTabletState::GetGarbageBlobs(ui64 collectCommitId)
 }
 
 void TIndexTabletState::DeleteGarbage(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 collectCommitId,
     const TVector<TPartialBlobId>& newBlobs,
     const TVector<TPartialBlobId>& garbageBlobs)

--- a/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_nodes.cpp
@@ -25,7 +25,7 @@ ui64 SizeDiff(const TString& v1, const TString& v2)
 // Nodes
 
 void TIndexTabletState::UpdateUsedBlocksCount(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 currentSize,
     ui64 prevSize)
 {
@@ -38,7 +38,7 @@ void TIndexTabletState::UpdateUsedBlocksCount(
 }
 
 void TIndexTabletState::CreateNodeWithId(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     const NProto::TNode& attrs)
@@ -51,7 +51,7 @@ void TIndexTabletState::CreateNodeWithId(
 }
 
 ui64 TIndexTabletState::CreateNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 commitId,
     const NProto::TNode& attrs)
 {
@@ -64,7 +64,7 @@ ui64 TIndexTabletState::CreateNode(
 }
 
 void TIndexTabletState::UpdateNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -87,7 +87,7 @@ void TIndexTabletState::UpdateNode(
 }
 
 NProto::TError TIndexTabletState::RemoveNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const INodeIndexTabletDatabase::TNode& node,
     ui64 minCommitId,
     ui64 maxCommitId)
@@ -123,7 +123,7 @@ NProto::TError TIndexTabletState::RemoveNode(
 }
 
 NProto::TError TIndexTabletState::UnlinkNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 parentNodeId,
     const TString& name,
     const INodeIndexTabletDatabase::TNode& node,
@@ -171,7 +171,7 @@ NProto::TError TIndexTabletState::UnlinkNode(
 }
 
 void TIndexTabletState::UnlinkExternalNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 parentNodeId,
     const TString& name,
     const TString& shardId,
@@ -215,7 +215,7 @@ bool TIndexTabletState::ReadNode(
 }
 
 void TIndexTabletState::RewriteNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -234,7 +234,7 @@ void TIndexTabletState::RewriteNode(
 }
 
 void TIndexTabletState::WriteOrphanNode(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TString& message,
     ui64 nodeId)
 {
@@ -263,7 +263,7 @@ void TIndexTabletState::EndNodeCreateInShard(const TString& nodeName)
 // NodeAttrs
 
 ui64 TIndexTabletState::CreateNodeAttr(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -278,7 +278,7 @@ ui64 TIndexTabletState::CreateNodeAttr(
 }
 
 ui64 TIndexTabletState::UpdateNodeAttr(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -313,7 +313,7 @@ ui64 TIndexTabletState::UpdateNodeAttr(
 }
 
 void TIndexTabletState::RemoveNodeAttr(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -383,7 +383,7 @@ bool TIndexTabletState::ReadNodeAttrs(
 }
 
 void TIndexTabletState::RewriteNodeAttr(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -411,7 +411,7 @@ void TIndexTabletState::RewriteNodeAttr(
 // HasXAttrs
 
 void TIndexTabletState::WriteHasXAttrs(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TIndexTabletState::EHasXAttrs hasXAttrs)
 {
     SetHasXAttrs(db, static_cast<ui64>(hasXAttrs));
@@ -459,7 +459,7 @@ inline bool TryToDecodeShardId(
 // NodeRefs
 
 void TIndexTabletState::CreateNodeRef(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 commitId,
     const TString& childName,
@@ -486,7 +486,7 @@ void TIndexTabletState::CreateNodeRef(
 }
 
 void TIndexTabletState::RemoveNodeRef(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -617,7 +617,7 @@ bool TIndexTabletState::PrechargeNodeRefs(
 }
 
 void TIndexTabletState::RewriteNodeRef(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,

--- a/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_sessions.cpp
@@ -124,7 +124,7 @@ void TIndexTabletState::LoadSessions(
 }
 
 TSession* TIndexTabletState::CreateSession(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TString& clientId,
     const TString& sessionId,
     const TString& checkpointId,
@@ -379,7 +379,7 @@ void TIndexTabletState::OrphanSession(const TActorId& owner, TInstant deadline)
 }
 
 void TIndexTabletState::ResetSession(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TSession* session,
     const TMaybe<TString>& state)
 {
@@ -419,7 +419,7 @@ void TIndexTabletState::ResetSession(
 }
 
 void TIndexTabletState::RemoveSession(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TString& sessionId)
 {
     auto* session = FindSession(sessionId);
@@ -520,7 +520,7 @@ const TSessionHistoryList& TIndexTabletState::GetSessionHistoryList() const
 }
 
 void TIndexTabletState::AddSessionHistoryEntry(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TSessionHistoryEntry& entry,
     size_t maxEntryCount)
 {
@@ -767,7 +767,7 @@ void TIndexTabletState::ChangeNodeCounters(
 }
 
 TSessionHandle* TIndexTabletState::CreateHandle(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TSession* session,
     ui64 nodeId,
     ui64 commitId,
@@ -793,7 +793,7 @@ TSessionHandle* TIndexTabletState::CreateHandle(
 // method for testing purposes, such as verifying the response to handles with
 // an incorrect shard number.
 TSessionHandle* TIndexTabletState::UnsafeCreateHandle(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TSession* session,
     ui64 handleId,
     ui64 nodeId,
@@ -814,7 +814,7 @@ TSessionHandle* TIndexTabletState::UnsafeCreateHandle(
 }
 
 void TIndexTabletState::DestroyHandle(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TSessionHandle* handle)
 {
     db.DeleteSessionHandle(
@@ -893,7 +893,7 @@ void TIndexTabletState::RemoveLock(TSessionLock* lock)
 }
 
 TRangeLockOperationResult TIndexTabletState::AcquireLock(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TSession* session,
     ui64 handle,
     const TLockRange& range)
@@ -934,7 +934,7 @@ TRangeLockOperationResult TIndexTabletState::AcquireLock(
 }
 
 TRangeLockOperationResult TIndexTabletState::ReleaseLock(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     TSession* session,
     const TLockRange& range)
 {
@@ -988,7 +988,7 @@ TRangeLockOperationResult TIndexTabletState::TestLock(
 }
 
 void TIndexTabletState::ReleaseLocks(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     ui64 handle)
 {
     TSmallVec<TSessionLock*> locks;
@@ -1005,7 +1005,7 @@ void TIndexTabletState::ReleaseLocks(
 
 #define FILESTORE_IMPLEMENT_DUPCACHE(name, ...)                                \
 void TIndexTabletState::AddDupCacheEntry(                                      \
-    TIndexTabletDatabase& db,                                                  \
+    IIndexTabletDatabase& db,                                                  \
     TSession* session,                                                         \
     ui64 requestId,                                                            \
     const NProto::T##name##Response& response,                                 \
@@ -1053,7 +1053,7 @@ FILESTORE_DUPCACHE_REQUESTS(FILESTORE_IMPLEMENT_DUPCACHE)
 #undef FILESTORE_IMPLEMENT_DUPCACHE
 
 void TIndexTabletState::PatchDupCacheEntry(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TString& sessionId,
     ui64 requestId,
     NProto::TCreateNodeResponse response)
@@ -1078,7 +1078,7 @@ void TIndexTabletState::PatchDupCacheEntry(
 }
 
 void TIndexTabletState::PatchDupCacheEntry(
-    TIndexTabletDatabase& db,
+    IIndexTabletDatabase& db,
     const TString& sessionId,
     ui64 requestId,
     NProto::TRenameNodeResponse response)


### PR DESCRIPTION
### Notes
This is a preliminary step required for fixes requested on review of the https://github.com/ydb-platform/nbs/pull/6423. Idea is to later provide another implementation of that interface that would randomly fail read operations.

This PR is part **3** of the following chain:

- Rename IIndexTabletDatabase to INodeIndexTabletDatabase
- Introduce a new IIndexTabletDatabase containing every public method from TIndexTabletDatabase and makes TIndexTabletDatabase implement that interface.  
- Create TIndexTabletDatabase in tablet_actor_* via factory functions instead of creating the objects on stack. **<<< **We are here****

### Issue
https://github.com/ydb-platform/nbs/issues/6467
