### PR TITLE
[Blockstore] fix read-only access mode check in TExternalVhostEndpointListener

### DIFF
--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/encryption/model/utils.h>
 #include <cloud/blockstore/libs/endpoints/endpoint_listener.h>
 #include <cloud/blockstore/libs/server/config.h>
+#include <cloud/blockstore/libs/service/request_helpers.h>
 #include <cloud/blockstore/vhost-server/options.h>
 
 #include <cloud/storage/core/libs/common/backoff_delay_provider.h>
@@ -1105,7 +1106,8 @@ private:
                 });
         }
 
-        if (request.GetVolumeAccessMode() == NProto::VOLUME_ACCESS_READ_ONLY) {
+        if (!IsReadWriteMode(request.GetVolumeAccessMode()))
+        {
             args.emplace_back("--read-only");
         }
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server.cpp
@@ -1106,8 +1106,7 @@ private:
                 });
         }
 
-        if (!IsReadWriteMode(request.GetVolumeAccessMode()))
-        {
+        if (!IsReadWriteMode(request.GetVolumeAccessMode())) {
             args.emplace_back("--read-only");
         }
 

--- a/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/external_vhost_server_ut.cpp
@@ -1024,6 +1024,28 @@ Y_UNIT_TEST_SUITE(TExternalEndpointTest)
         }
     }
 
+    Y_UNIT_TEST_F(ShouldMountVolumeAsReadOnly, TFixture)
+    {
+        UNIT_ASSERT_VALUES_EQUAL(0, History.size());
+        const ui64 vhostPteFlushByteThreshold = RandInt<ui64>();
+        NProto::TServerConfig serverConfig;
+        serverConfig.SetVhostPteFlushByteThreshold(vhostPteFlushByteThreshold);
+        Listener = CreateEndpointListener(false, serverConfig);
+        auto request = CreateDefaultStartEndpointRequest();
+        request.SetVolumeAccessMode(NProto::VOLUME_ACCESS_USER_READ_ONLY);
+
+        auto error =
+            Listener->StartEndpoint(request, Volume, Session).GetValueSync();
+        UNIT_ASSERT_C(!HasError(error), error);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, History.size());
+
+        auto* create = std::get_if<TCreateExternalEndpoint>(&History[0]);
+        UNIT_ASSERT_C(create, "actual entry: " << History[0].index());
+
+        UNIT_ASSERT_VALUES_EQUAL(Volume.GetDiskId(), create->DiskId);
+        UNIT_ASSERT(FindPtr(create->CmdArgs, "--read-only"));
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NServer


### PR DESCRIPTION
issue: https://github.com/ydb-platform/nbs/issues/6547

found by [codex](https://github.com/ydb-platform/nbs/pull/6546#discussion_r3602230273)