### PR TITLE
use memory windows to invalidate request buffers; resolves issue-5729

### DIFF
--- a/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
@@ -103,6 +103,7 @@ void TBootstrap::Init()
         config->QpRnrRetryCount = Options->QpRnrRetryCount;
         config->QpTimeout = Options->QpTimeout;
         config->QpMinRnrTimer = Options->QpMinRnrTimer;
+        config->UseMemoryWindows = Options->UseMemoryWindows;
 
         Client = NCloud::NBlockStore::NRdma::CreateRdmaClient(
             Logging,

--- a/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
@@ -103,6 +103,8 @@ void TBootstrap::Init()
         config->QpRnrRetryCount = Options->QpRnrRetryCount;
         config->QpTimeout = Options->QpTimeout;
         config->QpMinRnrTimer = Options->QpMinRnrTimer;
+        config->UseMemoryWindows = Options->UseMemoryWindows;
+        config->MemoryWindowsPoolSize = Options->MemoryWindowsPoolSize;
 
         Client = NCloud::NBlockStore::NRdma::CreateRdmaClient(
             Logging,

--- a/cloud/blockstore/tools/testing/rdma-test/options.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/options.cpp
@@ -115,6 +115,14 @@ void TOptions::Parse(int argc, char** argv)
         .DefaultValue(QpMinRnrTimer)
         .StoreResult(&QpMinRnrTimer);
 
+    opts.AddLongOption("memory-windows")
+        .StoreTrue(&UseMemoryWindows);
+
+    opts.AddLongOption("memory-windows-pool-size")
+        .RequiredArgument("NUM")
+        .DefaultValue(MemoryWindowsPoolSize)
+        .StoreResult(&MemoryWindowsPoolSize);
+
     // device geometry
     opts.AddLongOption("storage")
         .RequiredArgument("{" + GetEnumAllNames<EStorageKind>() + "}")

--- a/cloud/blockstore/tools/testing/rdma-test/options.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/options.cpp
@@ -115,6 +115,9 @@ void TOptions::Parse(int argc, char** argv)
         .DefaultValue(QpMinRnrTimer)
         .StoreResult(&QpMinRnrTimer);
 
+    opts.AddLongOption("memory-windows")
+        .StoreTrue(&UseMemoryWindows);
+
     // device geometry
     opts.AddLongOption("storage")
         .RequiredArgument("{" + GetEnumAllNames<EStorageKind>() + "}")

--- a/cloud/blockstore/tools/testing/rdma-test/options.h
+++ b/cloud/blockstore/tools/testing/rdma-test/options.h
@@ -64,6 +64,8 @@ struct TOptions
     ui8 QpRnrRetryCount = 7;
     ui8 QpTimeout = 0;
     ui8 QpMinRnrTimer = 0;
+    bool UseMemoryWindows = false;
+    ui32 MemoryWindowsPoolSize = 0;
 
     // storage options
     EStorageKind StorageKind = EStorageKind::Null;

--- a/cloud/blockstore/tools/testing/rdma-test/options.h
+++ b/cloud/blockstore/tools/testing/rdma-test/options.h
@@ -64,6 +64,7 @@ struct TOptions
     ui8 QpRnrRetryCount = 7;
     ui8 QpTimeout = 0;
     ui8 QpMinRnrTimer = 0;
+    bool UseMemoryWindows = false;
 
     // storage options
     EStorageKind StorageKind = EStorageKind::Null;

--- a/cloud/storage/core/libs/rdma/iface/client.cpp
+++ b/cloud/storage/core/libs/rdma/iface/client.cpp
@@ -86,6 +86,8 @@ void TClientConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(QpRnrRetryCount, static_cast<ui32>(QpRnrRetryCount));
                 ENTRY(QpTimeout, static_cast<ui32>(QpTimeout));
                 ENTRY(QpMinRnrTimer, static_cast<ui32>(QpMinRnrTimer));
+                ENTRY(UseMemoryWindows, UseMemoryWindows);
+                ENTRY(MemoryWindowsPoolSize, MemoryWindowsPoolSize);
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/iface/client.cpp
+++ b/cloud/storage/core/libs/rdma/iface/client.cpp
@@ -86,6 +86,7 @@ void TClientConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(QpRnrRetryCount, static_cast<ui32>(QpRnrRetryCount));
                 ENTRY(QpTimeout, static_cast<ui32>(QpTimeout));
                 ENTRY(QpMinRnrTimer, static_cast<ui32>(QpMinRnrTimer));
+                ENTRY(UseMemoryWindows, UseMemoryWindows);
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/iface/client.h
+++ b/cloud/storage/core/libs/rdma/iface/client.h
@@ -48,6 +48,8 @@ struct TClientConfig
     ui8 QpRnrRetryCount = 7;
     ui8 QpTimeout = 0;
     ui8 QpMinRnrTimer = 0;
+    bool UseMemoryWindows = false;
+    ui32 MemoryWindowsPoolSize = 0;
 
     TClientConfig();
 

--- a/cloud/storage/core/libs/rdma/iface/client.h
+++ b/cloud/storage/core/libs/rdma/iface/client.h
@@ -48,6 +48,7 @@ struct TClientConfig
     ui8 QpRnrRetryCount = 7;
     ui8 QpTimeout = 0;
     ui8 QpMinRnrTimer = 0;
+    bool UseMemoryWindows = false;
 
     TClientConfig();
 

--- a/cloud/storage/core/libs/rdma/iface/config.h
+++ b/cloud/storage/core/libs/rdma/iface/config.h
@@ -66,6 +66,7 @@ inline TClientConfig CreateClientConfig(const NProto::TRdmaClient& config)
     SET(QpRnrRetryCount);
     SET(QpTimeout);
     SET(QpMinRnrTimer);
+    SET(UseMemoryWindows);
 
     SET_NESTED(BufferPool, ChunkSize);
     SET_NESTED(BufferPool, MaxChunkAlloc);

--- a/cloud/storage/core/libs/rdma/iface/config.h
+++ b/cloud/storage/core/libs/rdma/iface/config.h
@@ -66,6 +66,8 @@ inline TClientConfig CreateClientConfig(const NProto::TRdmaClient& config)
     SET(QpRnrRetryCount);
     SET(QpTimeout);
     SET(QpMinRnrTimer);
+    SET(UseMemoryWindows);
+    SET(MemoryWindowsPoolSize);
 
     SET_NESTED(BufferPool, ChunkSize);
     SET_NESTED(BufferPool, MaxChunkAlloc);

--- a/cloud/storage/core/libs/rdma/iface/probes.h
+++ b/cloud/storage/core/libs/rdma/iface/probes.h
@@ -63,6 +63,22 @@
         GROUPS("StorageRequest"),                                              \
         TYPES(),                                                               \
         NAMES())                                                               \
+    PROBE(BindInBufferStarted,                                                 \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindInBufferCompleted,                                               \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindOutBufferStarted,                                                \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindOutBufferCompleted,                                              \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
 // STORAGE_RDMA_PROVIDER
 
 LWTRACE_DECLARE_PROVIDER(STORAGE_RDMA_PROVIDER)

--- a/cloud/storage/core/libs/rdma/iface/probes.h
+++ b/cloud/storage/core/libs/rdma/iface/probes.h
@@ -63,6 +63,42 @@
         GROUPS("StorageRequest"),                                              \
         TYPES(),                                                               \
         NAMES())                                                               \
+    PROBE(BindInBufferStarted,                                                 \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindInBufferCompleted,                                               \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindOutBufferStarted,                                                \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindOutBufferCompleted,                                              \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(RequestQueuedForInvalidation,                                        \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(InvalidateInBufferStarted,                                           \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(InvalidateInBufferCompleted,                                         \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(InvalidateOutBufferStarted,                                          \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(InvalidateOutBufferCompleted,                                        \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
 // STORAGE_RDMA_PROVIDER
 
 LWTRACE_DECLARE_PROVIDER(STORAGE_RDMA_PROVIDER)

--- a/cloud/storage/core/libs/rdma/impl/buffer.cpp
+++ b/cloud/storage/core/libs/rdma/impl/buffer.cpp
@@ -9,13 +9,6 @@ namespace NCloud::NStorage::NRdma {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TPooledBuffer::operator TStringBuf() const
-{
-    return {reinterpret_cast<char*>(Address), Length};
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TBufferPool::TChunk
     : public TIntrusiveListItem<TChunk>
 {
@@ -100,7 +93,24 @@ public:
         AllocatedBytes = 0;
         FreedBytes = 0;
     }
+
+    ibv_mr* GetMemoryRegion() const
+    {
+        return MemoryRegion.get();
+    }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+TPooledBuffer::operator TStringBuf() const
+{
+    return {reinterpret_cast<char*>(Address), Length};
+}
+
+ibv_mr* TPooledBuffer::GetMemoryRegion() const
+{
+    return Chunk->GetMemoryRegion();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/storage/core/libs/rdma/impl/buffer.h
+++ b/cloud/storage/core/libs/rdma/impl/buffer.h
@@ -39,6 +39,9 @@ public:
     {
         TChunk* Chunk;
         ui32 LKey;
+        ui32 WindowRKey;
+
+        ibv_mr* GetMemoryRegion() const;
 
         explicit operator TStringBuf() const;
     };

--- a/cloud/storage/core/libs/rdma/impl/buffer.h
+++ b/cloud/storage/core/libs/rdma/impl/buffer.h
@@ -40,6 +40,8 @@ public:
         TChunk* Chunk;
         ui32 LKey;
 
+        ibv_mr* GetMemoryRegion() const;
+
         explicit operator TStringBuf() const;
     };
 

--- a/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
@@ -44,6 +44,11 @@ public:
         RegisterMemoryRegion,
         (ibv_pd * pd, void* addr, size_t length, int flags),
         (override));
+    MOCK_METHOD(
+        NVerbs::TMemoryWindowPtr,
+        CreateMemoryWindow,
+        (ibv_pd* pd),
+        (override));
 
     MOCK_METHOD(
         NVerbs::TCompletionChannelPtr,

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -38,6 +38,8 @@
 #include <util/system/mutex.h>
 #include <util/system/thread.h>
 
+#include <deque>
+
 namespace NCloud::NStorage::NRdma {
 
 using namespace NMonitoring;
@@ -151,8 +153,8 @@ struct TRequest
     ui64 ClientReqId = 0;
 
     // set upon receiving response
-    ui32 Status;
-    ui32 ResponseBytes;
+    ui32 Status = 0;
+    ui32 ResponseBytes = 0;
 
     TPooledBuffer InBuffer{};
     TPooledBuffer OutBuffer{};
@@ -623,6 +625,7 @@ private:
     TEventHandle DisconnectEvent;
 
     TSimpleList<TRequest> QueuedRequests;
+    std::deque<ui32> InvalidationQueue;
     TActiveRequests ActiveRequests;
 
     std::atomic<ui64> ReqIdPool{0};
@@ -692,6 +695,7 @@ public:
 private:
     // called from CQ thread
     void HandleQueuedRequests() noexcept;
+    bool HandleInvalidations() noexcept;
     void StartRequest(TRequestPtr req, TSendWr* send) noexcept;
     void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
@@ -701,11 +705,11 @@ private:
     void BindCompleted(TSendWr* send) noexcept;
     void RecvResponse(TRecvWr* recv) noexcept;
     void RecvResponseCompleted(TRecvWr* recv) noexcept;
-    void InvalidateInBuffer(TRequestPtr req, TSendWr* send) noexcept;
+    void InvalidateInBuffer(TRequest* req, TSendWr* send) noexcept;
     void InvalidateOutBuffer(TRequest* req, TSendWr* send) noexcept;
     void InvalidateCompleted(TSendWr* send) noexcept;
-    void InvalidateBuffers(TRequestPtr req) noexcept;
-    void CompleteRequest(TRequestPtr req) noexcept;
+    void InvalidateBuffers(TRequest* req) noexcept;
+    void CompleteRequest(ui32 reqId) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     bool PostSend(TRequest* req, TSendWr* send, ibv_send_wr* wr) noexcept;
@@ -1055,18 +1059,25 @@ bool TClientEndpoint::HandleInputRequests() noexcept
         RequestEvent.Clear();
     }
 
-    auto requests = InputRequests.DequeueAll();
-    if (!requests) {
-        return false;
+    bool hasWork = false;
+
+    if (auto requests = InputRequests.DequeueAll()) {
+        QueuedRequests.Append(std::move(requests));
+        HandleQueuedRequests();
+        hasWork = true;
     }
 
-    QueuedRequests.Append(std::move(requests));
-    HandleQueuedRequests();
-    return true;
+    if (HandleInvalidations()) {
+        hasWork = true;
+    }
+
+    return hasWork;
 }
 
 void TClientEndpoint::HandleQueuedRequests() noexcept
 {
+    // in Poll mode events can get through in any state, so it's important to
+    // cancel requests here, otherwise HandleInputEvent may get lost
     if (!CheckState(EEndpointState::Connected)) {
         while (QueuedRequests) {
             auto req = QueuedRequests.Dequeue();
@@ -1085,20 +1096,43 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
 
         auto req = QueuedRequests.Dequeue();
         Y_ABORT_UNLESS(req);
-
         Counters->RequestDequeued();
 
-        switch (req->State) {
-            case ERequestState::Enqueued:
-                StartRequest(std::move(req), send);
-                break;
+        if (req->State != ERequestState::Enqueued) {
+            RDMA_ERROR(
+                "request " << req->ReqId << " has unexpected state "
+                            << req->State);
 
-            case ERequestState::InvalidateBuffers:
-                Counters->InvalidationDequeued();
-                InvalidateInBuffer(std::move(req), send);
-                break;
+            QueuedRequests.Enqueue(std::move(req));
+            Counters->RequestEnqueued();
 
-            default:
+            SendQueue.Push(send);
+            Counters->Error();
+            Disconnect();
+            return;
+        }
+
+        StartRequest(std::move(req), send);
+    }
+}
+
+bool TClientEndpoint::HandleInvalidations() noexcept
+{
+    bool hasWork = InvalidationQueue.size();
+
+    while (InvalidationQueue.size()) {
+        auto* send = SendQueue.Pop();
+        if (!send) {
+            // no more WRs available
+            break;
+        }
+
+        auto reqId = InvalidationQueue.front();
+        InvalidationQueue.pop_front();
+        Counters->InvalidationDequeued();
+
+        if (auto* req = ActiveRequests.Get(reqId)) {
+            if (req->State != ERequestState::InvalidateBuffers) {
                 RDMA_ERROR(
                     "request " << req->ReqId << " has unexpected state "
                                << req->State);
@@ -1106,9 +1140,16 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
                 SendQueue.Push(send);
                 Counters->Error();
                 Disconnect();
-                return;
+                return true;
+            }
+
+            Counters->InvalidationStarted();
+            InvalidateInBuffer(req, send);
         }
+        // request has been cancelled or timed out
     }
+
+    return hasWork;
 }
 
 void TClientEndpoint::CancelRequest(ui64 clientRequestId) noexcept
@@ -1212,6 +1253,9 @@ void TClientEndpoint::AbortRequests() noexcept
         RDMA_DEBUG("abort request " << req->ReqId);
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }
+
+    // drop all invalidations
+    InvalidationQueue.clear();
 }
 
 void TClientEndpoint::AbortRequest(
@@ -1669,7 +1713,7 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv) noexcept
     RecvResponse(recv);
 
     // request has been aborted
-    auto req = ActiveRequests.Pop(reqId);
+    auto* req = ActiveRequests.Get(reqId);
     if (!req) {
         return;
     }
@@ -1683,13 +1727,13 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv) noexcept
         req->CallContext->RequestId);
 
     if (Config.UseMemoryWindows) {
-        InvalidateBuffers(std::move(req));
+        InvalidateBuffers(req);
     } else {
-        CompleteRequest(std::move(req));
+        CompleteRequest(req->ReqId);
     }
 }
 
-void TClientEndpoint::InvalidateBuffers(TRequestPtr req) noexcept
+void TClientEndpoint::InvalidateBuffers(TRequest* req) noexcept
 {
     req->State = ERequestState::InvalidateBuffers;
 
@@ -1700,8 +1744,7 @@ void TClientEndpoint::InvalidateBuffers(TRequestPtr req) noexcept
 
     RDMA_TRACE("invalidate request " << req->ReqId << " buffers");
 
-    InputRequests.Enqueue(std::move(req));
-    Counters->RequestEnqueued();
+    InvalidationQueue.push_back(req->ReqId);
     Counters->InvalidationEnqueued();
 
     if (WaitMode == EWaitMode::Poll) {
@@ -1709,10 +1752,12 @@ void TClientEndpoint::InvalidateBuffers(TRequestPtr req) noexcept
     }
 }
 
-void TClientEndpoint::CompleteRequest(TRequestPtr req) noexcept
+void TClientEndpoint::CompleteRequest(ui32 reqId) noexcept
 {
-    RDMA_TRACE("request " << req->ReqId << " completed");
+    auto req = ActiveRequests.Pop(reqId);
+    Y_ABORT_UNLESS(req);
 
+    RDMA_TRACE("request " << reqId << " completed");
     Counters->RequestCompleted();
 
     auto* handler = req->Handler.get();
@@ -1722,16 +1767,11 @@ void TClientEndpoint::CompleteRequest(TRequestPtr req) noexcept
     handler->HandleResponse(std::move(req), status, responseBytes);
 }
 
-void TClientEndpoint::InvalidateInBuffer(
-    TRequestPtr request,
-    TSendWr* send) noexcept
+void TClientEndpoint::InvalidateInBuffer(TRequest* req, TSendWr* send) noexcept
 {
-    auto* req = request.get();
-    req->State = ERequestState::InvalidateInBuffer;
-    Counters->InvalidationStarted();
-
-    ActiveRequests.Push(std::move(request));
     send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
+
+    req->State = ERequestState::InvalidateInBuffer;
 
     ibv_send_wr wr = {
         .wr_id = send->wr.wr_id,
@@ -1805,7 +1845,7 @@ void TClientEndpoint::InvalidateCompleted(TSendWr* send) noexcept
             MemoryWindows.Release(std::move(req->OutMemoryWindow));
             Counters->ReleaseMemoryWindow();
             Counters->InvalidationCompleted();
-            CompleteRequest(ActiveRequests.Pop(reqId));
+            CompleteRequest(req->ReqId);
             break;
 
         default:

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -75,6 +75,32 @@ using TCompletionPollerPtr = std::unique_ptr<TCompletionPoller>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class ERequestState
+{
+    BindInBuffer,
+    BindOutBuffer,
+    SendRequest,
+    RecvResponse,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+inline IOutputStream& operator<<(IOutputStream& out, ERequestState state)
+{
+    static const char* string[] = {
+        "BindInBuffer",
+        "BindOutBuffer",
+        "SendRequest",
+        "RecvResponse",
+    };
+    if (static_cast<size_t>(state) < Y_ARRAY_SIZE(string)) {
+        return out << string[static_cast<size_t>(state)];
+    }
+    return out << "Undefined";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TRequest
     : TClientRequest
     , TListNode<TRequest>
@@ -89,6 +115,11 @@ struct TRequest
 
     TPooledBuffer InBuffer{};
     TPooledBuffer OutBuffer{};
+
+    NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
+    NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
+
+    ERequestState State;
 
     TRequest(
             std::weak_ptr<TClientEndpoint> endpoint,
@@ -472,14 +503,11 @@ private:
     TWorkQueue<TSendWr> SendQueue;
     TWorkQueue<TRecvWr> RecvQueue;
 
-    union {
-        const ui64 Id = RandomNumber(Max<ui64>());
-        struct {
-            const ui32 RecvMagic;
-            const ui32 SendMagic;
-        };
-    };
+    const ui64 Id = RandomNumber(Max<ui64>());
     ui16 Generation = Max<ui16>();
+
+    const ui32 RecvMagic = RandomNumber(Max<ui32>());
+    const ui32 SendMagic = RecvMagic ^ (1u << 31);
 
     TLockFreeList<TRequest> InputRequests;
     TLockFreeList<TClientRequestId> CancelRequests;
@@ -559,7 +587,11 @@ private:
     // called from CQ thread
     void HandleQueuedRequests() noexcept;
     void SendRequest(TRequestPtr req, TSendWr* send) noexcept;
+    void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
+    void BindInBuffer(TRequest* req, TSendWr* send) noexcept;
+    void BindOutBuffer(TRequest* req, TSendWr* send) noexcept;
+    void BindCompleted(TSendWr* send) noexcept;
     void RecvResponse(TRecvWr* recv) noexcept;
     void RecvResponseCompleted(TRecvWr* recv) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
@@ -828,9 +860,12 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         with_lock (AllocationLock) {
             if (requestBytes) {
                 req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
+                req->InMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
             }
+
             if (responseBytes) {
                 req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
+                req->OutMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
             }
         }
     } catch (...) {
@@ -1088,7 +1123,7 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
             SendQueue.Push(send);
             return -1;
         }
-        if (wc->opcode != IBV_WC_SEND) {
+        if (wc->opcode != IBV_WC_SEND && wc->opcode != IBV_WC_BIND_MW) {
             RDMA_ERROR(
                 send << " unexpected opcode "
                      << NVerbs::GetOpcodeName(wc->opcode));
@@ -1144,6 +1179,13 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
     }
 
     switch (wc->opcode) {
+        case IBV_WC_BIND_MW: {
+            TSendWr* send = &SendWrs[id.Index];
+            RDMA_TRACE(wc->opcode << " " << id << " completed")
+            BindCompleted(send);
+            break;
+        }
+
         case IBV_WC_SEND: {
             TSendWr* send = &SendWrs[id.Index];
             RDMA_TRACE(send << " completed");
@@ -1164,29 +1206,165 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
     }
 }
 
-void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send) noexcept
+void TClientEndpoint::SendRequest(TRequestPtr request, TSendWr* send) noexcept
 {
-    req->ReqId = ActiveRequests.CreateId();
+    // hand request over to simplify error handling
+    auto* req = request.get();
+    request->ReqId = ActiveRequests.CreateId();
+    ActiveRequests.Push(std::move(request));
 
-    auto* requestMsg = send->Message();
-    Zero(*requestMsg);
+    send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
 
-    InitMessageHeader(requestMsg, NegotiatedProtocolVersion);
+    auto* msg = send->Message();
+    Zero(*msg);
 
-    requestMsg->ReqId = req->ReqId;
-    requestMsg->In = req->InBuffer;
-    requestMsg->Out = req->OutBuffer;
+    InitMessageHeader(msg, NegotiatedProtocolVersion);
+
+    msg->ReqId = req->ReqId;
+    msg->In = req->InBuffer;
+    msg->Out = req->OutBuffer;
+
+    if (Config.UseMemoryWindows) {
+        BindInBuffer(req, send);
+    } else {
+        SendRequest(req, send);
+    }
+}
+
+void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::BindInBuffer;
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_BIND_MW,
+        .bind_mw = {
+            .mw = req->InMemoryWindow.get(),
+            .rkey = req->InMemoryWindow->rkey,
+            .bind_info = {
+                .mr = req->InBuffer.GetMemoryRegion(),
+                .addr = req->InBuffer.Address,
+                .length = req->InBuffer.Length,
+                .mw_access_flags = IBV_ACCESS_REMOTE_READ,
+            },
+        },
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE("bind request " << reqId << " input buffer");
+        RDMA_TRACE(wr << "[request=" << req->ReqId << "]" << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        BindInBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::BindOutBuffer(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::BindOutBuffer;
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_BIND_MW,
+        .bind_mw = {
+            .mw = req->OutMemoryWindow.get(),
+            .rkey = req->OutMemoryWindow->rkey,
+            .bind_info = {
+                .mr = req->OutBuffer.GetMemoryRegion(),
+                .addr = req->OutBuffer.Address,
+                .length = req->OutBuffer.Length,
+                .mw_access_flags = IBV_ACCESS_REMOTE_WRITE,
+            },
+        },
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE(wr << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        BindOutBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
+{
+    const ui32 reqId =
+        SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
+
+    if (auto* req = ActiveRequests.Get(reqId)) {
+        switch (req->State) {
+            case ERequestState::BindInBuffer:
+                LWTRACK(
+                    BindInBufferCompleted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
+
+                RDMA_DEBUG(
+                    "change request #" << req->ReqId << " input buffer rkey: "
+                                       << req->InBuffer.RKey << " -> "
+                                       << req->InMemoryWindow->rkey);
+
+                send->Message()->In.RKey = req->InMemoryWindow->rkey;
+                BindOutBuffer(req, send);
+                break;
+
+            case ERequestState::BindOutBuffer:
+                LWTRACK(
+                    BindOutBufferCompleted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
+
+                RDMA_DEBUG(
+                    "change request #" << req->ReqId << " output buffer rkey: "
+                                       << req->OutBuffer.RKey << " -> "
+                                       << req->OutMemoryWindow->rkey);
+
+                send->Message()->Out.RKey = req->OutMemoryWindow->rkey;
+                SendRequest(req, send);
+                break;
+
+            default:
+                Counters->Error();
+                RDMA_ERROR(
+                    "bind " << send->wr << " completed in unexpected state "
+                            << req->State);
+        }
+    }
+    // request has been cancelled before bind completed
+}
+
+void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::SendRequest;
 
     try {
         Verbs->PostSend(Connection->qp, &send->wr);
         RDMA_TRACE(send << " posted");
-
-    } catch (const TServiceError& e) {
+    }
+    catch (const TServiceError& e) {
         RDMA_ERROR(send << " " << e.what());
         SendQueue.Push(send);
         Counters->Error();
-        Counters->RequestEnqueued();
-        QueuedRequests.Enqueue(std::move(req));
         Disconnect();
         return;
     }
@@ -1197,9 +1375,6 @@ void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send) noexcept
         req->CallContext->RequestId);
 
     Counters->SendRequestStarted();
-
-    send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
-    ActiveRequests.Push(std::move(req));
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1215,6 +1390,8 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
             SendRequestCompleted,
             req->CallContext->LWOrbit,
             req->CallContext->RequestId);
+
+        req->State = ERequestState::RecvResponse;
     }
     // request has already been completed
 }

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -4,6 +4,7 @@
 #include "buffer.h"
 #include "event.h"
 #include "list.h"
+#include "memory_window.h"
 #include "poll.h"
 #include "rcu.h"
 #include "utils.h"
@@ -75,6 +76,38 @@ using TCompletionPollerPtr = std::unique_ptr<TCompletionPoller>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class ERequestState
+{
+    Init,
+    BindInBuffer,
+    BindOutBuffer,
+    RecvResponse,
+    InvalidateBuffers,
+    InvalidateInBuffer,
+    InvalidateOutBuffer,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+inline IOutputStream& operator<<(IOutputStream& out, ERequestState state)
+{
+    static const char* string[] = {
+        "Init",
+        "BindInBuffer",
+        "BindOutBuffer",
+        "RecvResponse",
+        "InvalidateBuffers",
+        "InvalidateInBuffer",
+        "InvalidateOutBuffer",
+    };
+    if (static_cast<size_t>(state) < Y_ARRAY_SIZE(string)) {
+        return out << string[static_cast<size_t>(state)];
+    }
+    return out << "Undefined";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TRequest
     : TClientRequest
     , TListNode<TRequest>
@@ -87,8 +120,17 @@ struct TRequest
     ui32 ReqId = 0;   // 16-bit RDMA request id
     ui64 ClientReqId = 0;
 
+    // set upon receiving response
+    ui32 Status;
+    ui32 ResponseBytes;
+
     TPooledBuffer InBuffer{};
     TPooledBuffer OutBuffer{};
+
+    NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
+    NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
+
+    ERequestState State = ERequestState::Init;
 
     TRequest(
             std::weak_ptr<TClientEndpoint> endpoint,
@@ -472,6 +514,8 @@ private:
     TWorkQueue<TSendWr> SendQueue;
     TWorkQueue<TRecvWr> RecvQueue;
 
+    TMemoryWindowsPool MemoryWindows;
+
     union {
         const ui64 Id = RandomNumber(Max<ui64>());
         struct {
@@ -558,10 +602,19 @@ public:
 private:
     // called from CQ thread
     void HandleQueuedRequests() noexcept;
-    void SendRequest(TRequestPtr req, TSendWr* send) noexcept;
+    void StartRequest(TRequestPtr req, TSendWr* send) noexcept;
+    void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
+    void BindInBuffer(TRequest* req, TSendWr* send) noexcept;
+    void BindOutBuffer(TRequest* req, TSendWr* send) noexcept;
+    void BindCompleted(TSendWr* send) noexcept;
     void RecvResponse(TRecvWr* recv) noexcept;
     void RecvResponseCompleted(TRecvWr* recv) noexcept;
+    void InvalidateInBuffer(TRequestPtr req, TSendWr* send) noexcept;
+    void InvalidateOutBuffer(TRequest* req, TSendWr* send) noexcept;
+    void InvalidateCompleted(TSendWr* send) noexcept;
+    void InvalidateBuffers(TRequestPtr req) noexcept;
+    void CompleteRequest(TRequestPtr req) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     int ValidateCompletion(ibv_wc* wc) noexcept;
@@ -684,15 +737,24 @@ void TClientEndpoint::CreateQP()
         Verbs->RdmaCreateQP(Connection.get(), &qp_attrs);
     }
 
+    if (Config.UseMemoryWindows && Config.MemoryWindowsPoolSize == 0) {
+        Config.MemoryWindowsPoolSize = Config.SendQueueSize * 2;
+        RDMA_INFO(
+            "MemoryWindowsPoolSize is not configured, set to "
+            << "SendQueueSize * 2 = " << Config.MemoryWindowsPoolSize);
+    }
+
+    MemoryWindows.Init(Verbs, Connection->pd, Config.MemoryWindowsPoolSize);
+
     SendBuffers.Init(
         Verbs,
         Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_MW_BIND);
 
     RecvBuffers.Init(
         Verbs,
         Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_MW_BIND);
 
     SendBuffer = SendBuffers.AcquireBuffer(
         Config.SendQueueSize * sizeof(TRequestMessage), true);
@@ -783,6 +845,8 @@ void TClientEndpoint::DestroyQP() noexcept
         }
     }
 
+    MemoryWindows.Clear();
+
     SendQueue.Clear();
     RecvQueue.Clear();
 
@@ -829,6 +893,7 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
             if (requestBytes) {
                 req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
             }
+
             if (responseBytes) {
                 req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
             }
@@ -907,26 +972,47 @@ bool TClientEndpoint::HandleInputRequests() noexcept
 
 void TClientEndpoint::HandleQueuedRequests() noexcept
 {
-    while (QueuedRequests) {
-        if (CheckState(EEndpointState::Connected)) {
-            auto* send = SendQueue.Pop();
-            if (!send) {
-                // no more WRs available
-                break;
-            }
-
-            auto req = QueuedRequests.Dequeue();
-            Y_ABORT_UNLESS(req);
-
-            Counters->RequestDequeued();
-            SendRequest(std::move(req), send);
-        }
-        else {
+    if (!CheckState(EEndpointState::Connected)) {
+        while (QueuedRequests) {
             auto req = QueuedRequests.Dequeue();
             Y_ABORT_UNLESS(req);
 
             Counters->RequestDequeued();
             AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
+        }
+        return;
+    }
+
+    while (QueuedRequests) {
+        auto* send = SendQueue.Pop();
+        if (!send) {
+            // no more WRs available
+            break;
+        }
+
+        auto req = QueuedRequests.Dequeue();
+        Y_ABORT_UNLESS(req);
+
+        Counters->RequestDequeued();
+
+        switch (req->State) {
+            case ERequestState::Init:
+                StartRequest(std::move(req), send);
+                break;
+
+            case ERequestState::InvalidateBuffers:
+                InvalidateInBuffer(std::move(req), send);
+                break;
+
+            default:
+                RDMA_ERROR(
+                    "request " << req->ReqId << " has unexpected state "
+                               << req->State);
+
+                SendQueue.Push(send);
+                Counters->Error();
+                Disconnect();
+                return;
         }
     }
 }
@@ -1002,6 +1088,7 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
         return false;
     }
 
+    // handle new requests right away
     QueuedRequests.Append(std::move(requests));
     HandleQueuedRequests();
     return true;
@@ -1039,9 +1126,15 @@ void TClientEndpoint::AbortRequests() noexcept
 
 void TClientEndpoint::AbortRequest(
     TRequestPtr req,
-    ui32 err, const
-    TString& msg) noexcept
+    ui32 err,
+    const TString& msg) noexcept
 {
+    // destroying memory window automatically invalidates it. this ensures no
+    // remote write can succeed after this point
+    if (req->OutMemoryWindow) {
+        req->OutMemoryWindow.reset();
+    }
+
     auto len = SerializeError(
         err,
         msg,
@@ -1062,6 +1155,7 @@ bool TClientEndpoint::HandleCompletionEvents() noexcept
             Verbs->RequestCompletionEvent(cq, 0);
         }
 
+        // some sends might have been freed up, try it
         if (Verbs->PollCompletionQueue(cq, this)) {
             HandleQueuedRequests();
             return true;
@@ -1097,7 +1191,9 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
             SendQueue.Push(send);
             return -1;
         }
-        if (wc->opcode != IBV_WC_SEND) {
+        if (wc->opcode != IBV_WC_SEND && wc->opcode != IBV_WC_BIND_MW &&
+            wc->opcode != IBV_WC_LOCAL_INV)
+        {
             RDMA_ERROR(
                 send << " unexpected opcode "
                      << NVerbs::GetOpcodeName(wc->opcode));
@@ -1153,6 +1249,20 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
     }
 
     switch (wc->opcode) {
+        case IBV_WC_BIND_MW: {
+            TSendWr* send = &SendWrs[id.Index];
+            RDMA_TRACE(wc->opcode << " " << id << " completed");
+            BindCompleted(send);
+            break;
+        }
+
+        case IBV_WC_LOCAL_INV: {
+            TSendWr* send = &SendWrs[id.Index];
+            RDMA_TRACE(wc->opcode << " " << id << " completed");
+            InvalidateCompleted(send);
+            break;
+        }
+
         case IBV_WC_SEND: {
             TSendWr* send = &SendWrs[id.Index];
             RDMA_TRACE(send << " completed");
@@ -1173,29 +1283,164 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
     }
 }
 
-void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send) noexcept
+void TClientEndpoint::StartRequest(TRequestPtr request, TSendWr* send) noexcept
 {
+    // hand request over to simplify error handling
+    auto* req = request.get();
     req->ReqId = ActiveRequests.CreateId();
+    ActiveRequests.Push(std::move(request));
 
-    auto* requestMsg = send->Message();
-    Zero(*requestMsg);
+    send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
 
-    InitMessageHeader(requestMsg, NegotiatedProtocolVersion);
+    auto* msg = send->Message();
+    Zero(*msg);
 
-    requestMsg->ReqId = req->ReqId;
-    requestMsg->In = req->InBuffer;
-    requestMsg->Out = req->OutBuffer;
+    InitMessageHeader(msg, NegotiatedProtocolVersion);
+    msg->ReqId = req->ReqId;
+    msg->In = req->InBuffer;
+    msg->Out = req->OutBuffer;
+
+    if (Config.UseMemoryWindows) {
+        req->InMemoryWindow = MemoryWindows.Acquire();
+        req->OutMemoryWindow = MemoryWindows.Acquire();
+        BindInBuffer(req, send);
+    } else {
+        SendRequest(req, send);
+    }
+}
+
+void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::BindInBuffer;
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_BIND_MW,
+        .bind_mw = {
+            .mw = req->InMemoryWindow.get(),
+            .rkey = req->InMemoryWindow->rkey,
+            .bind_info = {
+                .mr = req->InBuffer.GetMemoryRegion(),
+                .addr = req->InBuffer.Address,
+                .length = req->InBuffer.Length,
+                .mw_access_flags = IBV_ACCESS_REMOTE_READ,
+            },
+        },
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        BindInBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::BindOutBuffer(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::BindOutBuffer;
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_BIND_MW,
+        .bind_mw = {
+            .mw = req->OutMemoryWindow.get(),
+            .rkey = req->OutMemoryWindow->rkey,
+            .bind_info = {
+                .mr = req->OutBuffer.GetMemoryRegion(),
+                .addr = req->OutBuffer.Address,
+                .length = req->OutBuffer.Length,
+                .mw_access_flags = IBV_ACCESS_REMOTE_WRITE,
+            },
+        },
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
+        RDMA_TRACE(wr << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        BindOutBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
+{
+    const ui32 reqId =
+        SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
+    auto* req = ActiveRequests.Get(reqId);
+
+    // request got cancelled before bind completed
+    if (req == nullptr) {
+        SendQueue.Push(send);
+        return;
+    }
+
+    switch (req->State) {
+        case ERequestState::BindInBuffer:
+            LWTRACK(
+                BindInBufferCompleted,
+                req->CallContext->LWOrbit,
+                req->CallContext->RequestId);
+
+            send->Message()->In.RKey = req->InMemoryWindow->rkey;
+            BindOutBuffer(req, send);
+            break;
+
+        case ERequestState::BindOutBuffer:
+            LWTRACK(
+                BindOutBufferCompleted,
+                req->CallContext->LWOrbit,
+                req->CallContext->RequestId);
+
+            send->Message()->Out.RKey = req->OutMemoryWindow->rkey;
+            SendRequest(req, send);
+            break;
+
+        default:
+            RDMA_ERROR(
+                "bind " << send->wr << " completed in unexpected state "
+                        << req->State);
+
+            SendQueue.Push(send);
+            Counters->Error();
+            Disconnect();
+            return;
+    }
+}
+
+void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::RecvResponse;
 
     try {
         Verbs->PostSend(Connection->qp, &send->wr);
         RDMA_TRACE(send << " posted");
-
-    } catch (const TServiceError& e) {
+    }
+    catch (const TServiceError& e) {
         RDMA_ERROR(send << " " << e.what());
         SendQueue.Push(send);
         Counters->Error();
-        Counters->RequestEnqueued();
-        QueuedRequests.Enqueue(std::move(req));
         Disconnect();
         return;
     }
@@ -1206,9 +1451,6 @@ void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send) noexcept
         req->CallContext->RequestId);
 
     Counters->SendRequestStarted();
-
-    send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
-    ActiveRequests.Push(std::move(req));
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1225,7 +1467,7 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
             req->CallContext->LWOrbit,
             req->CallContext->RequestId);
     }
-    // request has already been completed
+    // request has been completed or aborted
 }
 
 void TClientEndpoint::RecvResponse(TRecvWr* recv) noexcept
@@ -1269,31 +1511,167 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv) noexcept
     const ui32 responseBytes = msg->ResponseBytes;
 
     Counters->RecvResponseCompleted();
-
-    auto req = ActiveRequests.Pop(reqId);
-    if (!req) {
-        RDMA_WARN(
-            recv << " request not found, last active request id "
-                 << ActiveRequests.GetCurrentId());
-        Counters->Error();
-        RecvResponse(recv);
-        return;
-    }
-    Counters->RequestCompleted();
     RecvResponse(recv);
 
-    RDMA_TRACE("request " << reqId << " completed");
+    // request has been aborted
+    auto req = ActiveRequests.Pop(reqId);
+    if (!req) {
+        return;
+    }
+
+    req->Status = status;
+    req->ResponseBytes = responseBytes;
 
     LWTRACK(
         RecvResponseCompleted,
         req->CallContext->LWOrbit,
         req->CallContext->RequestId);
 
+    if (Config.UseMemoryWindows) {
+        InvalidateBuffers(std::move(req));
+    } else {
+        CompleteRequest(std::move(req));
+    }
+}
+
+void TClientEndpoint::InvalidateBuffers(TRequestPtr req) noexcept
+{
+    req->State = ERequestState::InvalidateBuffers;
+
+    LWTRACK(
+        RequestQueuedForInvalidation,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+
+    InputRequests.Enqueue(std::move(req));
+    Counters->RequestEnqueued();
+
+    if (WaitMode == EWaitMode::Poll) {
+        RequestEvent.Set();
+    }
+}
+
+void TClientEndpoint::CompleteRequest(TRequestPtr req) noexcept
+{
+    RDMA_TRACE("request " << req->ReqId << " completed");
+
+    Counters->RequestCompleted();
+
     auto* handler = req->Handler.get();
-    handler->HandleResponse(
-        std::move(req),
-        status,
-        responseBytes);
+    ui32 status = req->Status;
+    ui32 responseBytes = req->ResponseBytes;
+
+    handler->HandleResponse(std::move(req), status, responseBytes);
+}
+
+void TClientEndpoint::InvalidateInBuffer(
+    TRequestPtr request,
+    TSendWr* send) noexcept
+{
+    auto* req = request.get();
+    req->State = ERequestState::InvalidateInBuffer;
+
+    ActiveRequests.Push(std::move(request));
+    send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_LOCAL_INV,
+        .invalidate_rkey = req->InMemoryWindow->rkey,
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        InvalidateInBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::InvalidateOutBuffer(
+    TRequest* req,
+    TSendWr* send) noexcept
+{
+    req->State = ERequestState::InvalidateOutBuffer;
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_LOCAL_INV,
+        .invalidate_rkey = req->OutMemoryWindow->rkey,
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        InvalidateOutBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::InvalidateCompleted(TSendWr* send) noexcept
+{
+    const ui32 reqId =
+        SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
+    auto* req = ActiveRequests.Get(reqId);
+
+    // request was aborted before invalidate completed
+    if (req == nullptr) {
+        SendQueue.Push(send);
+        return;
+    }
+
+    switch (req->State) {
+        case ERequestState::InvalidateInBuffer:
+            LWTRACK(
+                InvalidateInBufferCompleted,
+                req->CallContext->LWOrbit,
+                req->CallContext->RequestId);
+
+            MemoryWindows.Release(std::move(req->InMemoryWindow));
+            InvalidateOutBuffer(req, send);
+            break;
+
+        case ERequestState::InvalidateOutBuffer:
+            LWTRACK(
+                InvalidateOutBufferCompleted,
+                req->CallContext->LWOrbit,
+                req->CallContext->RequestId);
+
+            SendQueue.Push(send);
+            MemoryWindows.Release(std::move(req->OutMemoryWindow));
+            CompleteRequest(ActiveRequests.Pop(reqId));
+            break;
+
+        default:
+            RDMA_ERROR(
+                "invalidate " << send->wr << " completed in unexpected state "
+                              << req->State);
+
+            SendQueue.Push(send);
+            Counters->Error();
+            Disconnect();
+            return;
+    }
 }
 
 TFuture<void> TClientEndpoint::Stop() noexcept
@@ -1391,6 +1769,10 @@ bool TClientEndpoint::FlushHanging() const
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
     with_lock (AllocationLock) {
+        // destroy memory windows that haven't been invalidated properly
+        req->InMemoryWindow.reset();
+        req->OutMemoryWindow.reset();
+
         SendBuffers.ReleaseBuffer(req->InBuffer);
         RecvBuffers.ReleaseBuffer(req->OutBuffer);
     }

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -110,6 +110,7 @@ enum class ERequestState
 {
     Init,
     Enqueued,
+    Started,
     BindInBuffer,
     BindOutBuffer,
     SendRequest,
@@ -125,6 +126,7 @@ inline IOutputStream& operator<<(IOutputStream& out, ERequestState state)
     static const char* string[] = {
         "Init",
         "Enqueued",
+        "Started",
         "BindInBuffer",
         "BindOutBuffer",
         "SendRequest",
@@ -1284,12 +1286,12 @@ void TClientEndpoint::AbortRequest(
             Counters->RequestAborted();
             break;
 
+        case ERequestState::Started:
         case ERequestState::SendRequest:
             Counters->RequestAborted();
             break;
 
         case ERequestState::InvalidateBuffers:
-            Counters->RequestDequeued();
             Counters->InvalidationDequeued();
             Counters->RequestAborted();
             break;
@@ -1487,12 +1489,12 @@ void TClientEndpoint::StartRequest(TRequestPtr request, TSendWr* send) noexcept
 
     auto* msg = send->Message();
     Zero(*msg);
-
     InitMessageHeader(msg, NegotiatedProtocolVersion);
     msg->ReqId = req->ReqId;
     msg->In = req->InBuffer;
     msg->Out = req->OutBuffer;
 
+    req->State = ERequestState::Started;
     Counters->RequestStarted();
 
     if (Config.UseMemoryWindows) {

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -76,6 +76,34 @@ using TCompletionPollerPtr = std::unique_ptr<TCompletionPoller>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TBindWr
+    : ibv_send_wr
+{
+    TBindWr(
+        ui64 wrId,
+        TPooledBuffer& buf,
+        ibv_mw* mw,
+        ibv_access_flags flags)
+    {
+        Zero(*this);
+
+        wr_id = wrId;
+        opcode = IBV_WR_BIND_MW;
+        bind_mw = {
+            .mw = mw,
+            .rkey = mw->rkey,
+            .bind_info = {
+                .mr = buf.GetMemoryRegion(),
+                .addr = buf.Address,
+                .length = buf.Length,
+                .mw_access_flags = flags,
+            },
+        };
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 enum class ERequestState
 {
     Init,
@@ -617,6 +645,7 @@ private:
     void CompleteRequest(TRequestPtr req) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
+    bool PostSend(TRequest* req, TSendWr* send, ibv_send_wr* wr) noexcept;
     int ValidateCompletion(ibv_wc* wc) noexcept;
     ui64 GetNewReqId() noexcept;
 };
@@ -1309,34 +1338,37 @@ void TClientEndpoint::StartRequest(TRequestPtr request, TSendWr* send) noexcept
     }
 }
 
+// returns true in case of an error
+bool TClientEndpoint::PostSend(
+    TRequest* req,
+    TSendWr* send,
+    ibv_send_wr* wr) noexcept
+{
+    try {
+        Verbs->PostSend(Connection->qp, wr);
+        RDMA_TRACE(*wr << " [request=" << req->ReqId << "]" << " posted");
+        return false;
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(*wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return true;
+    }
+}
+
 void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
 {
     req->State = ERequestState::BindInBuffer;
 
-    ibv_send_wr wr = {
-        .wr_id = send->wr.wr_id,
-        .opcode = IBV_WR_BIND_MW,
-        .bind_mw = {
-            .mw = req->InMemoryWindow.get(),
-            .rkey = req->InMemoryWindow->rkey,
-            .bind_info = {
-                .mr = req->InBuffer.GetMemoryRegion(),
-                .addr = req->InBuffer.Address,
-                .length = req->InBuffer.Length,
-                .mw_access_flags = IBV_ACCESS_REMOTE_READ,
-            },
-        },
-    };
+    TBindWr wr(
+        send->wr.wr_id,
+        req->InBuffer,
+        req->InMemoryWindow.get(),
+        IBV_ACCESS_REMOTE_READ);
 
-    try {
-        Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
-    }
-    catch (const TServiceError& e) {
-        RDMA_ERROR(wr << " " << e.what());
-        SendQueue.Push(send);
-        Counters->Error();
-        Disconnect();
+    if (PostSend(req, send, &wr)) {
         return;
     }
 
@@ -1350,31 +1382,13 @@ void TClientEndpoint::BindOutBuffer(TRequest* req, TSendWr* send) noexcept
 {
     req->State = ERequestState::BindOutBuffer;
 
-    ibv_send_wr wr = {
-        .wr_id = send->wr.wr_id,
-        .opcode = IBV_WR_BIND_MW,
-        .bind_mw = {
-            .mw = req->OutMemoryWindow.get(),
-            .rkey = req->OutMemoryWindow->rkey,
-            .bind_info = {
-                .mr = req->OutBuffer.GetMemoryRegion(),
-                .addr = req->OutBuffer.Address,
-                .length = req->OutBuffer.Length,
-                .mw_access_flags = IBV_ACCESS_REMOTE_WRITE,
-            },
-        },
-    };
+    TBindWr wr(
+        send->wr.wr_id,
+        req->OutBuffer,
+        req->OutMemoryWindow.get(),
+        IBV_ACCESS_REMOTE_WRITE);
 
-    try {
-        Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
-        RDMA_TRACE(wr << " posted");
-    }
-    catch (const TServiceError& e) {
-        RDMA_ERROR(wr << " " << e.what());
-        SendQueue.Push(send);
-        Counters->Error();
-        Disconnect();
+    if (PostSend(req, send, &wr)) {
         return;
     }
 
@@ -1382,6 +1396,22 @@ void TClientEndpoint::BindOutBuffer(TRequest* req, TSendWr* send) noexcept
         BindOutBufferStarted,
         req->CallContext->LWOrbit,
         req->CallContext->RequestId);
+}
+
+void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::RecvResponse;
+
+    if (PostSend(req, send, &send->wr)) {
+        return;
+    }
+
+    LWTRACK(
+        SendRequestStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+
+    Counters->SendRequestStarted();
 }
 
 void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
@@ -1427,30 +1457,6 @@ void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
             Disconnect();
             return;
     }
-}
-
-void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
-{
-    req->State = ERequestState::RecvResponse;
-
-    try {
-        Verbs->PostSend(Connection->qp, &send->wr);
-        RDMA_TRACE(send << " posted");
-    }
-    catch (const TServiceError& e) {
-        RDMA_ERROR(send << " " << e.what());
-        SendQueue.Push(send);
-        Counters->Error();
-        Disconnect();
-        return;
-    }
-
-    LWTRACK(
-        SendRequestStarted,
-        req->CallContext->LWOrbit,
-        req->CallContext->RequestId);
-
-    Counters->SendRequestStarted();
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1580,15 +1586,7 @@ void TClientEndpoint::InvalidateInBuffer(
         .invalidate_rkey = req->InMemoryWindow->rkey,
     };
 
-    try {
-        Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
-    }
-    catch (const TServiceError& e) {
-        RDMA_ERROR(wr << " " << e.what());
-        SendQueue.Push(send);
-        Counters->Error();
-        Disconnect();
+    if (PostSend(req, send, &wr)) {
         return;
     }
 
@@ -1610,15 +1608,7 @@ void TClientEndpoint::InvalidateOutBuffer(
         .invalidate_rkey = req->OutMemoryWindow->rkey,
     };
 
-    try {
-        Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE(wr << " [request=" << req->ReqId << "]" << " posted");
-    }
-    catch (const TServiceError& e) {
-        RDMA_ERROR(wr << " " << e.what());
-        SendQueue.Push(send);
-        Counters->Error();
-        Disconnect();
+    if (PostSend(req, send, &wr)) {
         return;
     }
 

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -367,9 +367,13 @@ struct TEndpointCounters
         QueuedRequests->Dec();
     }
 
-    void SendRequestStarted()
+    void RequestStarted()
     {
         ActiveRequests->Inc();
+    }
+
+    void SendRequestStarted()
+    {
         ActiveSend->Inc();
     }
 
@@ -633,6 +637,7 @@ private:
     void StartRequest(TRequestPtr req, TSendWr* send) noexcept;
     void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
+    void BindBuffers(TRequest* req, TSendWr* send) noexcept;
     void BindInBuffer(TRequest* req, TSendWr* send) noexcept;
     void BindOutBuffer(TRequest* req, TSendWr* send) noexcept;
     void BindCompleted(TSendWr* send) noexcept;
@@ -766,24 +771,25 @@ void TClientEndpoint::CreateQP()
         Verbs->RdmaCreateQP(Connection.get(), &qp_attrs);
     }
 
-    if (Config.UseMemoryWindows && Config.MemoryWindowsPoolSize == 0) {
-        Config.MemoryWindowsPoolSize = Config.SendQueueSize * 2;
-        RDMA_INFO(
-            "MemoryWindowsPoolSize is not configured, set to "
-            << "SendQueueSize * 2 = " << Config.MemoryWindowsPoolSize);
+    int sendFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
+    int recvFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
+
+    if (Config.UseMemoryWindows) {
+        if (Config.MemoryWindowsPoolSize == 0) {
+            Config.MemoryWindowsPoolSize = Config.SendQueueSize * 2;
+            RDMA_INFO(
+                "MemoryWindowsPoolSize is not configured, set to "
+                << "SendQueueSize * 2 = " << Config.MemoryWindowsPoolSize);
+        }
+
+        MemoryWindows.Init(Verbs, Connection->pd, Config.MemoryWindowsPoolSize);
+
+        sendFlags |= IBV_ACCESS_MW_BIND;
+        recvFlags |= IBV_ACCESS_MW_BIND;
     }
 
-    MemoryWindows.Init(Verbs, Connection->pd, Config.MemoryWindowsPoolSize);
-
-    SendBuffers.Init(
-        Verbs,
-        Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_MW_BIND);
-
-    RecvBuffers.Init(
-        Verbs,
-        Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_MW_BIND);
+    SendBuffers.Init(Verbs, Connection->pd, sendFlags);
+    RecvBuffers.Init(Verbs, Connection->pd, recvFlags);
 
     SendBuffer = SendBuffers.AcquireBuffer(
         Config.SendQueueSize * sizeof(TRequestMessage), true);
@@ -1143,6 +1149,9 @@ void TClientEndpoint::AbortRequests() noexcept
         Y_ABORT_UNLESS(req);
         RDMA_DEBUG("abort request " << req->ReqId);
         Counters->RequestDequeued();
+        if (req->State != ERequestState::Init) {
+            Counters->RequestAborted();
+        }
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }
 
@@ -1329,10 +1338,10 @@ void TClientEndpoint::StartRequest(TRequestPtr request, TSendWr* send) noexcept
     msg->In = req->InBuffer;
     msg->Out = req->OutBuffer;
 
+    Counters->RequestStarted();
+
     if (Config.UseMemoryWindows) {
-        req->InMemoryWindow = MemoryWindows.Acquire();
-        req->OutMemoryWindow = MemoryWindows.Acquire();
-        BindInBuffer(req, send);
+        BindBuffers(req, send);
     } else {
         SendRequest(req, send);
     }
@@ -1351,6 +1360,27 @@ bool TClientEndpoint::PostSend(
     }
     catch (const TServiceError& e) {
         RDMA_ERROR(*wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return true;
+    }
+}
+
+void TClientEndpoint::BindBuffers(TRequest* req, TSendWr* send) noexcept
+{
+    try {
+        req->InMemoryWindow = MemoryWindows.Acquire();
+        req->OutMemoryWindow = MemoryWindows.Acquire();
+
+        BindInBuffer(req, send);
+    }
+    catch (TServiceError& e) {
+        RDMA_ERROR(send << " " << e.what());
+
+        req->InMemoryWindow.reset();
+        req->OutMemoryWindow.reset();
+
         SendQueue.Push(send);
         Counters->Error();
         Disconnect();

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -107,9 +107,10 @@ struct TBindWr
 enum class ERequestState
 {
     Init,
+    Enqueued,
     BindInBuffer,
     BindOutBuffer,
-    RecvResponse,
+    SendRequest,
     InvalidateBuffers,
     InvalidateInBuffer,
     InvalidateOutBuffer,
@@ -121,9 +122,10 @@ inline IOutputStream& operator<<(IOutputStream& out, ERequestState state)
 {
     static const char* string[] = {
         "Init",
+        "Enqueued",
         "BindInBuffer",
         "BindOutBuffer",
-        "RecvResponse",
+        "SendRequest",
         "InvalidateBuffers",
         "InvalidateInBuffer",
         "InvalidateOutBuffer",
@@ -344,6 +346,12 @@ struct TEndpointCounters
 
     TDynamicCounters::TCounterPtr Errors;
 
+    TDynamicCounters::TCounterPtr MemoryWindows;
+    TDynamicCounters::TCounterPtr MaxMemoryWindows;
+    TDynamicCounters::TCounterPtr ActiveBinds;
+    TDynamicCounters::TCounterPtr QueuedInvalidations;
+    TDynamicCounters::TCounterPtr ActiveInvalidations;
+
     void Register(TDynamicCounters& counters)
     {
         QueuedRequests = counters.GetCounter("QueuedRequests");
@@ -355,6 +363,56 @@ struct TEndpointCounters
         ActiveRecv = counters.GetCounter("ActiveRecv");
 
         Errors = counters.GetCounter("Errors", true);
+
+        MemoryWindows = counters.GetCounter("MemoryWindows");
+        MaxMemoryWindows = counters.GetCounter("MaxMemoryWindows");
+        ActiveBinds = counters.GetCounter("ActiveBinds");
+        QueuedInvalidations = counters.GetCounter("QueuedInvalidations");
+        ActiveInvalidations = counters.GetCounter("ActiveInvalidations");
+    }
+
+    void AcquireMemoryWindow()
+    {
+        auto cur = MemoryWindows->Inc();
+
+        if (cur > MaxMemoryWindows->Val()) {
+            MaxMemoryWindows->Set(cur);
+        }
+    }
+
+    void ReleaseMemoryWindow()
+    {
+        MemoryWindows->Dec();
+    }
+
+    void BindStarted()
+    {
+        ActiveBinds->Inc();
+    }
+
+    void BindCompleted()
+    {
+        ActiveBinds->Dec();
+    }
+
+    void InvalidationEnqueued()
+    {
+        QueuedInvalidations->Inc();
+    }
+
+    void InvalidationDequeued()
+    {
+        QueuedInvalidations->Dec();
+    }
+
+    void InvalidationStarted()
+    {
+        ActiveInvalidations->Inc();
+    }
+
+    void InvalidationCompleted()
+    {
+        ActiveInvalidations->Dec();
     }
 
     void RequestEnqueued()
@@ -651,6 +709,7 @@ private:
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     bool PostSend(TRequest* req, TSendWr* send, ibv_send_wr* wr) noexcept;
+    void HandleSendError(TSendWr* send) noexcept;
     int ValidateCompletion(ibv_wc* wc) noexcept;
     ui64 GetNewReqId() noexcept;
 };
@@ -980,6 +1039,7 @@ ui64 TClientEndpoint::SendRequest(
         req->CallContext->RequestId);
 
     Counters->RequestEnqueued();
+    req->State = ERequestState::Enqueued;
     InputRequests.Enqueue(std::move(req));
 
     if (WaitMode == EWaitMode::Poll) {
@@ -1011,8 +1071,6 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
         while (QueuedRequests) {
             auto req = QueuedRequests.Dequeue();
             Y_ABORT_UNLESS(req);
-
-            Counters->RequestDequeued();
             AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
         }
         return;
@@ -1031,11 +1089,12 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
         Counters->RequestDequeued();
 
         switch (req->State) {
-            case ERequestState::Init:
+            case ERequestState::Enqueued:
                 StartRequest(std::move(req), send);
                 break;
 
             case ERequestState::InvalidateBuffers:
+                Counters->InvalidationDequeued();
                 InvalidateInBuffer(std::move(req), send);
                 break;
 
@@ -1107,7 +1166,6 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
     cancelled.Append(QueuedRequests.DequeueIf(wasCancelled));
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
-        Counters->RequestDequeued();
         AbortRequest(std::move(req), E_CANCELLED, "request was cancelled");
     }
 
@@ -1115,7 +1173,6 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
     cancelled.Append(ActiveRequests.PopCancelledRequests(clientRequestIdToCancel));
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
-        Counters->RequestAborted();
         AbortRequest(std::move(req), E_CANCELLED, "request was cancelled");
     }
 
@@ -1148,16 +1205,11 @@ void TClientEndpoint::AbortRequests() noexcept
         auto req = QueuedRequests.Dequeue();
         Y_ABORT_UNLESS(req);
         RDMA_DEBUG("abort request " << req->ReqId);
-        Counters->RequestDequeued();
-        if (req->State != ERequestState::Init) {
-            Counters->RequestAborted();
-        }
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }
 
     while (auto req = ActiveRequests.Pop()) {
         RDMA_DEBUG("abort request " << req->ReqId);
-        Counters->RequestAborted();
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }
 }
@@ -1171,6 +1223,38 @@ void TClientEndpoint::AbortRequest(
     // remote write can succeed after this point
     if (req->OutMemoryWindow) {
         req->OutMemoryWindow.reset();
+        Counters->ReleaseMemoryWindow();
+    }
+
+    switch (req->State) {
+        case ERequestState::Init:
+            break;
+
+        case ERequestState::Enqueued:
+            Counters->RequestDequeued();
+            break;
+
+        case ERequestState::BindInBuffer:
+        case ERequestState::BindOutBuffer:
+            Counters->BindCompleted();
+            Counters->RequestAborted();
+            break;
+
+        case ERequestState::SendRequest:
+            Counters->RequestAborted();
+            break;
+
+        case ERequestState::InvalidateBuffers:
+            Counters->RequestDequeued();
+            Counters->InvalidationDequeued();
+            Counters->RequestAborted();
+            break;
+
+        case ERequestState::InvalidateInBuffer:
+        case ERequestState::InvalidateOutBuffer:
+            Counters->InvalidationCompleted();
+            Counters->RequestAborted();
+            break;
     }
 
     auto len = SerializeError(
@@ -1209,6 +1293,36 @@ bool TClientEndpoint::HandleCompletionEvents() noexcept
     return false;
 }
 
+void TClientEndpoint::HandleSendError(TSendWr* send) noexcept
+{
+    const ui32 reqId =
+        SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
+
+    if (auto* req = ActiveRequests.Get(reqId)) {
+        switch (req->State) {
+            case ERequestState::BindInBuffer:
+            case ERequestState::BindOutBuffer:
+                Counters->BindCompleted();
+                break;
+
+            case ERequestState::SendRequest:
+                Counters->SendRequestCompleted();
+                break;
+
+            case ERequestState::InvalidateInBuffer:
+            case ERequestState::InvalidateOutBuffer:
+                Counters->InvalidationCompleted();
+                break;
+
+            default:
+                RDMA_ERROR(
+                    send->wr.wr_id << " unexpected request " << reqId
+                                   << " state " << req->State);
+        }
+    }
+    SendQueue.Push(send);
+}
+
 int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
 {
     auto id = TWorkRequestId(wc->wr_id);
@@ -1218,15 +1332,13 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
 
         if (wc->status == IBV_WC_WR_FLUSH_ERR) {
             RDMA_TRACE(send << " " << NVerbs::GetStatusString(wc->status));
-            Counters->SendRequestCompleted();
-            SendQueue.Push(send);
+            HandleSendError(send);
             return -1;
         }
         if (wc->status != IBV_WC_SUCCESS) {
             RDMA_ERROR(send << " " << NVerbs::GetStatusString(wc->status));
             Counters->Error();
-            Counters->SendRequestCompleted();
-            SendQueue.Push(send);
+            HandleSendError(send);
             return -1;
         }
         if (wc->opcode != IBV_WC_SEND && wc->opcode != IBV_WC_BIND_MW &&
@@ -1236,8 +1348,7 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
                 send << " unexpected opcode "
                      << NVerbs::GetOpcodeName(wc->opcode));
             Counters->Error();
-            Counters->SendRequestCompleted();
-            SendQueue.Push(send);
+            HandleSendError(send);
             return -1;
         }
         return 0;
@@ -1370,26 +1481,32 @@ bool TClientEndpoint::PostSend(
 void TClientEndpoint::BindBuffers(TRequest* req, TSendWr* send) noexcept
 {
     try {
+        // buffers have to fit at least TProtoHeader, so they can't be empty
         req->InMemoryWindow = MemoryWindows.Acquire();
+        Counters->AcquireMemoryWindow();
+
         req->OutMemoryWindow = MemoryWindows.Acquire();
+        Counters->AcquireMemoryWindow();
 
         BindInBuffer(req, send);
     }
-    catch (TServiceError& e) {
+    catch (const TServiceError& e) {
         RDMA_ERROR(send << " " << e.what());
 
-        req->InMemoryWindow.reset();
-        req->OutMemoryWindow.reset();
+        if (req->InMemoryWindow) {
+            req->InMemoryWindow.reset();
+            Counters->ReleaseMemoryWindow();
+        }
 
         SendQueue.Push(send);
         Counters->Error();
         Disconnect();
-        return true;
     }
 }
 
 void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
 {
+    Counters->BindStarted();
     req->State = ERequestState::BindInBuffer;
 
     TBindWr wr(
@@ -1430,7 +1547,7 @@ void TClientEndpoint::BindOutBuffer(TRequest* req, TSendWr* send) noexcept
 
 void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
 {
-    req->State = ERequestState::RecvResponse;
+    req->State = ERequestState::SendRequest;
 
     if (PostSend(req, send, &send->wr)) {
         return;
@@ -1472,6 +1589,8 @@ void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
                 BindOutBufferCompleted,
                 req->CallContext->LWOrbit,
                 req->CallContext->RequestId);
+
+            Counters->BindCompleted();
 
             send->Message()->Out.RKey = req->OutMemoryWindow->rkey;
             SendRequest(req, send);
@@ -1579,8 +1698,11 @@ void TClientEndpoint::InvalidateBuffers(TRequestPtr req) noexcept
         req->CallContext->LWOrbit,
         req->CallContext->RequestId);
 
+    RDMA_TRACE("invalidate request " << req->ReqId << " buffers");
+
     InputRequests.Enqueue(std::move(req));
     Counters->RequestEnqueued();
+    Counters->InvalidationEnqueued();
 
     if (WaitMode == EWaitMode::Poll) {
         RequestEvent.Set();
@@ -1606,6 +1728,7 @@ void TClientEndpoint::InvalidateInBuffer(
 {
     auto* req = request.get();
     req->State = ERequestState::InvalidateInBuffer;
+    Counters->InvalidationStarted();
 
     ActiveRequests.Push(std::move(request));
     send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
@@ -1668,6 +1791,7 @@ void TClientEndpoint::InvalidateCompleted(TSendWr* send) noexcept
                 req->CallContext->RequestId);
 
             MemoryWindows.Release(std::move(req->InMemoryWindow));
+            Counters->ReleaseMemoryWindow();
             InvalidateOutBuffer(req, send);
             break;
 
@@ -1679,6 +1803,8 @@ void TClientEndpoint::InvalidateCompleted(TSendWr* send) noexcept
 
             SendQueue.Push(send);
             MemoryWindows.Release(std::move(req->OutMemoryWindow));
+            Counters->ReleaseMemoryWindow();
+            Counters->InvalidationCompleted();
             CompleteRequest(ActiveRequests.Pop(reqId));
             break;
 
@@ -1789,9 +1915,15 @@ bool TClientEndpoint::FlushHanging() const
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
     with_lock (AllocationLock) {
-        // destroy memory windows that haven't been invalidated properly
-        req->InMemoryWindow.reset();
-        req->OutMemoryWindow.reset();
+        // destroy memory windows that haven't been properly invalidated
+        if (req->InMemoryWindow) {
+            req->InMemoryWindow.reset();
+            Counters->ReleaseMemoryWindow();
+        }
+        if (req->OutMemoryWindow) {
+            req->OutMemoryWindow.reset();
+            Counters->ReleaseMemoryWindow();
+        }
 
         SendBuffers.ReleaseBuffer(req->InBuffer);
         RecvBuffers.ReleaseBuffer(req->OutBuffer);
@@ -2187,7 +2319,7 @@ private:
             for (auto& request: requests) {
                 const ui32 reqId = request->ReqId;
                 RDMA_DEBUG(endpoint->Log, "request " << reqId << " timed out");
-                endpoint->Counters->RequestAborted();
+
                 endpoint->AbortRequest(
                     std::move(request),
                     E_TIMEOUT,

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -1566,6 +1566,18 @@ TEST(TRdmaClientTest, ShouldBindAndInvalidateBuffers)
         ASSERT_GE(6, bound);
         ASSERT_EQ(2, invalidated);
         ASSERT_EQ(4, destroyed);
+
+        // validate relevant counters
+        auto counters = GetClientCounters(monitoring);
+
+        while (counters->GetCounter("ActiveBinds")->Val() != 0 ||
+               counters->GetCounter("QueuedInvalidations")->Val() != 0 ||
+               counters->GetCounter("ActiveInvalidations")->Val() != 0 ||
+               counters->GetCounter("MemoryWindows")->Val() != 0 ||
+               counters->GetCounter("MaxMemoryWindows")->Val() != 2)
+        {
+            SpinLockPause();
+        }
 }
 
 }   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -1499,7 +1499,7 @@ TEST(TRdmaClientTest, ShouldBindAndInvalidateBuffers)
             }
         };
 
-        // normal completion will invalidate it's buffers
+        // normal completion will invalidate its buffers
         auto response1 = std::make_shared<TResponse>();
         auto request1 = endpoint->AllocateRequest(
             response1,

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -1076,7 +1076,7 @@ TEST(TRdmaClientTest, ShouldHandleErrors)
             context->CompletionHandle.Set();
         }
 
-        while (errors->Val() != 7 || active->Val() != 6) {
+        while (errors->Val() != 6 || active->Val() != 6) {
             SpinLockPause();
         }
 }
@@ -1399,6 +1399,173 @@ TEST(TRdmaClientTest, ShouldDisconnectOnUnknownProtocolVersionInRejectMessage)
     }
 
     ASSERT_GE(connectAttempts.load(), 1);
+}
+
+TEST(TRdmaClientTest, ShouldBindAndInvalidateBuffers)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 1s;
+
+        auto logging =
+            CreateLoggingService("console", TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(verbs, logging, monitoring, clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        std::atomic<int> bound = 0;
+        std::atomic<int> invalidated = 0;
+        std::atomic<int> destroyed = 0;
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            Y_UNUSED(qp);
+
+            auto guard = Guard(testContext->CompletionLock);
+
+            switch (wr->opcode) {
+                case IBV_WR_BIND_MW:
+                    bound++;
+                    break;
+
+                case IBV_WR_LOCAL_INV:
+                    invalidated++;
+                    break;
+
+                default:
+                    testContext->ReqIds.push_back(
+                        reinterpret_cast<TRequestMessage*>(wr->sg_list[0].addr)
+                            ->ReqId);
+            }
+
+            testContext->SendEvents.push_back(new ibv_send_wr(*wr));
+            testContext->CompletionHandle.Set();
+        };
+
+        testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
+            Y_UNUSED(mw);
+            destroyed++;
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        struct TResponse: IClientHandler
+        {
+            ui32 Status = 0;
+            TManualEvent Received;
+
+            void HandleResponse(
+                TClientRequestPtr req,
+                ui32 status,
+                size_t responseBytes) override
+            {
+                Y_UNUSED(req);
+                Y_UNUSED(responseBytes);
+
+                Status = status;
+                Received.Signal();
+            }
+        };
+
+        auto handleRequest = [&]()
+        {
+            while (true) {
+                with_lock (testContext->CompletionLock) {
+                    if (testContext->RecvEvents && testContext->ReqIds) {
+                        auto* recv = testContext->RecvEvents.front();
+                        auto* response = reinterpret_cast<TResponseMessage*>(
+                            recv->sg_list[0].addr);
+                        Zero(*response);
+                        InitMessageHeader(response, RDMA_PROTO_VERSION);
+                        response->ReqId = testContext->ReqIds.front();
+
+                        testContext->ReqIds.pop_front();
+                        testContext->RecvEvents.pop_front();
+                        testContext->ProcessedRecvEvents.push_back(recv);
+                        testContext->CompletionHandle.Set();
+                        break;
+                    }
+                }
+            }
+        };
+
+        // normal completion will invalidate it's buffers
+        auto response1 = std::make_shared<TResponse>();
+        auto request1 = endpoint->AllocateRequest(
+            response1,
+            std::make_unique<TNullContext>(),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request1.GetError()));
+
+        endpoint->SendRequest(
+            request1.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        handleRequest();
+
+        ASSERT_TRUE(response1->Received.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_OK), response1->Status);
+        ASSERT_EQ(2, bound);
+        ASSERT_EQ(2, invalidated);
+        ASSERT_EQ(0, destroyed);
+
+        // timeout will result in memory windows destruction
+        auto response2 = std::make_shared<TResponse>();
+        auto request2 = endpoint->AllocateRequest(
+            response2,
+            std::make_unique<TNullContext>(),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request2.GetError()));
+
+        endpoint->SendRequest(
+            request2.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        // do not complete request to trigger timeout
+        ASSERT_TRUE(response2->Received.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response2->Status);
+        ASSERT_EQ(4, bound);
+        ASSERT_EQ(2, invalidated);
+        ASSERT_EQ(2, destroyed);
+
+        // complete request to drain the test transport
+        handleRequest();
+
+        // cancellation will also result in memory windows destruction
+        auto response3 = std::make_shared<TResponse>();
+        auto request3 = endpoint->AllocateRequest(
+            response3,
+            std::make_unique<TNullContext>(),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request3.GetError()));
+
+        auto requestId3 = endpoint->SendRequest(
+            request3.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        endpoint->CancelRequest(requestId3);
+
+        ASSERT_TRUE(response3->Received.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response3->Status);
+
+        // request can get cancelled at any stage, so `bound` can be anything
+        // between 4 and 6
+        ASSERT_GE(6, bound);
+        ASSERT_EQ(2, invalidated);
+        ASSERT_EQ(4, destroyed);
 }
 
 }   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/memory_window.cpp
+++ b/cloud/storage/core/libs/rdma/impl/memory_window.cpp
@@ -1,0 +1,39 @@
+#include "memory_window.h"
+
+namespace NCloud::NStorage::NRdma {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TMemoryWindowsPool::Init(
+    NVerbs::IVerbsPtr verbs,
+    ibv_pd* protectionDomain,
+    size_t capacity)
+{
+    Verbs = verbs;
+    ProtectionDomain = protectionDomain;
+    Capacity = capacity;
+}
+
+NVerbs::TMemoryWindowPtr TMemoryWindowsPool::Acquire()
+{
+    if (Pool.size()) {
+        auto window = std::move(Pool.front());
+        Pool.pop_front();
+        return window;
+    }
+    return Verbs->CreateMemoryWindow(ProtectionDomain);
+}
+
+void TMemoryWindowsPool::Release(NVerbs::TMemoryWindowPtr window)
+{
+    if (window && Pool.size() < Capacity) {
+        Pool.emplace_back(std::move(window));
+    }
+}
+
+void TMemoryWindowsPool::Clear()
+{
+    Pool.clear();
+}
+
+}   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/memory_window.cpp
+++ b/cloud/storage/core/libs/rdma/impl/memory_window.cpp
@@ -1,5 +1,7 @@
 #include "memory_window.h"
 
+#include <cloud/storage/common/libs/common/error.h>
+
 namespace NCloud::NStorage::NRdma {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -21,7 +23,9 @@ NVerbs::TMemoryWindowPtr TMemoryWindowsPool::Acquire()
         Pool.pop_front();
         return window;
     }
-    return Verbs->CreateMemoryWindow(ProtectionDomain);
+    if (Verbs && ProtectionDomain) {
+        return Verbs->CreateMemoryWindow(ProtectionDomain);
+    }
 }
 
 void TMemoryWindowsPool::Release(NVerbs::TMemoryWindowPtr window)

--- a/cloud/storage/core/libs/rdma/impl/memory_window.cpp
+++ b/cloud/storage/core/libs/rdma/impl/memory_window.cpp
@@ -1,6 +1,6 @@
 #include "memory_window.h"
 
-#include <cloud/storage/common/libs/common/error.h>
+#include <cloud/storage/core/libs/common/error.h>
 
 namespace NCloud::NStorage::NRdma {
 
@@ -23,9 +23,10 @@ NVerbs::TMemoryWindowPtr TMemoryWindowsPool::Acquire()
         Pool.pop_front();
         return window;
     }
-    if (Verbs && ProtectionDomain) {
-        return Verbs->CreateMemoryWindow(ProtectionDomain);
+    if (!Verbs || !ProtectionDomain) {
+        STORAGE_THROW_SERVICE_ERROR(E_INVALID_STATE) << "not initialized";
     }
+    return Verbs->CreateMemoryWindow(ProtectionDomain);
 }
 
 void TMemoryWindowsPool::Release(NVerbs::TMemoryWindowPtr window)

--- a/cloud/storage/core/libs/rdma/impl/memory_window.h
+++ b/cloud/storage/core/libs/rdma/impl/memory_window.h
@@ -12,14 +12,15 @@ namespace NCloud::NStorage::NRdma {
 class TMemoryWindowsPool
 {
 private:
-    NVerbs::IVerbsPtr Verbs = NVerbs::NullPtr;
+    NVerbs::IVerbsPtr Verbs;
     ibv_pd* ProtectionDomain = nullptr;
     size_t Capacity = 0;
 
     std::deque<NVerbs::TMemoryWindowPtr> Pool;
 
 public:
-    void Init(NVerbs::IVerbsPtr, ibv_pd* protectionDomain, size_t capacity);
+    void
+    Init(NVerbs::IVerbsPtr verbs, ibv_pd* protectionDomain, size_t capacity);
 
     NVerbs::TMemoryWindowPtr Acquire();
     void Release(NVerbs::TMemoryWindowPtr window);

--- a/cloud/storage/core/libs/rdma/impl/memory_window.h
+++ b/cloud/storage/core/libs/rdma/impl/memory_window.h
@@ -12,9 +12,9 @@ namespace NCloud::NStorage::NRdma {
 class TMemoryWindowsPool
 {
 private:
-    NVerbs::IVerbsPtr Verbs;
-    ibv_pd* ProtectionDomain;
-    size_t Capacity;
+    NVerbs::IVerbsPtr Verbs = NVerbs::NullPtr;
+    ibv_pd* ProtectionDomain = nullptr;
+    size_t Capacity = 0;
 
     std::deque<NVerbs::TMemoryWindowPtr> Pool;
 

--- a/cloud/storage/core/libs/rdma/impl/memory_window.h
+++ b/cloud/storage/core/libs/rdma/impl/memory_window.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "public.h"
+#include "verbs.h"
+
+#include <deque>
+
+namespace NCloud::NStorage::NRdma {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TMemoryWindowsPool
+{
+private:
+    NVerbs::IVerbsPtr Verbs;
+    ibv_pd* ProtectionDomain;
+    size_t Capacity;
+
+    std::deque<NVerbs::TMemoryWindowPtr> Pool;
+
+public:
+    void Init(NVerbs::IVerbsPtr, ibv_pd* protectionDomain, size_t capacity);
+
+    NVerbs::TMemoryWindowPtr Acquire();
+    void Release(NVerbs::TMemoryWindowPtr window);
+    void Clear();
+};
+
+}   // namespace NCloud::NStorage::NRdma

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -163,6 +163,12 @@ struct TTestVerbs
         };
     }
 
+    TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) override
+    {
+        Y_UNUSED(pd);
+        return NullPtr;
+    }
+
     struct TCompletionChannel
         : ibv_comp_channel
     {

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -163,6 +163,37 @@ struct TTestVerbs
         };
     }
 
+    struct TMemoryWindow
+        : ibv_mw
+    {
+        TTestContextPtr TestContext;
+
+        TMemoryWindow(ibv_pd* pd, TTestContextPtr testContext)
+            : TestContext(std::move(testContext))
+        {
+            Y_UNUSED(pd);
+            rkey = TestContext->RKey++;
+        }
+
+        static int Destroy(ibv_mw* mw)
+        {
+            auto* window = static_cast<TMemoryWindow*>(mw);
+            if (window->TestContext->DestroyMemoryWindow) {
+                window->TestContext->DestroyMemoryWindow(mw);
+            }
+            delete window;
+            return 0;
+        }
+    };
+
+    TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) override
+    {
+        return {
+            static_cast<ibv_mw*>(new TMemoryWindow(pd, TestContext)),
+            TMemoryWindow::Destroy,
+        };
+    }
+
     struct TCompletionChannel
         : ibv_comp_channel
     {
@@ -270,6 +301,12 @@ struct TTestVerbs
                     break;
                 case IBV_WR_RDMA_WRITE:
                     handleEvent(x->wr_id, IBV_WC_RDMA_WRITE);
+                    break;
+                case IBV_WR_BIND_MW:
+                    handleEvent(x->wr_id, IBV_WC_BIND_MW);
+                    break;
+                case IBV_WR_LOCAL_INV:
+                    handleEvent(x->wr_id, IBV_WC_LOCAL_INV);
                     break;
                 default:
                     handleEvent(x->wr_id, IBV_WC_SEND);

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -37,6 +37,7 @@ struct TTestContext: TAtomicRefCount<TTestContext>
     TDeque<ibv_recv_wr*> ProcessedRecvEvents;
     TSpinLock CompletionLock;
     TAtomic PostRecvCounter = 0;
+    std::atomic<ui32> RKey = 0;
 
     std::function<void(ibv_qp* qp, ibv_send_wr* wr)> PostSend;
     std::function<void(ibv_qp* qp, ibv_recv_wr* wr)> PostRecv;
@@ -51,6 +52,7 @@ struct TTestContext: TAtomicRefCount<TTestContext>
     std::function<void(ibv_qp* qp, ibv_qp_attr* attr, int mask)> ModifyQP;
     std::function<void(ibv_pd* pd, void* addr, size_t length, int flags)>
         RegisterMemoryRegion;
+    std::function<void(ibv_mw* mw)> DestroyMemoryWindow;
 
     // If set, called when TTestVerbs resolves address/route.
     std::function<void(

--- a/cloud/storage/core/libs/rdma/impl/verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/verbs.cpp
@@ -80,6 +80,15 @@ struct TVerbs
         return WrapPtr(mr);
     }
 
+    TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) override
+    {
+        auto* mw = ibv_alloc_mw(pd, IBV_MW_TYPE_2);
+        if (!mw) {
+            RDMA_THROW_ERROR("ibv_alloc_mw");
+        }
+        return WrapPtr(mw);
+    }
+
     TCompletionChannelPtr CreateCompletionChannel(ibv_context* context) override
     {
         auto* channel = ibv_create_comp_channel(context);
@@ -404,6 +413,11 @@ IVerbsPtr CreateVerbs()
     return std::make_shared<TVerbs>();
 }
 
+int DestroyId(rdma_cm_id* id)
+{
+    return rdma_destroy_id(id);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 const char* GetOpcodeName(ibv_wc_opcode opcode)
@@ -540,11 +554,6 @@ TString PrintCompletion(ibv_wc* wc)
         << " status=" << GetStatusString(wc->status)
         << " vendor_err=" << wc->vendor_err
         << "]";
-}
-
-int DestroyId(rdma_cm_id* id)
-{
-    return rdma_destroy_id(id);
 }
 
 }   // namespace NCloud::NStorage::NRdma::NVerbs

--- a/cloud/storage/core/libs/rdma/impl/verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/verbs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "public.h"
+#include "work_queue.h"
 
 #include <util/datetime/base.h>
 #include <util/generic/string.h>
@@ -26,6 +27,7 @@ RDMA_DECLARE_PTR(Context, ibv_context, ibv_close_device);
 RDMA_DECLARE_PTR(DeviceList, ibv_device*, ibv_free_device_list);
 RDMA_DECLARE_PTR(ProtectionDomain, ibv_pd, ibv_dealloc_pd);
 RDMA_DECLARE_PTR(MemoryRegion, ibv_mr, ibv_dereg_mr);
+RDMA_DECLARE_PTR(MemoryWindow, ibv_mw, ibv_dealloc_mw);
 RDMA_DECLARE_PTR(CompletionChannel, ibv_comp_channel, ibv_destroy_comp_channel);
 RDMA_DECLARE_PTR(CompletionQueue, ibv_cq, ibv_destroy_cq);
 RDMA_DECLARE_PTR(AddressInfo, rdma_addrinfo, rdma_freeaddrinfo);
@@ -70,6 +72,7 @@ struct IVerbs
         void* addr,
         size_t length,
         int flags) = 0;
+    virtual TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) = 0;
 
     virtual TCompletionChannelPtr CreateCompletionChannel(
         ibv_context* context) = 0;
@@ -149,3 +152,39 @@ TString PrintConnectionParams(const rdma_conn_param* param);
 TString PrintCompletion(ibv_wc* wc);
 
 }   // namespace NCloud::NStorage::NRdma::NVerbs
+
+inline IOutputStream& operator<<(IOutputStream& out, ibv_wr_opcode opcode)
+{
+    static const char* string[] = {
+        "RDMA_WRITE",
+        "RDMA_WRITE_WITH_IMM",
+        "SEND",
+        "SEND_WITH_IMM",
+        "RDMA_READ",
+        "ATOMIC_CMP_AND_SWP",
+        "ATOMIC_FETCH_AND_ADD",
+        "LOCAL_INV",
+        "BIND_MW",
+        "SEND_WITH_INV",
+        "TSO",
+        "DRIVER1",
+        "FLUSH",
+        "ATOMIC_WRITE",
+    };
+
+    if ((size_t)opcode < Y_ARRAY_SIZE(string)) {
+        return out << string[(size_t)opcode];
+    }
+
+    return out << "UNKNOWN";
+}
+
+inline IOutputStream& operator<<(IOutputStream& out, ibv_wc_opcode opcode)
+{
+    return out << NCloud::NStorage::NRdma::NVerbs::GetOpcodeName(opcode);
+}
+
+inline IOutputStream& operator<<(IOutputStream& out, const ibv_send_wr& send)
+{
+    return out << send.opcode << " " << NCloud::NStorage::NRdma::TWorkRequestId(send.wr_id);
+}

--- a/cloud/storage/core/libs/rdma/impl/ya.make
+++ b/cloud/storage/core/libs/rdma/impl/ya.make
@@ -6,6 +6,7 @@ SRCS(
     client.cpp
     event.cpp
     list.cpp
+    memory_window.cpp
     observability.cpp
     poll.cpp
     rcu.cpp

--- a/cloud/storage/core/protos/rdma.proto
+++ b/cloud/storage/core/protos/rdma.proto
@@ -107,15 +107,21 @@ message TRdmaClient
     // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 7].
     uint32 QpRetryCount = 18;
+
     // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 7].
     uint32 QpRnrRetryCount = 19;
+
     // Sets the "timeout" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 31].
     // The resulting timeout is calculated as 4096*2^{QpTimeout} microseconds.
     // 0 means infinite timeout.
     uint32 QpTimeout = 20;
+
     // Sets the "min_rnr_timer" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 31].
     uint32 QpMinRnrTimer = 21;
+
+    // quick way to invalidate request buffers without heavy ibv_dereg_mr call
+    bool UseMemoryWindows = 22;
 }

--- a/cloud/storage/core/protos/rdma.proto
+++ b/cloud/storage/core/protos/rdma.proto
@@ -107,15 +107,25 @@ message TRdmaClient
     // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 7].
     uint32 QpRetryCount = 18;
+
     // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 7].
     uint32 QpRnrRetryCount = 19;
+
     // Sets the "timeout" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 31].
     // The resulting timeout is calculated as 4096*2^{QpTimeout} microseconds.
     // 0 means infinite timeout.
     uint32 QpTimeout = 20;
+
     // Sets the "min_rnr_timer" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 31].
     uint32 QpMinRnrTimer = 21;
+
+    // Use memory windows to invalidate request buffers after completion.
+    bool UseMemoryWindows = 22;
+
+    // Size of the memory windows pool. If not specified or 0, will be set to
+    // SendQueueSize * 2.
+    uint32 MemoryWindowsPoolSize = 23;
 }


### PR DESCRIPTION
use memory windows to invalidate request buffers
#5729 
