### PR TITLE
fix: pre-commit regression introduced in #6493 and pre-commit workflow fix was not working at all

### DIFF
--- a/.github/actions/pre_commit/action.yaml
+++ b/.github/actions/pre_commit/action.yaml
@@ -1,5 +1,5 @@
 name: pre-commit
-description: Run pre-commit with a cached hook environment
+description: Run pre-commit
 
 inputs:
   extra_args:
@@ -17,12 +17,6 @@ runs:
     - name: show python packages
       shell: bash
       run: python -m pip freeze --local
-
-    - name: cache pre-commit environments
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: run pre-commit
       shell: bash

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -57,6 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
         clean: true
     - uses: actions/setup-python@v6.3.0

--- a/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
+++ b/cloud/filestore/apps/client/lib/diagnose_filesystem.cpp
@@ -179,5 +179,5 @@ TCommandPtr NewDiagnoseFilesystemCommand()
 {
     return std::make_shared<TDiagnoseFilesystemCommand>();
 }
-  
+
 }   // namespace NCloud::NFileStore::NClient


### PR DESCRIPTION
https://github.com/ydb-platform/nbs/actions/runs/29575429210/job/87868740711?pr=6493
1. After migration to root-less github runners cache had been using root-owned resources and failed to extract cache. This is not critical problem.
2. Critical problem was that by default checkout action checks out base sha, not head sha. And it resulted pre-commit comparing main to main branch. Which is how it has been done [initially](https://github.com/ydb-platform/nbs/commit/72a037911e215c8ac03bf8aab0d2a423675dd5d7#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R25) and haven't been noticed before