### PR TITLE
making TIndexTabletTest_Data::ShouldReturnBackendInfoForIOForOverloadedTabletActor more stable

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -8730,9 +8730,20 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         const i64 overloadThresholdMicros = 1'000'000 * overloadThreshold / 100;
 
         NProto::TStorageConfig storageConfig;
+        // disabling background ops to have as few activity unrelated to the
+        // test scenario as possible
+        storageConfig.SetCompactionThreshold(999'999);
+        storageConfig.SetCleanupThreshold(999'999);
+        storageConfig.SetCollectGarbageThreshold(1_GB);
+        storageConfig.SetFlushBytesThreshold(1_GB);
+        storageConfig.SetFlushThreshold(1_GB);
+        storageConfig.SetFlushThresholdForBackpressure(1_GB);
+        // setting a proper threshold to make sure that all writes go through
+        // the fresh layer (and thus use tablet actor's cpu time)
         storageConfig.SetWriteBlobThreshold(wbt);
         // setting a tiny value to make sure that we're always "overloaded"
-        storageConfig.SetTabletActorCpuUsageOverloadThreshold(1);
+        storageConfig.SetTabletActorCpuUsageOverloadThreshold(
+            overloadThreshold);
 
         TTestEnv env(
             testEnvConfig,
@@ -8799,6 +8810,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         }
 
         UNIT_ASSERT_GT(cpuUsageMicros, overloadThresholdMicros);
+        Cdbg << "cpuUsageMicros=" << cpuUsageMicros << Endl;
 
         {
             //
@@ -8841,6 +8853,8 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             //
             // Blob read - uses separate actor code path.
             //
+
+            tablet.Flush();
 
             auto response =
                 tablet.ReadData(handle, 0, 3 * tabletConfig.BlockSize);


### PR DESCRIPTION
### Notes
Decreasing the probability of things like this: https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/Nightly-build-(tsan)/29879592736/1/nebius-x86-64-tsan/logs/1/cloud/filestore/libs/storage/tablet/ut/test-results/unittest/chunk3/testing_out_stuff/TIndexTabletTest_Data.ShouldReturnBackendInfoForIOForOverloadedTabletActor128_KB.err

The test used to spend wall time doing read/write-blob ops caused by background ops which could sometimes cause the tablet to just wait without doing anything and without recording cpu cycles so eventually we could end up not recording any overload because of the following event sequence:
1. lots of WriteData calls - some overload is recorded
2. heavy bg ops start, the work is mostly done by read/write-blob actors, the tablet just waits
3. counters are updated - this time no overload is recorded because during step 2 the tablet actor & executor actor were almost idle
4. the test fails because of no overload

### Issue
None