### PR TITLE
[NBS] Local NVMe service: add SILENT flag to E_TRY_AGAIN error

### DIFF
--- a/cloud/blockstore/libs/local_nvme/service_linux.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux.cpp
@@ -6,6 +6,7 @@
 
 #include <cloud/blockstore/libs/nvme/nvme.h>
 
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/proto_helpers.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
@@ -769,10 +770,15 @@ auto TLocalNVMeService::GetOperationResult(
     const TString& idempotenceId) const
     -> std::optional<TFuture<typename TOpResult::value_type>>
 {
-    auto makeErrorFuture = [](ui32 code, TString msg)
+    auto makeErrorFuture = [](ui32 code,
+                              TString msg,
+                              NProto::EErrorFlag protoFlag = NProto::EF_NONE)
     {
+        ui32 flags = 0;
+        SetProtoFlag(flags, protoFlag);
+
         return MakeFuture<typename TOpResult::value_type>(
-            MakeError(code, std::move(msg)));
+            MakeError(code, std::move(msg), flags));
     };
 
     auto it = Operations.find(serialNumber);
@@ -796,7 +802,10 @@ auto TLocalNVMeService::GetOperationResult(
         }
 
         if (!op.FinishTime) {
-            return makeErrorFuture(E_TRY_AGAIN, "Operation is in progress");
+            return makeErrorFuture(
+                E_TRY_AGAIN,
+                "Operation is in progress",
+                NProto::EF_SILENT);
         }
 
         return *typedOp;
@@ -897,8 +906,11 @@ auto TLocalNVMeService::AcquireDevice(
         "Acquire NVMe device operation is still in progress for "
         << serialNumber.Quote() << ", idempotenceId: " << idempotenceId);
 
+    ui32 flags = 0;
+    SetProtoFlag(flags, NProto::EF_SILENT);
+
     return MakeFuture<TAcquireResult>(
-        MakeError(E_TRY_AGAIN, "Acquire in progress"));
+        MakeError(E_TRY_AGAIN, "Acquire in progress", flags));
 }
 
 auto TLocalNVMeService::AcquireDeviceImpl(const TSerialNumber& serialNumber)
@@ -1082,8 +1094,11 @@ auto TLocalNVMeService::ReleaseDevice(
         "Release NVMe device operation is still in progress for "
         << serialNumber.Quote() << ", idempotenceId: " << idempotenceId);
 
+    ui32 flags = 0;
+    SetProtoFlag(flags, NProto::EF_SILENT);
+
     return MakeFuture<NProto::TError>(
-        MakeError(E_TRY_AGAIN, "Release in progress"));
+        MakeError(E_TRY_AGAIN, "Release in progress", flags));
 }
 
 auto TLocalNVMeService::GetDevice(const TSerialNumber& serialNumber)

--- a/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/service_linux_ut.cpp
@@ -8,6 +8,7 @@
 #include <cloud/blockstore/libs/nvme/nvme_stub.h>
 
 #include <cloud/storage/core/libs/common/error.h>
+#include <cloud/storage/core/libs/common/helpers.h>
 #include <cloud/storage/core/libs/common/proto_helpers.h>
 #include <cloud/storage/core/libs/common/thread_pool.h>
 #include <cloud/storage/core/libs/coroutine/executor.h>
@@ -1232,6 +1233,10 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 E_TRY_AGAIN,
                 error.GetCode(),
                 FormatError(error));
+
+            UNIT_ASSERT_C(
+                !HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
+                FormatError(error));
         }
 
         NVMeManager->UpdateSanitizeStatus(ctrlPath, MakeError(S_OK), 100.0);
@@ -1276,6 +1281,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 E_TRY_AGAIN,
                 error.GetCode(),
                 FormatError(error));
+            UNIT_ASSERT_C(
+                HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
+                FormatError(error));
             UNIT_ASSERT_STRING_CONTAINS_C(
                 error.GetMessage(),
                 "Release in progress",
@@ -1289,7 +1297,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 E_TRY_AGAIN,
                 error.GetCode(),
                 FormatError(error));
-
+            UNIT_ASSERT_C(
+                !HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
+                FormatError(error));
             UNIT_ASSERT_STRING_CONTAINS_C(
                 error.GetMessage(),
                 "Another operation is in progress",
@@ -1327,6 +1337,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 E_TRY_AGAIN,
                 error.GetCode(),
                 FormatError(error));
+            UNIT_ASSERT_C(
+                !HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
+                FormatError(error));
             UNIT_ASSERT_STRING_CONTAINS_C(
                 error.GetMessage(),
                 "Another operation is in progress",
@@ -1349,6 +1362,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_TRY_AGAIN,
                 error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_C(
+                HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
                 FormatError(error));
             Sleep(100ms);
         }
@@ -1419,6 +1435,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
                 E_TRY_AGAIN,
                 error.GetCode(),
                 FormatError(error));
+            UNIT_ASSERT_C(
+                HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
+                FormatError(error));
             Sleep(100ms);
         }
 
@@ -1437,6 +1456,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_TRY_AGAIN,
                 error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_C(
+                HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
                 FormatError(error));
         }
 
@@ -1475,6 +1497,9 @@ Y_UNIT_TEST_SUITE(TLocalNVMeServiceTest)
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_TRY_AGAIN,
                 error.GetCode(),
+                FormatError(error));
+            UNIT_ASSERT_C(
+                HasProtoFlag(error.GetFlags(), NProto::EF_SILENT),
                 FormatError(error));
         }
 


### PR DESCRIPTION
Marks E_TRY_AGAIN responses from the Local NVMe service with the EF_SILENT flag only when the in-progress operation has the same idempotence key.

This means the error is muted only when the client is retrying an operation that it previously started.