### PR TITLE
[Filestore] add some unit tests with BSProxy failures enabled

### DIFF
--- a/cloud/filestore/libs/storage/testlib/test_env.cpp
+++ b/cloud/filestore/libs/storage/testlib/test_env.cpp
@@ -107,7 +107,12 @@ TTestEnv::TTestEnv(
     SetupDomain(app);
     app.AddHive(Config.DomainUid, GetHive());
     SetupChannelProfiles(app);
-    SetupTabletServices(Runtime, &app, false, {}, std::move(cachesConfig));
+    SetupTabletServices(
+        Runtime,
+        &app,
+        false,
+        {.FakeBSProxyFailureProbability = Config.FakeBSProxyFailureProbability},
+        std::move(cachesConfig));
     BootTablets();
     SetupStorage();
     SetupProxies();
@@ -310,6 +315,7 @@ void TTestEnv::SetupLogging()
     auto kikimrServices = {
         NKikimrServices::BS_CONTROLLER,
         NKikimrServices::BS_NODE,
+        NKikimrServices::BS_PROXY,
         NKikimrServices::FLAT_TX_SCHEMESHARD,
         NKikimrServices::HIVE,
         NKikimrServices::LOCAL,

--- a/cloud/filestore/libs/storage/testlib/test_env.h
+++ b/cloud/filestore/libs/storage/testlib/test_env.h
@@ -80,6 +80,9 @@ struct TTestEnvConfig
     // This controls probability that read will be restarted
     double FakePageFaultsProbability = 0.0;
     std::optional<ui64> FakePageFaultsRandomSeed = std::nullopt;
+
+    // This controls probability that DSProxy would reject a request with an error
+    double FakeBSProxyFailureProbability = 0.0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -280,6 +283,11 @@ TStorageConfigPtr CreateTestStorageConfig(NProto::TStorageConfig storageConfig);
     {                                                                          \
         TestImpl##name(TFileSystemConfig{.BlockSize = 4_KB},                   \
                        TTestEnvConfig{.FakePageFaultsProbability = 0.01});     \
+    }                                                                          \
+    Y_UNIT_TEST(name##WithBSFailureInjection)                                  \
+    {                                                                          \
+        TestImpl##name(TFileSystemConfig{.BlockSize = 4_KB},                   \
+                       TTestEnvConfig{.FakeBSProxyFailureProbability = 0.01}); \
     }                                                                          \
 // TABLET_TEST_HEAD
 

--- a/contrib/ydb/core/testlib/basics/helpers.h
+++ b/contrib/ydb/core/testlib/basics/helpers.h
@@ -17,6 +17,7 @@ namespace NFake {
         ui64 SectorSize = 0;
         ui64 ChunkSize = 0;
         ui64 DiskSize = 0;
+        double FakeBSProxyFailureProbability = 0.0;
     };
 
     struct TCaches {

--- a/contrib/ydb/core/testlib/basics/storage.h
+++ b/contrib/ydb/core/testlib/basics/storage.h
@@ -91,7 +91,13 @@ namespace NKikimr {
                 google::protobuf::TextFormat::ParseFromString(text, conf->BlobStorageConfig.MutableServiceSet());
             }
 
-            conf->BlobStorageConfig.MutableServiceSet()->SetEnableProxyMock(Mock);
+            auto* serviceSet = conf->BlobStorageConfig.MutableServiceSet();
+            serviceSet->SetEnableProxyMock(Mock);
+            if (Conf.FakeBSProxyFailureProbability > 0) {
+                auto* config = serviceSet->MutableFailureInjectionConfig();
+                config->SetFailureProbability(Conf.FakeBSProxyFailureProbability);
+                config->SetIncludeStaticGroups(true);
+            }
             conf->PDiskConfigOverlay.SetGetDriveDataSwitch(NKikimrBlobStorage::TPDiskConfig::DoNotTouch);
             conf->PDiskConfigOverlay.SetWriteCacheSwitch(NKikimrBlobStorage::TPDiskConfig::DoNotTouch);
 


### PR DESCRIPTION
### Notes
This is an experimental PR enabling random BSProxy failures for a large number of new tests.

Running new tests:
~/nbs/cloud/filestore/libs/storage/tablet/ut$ ya test -F '*WithBSFailureInjection'

Note that many tests are using groupid = 0, so I have to enable BSProxy interception for static groups. Unfortunately, this may lead to unrelated failures during initialization.

### Issue
https://github.com/ydb-platform/nbs/issues/6467
