### PR TITLE
issue-1541: drain HandleOpsQueue when AsyncDestroy is disabled

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -334,8 +334,10 @@ void TFileSystem::Release(
 {
     auto handle = fi->fh;
     const bool readOnly = (fi->flags & O_ACCMODE) == O_RDONLY;
-    const bool processAsynchronously = Config->GetAsyncDestroyHandleEnabled() ||
-        (Config->GetAsyncDestroyReadOnlyHandleEnabled() && readOnly);
+    const bool processAsynchronously =
+        HandleOpsQueue &&
+        (Config->GetAsyncDestroyHandleEnabled() ||
+         (Config->GetAsyncDestroyReadOnlyHandleEnabled() && readOnly));
 
     STORAGE_DEBUG("Release #" << ino << " @" << handle);
 

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -3456,36 +3456,21 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
 
     Y_UNIT_TEST(ShouldDrainHandleOpsQueueAfterAsyncDestroyDisabled)
     {
-        const TString sessionId = CreateGuidAsString();
         const ui64 queuedNodeId = 10;
         const ui64 queuedHandle = 2;
         const ui64 directNodeId = 11;
         const ui64 directHandle = 3;
 
         auto createBootstrap =
-            [&](bool asyncDestroyHandleEnabled, ISchedulerPtr scheduler)
+            [](bool asyncDestroyHandleEnabled, ISchedulerPtr scheduler)
         {
             NProto::TFileStoreFeatures features;
             features.SetAsyncDestroyHandleEnabled(asyncDestroyHandleEnabled);
 
-            TBootstrap bootstrap(
+            return TBootstrap(
                 CreateWallClockTimer(),
                 std::move(scheduler),
                 features);
-
-            bootstrap.Service->CreateSessionHandler =
-                [features, &sessionId](auto, auto)
-            {
-                NProto::TCreateSessionResponse result;
-                result.MutableSession()->SetSessionId(sessionId);
-                result.MutableFileStore()->SetBlockSize(4096);
-                result.MutableFileStore()->MutableFeatures()->CopyFrom(
-                    features);
-                result.MutableFileStore()->SetFileSystemId(FileSystemId);
-                return MakeFuture(result);
-            };
-
-            return bootstrap;
         };
 
         {

--- a/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_ut.cpp
@@ -259,12 +259,10 @@ struct TBootstrap
         proto.SetDebug(true);
         proto.SetSocketPath(SocketPath);
         proto.SetFileSystemId(FileSystemId);
-        if (featuresConfig.GetAsyncDestroyHandleEnabled() ||
-            featuresConfig.GetAsyncDestroyReadOnlyHandleEnabled())
-        {
-            proto.SetHandleOpsQueuePath(TempDir.Path() / "HandleOpsQueue");
-            proto.SetHandleOpsQueueSize(handleOpsQueueSize);
-        }
+        // Keep the path configured to allow restoring
+        // an existing HandleOpsQueue.
+        proto.SetHandleOpsQueuePath(TempDir.Path() / "HandleOpsQueue");
+        proto.SetHandleOpsQueueSize(handleOpsQueueSize);
 
         proto.SetDirectoryHandlesStoragePath(
             TempDir.Path() / "DirectoryHandles");
@@ -3454,6 +3452,130 @@ Y_UNIT_TEST_SUITE(TFileSystemTest)
                     true);
 
         UNIT_ASSERT_VALUES_EQUAL(1, static_cast<int>(*handleOpsQueueError));
+    }
+
+    Y_UNIT_TEST(ShouldDrainHandleOpsQueueAfterAsyncDestroyDisabled)
+    {
+        const TString sessionId = CreateGuidAsString();
+        const ui64 queuedNodeId = 10;
+        const ui64 queuedHandle = 2;
+        const ui64 directNodeId = 11;
+        const ui64 directHandle = 3;
+
+        auto createBootstrap =
+            [&](bool asyncDestroyHandleEnabled, ISchedulerPtr scheduler)
+        {
+            NProto::TFileStoreFeatures features;
+            features.SetAsyncDestroyHandleEnabled(asyncDestroyHandleEnabled);
+
+            TBootstrap bootstrap(
+                CreateWallClockTimer(),
+                std::move(scheduler),
+                features);
+
+            bootstrap.Service->CreateSessionHandler =
+                [features, &sessionId](auto, auto)
+            {
+                NProto::TCreateSessionResponse result;
+                result.MutableSession()->SetSessionId(sessionId);
+                result.MutableFileStore()->SetBlockSize(4096);
+                result.MutableFileStore()->MutableFeatures()->CopyFrom(
+                    features);
+                result.MutableFileStore()->SetFileSystemId(FileSystemId);
+                return MakeFuture(result);
+            };
+
+            return bootstrap;
+        };
+
+        {
+            auto bootstrap = createBootstrap(true, CreateScheduler());
+            auto destroyStarted = NewPromise<void>();
+            bootstrap.Service->SetHandlerDestroyHandle(
+                [destroyStarted](auto, auto) mutable
+                {
+                    destroyStarted.TrySetValue();
+                    return NewPromise<NProto::TDestroyHandleResponse>();
+                });
+
+            bootstrap.Start();
+            Y_DEFER
+            {
+                bootstrap.Stop();
+            };
+
+            auto release = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+                queuedNodeId,
+                queuedHandle,
+                O_RDONLY);
+            UNIT_ASSERT_NO_EXCEPTION(release.GetValue(WaitTimeout));
+            UNIT_ASSERT(destroyStarted.GetFuture().Wait(WaitTimeout));
+
+            bootstrap.ModuleStatsRegistry->UpdateStats(true);
+            auto counters = bootstrap.GetHandleOpsQueueCounters();
+            auto entryCount = counters->FindCounter("EntryCount");
+            UNIT_ASSERT(entryCount);
+            UNIT_ASSERT_VALUES_EQUAL(1, entryCount->GetAtomic());
+
+            auto suspend = bootstrap.Loop->SuspendAsync();
+            UNIT_ASSERT(suspend.Wait(WaitTimeout));
+        }
+
+        {
+            auto scheduler = std::make_shared<TTestScheduler>();
+            auto bootstrap = createBootstrap(false, scheduler);
+            std::atomic_uint destroyHandleCalled = 0;
+            bootstrap.Service->SetHandlerDestroyHandle(
+                [&](auto, const auto& request)
+                {
+                    if (++destroyHandleCalled == 1) {
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            queuedNodeId,
+                            request->GetNodeId());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            queuedHandle,
+                            request->GetHandle());
+                    } else {
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            directNodeId,
+                            request->GetNodeId());
+                        UNIT_ASSERT_VALUES_EQUAL(
+                            directHandle,
+                            request->GetHandle());
+                    }
+                    return MakeFuture(NProto::TDestroyHandleResponse{});
+                });
+
+            bootstrap.Start();
+            Y_DEFER
+            {
+                bootstrap.Stop();
+            };
+
+            bootstrap.ModuleStatsRegistry->UpdateStats(true);
+            auto counters = bootstrap.GetHandleOpsQueueCounters();
+            auto entryCount = counters->FindCounter("EntryCount");
+            UNIT_ASSERT(entryCount);
+            UNIT_ASSERT_VALUES_EQUAL(1, entryCount->GetAtomic());
+
+            scheduler->RunAllScheduledTasks();
+            UNIT_ASSERT_VALUES_EQUAL(1, destroyHandleCalled.load());
+            bootstrap.ModuleStatsRegistry->UpdateStats(true);
+            UNIT_ASSERT_VALUES_EQUAL(0, entryCount->GetAtomic());
+
+            auto release = bootstrap.Fuse->SendRequest<TReleaseRequest>(
+                directNodeId,
+                directHandle,
+                O_RDONLY);
+            UNIT_ASSERT_NO_EXCEPTION(release.GetValue(WaitTimeout));
+
+            // Do not run the test scheduler after Release. If the request were
+            // added to HandleOpsQueue, DestroyHandle would not be called and
+            // EntryCount would be 1.
+            UNIT_ASSERT_VALUES_EQUAL(2, destroyHandleCalled.load());
+            bootstrap.ModuleStatsRegistry->UpdateStats(true);
+            UNIT_ASSERT_VALUES_EQUAL(0, entryCount->GetAtomic());
+        }
     }
 
     Y_UNIT_TEST(ShouldReadAndWriteWithServerWriteBackCacheEnabled)

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -992,14 +992,14 @@ private:
             SessionId = response.GetSession().GetSessionId();
 
             THandleOpsQueuePtr handleOpsQueue;
-            if (FileSystemConfig->GetAsyncDestroyHandleEnabled() ||
-                FileSystemConfig->GetAsyncDestroyReadOnlyHandleEnabled())
-            {
-                if (Config->GetHandleOpsQueuePath()) {
-                    auto path = TFsPath(Config->GetHandleOpsQueuePath()) /
-                        FileSystemConfig->GetFileSystemId() /
-                        SessionId;
-
+            if (Config->GetHandleOpsQueuePath()) {
+                const auto path = TFsPath(Config->GetHandleOpsQueuePath()) /
+                                  FileSystemConfig->GetFileSystemId() /
+                                  SessionId;
+                if (path.Exists() ||
+                    FileSystemConfig->GetAsyncDestroyHandleEnabled() ||
+                    FileSystemConfig->GetAsyncDestroyReadOnlyHandleEnabled())
+                {
                     auto error = CreateAndLockFile(
                         path,
                         HandleOpsQueueFileName,
@@ -1019,13 +1019,16 @@ private:
                         path / HandleOpsQueueFileName,
                         Config->GetHandleOpsQueueSize());
                     HandleOpsQueueInitialized = true;
-                } else {
-                    ReportHandleOpsQueueCreatingOrDeletingError(Sprintf(
-                        "[f:%s][c:%s] Error initializing HandleOpsQueue: "
-                        "HandleOpsQueuePath is not set",
-                        Config->GetFileSystemId().Quote().c_str(),
-                        Config->GetClientId().Quote().c_str()));
                 }
+            } else if (
+                FileSystemConfig->GetAsyncDestroyHandleEnabled() ||
+                FileSystemConfig->GetAsyncDestroyReadOnlyHandleEnabled())
+            {
+                ReportHandleOpsQueueCreatingOrDeletingError(Sprintf(
+                    "[f:%s][c:%s] Error initializing HandleOpsQueue: "
+                    "HandleOpsQueuePath is not set",
+                    Config->GetFileSystemId().Quote().c_str(),
+                    Config->GetClientId().Quote().c_str()));
             }
 
             if (Config->GetWriteBackCachePath()) {

--- a/cloud/filestore/libs/vfs_fuse/loop.cpp
+++ b/cloud/filestore/libs/vfs_fuse/loop.cpp
@@ -992,14 +992,14 @@ private:
             SessionId = response.GetSession().GetSessionId();
 
             THandleOpsQueuePtr handleOpsQueue;
+            const bool asyncDestroyEnabled =
+                FileSystemConfig->GetAsyncDestroyHandleEnabled() ||
+                FileSystemConfig->GetAsyncDestroyReadOnlyHandleEnabled();
             if (Config->GetHandleOpsQueuePath()) {
                 const auto path = TFsPath(Config->GetHandleOpsQueuePath()) /
                                   FileSystemConfig->GetFileSystemId() /
                                   SessionId;
-                if (path.Exists() ||
-                    FileSystemConfig->GetAsyncDestroyHandleEnabled() ||
-                    FileSystemConfig->GetAsyncDestroyReadOnlyHandleEnabled())
-                {
+                if (path.Exists() || asyncDestroyEnabled) {
                     auto error = CreateAndLockFile(
                         path,
                         HandleOpsQueueFileName,
@@ -1020,10 +1020,7 @@ private:
                         Config->GetHandleOpsQueueSize());
                     HandleOpsQueueInitialized = true;
                 }
-            } else if (
-                FileSystemConfig->GetAsyncDestroyHandleEnabled() ||
-                FileSystemConfig->GetAsyncDestroyReadOnlyHandleEnabled())
-            {
+            } else if (asyncDestroyEnabled) {
                 ReportHandleOpsQueueCreatingOrDeletingError(Sprintf(
                     "[f:%s][c:%s] Error initializing HandleOpsQueue: "
                     "HandleOpsQueuePath is not set",


### PR DESCRIPTION
### Notes
HandleOpsQueue is now restored and drained when AsyncDestroy is disabled if a persistent queue from a previous session exists.

New Release requests continue to use the synchronous path while previously queued DestroyHandle requests are processed in the background.

### Issue
#1541 