### PR TITLE
Stream recipe error log scanning by chunks

### DIFF
--- a/cloud/storage/core/tests/common/__init__.py
+++ b/cloud/storage/core/tests/common/__init__.py
@@ -39,8 +39,9 @@ def find_sanitizer_error(file_path: str):
             buffer = tail + chunk
             match = re.search(common.SANITIZER_ERROR_PATTERN, buffer)
             if match:
-                context = buffer[match.start():]
-                context += f.read(common.process.MAX_OUT_LEN)
+                context_start = match.start()
+                context = buffer[context_start:context_start + common.process.MAX_OUT_LEN]
+                context += f.read(common.process.MAX_OUT_LEN - len(context))
                 return match, context
 
             tail = buffer[-SANITIZER_SCAN_TAIL_SIZE:]

--- a/cloud/storage/core/tests/common/__init__.py
+++ b/cloud/storage/core/tests/common/__init__.py
@@ -39,7 +39,7 @@ def find_sanitizer_error(file_path: str):
             buffer = tail + chunk
             match = re.search(common.SANITIZER_ERROR_PATTERN, buffer)
             if match:
-                context_start = match.start()
+                context_start = match.end()
                 context = buffer[context_start:context_start + common.process.MAX_OUT_LEN]
                 context += f.read(common.process.MAX_OUT_LEN - len(context))
                 return match, context
@@ -72,10 +72,6 @@ def process_recipe_err_files(common_file_name: str) -> list[str]:
         if not match:
             yatest_logger.debug("No sanitizer errors found in %s", file_path)
             continue
-
-        sanitizer_pos = ctx.find(b"Sanitizer")
-        if sanitizer_pos != -1:
-            ctx = ctx[sanitizer_pos + len(b"Sanitizer"):]
 
         truncated_std_err = common.process.truncate(
             ctx.decode("utf-8", errors="backslashreplace"),

--- a/cloud/storage/core/tests/common/__init__.py
+++ b/cloud/storage/core/tests/common/__init__.py
@@ -6,6 +6,9 @@ import yatest.common as common
 
 yatest_logger = logging.getLogger("ya.test")
 
+SANITIZER_SCAN_CHUNK_SIZE = 1024 * 1024
+SANITIZER_SCAN_TAIL_SIZE = 4096
+
 
 def append_recipe_err_files(common_file_name: str, err_file_path: str) -> None:
     """
@@ -18,6 +21,29 @@ def append_recipe_err_files(common_file_name: str, err_file_path: str) -> None:
     with open(common_file_name, "a") as f:
         f.write(err_file_path + "\n")
         yatest_logger.debug("Appended: %s", err_file_path)
+
+
+def find_sanitizer_error(file_path: str):
+    """
+    Search for a sanitizer error in the given file.
+
+    Reads the file in chunks to avoid loading large recipe logs into memory.
+    """
+    tail = b""
+    with open(file_path, "rb") as f:
+        while True:
+            chunk = f.read(SANITIZER_SCAN_CHUNK_SIZE)
+            if not chunk:
+                return None, b""
+
+            buffer = tail + chunk
+            match = re.search(common.SANITIZER_ERROR_PATTERN, buffer)
+            if match:
+                context = buffer[match.start():]
+                context += f.read(common.process.MAX_OUT_LEN)
+                return match, context
+
+            tail = buffer[-SANITIZER_SCAN_TAIL_SIZE:]
 
 
 def process_recipe_err_files(common_file_name: str) -> list[str]:
@@ -41,16 +67,18 @@ def process_recipe_err_files(common_file_name: str) -> list[str]:
             continue
         file_path = file_path.strip()
 
-        with open(file_path, "rb") as f:
-            std_err = f.read()
-
-        match = re.search(common.SANITIZER_ERROR_PATTERN, std_err)
+        match, ctx = find_sanitizer_error(file_path)
         if not match:
             yatest_logger.debug("No sanitizer errors found in %s", file_path)
             continue
 
+        sanitizer_pos = ctx.find(b"Sanitizer")
+        if sanitizer_pos != -1:
+            ctx = ctx[sanitizer_pos + len(b"Sanitizer"):]
+
         truncated_std_err = common.process.truncate(
-            str(std_err).split("Sanitizer")[1], common.process.MAX_OUT_LEN
+            ctx.decode("utf-8", errors="backslashreplace"),
+            common.process.MAX_OUT_LEN,
         )
         sanitizer_name = str(match.group(1)).strip()
         yatest_logger.error(


### PR DESCRIPTION
### Notes
Process recipe error logs with a streaming sanitizer scan instead of reading the whole `.err` file into memory.

This avoids OOM during recipe teardown when verbose service logs are large. The sanitizer error report still includes a bounded context around the first match and keeps a final output-size limit.

affected tests with large size of logs

```
cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test
cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test
```

Original size log files 7.2G:
```
2026-07-15 19:46:46,676 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: ============================= POSTPROCESS_OUTPUTS ==============================
2026-07-15 19:46:46,676 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Removing symlinks: $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff
2026-07-15 19:46:46,677 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Postprocessing $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff (output_limit:104857600)
2026-07-15 19:46:46,677 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Going to process 73 files with total output size: 7686240407b (7.2G)
2026-07-15 19:46:46,677 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Postprocess: $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff/vhost-profile.log is truncated up to 371491 bytes (original size is 27798190 bytes)
2026-07-15 19:46:46,681 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Postprocess: $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff/nfs-profile.log is truncated up to 520972 bytes (original size is 38983614 bytes)
2026-07-15 19:46:46,684 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Postprocess: $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff/filestore-server.err is truncated up to 29569872 bytes (original size is 2212671416 bytes)
2026-07-15 19:46:46,820 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Postprocess: $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff/filestore-vhost.err is truncated up to 72226668 bytes (original size is 5404618592 bytes)
2026-07-15 19:46:47,020 DEBUG devtools.ya.test.programs.test_tool.run_test.run_test: Postprocessing finished
```

### Issue

```
2026-07-15 19:46:14,532 - INFO - cloud.filestore.tests.python.lib.common - shutdown: shutting down process with pid 709692
2026-07-15 19:46:15,532 - DEBUG - ya.test - process_recipe_err_files: Processing recipe error files: ['$(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff/filestore-vhost.err']

	std_err:Traceback (most recent call last):
  File "contrib/tools/python3/Lib/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
                     "__main__", mod_spec)
  File "contrib/tools/python3/Lib/runpy.py", line 88, in _run_code
    exec(code, run_globals)
    ~~~~^^^^^^^^^^^^^^^^^^^
  File "cloud/filestore/tests/recipes/vhost/__main__.py", line 216, in <module>
    declare_recipe(start, stop)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "library/python/testing/recipe/__init__.py", line 110, in declare_recipe
    stop(argv[1:])
    ~~~~^^^^^^^^^^
  File "cloud/filestore/tests/recipes/vhost/__main__.py", line 210, in stop
    errors = process_recipe_err_files(ERR_LOG_FILE_NAMES_FILE)
  File "cloud/storage/core/tests/common/__init__.py", line 45, in process_recipe_err_files
    std_err = f.read()
OSError: [Errno 12] Cannot allocate memory


2026-07-15 19:46:32,951 ERROR devtools.ya.test.programs.test_tool.run_test.run_test: Recipe vhost-recipe-2 tear down exception: Command '$(BUILD_ROOT)/cloud/filestore/tests/recipes/vhost/vhost-recipe --build-root $(BUILD_ROOT) --source-root $(SOURCE_ROOT) --gdb-path $(TOOL_ROOT)/10774583136/gdb/bin/gdb --env-file $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/env.json.txt ssh -n -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o IdentitiesOnly=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=10 -i $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/id_rsa -l qemu -p 35653 -o LogLevel=VERBOSE 127.0.0.1 sudo /run_test.sh $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/fio_index-qemu-kikimr-multishard-test --basetemp $(BUILD_ROOT)/tmp --capture no -c pkg:library.python.pytest:pytest.yatest.ini -p no:factor --doctest-modules --ya-trace $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/ytest.report.trace --build-root $(BUILD_ROOT) --source-root $(SOURCE_ROOT) --output-dir $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff --durations 0 --project-path cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test --test-tool-bin $(TOOL_ROOT)/11121623955/test_tool --ya-version 2 --build-type release --tb short --modulo 7 --modulo-index 4 --partition-mode SEQUENTIAL --split-by-tests --dep-root cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test --flags ADD_PEERDIRS_GEN_TESTS=yes --flags AUTOCHECK=yes --flags DEBUGINFO_LINES_ONLY=yes --flags HARDENING=yes --flags NO_DEBUGINFO=yes --flags PIC=yes --flags TRAVERSE_RECURSE_FOR_TESTS=yes stop --service kikimr --restart-interval $VHOST_RESTART_INTERVAL --restart-flag $VHOST_RESTART_FLAG --storage-config-patch cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt --verbose' has failed with code 255.
Errors:
Traceback (most recent call last):
  File "contrib/tools/python3/Lib/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
                     "__main__", mod_spec)
  File "contrib/tools/python3/Lib/runpy.py", line 88, in _run_code
    exec(code, run_globals)
    ~~~~^^^^^^^^^^^^^^^^^^^
  File "cloud/filestore/tests/recipes/vhost/__main__.py", line 216, in <module>
    declare_recipe(start, stop)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "library/python/testing/recipe/__init__.py", line 110, in declare_recipe
    stop(argv[1:])
    ~~~~^^^^^^^^^^
  File "cloud/filestore/tests/recipes/vhost/__main__.py", line 210, in stop
    errors = process_recipe_err_files(ERR_LOG_FILE_NAMES_FILE)
  File "cloud/storage/core/tests/common/__init__.py", line 45, in process_recipe_err_files
    std_err = f.read()
OSError: [Errno 12] Cannot allocate memory

Traceback (most recent call last):
  File "devtools/ya/test/programs/test_tool/run_test/run_test.py", line 1831, in main
    res.wait(timeout=chunk_time_left)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "library/python/testing/yatest_common/yatest/common/process.py", line 411, in wait
    self._finalise(check_exit_code)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "library/python/testing/yatest_common/yatest/common/process.py", line 422, in _finalise
    raise ExecutionError(self)
yatest.common.process.ExecutionError: Command '$(BUILD_ROOT)/cloud/filestore/tests/recipes/vhost/vhost-recipe --build-root $(BUILD_ROOT) --source-root $(SOURCE_ROOT) --gdb-path $(TOOL_ROOT)/10774583136/gdb/bin/gdb --env-file $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/env.json.txt ssh -n -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o IdentitiesOnly=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=10 -i $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/id_rsa -l qemu -p 35653 -o LogLevel=VERBOSE 127.0.0.1 sudo /run_test.sh $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/fio_index-qemu-kikimr-multishard-test --basetemp $(BUILD_ROOT)/tmp --capture no -c pkg:library.python.pytest:pytest.yatest.ini -p no:factor --doctest-modules --ya-trace $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/ytest.report.trace --build-root $(BUILD_ROOT) --source-root $(SOURCE_ROOT) --output-dir $(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff --durations 0 --project-path cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test --test-tool-bin $(TOOL_ROOT)/11121623955/test_tool --ya-version 2 --build-type release --tb short --modulo 7 --modulo-index 4 --partition-mode SEQUENTIAL --split-by-tests --dep-root cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test --flags ADD_PEERDIRS_GEN_TESTS=yes --flags AUTOCHECK=yes --flags DEBUGINFO_LINES_ONLY=yes --flags HARDENING=yes --flags NO_DEBUGINFO=yes --flags PIC=yes --flags TRAVERSE_RECURSE_FOR_TESTS=yes stop --service kikimr --restart-interval $VHOST_RESTART_INTERVAL --restart-flag $VHOST_RESTART_FLAG --storage-config-patch cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt --verbose' has failed with code 255.
Errors:
Traceback (most recent call last):
  File "contrib/tools/python3/Lib/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
                     "__main__", mod_spec)
  File "contrib/tools/python3/Lib/runpy.py", line 88, in _run_code
    exec(code, run_globals)
    ~~~~^^^^^^^^^^^^^^^^^^^
  File "cloud/filestore/tests/recipes/vhost/__main__.py", line 216, in <module>
    declare_recipe(start, stop)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "library/python/testing/recipe/__init__.py", line 110, in declare_recipe
    stop(argv[1:])
    ~~~~^^^^^^^^^^
  File "cloud/filestore/tests/recipes/vhost/__main__.py", line 210, in stop
    errors = process_recipe_err_files(ERR_LOG_FILE_NAMES_FILE)
  File "cloud/storage/core/tests/common/__init__.py", line 45, in process_recipe_err_files
    std_err = f.read()
OSError: [Errno 12] Cannot allocate memory


2026-07-15 19:46:32,955 DEBUG ya.test: Executing '['$(BUILD_ROOT)/cloud/filestore/tests/recipes/service-kikimr/service-kikimr-recipe', '--build-root', '$(BUILD_ROOT)', '--source-root', '$(SOURCE_ROOT)', '--gdb-path', '$(TOOL_ROOT)/10774583136/gdb/bin/gdb', '--env-file', '$(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/env.json.txt', 'ssh', '-n', '-F', '/dev/null', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'ConnectTimeout=10', '-o', 'IdentitiesOnly=yes', '-o', 'ServerAliveInterval=10', '-o', 'ServerAliveCountMax=10', '-i', '$(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/id_rsa', '-l', 'qemu', '-p', '35653', '-o', 'LogLevel=VERBOSE', '127.0.0.1', 'sudo', '/run_test.sh', '$(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/fio_index-qemu-kikimr-multishard-test', '--basetemp', '$(BUILD_ROOT)/tmp', '--capture', 'no', '-c', 'pkg:library.python.pytest:pytest.yatest.ini', '-p', 'no:factor', '--doctest-modules', '--ya-trace', '$(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/ytest.report.trace', '--build-root', '$(BUILD_ROOT)', '--source-root', '$(SOURCE_ROOT)', '--output-dir', '$(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4/testing_out_stuff', '--durations', '0', '--project-path', 'cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test', '--test-tool-bin', '$(TOOL_ROOT)/11121623955/test_tool', '--ya-version', '2', '--build-type', 'release', '--tb', 'short', '--modulo', '7', '--modulo-index', '4', '--partition-mode', 'SEQUENTIAL', '--split-by-tests', '--dep-root', 'cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test', '--flags', 'ADD_PEERDIRS_GEN_TESTS=yes', '--flags', 'AUTOCHECK=yes', '--flags', 'DEBUGINFO_LINES_ONLY=yes', '--flags', 'HARDENING=yes', '--flags', 'NO_DEBUGINFO=yes', '--flags', 'PIC=yes', '--flags', 'TRAVERSE_RECURSE_FOR_TESTS=yes', 'stop', '--use-log-files', '--in-memory-pdisks', '--restart-interval', '$NFS_RESTART_INTERVAL', '--storage-config-patch', 'cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt', '--verbose']' in '$(BUILD_ROOT)/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/test-results/py3test/default-linux-x86_64-release-ADD_PEERDIRS_GEN_TESTS=yes-AUTOCHECK=yes-DEBUGINFO_LINES_ONLY=yes-HARDENING=yes-PIC=yes-TRAVERSE_RECURSE_FOR_TESTS=yes/chunk4' (no wait)
2026-07-15 19:46:32,957 DEBUG ya.test: Command pid: 948668
2026-07-15 19:46:46,673 DEBUG ya.test: Process resource usage is not available as process finished before wait4 was called
```