### PR TITLE
Journalled Device Server: handle backend exceptions

### DIFF
--- a/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
@@ -21,6 +21,63 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#define STORAGE_JD_SERVER(xxx, ...)  \
+    xxx(AcquireDevices, __VA_ARGS__) \
+    xxx(ReleaseDevices, __VA_ARGS__) \
+    xxx(ReadPages, __VA_ARGS__)      \
+    xxx(WriteLogRecord, __VA_ARGS__)
+
+// STORAGE_JD_SERVER
+
+template <
+    typename TProtoRequest,
+    typename TProtoResponse,
+    TFuture<TProtoResponse> (IServerBackend::*M)(TInstant, TProtoRequest),
+    TProtoRequest* (NProto::TDeviceProtocolRequest::*F1)(),
+    TProtoResponse* (NProto::TDeviceProtocolResponse::*F2)()>
+struct TServerMethod
+{
+    using TRequest = TProtoRequest;
+    using TResponse = TProtoResponse;
+
+    static auto Execute(
+        IServerBackend& backend,
+        TInstant now,
+        TRequest&& request) -> TFuture<TResponse>
+    {
+        return (backend.*M)(now, std::move(request));
+    }
+
+    static auto MutableProto(NProto::TDeviceProtocolRequest& request)
+        -> TRequest&
+    {
+        return *(request.*F1)();
+    }
+
+    static auto MutableProto(NProto::TDeviceProtocolResponse& response)
+        -> TResponse&
+    {
+        return *(response.*F2)();
+    }
+};
+
+#define STORAGE_DECLARE_METHOD(name, ...)                      \
+    struct T##name##Method                                     \
+        : TServerMethod<                                       \
+              NProto::T##name##Request,                        \
+              NProto::T##name##Response,                       \
+              &IServerBackend::name,                           \
+              &NProto::TDeviceProtocolRequest::Mutable##name,  \
+              &NProto::TDeviceProtocolResponse::Mutable##name> \
+    {                                                          \
+        constexpr static TStringBuf Name = #name;              \
+    };                                                         \
+    // STORAGE_DECLARE_METHOD
+
+STORAGE_JD_SERVER(STORAGE_DECLARE_METHOD)
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TConnection
 {
     TSocketHolder Socket;
@@ -120,6 +177,40 @@ private:
     void HandleRequest(
         NProto::TDeviceProtocolRequest& request,
         TConnectionPtr conn);
+
+    template <typename TMethod>
+    void ProcessRequest(
+        TConnectionPtr conn,
+        NProto::TDeviceProtocolRequest&& request)
+    {
+        using TResponse = typename TMethod::TResponse;
+
+        TFuture<TResponse> future;
+
+        const ui64 requestId = request.GetRequestId();
+
+        try {
+            auto& proto = TMethod::MutableProto(request);
+
+            future = TMethod::Execute(*Backend, Now(), std::move(proto));
+        } catch (...) {
+            STORAGE_ERROR(
+                TMethod::Name << " failed: " << CurrentExceptionMessage());
+
+            future = MakeErrorFuture<TResponse>(std::current_exception());
+        }
+
+        future.Subscribe(
+            [conn, requestId](const auto& future)
+            {
+                NProto::TDeviceProtocolResponse response;
+                response.SetRequestId(requestId);
+                TMethod::MutableProto(response).CopyFrom(
+                    SafeExecute<TResponse>([&] { return future.GetValue(); }));
+
+                conn->ResponseQueue.Enqueue(std::move(response));
+            });
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -314,75 +405,19 @@ void TServer::HandleRequest(
 
     switch (request.GetRequestCase()) {
         case ERequestCase::kAcquireDevices: {
-            auto future = Backend->AcquireDevices(
-                Now(),
-                std::move(*request.MutableAcquireDevices()));
-
-            future.Subscribe(
-                [conn, requestId](
-                    const TFuture<NProto::TAcquireDevicesResponse>& future)
-                {
-                    NProto::TDeviceProtocolResponse response;
-                    response.SetRequestId(requestId);
-                    response.MutableAcquireDevices()->CopyFrom(
-                        future.GetValue());
-
-                    conn->ResponseQueue.Enqueue(std::move(response));
-                });
-
+            ProcessRequest<TAcquireDevicesMethod>(conn, std::move(request));
             break;
         }
         case ERequestCase::kReleaseDevices: {
-            auto future = Backend->ReleaseDevices(
-                Now(),
-                std::move(*request.MutableReleaseDevices()));
-
-            future.Subscribe(
-                [conn, requestId](
-                    const TFuture<NProto::TReleaseDevicesResponse>& future)
-                {
-                    NProto::TDeviceProtocolResponse response;
-                    response.SetRequestId(requestId);
-                    response.MutableReleaseDevices()->CopyFrom(
-                        future.GetValue());
-
-                    conn->ResponseQueue.Enqueue(std::move(response));
-                });
+            ProcessRequest<TReleaseDevicesMethod>(conn, std::move(request));
             break;
         }
         case ERequestCase::kReadPages: {
-            auto future = Backend->ReadPages(
-                Now(),
-                std::move(*request.MutableReadPages()));
-
-            future.Subscribe(
-                [conn,
-                 requestId](const TFuture<NProto::TReadPagesResponse>& future)
-                {
-                    NProto::TDeviceProtocolResponse response;
-                    response.SetRequestId(requestId);
-                    response.MutableReadPages()->CopyFrom(future.GetValue());
-
-                    conn->ResponseQueue.Enqueue(std::move(response));
-                });
+            ProcessRequest<TReadPagesMethod>(conn, std::move(request));
             break;
         }
         case ERequestCase::kWriteLogRecord: {
-            auto future = Backend->WriteLogRecord(
-                Now(),
-                std::move(*request.MutableWriteLogRecord()));
-
-            future.Subscribe(
-                [conn, requestId](
-                    const TFuture<NProto::TWriteLogRecordResponse>& future)
-                {
-                    NProto::TDeviceProtocolResponse response;
-                    response.SetRequestId(requestId);
-                    response.MutableWriteLogRecord()->CopyFrom(
-                        future.GetValue());
-
-                    conn->ResponseQueue.Enqueue(std::move(response));
-                });
+            ProcessRequest<TWriteLogRecordMethod>(conn, std::move(request));
             break;
         }
         default: {

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server.cpp
@@ -21,20 +21,20 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define STORAGE_JD_SERVER(xxx, ...)  \
-    xxx(AcquireDevices, __VA_ARGS__) \
-    xxx(ReleaseDevices, __VA_ARGS__) \
-    xxx(ReadPages, __VA_ARGS__)      \
+#define STORAGE_JOURNALLED_DEVICE_SERVER(xxx, ...) \
+    xxx(AcquireDevices, __VA_ARGS__)               \
+    xxx(ReleaseDevices, __VA_ARGS__)               \
+    xxx(ReadPages, __VA_ARGS__)                    \
     xxx(WriteLogRecord, __VA_ARGS__)
 
-// STORAGE_JD_SERVER
+// STORAGE_JOURNALLED_DEVICE_SERVER
 
 template <
     typename TProtoRequest,
     typename TProtoResponse,
-    TFuture<TProtoResponse> (IServerBackend::*M)(TInstant, TProtoRequest),
-    TProtoRequest* (NProto::TDeviceProtocolRequest::*F1)(),
-    TProtoResponse* (NProto::TDeviceProtocolResponse::*F2)()>
+    TFuture<TProtoResponse> (IServerBackend::*Method)(TInstant, TProtoRequest),
+    TProtoRequest* (NProto::TDeviceProtocolRequest::*mutableRequest)(),
+    TProtoResponse* (NProto::TDeviceProtocolResponse::*mutableResponse)()>
 struct TServerMethod
 {
     using TRequest = TProtoRequest;
@@ -45,19 +45,19 @@ struct TServerMethod
         TInstant now,
         TRequest&& request) -> TFuture<TResponse>
     {
-        return (backend.*M)(now, std::move(request));
+        return (backend.*Method)(now, std::move(request));
     }
 
     static auto MutableProto(NProto::TDeviceProtocolRequest& request)
         -> TRequest&
     {
-        return *(request.*F1)();
+        return *(request.*mutableRequest)();
     }
 
     static auto MutableProto(NProto::TDeviceProtocolResponse& response)
         -> TResponse&
     {
-        return *(response.*F2)();
+        return *(response.*mutableResponse)();
     }
 };
 
@@ -74,7 +74,7 @@ struct TServerMethod
     };                                                         \
     // STORAGE_DECLARE_METHOD
 
-STORAGE_JD_SERVER(STORAGE_DECLARE_METHOD)
+STORAGE_JOURNALLED_DEVICE_SERVER(STORAGE_DECLARE_METHOD)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
+++ b/cloud/storage/core/libs/journalled_device_tcp_server/server_ut.cpp
@@ -38,13 +38,10 @@ struct TTestBackend: public IServerBackend
         std::function<TFuture<NProto::TWriteLogRecordResponse>(
             NProto::TWriteLogRecordRequest)>;
 
-    TPromise<TAcquireDevicesFunc> AcquireDevicesImpl =
-        NewPromise<TAcquireDevicesFunc>();
-    TPromise<TReleaseDevicesFunc> ReleaseDevicesImpl =
-        NewPromise<TReleaseDevicesFunc>();
-    TPromise<TReadPagesFunc> ReadPagesImpl = NewPromise<TReadPagesFunc>();
-    TPromise<TWriteLogRecordFunc> WriteLogRecordImpl =
-        NewPromise<TWriteLogRecordFunc>();
+    TAcquireDevicesFunc AcquireDevicesImpl;
+    TReleaseDevicesFunc ReleaseDevicesImpl;
+    TReadPagesFunc ReadPagesImpl;
+    TWriteLogRecordFunc WriteLogRecordImpl;
 
     [[nodiscard]] auto AcquireDevices(
         TInstant now,
@@ -53,9 +50,7 @@ struct TTestBackend: public IServerBackend
     {
         Y_UNUSED(now);
 
-        return AcquireDevicesImpl.GetFuture().Apply(
-            [request](const auto& future)
-            { return future.GetValue()(request); });
+        return AcquireDevicesImpl(std::move(request));
     }
 
     [[nodiscard]] auto ReleaseDevices(
@@ -65,9 +60,7 @@ struct TTestBackend: public IServerBackend
     {
         Y_UNUSED(now);
 
-        return ReleaseDevicesImpl.GetFuture().Apply(
-            [request](const auto& future)
-            { return future.GetValue()(request); });
+        return ReleaseDevicesImpl(std::move(request));
     }
 
     [[nodiscard]] auto ReadPages(
@@ -77,9 +70,7 @@ struct TTestBackend: public IServerBackend
     {
         Y_UNUSED(now);
 
-        return ReadPagesImpl.GetFuture().Apply(
-            [request](const auto& future)
-            { return future.GetValue()(request); });
+        return ReadPagesImpl(std::move(request));
     }
 
     [[nodiscard]] auto WriteLogRecord(
@@ -89,9 +80,7 @@ struct TTestBackend: public IServerBackend
     {
         Y_UNUSED(now);
 
-        return WriteLogRecordImpl.GetFuture().Apply(
-            [request](const auto& future)
-            { return future.GetValue()(request); });
+        return WriteLogRecordImpl(std::move(request));
     }
 };
 
@@ -361,6 +350,40 @@ Y_UNIT_TEST_SUITE(TDeviceTCPServerTest)
             return proto;
         }();
 
+        std::mutex mutex;
+        std::optional<NProto::TAcquireDevicesRequest> acquireDevicesRequest;
+        std::optional<NProto::TReleaseDevicesRequest> releaseDevicesRequest;
+        std::optional<NProto::TReadPagesRequest> readPagesRequest;
+        std::optional<NProto::TWriteLogRecordRequest> writeLogRecordRequest;
+
+        Backend->AcquireDevicesImpl = [&](auto request)
+        {
+            std::unique_lock lock(mutex);
+            acquireDevicesRequest = std::move(request);
+            return MakeFuture(expectedAcquireDevicesResponse);
+        };
+
+        Backend->ReleaseDevicesImpl = [&](auto request)
+        {
+            std::unique_lock lock(mutex);
+            releaseDevicesRequest = std::move(request);
+            return MakeFuture(expectedReleaseDevicesResponse);
+        };
+
+        Backend->ReadPagesImpl = [&](auto request)
+        {
+            std::unique_lock lock(mutex);
+            readPagesRequest = std::move(request);
+            return MakeFuture(expectedReadPagesResponse);
+        };
+
+        Backend->WriteLogRecordImpl = [&](auto request)
+        {
+            std::unique_lock lock(mutex);
+            writeLogRecordRequest = std::move(request);
+            return MakeFuture(expectedWriteLogRecordResponse);
+        };
+
         TTestClient client{Port};
 
         {
@@ -393,44 +416,6 @@ Y_UNIT_TEST_SUITE(TDeviceTCPServerTest)
                 expectedWriteLogRecordRequest);
             client.Send(request);
         }
-
-        std::mutex mutex;
-        std::optional<NProto::TAcquireDevicesRequest> acquireDevicesRequest;
-        std::optional<NProto::TReleaseDevicesRequest> releaseDevicesRequest;
-        std::optional<NProto::TReadPagesRequest> readPagesRequest;
-        std::optional<NProto::TWriteLogRecordRequest> writeLogRecordRequest;
-
-        Backend->AcquireDevicesImpl.SetValue(
-            [&](auto request)
-            {
-                std::unique_lock lock(mutex);
-                acquireDevicesRequest = std::move(request);
-                return MakeFuture(expectedAcquireDevicesResponse);
-            });
-
-        Backend->ReleaseDevicesImpl.SetValue(
-            [&](auto request)
-            {
-                std::unique_lock lock(mutex);
-                releaseDevicesRequest = std::move(request);
-                return MakeFuture(expectedReleaseDevicesResponse);
-            });
-
-        Backend->ReadPagesImpl.SetValue(
-            [&](auto request)
-            {
-                std::unique_lock lock(mutex);
-                readPagesRequest = std::move(request);
-                return MakeFuture(expectedReadPagesResponse);
-            });
-
-        Backend->WriteLogRecordImpl.SetValue(
-            [&](auto request)
-            {
-                std::unique_lock lock(mutex);
-                writeLogRecordRequest = std::move(request);
-                return MakeFuture(expectedWriteLogRecordResponse);
-            });
 
         TVector<NProto::TDeviceProtocolResponse> responses;
 
@@ -500,9 +485,10 @@ Y_UNIT_TEST_SUITE(TDeviceTCPServerTest)
     {
         const ui32 requestCount = 100;
 
-        Backend->AcquireDevicesImpl.SetValue(
-            [&](auto)
-            { return MakeFuture(NProto::TAcquireDevicesResponse()); });
+        Backend->AcquireDevicesImpl = [&](auto)
+        {
+            return MakeFuture(NProto::TAcquireDevicesResponse());
+        };
 
         TTestClient client1{Port};
         TTestClient client2{Port};
@@ -556,6 +542,175 @@ Y_UNIT_TEST_SUITE(TDeviceTCPServerTest)
         UNIT_ASSERT_EQUAL(expectedIds, ids2);
 
         queue.Stop();
+    }
+
+    Y_UNIT_TEST_F(ShouldHandleBackendExecptions, TFixture)
+    {
+        const ui64 requestId = 42;
+
+        TTestClient client{Port};
+
+        auto acquire = [&]
+        {
+            NProto::TDeviceProtocolRequest request;
+            request.SetRequestId(requestId);
+            request.MutableAcquireDevices();
+            client.Send(request);
+
+            auto response = client.Receive();
+
+            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
+            return response.GetAcquireDevices().GetError();
+        };
+
+        auto release = [&]
+        {
+            NProto::TDeviceProtocolRequest request;
+            request.SetRequestId(requestId);
+            request.MutableReleaseDevices();
+            client.Send(request);
+
+            auto response = client.Receive();
+
+            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
+            return response.GetReleaseDevices().GetError();
+        };
+
+        auto readPages = [&]
+        {
+            NProto::TDeviceProtocolRequest request;
+            request.SetRequestId(requestId);
+            request.MutableReadPages();
+            client.Send(request);
+
+            auto response = client.Receive();
+
+            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
+            return response.GetReadPages().GetError();
+        };
+
+        auto writeLogRecord = [&]
+        {
+            NProto::TDeviceProtocolRequest request;
+            request.SetRequestId(requestId);
+            request.MutableWriteLogRecord();
+            client.Send(request);
+
+            auto response = client.Receive();
+
+            UNIT_ASSERT_VALUES_EQUAL(requestId, response.GetRequestId());
+            return response.GetWriteLogRecord().GetError();
+        };
+
+        Backend->AcquireDevicesImpl =
+            [](auto) -> TFuture<NProto::TAcquireDevicesResponse>
+        {
+            throw TServiceError(E_FAIL) << "acquire-inline-error";
+        };
+
+        Backend->ReleaseDevicesImpl =
+            [](auto) -> TFuture<NProto::TReleaseDevicesResponse>
+        {
+            throw TServiceError(E_FAIL) << "release-inline-error";
+        };
+
+        Backend->ReadPagesImpl = [](auto) -> TFuture<NProto::TReadPagesResponse>
+        {
+            throw TServiceError(E_FAIL) << "readPages-inline-error";
+        };
+        Backend->WriteLogRecordImpl =
+            [](auto) -> TFuture<NProto::TWriteLogRecordResponse>
+        {
+            throw TServiceError(E_FAIL) << "writeLogRecord-inline-error";
+        };
+
+        {
+            auto error = acquire();
+            UNIT_ASSERT_VALUES_EQUAL(E_FAIL, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "acquire-inline-error",
+                error.GetMessage());
+        }
+
+        {
+            auto error = release();
+            UNIT_ASSERT_VALUES_EQUAL(E_FAIL, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "release-inline-error",
+                error.GetMessage());
+        }
+
+        {
+            auto error = readPages();
+            UNIT_ASSERT_VALUES_EQUAL(E_FAIL, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "readPages-inline-error",
+                error.GetMessage());
+        }
+
+        {
+            auto error = writeLogRecord();
+            UNIT_ASSERT_VALUES_EQUAL(E_FAIL, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "writeLogRecord-inline-error",
+                error.GetMessage());
+        }
+
+        Backend->AcquireDevicesImpl = [](auto)
+        {
+            return MakeErrorFuture<NProto::TAcquireDevicesResponse>(
+                std::make_exception_ptr(
+                    TServiceError{E_ARGUMENT} << "acquire-async-error"));
+        };
+
+        Backend->ReleaseDevicesImpl = [](auto)
+        {
+            return MakeErrorFuture<NProto::TReleaseDevicesResponse>(
+                std::make_exception_ptr(
+                    TServiceError{E_ARGUMENT} << "release-async-error"));
+        };
+
+        Backend->ReadPagesImpl = [](auto)
+        {
+            return MakeErrorFuture<NProto::TReadPagesResponse>(
+                std::make_exception_ptr(
+                    TServiceError{E_ARGUMENT} << "readPages-async-error"));
+        };
+
+        Backend->WriteLogRecordImpl = [](auto)
+        {
+            return MakeErrorFuture<NProto::TWriteLogRecordResponse>(
+                std::make_exception_ptr(
+                    TServiceError{E_ARGUMENT} << "writeLogRecord-async-error"));
+        };
+
+        {
+            auto error = acquire();
+            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL("acquire-async-error", error.GetMessage());
+        }
+
+        {
+            auto error = release();
+            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL("release-async-error", error.GetMessage());
+        }
+
+        {
+            auto error = readPages();
+            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "readPages-async-error",
+                error.GetMessage());
+        }
+
+        {
+            auto error = writeLogRecord();
+            UNIT_ASSERT_VALUES_EQUAL(E_ARGUMENT, error.GetCode());
+            UNIT_ASSERT_VALUES_EQUAL(
+                "writeLogRecord-async-error",
+                error.GetMessage());
+        }
     }
 }
 


### PR DESCRIPTION
Handle exceptions thrown by the Journalled Device backend while processing requests.

Previously, a synchronous backend exception escaped the request-handling path and was treated as a protocol-level failure. The server now catches such exceptions, converts them into failed futures, and returns them to the client as request errors.