### PR TITLE
deleting TIndexTabletTest_Data::ShouldReturnBackendInfoForIOForOverloadedTabletActor128_KB (4_KB stays)

### DIFF
--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -8723,7 +8723,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         tablet.DestroyHandle(handle);
     }
 
-    TABLET_TEST(ShouldReturnBackendInfoForIOForOverloadedTabletActor)
+    TABLET_TEST_4K_ONLY(ShouldReturnBackendInfoForIOForOverloadedTabletActor)
     {
         const ui64 wbt = 64 * tabletConfig.BlockSize;
         const ui64 overloadThreshold = 1;


### PR DESCRIPTION
### Notes
Follow-up for https://github.com/ydb-platform/nbs/pull/6591

It's harder to make the 128_KB version stable

### Issue
None