### PR TITLE
[Disk Manager] Support overriding chunk_blobs table name via config

### DIFF
--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/config/config.proto
@@ -22,4 +22,8 @@ message SnapshotConfig {
     optional string S3Bucket = 11;
     optional string ChunkBlobsS3KeyPrefix = 12 [default = "snapshot/chunks"];
     map<string, uint32> ProbeCompressionPercentage = 13;  // by codec
+    // Name of the table that stores chunk data and reference counts. Allows
+    // to switch the storage to another table, e.g. to a copy of chunk_blobs
+    // created without external blobs.
+    optional string ChunkBlobsTableName = 14 [default = "chunk_blobs"];
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/common.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/common.go
@@ -14,16 +14,19 @@ import (
 type storageCommon struct {
 	db         *persistence.YDBClient
 	tablesPath string
+	tableName  string
 }
 
 func newStorageCommon(
 	db *persistence.YDBClient,
 	tablesPath string,
+	tableName string,
 ) storageCommon {
 
 	return storageCommon{
 		db:         db,
 		tablesPath: tablesPath,
+		tableName:  tableName,
 	}
 }
 
@@ -37,7 +40,7 @@ func (s *storageCommon) writeToChunkBlobs(
 
 	_, err := s.db.ExecuteRW(ctx, fmt.Sprintf(`
 		--!syntax_v1
-		pragma TablePathPrefix = "%v";
+		pragma TablePathPrefix = "%[1]v";
 		declare $shard_id as Uint64;
 		declare $referer as Utf8;
 		declare $chunk_id as Utf8;
@@ -45,11 +48,11 @@ func (s *storageCommon) writeToChunkBlobs(
 		declare $checksum as Uint32;
 		declare $compression as Utf8;
 
-		upsert into chunk_blobs (shard_id, chunk_id, referer, data, refcnt, checksum, compression)
+		upsert into %[2]v (shard_id, chunk_id, referer, data, refcnt, checksum, compression)
 		values
 			($shard_id, $chunk_id, "", $data, cast(1 as Uint32), $checksum, $compression),
 			($shard_id, $chunk_id, $referer, null, null, null, null)
-	`, s.tablesPath),
+	`, s.tablesPath, s.tableName),
 		persistence.ValueParam("$shard_id", persistence.Uint64Value(makeShardID(chunk.ID))),
 		persistence.ValueParam("$chunk_id", persistence.UTF8Value(chunk.ID)),
 		persistence.ValueParam("$referer", persistence.UTF8Value(referer)),
@@ -69,14 +72,14 @@ func (s *storageCommon) refChunk(
 	// We use |referer| column to implement `exactly once` update semantics.
 	_, err := s.db.ExecuteRW(ctx, fmt.Sprintf(`
 		--!syntax_v1
-		pragma TablePathPrefix = "%v";
+		pragma TablePathPrefix = "%[1]v";
 		declare $shard_id as Uint64;
 		declare $chunk_id as Utf8;
 		declare $referer as Utf8;
 
 		$existing = (
 			select chunk_id
-			from chunk_blobs
+			from %[2]v
 			where shard_id = $shard_id and
 				chunk_id = $chunk_id and
 				referer = $referer
@@ -88,19 +91,19 @@ func (s *storageCommon) refChunk(
 				chunk_id,
 				referer,
 				refcnt + cast(1 as Uint32) as refcnt,
-			from chunk_blobs
+			from %[2]v
 			where shard_id = $shard_id and
 				chunk_id = $chunk_id and
 				referer = "" and
 				$chunk_id not in $existing
 		);
 
-		update chunk_blobs
+		update %[2]v
 		on select * from $to_update;
 
-		upsert into chunk_blobs (shard_id, chunk_id, referer)
+		upsert into %[2]v (shard_id, chunk_id, referer)
 		values ($shard_id, $chunk_id, $referer);
-	`, s.tablesPath),
+	`, s.tablesPath, s.tableName),
 		persistence.ValueParam("$shard_id", persistence.Uint64Value(makeShardID(chunkID))),
 		persistence.ValueParam("$chunk_id", persistence.UTF8Value(chunkID)),
 		persistence.ValueParam("$referer", persistence.UTF8Value(referer)),
@@ -127,7 +130,7 @@ func (s *storageCommon) unrefChunk(
 	// Chunk with zero ref count is deleted.
 	res, err := s.db.ExecuteRW(ctx, fmt.Sprintf(`
 		--!syntax_v1
-		pragma TablePathPrefix = "%v";
+		pragma TablePathPrefix = "%[1]v";
 		pragma AnsiInForEmptyOrNullableItemsCollections;
 		declare $shard_id as Uint64;
 		declare $chunk_id as Utf8;
@@ -135,7 +138,7 @@ func (s *storageCommon) unrefChunk(
 
 		$existing = (
 			select chunk_id
-			from chunk_blobs
+			from %[2]v
 			where shard_id = $shard_id and
 				chunk_id = $chunk_id and
 				referer = $referer
@@ -147,7 +150,7 @@ func (s *storageCommon) unrefChunk(
 				chunk_id,
 				referer,
 				refcnt - cast(1 as Uint32) as refcnt,
-			from chunk_blobs
+			from %[2]v
 			where shard_id = $shard_id and
 				chunk_id = $chunk_id and
 				referer = "" and
@@ -160,7 +163,7 @@ func (s *storageCommon) unrefChunk(
 				shard_id,
 				chunk_id,
 				referer,
-			from chunk_blobs
+			from %[2]v
 			where shard_id = $shard_id and
 				chunk_id = $chunk_id and
 				referer = "" and
@@ -171,30 +174,30 @@ func (s *storageCommon) unrefChunk(
 				shard_id,
 				chunk_id,
 				referer,
-			from chunk_blobs
+			from %[2]v
 			where shard_id = $shard_id and
 				chunk_id = $chunk_id and
 				referer = $referer
 		);
 
 		select refcnt
-		from chunk_blobs
+		from %[2]v
 		where shard_id = $shard_id and
 			chunk_id = $chunk_id and
 			referer = "";
 
 		select count(*) as refs_to_delete
-		from chunk_blobs
+		from %[2]v
 		where shard_id = $shard_id and
 			chunk_id = $chunk_id and
 			referer = $referer;
 
-		update chunk_blobs
+		update %[2]v
 		on select * from $to_update;
 
-		delete from chunk_blobs
+		delete from %[2]v
 		on select * from $to_delete;
-	`, s.tablesPath),
+	`, s.tablesPath, s.tableName),
 		persistence.ValueParam("$shard_id", persistence.Uint64Value(makeShardID(chunkID))),
 		persistence.ValueParam("$chunk_id", persistence.UTF8Value(chunkID)),
 		persistence.ValueParam("$referer", persistence.UTF8Value(referer)),

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_s3.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_s3.go
@@ -32,12 +32,13 @@ func NewStorageS3(
 	bucket string,
 	keyPrefix string,
 	tablesPath string,
+	tableName string,
 	metrics metrics.Metrics,
 	probeCompressionPercentage map[string]uint32,
 ) *StorageS3 {
 
 	return &StorageS3{
-		storageCommon:              newStorageCommon(db, tablesPath),
+		storageCommon:              newStorageCommon(db, tablesPath, tableName),
 		s3:                         s3,
 		bucket:                     bucket,
 		keyPrefix:                  keyPrefix,

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_test.go
@@ -54,6 +54,7 @@ func newStorage(
 			config.GetS3Bucket(),
 			config.GetChunkBlobsS3KeyPrefix(),
 			tablesPath,
+			config.GetChunkBlobsTableName(),
 			metrics,
 			map[string]uint32{
 				"gzip": 0,
@@ -63,6 +64,7 @@ func newStorage(
 		return NewStorageYDB(
 			db,
 			tablesPath,
+			config.GetChunkBlobsTableName(),
 			metrics,
 			map[string]uint32{
 				"gzip": 0,
@@ -177,13 +179,13 @@ func chunkDataExistsInYDB(
 
 	res, err := db.ExecuteRO(ctx, fmt.Sprintf(`
 		--!syntax_v1
-		pragma TablePathPrefix = "%v";
+		pragma TablePathPrefix = "%[1]v";
 		declare $chunk_id as Utf8;
 
 		select *
-		from chunk_blobs
+		from %[2]v
 		where chunk_id = $chunk_id and referer = "";
-	`, db.AbsolutePath(config.GetStorageFolder())),
+	`, db.AbsolutePath(config.GetStorageFolder()), config.GetChunkBlobsTableName()),
 		persistence.ValueParam("$chunk_id", persistence.UTF8Value(chunkID)),
 	)
 	require.NoError(t, err)
@@ -225,15 +227,15 @@ func deleteMetadata(
 
 	_, err := db.ExecuteRW(ctx, fmt.Sprintf(`
 		--!syntax_v1
-		pragma TablePathPrefix = "%v";
+		pragma TablePathPrefix = "%[1]v";
 		pragma AnsiInForEmptyOrNullableItemsCollections;
 		declare $chunk_id as Utf8;
 
-		delete from chunk_blobs
+		delete from %[2]v
 		where chunk_id = $chunk_id and
 			referer = "" and
 			refcnt <= 1;
-	`, db.AbsolutePath(config.GetStorageFolder())),
+	`, db.AbsolutePath(config.GetStorageFolder()), config.GetChunkBlobsTableName()),
 		persistence.ValueParam("$chunk_id", persistence.UTF8Value(chunkID)),
 	)
 	require.NoError(t, err)
@@ -251,6 +253,25 @@ func TestWriteIdempotency(t *testing.T) {
 				_, _, err := writeTestChunk(t, ctx, storage)
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestWriteChunkWithOverriddenTableName(t *testing.T) {
+	for _, testCase := range testCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, db, s3, config := setupEnvironment(t)
+
+			tableName := "chunk_blobs_v2"
+			config.ChunkBlobsTableName = &tableName
+			err := schema.Create(ctx, config, db, s3, false /* dropUnusedColumns */)
+			require.NoError(t, err)
+
+			storage := newStorage(db, s3, config, testCase.useS3)
+
+			_, chunkID, err := writeTestChunk(t, ctx, storage)
+			require.NoError(t, err)
+			require.True(t, chunkDataExists(t, ctx, s3, db, config, chunkID, testCase.useS3))
 		})
 	}
 }

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/chunks/storage_ydb.go
@@ -25,12 +25,13 @@ type StorageYDB struct {
 func NewStorageYDB(
 	db *persistence.YDBClient,
 	tablesPath string,
+	tableName string,
 	metrics metrics.Metrics,
 	probeCompressionPercentage map[string]uint32,
 ) *StorageYDB {
 
 	return &StorageYDB{
-		storageCommon:              newStorageCommon(db, tablesPath),
+		storageCommon:              newStorageCommon(db, tablesPath, tableName),
 		metrics:                    metrics,
 		probeCompressionPercentage: probeCompressionPercentage,
 	}
@@ -47,15 +48,15 @@ func (s *StorageYDB) ReadChunk(
 
 	res, err := s.db.ExecuteRO(ctx, fmt.Sprintf(`
 		--!syntax_v1
-		pragma TablePathPrefix = "%v";
+		pragma TablePathPrefix = "%[1]v";
 		declare $shard_id as Uint64;
 		declare $chunk_id as Utf8;
 
-		select * from chunk_blobs
+		select * from %[2]v
 		where shard_id = $shard_id and
 			chunk_id = $chunk_id and
 			referer = "";
-	`, s.tablesPath),
+	`, s.tablesPath, s.tableName),
 		persistence.ValueParam("$shard_id", persistence.Uint64Value(makeShardID(chunk.ID))),
 		persistence.ValueParam("$chunk_id", persistence.UTF8Value(chunk.ID)),
 	)

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/factory.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/factory.go
@@ -29,6 +29,7 @@ func NewStorage(
 			config.GetS3Bucket(),
 			config.GetChunkBlobsS3KeyPrefix(),
 			tablesPath,
+			config.GetChunkBlobsTableName(),
 			metrics.New(metricsRegistry, "s3"),
 			probeCompressionPercentage,
 		)
@@ -46,6 +47,7 @@ func NewStorage(
 		chunkStorageYDB: chunks.NewStorageYDB(
 			db,
 			tablesPath,
+			config.GetChunkBlobsTableName(),
 			ydbMetrics,
 			probeCompressionPercentage,
 		),

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/schema/schema.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/schema/schema.go
@@ -77,7 +77,7 @@ func Create(
 	err = db.CreateOrAlterTable(
 		ctx,
 		config.GetStorageFolder(),
-		"chunk_blobs",
+		config.GetChunkBlobsTableName(),
 		persistence.NewCreateTableDescription(
 			persistence.WithColumn("shard_id", persistence.Optional(persistence.TypeUint64)),
 			persistence.WithColumn("chunk_id", persistence.Optional(persistence.TypeUTF8)),
@@ -95,7 +95,7 @@ func Create(
 	if err != nil {
 		return err
 	}
-	logging.Info(ctx, "Created chunk_blobs table")
+	logging.Info(ctx, "Created %v table", config.GetChunkBlobsTableName())
 
 	err = db.CreateOrAlterTable(
 		ctx,
@@ -168,11 +168,11 @@ func Drop(
 	}
 	logging.Info(ctx, "Dropped incremental table")
 
-	err = db.DropTable(ctx, config.GetStorageFolder(), "chunk_blobs")
+	err = db.DropTable(ctx, config.GetStorageFolder(), config.GetChunkBlobsTableName())
 	if err != nil {
 		return err
 	}
-	logging.Info(ctx, "Dropped chunk_blobs table")
+	logging.Info(ctx, "Dropped %v table", config.GetChunkBlobsTableName())
 
 	err = db.DropTable(ctx, config.GetStorageFolder(), "chunk_map")
 	if err != nil {

--- a/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/dataplane/snapshot/storage/storage_ydb_test.go
@@ -91,13 +91,13 @@ func readChunkBlobsFromYDB(
 		func(ctx context.Context, session *persistence.Session) error {
 			res, err := session.ExecuteRO(ctx, fmt.Sprintf(`
 				--!syntax_v1
-				pragma TablePathPrefix = "%v";
+				pragma TablePathPrefix = "%[1]v";
 				declare $chunk_ids as List<Utf8>;
 
 				select *
-				from chunk_blobs
+				from %[2]v
 				where chunk_id in $chunk_ids and referer = "";
-			`, f.db.AbsolutePath(f.config.GetStorageFolder())),
+			`, f.db.AbsolutePath(f.config.GetStorageFolder()), f.config.GetChunkBlobsTableName()),
 				persistence.ValueParam("$chunk_ids", persistence.ListValue(values...)),
 			)
 			if err != nil {
@@ -263,14 +263,14 @@ func updateYDBBlobChecksum(f *fixture, chunkID string, checksum uint32) {
 		func(ctx context.Context, session *persistence.Session) error {
 			_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
 					--!syntax_v1
-					pragma TablePathPrefix = "%v";
+					pragma TablePathPrefix = "%[1]v";
 					declare $shard_id as Uint64;
 					declare $chunk_id as Utf8;
 					declare $checksum as Uint32;
-					update chunk_blobs
+					update %[2]v
 					set checksum = $checksum
 					where shard_id = $shard_id and chunk_id = $chunk_id
-			`, f.db.AbsolutePath(f.config.GetStorageFolder())),
+			`, f.db.AbsolutePath(f.config.GetStorageFolder()), f.config.GetChunkBlobsTableName()),
 				persistence.ValueParam("$shard_id", persistence.Uint64Value(makeShardID(chunkID))),
 				persistence.ValueParam("$checksum", persistence.Uint32Value(checksum)),
 				persistence.ValueParam("$chunk_id", persistence.UTF8Value(chunkID)),


### PR DESCRIPTION
## Что делает

Добавляет в `SnapshotConfig` поле `ChunkBlobsTableName` (дефолт — `chunk_blobs`) и использует его в управлении схемой и во всех запросах чанкового стораджа.

## Зачем

Таблица `chunk_blobs` создана с external blobs, из-за чего для неё запрещён CopyTable и, как следствие, недоступен серверный `ydb export s3`. План ухода: рядом наполняется копия таблицы без external blobs, после чего сторадж переключается на неё одним конфигом — без релиза. Это поле и есть механизм переключения.

## Что изменено

- `config.proto`: новое поле `ChunkBlobsTableName = 14 [default = "chunk_blobs"]`;
- `chunks/common.go`, `chunks/storage_ydb.go`: имя таблицы в запросах берётся из конфига (`%[1]v` — путь, `%[2]v` — имя);
- конструкторы `NewStorageYDB`/`NewStorageS3` и фабрика прокидывают имя;
- `schema.go`: create/drop таблицы по имени из конфига;
- тестовые хелперы читают имя из конфига.

## Тесты

- Новый `TestWriteChunkWithOverriddenTableName`: продакшн-путь (`schema.Create` с переопределённым именем → фабрика → запись чанка → проверка строки в таблице `chunk_blobs_v2`), оба бэкенда (ydb и s3).
- Полный прогон `ya make -tA cloud/disk_manager/internal/pkg/dataplane/snapshot/storage`.