### PR TITLE
[Filestore] Do not report DescribeFileStoreError critical event from TCreateSessionActor if the request came from a source we can not control (gRPC request / filestore-client)

### DIFF
--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -439,6 +439,14 @@ void TAppContext::ValidateRequest(
     internal.SetRequestSource(*source);
     internal.SetPeer(TString(context.peer()));
 
+    // don't override a value set earlier
+    if (internal.GetRequestOrigin() ==
+        NProto::THeaders::TInternal::REQUEST_ORIGIN_UNSPECIFIED)
+    {
+        internal.SetRequestOrigin(
+            NProto::THeaders::TInternal::REQUEST_ORIGIN_UNCONTROLLED);
+    }
+
     // we will only get token from secure control channel
     if (source == NProto::SOURCE_SECURE_CONTROL_CHANNEL) {
         internal.SetAuthToken(GetAuthToken(context.client_metadata()));

--- a/cloud/filestore/libs/server/server.cpp
+++ b/cloud/filestore/libs/server/server.cpp
@@ -444,7 +444,7 @@ void TAppContext::ValidateRequest(
         NProto::THeaders::TInternal::REQUEST_ORIGIN_UNSPECIFIED)
     {
         internal.SetRequestOrigin(
-            NProto::THeaders::TInternal::REQUEST_ORIGIN_UNCONTROLLED);
+            NProto::THeaders::TInternal::REQUEST_ORIGIN_EXTERNAL);
     }
 
     // we will only get token from secure control channel

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -52,7 +52,7 @@ private:
     TString CheckpointId;
     TString OriginFqdn;
     // Whether the filesystem id came from the public gRPC API
-    bool FromUncontrolledSource;
+    bool FromExternalSource;
     bool RestoreClientSession;
     ui64 SeqNo;
     bool ReadOnly;
@@ -89,7 +89,7 @@ public:
         ui64 seqNo,
         bool readOnly,
         bool restoreClientSession,
-        bool fromUncontrolledSource,
+        bool fromExternalSource,
         TActorId owner);
 
     void Bootstrap(const TActorContext& ctx);
@@ -185,7 +185,7 @@ TCreateSessionActor::TCreateSessionActor(
         ui64 seqNo,
         bool readOnly,
         bool restoreClientSession,
-        bool fromUncontrolledSource,
+        bool fromExternalSource,
         TActorId owner)
     : Config(std::move(config))
     , RequestInfo(std::move(requestInfo))
@@ -193,7 +193,7 @@ TCreateSessionActor::TCreateSessionActor(
     , FileSystemId(std::move(fileSystemId))
     , CheckpointId(std::move(checkpointId))
     , OriginFqdn(std::move(originFqdn))
-    , FromUncontrolledSource(fromUncontrolledSource)
+    , FromExternalSource(fromExternalSource)
     , RestoreClientSession(restoreClientSession)
     , SeqNo(seqNo)
     , ReadOnly(readOnly)
@@ -232,8 +232,8 @@ void TCreateSessionActor::HandleDescribeFileStoreResponse(
                 FileSystemId.c_str(),
                 FormatError(msg->GetError()).c_str());
 
-            // not_found is expected from an uncontrolled source
-            if (!(FromUncontrolledSource && msg->GetStatus() == E_NOT_FOUND)) {
+            // not_found is expected from an external source
+            if (!(FromExternalSource && msg->GetStatus() == E_NOT_FOUND)) {
                 ReportDescribeFileStoreError();
             }
         }
@@ -807,7 +807,7 @@ void TStorageServiceActor::HandleCreateSession(
         msg->Record.GetReadOnly(),
         msg->Record.GetRestoreClientSession(),
         msg->Record.GetHeaders().GetInternal().GetRequestOrigin() ==
-            NProto::THeaders::TInternal::REQUEST_ORIGIN_UNCONTROLLED,
+            NProto::THeaders::TInternal::REQUEST_ORIGIN_EXTERNAL,
         SelfId());
 
     auto actorId = NCloud::Register(ctx, std::move(actor));

--- a/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_createsession.cpp
@@ -51,6 +51,8 @@ private:
     TString FileSystemId;
     TString CheckpointId;
     TString OriginFqdn;
+    // Whether the filesystem id came from the public gRPC API
+    bool FromUncontrolledSource;
     bool RestoreClientSession;
     ui64 SeqNo;
     bool ReadOnly;
@@ -87,6 +89,7 @@ public:
         ui64 seqNo,
         bool readOnly,
         bool restoreClientSession,
+        bool fromUncontrolledSource,
         TActorId owner);
 
     void Bootstrap(const TActorContext& ctx);
@@ -182,6 +185,7 @@ TCreateSessionActor::TCreateSessionActor(
         ui64 seqNo,
         bool readOnly,
         bool restoreClientSession,
+        bool fromUncontrolledSource,
         TActorId owner)
     : Config(std::move(config))
     , RequestInfo(std::move(requestInfo))
@@ -189,6 +193,7 @@ TCreateSessionActor::TCreateSessionActor(
     , FileSystemId(std::move(fileSystemId))
     , CheckpointId(std::move(checkpointId))
     , OriginFqdn(std::move(originFqdn))
+    , FromUncontrolledSource(fromUncontrolledSource)
     , RestoreClientSession(restoreClientSession)
     , SeqNo(seqNo)
     , ReadOnly(readOnly)
@@ -226,7 +231,11 @@ void TCreateSessionActor::HandleDescribeFileStoreResponse(
                 LogTag().c_str(),
                 FileSystemId.c_str(),
                 FormatError(msg->GetError()).c_str());
-            ReportDescribeFileStoreError();
+
+            // not_found is expected from an uncontrolled source
+            if (!(FromUncontrolledSource && msg->GetStatus() == E_NOT_FOUND)) {
+                ReportDescribeFileStoreError();
+            }
         }
 
         Notify(ctx, msg->GetError(), false);
@@ -797,6 +806,8 @@ void TStorageServiceActor::HandleCreateSession(
         msg->Record.GetMountSeqNumber(),
         msg->Record.GetReadOnly(),
         msg->Record.GetRestoreClientSession(),
+        msg->Record.GetHeaders().GetInternal().GetRequestOrigin() ==
+            NProto::THeaders::TInternal::REQUEST_ORIGIN_UNCONTROLLED,
         SelfId());
 
     auto actorId = NCloud::Register(ctx, std::move(actor));

--- a/cloud/filestore/libs/storage/service/service_ut.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut.cpp
@@ -814,6 +814,36 @@ Y_UNIT_TEST_SUITE(TStorageServiceTest)
         service.CreateSession(headers);
     }
 
+    Y_UNIT_TEST(ShouldReportDescribeFileStoreErrorOnCreateSession)
+    {
+        TTestEnv env;
+        ui32 nodeIdx = env.AddDynamicNode();
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+
+        TDynamicCountersPtr counters = new TDynamicCounters();
+        InitCriticalEventsCounter(counters);
+        auto describeFileStoreError = counters->GetCounter(
+            "AppCriticalEvents/DescribeFileStoreError",
+            true);
+        UNIT_ASSERT_VALUES_EQUAL(0, describeFileStoreError->Val());
+
+        // external source (e.g. public gRPC API): not-found is expected
+        THeaders headers = {"nonexistent", "client", ""};
+        auto request = service.CreateCreateSessionRequest(headers);
+        request->Record.MutableHeaders()->MutableInternal()->SetRequestOrigin(
+            NProto::THeaders::TInternal::REQUEST_ORIGIN_EXTERNAL);
+        auto response = service.SendAndRecvCreateSession(std::move(request));
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_NOT_FOUND,
+            response->GetError().GetCode(),
+            FormatError(response->GetError()));
+        UNIT_ASSERT_VALUES_EQUAL(0, describeFileStoreError->Val());
+
+        // internal source (default): not-found is unexpected
+        service.AssertCreateSessionFailed(headers);
+        UNIT_ASSERT_VALUES_EQUAL(1, describeFileStoreError->Val());
+    }
+
     Y_UNIT_TEST(ShouldCleanUpIfSessionFailed)
     {
         TTestEnv env;

--- a/cloud/filestore/public/api/protos/headers.proto
+++ b/cloud/filestore/public/api/protos/headers.proto
@@ -59,10 +59,10 @@ message THeaders
             REQUEST_ORIGIN_UNSPECIFIED = 0;
 
             // Internal caller; arguments are picked by us
-            REQUEST_ORIGIN_CONTROLLED = 1;
+            REQUEST_ORIGIN_INTERNAL = 1;
 
             // Came over the public gRPC API; arguments are client-supplied
-            REQUEST_ORIGIN_UNCONTROLLED = 2;
+            REQUEST_ORIGIN_EXTERNAL = 2;
         }
 
         ERequestOrigin RequestOrigin = 6;

--- a/cloud/filestore/public/api/protos/headers.proto
+++ b/cloud/filestore/public/api/protos/headers.proto
@@ -53,6 +53,19 @@ message THeaders
 
         // Peer address of the request sender.
         string Peer = 5;
+
+        enum ERequestOrigin
+        {
+            REQUEST_ORIGIN_UNSPECIFIED = 0;
+
+            // Internal caller; arguments are picked by us
+            REQUEST_ORIGIN_CONTROLLED = 1;
+
+            // Came over the public gRPC API; arguments are client-supplied
+            REQUEST_ORIGIN_UNCONTROLLED = 2;
+        }
+
+        ERequestOrigin RequestOrigin = 6;
     }
 
     // Internal header, should not be used outside.


### PR DESCRIPTION
### Notes
A create session request can come from the filestore-client/GRPC request. For those requests, we do not want to report a critical event about non-existent filesystems with these errors: `E_NOT_FOUND ss error: SEVERITY_ERROR | FACILITY_SCHEMESHARD | 2 Path not found`. 

To do it, I add the source of the request distinguishing between ones we can and cannot control

### Issue
Put links to the related issues here
