### PR TITLE
[NBS] Dont fire CleanupBlobMetaBlocksMismatch impossible event if leaked blocks has another blob id

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -115,6 +115,10 @@ TVerifyBlocksMetaResult VerifyMixedBlocksMeta(
 
             // The same block may be present in multiple blobs, so we need to
             // check if the block is present in the original blob.
+            // This can happen if the AddBlobs transaction for a flush has
+            // already been committed when the tablet restarts, but the fresh
+            // blobs have not yet been trimmed. After the restart, we load the
+            // same fresh blobs and try to flush them again.
             if (blobId != OriginalBlobId) {
                 return true;
             }

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -96,7 +96,12 @@ TVerifyBlocksMetaResult VerifyMixedBlocksMeta(
 
     struct TVisitor final: public IMixedBlocksIndexVisitor
     {
+        TPartialBlobId OriginalBlobId;
         TVector<TBlock> LeakedBlocks;
+
+        TVisitor(TPartialBlobId originalBlobId)
+            : OriginalBlobId(originalBlobId)
+        {}
 
         bool VisitBlock(
             ui32 blockIndex,
@@ -105,9 +110,12 @@ TVerifyBlocksMetaResult VerifyMixedBlocksMeta(
             ui16 blobOffset,
             ui8 compactionRangeCount) override
         {
-            Y_UNUSED(blobId);
             Y_UNUSED(blobOffset);
             Y_UNUSED(compactionRangeCount);
+
+            if (blobId != OriginalBlobId) {
+                return true;
+            }
 
             LeakedBlocks.emplace_back(blockIndex, commitId, false);
 
@@ -115,7 +123,7 @@ TVerifyBlocksMetaResult VerifyMixedBlocksMeta(
         }
     };
 
-    TVisitor visitor;
+    TVisitor visitor{originalBlobId};
     bool ready = db.FindMixedBlocks(visitor, missedBlocks);
     if (!ready) {
         return {.Ready = false};
@@ -302,7 +310,8 @@ void ExecuteCleanupTransaction(
                 }
             } else {
                 // each block has its own commitId
-                Y_ABORT_UNLESS(mixedBlocks.BlocksSize() == mixedBlocks.CommitIdsSize());
+                Y_ABORT_UNLESS(
+                    mixedBlocks.BlocksSize() == mixedBlocks.CommitIdsSize());
                 for (size_t j = 0; j < mixedBlocks.BlocksSize(); ++j) {
                     ui32 blockIndex = mixedBlocks.GetBlocks(j);
                     ui64 commitId = mixedBlocks.GetCommitIds(j);
@@ -342,8 +351,8 @@ void ExecuteCleanupTransaction(
 
             ++mergedBlobsCount;
             if (!IsDeletionMarker(item.BlobId)) {
-                // Mins for block counts are needed due to some inconsistencies caused by
-                // NBS-1422
+                // Mins for block counts are needed due to some inconsistencies
+                // caused by NBS-1422
                 ui64 delta = blockRange.Size() - mergedBlocks.GetSkipped();
                 state.DecrementMergedBlocksCount(
                     Min(delta, state.GetMergedBlocksCount()));
@@ -351,7 +360,7 @@ void ExecuteCleanupTransaction(
         }
 
         LOG_DEBUG(
-           *actorSystem,
+            *actorSystem,
             TBlockStoreComponents::PARTITION,
             "%s Delete blob: %s",
             logTitle.GetWithTime().c_str(),

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -113,6 +113,8 @@ TVerifyBlocksMetaResult VerifyMixedBlocksMeta(
             Y_UNUSED(blobOffset);
             Y_UNUSED(compactionRangeCount);
 
+            // The same block may be present in multiple blobs, so we need to
+            // check if the block is present in the original blob.
             if (blobId != OriginalBlobId) {
                 return true;
             }

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -512,6 +512,38 @@ Y_UNIT_TEST_SUITE(TVerifyRecreatedBlobMetaTest)
             });
     }
 
+    Y_UNIT_TEST(ShouldRejectLeakedBlocksInRecreatedMixedMetaOnlyIfBlobIdMatches)
+    {
+        TTestExecutor executor;
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        TPartialBlobId blobId;
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                blobId = executor.MakeBlobId(1);
+
+                auto anotherBlobId = executor.MakeBlobId(1);
+                db.WriteMixedBlock({anotherBlobId, 1, 0, 0, 0});
+            });
+
+        const auto blobMeta = MakeMixedBlobMeta({0}, {1});
+        const auto recreatedBlobMeta = MakeMixedBlobMeta({}, {});
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                const auto result = VerifyRecreatedBlobMeta(
+                    db,
+                    blobId,
+                    blobMeta,
+                    recreatedBlobMeta);
+
+                UNIT_ASSERT(result.Ready);
+                UNIT_ASSERT(!HasError(result.Error));
+            });
+    }
+
     Y_UNIT_TEST(ShouldRejectExtraBlocksInRecreatedMixedMeta)
     {
         TTestExecutor executor;


### PR DESCRIPTION
### Notes
We can flush the same block multiple times when restarting a tablet, so while checking blob metas, we will find a block with the same commitId, but it belongs to a different blob. Therefore, we should not fire an impossible event in this case.
### Issue
#6279 
