### PR TITLE
[Filestore] Inject index tablet database failures

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -848,4 +848,8 @@ message TStorageConfig
 
     // Pass data buffer to the tablet as a message payload
     optional bool ExternalWriteDataPayloadEnabled = 526;
+
+    // Enables injecting of errors in TIndexTabletDatabase. Must be only used in tests!
+    optional bool FakeTxPageFaultsEnabled = 527;
+    optional double FakeTxPageFaultsProbabilityPercentage = 528;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -851,5 +851,5 @@ message TStorageConfig
 
     // Enables injecting of errors in TIndexTabletDatabase. Must be only used in tests!
     optional bool FakeTxPageFaultsEnabled = 527;
-    optional double FakeTxPageFaultsProbabilityPercentage = 528;
+    optional double FakeTxPageFaultsProbability = 528;
 }

--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -850,6 +850,5 @@ message TStorageConfig
     optional bool ExternalWriteDataPayloadEnabled = 526;
 
     // Enables injecting of errors in TIndexTabletDatabase. Must be only used in tests!
-    optional bool FakeTxPageFaultsEnabled = 527;
-    optional double FakeTxPageFaultsProbability = 528;
+    optional double FakeTxPageFaultsProbability = 527;
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -384,7 +384,6 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
                                                                                \
     xxx(ExternalWriteDataPayloadEnabled,               bool,    false         )\
-    xxx(FakeTxPageFaultsEnabled,                       bool,    false         )\
     xxx(FakeTxPageFaultsProbability,                   double,   0            )\
 // FILESTORE_STORAGE_CONFIG
 

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -385,7 +385,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
                                                                                \
     xxx(ExternalWriteDataPayloadEnabled,               bool,    false         )\
     xxx(FakeTxPageFaultsEnabled,                       bool,    false         )\
-    xxx(FakeTxPageFaultsProbabilityPercentage,         double,   0            )\
+    xxx(FakeTxPageFaultsProbability,                   double,   0            )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -384,6 +384,8 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(SoftBackpressureMaxReadIops,                   ui32,    100'000       )\
                                                                                \
     xxx(ExternalWriteDataPayloadEnabled,               bool,    false         )\
+    xxx(FakeTxPageFaultsEnabled,                       bool,    false         )\
+    xxx(FakeTxPageFaultsProbabilityPercentage,         double,   0            )\
 // FILESTORE_STORAGE_CONFIG
 
 #define FILESTORE_STORAGE_CONFIG_REF(xxx)                                      \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -441,7 +441,6 @@ public:
 
     [[nodiscard]] bool GetExternalWriteDataPayloadEnabled() const;
 
-    [[nodiscard]] bool GetFakeTxPageFaultsEnabled() const;
     [[nodiscard]] double GetFakeTxPageFaultsProbability() const;
 };
 

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -440,6 +440,9 @@ public:
     ui32 GetSoftBackpressureMaxReadIops() const;
 
     [[nodiscard]] bool GetExternalWriteDataPayloadEnabled() const;
+
+    [[nodiscard]] bool GetFakeTxPageFaultsEnabled() const;
+    [[nodiscard]] double GetFakeTxPageFaultsProbabilityPercentage() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -442,7 +442,7 @@ public:
     [[nodiscard]] bool GetExternalWriteDataPayloadEnabled() const;
 
     [[nodiscard]] bool GetFakeTxPageFaultsEnabled() const;
-    [[nodiscard]] double GetFakeTxPageFaultsProbabilityPercentage() const;
+    [[nodiscard]] double GetFakeTxPageFaultsProbability() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet.h
+++ b/cloud/filestore/libs/storage/core/tablet.h
@@ -143,26 +143,6 @@ protected:
             Generation = tx.Generation;
             Step = tx.Step;
 
-            // Reschedule (restart) the transaction from PrepareTx when the
-            // injected rescheduler asks for it. In production this is a no-op
-            // stub; tests inject an implementation to make the transaction
-            // restart/reorder path.
-            if (Self->TxRescheduler->ShouldReschedule()) {
-                LOG_INFO(
-                    ctx,
-                    T::LogComponent,
-                    "[%lu] Forced reschedule of %s (gen: %u, step: %u)",
-                    Self->TabletID(),
-                    TTx::Name,
-                    Generation,
-                    Step);
-
-                Args.Clear();
-                Args.OnRestart();
-                tx.Reschedule();
-                return false;
-            }
-
             TX_TRACK(TxPrepare);
             LOG_TRACE(ctx, T::LogComponent,
                 "[%lu] PrepareTx %s (gen: %u, step: %u)",
@@ -176,6 +156,27 @@ protected:
 
                 Args.Clear();
                 Args.OnRestart();
+
+                // Reschedules the transaction from PrepareTx assuming the
+                // rescheduler was triggered during PrepareTx() call.
+                if (Y_UNLIKELY(
+                        Self->TxRescheduler &&
+                        Self->TxRescheduler->IsTriggered()))
+                {
+                    Self->TxRescheduler->Reset();
+                    LOG_DEBUG(
+                        ctx,
+                        T::LogComponent,
+                        "[%lu] Forced reschedule of %s (gen: %u, step: %u, "
+                        "random seed=%lu)",
+                        Self->TabletID(),
+                        TTx::Name,
+                        Generation,
+                        Step,
+                        Self->TxRescheduler->GetSeed());
+                    tx.Reschedule();
+                }
+
                 return false;
             }
 

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
@@ -28,9 +28,9 @@ private:
     TMersenne<ui64> RandomGen;
 
 public:
-    explicit TRandomTxRescheduler(float probabilityPercentage,
+    explicit TRandomTxRescheduler(double probability,
                                   std::optional<ui64> randomSeed)
-        : Probability(probabilityPercentage / 100.0)
+        : Probability(std::clamp(probability, 0.0, 1.0))
         , Seed(randomSeed ? *randomSeed : RandomNumber<ui64>())
         , RandomGen(Seed)
     {
@@ -66,7 +66,7 @@ public:
 ITxReschedulerPtr CreateRescheduler(TReschedulerParams params)
 {
     return std::make_shared<TRandomTxRescheduler>(
-        params.ProbabilityPercentage,
+        params.Probability,
         params.RandomSeed);
 }
 

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
@@ -17,7 +17,7 @@ namespace {
 // With a given probability decides if a transaction should be rescheduled.
 // Used in tests to exercise behaviour in case of transaction restarts/reorderings.
 // Note that it does not reschedule anything by itself and only serves for communication
-// between TIndexActorDatabase and Tx::Execute().
+// between TIndexTabletDatabase and Tx::Execute().
 class TRandomTxRescheduler final
     : public ITxRescheduler
 {

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.cpp
@@ -1,18 +1,61 @@
 #include "tablet_tx_rescheduler.h"
 
+#include <cloud/filestore/libs/storage/api/components.h>
+
+#include <contrib/ydb/library/actors/core/actor.h>
+#include <contrib/ydb/library/actors/core/log.h>
+
+#include <util/random/mersenne.h>
+#include <util/random/random.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TNoOpTxRescheduler final
+// With a given probability decides if a transaction should be rescheduled.
+// Used in tests to exercise behaviour in case of transaction restarts/reorderings.
+// Note that it does not reschedule anything by itself and only serves for communication
+// between TIndexActorDatabase and Tx::Execute().
+class TRandomTxRescheduler final
     : public ITxRescheduler
 {
+private:
+    const double Probability = 0;
+    bool Triggered = false;
+    ui64 Seed;
+    TMersenne<ui64> RandomGen;
+
 public:
+    explicit TRandomTxRescheduler(float probabilityPercentage,
+                                  std::optional<ui64> randomSeed)
+        : Probability(probabilityPercentage / 100.0)
+        , Seed(randomSeed ? *randomSeed : RandomNumber<ui64>())
+        , RandomGen(Seed)
+    {
+    }
+
     bool ShouldReschedule() override
     {
-        return false;
+        const bool ret = RandomGen.GenRandReal4() < Probability;
+        Triggered |= ret;
+        return ret;
+    }
+
+    bool IsTriggered() const override
+    {
+        return Triggered;
+    }
+
+    void Reset() override
+    {
+        Triggered = false;
+    }
+
+    ui64 GetSeed() const override
+    {
+        return Seed;
     }
 };
 
@@ -20,9 +63,11 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ITxReschedulerPtr CreateNoOpTxRescheduler()
+ITxReschedulerPtr CreateRescheduler(TReschedulerParams params)
 {
-    return std::make_shared<TNoOpTxRescheduler>();
+    return std::make_shared<TRandomTxRescheduler>(
+        params.ProbabilityPercentage,
+        params.RandomSeed);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
@@ -1,26 +1,39 @@
 #pragma once
 
+#include <util/system/types.h>
+
 #include <memory>
+#include <optional>
 
 namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 // Decides whether a tablet transaction should be rescheduled (restarted) from
-// PrepareTx. Production uses a no-op stub; tests inject an implementation that
-// reschedules to make the transaction restart/reorder path.
+// PrepareTx. Tests inject an implementation that reschedules to make the
+// transaction restart/reorder path.
 struct ITxRescheduler
 {
     virtual ~ITxRescheduler() = default;
 
     virtual bool ShouldReschedule() = 0;
+    virtual bool IsTriggered() const = 0;
+    virtual void Reset() = 0;
+    virtual ui64 GetSeed() const = 0;
 };
 
 using ITxReschedulerPtr = std::shared_ptr<ITxRescheduler>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Default rescheduler used in production: never reschedules.
-ITxReschedulerPtr CreateNoOpTxRescheduler();
+// Creates a rescheduler that forces a read transaction to be restarted
+// with a given probability.
+struct TReschedulerParams
+{
+    double ProbabilityPercentage = 1;
+    std::optional<ui64> RandomSeed;
+};
+
+ITxReschedulerPtr CreateRescheduler(TReschedulerParams params);
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
+++ b/cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h
@@ -30,7 +30,7 @@ using ITxReschedulerPtr = std::shared_ptr<ITxRescheduler>;
 // with a given probability.
 struct TReschedulerParams
 {
-    double ProbabilityPercentage = 1;
+    double Probability = 0.01;
     std::optional<ui64> RandomSeed;
 };
 

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -246,7 +246,11 @@ public:
                     systemCounters,
                     metricsRegistry,
                     fastShardServer,
-                    CreateNoOpTxRescheduler());
+                    config->GetFakeTxPageFaultsEnabled() ?
+                        CreateRescheduler({
+                            .ProbabilityPercentage = config->GetFakeTxPageFaultsProbabilityPercentage(),
+                            .RandomSeed = std::nullopt
+                        }) : nullptr);
                 return actor.release();
             };
 

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -248,7 +248,7 @@ public:
                     fastShardServer,
                     config->GetFakeTxPageFaultsEnabled() ?
                         CreateRescheduler({
-                            .ProbabilityPercentage = config->GetFakeTxPageFaultsProbabilityPercentage(),
+                            .Probability = config->GetFakeTxPageFaultsProbability(),
                             .RandomSeed = std::nullopt
                         }) : nullptr);
                 return actor.release();

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -246,7 +246,7 @@ public:
                     systemCounters,
                     metricsRegistry,
                     fastShardServer,
-                    config->GetFakeTxPageFaultsEnabled() ?
+                    config->GetFakeTxPageFaultsProbability() > 0 ?
                         CreateRescheduler({
                             .Probability = config->GetFakeTxPageFaultsProbability(),
                             .RandomSeed = std::nullopt

--- a/cloud/filestore/libs/storage/init/actorsystem.cpp
+++ b/cloud/filestore/libs/storage/init/actorsystem.cpp
@@ -246,11 +246,12 @@ public:
                     systemCounters,
                     metricsRegistry,
                     fastShardServer,
-                    config->GetFakeTxPageFaultsProbability() > 0 ?
-                        CreateRescheduler({
-                            .Probability = config->GetFakeTxPageFaultsProbability(),
-                            .RandomSeed = std::nullopt
-                        }) : nullptr);
+                    config->GetFakeTxPageFaultsProbability() > 0
+                        ? CreateRescheduler(
+                              {.Probability =
+                                   config->GetFakeTxPageFaultsProbability(),
+                               .RandomSeed = std::nullopt})
+                        : nullptr);
                 return actor.release();
             };
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -371,7 +371,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     config.SetAutomaticallyCreatedShardSize(fsConfig.ShardBlockCount * 4_KB); \
     config.SetShardAllocationUnit(fsConfig.ShardBlockCount * 4_KB);           \
                                                                               \
-    TTestEnv env({.FakePageFaultsEnabled = false}, config);                   \
+    TTestEnv env({}, config);                                                 \
                                                                               \
     ui32 nodeIdx = env.AddDynamicNode();                                      \
                                                                               \
@@ -1583,7 +1583,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldNotReturnInvalidShardNoErrorForDirectShardRequests)
     {
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3048,7 +3048,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3126,7 +3126,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4153,7 +4153,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4177,7 +4177,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4194,7 +4194,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4357,7 +4357,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(2);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4414,7 +4414,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4468,7 +4468,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4609,7 +4609,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(1);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4683,7 +4683,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4735,7 +4735,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4939,7 +4939,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateShardList)
     {
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5235,7 +5235,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldCreateSessionDirectlyInShard)
     {
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5275,7 +5275,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5436,7 +5436,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardBalancerDesiredFreeSpaceReserve(1_MB);
         config.SetShardBalancerPrecisionBytes(4_KB);
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5567,7 +5567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(4_TB);
         config.SetAutomaticallyCreatedShardSize(5_TB);
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5935,7 +5935,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6049,7 +6049,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6123,7 +6123,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // mode
         config.SetStrictFileSystemSizeEnforcementEnabled(false);
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6342,7 +6342,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -6410,7 +6410,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -8144,7 +8144,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8248,7 +8248,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8295,7 +8295,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8363,7 +8363,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8567,7 +8567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             .MainFsBlockCount = fsSize
         };
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -9334,7 +9334,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "testfilesystem-filesystem1234id";
 
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
         service.CreateFileStore(fsId, fsSize);
@@ -9546,7 +9546,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateFilesystemIdDuringCreation)
     {
-        TTestEnv env({.FakePageFaultsEnabled = false}, config);
+        TTestEnv env({}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -9615,7 +9615,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         {
             // Create a filesystem without shards.
-            TTestEnv env({.FakePageFaultsEnabled = false}, config);
+            TTestEnv env({}, config);
 
             ui32 nodeIdx = env.AddDynamicNode();
 

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -371,7 +371,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
     config.SetAutomaticallyCreatedShardSize(fsConfig.ShardBlockCount * 4_KB); \
     config.SetShardAllocationUnit(fsConfig.ShardBlockCount * 4_KB);           \
                                                                               \
-    TTestEnv env({}, config);                                                 \
+    TTestEnv env({.FakePageFaultsEnabled = false}, config);                   \
                                                                               \
     ui32 nodeIdx = env.AddDynamicNode();                                      \
                                                                               \
@@ -1583,7 +1583,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldNotReturnInvalidShardNoErrorForDirectShardRequests)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3048,7 +3048,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -3126,7 +3126,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         TStorageConfig storageConfig(config);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4153,7 +4153,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4177,7 +4177,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4194,7 +4194,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4357,7 +4357,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(2);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4414,7 +4414,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4468,7 +4468,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4609,7 +4609,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(1);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4683,7 +4683,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
         config.SetMaxShardManagementRequestsInFlight(0);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4735,7 +4735,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -4939,7 +4939,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateShardList)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5235,7 +5235,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldCreateSessionDirectlyInShard)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5275,7 +5275,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(1_GB);
         config.SetAutomaticallyCreatedShardSize(2_GB);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5436,7 +5436,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardBalancerDesiredFreeSpaceReserve(1_MB);
         config.SetShardBalancerPrecisionBytes(4_KB);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5567,7 +5567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetAutomaticShardCreationEnabled(true);
         config.SetShardAllocationUnit(4_TB);
         config.SetAutomaticallyCreatedShardSize(5_TB);
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -5935,7 +5935,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6049,7 +6049,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         config.SetShardAllocationUnit(1_GB);
         config.SetStrictFileSystemSizeEnforcementEnabled(true);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6123,7 +6123,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         // mode
         config.SetStrictFileSystemSizeEnforcementEnabled(false);
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -6342,7 +6342,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -6410,7 +6410,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         const TString fsId = "test";
         const ui64 blockCount = 1'000;
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -8144,7 +8144,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8248,7 +8248,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8295,7 +8295,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8363,7 +8363,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "test";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8567,7 +8567,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             .MainFsBlockCount = fsSize
         };
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
         ui32 nodeIdx = env.AddDynamicNode();
 
@@ -9334,7 +9334,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         const TString fsId = "testfilesystem-filesystem1234id";
 
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
         service.CreateFileStore(fsId, fsSize);
@@ -9546,7 +9546,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
     SERVICE_TEST(ShouldValidateFilesystemIdDuringCreation)
     {
-        TTestEnv env({}, config);
+        TTestEnv env({.FakePageFaultsEnabled = false}, config);
         ui32 nodeIdx = env.AddDynamicNode();
         TServiceClient service(env.GetRuntime(), nodeIdx);
 
@@ -9615,7 +9615,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         {
             // Create a filesystem without shards.
-            TTestEnv env({}, config);
+            TTestEnv env({.FakePageFaultsEnabled = false}, config);
 
             ui32 nodeIdx = env.AddDynamicNode();
 

--- a/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
+++ b/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
@@ -63,7 +63,8 @@ struct TTabletSetup
             // Turn off logging in order to reduce performance overhead
             .LogPriority_NFS = NActors::NLog::PRI_ALERT,
             .LogPriority_KiKiMR = NActors::NLog::PRI_ALERT,
-            .LogPriority_Others = NActors::NLog::PRI_ALERT})
+            .LogPriority_Others = NActors::NLog::PRI_ALERT,
+            .FakePageFaultsEnabled = false})
     {
         NCloud::NFileStore::NProto::TStorageConfig storageConfig;
         storageConfig.SetInMemoryIndexCacheEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
+++ b/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
@@ -64,7 +64,7 @@ struct TTabletSetup
             .LogPriority_NFS = NActors::NLog::PRI_ALERT,
             .LogPriority_KiKiMR = NActors::NLog::PRI_ALERT,
             .LogPriority_Others = NActors::NLog::PRI_ALERT,
-            .FakePageFaultsEnabled = false})
+            })
     {
         NCloud::NFileStore::NProto::TStorageConfig storageConfig;
         storageConfig.SetInMemoryIndexCacheEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
+++ b/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
@@ -63,8 +63,7 @@ struct TTabletSetup
             // Turn off logging in order to reduce performance overhead
             .LogPriority_NFS = NActors::NLog::PRI_ALERT,
             .LogPriority_KiKiMR = NActors::NLog::PRI_ALERT,
-            .LogPriority_Others = NActors::NLog::PRI_ALERT,
-            })
+            .LogPriority_Others = NActors::NLog::PRI_ALERT})
     {
         NCloud::NFileStore::NProto::TStorageConfig storageConfig;
         storageConfig.SetInMemoryIndexCacheEnabled(true);

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -1825,7 +1825,7 @@ TIndexTabletActor::CreateIndexTabletDatabase(
     std::unique_ptr<IIndexTabletDatabase> db =
         std::make_unique<TIndexTabletDatabase>(database);
     if (TxRescheduler) {
-        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+        db = std::make_unique<TIndexTabletDatabaseWithFailureInjection>(
             std::move(db),
             TxRescheduler);
     }
@@ -1840,7 +1840,7 @@ TIndexTabletActor::CreateIndexTabletDatabaseProxy(
     std::unique_ptr<IIndexTabletDatabase> db =
         std::make_unique<TIndexTabletDatabaseProxy>(database, nodeUpdates);
     if (TxRescheduler) {
-        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+        db = std::make_unique<TIndexTabletDatabaseWithFailureInjection>(
             std::move(db),
             TxRescheduler);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -5,7 +5,7 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/registry.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttler_logger.h>
-#include "cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h"
+#include <cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h>
 #include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler_logger.h>

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -5,6 +5,7 @@
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/registry.h>
 #include <cloud/filestore/libs/storage/tablet/model/throttler_logger.h>
+#include "cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h"
 #include <cloud/storage/core/libs/api/hive_proxy.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler.h>
 #include <cloud/storage/core/libs/throttling/tablet_throttler_logger.h>
@@ -1821,7 +1822,14 @@ std::unique_ptr<IIndexTabletDatabase>
 TIndexTabletActor::CreateIndexTabletDatabase(
     NKikimr::NTable::TDatabase& database)
 {
-    return std::make_unique<TIndexTabletDatabase>(database);
+    std::unique_ptr<IIndexTabletDatabase> db =
+        std::make_unique<TIndexTabletDatabase>(database);
+    if (TxRescheduler) {
+        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+            std::move(db),
+            TxRescheduler);
+    }
+    return db;
 }
 
 std::unique_ptr<IIndexTabletDatabase>
@@ -1829,7 +1837,14 @@ TIndexTabletActor::CreateIndexTabletDatabaseProxy(
     NKikimr::NTable::TDatabase& database,
     TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates)
 {
-    return std::make_unique<TIndexTabletDatabaseProxy>(database, nodeUpdates);
+    std::unique_ptr<IIndexTabletDatabase> db =
+        std::make_unique<TIndexTabletDatabaseProxy>(database, nodeUpdates);
+    if (TxRescheduler) {
+        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+            std::move(db),
+            TxRescheduler);
+    }
+    return db;
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.cpp
@@ -4,18 +4,18 @@ namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TIndexTabletDatabaseFailureInjection::InitSchema()
+void TIndexTabletDatabaseWithFailureInjection::InitSchema()
 {
     Real->InitSchema();
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteFileSystem(
+void TIndexTabletDatabaseWithFailureInjection::WriteFileSystem(
     const NProto::TFileSystem& fileSystem)
 {
     Real->WriteFileSystem(fileSystem);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadFileSystem(
+bool TIndexTabletDatabaseWithFailureInjection::ReadFileSystem(
     NProto::TFileSystem& fileSystem)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -25,7 +25,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadFileSystem(
     return Real->ReadFileSystem(fileSystem);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadFileSystemStats(
+bool TIndexTabletDatabaseWithFailureInjection::ReadFileSystemStats(
     NProto::TFileSystemStats& stats)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -36,9 +36,9 @@ bool TIndexTabletDatabaseFailureInjection::ReadFileSystemStats(
 }
 
 #define FILESTORE_IMPLEMENT_STATS(name, ...)                                   \
-    void TIndexTabletDatabaseFailureInjection::Write##name(ui64 value)         \
+    void TIndexTabletDatabaseWithFailureInjection::Write##name(ui64 value)     \
     {                                                                          \
-        Real->Write##name(value);                                               \
+        Real->Write##name(value);                                              \
     }                                                                          \
 // FILESTORE_IMPLEMENT_STATS
 
@@ -46,13 +46,13 @@ FILESTORE_FILESYSTEM_STATS(FILESTORE_IMPLEMENT_STATS)
 
 #undef FILESTORE_IMPLEMENT_STATS
 
-void TIndexTabletDatabaseFailureInjection::WriteStorageConfig(
+void TIndexTabletDatabaseWithFailureInjection::WriteStorageConfig(
     const NProto::TStorageConfig& storageConfig)
 {
     Real->WriteStorageConfig(storageConfig);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadStorageConfig(
+bool TIndexTabletDatabaseWithFailureInjection::ReadStorageConfig(
     TMaybe<NProto::TStorageConfig>& storageConfig)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -62,7 +62,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadStorageConfig(
     return Real->ReadStorageConfig(storageConfig);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadTabletStorageInfo(
+bool TIndexTabletDatabaseWithFailureInjection::ReadTabletStorageInfo(
     NCloud::NProto::TTabletStorageInfo& tabletStorageInfo)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -72,13 +72,13 @@ bool TIndexTabletDatabaseFailureInjection::ReadTabletStorageInfo(
     return Real->ReadTabletStorageInfo(tabletStorageInfo);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteTabletStorageInfo(
+void TIndexTabletDatabaseWithFailureInjection::WriteTabletStorageInfo(
     const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo)
 {
     Real->WriteTabletStorageInfo(tabletStorageInfo);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteNode(
+void TIndexTabletDatabaseWithFailureInjection::WriteNode(
     ui64 nodeId,
     ui64 commitId,
     const NProto::TNode& attrs)
@@ -86,12 +86,12 @@ void TIndexTabletDatabaseFailureInjection::WriteNode(
     Real->WriteNode(nodeId, commitId, attrs);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteNode(ui64 nodeId)
+void TIndexTabletDatabaseWithFailureInjection::DeleteNode(ui64 nodeId)
 {
     Real->DeleteNode(nodeId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNode(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNode(
     ui64 nodeId,
     ui64 commitId,
     TMaybe<TNode>& node)
@@ -103,7 +103,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNode(
     return Real->ReadNode(nodeId, commitId, node);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodes(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodes(
     ui64 startNodeId,
     ui64 maxNodes,
     ui64& nextNodeId,
@@ -120,7 +120,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodes(
         nodes);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteNodeVer(
+void TIndexTabletDatabaseWithFailureInjection::WriteNodeVer(
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -129,14 +129,14 @@ void TIndexTabletDatabaseFailureInjection::WriteNodeVer(
     Real->WriteNodeVer(nodeId, minCommitId, maxCommitId, attrs);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteNodeVer(
+void TIndexTabletDatabaseWithFailureInjection::DeleteNodeVer(
     ui64 nodeId,
     ui64 commitId)
 {
     Real->DeleteNodeVer(nodeId, commitId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeVer(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeVer(
     ui64 nodeId,
     ui64 commitId,
     TMaybe<TNode>& node)
@@ -148,7 +148,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeVer(
     return Real->ReadNodeVer(nodeId, commitId, node);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteNodeAttr(
+void TIndexTabletDatabaseWithFailureInjection::WriteNodeAttr(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -158,14 +158,14 @@ void TIndexTabletDatabaseFailureInjection::WriteNodeAttr(
     Real->WriteNodeAttr(nodeId, commitId, name, value, version);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteNodeAttr(
+void TIndexTabletDatabaseWithFailureInjection::DeleteNodeAttr(
     ui64 nodeId,
     const TString& name)
 {
     Real->DeleteNodeAttr(nodeId, name);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeAttr(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeAttr(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -178,7 +178,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeAttr(
     return Real->ReadNodeAttr(nodeId, commitId, name, attr);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrs(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeAttrs(
     ui64 nodeId,
     ui64 commitId,
     TVector<TNodeAttr>& attrs)
@@ -190,7 +190,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrs(
     return Real->ReadNodeAttrs(nodeId, commitId, attrs);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteNodeAttrVer(
+void TIndexTabletDatabaseWithFailureInjection::WriteNodeAttrVer(
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -207,7 +207,7 @@ void TIndexTabletDatabaseFailureInjection::WriteNodeAttrVer(
         version);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteNodeAttrVer(
+void TIndexTabletDatabaseWithFailureInjection::DeleteNodeAttrVer(
     ui64 nodeId,
     ui64 commitId,
     const TString& name)
@@ -215,7 +215,7 @@ void TIndexTabletDatabaseFailureInjection::DeleteNodeAttrVer(
     Real->DeleteNodeAttrVer(nodeId, commitId, name);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrVer(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeAttrVer(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -228,7 +228,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrVer(
     return Real->ReadNodeAttrVer(nodeId, commitId, name, attr);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrVers(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeAttrVers(
     ui64 nodeId,
     ui64 commitId,
     TVector<TNodeAttr>& attrs)
@@ -240,21 +240,21 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrVers(
     return Real->ReadNodeAttrVers(nodeId, commitId, attrs);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteNodeRef(
+void TIndexTabletDatabaseWithFailureInjection::WriteNodeRef(
     const TNodeRef& nodeRef,
     bool markExhaustive)
 {
     Real->WriteNodeRef(nodeRef, markExhaustive);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteNodeRef(
+void TIndexTabletDatabaseWithFailureInjection::DeleteNodeRef(
     ui64 nodeId,
     const TString& name)
 {
     Real->DeleteNodeRef(nodeId, name);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeRef(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeRef(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -267,7 +267,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeRef(
     return Real->ReadNodeRef(nodeId, commitId, name, ref);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeRefs(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeRefs(
     ui64 nodeId,
     ui64 commitId,
     const TString& cookie,
@@ -294,7 +294,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeRefs(
         sizeMode);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeRefs(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeRefs(
     ui64 startNodeId,
     const TString& startCookie,
     ui64 maxCount,
@@ -315,7 +315,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeRefs(
         nextCookie);
 }
 
-bool TIndexTabletDatabaseFailureInjection::PrechargeNodeRefs(
+bool TIndexTabletDatabaseWithFailureInjection::PrechargeNodeRefs(
     ui64 nodeId,
     const TString& cookie,
     ui64 rowsToPrecharge,
@@ -332,7 +332,7 @@ bool TIndexTabletDatabaseFailureInjection::PrechargeNodeRefs(
         bytesToPrecharge);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteNodeRefVer(
+void TIndexTabletDatabaseWithFailureInjection::WriteNodeRefVer(
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -351,7 +351,7 @@ void TIndexTabletDatabaseFailureInjection::WriteNodeRefVer(
         shardNodeName);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteNodeRefVer(
+void TIndexTabletDatabaseWithFailureInjection::DeleteNodeRefVer(
     ui64 nodeId,
     ui64 commitId,
     const TString& name)
@@ -359,7 +359,7 @@ void TIndexTabletDatabaseFailureInjection::DeleteNodeRefVer(
     Real->DeleteNodeRefVer(nodeId, commitId, name);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeRefVer(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeRefVer(
     ui64 nodeId,
     ui64 commitId,
     const TString& name,
@@ -372,7 +372,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeRefVer(
     return Real->ReadNodeRefVer(nodeId, commitId, name, ref);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNodeRefVers(
+bool TIndexTabletDatabaseWithFailureInjection::ReadNodeRefVers(
     ui64 nodeId,
     ui64 commitId,
     TVector<TNodeRef>& refs)
@@ -384,19 +384,19 @@ bool TIndexTabletDatabaseFailureInjection::ReadNodeRefVers(
     return Real->ReadNodeRefVers(nodeId, commitId, refs);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteTruncateQueueEntry(
+void TIndexTabletDatabaseWithFailureInjection::WriteTruncateQueueEntry(
     ui64 nodeId,
     TByteRange range)
 {
     Real->WriteTruncateQueueEntry(nodeId, range);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteTruncateQueueEntry(ui64 id)
+void TIndexTabletDatabaseWithFailureInjection::DeleteTruncateQueueEntry(ui64 id)
 {
     Real->DeleteTruncateQueueEntry(id);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadTruncateQueue(
+bool TIndexTabletDatabaseWithFailureInjection::ReadTruncateQueue(
     TVector<NProto::TTruncateEntry>& entries)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -406,19 +406,19 @@ bool TIndexTabletDatabaseFailureInjection::ReadTruncateQueue(
     return Real->ReadTruncateQueue(entries);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteSession(
+void TIndexTabletDatabaseWithFailureInjection::WriteSession(
     const NProto::TSession& session)
 {
     Real->WriteSession(session);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteSession(
+void TIndexTabletDatabaseWithFailureInjection::DeleteSession(
     const TString& sessionId)
 {
     Real->DeleteSession(sessionId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadSessions(
+bool TIndexTabletDatabaseWithFailureInjection::ReadSessions(
     TVector<NProto::TSession>& sessions)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -428,20 +428,20 @@ bool TIndexTabletDatabaseFailureInjection::ReadSessions(
     return Real->ReadSessions(sessions);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteSessionHandle(
+void TIndexTabletDatabaseWithFailureInjection::WriteSessionHandle(
     const NProto::TSessionHandle& handle)
 {
     Real->WriteSessionHandle(handle);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteSessionHandle(
+void TIndexTabletDatabaseWithFailureInjection::DeleteSessionHandle(
     const TString& sessionId,
     ui64 handle)
 {
     Real->DeleteSessionHandle(sessionId, handle);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadSessionHandles(
+bool TIndexTabletDatabaseWithFailureInjection::ReadSessionHandles(
     TVector<NProto::TSessionHandle>& handles)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -451,7 +451,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadSessionHandles(
     return Real->ReadSessionHandles(handles);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadSessionHandles(
+bool TIndexTabletDatabaseWithFailureInjection::ReadSessionHandles(
     const TString& sessionId,
     TVector<NProto::TSessionHandle>& handles)
 {
@@ -462,20 +462,20 @@ bool TIndexTabletDatabaseFailureInjection::ReadSessionHandles(
     return Real->ReadSessionHandles(sessionId, handles);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteSessionLock(
+void TIndexTabletDatabaseWithFailureInjection::WriteSessionLock(
     const NProto::TSessionLock& lock)
 {
     Real->WriteSessionLock(lock);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteSessionLock(
+void TIndexTabletDatabaseWithFailureInjection::DeleteSessionLock(
     const TString& sessionId,
     ui64 lockId)
 {
     Real->DeleteSessionLock(sessionId, lockId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadSessionLocks(
+bool TIndexTabletDatabaseWithFailureInjection::ReadSessionLocks(
     TVector<NProto::TSessionLock>& locks)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -485,7 +485,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadSessionLocks(
     return Real->ReadSessionLocks(locks);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadSessionLocks(
+bool TIndexTabletDatabaseWithFailureInjection::ReadSessionLocks(
     const TString& sessionId,
     TVector<NProto::TSessionLock>& locks)
 {
@@ -496,20 +496,20 @@ bool TIndexTabletDatabaseFailureInjection::ReadSessionLocks(
     return Real->ReadSessionLocks(sessionId, locks);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteSessionDupCacheEntry(
+void TIndexTabletDatabaseWithFailureInjection::WriteSessionDupCacheEntry(
     const NProto::TDupCacheEntry& entry)
 {
     Real->WriteSessionDupCacheEntry(entry);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteSessionDupCacheEntry(
+void TIndexTabletDatabaseWithFailureInjection::DeleteSessionDupCacheEntry(
     const TString& sessionId,
     ui64 entryId)
 {
     Real->DeleteSessionDupCacheEntry(sessionId, entryId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadSessionDupCacheEntries(
+bool TIndexTabletDatabaseWithFailureInjection::ReadSessionDupCacheEntries(
     TVector<NProto::TDupCacheEntry>& entries)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -519,19 +519,19 @@ bool TIndexTabletDatabaseFailureInjection::ReadSessionDupCacheEntries(
     return Real->ReadSessionDupCacheEntries(entries);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteSessionHistoryEntry(
+void TIndexTabletDatabaseWithFailureInjection::WriteSessionHistoryEntry(
     const NProto::TSessionHistoryEntry& entry)
 {
     Real->WriteSessionHistoryEntry(entry);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteSessionHistoryEntry(
+void TIndexTabletDatabaseWithFailureInjection::DeleteSessionHistoryEntry(
     ui64 entryId)
 {
     Real->DeleteSessionHistoryEntry(entryId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadSessionHistoryEntries(
+bool TIndexTabletDatabaseWithFailureInjection::ReadSessionHistoryEntries(
     TVector<NProto::TSessionHistoryEntry>& entries)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -541,7 +541,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadSessionHistoryEntries(
     return Real->ReadSessionHistoryEntries(entries);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteFreshBytes(
+void TIndexTabletDatabaseWithFailureInjection::WriteFreshBytes(
     ui64 nodeId,
     ui64 commitId,
     ui64 offset,
@@ -550,7 +550,7 @@ void TIndexTabletDatabaseFailureInjection::WriteFreshBytes(
     Real->WriteFreshBytes(nodeId, commitId, offset, data);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteFreshBytesDeletionMarker(
+void TIndexTabletDatabaseWithFailureInjection::WriteFreshBytesDeletionMarker(
     ui64 nodeId,
     ui64 commitId,
     ui64 offset,
@@ -559,7 +559,7 @@ void TIndexTabletDatabaseFailureInjection::WriteFreshBytesDeletionMarker(
     Real->WriteFreshBytesDeletionMarker(nodeId, commitId, offset, len);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteFreshBytes(
+void TIndexTabletDatabaseWithFailureInjection::DeleteFreshBytes(
     ui64 nodeId,
     ui64 commitId,
     ui64 offset)
@@ -567,7 +567,7 @@ void TIndexTabletDatabaseFailureInjection::DeleteFreshBytes(
     Real->DeleteFreshBytes(nodeId, commitId, offset);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadFreshBytes(
+bool TIndexTabletDatabaseWithFailureInjection::ReadFreshBytes(
     TVector<TFreshBytesEntry>& bytes)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -577,7 +577,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadFreshBytes(
     return Real->ReadFreshBytes(bytes);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteFreshBlock(
+void TIndexTabletDatabaseWithFailureInjection::WriteFreshBlock(
     ui64 nodeId,
     ui64 commitId,
     ui32 blockIndex,
@@ -586,7 +586,7 @@ void TIndexTabletDatabaseFailureInjection::WriteFreshBlock(
     Real->WriteFreshBlock(nodeId, commitId, blockIndex, blockData);
 }
 
-void TIndexTabletDatabaseFailureInjection::MarkFreshBlockDeleted(
+void TIndexTabletDatabaseWithFailureInjection::MarkFreshBlockDeleted(
     ui64 nodeId,
     ui64 minCommitId,
     ui64 maxCommitId,
@@ -599,7 +599,7 @@ void TIndexTabletDatabaseFailureInjection::MarkFreshBlockDeleted(
         blockIndex);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteFreshBlock(
+void TIndexTabletDatabaseWithFailureInjection::DeleteFreshBlock(
     ui64 nodeId,
     ui64 commitId,
     ui32 blockIndex)
@@ -607,7 +607,7 @@ void TIndexTabletDatabaseFailureInjection::DeleteFreshBlock(
     Real->DeleteFreshBlock(nodeId, commitId, blockIndex);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadFreshBlocks(TVector<TFreshBlock>& blocks)
+bool TIndexTabletDatabaseWithFailureInjection::ReadFreshBlocks(TVector<TFreshBlock>& blocks)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
         return false;
@@ -616,7 +616,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadFreshBlocks(TVector<TFreshBlock>&
     return Real->ReadFreshBlocks(blocks);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteMixedBlocks(
+void TIndexTabletDatabaseWithFailureInjection::WriteMixedBlocks(
     ui32 rangeId,
     const TPartialBlobId& blobId,
     const TBlockList& blockList,
@@ -631,14 +631,14 @@ void TIndexTabletDatabaseFailureInjection::WriteMixedBlocks(
         checkpointBlocks);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteMixedBlocks(
+void TIndexTabletDatabaseWithFailureInjection::DeleteMixedBlocks(
     ui32 rangeId,
     const TPartialBlobId& blobId)
 {
     Real->DeleteMixedBlocks(rangeId, blobId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadMixedBlocks(
+bool TIndexTabletDatabaseWithFailureInjection::ReadMixedBlocks(
     ui32 rangeId,
     const TPartialBlobId& blobId,
     TMaybe<TMixedBlob>& blob,
@@ -651,7 +651,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadMixedBlocks(
     return Real->ReadMixedBlocks(rangeId, blobId, blob, alloc);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadMixedBlocks(
+bool TIndexTabletDatabaseWithFailureInjection::ReadMixedBlocks(
     ui32 rangeId,
     TVector<TMixedBlob>& blobs,
     IAllocator* alloc)
@@ -663,7 +663,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadMixedBlocks(
     return Real->ReadMixedBlocks(rangeId, blobs, alloc);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteDeletionMarkers(
+void TIndexTabletDatabaseWithFailureInjection::WriteDeletionMarkers(
     ui32 rangeId,
     ui64 nodeId,
     ui64 commitId,
@@ -678,7 +678,7 @@ void TIndexTabletDatabaseFailureInjection::WriteDeletionMarkers(
         blocksCount);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteDeletionMarker(
+void TIndexTabletDatabaseWithFailureInjection::DeleteDeletionMarker(
     ui32 rangeId,
     ui64 nodeId,
     ui64 commitId,
@@ -687,7 +687,7 @@ void TIndexTabletDatabaseFailureInjection::DeleteDeletionMarker(
     Real->DeleteDeletionMarker(rangeId, nodeId, commitId, blockIndex);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadDeletionMarkers(
+bool TIndexTabletDatabaseWithFailureInjection::ReadDeletionMarkers(
     ui32 rangeId,
     TVector<TDeletionMarker>& deletionMarkers)
 {
@@ -698,7 +698,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadDeletionMarkers(
     return Real->ReadDeletionMarkers(rangeId, deletionMarkers);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteLargeDeletionMarkers(
+void TIndexTabletDatabaseWithFailureInjection::WriteLargeDeletionMarkers(
     ui64 nodeId,
     ui64 commitId,
     ui32 blockIndex,
@@ -711,7 +711,7 @@ void TIndexTabletDatabaseFailureInjection::WriteLargeDeletionMarkers(
         blocksCount);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteLargeDeletionMarker(
+void TIndexTabletDatabaseWithFailureInjection::DeleteLargeDeletionMarker(
     ui64 nodeId,
     ui64 commitId,
     ui32 blockIndex)
@@ -719,7 +719,7 @@ void TIndexTabletDatabaseFailureInjection::DeleteLargeDeletionMarker(
     Real->DeleteLargeDeletionMarker(nodeId, commitId, blockIndex);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadLargeDeletionMarkers(
+bool TIndexTabletDatabaseWithFailureInjection::ReadLargeDeletionMarkers(
     TVector<TDeletionMarker>& deletionMarkers)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -729,17 +729,17 @@ bool TIndexTabletDatabaseFailureInjection::ReadLargeDeletionMarkers(
     return Real->ReadLargeDeletionMarkers(deletionMarkers);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteOrphanNode(ui64 nodeId)
+void TIndexTabletDatabaseWithFailureInjection::WriteOrphanNode(ui64 nodeId)
 {
     Real->WriteOrphanNode(nodeId);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteOrphanNode(ui64 nodeId)
+void TIndexTabletDatabaseWithFailureInjection::DeleteOrphanNode(ui64 nodeId)
 {
     Real->DeleteOrphanNode(nodeId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadOrphanNodes(TVector<ui64>& nodeIds)
+bool TIndexTabletDatabaseWithFailureInjection::ReadOrphanNodes(TVector<ui64>& nodeIds)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
         return false;
@@ -748,19 +748,19 @@ bool TIndexTabletDatabaseFailureInjection::ReadOrphanNodes(TVector<ui64>& nodeId
     return Real->ReadOrphanNodes(nodeIds);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteNewBlob(
+void TIndexTabletDatabaseWithFailureInjection::WriteNewBlob(
     const TPartialBlobId& blobId)
 {
     Real->WriteNewBlob(blobId);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteNewBlob(
+void TIndexTabletDatabaseWithFailureInjection::DeleteNewBlob(
     const TPartialBlobId& blobId)
 {
     Real->DeleteNewBlob(blobId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadNewBlobs(TVector<TPartialBlobId>& blobIds)
+bool TIndexTabletDatabaseWithFailureInjection::ReadNewBlobs(TVector<TPartialBlobId>& blobIds)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
         return false;
@@ -769,19 +769,19 @@ bool TIndexTabletDatabaseFailureInjection::ReadNewBlobs(TVector<TPartialBlobId>&
     return Real->ReadNewBlobs(blobIds);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteGarbageBlob(
+void TIndexTabletDatabaseWithFailureInjection::WriteGarbageBlob(
     const TPartialBlobId& blobId)
 {
     Real->WriteGarbageBlob(blobId);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteGarbageBlob(
+void TIndexTabletDatabaseWithFailureInjection::DeleteGarbageBlob(
     const TPartialBlobId& blobId)
 {
     Real->DeleteGarbageBlob(blobId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadGarbageBlobs(
+bool TIndexTabletDatabaseWithFailureInjection::ReadGarbageBlobs(
     TVector<TPartialBlobId>& blobIds)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -791,19 +791,19 @@ bool TIndexTabletDatabaseFailureInjection::ReadGarbageBlobs(
     return Real->ReadGarbageBlobs(blobIds);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteCheckpoint(
+void TIndexTabletDatabaseWithFailureInjection::WriteCheckpoint(
     const NProto::TCheckpoint& checkpoint)
 {
     Real->WriteCheckpoint(checkpoint);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteCheckpoint(
+void TIndexTabletDatabaseWithFailureInjection::DeleteCheckpoint(
     const TString& checkpointId)
 {
     Real->DeleteCheckpoint(checkpointId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadCheckpoints(
+bool TIndexTabletDatabaseWithFailureInjection::ReadCheckpoints(
     TVector<NProto::TCheckpoint>& checkpoints)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -813,21 +813,21 @@ bool TIndexTabletDatabaseFailureInjection::ReadCheckpoints(
     return Real->ReadCheckpoints(checkpoints);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteCheckpointNode(
+void TIndexTabletDatabaseWithFailureInjection::WriteCheckpointNode(
     ui64 checkpointId,
     ui64 nodeId)
 {
     Real->WriteCheckpointNode(checkpointId, nodeId);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteCheckpointNode(
+void TIndexTabletDatabaseWithFailureInjection::DeleteCheckpointNode(
     ui64 checkpointId,
     ui64 nodeId)
 {
     Real->DeleteCheckpointNode(checkpointId, nodeId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadCheckpointNodes(
+bool TIndexTabletDatabaseWithFailureInjection::ReadCheckpointNodes(
     ui64 checkpointId,
     TVector<ui64>& nodes,
     size_t maxCount)
@@ -842,7 +842,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadCheckpointNodes(
         maxCount);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteCheckpointBlob(
+void TIndexTabletDatabaseWithFailureInjection::WriteCheckpointBlob(
     ui64 checkpointId,
     ui32 rangeId,
     const TPartialBlobId& blobId)
@@ -850,7 +850,7 @@ void TIndexTabletDatabaseFailureInjection::WriteCheckpointBlob(
     Real->WriteCheckpointBlob(checkpointId, rangeId, blobId);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteCheckpointBlob(
+void TIndexTabletDatabaseWithFailureInjection::DeleteCheckpointBlob(
     ui64 checkpointId,
     ui32 rangeId,
     const TPartialBlobId& blobId)
@@ -858,7 +858,7 @@ void TIndexTabletDatabaseFailureInjection::DeleteCheckpointBlob(
     Real->DeleteCheckpointBlob(checkpointId, rangeId, blobId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadCheckpointBlobs(
+bool TIndexTabletDatabaseWithFailureInjection::ReadCheckpointBlobs(
     ui64 checkpointId,
     TVector<TCheckpointBlob>& blobs,
     size_t maxCount)
@@ -873,7 +873,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadCheckpointBlobs(
         maxCount);
 }
 
-void TIndexTabletDatabaseFailureInjection::ForceWriteCompactionMap(
+void TIndexTabletDatabaseWithFailureInjection::ForceWriteCompactionMap(
     ui32 rangeId,
     ui32 blobsCount,
     ui32 deletionsCount,
@@ -886,7 +886,7 @@ void TIndexTabletDatabaseFailureInjection::ForceWriteCompactionMap(
         garbageBlocksCount);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteCompactionMap(
+void TIndexTabletDatabaseWithFailureInjection::WriteCompactionMap(
     ui32 rangeId,
     ui32 blobsCount,
     ui32 deletionsCount,
@@ -899,7 +899,7 @@ void TIndexTabletDatabaseFailureInjection::WriteCompactionMap(
         garbageBlocksCount);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadCompactionMap(
+bool TIndexTabletDatabaseWithFailureInjection::ReadCompactionMap(
     TVector<TCompactionRangeInfo>& compactionMap)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -909,7 +909,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadCompactionMap(
     return Real->ReadCompactionMap(compactionMap);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadCompactionMap(
+bool TIndexTabletDatabaseWithFailureInjection::ReadCompactionMap(
     TVector<TCompactionRangeInfo>& compactionMap,
     ui32 firstRangeId,
     ui32 rangeCount,
@@ -926,18 +926,18 @@ bool TIndexTabletDatabaseFailureInjection::ReadCompactionMap(
         prechargeAll);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteOpLogEntry(
+void TIndexTabletDatabaseWithFailureInjection::WriteOpLogEntry(
     const NProto::TOpLogEntry& entry)
 {
     Real->WriteOpLogEntry(entry);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteOpLogEntry(ui64 entryId)
+void TIndexTabletDatabaseWithFailureInjection::DeleteOpLogEntry(ui64 entryId)
 {
     Real->DeleteOpLogEntry(entryId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadOpLogEntry(
+bool TIndexTabletDatabaseWithFailureInjection::ReadOpLogEntry(
     ui64 entryId,
     TMaybe<NProto::TOpLogEntry>& entry)
 {
@@ -948,7 +948,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadOpLogEntry(
     return Real->ReadOpLogEntry(entryId, entry);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadOpLog(TVector<NProto::TOpLogEntry>& opLog)
+bool TIndexTabletDatabaseWithFailureInjection::ReadOpLog(TVector<NProto::TOpLogEntry>& opLog)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
         return false;
@@ -957,20 +957,20 @@ bool TIndexTabletDatabaseFailureInjection::ReadOpLog(TVector<NProto::TOpLogEntry
     return Real->ReadOpLog(opLog);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteResponseLogEntry(
+void TIndexTabletDatabaseWithFailureInjection::WriteResponseLogEntry(
     const NProtoPrivate::TResponseLogEntry& entry)
 {
     Real->WriteResponseLogEntry(entry);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteResponseLogEntry(
+void TIndexTabletDatabaseWithFailureInjection::DeleteResponseLogEntry(
     ui64 clientTabletId,
     ui64 requestId)
 {
     Real->DeleteResponseLogEntry(clientTabletId, requestId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadResponseLogEntry(
+bool TIndexTabletDatabaseWithFailureInjection::ReadResponseLogEntry(
     ui64 clientTabletId,
     ui64 requestId,
     TMaybe<NProtoPrivate::TResponseLogEntry>& entry)
@@ -985,7 +985,7 @@ bool TIndexTabletDatabaseFailureInjection::ReadResponseLogEntry(
         entry);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadResponseLog(
+bool TIndexTabletDatabaseWithFailureInjection::ReadResponseLog(
     TVector<NProtoPrivate::TResponseLogEntry>& responseLog)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -995,19 +995,19 @@ bool TIndexTabletDatabaseFailureInjection::ReadResponseLog(
     return Real->ReadResponseLog(responseLog);
 }
 
-void TIndexTabletDatabaseFailureInjection::WriteUnconfirmedData(
+void TIndexTabletDatabaseWithFailureInjection::WriteUnconfirmedData(
     ui64 commitId,
     const NProto::TUnconfirmedData& data)
 {
     Real->WriteUnconfirmedData(commitId, data);
 }
 
-void TIndexTabletDatabaseFailureInjection::DeleteUnconfirmedData(ui64 commitId)
+void TIndexTabletDatabaseWithFailureInjection::DeleteUnconfirmedData(ui64 commitId)
 {
     Real->DeleteUnconfirmedData(commitId);
 }
 
-bool TIndexTabletDatabaseFailureInjection::ReadUnconfirmedData(
+bool TIndexTabletDatabaseWithFailureInjection::ReadUnconfirmedData(
     TVector<TUnconfirmedDataEntry>& entries)
 {
     if (Y_UNLIKELY(ShouldFailReadInTest())) {
@@ -1024,7 +1024,7 @@ std::unique_ptr<IIndexTabletDatabase> CreateIndexTabletDatabase(
     std::unique_ptr<IIndexTabletDatabase> db =
         std::make_unique<TIndexTabletDatabase>(database);
     if (rescheduler) {
-        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+        db = std::make_unique<TIndexTabletDatabaseWithFailureInjection>(
             std::move(db),
             rescheduler);
     }
@@ -1039,7 +1039,7 @@ std::unique_ptr<IIndexTabletDatabase> CreateIndexTabletDatabaseProxy(
     std::unique_ptr<IIndexTabletDatabase> db =
         std::make_unique<TIndexTabletDatabaseProxy>(database, nodeUpdates);
     if (rescheduler) {
-        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+        db = std::make_unique<TIndexTabletDatabaseWithFailureInjection>(
             std::move(db),
             rescheduler);
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.cpp
@@ -1,0 +1,1049 @@
+#include "tablet_database_failure_injection.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletDatabaseFailureInjection::InitSchema()
+{
+    Real->InitSchema();
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteFileSystem(
+    const NProto::TFileSystem& fileSystem)
+{
+    Real->WriteFileSystem(fileSystem);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadFileSystem(
+    NProto::TFileSystem& fileSystem)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadFileSystem(fileSystem);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadFileSystemStats(
+    NProto::TFileSystemStats& stats)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadFileSystemStats(stats);
+}
+
+#define FILESTORE_IMPLEMENT_STATS(name, ...)                                   \
+    void TIndexTabletDatabaseFailureInjection::Write##name(ui64 value)         \
+    {                                                                          \
+        Real->Write##name(value);                                               \
+    }                                                                          \
+// FILESTORE_IMPLEMENT_STATS
+
+FILESTORE_FILESYSTEM_STATS(FILESTORE_IMPLEMENT_STATS)
+
+#undef FILESTORE_IMPLEMENT_STATS
+
+void TIndexTabletDatabaseFailureInjection::WriteStorageConfig(
+    const NProto::TStorageConfig& storageConfig)
+{
+    Real->WriteStorageConfig(storageConfig);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadStorageConfig(
+    TMaybe<NProto::TStorageConfig>& storageConfig)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadStorageConfig(storageConfig);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadTabletStorageInfo(
+    NCloud::NProto::TTabletStorageInfo& tabletStorageInfo)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadTabletStorageInfo(tabletStorageInfo);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteTabletStorageInfo(
+    const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo)
+{
+    Real->WriteTabletStorageInfo(tabletStorageInfo);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteNode(
+    ui64 nodeId,
+    ui64 commitId,
+    const NProto::TNode& attrs)
+{
+    Real->WriteNode(nodeId, commitId, attrs);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteNode(ui64 nodeId)
+{
+    Real->DeleteNode(nodeId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNode(
+    ui64 nodeId,
+    ui64 commitId,
+    TMaybe<TNode>& node)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNode(nodeId, commitId, node);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodes(
+    ui64 startNodeId,
+    ui64 maxNodes,
+    ui64& nextNodeId,
+    TVector<TNode>& nodes)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodes(
+        startNodeId,
+        maxNodes,
+        nextNodeId,
+        nodes);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteNodeVer(
+    ui64 nodeId,
+    ui64 minCommitId,
+    ui64 maxCommitId,
+    const NProto::TNode& attrs)
+{
+    Real->WriteNodeVer(nodeId, minCommitId, maxCommitId, attrs);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteNodeVer(
+    ui64 nodeId,
+    ui64 commitId)
+{
+    Real->DeleteNodeVer(nodeId, commitId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeVer(
+    ui64 nodeId,
+    ui64 commitId,
+    TMaybe<TNode>& node)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeVer(nodeId, commitId, node);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteNodeAttr(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    const TString& value,
+    ui64 version)
+{
+    Real->WriteNodeAttr(nodeId, commitId, name, value, version);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteNodeAttr(
+    ui64 nodeId,
+    const TString& name)
+{
+    Real->DeleteNodeAttr(nodeId, name);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeAttr(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeAttr>& attr)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeAttr(nodeId, commitId, name, attr);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrs(
+    ui64 nodeId,
+    ui64 commitId,
+    TVector<TNodeAttr>& attrs)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeAttrs(nodeId, commitId, attrs);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteNodeAttrVer(
+    ui64 nodeId,
+    ui64 minCommitId,
+    ui64 maxCommitId,
+    const TString& name,
+    const TString& value,
+    ui64 version)
+{
+    Real->WriteNodeAttrVer(
+        nodeId,
+        minCommitId,
+        maxCommitId,
+        name,
+        value,
+        version);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteNodeAttrVer(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name)
+{
+    Real->DeleteNodeAttrVer(nodeId, commitId, name);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrVer(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeAttr>& attr)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeAttrVer(nodeId, commitId, name, attr);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeAttrVers(
+    ui64 nodeId,
+    ui64 commitId,
+    TVector<TNodeAttr>& attrs)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeAttrVers(nodeId, commitId, attrs);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteNodeRef(
+    const TNodeRef& nodeRef,
+    bool markExhaustive)
+{
+    Real->WriteNodeRef(nodeRef, markExhaustive);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteNodeRef(
+    ui64 nodeId,
+    const TString& name)
+{
+    Real->DeleteNodeRef(nodeId, name);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeRef(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeRef>& ref)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeRef(nodeId, commitId, name, ref);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeRefs(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& cookie,
+    TVector<TNodeRef>& refs,
+    ui32 maxBytes,
+    TString* next,
+    ui32* skippedRefs,
+    bool noAutoPrecharge,
+    NProto::EListNodesSizeMode sizeMode)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeRefs(
+        nodeId,
+        commitId,
+        cookie,
+        refs,
+        maxBytes,
+        next,
+        skippedRefs,
+        noAutoPrecharge,
+        sizeMode);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeRefs(
+    ui64 startNodeId,
+    const TString& startCookie,
+    ui64 maxCount,
+    TVector<TNodeRef>& refs,
+    ui64& nextNodeId,
+    TString& nextCookie)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeRefs(
+        startNodeId,
+        startCookie,
+        maxCount,
+        refs,
+        nextNodeId,
+        nextCookie);
+}
+
+bool TIndexTabletDatabaseFailureInjection::PrechargeNodeRefs(
+    ui64 nodeId,
+    const TString& cookie,
+    ui64 rowsToPrecharge,
+    ui64 bytesToPrecharge)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->PrechargeNodeRefs(
+        nodeId,
+        cookie,
+        rowsToPrecharge,
+        bytesToPrecharge);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteNodeRefVer(
+    ui64 nodeId,
+    ui64 minCommitId,
+    ui64 maxCommitId,
+    const TString& name,
+    ui64 childNode,
+    const TString& shardId,
+    const TString& shardNodeName)
+{
+    Real->WriteNodeRefVer(
+        nodeId,
+        minCommitId,
+        maxCommitId,
+        name,
+        childNode,
+        shardId,
+        shardNodeName);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteNodeRefVer(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name)
+{
+    Real->DeleteNodeRefVer(nodeId, commitId, name);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeRefVer(
+    ui64 nodeId,
+    ui64 commitId,
+    const TString& name,
+    TMaybe<TNodeRef>& ref)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeRefVer(nodeId, commitId, name, ref);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNodeRefVers(
+    ui64 nodeId,
+    ui64 commitId,
+    TVector<TNodeRef>& refs)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNodeRefVers(nodeId, commitId, refs);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteTruncateQueueEntry(
+    ui64 nodeId,
+    TByteRange range)
+{
+    Real->WriteTruncateQueueEntry(nodeId, range);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteTruncateQueueEntry(ui64 id)
+{
+    Real->DeleteTruncateQueueEntry(id);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadTruncateQueue(
+    TVector<NProto::TTruncateEntry>& entries)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadTruncateQueue(entries);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteSession(
+    const NProto::TSession& session)
+{
+    Real->WriteSession(session);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteSession(
+    const TString& sessionId)
+{
+    Real->DeleteSession(sessionId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadSessions(
+    TVector<NProto::TSession>& sessions)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadSessions(sessions);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteSessionHandle(
+    const NProto::TSessionHandle& handle)
+{
+    Real->WriteSessionHandle(handle);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteSessionHandle(
+    const TString& sessionId,
+    ui64 handle)
+{
+    Real->DeleteSessionHandle(sessionId, handle);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadSessionHandles(
+    TVector<NProto::TSessionHandle>& handles)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadSessionHandles(handles);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadSessionHandles(
+    const TString& sessionId,
+    TVector<NProto::TSessionHandle>& handles)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadSessionHandles(sessionId, handles);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteSessionLock(
+    const NProto::TSessionLock& lock)
+{
+    Real->WriteSessionLock(lock);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteSessionLock(
+    const TString& sessionId,
+    ui64 lockId)
+{
+    Real->DeleteSessionLock(sessionId, lockId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadSessionLocks(
+    TVector<NProto::TSessionLock>& locks)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadSessionLocks(locks);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadSessionLocks(
+    const TString& sessionId,
+    TVector<NProto::TSessionLock>& locks)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadSessionLocks(sessionId, locks);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteSessionDupCacheEntry(
+    const NProto::TDupCacheEntry& entry)
+{
+    Real->WriteSessionDupCacheEntry(entry);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteSessionDupCacheEntry(
+    const TString& sessionId,
+    ui64 entryId)
+{
+    Real->DeleteSessionDupCacheEntry(sessionId, entryId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadSessionDupCacheEntries(
+    TVector<NProto::TDupCacheEntry>& entries)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadSessionDupCacheEntries(entries);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteSessionHistoryEntry(
+    const NProto::TSessionHistoryEntry& entry)
+{
+    Real->WriteSessionHistoryEntry(entry);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteSessionHistoryEntry(
+    ui64 entryId)
+{
+    Real->DeleteSessionHistoryEntry(entryId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadSessionHistoryEntries(
+    TVector<NProto::TSessionHistoryEntry>& entries)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadSessionHistoryEntries(entries);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteFreshBytes(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 offset,
+    TStringBuf data)
+{
+    Real->WriteFreshBytes(nodeId, commitId, offset, data);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteFreshBytesDeletionMarker(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 offset,
+    ui64 len)
+{
+    Real->WriteFreshBytesDeletionMarker(nodeId, commitId, offset, len);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteFreshBytes(
+    ui64 nodeId,
+    ui64 commitId,
+    ui64 offset)
+{
+    Real->DeleteFreshBytes(nodeId, commitId, offset);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadFreshBytes(
+    TVector<TFreshBytesEntry>& bytes)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadFreshBytes(bytes);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteFreshBlock(
+    ui64 nodeId,
+    ui64 commitId,
+    ui32 blockIndex,
+    TStringBuf blockData)
+{
+    Real->WriteFreshBlock(nodeId, commitId, blockIndex, blockData);
+}
+
+void TIndexTabletDatabaseFailureInjection::MarkFreshBlockDeleted(
+    ui64 nodeId,
+    ui64 minCommitId,
+    ui64 maxCommitId,
+    ui32 blockIndex)
+{
+    Real->MarkFreshBlockDeleted(
+        nodeId,
+        minCommitId,
+        maxCommitId,
+        blockIndex);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteFreshBlock(
+    ui64 nodeId,
+    ui64 commitId,
+    ui32 blockIndex)
+{
+    Real->DeleteFreshBlock(nodeId, commitId, blockIndex);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadFreshBlocks(TVector<TFreshBlock>& blocks)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadFreshBlocks(blocks);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteMixedBlocks(
+    ui32 rangeId,
+    const TPartialBlobId& blobId,
+    const TBlockList& blockList,
+    ui32 garbageBlocks,
+    ui32 checkpointBlocks)
+{
+    Real->WriteMixedBlocks(
+        rangeId,
+        blobId,
+        blockList,
+        garbageBlocks,
+        checkpointBlocks);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteMixedBlocks(
+    ui32 rangeId,
+    const TPartialBlobId& blobId)
+{
+    Real->DeleteMixedBlocks(rangeId, blobId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadMixedBlocks(
+    ui32 rangeId,
+    const TPartialBlobId& blobId,
+    TMaybe<TMixedBlob>& blob,
+    IAllocator* alloc)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadMixedBlocks(rangeId, blobId, blob, alloc);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadMixedBlocks(
+    ui32 rangeId,
+    TVector<TMixedBlob>& blobs,
+    IAllocator* alloc)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadMixedBlocks(rangeId, blobs, alloc);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteDeletionMarkers(
+    ui32 rangeId,
+    ui64 nodeId,
+    ui64 commitId,
+    ui32 blockIndex,
+    ui32 blocksCount)
+{
+    Real->WriteDeletionMarkers(
+        rangeId,
+        nodeId,
+        commitId,
+        blockIndex,
+        blocksCount);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteDeletionMarker(
+    ui32 rangeId,
+    ui64 nodeId,
+    ui64 commitId,
+    ui32 blockIndex)
+{
+    Real->DeleteDeletionMarker(rangeId, nodeId, commitId, blockIndex);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadDeletionMarkers(
+    ui32 rangeId,
+    TVector<TDeletionMarker>& deletionMarkers)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadDeletionMarkers(rangeId, deletionMarkers);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteLargeDeletionMarkers(
+    ui64 nodeId,
+    ui64 commitId,
+    ui32 blockIndex,
+    ui32 blocksCount)
+{
+    Real->WriteLargeDeletionMarkers(
+        nodeId,
+        commitId,
+        blockIndex,
+        blocksCount);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteLargeDeletionMarker(
+    ui64 nodeId,
+    ui64 commitId,
+    ui32 blockIndex)
+{
+    Real->DeleteLargeDeletionMarker(nodeId, commitId, blockIndex);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadLargeDeletionMarkers(
+    TVector<TDeletionMarker>& deletionMarkers)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadLargeDeletionMarkers(deletionMarkers);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteOrphanNode(ui64 nodeId)
+{
+    Real->WriteOrphanNode(nodeId);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteOrphanNode(ui64 nodeId)
+{
+    Real->DeleteOrphanNode(nodeId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadOrphanNodes(TVector<ui64>& nodeIds)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadOrphanNodes(nodeIds);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteNewBlob(
+    const TPartialBlobId& blobId)
+{
+    Real->WriteNewBlob(blobId);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteNewBlob(
+    const TPartialBlobId& blobId)
+{
+    Real->DeleteNewBlob(blobId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadNewBlobs(TVector<TPartialBlobId>& blobIds)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadNewBlobs(blobIds);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteGarbageBlob(
+    const TPartialBlobId& blobId)
+{
+    Real->WriteGarbageBlob(blobId);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteGarbageBlob(
+    const TPartialBlobId& blobId)
+{
+    Real->DeleteGarbageBlob(blobId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadGarbageBlobs(
+    TVector<TPartialBlobId>& blobIds)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadGarbageBlobs(blobIds);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteCheckpoint(
+    const NProto::TCheckpoint& checkpoint)
+{
+    Real->WriteCheckpoint(checkpoint);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteCheckpoint(
+    const TString& checkpointId)
+{
+    Real->DeleteCheckpoint(checkpointId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadCheckpoints(
+    TVector<NProto::TCheckpoint>& checkpoints)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadCheckpoints(checkpoints);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteCheckpointNode(
+    ui64 checkpointId,
+    ui64 nodeId)
+{
+    Real->WriteCheckpointNode(checkpointId, nodeId);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteCheckpointNode(
+    ui64 checkpointId,
+    ui64 nodeId)
+{
+    Real->DeleteCheckpointNode(checkpointId, nodeId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadCheckpointNodes(
+    ui64 checkpointId,
+    TVector<ui64>& nodes,
+    size_t maxCount)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadCheckpointNodes(
+        checkpointId,
+        nodes,
+        maxCount);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteCheckpointBlob(
+    ui64 checkpointId,
+    ui32 rangeId,
+    const TPartialBlobId& blobId)
+{
+    Real->WriteCheckpointBlob(checkpointId, rangeId, blobId);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteCheckpointBlob(
+    ui64 checkpointId,
+    ui32 rangeId,
+    const TPartialBlobId& blobId)
+{
+    Real->DeleteCheckpointBlob(checkpointId, rangeId, blobId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadCheckpointBlobs(
+    ui64 checkpointId,
+    TVector<TCheckpointBlob>& blobs,
+    size_t maxCount)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadCheckpointBlobs(
+        checkpointId,
+        blobs,
+        maxCount);
+}
+
+void TIndexTabletDatabaseFailureInjection::ForceWriteCompactionMap(
+    ui32 rangeId,
+    ui32 blobsCount,
+    ui32 deletionsCount,
+    ui32 garbageBlocksCount)
+{
+    Real->ForceWriteCompactionMap(
+        rangeId,
+        blobsCount,
+        deletionsCount,
+        garbageBlocksCount);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteCompactionMap(
+    ui32 rangeId,
+    ui32 blobsCount,
+    ui32 deletionsCount,
+    ui32 garbageBlocksCount)
+{
+    Real->WriteCompactionMap(
+        rangeId,
+        blobsCount,
+        deletionsCount,
+        garbageBlocksCount);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadCompactionMap(
+    TVector<TCompactionRangeInfo>& compactionMap)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadCompactionMap(compactionMap);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadCompactionMap(
+    TVector<TCompactionRangeInfo>& compactionMap,
+    ui32 firstRangeId,
+    ui32 rangeCount,
+    bool prechargeAll)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadCompactionMap(
+        compactionMap,
+        firstRangeId,
+        rangeCount,
+        prechargeAll);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteOpLogEntry(
+    const NProto::TOpLogEntry& entry)
+{
+    Real->WriteOpLogEntry(entry);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteOpLogEntry(ui64 entryId)
+{
+    Real->DeleteOpLogEntry(entryId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadOpLogEntry(
+    ui64 entryId,
+    TMaybe<NProto::TOpLogEntry>& entry)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadOpLogEntry(entryId, entry);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadOpLog(TVector<NProto::TOpLogEntry>& opLog)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadOpLog(opLog);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteResponseLogEntry(
+    const NProtoPrivate::TResponseLogEntry& entry)
+{
+    Real->WriteResponseLogEntry(entry);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteResponseLogEntry(
+    ui64 clientTabletId,
+    ui64 requestId)
+{
+    Real->DeleteResponseLogEntry(clientTabletId, requestId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadResponseLogEntry(
+    ui64 clientTabletId,
+    ui64 requestId,
+    TMaybe<NProtoPrivate::TResponseLogEntry>& entry)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadResponseLogEntry(
+        clientTabletId,
+        requestId,
+        entry);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadResponseLog(
+    TVector<NProtoPrivate::TResponseLogEntry>& responseLog)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadResponseLog(responseLog);
+}
+
+void TIndexTabletDatabaseFailureInjection::WriteUnconfirmedData(
+    ui64 commitId,
+    const NProto::TUnconfirmedData& data)
+{
+    Real->WriteUnconfirmedData(commitId, data);
+}
+
+void TIndexTabletDatabaseFailureInjection::DeleteUnconfirmedData(ui64 commitId)
+{
+    Real->DeleteUnconfirmedData(commitId);
+}
+
+bool TIndexTabletDatabaseFailureInjection::ReadUnconfirmedData(
+    TVector<TUnconfirmedDataEntry>& entries)
+{
+    if (Y_UNLIKELY(ShouldFailReadInTest())) {
+        return false;
+    }
+
+    return Real->ReadUnconfirmedData(entries);
+}
+
+std::unique_ptr<IIndexTabletDatabase> CreateIndexTabletDatabase(
+    NKikimr::NTable::TDatabase& database,
+    const ITxReschedulerPtr& rescheduler)
+{
+    std::unique_ptr<IIndexTabletDatabase> db =
+        std::make_unique<TIndexTabletDatabase>(database);
+    if (rescheduler) {
+        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+            std::move(db),
+            rescheduler);
+    }
+    return db;
+}
+
+std::unique_ptr<IIndexTabletDatabase> CreateIndexTabletDatabaseProxy(
+    NKikimr::NTable::TDatabase& database,
+    TVector<IInMemoryIndexState::TIndexStateRequest>& nodeUpdates,
+    const ITxReschedulerPtr& rescheduler)
+{
+    std::unique_ptr<IIndexTabletDatabase> db =
+        std::make_unique<TIndexTabletDatabaseProxy>(database, nodeUpdates);
+    if (rescheduler) {
+        db = std::make_unique<TIndexTabletDatabaseFailureInjection>(
+            std::move(db),
+            rescheduler);
+    }
+    return db;
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h
@@ -1,0 +1,484 @@
+#pragma once
+
+#include "tablet_database.h"
+
+#include <cloud/filestore/libs/storage/core/tablet_tx_rescheduler.h>
+
+
+namespace NCloud::NFileStore::NStorage {
+
+class TIndexTabletDatabaseFailureInjection : public IIndexTabletDatabase
+{
+    std::unique_ptr<IIndexTabletDatabase> Real;
+
+    ITxReschedulerPtr TestReadRescheduler;
+
+    bool ShouldFailReadInTest() {
+        return TestReadRescheduler && TestReadRescheduler->ShouldReschedule();
+    }
+
+public:
+    TIndexTabletDatabaseFailureInjection(
+        std::unique_ptr<IIndexTabletDatabase> real,
+        ITxReschedulerPtr rescheduler)
+        : Real(std::move(real))
+        , TestReadRescheduler(std::move(rescheduler))
+    {}
+
+    void InitSchema() override;
+
+    //
+    // FileSystem
+    //
+
+    void WriteFileSystem(const NProto::TFileSystem& fileSystem) override;
+    bool ReadFileSystem(NProto::TFileSystem& fileSystem) override;
+    bool ReadFileSystemStats(NProto::TFileSystemStats& stats) override;
+
+#define FILESTORE_DECLARE_STATS(name, ...)                                     \
+    void Write##name(ui64 value) override;                                     \
+// FILESTORE_DECLARE_STATS
+
+FILESTORE_FILESYSTEM_STATS(FILESTORE_DECLARE_STATS)
+
+#undef FILESTORE_DECLARE_STATS
+    void WriteStorageConfig(
+        const NProto::TStorageConfig& storageConfig) override;
+    bool ReadStorageConfig(
+        TMaybe<NProto::TStorageConfig>& storageConfig) override;
+
+    bool ReadTabletStorageInfo(
+        NCloud::NProto::TTabletStorageInfo& tabletStorageInfo) override;
+    void WriteTabletStorageInfo(
+        const NCloud::NProto::TTabletStorageInfo& tabletStorageInfo) override;
+
+    //
+    // Nodes
+    //
+
+    void WriteNode(
+        ui64 nodeId,
+        ui64 commitId,
+        const NProto::TNode& attrs) override;
+    void DeleteNode(ui64 nodeId) override;
+    bool ReadNode(
+        ui64 nodeId,
+        ui64 commitId,
+        TMaybe<TNode>& node) override;
+    bool ReadNodes(
+        ui64 startNodeId,
+        ui64 maxNodes,
+        ui64& nextNodeId,
+        TVector<TNode>& nodes) override;
+
+    //
+    // Nodes_Ver
+    //
+
+    void WriteNodeVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const NProto::TNode& attrs) override;
+    void DeleteNodeVer(ui64 nodeId, ui64 commitId) override;
+    bool ReadNodeVer(
+        ui64 nodeId,
+        ui64 commitId,
+        TMaybe<TNode>& node) override;
+
+    //
+    // NodeAttrs
+    //
+
+    void WriteNodeAttr(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        const TString& value,
+        ui64 version) override;
+    void DeleteNodeAttr(ui64 nodeId, const TString& name) override;
+    bool ReadNodeAttr(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeAttr>& attr) override;
+    bool ReadNodeAttrs(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeAttr>& attrs) override;
+
+    //
+    // NodeAttrs_Ver
+    //
+
+    void WriteNodeAttrVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const TString& name,
+        const TString& value,
+        ui64 version) override;
+    void DeleteNodeAttrVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name) override;
+    bool ReadNodeAttrVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeAttr>& attr) override;
+    bool ReadNodeAttrVers(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeAttr>& attrs) override;
+
+    //
+    // NodeRefs
+    //
+
+    void WriteNodeRef(
+        const TNodeRef& nodeRef,
+        bool markExhaustive) override;
+    void DeleteNodeRef(ui64 nodeId, const TString& name) override;
+    bool ReadNodeRef(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeRef>& ref) override;
+    bool ReadNodeRefs(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& cookie,
+        TVector<TNodeRef>& refs,
+        ui32 maxBytes,
+        TString* next,
+        ui32* skippedRefs,
+        bool noAutoPrecharge,
+        NProto::EListNodesSizeMode sizeMode) override;
+    bool ReadNodeRefs(
+        ui64 startNodeId,
+        const TString& startCookie,
+        ui64 maxCount,
+        TVector<TNodeRef>& refs,
+        ui64& nextNodeId,
+        TString& nextCookie) override;
+    bool PrechargeNodeRefs(
+        ui64 nodeId,
+        const TString& cookie,
+        ui64 rowsToPrecharge,
+        ui64 bytesToPrecharge) override;
+
+    //
+    // NodeRefs_Ver
+    //
+
+    void WriteNodeRefVer(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        const TString& name,
+        ui64 childNode,
+        const TString& shardId,
+        const TString& shardNodeName) override;
+    void DeleteNodeRefVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name) override;
+    bool ReadNodeRefVer(
+        ui64 nodeId,
+        ui64 commitId,
+        const TString& name,
+        TMaybe<TNodeRef>& ref) override;
+    bool ReadNodeRefVers(
+        ui64 nodeId,
+        ui64 commitId,
+        TVector<TNodeRef>& refs) override;
+
+    //
+    // TruncateQueue
+    //
+
+    void WriteTruncateQueueEntry(ui64 nodeId, TByteRange range) override;
+    void DeleteTruncateQueueEntry(ui64 id) override;
+    bool ReadTruncateQueue(
+        TVector<NProto::TTruncateEntry>& entries) override;
+
+    //
+    // Sessions
+    //
+
+    void WriteSession(const NProto::TSession& session) override;
+    void DeleteSession(const TString& sessionId) override;
+    bool ReadSessions(TVector<NProto::TSession>& sessions) override;
+
+    //
+    // SessionHandles
+    //
+
+    void WriteSessionHandle(const NProto::TSessionHandle& handle) override;
+    void DeleteSessionHandle(
+        const TString& sessionId,
+        ui64 handle) override;
+    bool ReadSessionHandles(
+        TVector<NProto::TSessionHandle>& handles) override;
+    bool ReadSessionHandles(
+        const TString& sessionId,
+        TVector<NProto::TSessionHandle>& handles) override;
+
+    //
+    // SessionLocks
+    //
+
+    void WriteSessionLock(const NProto::TSessionLock& lock) override;
+    void DeleteSessionLock(
+        const TString& sessionId,
+        ui64 lockId) override;
+    bool ReadSessionLocks(TVector<NProto::TSessionLock>& locks) override;
+    bool ReadSessionLocks(
+        const TString& sessionId,
+        TVector<NProto::TSessionLock>& locks) override;
+
+    //
+    // SessionDuplicateCache
+    //
+
+    void WriteSessionDupCacheEntry(
+        const NProto::TDupCacheEntry& entry) override;
+    void DeleteSessionDupCacheEntry(
+        const TString& sessionId,
+        ui64 entryId) override;
+    bool ReadSessionDupCacheEntries(
+        TVector<NProto::TDupCacheEntry>& entries) override;
+
+    //
+    // SessionHistory
+    //
+
+    void WriteSessionHistoryEntry(
+        const NProto::TSessionHistoryEntry& entry) override;
+    void DeleteSessionHistoryEntry(ui64 entryId) override;
+    bool ReadSessionHistoryEntries(
+        TVector<NProto::TSessionHistoryEntry>& entries) override;
+
+    //
+    // FreshBytes
+    //
+
+    void WriteFreshBytes(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 offset,
+        TStringBuf data) override;
+    void WriteFreshBytesDeletionMarker(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 offset,
+        ui64 len) override;
+    void DeleteFreshBytes(
+        ui64 nodeId,
+        ui64 commitId,
+        ui64 offset) override;
+    bool ReadFreshBytes(TVector<TFreshBytesEntry>& bytes) override;
+
+    //
+    // FreshBlocks
+    //
+
+    void WriteFreshBlock(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        TStringBuf blockData) override;
+    void MarkFreshBlockDeleted(
+        ui64 nodeId,
+        ui64 minCommitId,
+        ui64 maxCommitId,
+        ui32 blockIndex) override;
+    void DeleteFreshBlock(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex) override;
+    bool ReadFreshBlocks(TVector<TFreshBlock>& blocks) override;
+
+    //
+    // MixedBlocks
+    //
+
+    void WriteMixedBlocks(
+        ui32 rangeId,
+        const TPartialBlobId& blobId,
+        const TBlockList& blockList,
+        ui32 garbageBlocks,
+        ui32 checkpointBlocks) override;
+    void DeleteMixedBlocks(
+        ui32 rangeId,
+        const TPartialBlobId& blobId) override;
+    bool ReadMixedBlocks(
+        ui32 rangeId,
+        const TPartialBlobId& blobId,
+        TMaybe<TMixedBlob>& blob,
+        IAllocator* alloc) override;
+    bool ReadMixedBlocks(
+        ui32 rangeId,
+        TVector<TMixedBlob>& blobs,
+        IAllocator* alloc) override;
+
+    //
+    // DeletionMarkers
+    //
+
+    void WriteDeletionMarkers(
+        ui32 rangeId,
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount) override;
+    void DeleteDeletionMarker(
+        ui32 rangeId,
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex) override;
+    bool ReadDeletionMarkers(
+        ui32 rangeId,
+        TVector<TDeletionMarker>& deletionMarkers) override;
+
+    //
+    // LargeDeletionMarkers
+    //
+
+    void WriteLargeDeletionMarkers(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex,
+        ui32 blocksCount) override;
+    void DeleteLargeDeletionMarker(
+        ui64 nodeId,
+        ui64 commitId,
+        ui32 blockIndex) override;
+    bool ReadLargeDeletionMarkers(
+        TVector<TDeletionMarker>& deletionMarkers) override;
+
+    //
+    // OrphanNodes
+    //
+
+    void WriteOrphanNode(ui64 nodeId) override;
+    void DeleteOrphanNode(ui64 nodeId) override;
+    bool ReadOrphanNodes(TVector<ui64>& nodeIds) override;
+
+    //
+    // NewBlobs
+    //
+
+    void WriteNewBlob(const TPartialBlobId& blobId) override;
+    void DeleteNewBlob(const TPartialBlobId& blobId) override;
+    bool ReadNewBlobs(TVector<TPartialBlobId>& blobIds) override;
+
+    //
+    // GarbageBlobs
+    //
+
+    void WriteGarbageBlob(const TPartialBlobId& blobId) override;
+    void DeleteGarbageBlob(const TPartialBlobId& blobId) override;
+    bool ReadGarbageBlobs(TVector<TPartialBlobId>& blobIds) override;
+
+    //
+    // Checkpoints
+    //
+
+    void WriteCheckpoint(const NProto::TCheckpoint& checkpoint) override;
+    void DeleteCheckpoint(const TString& checkpointId) override;
+    bool ReadCheckpoints(
+        TVector<NProto::TCheckpoint>& checkpoints) override;
+
+    //
+    // CheckpointNodes
+    //
+
+    void WriteCheckpointNode(ui64 checkpointId, ui64 nodeId) override;
+    void DeleteCheckpointNode(ui64 checkpointId, ui64 nodeId) override;
+    bool ReadCheckpointNodes(
+        ui64 checkpointId,
+        TVector<ui64>& nodes,
+        size_t maxCount) override;
+
+    //
+    // CheckpointBlobs
+    //
+
+    void WriteCheckpointBlob(
+        ui64 checkpointId,
+        ui32 rangeId,
+        const TPartialBlobId& blobId) override;
+    void DeleteCheckpointBlob(
+        ui64 checkpointId,
+        ui32 rangeId,
+        const TPartialBlobId& blobId) override;
+    bool ReadCheckpointBlobs(
+        ui64 checkpointId,
+        TVector<TCheckpointBlob>& blobs,
+        size_t maxCount) override;
+
+    //
+    // CompactionMap
+    //
+
+    void ForceWriteCompactionMap(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount) override;
+    void WriteCompactionMap(
+        ui32 rangeId,
+        ui32 blobsCount,
+        ui32 deletionsCount,
+        ui32 garbageBlocksCount) override;
+    bool ReadCompactionMap(
+        TVector<TCompactionRangeInfo>& compactionMap) override;
+
+    bool ReadCompactionMap(
+        TVector<TCompactionRangeInfo>& compactionMap,
+        ui32 firstRangeId,
+        ui32 rangeCount,
+        bool prechargeAll) override;
+
+    //
+    // OpLog
+    //
+
+    void WriteOpLogEntry(const NProto::TOpLogEntry& entry) override;
+    void DeleteOpLogEntry(ui64 entryId) override;
+    bool ReadOpLogEntry(
+        ui64 entryId,
+        TMaybe<NProto::TOpLogEntry>& entry) override;
+    bool ReadOpLog(TVector<NProto::TOpLogEntry>& opLog) override;
+
+    //
+    // ResponseLog
+    //
+
+    void WriteResponseLogEntry(
+        const NProtoPrivate::TResponseLogEntry& entry) override;
+    void DeleteResponseLogEntry(
+        ui64 clientTabletId,
+        ui64 requestId) override;
+    bool ReadResponseLogEntry(
+        ui64 clientTabletId,
+        ui64 requestId,
+        TMaybe<NProtoPrivate::TResponseLogEntry>& entry) override;
+    bool ReadResponseLog(
+        TVector<NProtoPrivate::TResponseLogEntry>& responseLog) override;
+
+    //
+    // UnconfirmedData
+    //
+
+    void WriteUnconfirmedData(
+        ui64 commitId,
+        const NProto::TUnconfirmedData& data) override;
+    void DeleteUnconfirmedData(ui64 commitId) override;
+    bool ReadUnconfirmedData(
+        TVector<TUnconfirmedDataEntry>& entries) override;
+};
+
+} // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_database_failure_injection.h
@@ -7,7 +7,7 @@
 
 namespace NCloud::NFileStore::NStorage {
 
-class TIndexTabletDatabaseFailureInjection : public IIndexTabletDatabase
+class TIndexTabletDatabaseWithFailureInjection : public IIndexTabletDatabase
 {
     std::unique_ptr<IIndexTabletDatabase> Real;
 
@@ -18,7 +18,7 @@ class TIndexTabletDatabaseFailureInjection : public IIndexTabletDatabase
     }
 
 public:
-    TIndexTabletDatabaseFailureInjection(
+    TIndexTabletDatabaseWithFailureInjection(
         std::unique_ptr<IIndexTabletDatabase> real,
         ITxReschedulerPtr rescheduler)
         : Real(std::move(real))

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_adapter.cpp
@@ -22,7 +22,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Adapter)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetTwoStageReadEnabled(true);
         storageConfig.SetThreeStageWriteEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -81,7 +81,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldStoreFreshBytes)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -140,7 +140,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldLoadFreshBytesOnStartup)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -186,7 +186,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldFlushFreshBytes)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -329,7 +329,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldFlushFreshBytesByLargeOffset)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -369,7 +369,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldFlushFreshBytesWithPartialBlobIntersection)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -434,7 +434,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushBytesItemCountThreshold(1000);
         storageConfig.SetFlushBytesByItemCountEnabled(true);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -476,7 +476,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
@@ -654,7 +654,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const auto block = tabletConfig.BlockSize;
         const auto rangeSize = 3 * block;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
 
@@ -797,7 +797,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(2 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -858,7 +858,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldStoreFreshBlocks)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -896,7 +896,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(1_GB);  // no direct blob writes
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -956,7 +956,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldWriteBlobForLargeWrite)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1001,7 +1001,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(1_GB);  // no direct blob writes
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1075,7 +1075,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1143,7 +1143,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldHandleMultipleBlobsInRangeAndUpdateCompactionMap)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1202,7 +1202,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1257,7 +1257,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldHandleErasedRangeDuringCompaction)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1308,7 +1308,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushBytesThreshold(1_GB);
         storageConfig.SetFlushThreshold(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1398,7 +1398,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1505,7 +1505,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1549,7 +1549,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1575,7 +1575,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1630,7 +1630,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         constexpr ui64 maxBlocks = 256;
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1695,7 +1695,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1736,7 +1736,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1787,7 +1787,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(2 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1867,7 +1867,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1950,7 +1950,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetUseMixedBlocksInsteadOfAliveBlocksInCompaction(true);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2147,7 +2147,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(8);
         storageConfig.SetWriteBlobThreshold(2 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2218,7 +2218,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThresholdAverage(3);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2305,7 +2305,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetWriteBlobThreshold(2 * block);
         storageConfig.SetCollectGarbageThreshold(6 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2355,7 +2355,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -2456,7 +2456,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetWriteBlobThreshold(1_GB);
         storageConfig.SetFlushThreshold(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -2529,7 +2529,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushBytesThreshold(1_GB);
         storageConfig.SetWriteBlobThreshold(4 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
         auto registry = env.GetRegistry();
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -2697,7 +2697,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -2744,7 +2744,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -2883,7 +2883,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCompactionThreshold(999'999);
         storageConfig.SetCollectGarbageThreshold(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -2913,6 +2913,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     void DoTestSoftBackpressureWriteThrottling(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         bool softBackpressureEnabled)
     {
         const ui32 block = tabletConfig.BlockSize;
@@ -2926,7 +2927,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushThresholdForBackpressureSoft(block);
         storageConfig.SetFlushThresholdForBackpressure(3 * block);
 
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2992,6 +2993,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     void DoTestSoftBackpressureThrottlingDefaults(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         bool throttlingEnabled,
         ui32 expectedError,
         bool enableSoftBackpressureViaFeaturesConfig)
@@ -3009,7 +3011,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushThresholdForBackpressureSoft(block);
         storageConfig.SetFlushThresholdForBackpressure(3 * block);
 
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         if (enableSoftBackpressureViaFeaturesConfig) {
             NCloud::NProto::TFeaturesConfig featuresConfigProto;
@@ -3068,18 +3070,25 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST_16K(ShouldNotThrottleWritesDueToSoftBackpressureIfDisabled)
     {
-        DoTestSoftBackpressureWriteThrottling(tabletConfig, false);
+        DoTestSoftBackpressureWriteThrottling(
+            tabletConfig,
+            testEnvConfig,
+            false);
     }
 
     TABLET_TEST_16K(ShouldThrottleWritesDueToSoftBackpressureIfEnabled)
     {
-        DoTestSoftBackpressureWriteThrottling(tabletConfig, true);
+        DoTestSoftBackpressureWriteThrottling(
+            tabletConfig,
+            testEnvConfig,
+            true);
     }
 
     TABLET_TEST_16K(ShouldThrottleWritesDueToSoftBackpressureIfThrottlingDisabled)
     {
         DoTestSoftBackpressureThrottlingDefaults(
             tabletConfig,
+            testEnvConfig,
             false,
             E_FS_THROTTLED,
             false);
@@ -3089,6 +3098,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         DoTestSoftBackpressureThrottlingDefaults(
             tabletConfig,
+            testEnvConfig,
             true,
             S_OK,
             false);
@@ -3098,6 +3108,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         DoTestSoftBackpressureThrottlingDefaults(
             tabletConfig,
+            testEnvConfig,
             false,
             E_FS_THROTTLED,
             true);
@@ -3122,7 +3133,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetSoftBackpressureMaxWriteBandwidth(1);
         storageConfig.SetSoftBackpressureMaxWriteIops(1);
 
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3209,7 +3220,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushBytesItemCountThresholdForBackpressure(10);
         storageConfig.SetCollectGarbageThresholdForBackpressure(64 * block);
 
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3483,7 +3494,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThresholdForBackpressure(999);
         storageConfig.SetFlushBytesThresholdForBackpressure(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3575,7 +3586,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetMaxBackpressureErrorsBeforeSuicide(999999);
         storageConfig.SetMaxBackpressurePeriodBeforeSuicide(60'000); // 1m
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3650,7 +3661,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushThreshold(2 * block);
         storageConfig.SetFlushBytesThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3714,7 +3725,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3796,7 +3807,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3846,7 +3857,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3884,7 +3895,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldDoForcedCompaction)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3924,7 +3935,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldRetryForcedCompaction)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -3978,7 +3989,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldEnqueuePendingForcedCompaction)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4028,7 +4039,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldForceCompactAndCleanup)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4084,7 +4095,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const auto rangesCount = 13;
         const auto dataSize = BlockGroupSize * block * rangesCount;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4187,7 +4198,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const auto block = tabletConfig.BlockSize;
         const auto dataSize = 32 * block;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4285,7 +4296,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxZeroCompactionRangesToDeletePerTx(10);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 requests = 0;
         ui32 lastCompactionMapRangeId = 0;
@@ -4366,7 +4377,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldDumpCompactionRangeBlobs)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4399,7 +4410,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetLoadedCompactionRangesPerTx(2);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         TAutoPtr<IEventHandle> loadChunk;
@@ -4550,7 +4561,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetLoadedCompactionRangesPerTx(2);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4630,7 +4641,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetAddingUnconfirmedDataEnabled(true);
         storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4721,7 +4732,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetAddingUnconfirmedDataEnabled(true);
         storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -4799,7 +4810,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetLoadedCompactionRangesPerTx(2);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         TAutoPtr<IEventHandle> loadChunk;
         ui32 loadChunkCount = 0;
@@ -4888,7 +4899,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetLoadedCompactionRangesPerTx(2);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         bool intercepted = false;
@@ -5065,7 +5076,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetLoadedCompactionRangesPerTx(2);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         TVector<TEvIndexTabletPrivate::TLoadCompactionMapChunkRequest> requests;
@@ -5138,7 +5149,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetLoadedCompactionRangesPerTx(2);
         storageConfig.SetWriteBlobThreshold(2 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -5258,7 +5269,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFlushBytesThreshold(1);
         storageConfig.SetLoadedCompactionRangesPerTx(2);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -5348,7 +5359,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -5490,7 +5501,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -5576,7 +5587,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -5624,7 +5635,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldHandleErrorDuringDescribeData)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -5650,7 +5661,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetReadAheadCacheRangeSize(1_MB);
         storageConfig.SetReadAheadCacheMaxResultsPerNode(32);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
         auto registry = env.GetRegistry();
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -5731,6 +5742,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     void DoTestShouldHandleFakeDescribeData(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         ui32 fakeDescribeDataLatencyUs)
     {
         NProto::TStorageConfig storageConfig;
@@ -5738,7 +5750,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetFakeDescribeDataLatencyUs(
             fakeDescribeDataLatencyUs);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -5772,9 +5784,9 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     TABLET_TEST_16K(ShouldHandleFakeDescribeData)
     {
         // Zero is a special value
-        DoTestShouldHandleFakeDescribeData(tabletConfig, 0);
-        DoTestShouldHandleFakeDescribeData(tabletConfig, 100);
-        DoTestShouldHandleFakeDescribeData(tabletConfig, 1000);
+        DoTestShouldHandleFakeDescribeData(tabletConfig, testEnvConfig, 0);
+        DoTestShouldHandleFakeDescribeData(tabletConfig, testEnvConfig, 100);
+        DoTestShouldHandleFakeDescribeData(tabletConfig, testEnvConfig, 1000);
     }
 
     // See #2737 for more details
@@ -5783,7 +5795,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetReadAheadCacheRangeSize(1_MB);
         storageConfig.SetReadAheadCacheMaxResultsPerNode(32);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
         auto registry = env.GetRegistry();
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -5875,9 +5887,10 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     }
 
     void DoTestWriteRequestCancellationOnTabletReboot(
-        const TFileSystemConfig& tabletConfig)
+        const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -5930,12 +5943,14 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldCancelWriteRequestsIfTabletIsRebooted)
     {
-        DoTestWriteRequestCancellationOnTabletReboot(tabletConfig);
+        DoTestWriteRequestCancellationOnTabletReboot(
+            tabletConfig,
+            testEnvConfig);
     }
 
     TABLET_TEST(ShouldCancelReadRequestsIfTabletIsRebooted)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -6021,7 +6036,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -6068,7 +6083,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -6229,7 +6244,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -6348,7 +6363,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -6423,7 +6438,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -6540,7 +6555,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCollectGarbageThreshold(1_GB);
         storageConfig.SetWriteBlobThreshold(2 * block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
         auto registry = env.GetRegistry();
 
 
@@ -6718,7 +6733,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetWriteBlobThreshold(2 * block);
 
         const auto profileLog = std::make_shared<TTestProfileLog>();
-        TTestEnv env({}, std::move(storageConfig), {}, profileLog);
+        TTestEnv env(testEnvConfig, std::move(storageConfig), {}, profileLog);
         auto registry = env.GetRegistry();
 
 
@@ -6818,7 +6833,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetFlushBytesThreshold(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
         auto registry = env.GetRegistry();
 
 
@@ -6892,7 +6907,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetFlushBytesThreshold(100_GB + 1);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
         auto registry = env.GetRegistry();
 
 
@@ -6958,7 +6973,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
     TABLET_TEST(ShouldCountDudCompactions)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -7011,7 +7026,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
 
         NProto::TStorageConfig storageConfig;
         storageConfig.SetWriteBlobThreshold(2 * block);
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -7129,7 +7144,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCleanupThreshold(999'999);
         storageConfig.SetCollectGarbageThreshold(1_GB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -7200,7 +7215,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -7283,7 +7298,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
     {
         const auto block = tabletConfig.BlockSize;
 
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -7346,9 +7361,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetMinChannelCount(1);
 
         // ensure that all blobs use the same channel
-        TTestEnv env(
-            {.ChannelCount = TIndexTabletSchema::DataChannel + 1},
-            std::move(storageConfig));
+        testEnvConfig.ChannelCount = TIndexTabletSchema::DataChannel + 1;
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -7450,9 +7464,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetMinChannelCount(1);
 
         // ensure that all blobs use the same channel
-        TTestEnv env(
-            {.ChannelCount = TIndexTabletSchema::DataChannel + 1},
-            std::move(storageConfig));
+        testEnvConfig.ChannelCount = TIndexTabletSchema::DataChannel + 1;
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -7546,7 +7559,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetWriteBlobThreshold(block);
         storageConfig.SetCollectGarbageThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -7630,7 +7643,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const auto blobSize = 2 * block;
         storageConfig.SetWriteBlobThreshold(blobSize);
 
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -7724,7 +7737,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const auto blobSize = 2 * block;
         storageConfig.SetWriteBlobThreshold(blobSize);
 
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -7826,7 +7839,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCompactionThresholdForBackpressure(50);
         storageConfig.SetCleanupThresholdForBackpressure(100);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -7991,7 +8004,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetCompactRangeGarbagePercentageThreshold(99);
         storageConfig.SetCompactRangeAverageBlobSizeThreshold(256_KB);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -8071,7 +8084,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetUseMixedBlocksInsteadOfAliveBlocksInCompaction(true);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -8199,7 +8212,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetUseMixedBlocksInsteadOfAliveBlocksInCompaction(true);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -8283,7 +8296,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetWriteBlobThreshold(block);
         storageConfig.SetCalculateCleanupScoreBasedOnUsedBlocksCount(true);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -8410,7 +8423,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetWriteBlobThreshold(block);
         storageConfig.SetCalculateCleanupScoreBasedOnUsedBlocksCount(true);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -8445,7 +8458,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         // checks for handle O_READ or O_WRITE flags is performed.
         storageConfig.SetAllowHandlelessIO(true);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -8537,7 +8550,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         // 5. Flush the fresh bytes.
         // 6. Read and validate the expected data from the tail of the file.
         NProto::TStorageConfig storageConfig;
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -8599,7 +8612,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetWriteBlobThreshold(2 * tabletConfig.BlockSize);
         storageConfig.SetCpuLackOverloadThreshold(50);
 
-        TTestEnv env({} /* config */, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         auto systemCounters = env.GetSystemCounters();
 
@@ -8722,7 +8735,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetTabletActorCpuUsageOverloadThreshold(1);
 
         TTestEnv env(
-            {} /* config */,
+            testEnvConfig,
             std::move(storageConfig),
             {} /* cachesConfig */,
             CreateProfileLogStub(),
@@ -8862,7 +8875,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -8928,7 +8941,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -9003,7 +9016,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -9071,7 +9084,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         storageConfig.SetExternalReadDataPayload(true);
         storageConfig.SetExternalWriteDataPayloadEnabled(true);
 
-        TTestEnv env({} /* config */, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data_stress.cpp
@@ -387,7 +387,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
         storageConfig.SetLoadedCompactionRangesPerTx(2);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
 
         ui32 nodeIdx = env.AddDynamicNode();
@@ -498,7 +498,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
         const auto blobSize = 2 * block;
         storageConfig.SetWriteBlobThreshold(blobSize);
 
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -639,7 +639,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data_Stress)
         };
 
         NProto::TStorageConfig storageConfig;
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes.cpp
@@ -2110,7 +2110,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Nodes)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_nodes_internal.cpp
@@ -57,7 +57,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     TABLET_TEST_4K_ONLY(ShouldPrepareUnlinkDirectoryNodeInShard)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -202,7 +202,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     TABLET_TEST_4K_ONLY(ShouldAbortUnlinkDirectoryNodeInShard)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -276,11 +276,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     void DoTestShouldReturnErrorUponRenameNodeForFileToDirOp(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         bool useRenameInDestination)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -368,6 +369,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldReturnErrorUponRenameNodeForFileToDirOp(
             tabletConfig,
+            testEnvConfig,
             true /* useRenameInDestination */);
     }
 
@@ -375,16 +377,18 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldReturnErrorUponRenameNodeForFileToDirOp(
             tabletConfig,
+            testEnvConfig,
             false /* useRenameInDestination */);
     }
 
     void DoTestShouldCheckDstEmptinessUponRenameNodeForDirToDirOp(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         bool useRenameInDestination)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -517,6 +521,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldCheckDstEmptinessUponRenameNodeForDirToDirOp(
             tabletConfig,
+            testEnvConfig,
             true /* useRenameInDestination */);
     }
 
@@ -524,16 +529,18 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldCheckDstEmptinessUponRenameNodeForDirToDirOp(
             tabletConfig,
+            testEnvConfig,
             false /* useRenameInDestination */);
     }
 
     void DoTestShouldAbortUnlinkUponRenameNodeForDirToDirOp(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         bool useRenameInDestination)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -720,6 +727,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldAbortUnlinkUponRenameNodeForDirToDirOp(
             tabletConfig,
+            testEnvConfig,
             true /* useRenameInDestination */);
     }
 
@@ -727,16 +735,18 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldAbortUnlinkUponRenameNodeForDirToDirOp(
             tabletConfig,
+            testEnvConfig,
             false /* useRenameInDestination */);
     }
 
     void DoTestShouldAbortUnlinkUponRenameNodeForDirToDirOpAfterReboot(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         bool useRenameInDestination)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -951,6 +961,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldAbortUnlinkUponRenameNodeForDirToDirOpAfterReboot(
             tabletConfig,
+            testEnvConfig,
             true /* useRenameInDestination */);
     }
 
@@ -958,13 +969,14 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldAbortUnlinkUponRenameNodeForDirToDirOpAfterReboot(
             tabletConfig,
+            testEnvConfig,
             false /* useRenameInDestination */);
     }
 
     TABLET_TEST_4K_ONLY(
         ShouldReturnErrorUponRenameNodeInDestinationForLocalNode)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -998,7 +1010,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -1131,7 +1143,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -1263,7 +1275,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     TABLET_TEST_4K_ONLY(ShouldDeleteGetWriteResponseLog)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1385,7 +1397,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         storageConfig.SetResponseLogEntryTTL(10'000);
         storageConfig.SetTabletRegularTasksSchedulePeriod(5'000);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -1438,7 +1450,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     TABLET_TEST_4K_ONLY(
         ShouldDeleteResponseLogEntryUponCommitRenameNodeInSource)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -1521,7 +1533,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     TABLET_TEST_4K_ONLY(
         ShouldDeleteResponseLogEntryUponCommitRenameNodeInSourceWithError)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -1721,7 +1733,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -1844,7 +1856,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetMaxTabletStep(maxTabletStep);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         const ui32 nodeIdx = env.AddDynamicNode();
 
@@ -1949,7 +1961,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2083,7 +2095,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     TABLET_TEST_4K_ONLY(ShouldNotRequireActiveSessionForGetNodeAttrToShard)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2129,7 +2141,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     TABLET_TEST_4K_ONLY(ShouldRestoreSymLinkWithUnsafeCreateNode)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2162,7 +2174,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     TABLET_TEST_4K_ONLY(ShouldSendGetNodeAttrRequestWithoutBehaveAsDirectoryTabletFlagUponCreateNode)
     {
-        TTestEnv env;
+        TTestEnv env(testEnvConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2261,7 +2273,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
         storageConfig.SetParentlessFilesOnly(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2294,7 +2306,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2340,11 +2352,12 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
 
     void DoTestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNode(
         const TFileSystemConfig& tabletConfig,
+        const TTestEnvConfig& testEnvConfig,
         bool useRenameInDestination)
     {
         NProto::TStorageConfig storageConfig;
         storageConfig.SetDirectoryCreationInShardsEnabled(true);
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -2492,6 +2505,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNode(
             tabletConfig,
+            testEnvConfig,
             true /* useRenameInDestination */);
     }
 
@@ -2500,6 +2514,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
     {
         DoTestShouldProperlyCompleteUnlinkNodeUponTabletRebootAfterRenameNode(
             tabletConfig,
+            testEnvConfig,
             false /* useRenameInDestination */);
     }
 
@@ -2518,7 +2533,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_NodesInternal)
         // these circumstances, CreateHandle returns E_REJECTED.
 
         NProto::TStorageConfig storageConfig;
-        TTestEnv env({}, storageConfig);
+        TTestEnv env(testEnvConfig, storageConfig);
 
         const ui32 nodeIdx = env.AddDynamicNode();
         const ui64 tabletId = env.BootIndexTablet(nodeIdx);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_throttling.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_throttling.cpp
@@ -662,7 +662,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Throttling)
         storageConfig.SetCleanupThresholdAverage(999'999);
         storageConfig.SetWriteBlobThreshold(block);
 
-        TTestEnv env({}, std::move(storageConfig));
+        TTestEnv env(testEnvConfig, std::move(storageConfig));
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -29,27 +29,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Reschedules transactions with probability 1/Ratio, to exercise the recovery
-// confirmation path under transaction restarts/reorderings.
-class TRandomTxRescheduler final
-    : public ITxRescheduler
-{
-private:
-    const ui32 Ratio;
-
-public:
-    explicit TRandomTxRescheduler(ui32 ratio)
-        : Ratio(ratio)
-    {}
-
-    bool ShouldReschedule() override
-    {
-        return Ratio > 0 && RandomNumber<ui32>(Ratio) == 0;
-    }
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TTestProfileLog: public IProfileLog
 {
 public:
@@ -1479,10 +1458,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             storageConfig.SetAddingUnconfirmedDataEnabled(true);
             storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-            TTestEnv env({}, std::move(storageConfig));
-            // Inject a rescheduler so recovery confirmation is exercised under
-            // transaction restarts/reorderings.
-            env.SetTxRescheduler(std::make_shared<TRandomTxRescheduler>(3));
+            TTestEnv env({.FakePageFaultsProbabilityPercentage = 5}, std::move(storageConfig));
             ui32 nodeIdx = env.AddDynamicNode();
             ui64 tabletId = env.BootIndexTablet(nodeIdx);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_unconfirmed_data.cpp
@@ -1458,7 +1458,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_UnconfirmedData)
             storageConfig.SetAddingUnconfirmedDataEnabled(true);
             storageConfig.SetUnconfirmedDataCountHardLimit(10);
 
-            TTestEnv env({.FakePageFaultsProbabilityPercentage = 5}, std::move(storageConfig));
+            TTestEnv env({.FakePageFaultsProbability = 0.05}, std::move(storageConfig));
             ui32 nodeIdx = env.AddDynamicNode();
             ui64 tabletId = env.BootIndexTablet(nodeIdx);
 

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -90,6 +90,7 @@ SRCS(
     tablet_cache_read_bypass.cpp
     tablet_counters.cpp
     tablet_database.cpp
+    tablet_database_failure_injection.cpp
     tablet_schema.cpp
     tablet_state.cpp
     tablet_state_iface.cpp

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -477,7 +477,7 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
             nullptr /* fastShardServer */,
             Config.FakePageFaultsEnabled ?
                 CreateRescheduler({
-                    .ProbabilityPercentage = Config.FakePageFaultsProbabilityPercentage,
+                    .Probability = Config.FakePageFaultsProbability,
                     .RandomSeed = Config.FakePageFaultsRandomSeed
                 }) : nullptr);
         return actor.release();
@@ -614,7 +614,7 @@ void TTestEnv::SetupLocalServiceConfig(
             nullptr /* fastShardServer */,
             Config.FakePageFaultsEnabled ?
                 CreateRescheduler({
-                    .ProbabilityPercentage = Config.FakePageFaultsProbabilityPercentage,
+                    .Probability = Config.FakePageFaultsProbability,
                     .RandomSeed = Config.FakePageFaultsRandomSeed
                 }) : nullptr);
         return actor.release();

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -475,7 +475,11 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            TxRescheduler);
+            Config.FakePageFaultsEnabled ?
+                CreateRescheduler({
+                    .ProbabilityPercentage = Config.FakePageFaultsProbabilityPercentage,
+                    .RandomSeed = Config.FakePageFaultsRandomSeed
+                }) : nullptr);
         return actor.release();
     };
 
@@ -608,7 +612,11 @@ void TTestEnv::SetupLocalServiceConfig(
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            TxRescheduler);
+            Config.FakePageFaultsEnabled ?
+                CreateRescheduler({
+                    .ProbabilityPercentage = Config.FakePageFaultsProbabilityPercentage,
+                    .RandomSeed = Config.FakePageFaultsRandomSeed
+                }) : nullptr);
         return actor.release();
     };
 

--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -475,7 +475,7 @@ ui64 TTestEnv::BootIndexTablet(ui32 nodeIdx)
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            Config.FakePageFaultsEnabled ?
+            Config.FakePageFaultsProbability > 0 ?
                 CreateRescheduler({
                     .Probability = Config.FakePageFaultsProbability,
                     .RandomSeed = Config.FakePageFaultsRandomSeed
@@ -612,7 +612,7 @@ void TTestEnv::SetupLocalServiceConfig(
             SystemCounters,
             Registry,
             nullptr /* fastShardServer */,
-            Config.FakePageFaultsEnabled ?
+            Config.FakePageFaultsProbability > 0 ?
                 CreateRescheduler({
                     .Probability = Config.FakePageFaultsProbability,
                     .RandomSeed = Config.FakePageFaultsRandomSeed

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -269,10 +269,17 @@ TStorageConfigPtr CreateTestStorageConfig(NProto::TStorageConfig storageConfig);
 ////////////////////////////////////////////////////////////////////////////////
 
 #define TABLET_TEST_HEAD(name)                                                 \
-    void TestImpl##name(TFileSystemConfig tabletConfig);                       \
+    void TestImpl##name(                                                      \
+        TFileSystemConfig tabletConfig,                                        \
+        TTestEnvConfig testEnvConfig);                                         \
     Y_UNIT_TEST(name)                                                          \
     {                                                                          \
-        TestImpl##name(TFileSystemConfig{.BlockSize = 4_KB});                  \
+        TestImpl##name(TFileSystemConfig{.BlockSize = 4_KB}, {});              \
+    }                                                                          \
+    Y_UNIT_TEST(name##WithEmulatedPageFaults)                                  \
+    {                                                                          \
+        TestImpl##name(TFileSystemConfig{.BlockSize = 4_KB},                   \
+                       TTestEnvConfig{.FakePageFaultsProbability = 0.01});     \
     }                                                                          \
 // TABLET_TEST_HEAD
 
@@ -280,14 +287,18 @@ TStorageConfigPtr CreateTestStorageConfig(NProto::TStorageConfig storageConfig);
     TABLET_TEST_HEAD(name)                                                     \
     Y_UNIT_TEST(name##largeBS)                                                 \
     {                                                                          \
-        TestImpl##name(TFileSystemConfig{.BlockSize = largeBS});               \
+        TestImpl##name(TFileSystemConfig{.BlockSize = largeBS}, {});           \
     }                                                                          \
-    void TestImpl##name(TFileSystemConfig tabletConfig)                        \
+    void TestImpl##name(                                                       \
+        TFileSystemConfig tabletConfig,                                        \
+        TTestEnvConfig testEnvConfig)                                          \
 // TABLET_TEST_IMPL
 
 #define TABLET_TEST_4K_ONLY(name)                                              \
     TABLET_TEST_HEAD(name)                                                     \
-    void TestImpl##name(TFileSystemConfig tabletConfig)                        \
+    void TestImpl##name(                                                       \
+        TFileSystemConfig tabletConfig,                                        \
+        TTestEnvConfig testEnvConfig)                                          \
 // TABLET_TEST_4K_ONLY
 
 #define TABLET_TEST(name)                                                      \

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -76,6 +76,11 @@ struct TTestEnvConfig
     NActors::NLog::EPriority LogPriority_NFS = NActors::NLog::PRI_TRACE;
     NActors::NLog::EPriority LogPriority_KiKiMR = NActors::NLog::PRI_WARN;
     NActors::NLog::EPriority LogPriority_Others = NActors::NLog::PRI_WARN;
+
+    // This controls probability that read will be restarted
+    bool FakePageFaultsEnabled = true;
+    double FakePageFaultsProbabilityPercentage = 1;
+    std::optional<ui64> FakePageFaultsRandomSeed = std::nullopt;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -90,7 +95,6 @@ private:
     IProfileLogPtr ProfileLog;
     ITraceSerializerPtr TraceSerializer;
     TSystemCountersPtr SystemCounters;
-    ITxReschedulerPtr TxRescheduler = CreateNoOpTxRescheduler();
 
     NKikimr::TTestBasicRuntime Runtime;
     TVector<ui32> GroupIds;
@@ -118,14 +122,6 @@ public:
     NActors::TTestActorRuntime& GetRuntime()
     {
         return Runtime;
-    }
-
-    // Inject a transaction rescheduler.
-    // Defaults to a no-op stub; tests set a custom one to exercise the
-    // transaction restart/reorder path. Must be set before BootIndexTablet.
-    void SetTxRescheduler(ITxReschedulerPtr txRescheduler)
-    {
-        TxRescheduler = std::move(txRescheduler);
     }
 
     TStorageConfigPtr GetStorageConfig() const

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -78,8 +78,7 @@ struct TTestEnvConfig
     NActors::NLog::EPriority LogPriority_Others = NActors::NLog::PRI_WARN;
 
     // This controls probability that read will be restarted
-    bool FakePageFaultsEnabled = true;
-    double FakePageFaultsProbability = 0.01;
+    double FakePageFaultsProbability = 0.0;
     std::optional<ui64> FakePageFaultsRandomSeed = std::nullopt;
 };
 

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -79,7 +79,7 @@ struct TTestEnvConfig
 
     // This controls probability that read will be restarted
     bool FakePageFaultsEnabled = true;
-    double FakePageFaultsProbabilityPercentage = 1;
+    double FakePageFaultsProbability = 0.01;
     std::optional<ui64> FakePageFaultsRandomSeed = std::nullopt;
 };
 

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -33,5 +33,4 @@ GidPropagationEnabled: true
 NodeRefsNoAutoPrecharge: true
 UseCustomReadDataResponseParser: true
 MaxShardManagementRequestsInFlight: 3
-FakeTxPageFaultsEnabled: true
 FakeTxPageFaultsProbability: 0.001

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -33,3 +33,5 @@ GidPropagationEnabled: true
 NodeRefsNoAutoPrecharge: true
 UseCustomReadDataResponseParser: true
 MaxShardManagementRequestsInFlight: 3
+FakeTxPageFaultsEnabled: true
+FakeTxPageFaultsProbabilityPercentage: 0.1

--- a/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
+++ b/cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
@@ -34,4 +34,4 @@ NodeRefsNoAutoPrecharge: true
 UseCustomReadDataResponseParser: true
 MaxShardManagementRequestsInFlight: 3
 FakeTxPageFaultsEnabled: true
-FakeTxPageFaultsProbabilityPercentage: 0.1
+FakeTxPageFaultsProbability: 0.001


### PR DESCRIPTION
### Notes
This change allows randomly to restart transactions in tests using TTestEnv. Random page faults are enabled for a subset of unit and integration tests.

Currently there is some gap in testing transactions restarted due to "page faults" in YDB, which reschedule and restart read transactions after some delay. As we did not find a way to trigger page faults in YDB, I extended previously existing failure injection to all Read* methods of TInMemoryIndexState. 

This PR is a rework of https://github.com/ydb-platform/nbs/pull/6423.

### Issue
#6467

