### PR TITLE
issue-6554: [Filestore] Enable shard creation based on explicit shard count in create/alter request even in the case of diusabled `AutomaticShardCreationEnabled`

### DIFF
--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -433,14 +433,23 @@ void TAlterFileStoreActor::FillMultiShardFileStoreConfig(
         TargetConfig.GetProjectId().empty());
 
     currentConfig.SetBlocksCount(TargetConfig.GetBlocksCount());
-    if (!allocateMixed0
-            && StorageConfig->GetAutomaticShardCreationEnabled())
-    {
+    // The filesystem is sharded if automatic shard creation is enabled or if
+    // it was created with an explicitly specified shard count
+    const bool isSharded = StorageConfig->GetAutomaticShardCreationEnabled() ||
+                           ExplicitShardCount > 0 || !ExistingShardIds.empty();
+    if (!allocateMixed0 && isSharded) {
+        ui32 shardCount = ExplicitShardCount;
+        if (shardCount == 0 &&
+            !StorageConfig->GetAutomaticShardCreationEnabled())
+        {
+            // Keep the current number of shards
+            shardCount = ExistingShardIds.size();
+        }
         FileStoreConfig = SetupMultiShardFileStorePerformanceAndChannels(
             *StorageConfig,
             currentConfig,
             PerformanceProfile,
-            ExplicitShardCount);
+            shardCount);
     } else {
         SetupFileStorePerformanceAndChannels(
             allocateMixed0,
@@ -588,12 +597,12 @@ void TAlterFileStoreActor::HandleGetFileSystemTopologyResponse(
         msg->Record.GetStrictFileSystemSizeEnforcementEnabled();
     MaxShardCount = msg->Record.GetMaxShardCount();
 
-    PatchStorageConfig();
-    FillMultiShardFileStoreConfig(ctx);
-
     for (auto& shardId: *msg->Record.MutableShardFileSystemIds()) {
         ExistingShardIds.push_back(std::move(shardId));
     }
+
+    PatchStorageConfig();
+    FillMultiShardFileStoreConfig(ctx);
 
     if (SevenBytesHandlesCount > 0 &&
         ExistingShardIds.size() <= MaxOneByteShardCount &&

--- a/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_alterfs.cpp
@@ -601,6 +601,8 @@ void TAlterFileStoreActor::HandleGetFileSystemTopologyResponse(
         ExistingShardIds.push_back(std::move(shardId));
     }
 
+    // Intentionally called after the ExistingShardIds are filled because this
+    // vector is used in FillMultiShardFileStoreConfig
     PatchStorageConfig();
     FillMultiShardFileStoreConfig(ctx);
 

--- a/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createfs.cpp
@@ -156,7 +156,9 @@ void TCreateFileStoreActor::CreateMainFileStore(const TActorContext& ctx)
     config.SetStorageMediaKind(Request.GetStorageMediaKind());
     config.SetRangeIdHasherType(1);
 
-    if (StorageConfig->GetAutomaticShardCreationEnabled()) {
+    if (StorageConfig->GetAutomaticShardCreationEnabled() ||
+        Request.GetShardCount() > 0)
+    {
         FileStoreConfig = SetupMultiShardFileStorePerformanceAndChannels(
             *StorageConfig,
             config,

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5626,17 +5626,21 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             SUCCEEDED(response->GetStatus()),
             response->GetErrorReason());
 
+        auto listIds = [&] {
+            auto listing = service.ListFileStores();
+            auto fsIds = listing->Record.GetFileStores();
+            TVector<TString> ids(fsIds.begin(), fsIds.end());
+            Sort(ids);
+            return ids;
+        };
+
         TVector<TString> expected = {
             fsId,
             fsId + "_s1",
             fsId + "_s2",
             fsId + "_s3",
         };
-        auto listing = service.ListFileStores();
-        auto fsIds = listing->Record.GetFileStores();
-        TVector<TString> ids(fsIds.begin(), fsIds.end());
-        Sort(ids);
-        UNIT_ASSERT_VALUES_EQUAL(expected, ids);
+        UNIT_ASSERT_VALUES_EQUAL(expected, listIds());
 
         // without an explicit ShardCount no shards should be created
         const TString fsId2 = "test2";
@@ -5644,11 +5648,22 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
 
         expected.push_back(fsId2);
         Sort(expected);
-        listing = service.ListFileStores();
-        fsIds = listing->Record.GetFileStores();
-        ids = TVector<TString>(fsIds.begin(), fsIds.end());
-        Sort(ids);
-        UNIT_ASSERT_VALUES_EQUAL(expected, ids);
+        UNIT_ASSERT_VALUES_EQUAL(expected, listIds());
+
+        // resizing the sharded filesystem without an explicit ShardCount
+        // should keep the shard layout intact
+        service.ResizeFileStore(fsId, 2_GB / 4_KB);
+        UNIT_ASSERT_VALUES_EQUAL(expected, listIds());
+
+        // resizing with a larger explicit ShardCount should add shards
+        service.ResizeFileStore(fsId, 2_GB / 4_KB, false, 4);
+        expected.push_back(fsId + "_s4");
+        Sort(expected);
+        UNIT_ASSERT_VALUES_EQUAL(expected, listIds());
+
+        // decreasing the shard count is prohibited
+        service.AssertResizeFileStoreFailed(fsId, 2_GB / 4_KB, false, 2);
+        UNIT_ASSERT_VALUES_EQUAL(expected, listIds());
     }
 
     SERVICE_TEST(ShouldCreateDirectoryStructureInShards)

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -5606,6 +5606,51 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         UNIT_ASSERT_VALUES_EQUAL(expected, ids);
     }
 
+    SERVICE_TEST(ShouldCreateShardsUponExplicitShardCountInCreateRequest)
+    {
+        // AutomaticShardCreationEnabled is left disabled - shards should be
+        // created only because of the explicit ShardCount in the request
+        UNIT_ASSERT(!config.GetAutomaticShardCreationEnabled());
+        TTestEnv env({}, config);
+
+        ui32 nodeIdx = env.AddDynamicNode();
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        const TString fsId = "test";
+        auto request = service.CreateCreateFileStoreRequest(fsId, 1_GB / 4_KB);
+        request->Record.SetShardCount(3);
+        service.SendCreateFileStoreRequest(std::move(request));
+        auto response = service.RecvCreateFileStoreResponse();
+        UNIT_ASSERT_C(
+            SUCCEEDED(response->GetStatus()),
+            response->GetErrorReason());
+
+        TVector<TString> expected = {
+            fsId,
+            fsId + "_s1",
+            fsId + "_s2",
+            fsId + "_s3",
+        };
+        auto listing = service.ListFileStores();
+        auto fsIds = listing->Record.GetFileStores();
+        TVector<TString> ids(fsIds.begin(), fsIds.end());
+        Sort(ids);
+        UNIT_ASSERT_VALUES_EQUAL(expected, ids);
+
+        // without an explicit ShardCount no shards should be created
+        const TString fsId2 = "test2";
+        service.CreateFileStore(fsId2, 1_GB / 4_KB);
+
+        expected.push_back(fsId2);
+        Sort(expected);
+        listing = service.ListFileStores();
+        fsIds = listing->Record.GetFileStores();
+        ids = TVector<TString>(fsIds.begin(), fsIds.end());
+        Sort(ids);
+        UNIT_ASSERT_VALUES_EQUAL(expected, ids);
+    }
+
     SERVICE_TEST(ShouldCreateDirectoryStructureInShards)
     {
         config.SetDirectoryCreationInShardsEnabled(true);


### PR DESCRIPTION
### Notes
In clusters where `AutomaticShardCreationEnabled`, we sometimes still want to create or resize the filesystem by explicitly setting the number of shards using the `filestore-client {create/resize} --shard-count` param

### Issue
#6554