### PR TITLE
fix: extract instance id and disk id from packer build and use them for cleanup in case of cancellation

### DIFF
--- a/.github/actions/nebius_remove_by_ids/action.yaml
+++ b/.github/actions/nebius_remove_by_ids/action.yaml
@@ -1,0 +1,43 @@
+name: Delete Nebius resources by IDs
+description: Delete a Nebius VM instance and disk by their resource IDs
+inputs:
+  instance_id:
+    required: false
+    default: ""
+    description: "Nebius VM instance ID"
+  disk_id:
+    required: false
+    default: ""
+    description: "Nebius disk ID"
+  service_account_key:
+    required: false
+    description: "Deprecated legacy Nebius service-account JSON credentials"
+  nebius_config_yaml:
+    required: false
+    description: "Nebius CLI config.yaml content for SDK authentication"
+
+runs:
+  using: composite
+  steps:
+    - name: set up nebius cli
+      id: nebius-cli
+      uses: ./.github/actions/nebius_cli
+      with:
+        config_yaml: ${{ inputs.nebius_config_yaml }}
+        service_account_key: ${{ inputs.service_account_key }}
+    - name: install dependencies
+      shell: bash
+      run: pip install -r .github/scripts/requirements.txt
+    - name: remove resources by IDs
+      if: ${{ inputs.instance_id != '' || inputs.disk_id != '' }}
+      shell: bash
+      env:
+        NEBIUS_IAM_TOKEN: ${{ steps.nebius-cli.outputs.NEBIUS_IAM_TOKEN }}
+        INSTANCE_ID: ${{ inputs.instance_id }}
+        DISK_ID: ${{ inputs.disk_id }}
+      run: |
+        export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE/.github
+        python3 -m scripts.nebius_manage_vm remove-by-ids \
+            --instance-id "${INSTANCE_ID}" \
+            --disk-id "${DISK_ID}" \
+            --apply

--- a/.github/scripts/nebius_manage_vm.py
+++ b/.github/scripts/nebius_manage_vm.py
@@ -795,10 +795,24 @@ async def remove_vm_and_disk_by_ids(
         raise ValueError(f"Invalid disk ID: {disk_id}")
 
     if not instance_id and not disk_id:
-        logger.info("No instance or disk IDs were provided")
+        logger.info("No instance or disk IDs were provided; nothing to remove")
         return
 
+    if instance_id and disk_id:
+        logger.info(
+            "Cleanup plan: remove instance %s, then remove disk %s",
+            instance_id,
+            disk_id,
+        )
+    elif instance_id:
+        logger.info(
+            "Cleanup plan: remove instance %s; no disk was provided", instance_id
+        )
+    else:
+        logger.info("Cleanup plan: remove disk %s; no instance was created", disk_id)
+
     if instance_id:
+        logger.info("Removing instance with ID %s", instance_id)
         try:
             await remove_vm_by_id(sdk, instance_id)
         except RequestError as error:
@@ -808,9 +822,24 @@ async def remove_vm_and_disk_by_ids(
                     instance_id,
                 )
             else:
+                logger.error(
+                    "Failed to remove instance with ID %s; cleanup stopped",
+                    instance_id,
+                )
                 raise
+        except Exception:
+            logger.error(
+                "Failed to remove instance with ID %s; cleanup stopped",
+                instance_id,
+            )
+            raise
+        else:
+            logger.info("Successfully removed instance with ID %s", instance_id)
+    else:
+        logger.info("No instance ID provided; proceeding with disk-only cleanup")
 
     if disk_id:
+        logger.info("Removing disk with ID %s", disk_id)
         try:
             await remove_disk_by_id(sdk, disk_id)
         except RequestError as error:
@@ -820,7 +849,17 @@ async def remove_vm_and_disk_by_ids(
                     disk_id,
                 )
             else:
+                logger.error("Failed to remove disk with ID %s", disk_id)
                 raise
+        except Exception:
+            logger.error("Failed to remove disk with ID %s", disk_id)
+            raise
+        else:
+            logger.info("Successfully removed disk with ID %s", disk_id)
+    else:
+        logger.info("No disk ID provided; skipping disk removal")
+
+    logger.info("VM and disk cleanup completed successfully")
 
 
 def labels_match(

--- a/.github/scripts/nebius_manage_vm.py
+++ b/.github/scripts/nebius_manage_vm.py
@@ -332,7 +332,7 @@ async def create_disk(sdk: SDK, args: argparse.Namespace) -> str:
         logger.error("Response: %s", str(e.status), exc_info=True)
         if request is not None:
             logger.error("Removing created disk with ID %s", request.resource_id)
-            await remove_disk_by_id(sdk, args, request.resource_id)
+            await remove_disk_by_id(sdk, request.resource_id)
         raise
 
     logger.info(
@@ -559,7 +559,7 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
         await request.wait()
     except TypeError as e:
         logger.error("Failed to create VM, removing created disk", exc_info=True)
-        await remove_disk_by_id(sdk, args, disk_id)
+        await remove_disk_by_id(sdk, disk_id)
         raise e
 
     except RequestError as e:
@@ -568,9 +568,9 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
         if request is not None:
             logger.error("Removing created instance with ID %s", request.resource_id)
             await remove_vm_by_id(sdk, request.resource_id)
-            await remove_disk_by_id(sdk, args, disk_id)
+            await remove_disk_by_id(sdk, disk_id)
         else:
-            await remove_disk_by_id(sdk, args, disk_id)
+            await remove_disk_by_id(sdk, disk_id)
         raise e
 
     instance_id = request.resource_id
@@ -578,7 +578,7 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
     if request.status().code != grpc.StatusCode.OK:
         logger.error("Failed to create VM with request: %s", instance_request)
         await remove_vm_by_id(sdk, instance_id)
-        await remove_disk_by_id(sdk, args, disk_id)
+        await remove_disk_by_id(sdk, disk_id)
         raise RequestError("Failed to create VM")
 
     instance = await service.get(GetInstanceRequest(id=instance_id))
@@ -617,7 +617,7 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
                 exc_info=True,
             )
             await remove_vm_by_id(sdk, instance_id)
-            await remove_disk_by_id(sdk, args, disk_id)
+            await remove_disk_by_id(sdk, disk_id)
             raise
 
         if runner_id is not None:
@@ -625,7 +625,7 @@ async def create_vm(sdk: SDK, args: argparse.Namespace, attempt: int = 0):
         else:
             logger.error("Failed to register VM as Github Runner")
             await remove_vm_by_id(sdk, instance_id)
-            await remove_disk_by_id(sdk, args, disk_id)
+            await remove_disk_by_id(sdk, disk_id)
             raise ValueError("Failed to register VM as Github Runner")
     else:
         logger.error("Failed to create VM with request: %s", instance_request)
@@ -722,7 +722,7 @@ async def remove_disk_by_name(sdk: SDK, args: argparse.Namespace, instance_name:
         )
         raise e
 
-    await remove_disk_by_id(sdk, args, disk_id)
+    await remove_disk_by_id(sdk, disk_id)
 
 
 async def find_disk_by_instance_name(
@@ -751,10 +751,7 @@ async def find_disk_by_instance_name(
     return response
 
 
-async def remove_disk_by_id(sdk: SDK, args: argparse.Namespace, disk_id: int = None):
-    if not args.apply:
-        logger.info("Would delete disk with ID %s", disk_id)
-        return
+async def remove_disk_by_id(sdk: SDK, disk_id: str):
     service = DiskServiceClient(sdk)
     request = None
     try:
@@ -768,13 +765,10 @@ async def remove_disk_by_id(sdk: SDK, args: argparse.Namespace, disk_id: int = N
         raise e
 
 
-async def remove_vm_by_id(sdk: SDK, instance_id: int = None) -> str:
-    instance_name = None
+async def remove_vm_by_id(sdk: SDK, instance_id: str = None):
     service = InstanceServiceClient(sdk)
     request = None
     try:
-        instance_name = await service.get(GetInstanceRequest(id=instance_id))
-        instance_name = instance_name.metadata.name
         request = await service.delete(DeleteInstanceRequest(id=instance_id))
         await request.wait()
         logger.info("Deleted VM with ID %s", instance_id)
@@ -785,7 +779,48 @@ async def remove_vm_by_id(sdk: SDK, instance_id: int = None) -> str:
             logger.error("Response: %s", request.status)
         raise e
 
-    return instance_name
+
+def is_not_found_request_error(error: RequestError) -> bool:
+    return error.status.code == grpc.StatusCode.NOT_FOUND
+
+
+async def remove_vm_and_disk_by_ids(
+    sdk: SDK,
+    instance_id: str,
+    disk_id: str,
+):
+    if instance_id and not instance_id.startswith("computeinstance-"):
+        raise ValueError(f"Invalid instance ID: {instance_id}")
+    if disk_id and not disk_id.startswith("computedisk-"):
+        raise ValueError(f"Invalid disk ID: {disk_id}")
+
+    if not instance_id and not disk_id:
+        logger.info("No instance or disk IDs were provided")
+        return
+
+    if instance_id:
+        try:
+            await remove_vm_by_id(sdk, instance_id)
+        except RequestError as error:
+            if is_not_found_request_error(error):
+                logger.info(
+                    "Instance with ID %s has already been deleted",
+                    instance_id,
+                )
+            else:
+                raise
+
+    if disk_id:
+        try:
+            await remove_disk_by_id(sdk, disk_id)
+        except RequestError as error:
+            if is_not_found_request_error(error):
+                logger.info(
+                    "Disk with ID %s has already been deleted",
+                    disk_id,
+                )
+            else:
+                raise
 
 
 def labels_match(
@@ -904,20 +939,24 @@ async def remove_vm(sdk: SDK, args: argparse.Namespace):
     elif result == "removed" or result == "would_remove":
         logger.info("Runner with name %s removed from github", args.id)
 
-    if not args.apply:
-        logger.info("Would delete VM with ID %s", args.id)
-        return
-
-    instance_name = await remove_vm_by_id(sdk, args.id)
-
-    if instance_name is None:
+    instance_service = InstanceServiceClient(sdk)
+    instance = await instance_service.get(GetInstanceRequest(id=args.id))
+    instance_name = instance.metadata.name
+    disk = await find_disk_by_instance_name(sdk, args, instance_name)
+    if disk is None:
         logger.error(
-            "Failed to get instance name for ID %s, therefore we can't find disk",
+            "Failed to find disk for instance ID %s; removing the instance only",
             args.id,
         )
+
+    disk_id = disk.metadata.id if disk is not None else ""
+    if not args.apply:
+        logger.info("Would delete instance with ID %s", args.id)
+        if disk_id:
+            logger.info("Would delete disk with ID %s", disk_id)
         return
 
-    await remove_disk_by_name(sdk, args, instance_name)
+    await remove_vm_and_disk_by_ids(sdk, args.id, disk_id)
 
 
 async def main() -> None:
@@ -1070,15 +1109,32 @@ async def main() -> None:
     )
     remove.add_argument("--apply", action="store_true", help="Apply the changes")
 
-    create.set_defaults(func=create_vm)
-    remove.set_defaults(func=remove_vm)
+    remove_by_ids = subparsers.add_parser(
+        "remove-by-ids",
+        help="Remove a VM instance and disk by their resource IDs",
+    )
+    remove_by_ids.add_argument(
+        "--instance-id", default="", help="Nebius VM instance ID"
+    )
+    remove_by_ids.add_argument("--disk-id", default="", help="Nebius disk ID")
+    remove_by_ids.add_argument("--apply", action="store_true", help="Apply the changes")
 
     args = parser.parse_args()
 
     sdk = SDK(config_reader=Config())
 
-    if hasattr(args, "func"):
-        await args.func(sdk, args)
+    if args.action == "create":
+        await create_vm(sdk, args)
+    elif args.action == "remove":
+        await remove_vm(sdk, args)
+    elif args.action == "remove-by-ids":
+        if not args.apply:
+            if args.instance_id:
+                logger.info("Would delete instance with ID %s", args.instance_id)
+            if args.disk_id:
+                logger.info("Would delete disk with ID %s", args.disk_id)
+        else:
+            await remove_vm_and_disk_by_ids(sdk, args.instance_id, args.disk_id)
     else:
         parser.print_help()
 

--- a/.github/scripts/nebius_manage_vm_test.py
+++ b/.github/scripts/nebius_manage_vm_test.py
@@ -768,7 +768,9 @@ def test_remove_vm_and_disk_by_ids_deletes_instance_before_disk(monkeypatch):
 def test_remove_vm_and_disk_by_ids_removes_disk_when_instance_is_not_found(monkeypatch):
     removed = []
 
-    async def fake_remove_instance(_sdk, _resource_id):
+    async def fake_remove_instance(remove_sdk, resource_id):
+        assert remove_sdk is sdk
+        assert resource_id == "computeinstance-instance-id"
         raise m.RequestError(SimpleNamespace(code=m.grpc.StatusCode.NOT_FOUND))
 
     async def fake_remove_disk(sdk, resource_id):
@@ -790,8 +792,10 @@ def test_remove_vm_and_disk_by_ids_removes_disk_when_instance_is_not_found(monke
 def test_remove_vm_and_disk_by_ids_removes_disk_without_instance(monkeypatch):
     removed = []
 
-    async def fake_remove_instance(_sdk, _resource_id):
-        raise AssertionError("Instance removal should not be called")
+    async def fake_remove_instance(remove_sdk, resource_id):
+        raise AssertionError(
+            f"Instance removal should not be called: {remove_sdk!r}, {resource_id}"
+        )
 
     async def fake_remove_disk(sdk, resource_id):
         removed.append((sdk, resource_id))
@@ -808,11 +812,15 @@ def test_remove_vm_and_disk_by_ids_removes_disk_without_instance(monkeypatch):
 def test_remove_vm_and_disk_by_ids_does_not_remove_disk_when_instance_removal_fails(
     monkeypatch,
 ):
-    async def fake_remove_instance(_sdk, _resource_id):
+    async def fake_remove_instance(remove_sdk, resource_id):
+        assert remove_sdk is not None
+        assert resource_id == "computeinstance-instance-id"
         raise RuntimeError("instance is still present")
 
-    async def fake_remove_disk(_sdk, _resource_id):
-        raise AssertionError("Disk removal should not be called")
+    async def fake_remove_disk(remove_sdk, resource_id):
+        raise AssertionError(
+            f"Disk removal should not be called: {remove_sdk!r}, {resource_id}"
+        )
 
     monkeypatch.setattr(m, "remove_vm_by_id", fake_remove_instance)
     monkeypatch.setattr(m, "remove_disk_by_id", fake_remove_disk)
@@ -1065,6 +1073,7 @@ def test_remove_vm_resolves_disk_id_before_removing_resources(monkeypatch):
 
     async def fake_find_disk(search_sdk, args, instance_name):
         assert search_sdk is sdk
+        assert args.parent_id == "parent-id"
         events.append(("find-disk", instance_name))
         return SimpleNamespace(metadata=SimpleNamespace(id="computedisk-disk-id"))
 
@@ -1078,11 +1087,17 @@ def test_remove_vm_resolves_disk_id_before_removing_resources(monkeypatch):
             )
         )
 
+    def fake_remove_runner_from_github(*args):
+        assert len(args) == 5
+        return "not_found"
+
+    def fake_instance_service_client(service_sdk):
+        assert service_sdk is sdk
+        return FakeInstanceService()
+
     monkeypatch.setattr(m, "github_client_from_env", lambda: object())
-    monkeypatch.setattr(m, "remove_runner_from_github", lambda *args: "not_found")
-    monkeypatch.setattr(
-        m, "InstanceServiceClient", lambda service_sdk: FakeInstanceService()
-    )
+    monkeypatch.setattr(m, "remove_runner_from_github", fake_remove_runner_from_github)
+    monkeypatch.setattr(m, "InstanceServiceClient", fake_instance_service_client)
     monkeypatch.setattr(m, "find_disk_by_instance_name", fake_find_disk)
     monkeypatch.setattr(m, "remove_vm_and_disk_by_ids", fake_remove_resources)
 
@@ -1160,6 +1175,10 @@ def test_main_remove_by_ids_passes_explicit_ids(monkeypatch):
     async def fake_remove_resources(cleanup_sdk, instance_id, disk_id):
         calls.append((cleanup_sdk, instance_id, disk_id))
 
+    def fake_sdk(**kwargs):
+        assert "config_reader" in kwargs
+        return sdk
+
     monkeypatch.setattr(
         sys,
         "argv",
@@ -1173,7 +1192,7 @@ def test_main_remove_by_ids_passes_explicit_ids(monkeypatch):
             "--apply",
         ],
     )
-    monkeypatch.setattr(m, "SDK", lambda **kwargs: sdk)
+    monkeypatch.setattr(m, "SDK", fake_sdk)
     monkeypatch.setattr(m, "Config", lambda: object())
     monkeypatch.setattr(m, "remove_vm_and_disk_by_ids", fake_remove_resources)
 

--- a/.github/scripts/nebius_manage_vm_test.py
+++ b/.github/scripts/nebius_manage_vm_test.py
@@ -687,8 +687,8 @@ def test_create_disk_removes_created_disk_when_wait_fails(monkeypatch):
 
     removed = []
 
-    async def fake_remove_disk_by_id(_sdk, args, disk_id):
-        removed.append((_sdk, args, disk_id))
+    async def fake_remove_disk_by_id(_sdk, disk_id):
+        removed.append((_sdk, disk_id))
 
     fake_service = FakeDiskService()
     sdk = object()
@@ -707,7 +707,7 @@ def test_create_disk_removes_created_disk_when_wait_fails(monkeypatch):
 
     assert fake_service.request.metadata.name == "disk-vm-name"
     assert created_clients == [sdk]
-    assert removed == [(sdk, args, "disk-id")]
+    assert removed == [(sdk, "disk-id")]
 
 
 def test_build_vm_labels_adds_runner_metadata_to_copy_of_existing_labels():
@@ -721,6 +721,103 @@ def test_build_vm_labels_adds_runner_metadata_to_copy_of_existing_labels():
         "runner-flavor": "large",
     }
     assert original_labels == {"test": "librarian"}
+
+
+def test_remove_vm_and_disk_by_ids_deletes_instance_before_disk(monkeypatch):
+    removed = []
+
+    async def fake_remove_instance(sdk, resource_id):
+        removed.append(("instance", sdk, resource_id))
+
+    async def fake_remove_disk(sdk, resource_id):
+        removed.append(("disk", sdk, resource_id))
+
+    monkeypatch.setattr(m, "remove_vm_by_id", fake_remove_instance)
+    monkeypatch.setattr(m, "remove_disk_by_id", fake_remove_disk)
+
+    sdk = object()
+    asyncio.run(
+        m.remove_vm_and_disk_by_ids(
+            sdk, "computeinstance-instance-id", "computedisk-disk-id"
+        )
+    )
+
+    assert removed == [
+        ("instance", sdk, "computeinstance-instance-id"),
+        ("disk", sdk, "computedisk-disk-id"),
+    ]
+
+
+def test_remove_vm_and_disk_by_ids_removes_disk_when_instance_is_not_found(monkeypatch):
+    removed = []
+
+    async def fake_remove_instance(_sdk, _resource_id):
+        raise m.RequestError(SimpleNamespace(code=m.grpc.StatusCode.NOT_FOUND))
+
+    async def fake_remove_disk(sdk, resource_id):
+        removed.append((sdk, resource_id))
+
+    monkeypatch.setattr(m, "remove_vm_by_id", fake_remove_instance)
+    monkeypatch.setattr(m, "remove_disk_by_id", fake_remove_disk)
+
+    sdk = object()
+    asyncio.run(
+        m.remove_vm_and_disk_by_ids(
+            sdk, "computeinstance-instance-id", "computedisk-disk-id"
+        )
+    )
+
+    assert removed == [(sdk, "computedisk-disk-id")]
+
+
+def test_remove_vm_and_disk_by_ids_removes_disk_without_instance(monkeypatch):
+    removed = []
+
+    async def fake_remove_instance(_sdk, _resource_id):
+        raise AssertionError("Instance removal should not be called")
+
+    async def fake_remove_disk(sdk, resource_id):
+        removed.append((sdk, resource_id))
+
+    monkeypatch.setattr(m, "remove_vm_by_id", fake_remove_instance)
+    monkeypatch.setattr(m, "remove_disk_by_id", fake_remove_disk)
+
+    sdk = object()
+    asyncio.run(m.remove_vm_and_disk_by_ids(sdk, "", "computedisk-disk-id"))
+
+    assert removed == [(sdk, "computedisk-disk-id")]
+
+
+def test_remove_vm_and_disk_by_ids_does_not_remove_disk_when_instance_removal_fails(
+    monkeypatch,
+):
+    async def fake_remove_instance(_sdk, _resource_id):
+        raise RuntimeError("instance is still present")
+
+    async def fake_remove_disk(_sdk, _resource_id):
+        raise AssertionError("Disk removal should not be called")
+
+    monkeypatch.setattr(m, "remove_vm_by_id", fake_remove_instance)
+    monkeypatch.setattr(m, "remove_disk_by_id", fake_remove_disk)
+
+    with pytest.raises(RuntimeError, match="instance is still present"):
+        asyncio.run(
+            m.remove_vm_and_disk_by_ids(
+                object(), "computeinstance-instance-id", "computedisk-disk-id"
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "instance_id,disk_id,error",
+    [
+        ("wrong-instance-id", "", "Invalid instance ID"),
+        ("", "wrong-disk-id", "Invalid disk ID"),
+    ],
+)
+def test_remove_vm_and_disk_by_ids_rejects_invalid_ids(instance_id, disk_id, error):
+    with pytest.raises(ValueError, match=error):
+        asyncio.run(m.remove_vm_and_disk_by_ids(object(), instance_id, disk_id))
 
 
 def test_build_instance_request_with_public_ip():
@@ -940,6 +1037,59 @@ def test_remove_vm_with_empty_id_only_searches_by_labels(monkeypatch):
     assert searches == [(sdk, args)]
 
 
+def test_remove_vm_resolves_disk_id_before_removing_resources(monkeypatch):
+    events = []
+    sdk = object()
+
+    class FakeInstanceService:
+        async def get(self, request):
+            events.append(("get-instance", request.id))
+            return SimpleNamespace(metadata=SimpleNamespace(name="runner-name"))
+
+    async def fake_find_disk(search_sdk, args, instance_name):
+        assert search_sdk is sdk
+        events.append(("find-disk", instance_name))
+        return SimpleNamespace(metadata=SimpleNamespace(id="computedisk-disk-id"))
+
+    async def fake_remove_resources(cleanup_sdk, instance_id, disk_id):
+        assert cleanup_sdk is sdk
+        events.append(
+            (
+                "remove-resources",
+                instance_id,
+                disk_id,
+            )
+        )
+
+    monkeypatch.setattr(m, "github_client_from_env", lambda: object())
+    monkeypatch.setattr(m, "remove_runner_from_github", lambda *args: "not_found")
+    monkeypatch.setattr(
+        m, "InstanceServiceClient", lambda service_sdk: FakeInstanceService()
+    )
+    monkeypatch.setattr(m, "find_disk_by_instance_name", fake_find_disk)
+    monkeypatch.setattr(m, "remove_vm_and_disk_by_ids", fake_remove_resources)
+
+    args = argparse.Namespace(
+        id="computeinstance-instance-id",
+        parent_id="parent-id",
+        github_repo_owner="owner",
+        github_repo="repo",
+        apply=True,
+    )
+
+    asyncio.run(m.remove_vm(sdk, args))
+
+    assert events == [
+        ("get-instance", "computeinstance-instance-id"),
+        ("find-disk", "runner-name"),
+        (
+            "remove-resources",
+            "computeinstance-instance-id",
+            "computedisk-disk-id",
+        ),
+    ]
+
+
 def test_main_remove_with_empty_id_does_not_require_github_token(monkeypatch):
     searches = []
     sdk = object()
@@ -984,3 +1134,38 @@ def test_main_remove_with_empty_id_does_not_require_github_token(monkeypatch):
     assert len(searches) == 1
     assert searches[0][0] is sdk
     assert searches[0][1].labels == {"run": "1-1"}
+
+
+def test_main_remove_by_ids_passes_explicit_ids(monkeypatch):
+    calls = []
+    sdk = object()
+
+    async def fake_remove_resources(cleanup_sdk, instance_id, disk_id):
+        calls.append((cleanup_sdk, instance_id, disk_id))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "nebius_manage_vm.py",
+            "remove-by-ids",
+            "--instance-id",
+            "computeinstance-instance-id",
+            "--disk-id",
+            "computedisk-disk-id",
+            "--apply",
+        ],
+    )
+    monkeypatch.setattr(m, "SDK", lambda **kwargs: sdk)
+    monkeypatch.setattr(m, "Config", lambda: object())
+    monkeypatch.setattr(m, "remove_vm_and_disk_by_ids", fake_remove_resources)
+
+    asyncio.run(m.main())
+
+    assert calls == [
+        (
+            sdk,
+            "computeinstance-instance-id",
+            "computedisk-disk-id",
+        )
+    ]

--- a/.github/scripts/nebius_manage_vm_test.py
+++ b/.github/scripts/nebius_manage_vm_test.py
@@ -725,6 +725,7 @@ def test_build_vm_labels_adds_runner_metadata_to_copy_of_existing_labels():
 
 def test_remove_vm_and_disk_by_ids_deletes_instance_before_disk(monkeypatch):
     removed = []
+    logs = []
 
     async def fake_remove_instance(sdk, resource_id):
         removed.append(("instance", sdk, resource_id))
@@ -734,6 +735,14 @@ def test_remove_vm_and_disk_by_ids_deletes_instance_before_disk(monkeypatch):
 
     monkeypatch.setattr(m, "remove_vm_by_id", fake_remove_instance)
     monkeypatch.setattr(m, "remove_disk_by_id", fake_remove_disk)
+    monkeypatch.setattr(
+        m,
+        "logger",
+        SimpleNamespace(
+            info=lambda message, *args: logs.append(message % args),
+            error=lambda message, *args: logs.append(message % args),
+        ),
+    )
 
     sdk = object()
     asyncio.run(
@@ -745,6 +754,14 @@ def test_remove_vm_and_disk_by_ids_deletes_instance_before_disk(monkeypatch):
     assert removed == [
         ("instance", sdk, "computeinstance-instance-id"),
         ("disk", sdk, "computedisk-disk-id"),
+    ]
+    assert logs == [
+        "Cleanup plan: remove instance computeinstance-instance-id, then remove disk computedisk-disk-id",
+        "Removing instance with ID computeinstance-instance-id",
+        "Successfully removed instance with ID computeinstance-instance-id",
+        "Removing disk with ID computedisk-disk-id",
+        "Successfully removed disk with ID computedisk-disk-id",
+        "VM and disk cleanup completed successfully",
     ]
 
 

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -145,14 +145,7 @@ jobs:
           cd .github/packer || exit
           packer init github-runner.pkr.hcl
       - name: build image
-        if: >-
-          always() &&
-          inputs.image_id == '' &&
-          inputs.build_image == true &&
-          steps.cli.outcome == 'success' &&
-          steps.runner-release.outcome == 'success' &&
-          steps.setup-packer.outcome == 'success' &&
-          steps.init-packer.outcome == 'success'
+        if: inputs.image_id == '' && inputs.build_image == true
         id: build-image
         env:
           PASSWORD_HASH: ${{ secrets.VM_USER_PASSWD }}
@@ -164,9 +157,52 @@ jobs:
           SUBNET_ID: ${{ vars.POOLED_HEAVY_SUBNET_ID }}
         run: |
           cd .github/packer || exit
-          packer build -var "RUNNER_VERSION=${RUNNER_VERSION}" -var "RUNNER_SHA256_X64=${RUNNER_SHA256_X64}" github-runner.pkr.hcl
+          set +e
+          PACKER_NO_COLOR=1 packer build \
+              -var "RUNNER_VERSION=${RUNNER_VERSION}" \
+              -var "RUNNER_SHA256_X64=${RUNNER_SHA256_X64}" \
+              github-runner.pkr.hcl 2>&1 | awk -v github_output="${GITHUB_OUTPUT}" '
+                  {
+                      print
+                      fflush()
+                      for (i = 1; i < NF; i++) {
+                          if ($i == "disk" && $(i + 1) ~ /^computedisk-[[:alnum:]]+$/) {
+                              print "PACKER_DISK_ID=" $(i + 1) >> github_output
+                              close(github_output)
+                          }
+                          if ($i == "instance" && $(i + 1) ~ /^computeinstance-[[:alnum:]]+$/) {
+                              print "PACKER_INSTANCE_ID=" $(i + 1) >> github_output
+                              close(github_output)
+                          }
+                      }
+                  }
+              '
+          PACKER_EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          if (( PACKER_EXIT_CODE != 0 )); then
+              exit "${PACKER_EXIT_CODE}"
+          fi
           cat reports/manifest.json
-          echo "IMAGE_ID_2204=$(jq -r '.builds[0].artifact_id' reports/manifest.json)" >> $GITHUB_OUTPUT
+          echo "IMAGE_ID_2204=$(jq -r '.builds[0].artifact_id' reports/manifest.json)" >> "${GITHUB_OUTPUT}"
+      - name: Show Packer resource IDs
+        if: always()
+        env:
+          PACKER_INSTANCE_ID: ${{ steps.build-image.outputs.PACKER_INSTANCE_ID }}
+          PACKER_DISK_ID: ${{ steps.build-image.outputs.PACKER_DISK_ID }}
+        run: |
+          echo "PACKER_INSTANCE_ID=${PACKER_INSTANCE_ID}"
+          echo "PACKER_DISK_ID=${PACKER_DISK_ID}"
+      - name: Remove Nebius resources by IDs
+        if: >-
+          always() &&
+          (steps.build-image.outputs.PACKER_INSTANCE_ID != '' ||
+          steps.build-image.outputs.PACKER_DISK_ID != '')
+        uses: ./.github/actions/nebius_remove_by_ids
+        timeout-minutes: 60
+        with:
+          nebius_config_yaml: ${{ secrets.POOLED_LIGHT_NEBIUS_CONFIG_YAML }}
+          instance_id: ${{ steps.build-image.outputs.PACKER_INSTANCE_ID }}
+          disk_id: ${{ steps.build-image.outputs.PACKER_DISK_ID }}
       - name: Get latest image ID from Nebius
         id: get-image-id
         env:

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -147,6 +147,7 @@ jobs:
       - name: build image
         if: inputs.image_id == '' && inputs.build_image == true
         id: build-image
+        timeout-minutes: 60
         env:
           PASSWORD_HASH: ${{ secrets.VM_USER_PASSWD }}
           NEBIUS_IAM_TOKEN: ${{ steps.cli.outputs.NEBIUS_IAM_TOKEN }}
@@ -179,7 +180,7 @@ jobs:
               '
           PACKER_EXIT_CODE=${PIPESTATUS[0]}
           set -e
-          if (( PACKER_EXIT_CODE != 0 )); then
+          if ((PACKER_EXIT_CODE != 0)); then
               exit "${PACKER_EXIT_CODE}"
           fi
           cat reports/manifest.json
@@ -195,10 +196,12 @@ jobs:
       - name: Remove Nebius resources by IDs
         if: >-
           always() &&
+          (steps.build-image.outcome == 'failure' ||
+          steps.build-image.outcome == 'cancelled') &&
           (steps.build-image.outputs.PACKER_INSTANCE_ID != '' ||
           steps.build-image.outputs.PACKER_DISK_ID != '')
         uses: ./.github/actions/nebius_remove_by_ids
-        timeout-minutes: 60
+        timeout-minutes: 30
         with:
           nebius_config_yaml: ${{ secrets.POOLED_LIGHT_NEBIUS_CONFIG_YAML }}
           instance_id: ${{ steps.build-image.outputs.PACKER_INSTANCE_ID }}

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -130,6 +130,7 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE/.github
           python3 -m scripts.github_runner_release --version "${RUNNER_VERSION}"
       - name: set up packer
+        id: setup-packer
         if: inputs.image_id == '' && inputs.build_image == true
         # it is pinned to commit because fix only exist there ans is not tagges
         # and in general it is good practice to do so
@@ -138,12 +139,20 @@ jobs:
           version: 1.15.3
 
       - name: init packer
+        id: init-packer
         if: inputs.image_id == '' && inputs.build_image == true
         run: |
           cd .github/packer || exit
           packer init github-runner.pkr.hcl
       - name: build image
-        if: inputs.image_id == '' && inputs.build_image == true
+        if: >-
+          always() &&
+          inputs.image_id == '' &&
+          inputs.build_image == true &&
+          steps.cli.outcome == 'success' &&
+          steps.runner-release.outcome == 'success' &&
+          steps.setup-packer.outcome == 'success' &&
+          steps.init-packer.outcome == 'success'
         id: build-image
         env:
           PASSWORD_HASH: ${{ secrets.VM_USER_PASSWD }}


### PR DESCRIPTION
Initial thought was to use always() to prevent packer build from interrupting and thus allowing it to cleanup after himself. But this is problematic and would require force-cancel to cancel workflow.

Now we parse logs that are provided by packer and catch instance ids and disk ids and run clean up action after.

