### PR TITLE
Fixed dirty devices diskRegistry mon-page

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor.h
@@ -92,6 +92,7 @@ private:
     bool DiskStatesPublicationInProgress = false;
     bool AutomaticallyReplacedDevicesDeletionInProgress = false;
     THashSet<TString> SecureEraseInProgressPerPool;
+    THashMap<TString, TInstant> DeviceEraseStartTs;
     bool StartMigrationInProgress = false;
 
     TVector<TString> DisksBeingDestroyed;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -2496,7 +2496,7 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
     IOutputStream& out) const
 {
     auto dirtyDevices = State->GetDirtyDevices();
-    TMap<ESecureEraseAbility, TVector<TDirtyDeviceEntry>> classified;
+    TMap<ESecureEraseReadiness, TVector<TDirtyDeviceEntry>> classified;
     TVector<TDirtyDeviceEntry> eraseInProgress;
 
     for (const auto& device: dirtyDevices) {
@@ -2518,13 +2518,14 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
             entry.AgentId = agent->GetAgentId();
         }
 
-        const ESecureEraseAbility ability = State->CanSecureErase(device);
-        if (ability == ESecureEraseAbility::ReadyToErase &&
+        const ESecureEraseReadiness readiness =
+            State->GetSecureEraseReadiness(device);
+        if (readiness == ESecureEraseReadiness::ReadyToErase &&
             entry.EraseStartedAt)
         {
             eraseInProgress.push_back(std::move(entry));
         } else {
-            classified[ability].push_back(std::move(entry));
+            classified[readiness].push_back(std::move(entry));
         }
     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -2597,7 +2597,7 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
             }
         };
 
-        renderTable("Cleanup up in progress", eraseInProgress, true);
+        renderTable("Cleanup in progress", eraseInProgress, true);
         for (const auto& [ability, devices]: classified) {
             renderTable(ToString(ability), devices, false);
         }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_monitoring.cpp
@@ -444,6 +444,7 @@ struct TDirtyDeviceEntry
 {
     TString Uuid;
     TInstant StateTs;
+    TInstant EraseStartedAt;
     TString AgentId;
     TString PoolName;
     TString StateMessage;
@@ -507,6 +508,17 @@ TVector<TReplicaHistoryEntry> MergeMirrorDiskHistory(
         });
 
     return result;
+}
+
+TString RenderTime(TInstant ts, TInstant now, bool duration)
+{
+    if (!ts) {
+        return "N/A";
+    }
+    if (duration) {
+        return FormatDuration(now - ts);
+    }
+    return ts.FormatGmTime("%Y-%m-%d %H:%M:%S UTC");
 }
 
 }   // namespace
@@ -2484,12 +2496,9 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
     IOutputStream& out) const
 {
     auto dirtyDevices = State->GetDirtyDevices();
-    TVector<TDirtyDeviceEntry> processing;
-    TVector<TDirtyDeviceEntry> cleaning;
-    TVector<TDirtyDeviceEntry> waiting;
-    TVector<TDirtyDeviceEntry> agentDown;
-    TVector<TDirtyDeviceEntry> broken;
-    TVector<TDirtyDeviceEntry> blocked;
+    TMap<ESecureEraseAbility, TVector<TDirtyDeviceEntry>> classified;
+    TVector<TDirtyDeviceEntry> eraseInProgress;
+
     for (const auto& device: dirtyDevices) {
         TDirtyDeviceEntry entry{
             .Uuid = device.GetDeviceUUID(),
@@ -2498,41 +2507,32 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
             .StateMessage = device.GetStateMessage(),
         };
 
-        if (device.GetState() == NProto::DEVICE_STATE_ERROR) {
-            broken.push_back(std::move(entry));
-            continue;
-        }
-
-        if (device.GetState() != NProto::DEVICE_STATE_ONLINE &&
-            device.GetState() != NProto::DEVICE_STATE_WARNING)
+        if (const TInstant* ts =
+                DeviceEraseStartTs.FindPtr(device.GetDeviceUUID()))
         {
-            continue;
+            entry.EraseStartedAt = *ts;
+        }
+        if (const NProto::TAgentConfig* agent =
+                State->FindAgent(device.GetNodeId()))
+        {
+            entry.AgentId = agent->GetAgentId();
         }
 
-        const NProto::TAgentConfig* agent =
-            State->FindAgent(device.GetNodeId());
-        if (!agent) {
-            waiting.push_back(std::move(entry));
-        } else if (agent->GetState() == NProto::AGENT_STATE_UNAVAILABLE) {
-            entry.AgentId = agent->GetAgentId();
-            agentDown.push_back(std::move(entry));
-        } else if (State->CanSecureErase(device)) {
-            entry.AgentId = agent->GetAgentId();
-            if (SecureEraseInProgressPerPool.contains(device.GetPoolName())) {
-                processing.push_back(std::move(entry));
-            } else {
-                cleaning.push_back(std::move(entry));
-            }
+        const ESecureEraseAbility ability = State->CanSecureErase(device);
+        if (ability == ESecureEraseAbility::ReadyToErase &&
+            entry.EraseStartedAt)
+        {
+            eraseInProgress.push_back(std::move(entry));
         } else {
-            entry.AgentId = agent->GetAgentId();
-            blocked.push_back(std::move(entry));
+            classified[ability].push_back(std::move(entry));
         }
     }
 
     HTML (out) {
+        const auto now = TInstant::Now();
         auto renderTable = [&](const TString& title,
                                const TVector<TDirtyDeviceEntry>& rows,
-                               bool agentRed)
+                               bool showCleanupTime)
         {
             TAG (TH3) {
                 out << title << " (" << rows.size() << ")";
@@ -2560,7 +2560,9 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
                             out << "In state since";
                         }
                         TABLEH () {
-                            out << "Time in state";
+                            out
+                                << (showCleanupTime ? "Time in cleanup"
+                                                    : "Time in state");
                         }
                     }
                 }
@@ -2571,13 +2573,7 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
                         }
                         TABLED () {
                             if (e.AgentId) {
-                                if (agentRed) {
-                                    out << "<font color='red'>";
-                                    DumpAgentLink(out, TabletID(), e.AgentId);
-                                    out << "</font>";
-                                } else {
-                                    DumpAgentLink(out, TabletID(), e.AgentId);
-                                }
+                                DumpAgentLink(out, TabletID(), e.AgentId);
                             }
                         }
                         TABLED () {
@@ -2587,23 +2583,23 @@ void TDiskRegistryActor::RenderDirtyDevicesCleanupOverviewDetailed(
                             out << e.StateMessage;
                         }
                         TABLED () {
-                            out << e.StateTs.FormatGmTime(
-                                "%Y-%m-%d %H:%M:%S UTC");
+                            out << RenderTime(e.StateTs, now, false);
                         }
                         TABLED () {
-                            out << FormatDuration(TInstant::Now() - e.StateTs);
+                            out << RenderTime(
+                                showCleanupTime ? e.EraseStartedAt : e.StateTs,
+                                now,
+                                true);
                         }
                     }
                 }
             }
         };
 
-        renderTable("Clean up in progress", processing, false);
-        renderTable("Ready for cleanup", cleaning, false);
-        renderTable("Waiting for cleanup", waiting, false);
-        renderTable("Agent unavailable", agentDown, true);
-        renderTable("Cleanup blocked", blocked, false);
-        renderTable("Device broken", broken, false);
+        renderTable("Cleanup up in progress", eraseInProgress, true);
+        for (const auto& [ability, devices]: classified) {
+            renderTable(ToString(ability), devices, false);
+        }
     }
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -356,7 +356,10 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
     EraseIf(
         dirtyDevices,
         [this](const NProto::TDeviceConfig& device)
-        { return State->CanSecureErase(device) != ESecureEraseAbility::ReadyToErase; });
+        {
+            return State->GetSecureEraseReadiness(device) !=
+                   ESecureEraseReadiness::ReadyToErase;
+        });
 
     if (!dirtyDevices) {
         LOG_DEBUG(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -342,6 +342,10 @@ void TDiskRegistryActor::CompleteCleanupDevices(
     for (const auto& diskId: args.SyncDeallocatedDisks) {
         ReplyToPendingDeallocations(ctx, diskId);
     }
+
+    for (const auto& uuid: args.Devices) {
+        DeviceEraseStartTs.erase(uuid);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -351,7 +355,8 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
     auto dirtyDevices = State->GetDirtyDevices();
     EraseIf(
         dirtyDevices,
-        [this](auto& device) { return !State->CanSecureErase(device); });
+        [this](const NProto::TDeviceConfig& device)
+        { return State->CanSecureErase(device) != ESecureEraseAbility::ReadyToErase; });
 
     if (!dirtyDevices) {
         LOG_DEBUG(
@@ -452,6 +457,10 @@ void TDiskRegistryActor::HandleSecureErase(
         "%s Received SecureErase request. DirtyDevices: %s",
         LogTitle.GetWithTime().c_str(),
         MakeDevicesNamesString(msg->DirtyDevices).c_str());
+
+    for (const auto& device: msg->DirtyDevices) {
+        DeviceEraseStartTs[device.GetDeviceUUID()] = ctx.Now();
+    }
 
     auto actor = NCloud::Register<TSecureEraseActor>(
         ctx,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_secure_erase.cpp
@@ -150,7 +150,7 @@ void TSecureEraseActor::ReplyAndDie(const TActorContext& ctx, NProto::TError err
     auto response = std::make_unique<TEvDiskRegistryPrivate::TEvSecureEraseResponse>(
         std::move(error),
         PoolName,
-        CleanDevices.size());
+        std::move(CleanDevices));
     NCloud::Reply(ctx, *Request, std::move(response));
 
     NCloud::Send(
@@ -342,10 +342,6 @@ void TDiskRegistryActor::CompleteCleanupDevices(
     for (const auto& diskId: args.SyncDeallocatedDisks) {
         ReplyToPendingDeallocations(ctx, diskId);
     }
-
-    for (const auto& uuid: args.Devices) {
-        DeviceEraseStartTs.erase(uuid);
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -356,10 +352,7 @@ void TDiskRegistryActor::SecureErase(const TActorContext& ctx)
     EraseIf(
         dirtyDevices,
         [this](const NProto::TDeviceConfig& device)
-        {
-            return State->GetSecureEraseReadiness(device) !=
-                   ESecureEraseReadiness::ReadyToErase;
-        });
+        { return !State->CanSecureErase(device); });
 
     if (!dirtyDevices) {
         LOG_DEBUG(
@@ -487,9 +480,12 @@ void TDiskRegistryActor::HandleSecureEraseResponse(
         TBlockStoreComponents::DISK_REGISTRY,
         "%s Received SecureErase response: CleanDevices=%lu",
         LogTitle.GetWithTime().c_str(),
-        msg->CleanDevices);
+        msg->CleanDevices.size());
 
     SecureEraseInProgressPerPool.erase(msg->PoolName);
+    for (const auto& uuid: msg->CleanDevices) {
+        DeviceEraseStartTs.erase(uuid);
+    }
     SecureErase(ctx);
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_writable_state.cpp
@@ -105,6 +105,7 @@ void TDiskRegistryActor::CompleteWritableState(
     UsersNotificationInProgress = false;
     DiskStatesPublicationInProgress = false;
     SecureEraseInProgressPerPool.clear();
+    DeviceEraseStartTs.clear();
     StartMigrationInProgress = false;
 }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h
@@ -299,15 +299,15 @@ struct TEvDiskRegistryPrivate
     struct TSecureEraseResponse
     {
         TString PoolName;
-        size_t CleanDevices = 0;
+        TVector<TString> CleanDevices;
 
         TSecureEraseResponse() = default;
 
         TSecureEraseResponse(
                 TString poolName,
-                size_t cleanDevices)
+                TVector<TString> cleanDevices)
             : PoolName(std::move(poolName))
-            , CleanDevices(cleanDevices)
+            , CleanDevices(std::move(cleanDevices))
         {}
     };
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3121,6 +3121,21 @@ NProto::TError TDiskRegistryState::DeallocateDisk(
     return {};
 }
 
+bool TDiskRegistryState::CanSecureErase(const TDeviceId& uuid) const
+{
+    const NProto::TDeviceConfig* device = FindDevice(uuid);
+    if (!device) {
+        return false;
+    }
+    return CanSecureErase(*device);
+}
+
+bool TDiskRegistryState::CanSecureErase(const NProto::TDeviceConfig& device) const
+{
+    return GetSecureEraseReadiness(device) ==
+           ESecureEraseReadiness::ReadyToErase;
+}
+
 ESecureEraseReadiness TDiskRegistryState::GetSecureEraseReadiness(
     const NProto::TDeviceConfig& device) const
 {
@@ -3172,16 +3187,6 @@ ESecureEraseReadiness TDiskRegistryState::GetSecureEraseReadiness(
     }
 
     return ESecureEraseReadiness::ReadyToErase;
-}
-
-bool TDiskRegistryState::CanSecureErase(const TDeviceId& uuid) const
-{
-    const NProto::TDeviceConfig* device = FindDevice(uuid);
-    if (!device) {
-        return false;
-    }
-    return GetSecureEraseReadiness(*device) ==
-           ESecureEraseReadiness::ReadyToErase;
 }
 
 bool TDiskRegistryState::HasPendingCleanup(const TDiskId& diskId) const

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3121,21 +3121,21 @@ NProto::TError TDiskRegistryState::DeallocateDisk(
     return {};
 }
 
-ESecureEraseAbility TDiskRegistryState::CanSecureErase(
+ESecureEraseReadiness TDiskRegistryState::GetSecureEraseReadiness(
     const NProto::TDeviceConfig& device) const
 {
     if (DeviceList.IsSuspendedAndNotResumingDevice(device.GetDeviceUUID())) {
         STORAGE_DEBUG(
             "Skip SecureErase for device '%s'. Device is suspended.",
             device.GetDeviceUUID().c_str());
-        return ESecureEraseAbility::Suspended;
+        return ESecureEraseReadiness::Suspended;
     }
 
     if (device.GetState() == NProto::DEVICE_STATE_ERROR) {
         STORAGE_DEBUG(
             "Skip SecureErase for device '%s'. Device in error state",
             device.GetDeviceUUID().c_str());
-        return ESecureEraseAbility::DeviceInErrorState;
+        return ESecureEraseReadiness::DeviceInErrorState;
     }
 
     if (IsAutomaticallyReplaced(device.GetDeviceUUID())) {
@@ -3143,7 +3143,7 @@ ESecureEraseAbility TDiskRegistryState::CanSecureErase(
             "Skip SecureErase for device '%s'."
             " Device was automatically replaced recently.",
             device.GetDeviceUUID().c_str());
-        return ESecureEraseAbility::AutomaticallyReplaced;
+        return ESecureEraseReadiness::AutomaticallyReplaced;
     }
 
     const NProto::TAgentConfig* agent = FindAgent(device.GetNodeId());
@@ -3152,7 +3152,7 @@ ESecureEraseAbility TDiskRegistryState::CanSecureErase(
             "Skip SecureErase for device '%s'. Agent for node id %d not found",
             device.GetDeviceUUID().c_str(),
             device.GetNodeId());
-        return ESecureEraseAbility::AgentAbsent;
+        return ESecureEraseReadiness::AgentAbsent;
     }
 
     if (StorageConfig->GetAttachDetachPathsEnabled()) {
@@ -3160,7 +3160,7 @@ ESecureEraseAbility TDiskRegistryState::CanSecureErase(
             STORAGE_DEBUG(
                 "Skip SecureErase for device '%s'. Device is detached",
                 device.GetDeviceUUID().c_str());
-            return ESecureEraseAbility::DeviceDetached;
+            return ESecureEraseReadiness::DeviceDetached;
         }
     }
 
@@ -3168,10 +3168,10 @@ ESecureEraseAbility TDiskRegistryState::CanSecureErase(
         STORAGE_DEBUG(
             "Skip SecureErase for device '%s'. Agent is unavailable",
             device.GetDeviceUUID().c_str());
-        return ESecureEraseAbility::AgentUnavailable;
+        return ESecureEraseReadiness::AgentUnavailable;
     }
 
-    return ESecureEraseAbility::ReadyToErase;
+    return ESecureEraseReadiness::ReadyToErase;
 }
 
 bool TDiskRegistryState::CanSecureErase(const TDeviceId& uuid) const
@@ -3180,7 +3180,8 @@ bool TDiskRegistryState::CanSecureErase(const TDeviceId& uuid) const
     if (!device) {
         return false;
     }
-    return CanSecureErase(*device) == ESecureEraseAbility::ReadyToErase;
+    return GetSecureEraseReadiness(*device) ==
+           ESecureEraseReadiness::ReadyToErase;
 }
 
 bool TDiskRegistryState::HasPendingCleanup(const TDiskId& diskId) const

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -3121,21 +3121,21 @@ NProto::TError TDiskRegistryState::DeallocateDisk(
     return {};
 }
 
-bool TDiskRegistryState::CanSecureErase(
+ESecureEraseAbility TDiskRegistryState::CanSecureErase(
     const NProto::TDeviceConfig& device) const
 {
     if (DeviceList.IsSuspendedAndNotResumingDevice(device.GetDeviceUUID())) {
         STORAGE_DEBUG(
             "Skip SecureErase for device '%s'. Device is suspended.",
             device.GetDeviceUUID().c_str());
-        return false;
+        return ESecureEraseAbility::Suspended;
     }
 
     if (device.GetState() == NProto::DEVICE_STATE_ERROR) {
         STORAGE_DEBUG(
             "Skip SecureErase for device '%s'. Device in error state",
             device.GetDeviceUUID().c_str());
-        return false;
+        return ESecureEraseAbility::DeviceInErrorState;
     }
 
     if (IsAutomaticallyReplaced(device.GetDeviceUUID())) {
@@ -3143,7 +3143,7 @@ bool TDiskRegistryState::CanSecureErase(
             "Skip SecureErase for device '%s'."
             " Device was automatically replaced recently.",
             device.GetDeviceUUID().c_str());
-        return false;
+        return ESecureEraseAbility::AutomaticallyReplaced;
     }
 
     const NProto::TAgentConfig* agent = FindAgent(device.GetNodeId());
@@ -3152,7 +3152,7 @@ bool TDiskRegistryState::CanSecureErase(
             "Skip SecureErase for device '%s'. Agent for node id %d not found",
             device.GetDeviceUUID().c_str(),
             device.GetNodeId());
-        return false;
+        return ESecureEraseAbility::AgentAbsent;
     }
 
     if (StorageConfig->GetAttachDetachPathsEnabled()) {
@@ -3160,7 +3160,7 @@ bool TDiskRegistryState::CanSecureErase(
             STORAGE_DEBUG(
                 "Skip SecureErase for device '%s'. Device is detached",
                 device.GetDeviceUUID().c_str());
-            return false;
+            return ESecureEraseAbility::DeviceDetached;
         }
     }
 
@@ -3168,10 +3168,10 @@ bool TDiskRegistryState::CanSecureErase(
         STORAGE_DEBUG(
             "Skip SecureErase for device '%s'. Agent is unavailable",
             device.GetDeviceUUID().c_str());
-        return false;
+        return ESecureEraseAbility::AgentUnavailable;
     }
 
-    return true;
+    return ESecureEraseAbility::ReadyToErase;
 }
 
 bool TDiskRegistryState::CanSecureErase(const TDeviceId& uuid) const
@@ -3180,7 +3180,7 @@ bool TDiskRegistryState::CanSecureErase(const TDeviceId& uuid) const
     if (!device) {
         return false;
     }
-    return CanSecureErase(*device);
+    return CanSecureErase(*device) == ESecureEraseAbility::ReadyToErase;
 }
 
 bool TDiskRegistryState::HasPendingCleanup(const TDiskId& diskId) const

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -25,7 +25,7 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class ESecureEraseAbility {
+enum class ESecureEraseReadiness {
     ReadyToErase,
     Suspended,
     DeviceInErrorState,
@@ -751,7 +751,7 @@ public:
     bool IsReadyForCleanup(const TDiskId& diskId) const;
 
     bool CanSecureErase(const TDeviceId& uuid) const;
-    ESecureEraseAbility CanSecureErase(
+    ESecureEraseReadiness GetSecureEraseReadiness(
         const NProto::TDeviceConfig& device) const;
 
     NProto::TError SetUserId(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -751,6 +751,7 @@ public:
     bool IsReadyForCleanup(const TDiskId& diskId) const;
 
     bool CanSecureErase(const TDeviceId& uuid) const;
+    bool CanSecureErase(const NProto::TDeviceConfig& device) const;
     ESecureEraseReadiness GetSecureEraseReadiness(
         const NProto::TDeviceConfig& device) const;
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -25,6 +25,16 @@ namespace NCloud::NBlockStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class ESecureEraseAbility {
+    ReadyToErase,
+    Suspended,
+    DeviceInErrorState,
+    AutomaticallyReplaced,
+    AgentAbsent,
+    AgentUnavailable,
+    DeviceDetached,
+};
+
 struct TAgentStorageInfo
 {
     ui64 ChunkSize = 0;
@@ -741,7 +751,8 @@ public:
     bool IsReadyForCleanup(const TDiskId& diskId) const;
 
     bool CanSecureErase(const TDeviceId& uuid) const;
-    bool CanSecureErase(const NProto::TDeviceConfig& device) const;
+    ESecureEraseAbility CanSecureErase(
+        const NProto::TDeviceConfig& device) const;
 
     NProto::TError SetUserId(
         TDiskRegistryDatabase& db,

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_migration.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_migration.cpp
@@ -1341,7 +1341,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                 switch (event->GetTypeRewrite()) {
                     case TEvDiskRegistryPrivate::EvSecureEraseResponse: {
                         auto* msg = event->Get<TEvDiskRegistryPrivate::TEvSecureEraseResponse>();
-                        cleanDevices += msg->CleanDevices;
+                        cleanDevices += msg->CleanDevices.size();
                         break;
                     }
 

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_suspend.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_suspend.cpp
@@ -204,7 +204,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                     auto* msg = event->Get<
                         TEvDiskRegistryPrivate::TEvSecureEraseResponse>();
 
-                    cleanDevices += msg->CleanDevices;
+                    cleanDevices += msg->CleanDevices.size();
                 }
                 return false;
             });
@@ -355,7 +355,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
             if (event->GetTypeRewrite() == TEvDiskRegistryPrivate::EvSecureEraseResponse) {
                 auto* msg = event->Get<TEvDiskRegistryPrivate::TEvSecureEraseResponse>();
 
-                cleanDevices += msg->CleanDevices;
+                cleanDevices += msg->CleanDevices.size();
             }
 
             return false;
@@ -614,7 +614,7 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
                     auto* msg = event->Get<
                         TEvDiskRegistryPrivate::TEvSecureEraseResponse>();
 
-                    cleanDevices += msg->CleanDevices;
+                    cleanDevices += msg->CleanDevices.size();
                 }
 
                 return false;

--- a/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/testlib/test_env.cpp
@@ -222,7 +222,7 @@ void WaitForSecureErase(
             if (event->GetTypeRewrite() == TEvDiskRegistryPrivate::EvSecureEraseResponse) {
                 auto* msg = event->Get<TEvDiskRegistryPrivate::TEvSecureEraseResponse>();
 
-                cleanDevices += msg->CleanDevices;
+                cleanDevices += msg->CleanDevices.size();
             }
 
             return prev(event);
@@ -328,7 +328,7 @@ void RegisterAndWaitForAgent(
                 if (event->GetTypeRewrite() == TEvDiskRegistryPrivate::EvSecureEraseResponse) {
                     auto* msg = event->Get<TEvDiskRegistryPrivate::TEvSecureEraseResponse>();
 
-                    cleanDevices += msg->CleanDevices;
+                    cleanDevices += msg->CleanDevices.size();
                 }
 
                 return prev(event);

--- a/cloud/blockstore/libs/storage/disk_registry/ya.make
+++ b/cloud/blockstore/libs/storage/disk_registry/ya.make
@@ -1,5 +1,7 @@
 LIBRARY()
 
+GENERATE_ENUM_SERIALIZATION(disk_registry_state.h)
+
 SRCS(
     disk_registry_actor_acquire.cpp
     disk_registry_actor_add_lagging_devices.cpp


### PR DESCRIPTION
### Notes
Group dirty devices by table as they are classified by TDiskRegistryState::CanSecureErase()

### Issue
Continue https://github.com/ydb-platform/nbs/pull/6319

<img width="1213" height="1055" alt="image" src="https://github.com/user-attachments/assets/66e0aa01-6e33-40b5-9fd0-bdc482a585ef" />

