### PR TITLE
Log E_IO_SILENT no-retry errors as warnings

### DIFF
--- a/cloud/blockstore/libs/client/durable.cpp
+++ b/cloud/blockstore/libs/client/durable.cpp
@@ -69,6 +69,11 @@ ELogPriority GetDetailsLogPriority(const NProto::TError& error)
     }
 }
 
+ELogPriority GetNoRetryLogPriority(const NProto::TError& error)
+{
+    return error.GetCode() == E_IO_SILENT ? TLOG_WARNING : TLOG_ERR;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
@@ -351,7 +356,8 @@ private:
             }
 
             auto duration = TInstant::Now() - state->Started;
-            STORAGE_ERROR(
+            STORAGE_LOG(
+                GetNoRetryLogPriority(response.GetError()),
                 TRequestInfo(
                     TMethod::BlockStoreRequest,
                     requestId,

--- a/cloud/blockstore/libs/client/durable_ut.cpp
+++ b/cloud/blockstore/libs/client/durable_ut.cpp
@@ -60,6 +60,26 @@ struct TPostponedTimeTestService
     }
 };
 
+struct TStoredLogRecord
+{
+    ELogPriority Priority;
+    TString Message;
+};
+
+struct TTestLogBackend final
+    : TLogBackend
+{
+    TVector<TStoredLogRecord> Records;
+
+    void WriteData(const TLogRecord& rec) override
+    {
+        Records.push_back({rec.Priority, TString(rec.Data, rec.Len)});
+    }
+
+    void ReopenLog() override
+    {}
+};
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -379,6 +399,76 @@ Y_UNIT_TEST_SUITE(TDurableClientTest)
         UNIT_ASSERT(FAILED(response.GetError().GetCode()));
 
         UNIT_ASSERT_EQUAL(requestsCount, 1);
+    }
+
+    Y_UNIT_TEST(ShouldLogEIoSilentNoRetryErrorsAsWarnings)
+    {
+        auto runRequest = [] (ui32 errorCode) {
+            auto client = std::make_shared<TTestService>();
+
+            client->PingHandler =
+                [=] (std::shared_ptr<NProto::TPingRequest> request)
+                {
+                    UNIT_ASSERT_UNEQUAL(0, GetRequestId(*request));
+
+                    NProto::TPingResponse response;
+                    *response.MutableError() = MakeError(
+                        errorCode,
+                        "test error");
+                    return MakeFuture(std::move(response));
+                };
+
+            auto config = std::make_shared<TClientAppConfig>();
+
+            auto policy = CreateRetryPolicy(
+                config,
+                NProto::STORAGE_MEDIA_DEFAULT);
+
+            auto timer = CreateCpuCycleTimer();
+            auto scheduler = CreateScheduler(timer);
+            scheduler->Start();
+            Y_SCOPE_EXIT(=) {
+                scheduler->Stop();
+            };
+
+            auto requestStats = CreateRequestStatsStub();
+            auto volumeStats = CreateVolumeStatsStub();
+            auto logBackend = std::make_shared<TTestLogBackend>();
+
+            auto logging = CreateLoggingService(logBackend);
+
+            auto durable = CreateDurableClient(
+                config,
+                client,
+                std::move(policy),
+                std::move(logging),
+                std::move(timer),
+                std::move(scheduler),
+                std::move(requestStats),
+                std::move(volumeStats));
+
+            auto future = durable->Ping(
+                MakeIntrusive<TCallContext>(),
+                std::make_shared<NProto::TPingRequest>());
+
+            const auto& response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_EQUAL(response.GetError().GetCode(), errorCode);
+
+            UNIT_ASSERT_VALUES_EQUAL(1, logBackend->Records.size());
+            return logBackend->Records.back();
+        };
+
+        const auto silentRecord = runRequest(E_IO_SILENT);
+        UNIT_ASSERT_VALUES_EQUAL(TLOG_WARNING, silentRecord.Priority);
+        UNIT_ASSERT(silentRecord.Message.Contains("WARN"));
+        UNIT_ASSERT(silentRecord.Message.Contains("E_IO_SILENT"));
+        UNIT_ASSERT(silentRecord.Message.Contains("will not retry error"));
+
+        const auto errorRecord = runRequest(E_IO);
+        UNIT_ASSERT_VALUES_EQUAL(TLOG_ERR, errorRecord.Priority);
+        UNIT_ASSERT(errorRecord.Message.Contains("ERROR"));
+        UNIT_ASSERT(errorRecord.Message.Contains("E_IO"));
+        UNIT_ASSERT(errorRecord.Message.Contains("will not retry error"));
     }
 
     Y_UNIT_TEST(ShouldClosePreviousLocalRequestWhenRetry)


### PR DESCRIPTION
## Summary
- log durable-client no-retry `E_IO_SILENT` responses at WARN instead of ERROR
- keep other no-retry errors at ERROR
- add durable-client unit coverage for WARN/ERROR log levels

## Validation
- `./ya make -tt cloud/blockstore/libs/client -F TDurableClientTest::ShouldLogEIoSilentNoRetryErrorsAsWarnings`
- `./ya make cloud/blockstore/buildall`
- `git diff --check`