### PR TITLE
[NBS] Fix NBS shutdown hang when Device Provider socket is missing

### DIFF
--- a/cloud/blockstore/libs/local_nvme/generic_inventory_service_client.h
+++ b/cloud/blockstore/libs/local_nvme/generic_inventory_service_client.h
@@ -6,6 +6,7 @@
 #include <cloud/storage/core/libs/common/thread.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 #include <cloud/storage/core/libs/grpc/init.h>
+#include <cloud/storage/core/libs/grpc/time_point_specialization.h>
 
 #include <contrib/libs/grpc/include/grpcpp/channel.h>
 #include <contrib/libs/grpc/include/grpcpp/client_context.h>
@@ -15,8 +16,11 @@
 
 #include <library/cpp/threading/future/future.h>
 
+#include <util/generic/hash_set.h>
+#include <util/generic/scope.h>
 #include <util/generic/string.h>
 
+#include <mutex>
 #include <thread>
 
 namespace NCloud::NBlockStore {
@@ -36,10 +40,11 @@ class TGenericInventoryServiceClient
     struct IRequestHandler
     {
         virtual ~IRequestHandler() = default;
-        virtual void Complete() = 0;
+        virtual void Complete(bool ok) = 0;
+        virtual void Cancel() = 0;
     };
 
-    struct TListDevicesRequestHandler: IRequestHandler
+    struct TListDevicesRequestHandler final: IRequestHandler
     {
         using TReader = grpc::ClientAsyncResponseReader<TProtoResponse>;
 
@@ -58,12 +63,13 @@ class TGenericInventoryServiceClient
             : Request(std::move(request))
         {}
 
-        auto Execute(TServiceStub& service, grpc::CompletionQueue& cq)
-            -> NThreading::TFuture<TProtoResponse>
+        void Execute(
+            TServiceStub& service,
+            grpc::CompletionQueue& cq,
+            TInstant deadline)
         {
-            auto future = Promise.GetFuture();
-
             ClientContext.set_wait_for_ready(true);
+            ClientContext.set_deadline(deadline);
 
             Reader = TServiceTraits::AsyncListDevices(
                 service,
@@ -71,12 +77,18 @@ class TGenericInventoryServiceClient
                 Request,
                 cq);
             Reader->Finish(&Response, &Status, this);
-
-            return future;
         }
 
-        void Complete() override
+        void Complete(bool ok) final
         {
+            if (!ok) {
+                Promise.SetException(
+                    std::make_exception_ptr(
+                        TServiceError(E_REJECTED)
+                        << "gRPC completion operation was cancelled"));
+                return;
+            }
+
             if (!Status.ok()) {
                 Promise.SetException(
                     std::make_exception_ptr(
@@ -86,6 +98,11 @@ class TGenericInventoryServiceClient
                 Promise.SetValue(std::move(Response));
             }
         }
+
+        void Cancel() final
+        {
+            ClientContext.TryCancel();
+        }
     };
 
 private:
@@ -93,11 +110,17 @@ private:
 
     const ILoggingServicePtr Logging;
     const TString SocketPath;
+    const TDuration RequestTimeout = TDuration::Seconds(30);
 
     std::thread Thread;
     grpc::CompletionQueue CQ;
 
     std::shared_ptr<TServiceStub> Service;
+
+    std::mutex Mutex;
+    THashSet<IRequestHandler*> ActiveRequests;
+
+    bool ShouldStop = false;
 
 protected:
     TLog Log;
@@ -112,11 +135,13 @@ public:
 
     ~TGenericInventoryServiceClient()
     {
-        Stop();
+        Y_DEBUG_ABORT_UNLESS(!Thread.joinable());
     }
 
     void Start()
     {
+        Y_DEBUG_ABORT_UNLESS(!Thread.joinable());
+
         Log = Logging->CreateLog("BLOCKSTORE_NVME");
 
         STORAGE_INFO("Connecting to " << SocketPath << " socket");
@@ -132,14 +157,28 @@ public:
 
     void Stop()
     {
-        if (!Thread.joinable()) {
-            return;
+        {
+            std::lock_guard guard(Mutex);
+            if (ShouldStop) {
+                return;
+            }
+
+            ShouldStop = true;
+
+            STORAGE_INFO(
+                "Stopping, active requests: " << ActiveRequests.size());
+
+            for (auto* request: ActiveRequests) {
+                request->Cancel();
+            }
+
+            CQ.Shutdown();
         }
 
-        STORAGE_INFO("Stopping...");
-
-        CQ.Shutdown();
         Thread.join();
+        Y_DEBUG_ABORT_UNLESS(ActiveRequests.empty());
+
+        Service.reset();
 
         STORAGE_INFO("Stopped");
 
@@ -152,12 +191,41 @@ public:
         auto handler =
             std::make_unique<TListDevicesRequestHandler>(std::move(request));
 
-        auto future = handler->Execute(*Service, CQ);
-        Y_UNUSED(handler.release());
+        auto future = handler->Promise.GetFuture();
+
+        {
+            std::lock_guard guard(Mutex);
+
+            if (ShouldStop) {
+                handler->Promise.SetException(
+                    std::make_exception_ptr(
+                        TServiceError(E_REJECTED)
+                        << "Inventory service is stopping"));
+                return future;
+            }
+
+            ActiveRequests.insert(handler.get());
+            Y_DEFER
+            {
+                if (handler) {
+                    ActiveRequests.erase(handler.get());
+                }
+            };
+
+            handler->Execute(*Service, CQ, RequestTimeout.ToDeadLine());
+            Y_UNUSED(handler.release());
+        }
+
         return future;
     }
 
 private:
+    void UnregisterRequest(IRequestHandler* request)
+    {
+        std::lock_guard guard(Mutex);
+        ActiveRequests.erase(request);
+    }
+
     void ThreadFn()
     {
         SetCurrentThreadName("NVMeDP");
@@ -168,7 +236,10 @@ private:
         while (CQ.Next(&tag, &ok)) {
             std::unique_ptr<IRequestHandler> requestHandler(
                 static_cast<IRequestHandler*>(tag));
-            requestHandler->Complete();
+
+            UnregisterRequest(requestHandler.get());
+
+            requestHandler->Complete(ok);
         }
     }
 };

--- a/cloud/blockstore/libs/local_nvme/test_grpc_device_provider_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/test_grpc_device_provider_ut.cpp
@@ -1,14 +1,19 @@
-#include "device_provider.h"
 #include "test_grpc_device_provider.h"
 
+#include "device_provider.h"
+
+#include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/diagnostics/logging.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/future.h>
 
+#include <util/folder/tempdir.h>
 #include <util/system/env.h>
 
 namespace NCloud::NBlockStore {
+
+using namespace std::chrono_literals;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -45,6 +50,77 @@ Y_UNIT_TEST_SUITE(TGrpcDeviceProviderTest)
             UNIT_ASSERT_VALUES_EQUAL(2, devices.size());
 
             deviceProvider->Stop();
+        }
+    }
+
+    Y_UNIT_TEST(ShouldNotHangOnStopWithPendingRequest)
+    {
+        const ILoggingServicePtr logging =
+            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
+
+        TTempDir tempDir;
+
+        const TString socketPath = tempDir.Path() / "non-existent.sock";
+
+        auto deviceProvider =
+            CreateTestGrpcDeviceProvider(logging, "unix://nbs@" + socketPath);
+        deviceProvider->Start();
+
+        {
+            auto future = deviceProvider->ListNVMeDevices();
+
+            deviceProvider->Stop();
+
+            auto [_, error] = ResultOrError(future);
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_GRPC_CANCELLED,
+                error.GetCode(),
+                FormatError(error));
+
+            UNIT_ASSERT_C(
+                GetErrorKind(error) == EErrorKind::ErrorRetriable,
+                FormatError(error));
+        }
+
+        {
+            auto future = deviceProvider->ListNVMeDevices();
+            auto [_, error] = ResultOrError(future);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                E_REJECTED,
+                error.GetCode(),
+                FormatError(error));
+        }
+
+        deviceProvider->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldNotHangOnDestruction)
+    {
+        const ILoggingServicePtr logging =
+            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
+
+        TTempDir tempDir;
+
+        {
+            const TString socketPath = tempDir.Path() / "non-existent.sock";
+
+            auto deviceProvider = CreateTestGrpcDeviceProvider(
+                logging,
+                "unix://nbs@" + socketPath);
+
+            Y_UNUSED(deviceProvider);
+        }
+
+        {
+            const TString socketPath = GetEnv("INFRA_DEVICE_PROVIDER_SOCKET");
+            UNIT_ASSERT_UNEQUAL("", socketPath);
+
+            auto deviceProvider = CreateTestGrpcDeviceProvider(
+                logging,
+                "unix://nbs@" + socketPath);
+
+            Y_UNUSED(deviceProvider);
         }
     }
 }


### PR DESCRIPTION
Fix shutdown hanging when the Device Provider socket is unavailable.

The client now cancels active gRPC requests, rejects new requests after shutdown starts, and uses request deadlines.