### PR TITLE
[NBS] corrected leaky bucket Register method return value with non-standard rate

### DIFF
--- a/cloud/storage/core/libs/throttling/leaky_bucket.h
+++ b/cloud/storage/core/libs/throttling/leaky_bucket.h
@@ -151,6 +151,9 @@ public:
             Min(diff1, Min(Burst, Standard.TimePassed() / 1e6) * Beta);
 
         const auto boostDelaySeconds = Boost.Register(ts, maxBoostableDiff1);
+
+        Y_DEBUG_ABORT_UNLESS(
+            boostDelaySeconds == 0 || maxBoostableDiff1 > Boost.Budget());
         const auto diff2 =
             boostDelaySeconds ? maxBoostableDiff1 - Boost.Budget() : 0;
         // the remaining part of the update

--- a/cloud/storage/core/libs/throttling/leaky_bucket.h
+++ b/cloud/storage/core/libs/throttling/leaky_bucket.h
@@ -36,6 +36,7 @@ public:
     }
 
 public:
+    // returns time to wait in seconds to be able to spend the update
     double Register(TInstant ts, double update)
     {
         if (Y_LIKELY(State.LastUpdateTs.GetValue())) {
@@ -54,7 +55,7 @@ public:
             return 0;
         }
 
-        return update - State.Budget;
+        return (update - State.Budget) / (Rate * 1e6);
     }
 
     void Flush()
@@ -149,7 +150,9 @@ public:
         auto maxBoostableDiff1 =
             Min(diff1, Min(Burst, Standard.TimePassed() / 1e6) * Beta);
 
-        auto diff2 = Boost.Register(ts, maxBoostableDiff1);
+        const auto boostDelay = Boost.Register(ts, maxBoostableDiff1);
+        const auto diff2 =
+            boostDelay ? maxBoostableDiff1 - Boost.Budget() : 0;
         // the remaining part of the update
         auto fullDiff = diff2 + diff1 - maxBoostableDiff1;
         if (fullDiff == 0) {

--- a/cloud/storage/core/libs/throttling/leaky_bucket.h
+++ b/cloud/storage/core/libs/throttling/leaky_bucket.h
@@ -36,7 +36,7 @@ public:
     }
 
 public:
-    // returns time to wait in seconds to be able to spend the update
+    // returns time to wait in seconds to be able to register the update
     double Register(TInstant ts, double update)
     {
         if (Y_LIKELY(State.LastUpdateTs.GetValue())) {
@@ -150,9 +150,9 @@ public:
         auto maxBoostableDiff1 =
             Min(diff1, Min(Burst, Standard.TimePassed() / 1e6) * Beta);
 
-        const auto boostDelay = Boost.Register(ts, maxBoostableDiff1);
+        const auto boostDelaySeconds = Boost.Register(ts, maxBoostableDiff1);
         const auto diff2 =
-            boostDelay ? maxBoostableDiff1 - Boost.Budget() : 0;
+            boostDelaySeconds ? maxBoostableDiff1 - Boost.Budget() : 0;
         // the remaining part of the update
         auto fullDiff = diff2 + diff1 - maxBoostableDiff1;
         if (fullDiff == 0) {

--- a/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
+++ b/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
@@ -92,6 +92,17 @@ Y_UNIT_TEST_SUITE(TLeakyBucketTest)
         GET_SHARE_AND_CHECK(0.75, 2'500'000);    // share = (200 - (0 + 0.5 * 100)) / 200 = 0.75
     }
 
+    Y_UNIT_TEST(ShouldReturnDelayForPostponingRequest)
+    {
+        TLeakyBucket lb(0.5, 0.5, 0);
+
+        auto now = TInstant::Now();
+        auto delay = lb.Register(now, 42.0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            lb.Register(now + SecondsToDuration(delay), 42.0));
+    }
+
     Y_UNIT_TEST(ShouldCorrectlyCalculateBoostedTimeBucket)
     {
         TBoostedTimeBucket lb(

--- a/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
+++ b/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
@@ -49,7 +49,7 @@ Y_UNIT_TEST_SUITE(TLeakyBucketTest)
     {
         TLeakyBucket lb(100, 200, 10);
 
-        REG_AND_CHECK(100, 100'000, 110);       // 10
+        REG_AND_CHECK(1, 100'000, 110);         // 10
         REG_AND_CHECK(0.2, 500'000, 70);        // 10 + 0.4 * 100 = 50
         REG_AND_CHECK(0, 600'000, 40);          // 50 + 0.1 * 100 - 40 = 20
         REG_AND_CHECK(0.2, 800'000, 60);        // 20 + 0.2 * 100 = 40

--- a/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
+++ b/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
@@ -34,62 +34,62 @@ Y_UNIT_TEST_SUITE(TLeakyBucketTest)
     {
         TLeakyBucket lb(100, 200, 200);
 
-        REG_AND_CHECK(0, 100'000, 110);                 // 200 - 110 = 90
-        REG_AND_CHECK(0, 500'000, 70);                  // 90 + 0.4 * 100 - 70 = 60
-        REG_AND_CHECK(0, 600'000, 40);                  // 60 + 0.1 * 100 - 40 = 30
-        REG_AND_CHECK(0.1, 800'000, 60);                // 30 + 0.2 * 100 = 50
-        REG_AND_CHECK(0, 900'000, 60);                  // 50 + 0.1 * 100 - 60 = 0
-        REG_AND_CHECK(0, 10'000'000, 500);              // min(max(0, 200 - 500), 0 + 9.1 * 100 - 500) = 0
-        REG_AND_CHECK(0, 20'000'000, 1);                // 0 + min(max(0, 200 - 1), 10 * 100) = 199
-        REG_AND_CHECK(0.01, 20'000'000, 200);           // 199 + 0 = 199
-        REG_AND_CHECK(0, 20'010'000, 200);              // 199. + 0.01 * 100 - 200 = 0
+        REG_AND_CHECK(0, 100'000, 110);         // 200 - 110 = 90
+        REG_AND_CHECK(0, 500'000, 70);          // 90 + 0.4 * 100 - 70 = 60
+        REG_AND_CHECK(0, 600'000, 40);          // 60 + 0.1 * 100 - 40 = 30
+        REG_AND_CHECK(0.1, 800'000, 60);        // 30 + 0.2 * 100 = 50
+        REG_AND_CHECK(0, 900'000, 60);          // 50 + 0.1 * 100 - 60 = 0
+        REG_AND_CHECK(0, 10'000'000, 500);      // min(max(0, 200 - 500), 0 + 9.1 * 100 - 500) = 0
+        REG_AND_CHECK(0, 20'000'000, 1);        // 0 + min(max(0, 200 - 1), 10 * 100) = 199
+        REG_AND_CHECK(0.01, 20'000'000, 200);   // 199 + 0 = 199
+        REG_AND_CHECK(0, 20'010'000, 200);      // 199. + 0.01 * 100 - 200 = 0
     }
 
     Y_UNIT_TEST(ShouldRegisterWithCustomInitialBudget)
     {
         TLeakyBucket lb(100, 200, 10);
 
-        REG_AND_CHECK(1, 100'000, 110);                 // 10
-        REG_AND_CHECK(0.2, 500'000, 70);                // 10 + 0.4 * 100 = 50
-        REG_AND_CHECK(0, 600'000, 40);                  // 50 + 0.1 * 100 - 40 = 20
-        REG_AND_CHECK(0.2, 800'000, 60);                // 20 + 0.2 * 100 = 40
-        REG_AND_CHECK(0.1, 900'000, 60);                // 40 + 0.1 * 100 = 50
-        REG_AND_CHECK(0, 10'000'000, 500);              // min(max(0, 200 - 500), 40 + 9.1 * 100 - 500) = 0
-        REG_AND_CHECK(0, 20'000'000, 1);                // min(max(0, 200 - 1), 0 + 10 * 100 - 1) = 199
-        REG_AND_CHECK(0.01, 20'000'000, 200);           // 199 + 0 = 199
-        REG_AND_CHECK(0, 20'010'000, 200);              // 199. + 0.01 * 100 - 200 = 0
+        REG_AND_CHECK(100, 100'000, 110);       // 10
+        REG_AND_CHECK(0.2, 500'000, 70);        // 10 + 0.4 * 100 = 50
+        REG_AND_CHECK(0, 600'000, 40);          // 50 + 0.1 * 100 - 40 = 20
+        REG_AND_CHECK(0.2, 800'000, 60);        // 20 + 0.2 * 100 = 40
+        REG_AND_CHECK(0.1, 900'000, 60);        // 40 + 0.1 * 100 = 50
+        REG_AND_CHECK(0, 10'000'000, 500);      // min(max(0, 200 - 500), 40 + 9.1 * 100 - 500) = 0
+        REG_AND_CHECK(0, 20'000'000, 1);        // min(max(0, 200 - 1), 0 + 10 * 100 - 1) = 199
+        REG_AND_CHECK(0.01, 20'000'000, 200);   // 199 + 0 = 199
+        REG_AND_CHECK(0, 20'010'000, 200);      // 199. + 0.01 * 100 - 200 = 0
     }
 
     Y_UNIT_TEST(ShouldSpentBudgetShare)
     {
         TLeakyBucket lb(100, 200, 200);
 
-        GET_SHARE_AND_CHECK(0, 50'000);                 // share = (200 - 200) / 200 = 0
-        REG_AND_CHECK(0, 100'000, 110);                 // budget = 200 - 110 = 90
-        GET_SHARE_AND_CHECK(0.5, 200'000);              // share = (200 - (90 + 0.1 * 100)) / 200 = 0.5
-        GET_SHARE_AND_CHECK(0.475, 250'000);            // share = (200 - (90 + 0.15 * 100)) / 200 = 0.475
-        REG_AND_CHECK(0, 500'000, 70);                  // budget = 90 + 0.4 * 100 - 70 = 60
-        GET_SHARE_AND_CHECK(0.575, 750'000);            // share = (200 - (60 + 0.25 * 100)) / 200 = 0.575
-        GET_SHARE_AND_CHECK(0, 1'900'000);              // share = (200 - (60 + 1.4 * 100)) / 200 = 0
-        REG_AND_CHECK(0, 2'000'000, 200);               // budget = 60 + 1.4 * 100 - 200 = 0
-        GET_SHARE_AND_CHECK(1, 2'000'000);              // share = (200 - (0 + 0 * 100)) / 200 = 1
-        GET_SHARE_AND_CHECK(0.75, 2'500'000);           // share = (200 - (0 + 0.5 * 100)) = 0.75
+        GET_SHARE_AND_CHECK(0, 50'000);          // share = (200 - 200) / 200 = 0
+        REG_AND_CHECK(0, 100'000, 110);          // budget = 200 - 110 = 90
+        GET_SHARE_AND_CHECK(0.5, 200'000);       // share = (200 - (90 + 0.1 * 100)) / 200 = 0.5
+        GET_SHARE_AND_CHECK(0.475, 250'000);     // share = (200 - (90 + 0.15 * 100)) / 200 = 0.475
+        REG_AND_CHECK(0, 500'000, 70);           // budget = 90 + 0.4 * 100 - 70 = 60
+        GET_SHARE_AND_CHECK(0.575, 750'000);     // share = (200 - (60 + 0.25 * 100)) / 200 = 0.575
+        GET_SHARE_AND_CHECK(0, 1'900'000);       // share = (200 - (60 + 1.4 * 100)) / 200 = 0
+        REG_AND_CHECK(0, 2'000'000, 200);        // budget = 60 + 1.4 * 100 - 200 = 0
+        GET_SHARE_AND_CHECK(1, 2'000'000);       // share = (200 - (0 + 0 * 100)) / 200 = 1
+        GET_SHARE_AND_CHECK(0.75, 2'500'000);    // share = (200 - (0 + 0.5 * 100)) = 0.75
     }
 
     Y_UNIT_TEST(ShouldSpentBudgetShareWithCustomInitialBudget)
     {
         TLeakyBucket lb(100, 200, 10);
 
-        GET_SHARE_AND_CHECK(0.95, 50'000);              // share = (200 - 10) / 200 = 0.95
-        REG_AND_CHECK(1, 100'000, 110);                 // budget = 10
-        GET_SHARE_AND_CHECK(0.9, 200'000);              // share = (200 - (10 + 0.1 * 100)) / 200 = 0.9
-        GET_SHARE_AND_CHECK(0.875, 250'000);            // share = (200 - (10 + 0.15 * 100)) / 200 = 0.875
-        REG_AND_CHECK(0.2, 500'000, 70);                // budget = 10 + 0.4 * 100 = 50
-        GET_SHARE_AND_CHECK(0.625, 750'000);            // share = (200 - (50 + 0.25 * 100)) / 200 = 0.625
-        GET_SHARE_AND_CHECK(0.05, 1'900'000);           // share = (200 - (50 + 1.4 * 100)) / 200 = 0.05
-        REG_AND_CHECK(0, 2'000'000, 200);               // budget = 50 + 1.5 * 100 - 200 = 0
-        GET_SHARE_AND_CHECK(1.0, 2'000'000);            // share = (200 - (0 + 0 * 100)) / 200 = 1
-        GET_SHARE_AND_CHECK(0.75, 2'500'000);           // share = (200 - (0 + 0.5 * 100)) / 200 = 0.75
+        GET_SHARE_AND_CHECK(0.95, 50'000);       // share = (200 - 10) / 200 = 0.95
+        REG_AND_CHECK(1, 100'000, 110);          // budget = 10
+        GET_SHARE_AND_CHECK(0.9, 200'000);       // share = (200 - (10 + 0.1 * 100)) / 200 = 0.9
+        GET_SHARE_AND_CHECK(0.875, 250'000);     // share = (200 - (10 + 0.15 * 100)) / 200 = 0.875
+        REG_AND_CHECK(0.2, 500'000, 70);         // budget = 10 + 0.4 * 100 = 50
+        GET_SHARE_AND_CHECK(0.625, 750'000);     // share = (200 - (50 + 0.25 * 100)) / 200 = 0.625
+        GET_SHARE_AND_CHECK(0.05, 1'900'000);    // share = (200 - (50 + 1.4 * 100)) / 200 = 0.05
+        REG_AND_CHECK(0, 2'000'000, 200);        // budget = 50 + 1.5 * 100 - 200 = 0
+        GET_SHARE_AND_CHECK(1.0, 2'000'000);     // share = (200 - (0 + 0 * 100)) / 200 = 1
+        GET_SHARE_AND_CHECK(0.75, 2'500'000);    // share = (200 - (0 + 0.5 * 100)) / 200 = 0.75
     }
 
     Y_UNIT_TEST(ShouldCorrectlyCalculateBoostedTimeBucket)

--- a/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
+++ b/cloud/storage/core/libs/throttling/leaky_bucket_ut.cpp
@@ -10,9 +10,9 @@ namespace NCloud {
 
 Y_UNIT_TEST_SUITE(TLeakyBucketTest)
 {
-#define REG_AND_CHECK(budgetDiff, nowMcs, update)                              \
+#define REG_AND_CHECK(delaySeconds, nowMcs, update)                            \
         UNIT_ASSERT_VALUES_EQUAL(                                              \
-            budgetDiff,                                                        \
+            delaySeconds,                                                      \
             lb.Register(TInstant::MicroSeconds(nowMcs), update)                \
         );                                                                     \
 // REG_AND_CHECK
@@ -34,62 +34,62 @@ Y_UNIT_TEST_SUITE(TLeakyBucketTest)
     {
         TLeakyBucket lb(100, 200, 200);
 
-        REG_AND_CHECK(0, 100'000, 110);         // 200 - 110 = 90
-        REG_AND_CHECK(0, 500'000, 70);          // 90 + 0.4 * 100 - 70 = 60
-        REG_AND_CHECK(0, 600'000, 40);          // 60 + 0.1 * 100 - 40 = 30
-        REG_AND_CHECK(10, 800'000, 60);         // 30 + 0.2 * 100 = 50
-        REG_AND_CHECK(0, 900'000, 60);          // 50 + 0.1 * 100 - 60 = 0
-        REG_AND_CHECK(0, 10'000'000, 500);      // min(max(0, 200 - 500), 0 + 9.1 * 100 - 500) = 0
-        REG_AND_CHECK(0, 20'000'000, 1);        // 0 + min(max(0, 200 - 1), 10 * 100) = 199
-        REG_AND_CHECK(1, 20'000'000, 200);      // 199 + 0 = 199
-        REG_AND_CHECK(0, 20'010'000, 200);      // 199. + 0.01 * 100 - 200 = 0
+        REG_AND_CHECK(0, 100'000, 110);                 // 200 - 110 = 90
+        REG_AND_CHECK(0, 500'000, 70);                  // 90 + 0.4 * 100 - 70 = 60
+        REG_AND_CHECK(0, 600'000, 40);                  // 60 + 0.1 * 100 - 40 = 30
+        REG_AND_CHECK(0.1, 800'000, 60);                // 30 + 0.2 * 100 = 50
+        REG_AND_CHECK(0, 900'000, 60);                  // 50 + 0.1 * 100 - 60 = 0
+        REG_AND_CHECK(0, 10'000'000, 500);              // min(max(0, 200 - 500), 0 + 9.1 * 100 - 500) = 0
+        REG_AND_CHECK(0, 20'000'000, 1);                // 0 + min(max(0, 200 - 1), 10 * 100) = 199
+        REG_AND_CHECK(0.01, 20'000'000, 200);           // 199 + 0 = 199
+        REG_AND_CHECK(0, 20'010'000, 200);              // 199. + 0.01 * 100 - 200 = 0
     }
 
     Y_UNIT_TEST(ShouldRegisterWithCustomInitialBudget)
     {
         TLeakyBucket lb(100, 200, 10);
 
-        REG_AND_CHECK(100, 100'000, 110);       // 10
-        REG_AND_CHECK(20, 500'000, 70);         // 10 + 0.4 * 100 = 50
-        REG_AND_CHECK(0, 600'000, 40);          // 50 + 0.1 * 100 - 40 = 20
-        REG_AND_CHECK(20, 800'000, 60);         // 20 + 0.2 * 100 = 40
-        REG_AND_CHECK(10, 900'000, 60);         // 40 + 0.1 * 100 = 50
-        REG_AND_CHECK(0, 10'000'000, 500);      // min(max(0, 200 - 500), 40 + 9.1 * 100 - 500) = 0
-        REG_AND_CHECK(0, 20'000'000, 1);        // min(max(0, 200 - 1), 0 + 10 * 100 - 1) = 199
-        REG_AND_CHECK(1, 20'000'000, 200);      // 199 + 0 = 199
-        REG_AND_CHECK(0, 20'010'000, 200);      // 199. + 0.01 * 100 - 200 = 0
+        REG_AND_CHECK(1, 100'000, 110);                 // 10
+        REG_AND_CHECK(0.2, 500'000, 70);                // 10 + 0.4 * 100 = 50
+        REG_AND_CHECK(0, 600'000, 40);                  // 50 + 0.1 * 100 - 40 = 20
+        REG_AND_CHECK(0.2, 800'000, 60);                // 20 + 0.2 * 100 = 40
+        REG_AND_CHECK(0.1, 900'000, 60);                // 40 + 0.1 * 100 = 50
+        REG_AND_CHECK(0, 10'000'000, 500);              // min(max(0, 200 - 500), 40 + 9.1 * 100 - 500) = 0
+        REG_AND_CHECK(0, 20'000'000, 1);                // min(max(0, 200 - 1), 0 + 10 * 100 - 1) = 199
+        REG_AND_CHECK(0.01, 20'000'000, 200);           // 199 + 0 = 199
+        REG_AND_CHECK(0, 20'010'000, 200);              // 199. + 0.01 * 100 - 200 = 0
     }
 
     Y_UNIT_TEST(ShouldSpentBudgetShare)
     {
         TLeakyBucket lb(100, 200, 200);
 
-        GET_SHARE_AND_CHECK(0, 50'000);          // share = (200 - 200) / 200 = 0
-        REG_AND_CHECK(0, 100'000, 110);          // budget = 200 - 110 = 90
-        GET_SHARE_AND_CHECK(0.5, 200'000);       // share = (200 - (90 + 0.1 * 100)) / 200 = 0.5
-        GET_SHARE_AND_CHECK(0.475, 250'000);     // share = (200 - (90 + 0.15 * 100)) / 200 = 0.475
-        REG_AND_CHECK(0, 500'000, 70);           // budget = 90 + 0.4 * 100 - 70 = 60
-        GET_SHARE_AND_CHECK(0.575, 750'000);     // share = (200 - (60 + 0.25 * 100)) / 200 = 0.575
-        GET_SHARE_AND_CHECK(0, 1'900'000);       // share = (200 - (60 + 1.4 * 100)) / 200 = 0
-        REG_AND_CHECK(0, 2'000'000, 200);        // budget = 60 + 1.4 * 100 - 200 = 0
-        GET_SHARE_AND_CHECK(1, 2'000'000);       // share = (200 - (0 + 0 * 100)) / 200 = 1
-        GET_SHARE_AND_CHECK(0.75, 2'500'000);    // share = (200 - (0 + 0.5 * 100)) = 0.75
+        GET_SHARE_AND_CHECK(0, 50'000);                 // share = (200 - 200) / 200 = 0
+        REG_AND_CHECK(0, 100'000, 110);                 // budget = 200 - 110 = 90
+        GET_SHARE_AND_CHECK(0.5, 200'000);              // share = (200 - (90 + 0.1 * 100)) / 200 = 0.5
+        GET_SHARE_AND_CHECK(0.475, 250'000);            // share = (200 - (90 + 0.15 * 100)) / 200 = 0.475
+        REG_AND_CHECK(0, 500'000, 70);                  // budget = 90 + 0.4 * 100 - 70 = 60
+        GET_SHARE_AND_CHECK(0.575, 750'000);            // share = (200 - (60 + 0.25 * 100)) / 200 = 0.575
+        GET_SHARE_AND_CHECK(0, 1'900'000);              // share = (200 - (60 + 1.4 * 100)) / 200 = 0
+        REG_AND_CHECK(0, 2'000'000, 200);               // budget = 60 + 1.4 * 100 - 200 = 0
+        GET_SHARE_AND_CHECK(1, 2'000'000);              // share = (200 - (0 + 0 * 100)) / 200 = 1
+        GET_SHARE_AND_CHECK(0.75, 2'500'000);           // share = (200 - (0 + 0.5 * 100)) = 0.75
     }
 
     Y_UNIT_TEST(ShouldSpentBudgetShareWithCustomInitialBudget)
     {
         TLeakyBucket lb(100, 200, 10);
 
-        GET_SHARE_AND_CHECK(0.95, 50'000);       // share = (200 - 10) / 200 = 0.95
-        REG_AND_CHECK(100, 100'000, 110);        // budget = 10
-        GET_SHARE_AND_CHECK(0.9, 200'000);       // share = (200 - (10 + 0.1 * 100)) / 200 = 0.9
-        GET_SHARE_AND_CHECK(0.875, 250'000);     // share = (200 - (10 + 0.15 * 100)) / 200 = 0.875
-        REG_AND_CHECK(20, 500'000, 70);          // budget = 10 + 0.4 * 100 = 50
-        GET_SHARE_AND_CHECK(0.625, 750'000);     // share = (200 - (50 + 0.25 * 100)) / 200 = 0.625
-        GET_SHARE_AND_CHECK(0.05, 1'900'000);    // share = (200 - (50 + 1.4 * 100)) / 200 = 0.05
-        REG_AND_CHECK(0, 2'000'000, 200);        // budget = 50 + 1.5 * 100 - 200 = 0
-        GET_SHARE_AND_CHECK(1.0, 2'000'000);     // share = (200 - (0 + 0 * 100)) / 200 = 1
-        GET_SHARE_AND_CHECK(0.75, 2'500'000);    // share = (200 - (0 + 0.5 * 100)) / 200 = 0.75
+        GET_SHARE_AND_CHECK(0.95, 50'000);              // share = (200 - 10) / 200 = 0.95
+        REG_AND_CHECK(1, 100'000, 110);                 // budget = 10
+        GET_SHARE_AND_CHECK(0.9, 200'000);              // share = (200 - (10 + 0.1 * 100)) / 200 = 0.9
+        GET_SHARE_AND_CHECK(0.875, 250'000);            // share = (200 - (10 + 0.15 * 100)) / 200 = 0.875
+        REG_AND_CHECK(0.2, 500'000, 70);                // budget = 10 + 0.4 * 100 = 50
+        GET_SHARE_AND_CHECK(0.625, 750'000);            // share = (200 - (50 + 0.25 * 100)) / 200 = 0.625
+        GET_SHARE_AND_CHECK(0.05, 1'900'000);           // share = (200 - (50 + 1.4 * 100)) / 200 = 0.05
+        REG_AND_CHECK(0, 2'000'000, 200);               // budget = 50 + 1.5 * 100 - 200 = 0
+        GET_SHARE_AND_CHECK(1.0, 2'000'000);            // share = (200 - (0 + 0 * 100)) / 200 = 1
+        GET_SHARE_AND_CHECK(0.75, 2'500'000);           // share = (200 - (0 + 0.5 * 100)) / 200 = 0.75
     }
 
     Y_UNIT_TEST(ShouldCorrectlyCalculateBoostedTimeBucket)


### PR DESCRIPTION
### Notes
I expect this code to work, because we use the return value as the time we need to postpone the request before retrying it:
```
TLeakyBucket bucket(0.5, 0.5, 0);
auto now = TInstant::Now();
auto delay = bucket.Register(now, 42.0);
UNIT_ASSERT_VALUES_EQUAL(0, bucket.Register(now + SecondsToDuration(delay), 42.0));
```
Before the fix this code did not work: enough budget to register the update is accumulated only after `(update - State.Budget) / (Rate * 1e6)` seconds, but we were returning `(update - State.Budget)`.

Now this is not a big deal, but I want to use leaky bucket in implementing mixed blocks filter feature. And in that case pre-fix bucket behavior causing bugs.

### Issue
#6390 