### PR TITLE
Report endpoint restore failures

### DIFF
--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -672,6 +672,24 @@ private:
         return false;
     }
 
+    NProto::EEndpointRestoringState GetEndpointRestoringState()
+    {
+        switch (AtomicGet(RestoringStage)) {
+            case WaitingForRestoring:
+                return NProto::ENDPOINT_RESTORING_STATE_WAITING_FOR_RESTORING;
+            case ReadingStorage:
+                return NProto::ENDPOINT_RESTORING_STATE_READING_STORAGE;
+            case StartingEndpoints:
+                return NProto::ENDPOINT_RESTORING_STATE_STARTING_ENDPOINTS;
+            case Completed:
+                return NProto::ENDPOINT_RESTORING_STATE_COMPLETED;
+            case Failed:
+                return NProto::ENDPOINT_RESTORING_STATE_FAILED;
+        }
+
+        return NProto::ENDPOINT_RESTORING_STATE_FAILED;
+    }
+
     NProto::TStartEndpointResponse StartEndpointImpl(
         TCallContextPtr ctx,
         std::shared_ptr<NProto::TStartEndpointRequest> request,
@@ -1251,13 +1269,6 @@ NProto::TListEndpointsResponse TEndpointManager::DoListEndpoints(
     Y_UNUSED(ctx);
     Y_UNUSED(request);
 
-    if (AtomicGet(RestoringStage) == Failed) {
-        return TErrorResponse(
-            E_FAIL,
-            TStringBuilder()
-                << "failed to restore " << AtomicGet(RestoringErrors)
-                << " endpoint(s)");
-    }
 
     NProto::TListEndpointsResponse response;
     auto& responseEndpoints = *response.MutableEndpoints();
@@ -1267,8 +1278,12 @@ NProto::TListEndpointsResponse TEndpointManager::DoListEndpoints(
         responseEndpoints.Add()->CopyFrom(*endpoint->Request);
     }
 
+    const auto restoringStage = AtomicGet(RestoringStage);
     response.SetEndpointsWereRestored(
-        AtomicGet(RestoringStage) == Completed);
+        restoringStage == Completed || restoringStage == Failed);
+    response.SetEndpointRestoringState(GetEndpointRestoringState());
+    response.SetEndpointRestoringErrorCount(AtomicGet(RestoringErrors));
+
     return response;
 }
 

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -510,12 +510,14 @@ private:
 
     NClient::IMetricClientPtr RestoringClient;
     TSet<TString> RestoringEndpoints;
+    TAtomic RestoringErrors = 0;
 
     enum {
         WaitingForRestoring = 0,
         ReadingStorage = 1,
         StartingEndpoints = 2,
         Completed = 3,
+        Failed = 4,
     };
 
     TAtomic RestoringStage = WaitingForRestoring;
@@ -628,13 +630,18 @@ public:
 
     TFuture<void> RestoreEndpoints() override
     {
+        AtomicSet(RestoringErrors, 0);
         AtomicSet(RestoringStage, ReadingStorage);
         return Executor->Execute([weakSelf = weak_from_this()] () mutable {
             if (auto self = weakSelf.lock()) {
                 auto future = self->DoRestoreEndpoints();
                 AtomicSet(self->RestoringStage, self->StartingEndpoints);
                 self->Executor->WaitFor(future);
-                AtomicSet(self->RestoringStage, self->Completed);
+                AtomicSet(
+                    self->RestoringStage,
+                    AtomicGet(self->RestoringErrors)
+                        ? self->Failed
+                        : self->Completed);
             }
         });
     }
@@ -660,6 +667,7 @@ private:
             case ReadingStorage: return true;
             case StartingEndpoints: return RestoringEndpoints.contains(socket);
             case Completed: return false;
+            case Failed: return false;
         }
         return false;
     }
@@ -1242,6 +1250,14 @@ NProto::TListEndpointsResponse TEndpointManager::DoListEndpoints(
 {
     Y_UNUSED(ctx);
     Y_UNUSED(request);
+
+    if (AtomicGet(RestoringStage) == Failed) {
+        return TErrorResponse(
+            E_FAIL,
+            TStringBuilder()
+                << "failed to restore " << AtomicGet(RestoringErrors)
+                << " endpoint(s)");
+    }
 
     NProto::TListEndpointsResponse response;
     auto& responseEndpoints = *response.MutableEndpoints();
@@ -1826,10 +1842,14 @@ TFuture<NProto::TError> TEndpointManager::SwitchEndpointIfNeeded(
 TFuture<void> TEndpointManager::DoRestoreEndpoints()
 {
     auto [endpointIds, error] = EndpointStorage->GetEndpointIds();
-    if (HasError(error) && !HasProtoFlag(error.GetFlags(), NProto::EF_SILENT)) {
-        ReportEndpointRestoringError(
-            TStringBuilder()
-            << "Failed to get endpoints from storage: " << FormatError(error));
+    if (HasError(error)) {
+        AtomicIncrement(RestoringErrors);
+        if (!HasProtoFlag(error.GetFlags(), NProto::EF_SILENT)) {
+            ReportEndpointRestoringError(
+                TStringBuilder()
+                << "Failed to get endpoints from storage: "
+                << FormatError(error));
+        }
         return MakeFuture();
     }
 
@@ -1844,15 +1864,22 @@ TFuture<void> TEndpointManager::DoRestoreEndpoints()
         if (HasError(error)
                 && !HasProtoFlag(error.GetFlags(), NProto::EF_SILENT))
         {
+            AtomicIncrement(RestoringErrors);
             // NBS-3678
             STORAGE_WARN("Failed to restore endpoint. ID: " << endpointId
                 << ", error: " << FormatError(error));
             continue;
         }
 
+        if (HasError(error)) {
+            AtomicIncrement(RestoringErrors);
+            continue;
+        }
+
         auto request = DeserializeEndpoint<NProto::TStartEndpointRequest>(str);
 
         if (!request) {
+            AtomicIncrement(RestoringErrors);
             ReportEndpointRestoringError(
                 TStringBuilder() << "Failed to deserialize request, error: "
                                  << FormatError(error),
@@ -1867,6 +1894,7 @@ TFuture<void> TEndpointManager::DoRestoreEndpoints()
                 auto error = NbdDeviceManager.AcquireDevice(nbdDevice);
 
                 if (HasError(error)) {
+                    AtomicIncrement(RestoringErrors);
                     ReportEndpointRestoringError(
                         TStringBuilder()
                             << "Failed to acquire nbd device, error: "
@@ -1897,25 +1925,31 @@ TFuture<void> TEndpointManager::DoRestoreEndpoints()
             std::move(request));
 
         auto weakPtr = weak_from_this();
-        future.Subscribe([weakPtr, socketPath, endpointId] (const auto& f) {
-            const auto& response = f.GetValue();
-            if (HasError(response)) {
-                ReportEndpointRestoringError(
-                    TStringBuilder() << "Endpoint restoring error occurred for "
-                                        "endpoint, error: "
-                                     << FormatError(response.GetError()),
-                    {{"endpointId", endpointId}, {"socketPath", socketPath}});
-            }
+        auto handledFuture = future.Apply(
+            [weakPtr, socketPath, endpointId] (const auto& f) {
+                const auto& response = f.GetValue();
+                if (HasError(response)) {
+                    ReportEndpointRestoringError(
+                        TStringBuilder()
+                            << "Endpoint restoring error occurred for "
+                               "endpoint, error: "
+                            << FormatError(response.GetError()),
+                        {{"endpointId", endpointId},
+                         {"socketPath", socketPath}});
+                }
 
-            if (auto ptr = weakPtr.lock()) {
-                ptr->HandleRestoredEndpoint(
-                    socketPath,
-                    endpointId,
-                    response.GetError());
-            }
-        });
+                if (auto ptr = weakPtr.lock()) {
+                    if (HasError(response)) {
+                        AtomicIncrement(ptr->RestoringErrors);
+                    }
+                    ptr->HandleRestoredEndpoint(
+                        socketPath,
+                        endpointId,
+                        response.GetError());
+                }
+            });
 
-        futures.push_back(future.IgnoreResult());
+        futures.push_back(std::move(handledFuture));
     }
 
     return WaitAll(futures);

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -1761,11 +1761,14 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
 
         auto response =
             ListEndpoints(*manager).GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT_VALUES_EQUAL(E_FAIL, response.GetError().GetCode());
-        UNIT_ASSERT(!response.GetEndpointsWereRestored());
-        UNIT_ASSERT_STRING_CONTAINS(
-            response.GetError().GetMessage(),
-            "failed to restore 3 endpoint(s)");
+        UNIT_ASSERT(!HasError(response));
+        UNIT_ASSERT(response.GetEndpointsWereRestored());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NProto::ENDPOINT_RESTORING_STATE_FAILED),
+            static_cast<int>(response.GetEndpointRestoringState()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            wrongCount,
+            response.GetEndpointRestoringErrorCount());
     }
 
     Y_UNIT_TEST(ShouldRemoveEndpointForNotFoundVolume)

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -1758,6 +1758,14 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
 
         UNIT_ASSERT(wrongCount != correctCount);
         UNIT_ASSERT_VALUES_EQUAL(wrongCount, static_cast<int>(*configCounter));
+
+        auto response =
+            ListEndpoints(*manager).GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_VALUES_EQUAL(E_FAIL, response.GetError().GetCode());
+        UNIT_ASSERT(!response.GetEndpointsWereRestored());
+        UNIT_ASSERT_STRING_CONTAINS(
+            response.GetError().GetMessage(),
+            "failed to restore 3 endpoint(s)");
     }
 
     Y_UNIT_TEST(ShouldRemoveEndpointForNotFoundVolume)

--- a/cloud/blockstore/public/api/protos/endpoints.proto
+++ b/cloud/blockstore/public/api/protos/endpoints.proto
@@ -135,6 +135,15 @@ message TListEndpointsRequest
     THeaders Headers = 1;
 }
 
+enum EEndpointRestoringState
+{
+    ENDPOINT_RESTORING_STATE_WAITING_FOR_RESTORING = 0;
+    ENDPOINT_RESTORING_STATE_READING_STORAGE = 1;
+    ENDPOINT_RESTORING_STATE_STARTING_ENDPOINTS = 2;
+    ENDPOINT_RESTORING_STATE_COMPLETED = 3;
+    ENDPOINT_RESTORING_STATE_FAILED = 4;
+}
+
 message TListEndpointsResponse
 {
     // Optional error, set only if error happened.
@@ -145,6 +154,12 @@ message TListEndpointsResponse
 
     // Endpoints restoring status.
     bool EndpointsWereRestored = 3;
+
+    // Endpoint restoring stage.
+    EEndpointRestoringState EndpointRestoringState = 4;
+
+    // Number of endpoint restoring errors.
+    uint32 EndpointRestoringErrorCount = 5;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What changed

- Track endpoint restore errors in `TEndpointManager` with an atomic counter.
- Mark endpoint restoration as failed when any restore step fails.
- Return `E_FAIL` from `ListEndpoints` after failed restore, including the number of failed endpoints.
- Extend `ShouldRestoreEndpointWithNbdDevice` to verify the new `ListEndpoints` error behavior.

## Why

Previously restore errors were reported to logs/counters, but the final restore stage still became `Completed`. As a result, clients listing endpoints could observe `EndpointsWereRestored=true` even when some endpoints failed to restore.

## Validation

- `git diff --check`
- `./ya make -tt cloud/blockstore/libs/endpoints/ut -F TEndpointManagerTest::ShouldRestoreEndpointWithNbdDevice`
- `./ya make -tt cloud/blockstore/libs/endpoints/ut`