### PR TITLE
Enqueue compaction after CompactionMap has been loaded; Avoid sending compaction request in non-work state

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -1693,6 +1693,12 @@ TDuration TPartitionActor::ComputeGarbageCompactionExecTime(
 
 void TPartitionActor::EnqueueCompactionIfNeeded(const TActorContext& ctx)
 {
+    // Sending compaction request in non-work state can lead to rejection, which
+    // means that subsequent calls of this function will be ignored.
+    if (CurrentState != STATE_WORK) {
+        return;
+    }
+
     if (CompactionMapLoadState) {
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -476,6 +476,7 @@ void TPartitionActor::CompleteLoadCompactionMapChunk(
             "%s Compaction map loaded",
             LogTitle.GetWithTime().c_str());
 
+        EnqueueCompactionIfNeeded(ctx);
         return;
     }
 

--- a/cloud/blockstore/libs/storage/partition/part_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_ut.cpp
@@ -12918,6 +12918,163 @@ Y_UNIT_TEST_SUITE(TPartitionTest)
         }
     }
 
+    Y_UNIT_TEST(ShouldEnqueueCompactionAfterCompactionMapLoaded)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+
+        auto config = DefaultConfig();
+        config.SetSSDMaxBlobsPerRange(compactionThreshold);
+        config.SetHDDMaxBlobsPerRange(compactionThreshold);
+        config.SetMaxCompactionRangesLoadingPerTx(1);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // Drop compaction while building enough blobs so the tablet still needs
+        // compaction after reboot, once the lazily loaded map is ready.
+        bool dropCompaction = true;
+        bool compactionRequestObserved = false;
+        TAutoPtr<IEventHandle> capturedLoadCMRequest;
+        bool holdLoadCMRequest = false;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (dropCompaction) {
+                            return true;
+                        }
+                        compactionRequestObserved = true;
+                        break;
+                    }
+                    case TEvPartitionPrivate::EvLoadCompactionMapChunkRequest: {
+                        if (holdLoadCMRequest) {
+                            holdLoadCMRequest = false;
+                            capturedLoadCMRequest = event.Release();
+                            return true;
+                        }
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        for (size_t i = 1; i < compactionThreshold + 1; ++i) {
+            partition.WriteBlocks(i, i);
+            partition.Flush();
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold,
+                stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        dropCompaction = false;
+        holdLoadCMRequest = true;
+
+        partition.RebootTablet();
+
+        UNIT_ASSERT(capturedLoadCMRequest);
+        UNIT_ASSERT(!compactionRequestObserved);
+
+        runtime->Send(capturedLoadCMRequest.Release());
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvPartitionPrivate::EvCompactionRequest);
+        runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+        UNIT_ASSERT(compactionRequestObserved);
+    }
+
+    Y_UNIT_TEST(ShouldNotEnqueueCompactionBeforeStateWork)
+    {
+        static constexpr ui32 compactionThreshold = 4;
+
+        auto config = DefaultConfig();
+        config.SetSSDMaxBlobsPerRange(compactionThreshold);
+        config.SetHDDMaxBlobsPerRange(compactionThreshold);
+        config.SetMaxCompactionRangesLoadingPerTx(1);
+
+        auto runtime = PrepareTestActorRuntime(config);
+
+        TPartitionClient partition(*runtime);
+        partition.WaitReady();
+
+        // Drop compaction while building enough blobs so the tablet still needs
+        // compaction after reboot.
+        bool dropCompaction = true;
+        bool compactionRequestObserved = false;
+        TAutoPtr<IEventHandle> capturedLoadFreshBlobsCompleted;
+        bool holdLoadFreshBlobsCompleted = false;
+
+        runtime->SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& event)
+            {
+                switch (event->GetTypeRewrite()) {
+                    case TEvPartitionPrivate::EvCompactionRequest: {
+                        if (dropCompaction) {
+                            return true;
+                        }
+                        compactionRequestObserved = true;
+                        break;
+                    }
+                    case TEvPartitionCommonPrivate::EvLoadFreshBlobsCompleted: {
+                        if (holdLoadFreshBlobsCompleted) {
+                            holdLoadFreshBlobsCompleted = false;
+                            capturedLoadFreshBlobsCompleted = event.Release();
+                            return true;
+                        }
+                        break;
+                    }
+                }
+                return false;
+            });
+
+        for (size_t i = 1; i < compactionThreshold + 1; ++i) {
+            partition.WriteBlocks(i, i);
+            partition.Flush();
+        }
+
+        {
+            auto response = partition.StatPartition();
+            const auto& stats = response->Record.GetStats();
+            UNIT_ASSERT_VALUES_EQUAL(
+                compactionThreshold,
+                stats.GetMixedBlobsCount());
+            UNIT_ASSERT_VALUES_EQUAL(0, stats.GetMergedBlobsCount());
+        }
+
+        dropCompaction = false;
+        holdLoadFreshBlobsCompleted = true;
+
+        partition.RebootTablet();
+
+        UNIT_ASSERT(capturedLoadFreshBlobsCompleted);
+
+        // Compaction map finishes loading while the tablet is still in
+        // STATE_INIT. EnqueueCompactionIfNeeded must not send a request here:
+        // it would be rejected and leave compaction status stuck at Enqueued.
+        runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        UNIT_ASSERT(!compactionRequestObserved);
+
+        runtime->Send(capturedLoadFreshBlobsCompleted.Release());
+
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(
+            TEvPartitionPrivate::EvCompactionRequest);
+        runtime->DispatchEvents(options, TDuration::Seconds(1));
+
+        UNIT_ASSERT(compactionRequestObserved);
+    }
+
     Y_UNIT_TEST(ShouldAddRequestToLoadCompactionMapRangeIfNotLoaded)
     {
         const ui32 rangeCount = 100;


### PR DESCRIPTION
### Notes
When compaction map is loaded lazily (`MaxCompactionRangesLoadingPerTx` != 0), `EnqueueCompactionIfNeeded` on tablet activate returns early because `CompactionMapLoadState` is still set. After the map finished loading we never re-checked whether compaction was needed, so a partition that already had enough blobs could sit idle until the next write/flush.

Call `EnqueueCompactionIfNeeded()` once the compaction map is fully loaded.

Also, check added into `EnqueueCompactionIfNeeded()` to make sure that `TEvPartitionPrivate::TEvCompactionRequest` will not be sent in INIT state.
