### PR TITLE
[DM] Add TTL mechanism for idle base disks in pools

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/pools/cleanup_idle_base_disks_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/cleanup_idle_base_disks_task.go
@@ -1,0 +1,74 @@
+package pools
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/pools/storage"
+	"github.com/ydb-platform/nbs/cloud/tasks"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type cleanupIdleBaseDisksTask struct {
+	storage         storage.Storage
+	baseDiskIdleTTL time.Duration
+	limit           uint64
+}
+
+func (t *cleanupIdleBaseDisksTask) Save() ([]byte, error) {
+	return nil, nil
+}
+
+func (t *cleanupIdleBaseDisksTask) Load(_, _ []byte) error {
+	return nil
+}
+
+func (t *cleanupIdleBaseDisksTask) Run(
+	ctx context.Context,
+	execCtx tasks.ExecutionContext,
+) error {
+
+	if t.baseDiskIdleTTL <= 0 {
+		return nil
+	}
+
+	idleBefore := time.Now().Add(-t.baseDiskIdleTTL)
+
+	idleDisks, err := t.storage.GetIdleBaseDisks(ctx, t.baseDiskIdleTTL, t.limit)
+	if err != nil {
+		return err
+	}
+
+	if len(idleDisks) == 0 {
+		return nil
+	}
+
+	var baseDiskIDs []string
+	for _, d := range idleDisks {
+		baseDiskIDs = append(baseDiskIDs, d.ID)
+	}
+
+	return t.storage.EjectIdleBaseDisksFromPool(ctx, baseDiskIDs, idleBefore)
+}
+
+func (t *cleanupIdleBaseDisksTask) Cancel(
+	ctx context.Context,
+	execCtx tasks.ExecutionContext,
+) error {
+
+	return nil
+}
+
+func (t *cleanupIdleBaseDisksTask) GetMetadata(
+	ctx context.Context,
+) (proto.Message, error) {
+
+	return &empty.Empty{}, nil
+}
+
+func (t *cleanupIdleBaseDisksTask) GetResponse() proto.Message {
+	return &empty.Empty{}
+}

--- a/cloud/disk_manager/internal/pkg/services/pools/cleanup_idle_base_disks_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/cleanup_idle_base_disks_task_test.go
@@ -1,0 +1,98 @@
+package pools
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/pools/storage"
+	pools_storage_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/pools/storage/mocks"
+	tasks_mocks "github.com/ydb-platform/nbs/cloud/tasks/mocks"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func TestCleanupIdleBaseDisksTaskNoIdleDisks(t *testing.T) {
+	ctx := newContext()
+	s := pools_storage_mocks.NewStorageMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	task := &cleanupIdleBaseDisksTask{
+		storage:         s,
+		baseDiskIdleTTL: 24 * time.Hour,
+		limit:           100,
+	}
+
+	s.On(
+		"GetIdleBaseDisks",
+		ctx,
+		24*time.Hour,
+		uint64(100),
+	).Return([]storage.BaseDisk{}, nil)
+
+	err := task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, s, execCtx)
+}
+
+func TestCleanupIdleBaseDisksTaskWithIdleDisks(t *testing.T) {
+	ctx := newContext()
+	s := pools_storage_mocks.NewStorageMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	task := &cleanupIdleBaseDisksTask{
+		storage:         s,
+		baseDiskIdleTTL: 7 * 24 * time.Hour,
+		limit:           50,
+	}
+
+	idleDisks := []storage.BaseDisk{
+		{
+			ID:      "baseDisk1",
+			ImageID: "image1",
+			ZoneID:  "zone1",
+		},
+		{
+			ID:      "baseDisk2",
+			ImageID: "image1",
+			ZoneID:  "zone1",
+		},
+		{
+			ID:      "baseDisk3",
+			ImageID: "image2",
+			ZoneID:  "zone2",
+		},
+	}
+
+	s.On(
+		"GetIdleBaseDisks",
+		ctx,
+		7*24*time.Hour,
+		uint64(50),
+	).Return(idleDisks, nil)
+
+	s.On(
+		"EjectIdleBaseDisksFromPool",
+		ctx,
+		[]string{"baseDisk1", "baseDisk2", "baseDisk3"},
+		mock.AnythingOfType("time.Time"),
+	).Return(nil)
+
+	err := task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, s, execCtx)
+}
+
+func TestCleanupIdleBaseDisksTaskCancel(t *testing.T) {
+	ctx := newContext()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	task := &cleanupIdleBaseDisksTask{
+		baseDiskIdleTTL: 24 * time.Hour,
+		limit:           100,
+	}
+
+	err := task.Cancel(ctx, execCtx)
+	require.NoError(t, err)
+}

--- a/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
@@ -45,4 +45,10 @@ message PoolsConfig {
     //  * Reducing this number also increases the total size of the base disks
     //    that need to be allocated.
     optional uint32 BaseDiskOverSubscription = 24 [default = 2];
+    // TTL for idle base disks in pools. Base disks with zero overlay disks
+    // for longer than this duration will be ejected from pool and deleted.
+    // Set to "0s" to disable.
+    optional string BaseDiskIdleTTL = 25 [default = "0s"];
+    optional string CleanupIdleBaseDisksTaskScheduleInterval = 26 [default = "10m"];
+    optional uint64 CleanupIdleBaseDisksLimit = 27 [default = 100];
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/register.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/register.go
@@ -79,6 +79,20 @@ func RegisterForExecution(
 		return err
 	}
 
+	baseDiskIdleTTL, err := time.ParseDuration(
+		config.GetBaseDiskIdleTTL(),
+	)
+	if err != nil {
+		return err
+	}
+
+	cleanupIdleBaseDisksTaskScheduleInterval, err := time.ParseDuration(
+		config.GetCleanupIdleBaseDisksTaskScheduleInterval(),
+	)
+	if err != nil {
+		return err
+	}
+
 	err = taskRegistry.RegisterForExecution("pools.AcquireBaseDisk", func() tasks.Task {
 		return &acquireBaseDiskTask{
 			scheduler: taskScheduler,
@@ -228,6 +242,17 @@ func RegisterForExecution(
 		return err
 	}
 
+	err = taskRegistry.RegisterForExecution("pools.CleanupIdleBaseDisks", func() tasks.Task {
+		return &cleanupIdleBaseDisksTask{
+			storage:         storage,
+			baseDiskIdleTTL: baseDiskIdleTTL,
+			limit:           config.GetCleanupIdleBaseDisksLimit(),
+		}
+	})
+	if err != nil {
+		return err
+	}
+
 	taskScheduler.ScheduleRegularTasks(
 		ctx,
 		"pools.ScheduleBaseDisks",
@@ -274,6 +299,21 @@ func RegisterForExecution(
 			MaxTasksInflight: 1,
 		},
 	)
+
+	if baseDiskIdleTTL > 0 {
+		err = storage.InitializeIdleTimestamps(ctx)
+		if err != nil {
+			return err
+		}
+		taskScheduler.ScheduleRegularTasks(
+			ctx,
+			"pools.CleanupIdleBaseDisks",
+			tasks.TaskSchedule{
+				ScheduleInterval: cleanupIdleBaseDisksTaskScheduleInterval,
+				MaxTasksInflight: 1,
+			},
+		)
+	}
 
 	return nil
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -86,6 +86,12 @@ func baseDiskStatusToString(status baseDiskStatus) string {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+func isTimestampUnset(t time.Time) bool {
+	return !t.After(time.Unix(0, 0))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 type baseDisk struct {
 	id                  string
 	imageID             string
@@ -105,6 +111,7 @@ type baseDisk struct {
 	fromPool       bool
 	retiring       bool
 	deletedAt      time.Time
+	lastUnusedAt   time.Time // zero if disk has at least one active unit
 	status         baseDiskStatus
 }
 
@@ -205,6 +212,7 @@ func (d *baseDisk) structValue() persistence.Value {
 		persistence.StructFieldValue("from_pool", persistence.BoolValue(d.fromPool)),
 		persistence.StructFieldValue("retiring", persistence.BoolValue(d.retiring)),
 		persistence.StructFieldValue("deleted_at", persistence.TimestampValue(d.deletedAt)),
+		persistence.StructFieldValue("last_unused_at", persistence.TimestampValue(d.lastUnusedAt)),
 		persistence.StructFieldValue("status", persistence.Int64Value(int64(d.status))),
 	)
 }
@@ -229,6 +237,7 @@ func baseDiskStructTypeString() string {
 		from_pool: Bool,
 		retiring: Bool,
 		deleted_at: Timestamp,
+		last_unused_at: Timestamp,
 		status: Int64>`
 }
 
@@ -252,6 +261,7 @@ func baseDisksTableDescription() persistence.CreateTableDescription {
 		persistence.WithColumn("from_pool", persistence.Optional(persistence.TypeBool)),
 		persistence.WithColumn("retiring", persistence.Optional(persistence.TypeBool)),
 		persistence.WithColumn("deleted_at", persistence.Optional(persistence.TypeTimestamp)),
+		persistence.WithColumn("last_unused_at", persistence.Optional(persistence.TypeTimestamp)),
 		persistence.WithColumn("status", persistence.Optional(persistence.TypeInt64)),
 
 		persistence.WithPrimaryKeyColumn("id"),
@@ -278,6 +288,7 @@ func scanBaseDisk(res persistence.Result) (baseDisk baseDisk, err error) {
 		persistence.OptionalWithDefault("from_pool", &baseDisk.fromPool),
 		persistence.OptionalWithDefault("retiring", &baseDisk.retiring),
 		persistence.OptionalWithDefault("deleted_at", &baseDisk.deletedAt),
+		persistence.OptionalWithDefault("last_unused_at", &baseDisk.lastUnusedAt),
 		persistence.OptionalWithDefault("status", &baseDisk.status),
 	)
 	return
@@ -800,6 +811,8 @@ func acquireUnitsAndSlots(
 	slot.allottedUnits = computeAllottedUnits(slot)
 	disk.activeUnits += slot.allottedUnits
 
+	disk.lastUnusedAt = time.Time{}
+
 	return nil
 }
 
@@ -828,6 +841,8 @@ func acquireTargetUnitsAndSlots(
 
 	slot.targetAllottedUnits = computeAllottedUnits(slot)
 	disk.activeUnits += slot.targetAllottedUnits
+
+	disk.lastUnusedAt = time.Time{}
 
 	return nil
 }
@@ -884,6 +899,10 @@ func releaseUnitsAndSlots(
 	}
 	disk.activeUnits -= slot.allottedUnits
 
+	if disk.activeUnits == 0 && isTimestampUnset(disk.lastUnusedAt) {
+		disk.lastUnusedAt = time.Now()
+	}
+
 	return nil
 }
 
@@ -938,6 +957,10 @@ func releaseTargetUnitsAndSlots(
 		)
 	}
 	disk.activeUnits -= slot.targetAllottedUnits
+
+	if disk.activeUnits == 0 && isTimestampUnset(disk.lastUnusedAt) {
+		disk.lastUnusedAt = time.Now()
+	}
 
 	return nil
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
@@ -283,3 +283,96 @@ func TestCommonAcquireAndReleaseUnitsAndSlots(t *testing.T) {
 	require.Equal(t, uint64(4), baseDisk.freeSlots())
 	require.True(t, baseDisk.hasFreeSlots())
 }
+
+func TestCommonLastUnusedAtTracking(t *testing.T) {
+	ctx := newContext()
+
+	disk := &baseDisk{
+		maxActiveSlots: 4,
+		units:          6,
+		fromPool:       true,
+		status:         baseDiskStatusReady,
+	}
+
+	require.True(t, disk.lastUnusedAt.IsZero())
+
+	slot1 := &slot{}
+	err := acquireUnitsAndSlots(ctx, nil, disk, slot1)
+	require.NoError(t, err)
+	require.True(t, disk.lastUnusedAt.IsZero())
+
+	slot2 := &slot{}
+	err = acquireUnitsAndSlots(ctx, nil, disk, slot2)
+	require.NoError(t, err)
+	require.True(t, disk.lastUnusedAt.IsZero())
+
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), disk.activeUnits)
+	require.True(t, disk.lastUnusedAt.IsZero())
+
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot2)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), disk.activeUnits)
+	require.False(t, disk.lastUnusedAt.IsZero())
+
+	firstUnusedAt := disk.lastUnusedAt
+
+	slot3 := &slot{}
+	err = acquireUnitsAndSlots(ctx, nil, disk, slot3)
+	require.NoError(t, err)
+	require.True(t, disk.lastUnusedAt.IsZero())
+
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot3)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), disk.activeUnits)
+	require.False(t, disk.lastUnusedAt.IsZero())
+	require.True(t, disk.lastUnusedAt.After(firstUnusedAt) || disk.lastUnusedAt.Equal(firstUnusedAt))
+}
+
+func TestCommonLastUnusedAtSetOncePerIdlePeriod(t *testing.T) {
+	ctx := newContext()
+
+	disk := &baseDisk{
+		maxActiveSlots: 4,
+		units:          6,
+		fromPool:       true,
+		status:         baseDiskStatusReady,
+	}
+
+	slot1 := &slot{}
+	slot2 := &slot{}
+
+	err := acquireUnitsAndSlots(ctx, nil, disk, slot1)
+	require.NoError(t, err)
+	err = acquireUnitsAndSlots(ctx, nil, disk, slot2)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), disk.activeUnits)
+
+	// Releasing first slot: activeUnits goes to 1, lastUnusedAt stays zero.
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), disk.activeUnits)
+	require.True(t, disk.lastUnusedAt.IsZero())
+
+	// Releasing second slot: activeUnits goes to 0, lastUnusedAt gets set.
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot2)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), disk.activeUnits)
+	require.False(t, disk.lastUnusedAt.IsZero())
+}
+
+func TestCommonApplyInvariantsIdlePoolDisk(t *testing.T) {
+	disk := &baseDisk{
+		activeUnits: 0,
+		fromPool:    true,
+		status:      baseDiskStatusReady,
+	}
+
+	disk.applyInvariants()
+	require.Equal(t, baseDiskStatusReady, disk.status)
+
+	disk.fromPool = false
+	disk.applyInvariants()
+	require.Equal(t, baseDiskStatusDeleting, disk.status)
+}

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/mocks/storage_mock.go
@@ -280,6 +280,31 @@ func (s *StorageMock) CheckConsistency(ctx context.Context) error {
 	return args.Error(0)
 }
 
+func (s *StorageMock) GetIdleBaseDisks(
+	ctx context.Context,
+	idleDuration time.Duration,
+	limit uint64,
+) ([]storage.BaseDisk, error) {
+
+	args := s.Called(ctx, idleDuration, limit)
+	return args.Get(0).([]storage.BaseDisk), args.Error(1)
+}
+
+func (s *StorageMock) EjectIdleBaseDisksFromPool(
+	ctx context.Context,
+	baseDiskIDs []string,
+	idleBefore time.Time,
+) error {
+
+	args := s.Called(ctx, baseDiskIDs, idleBefore)
+	return args.Error(0)
+}
+
+func (s *StorageMock) InitializeIdleTimestamps(ctx context.Context) error {
+	args := s.Called(ctx)
+	return args.Error(0)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewStorageMock() *StorageMock {

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
@@ -192,4 +192,22 @@ type Storage interface {
 	// Used in tests and SRE tools.
 	// Executes both CheckPoolsConsistency and CheckBaseDisksConsistency.
 	CheckConsistency(ctx context.Context) error
+
+	// Returns base disks that belong to a pool, have zero active units, and
+	// have been idle longer than |idleDuration|.
+	GetIdleBaseDisks(
+		ctx context.Context,
+		idleDuration time.Duration,
+		limit uint64,
+	) ([]BaseDisk, error)
+
+	// Ejects idle base disks from their pools (sets fromPool=false), which
+	// triggers deletion via applyInvariants.
+	EjectIdleBaseDisksFromPool(
+		ctx context.Context,
+		baseDiskIDs []string,
+		idleBefore time.Time,
+	) error
+
+	InitializeIdleTimestamps(ctx context.Context) error
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
@@ -476,6 +476,48 @@ func (s *storageYDB) CheckConsistency(ctx context.Context) error {
 	)
 }
 
+func (s *storageYDB) GetIdleBaseDisks(
+	ctx context.Context,
+	idleDuration time.Duration,
+	limit uint64,
+) ([]BaseDisk, error) {
+
+	var baseDisks []BaseDisk
+
+	err := s.db.Execute(
+		ctx,
+		func(ctx context.Context, session *persistence.Session) error {
+			var err error
+			baseDisks, err = s.getIdleBaseDisks(ctx, session, idleDuration, limit)
+			return err
+		},
+	)
+	return baseDisks, err
+}
+
+func (s *storageYDB) EjectIdleBaseDisksFromPool(
+	ctx context.Context,
+	baseDiskIDs []string,
+	idleBefore time.Time,
+) error {
+
+	return s.db.Execute(
+		ctx,
+		func(ctx context.Context, session *persistence.Session) error {
+			return s.ejectIdleBaseDisksFromPool(ctx, session, baseDiskIDs, idleBefore)
+		},
+	)
+}
+
+func (s *storageYDB) InitializeIdleTimestamps(ctx context.Context) error {
+	return s.db.Execute(
+		ctx,
+		func(ctx context.Context, session *persistence.Session) error {
+			return s.initializeIdleTimestamps(ctx, session)
+		},
+	)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewStorage(

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
@@ -3602,3 +3602,194 @@ func (s *storageYDB) unlockPool(
 
 	return tx.Commit(ctx)
 }
+
+func (s *storageYDB) getIdleBaseDisks(
+	ctx context.Context,
+	session *persistence.Session,
+	idleDuration time.Duration,
+	limit uint64,
+) ([]BaseDisk, error) {
+
+	idleBefore := time.Now().Add(-idleDuration)
+
+	res, err := session.ExecuteRO(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $idle_before as Timestamp;
+		declare $status as Int64;
+		declare $limit as Uint64;
+
+		select *
+		from base_disks
+		where from_pool = true
+			and active_units = 0
+			and status = $status
+			and last_unused_at > cast(0 as Timestamp)
+			and last_unused_at < $idle_before
+		limit $limit
+	`, s.tablesPath),
+		persistence.ValueParam("$idle_before", persistence.TimestampValue(idleBefore)),
+		persistence.ValueParam("$status", persistence.Int64Value(int64(baseDiskStatusReady))),
+		persistence.ValueParam("$limit", persistence.Uint64Value(limit)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Close()
+
+	baseDisks, err := scanBaseDisks(ctx, res)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []BaseDisk
+	for _, d := range baseDisks {
+		result = append(result, d.toBaseDisk())
+	}
+
+	return result, nil
+}
+
+func (s *storageYDB) ejectIdleBaseDisksFromPool(
+	ctx context.Context,
+	session *persistence.Session,
+	baseDiskIDs []string,
+	idleBefore time.Time,
+) error {
+
+	if len(baseDiskIDs) == 0 {
+		return nil
+	}
+
+	tx, err := session.BeginRWTransaction(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	baseDisks, err := s.findBaseDisksTx(ctx, tx, baseDiskIDs)
+	if err != nil {
+		return err
+	}
+
+	var transitions []baseDiskTransition
+
+	// Track capacity reduction per pool (imageID+zoneID).
+	type poolKey struct{ imageID, zoneID string }
+	capacityReductions := make(map[poolKey]uint64)
+
+	for i := range baseDisks {
+		d := &baseDisks[i]
+
+		if !d.fromPool || d.isDoomed() || d.activeUnits != 0 || d.lastUnusedAt.After(idleBefore) {
+			continue
+		}
+
+		oldState := *d
+		d.fromPool = false
+
+		transitions = append(transitions, baseDiskTransition{
+			oldState: &oldState,
+			state:    d,
+		})
+
+		key := poolKey{d.imageID, d.zoneID}
+		capacityReductions[key] += oldState.freeSlots()
+	}
+
+	if len(transitions) == 0 {
+		return tx.Commit(ctx)
+	}
+
+	err = s.updateBaseDisks(ctx, tx, transitions)
+	if err != nil {
+		return err
+	}
+
+	// Decrease config capacity so scheduler doesn't recreate.
+	for key, reduction := range capacityReductions {
+		err = s.reducePoolCapacity(ctx, tx, key.imageID, key.zoneID, reduction)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (s *storageYDB) initializeIdleTimestamps(
+	ctx context.Context,
+	session *persistence.Session,
+) error {
+
+	now := time.Now()
+
+	_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $now as Timestamp;
+		declare $status as Int64;
+
+		update base_disks
+		set last_unused_at = $now
+		where from_pool = true
+			and active_units = 0
+			and status = $status
+			and (last_unused_at = cast(0 as Timestamp) OR last_unused_at IS NULL)
+	`, s.tablesPath),
+		persistence.ValueParam("$now", persistence.TimestampValue(now)),
+		persistence.ValueParam("$status", persistence.Int64Value(int64(baseDiskStatusReady))),
+	)
+	return err
+}
+
+func (s *storageYDB) reducePoolCapacity(
+	ctx context.Context,
+	tx *persistence.Transaction,
+	imageID string,
+	zoneID string,
+	reduction uint64,
+) error {
+
+	capacity, err := s.getPoolCapacity(ctx, tx, imageID, zoneID)
+	if err != nil {
+		return err
+	}
+
+	var newCapacity uint64
+	if capacity > reduction {
+		newCapacity = capacity - reduction
+	}
+
+	_, err = tx.Execute(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $image_id as Utf8;
+		declare $zone_id as Utf8;
+		declare $capacity as Uint64;
+
+		upsert into configs (image_id, zone_id, kind, capacity)
+		values ($image_id, $zone_id, 0, $capacity)
+	`, s.tablesPath),
+		persistence.ValueParam("$image_id", persistence.UTF8Value(imageID)),
+		persistence.ValueParam("$zone_id", persistence.UTF8Value(zoneID)),
+		persistence.ValueParam("$capacity", persistence.Uint64Value(newCapacity)),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Execute(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $image_id as Utf8;
+		declare $zone_id as Utf8;
+
+		delete from configs
+		where image_id = $image_id and zone_id = $zone_id and kind != 0
+	`, s.tablesPath),
+		persistence.ValueParam("$image_id", persistence.UTF8Value(imageID)),
+		persistence.ValueParam("$zone_id", persistence.UTF8Value(zoneID)),
+	)
+	return err
+}

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -2728,3 +2728,207 @@ func TestStorageYDBBaseDisksShouldHavePrefix(t *testing.T) {
 	require.Equal(t, 1, len(baseDisks))
 	require.True(t, strings.HasPrefix(baseDisks[0].ID, prefix))
 }
+
+func TestStorageYDBGetIdleBaseDisksEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	idleDisks, err := storage.GetIdleBaseDisks(ctx, time.Hour, 100)
+	require.NoError(t, err)
+	require.Empty(t, idleDisks)
+}
+
+func TestStorageYDBGetIdleBaseDisksAndEject(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	err = storage.ConfigurePool(ctx, "image", "zone", 1, 0)
+	require.NoError(t, err)
+
+	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(baseDisks))
+
+	baseDisks[0].CreateTaskID = "create"
+	err = storage.BaseDisksScheduled(ctx, baseDisks)
+	require.NoError(t, err)
+	err = storage.BaseDiskCreated(ctx, baseDisks[0])
+	require.NoError(t, err)
+
+	// Ready base disk without any overlays should not be idle yet (lastUnusedAt
+	// was never set because no overlay was acquired and released).
+	idleDisks, err := storage.GetIdleBaseDisks(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Empty(t, idleDisks)
+
+	// Acquire and release a slot to trigger lastUnusedAt.
+	overlay := &types.Disk{ZoneId: "zone", DiskId: "overlay"}
+	_, err = storage.AcquireBaseDiskSlot(ctx, "image", Slot{OverlayDisk: overlay})
+	require.NoError(t, err)
+
+	_, err = storage.ReleaseBaseDiskSlot(ctx, overlay)
+	require.NoError(t, err)
+
+	// Now the base disk should be idle with idleDuration=0.
+	idleDisks, err = storage.GetIdleBaseDisks(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(idleDisks))
+	require.Equal(t, baseDisks[0].ID, idleDisks[0].ID)
+	require.Equal(t, "image", idleDisks[0].ImageID)
+	require.Equal(t, "zone", idleDisks[0].ZoneID)
+
+	// With large idleDuration, the disk should not be returned.
+	idleDisks, err = storage.GetIdleBaseDisks(ctx, 24*time.Hour, 100)
+	require.NoError(t, err)
+	require.Empty(t, idleDisks)
+
+	// Eject the idle disk.
+	idleDisks, err = storage.GetIdleBaseDisks(ctx, 0, 100)
+	require.NoError(t, err)
+
+	var ids []string
+	for _, d := range idleDisks {
+		ids = append(ids, d.ID)
+	}
+	err = storage.EjectIdleBaseDisksFromPool(ctx, ids, time.Now())
+	require.NoError(t, err)
+
+	// After ejection the disk should be scheduled for deletion.
+	require.True(t, baseDiskShouldBeDeletedSoon(t, ctx, storage, baseDisks[0]))
+
+	// No more idle disks.
+	idleDisks, err = storage.GetIdleBaseDisks(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Empty(t, idleDisks)
+
+	err = storage.CheckConsistency(ctx)
+	require.NoError(t, err)
+}
+
+func TestStorageYDBEjectIdleBaseDisksSkipsActiveDisk(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	err = storage.ConfigurePool(ctx, "image", "zone", 1, 0)
+	require.NoError(t, err)
+
+	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(baseDisks))
+
+	baseDisks[0].CreateTaskID = "create"
+	err = storage.BaseDisksScheduled(ctx, baseDisks)
+	require.NoError(t, err)
+	err = storage.BaseDiskCreated(ctx, baseDisks[0])
+	require.NoError(t, err)
+
+	overlay := &types.Disk{ZoneId: "zone", DiskId: "overlay"}
+	_, err = storage.AcquireBaseDiskSlot(ctx, "image", Slot{OverlayDisk: overlay})
+	require.NoError(t, err)
+
+	// Disk has an active overlay — eject should not affect it.
+	err = storage.EjectIdleBaseDisksFromPool(ctx, []string{baseDisks[0].ID}, time.Now())
+	require.NoError(t, err)
+
+	require.False(t, baseDiskShouldBeDeletedSoon(t, ctx, storage, baseDisks[0]))
+
+	err = storage.CheckConsistency(ctx)
+	require.NoError(t, err)
+}
+
+func TestStorageYDBIdleDiskReacquired(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	err = storage.ConfigurePool(ctx, "image", "zone", 1, 0)
+	require.NoError(t, err)
+
+	baseDisks, err := storage.TakeBaseDisksToSchedule(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(baseDisks))
+
+	baseDisks[0].CreateTaskID = "create"
+	err = storage.BaseDisksScheduled(ctx, baseDisks)
+	require.NoError(t, err)
+	err = storage.BaseDiskCreated(ctx, baseDisks[0])
+	require.NoError(t, err)
+
+	overlay1 := &types.Disk{ZoneId: "zone", DiskId: "overlay1"}
+	_, err = storage.AcquireBaseDiskSlot(ctx, "image", Slot{OverlayDisk: overlay1})
+	require.NoError(t, err)
+
+	_, err = storage.ReleaseBaseDiskSlot(ctx, overlay1)
+	require.NoError(t, err)
+
+	// Disk is idle now.
+	idleDisks, err := storage.GetIdleBaseDisks(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(idleDisks))
+
+	// Re-acquire resets lastUnusedAt, disk should no longer be idle.
+	overlay2 := &types.Disk{ZoneId: "zone", DiskId: "overlay2"}
+	_, err = storage.AcquireBaseDiskSlot(ctx, "image", Slot{OverlayDisk: overlay2})
+	require.NoError(t, err)
+
+	idleDisks, err = storage.GetIdleBaseDisks(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Empty(t, idleDisks)
+
+	err = storage.CheckConsistency(ctx)
+	require.NoError(t, err)
+}
+
+func TestStorageYDBEjectEmptyList(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	err = storage.EjectIdleBaseDisksFromPool(ctx, []string{}, time.Now())
+	require.NoError(t, err)
+
+	err = storage.EjectIdleBaseDisksFromPool(ctx, nil, time.Now())
+	require.NoError(t, err)
+}
+
+func TestStorageYDBEjectNonexistentDisk(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	err = storage.EjectIdleBaseDisksFromPool(ctx, []string{"nonexistent"}, time.Now())
+	require.NoError(t, err)
+}

--- a/cloud/disk_manager/internal/pkg/services/pools/ya.make
+++ b/cloud/disk_manager/internal/pkg/services/pools/ya.make
@@ -7,6 +7,7 @@ SRCS(
     service.go
 
     acquire_base_disk_task.go
+    cleanup_idle_base_disks_task.go
     clear_deleted_base_disks_task.go
     clear_released_slots_task.go
     configure_pool_task.go
@@ -24,6 +25,7 @@ SRCS(
 
 GO_TEST_SRCS(
     acquire_base_disk_task_test.go
+    cleanup_idle_base_disks_task_test.go
     configure_pool_task_test.go
     optimize_base_disks_task_test.go
     release_base_disk_task_test.go


### PR DESCRIPTION
### Problem
Base disks in pools are never cleaned up even when they have zero overlay clients, wasting storage capacity for images that are no longer in use.

### Solution
Add a configurable TTL mechanism: when a pool base disk has had no overlay clients for longer than `BaseDiskIdleTTL`, a periodic task ejects it from the pool (sets `fromPool=false`), which triggers deletion through the existing `applyInvariants()` → `DeleteBaseDisks` flow.

Set `BaseDiskIdleTTL = "0s"` (by default) to keep current behavior (no cleanup).