### PR TITLE
issue-5894, issue-5895: better IStorageGroup interface + automatically setting DeviceUUIDs

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.cpp
@@ -16,40 +16,46 @@ namespace {
 
 struct TAcquireDevicesParams
 {
-    IStorageNodePtr Node;
+    TStorageDevice Device;
     NProto::TAcquireDevicesRequest* Request;
     NProto::TAcquireDevicesResponse* Response;
 };
 
 int AcquireDevicesFiberMain(TAcquireDevicesParams* params) noexcept
 {
-    *params->Response = params->Node->AcquireDevices(*params->Request);
+    NProto::TAcquireDevicesRequest request = *params->Request;
+    request.AddDeviceUUIDs(std::move(params->Device.DeviceUUID));
+    *params->Response = params->Device.Node->AcquireDevices(std::move(request));
     return 0;
 }
 
 struct TReleaseDevicesParams
 {
-    IStorageNodePtr Node;
+    TStorageDevice Device;
     NProto::TReleaseDevicesRequest* Request;
     NProto::TReleaseDevicesResponse* Response;
 };
 
 int ReleaseDevicesFiberMain(TReleaseDevicesParams* params) noexcept
 {
-    *params->Response = params->Node->ReleaseDevices(*params->Request);
+    NProto::TReleaseDevicesRequest request = *params->Request;
+    request.AddDeviceUUIDs(std::move(params->Device.DeviceUUID));
+    *params->Response = params->Device.Node->ReleaseDevices(std::move(request));
     return 0;
 }
 
 struct TWriteLogRecordParams
 {
-    IStorageNodePtr Node;
+    TStorageDevice Device;
     NProto::TWriteLogRecordRequest* Request;
     NProto::TWriteLogRecordResponse* Response;
 };
 
 int WriteLogRecordFiberMain(TWriteLogRecordParams* params) noexcept
 {
-    *params->Response = params->Node->WriteLogRecord(*params->Request);
+    NProto::TWriteLogRecordRequest request = *params->Request;
+    request.SetDeviceUUID(std::move(params->Device.DeviceUUID));
+    *params->Response = params->Device.Node->WriteLogRecord(std::move(request));
     return 0;
 }
 
@@ -58,38 +64,50 @@ int WriteLogRecordFiberMain(TWriteLogRecordParams* params) noexcept
 class TStorageGroupImpl: public IStorageGroup
 {
 private:
-    TVector<IStorageNodePtr> Nodes;
+    TVector<TStorageDevice> Devices;
     std::atomic<ui32> Selector{0};
 
 public:
-    explicit TStorageGroupImpl(TVector<IStorageNodePtr> nodes)
-        : Nodes(std::move(nodes))
+    explicit TStorageGroupImpl(TVector<TStorageDevice> devices)
+        : Devices(std::move(devices))
     {}
 
 public:
-    NProto::TAcquireDevicesResponse AcquireDevices(
-        NProto::TAcquireDevicesRequest request) override
+    NProto::TError AcquireDevices() override
     {
         return MirrorRequest<
             NProto::TAcquireDevicesRequest,
             NProto::TAcquireDevicesResponse,
             TAcquireDevicesParams
-        >(AcquireDevicesFiberMain, std::move(request));
+        >(AcquireDevicesFiberMain, NProto::TAcquireDevicesRequest{});
     }
 
-    NProto::TReleaseDevicesResponse ReleaseDevices(
-        NProto::TReleaseDevicesRequest request) override
+    NProto::TError ReleaseDevices() override
     {
         return MirrorRequest<
             NProto::TReleaseDevicesRequest,
             NProto::TReleaseDevicesResponse,
             TReleaseDevicesParams
-        >(ReleaseDevicesFiberMain, std::move(request));
+        >(ReleaseDevicesFiberMain, NProto::TReleaseDevicesRequest{});
     }
 
-    NProto::TWriteLogRecordResponse WriteLogRecord(
-        NProto::TWriteLogRecordRequest request) override
+    NProto::TError WriteLogRecord(
+        NProto::TDeviceRequestHeaders headers,
+        TVector<TPageGroup> pageGroups) override
     {
+        NProto::TWriteLogRecordRequest request;
+        *request.MutableHeaders() = std::move(headers);
+        request.MutablePageGroups()->Reserve(pageGroups.size());
+        for (auto& pg: pageGroups) {
+            auto* w = request.AddPageGroups();
+            w->SetFirstPageNo(pg.FirstPageNo);
+            w->MutableContent()->Reserve(pg.Content.size());
+            for (auto& c: pg.Content) {
+                *w->AddContent() = std::move(c);
+            }
+        }
+        SILK_DEBUG("sg write: %s", DebugMessage(request).c_str());
+
         return MirrorRequest<
             NProto::TWriteLogRecordRequest,
             NProto::TWriteLogRecordResponse,
@@ -97,42 +115,82 @@ public:
         >(WriteLogRecordFiberMain, std::move(request));
     }
 
-    NProto::TReadPagesResponse ReadPages(
-        NProto::TReadPagesRequest request) override
+    NProto::TError ReadPages(
+        NProto::TDeviceRequestHeaders headers,
+        const TVector<TPageGroupRef>& pageGroupRefs,
+        TVector<TPageGroup>* pageGroups) override
     {
+        pageGroups->clear();
+
+        NProto::TReadPagesRequest request;
         const ui32 i =
-            Selector.fetch_add(1, std::memory_order_relaxed) % Nodes.size();
-        return Nodes[i]->ReadPages(request);
+            Selector.fetch_add(1, std::memory_order_relaxed) % Devices.size();
+        request.SetDeviceUUID(Devices[i].DeviceUUID);
+        *request.MutableHeaders() = std::move(headers);
+        for (const auto& pg: pageGroupRefs) {
+            auto* pgr = request.AddPageGroupRefs();
+            pgr->SetPageSize(pg.PageSize);
+            pgr->SetFirstPageNo(pg.FirstPageNo);
+            pgr->SetPageCount(pg.PageCount);
+        }
+        SILK_DEBUG("sg read: %s", request.ShortUtf8DebugString().c_str());
+        auto response = Devices[i].Node->ReadPages(request);
+        if (!HasError(response.GetError())) {
+            pageGroups->reserve(response.PageGroupsSize());
+            for (auto& pg: *response.MutablePageGroups()) {
+                auto& r = pageGroups->emplace_back();
+                r.FirstPageNo = pg.GetFirstPageNo();
+                r.Content.reserve(pg.ContentSize());
+                for (auto& c: *pg.MutableContent()) {
+                    r.Content.emplace_back(std::move(c));
+                }
+            }
+        }
+
+        return response.GetError();
     }
 
 private:
+    TString DebugMessage(const NProto::TWriteLogRecordRequest& w)
+    {
+        NProto::TReadPagesRequest r;
+        *r.MutableHeaders() = w.GetHeaders();
+        for (auto& pg: w.GetPageGroups()) {
+            auto* rpg = r.AddPageGroupRefs();
+            rpg->SetPageSize(pg.ContentSize() ? pg.GetContent(0).Size() : 0);
+            rpg->SetPageCount(pg.ContentSize());
+            rpg->SetFirstPageNo(pg.GetFirstPageNo());
+        }
+        return r.ShortUtf8DebugString();
+    }
+
     template <
         typename TRequest,
         typename TResponse,
         typename TParams,
         typename TFiberMain>
-    TResponse MirrorRequest(TFiberMain fiberMain, TRequest request)
+    NProto::TError MirrorRequest(TFiberMain fiberMain, TRequest request)
     {
-        TVector<silk::FiberFuture> futures(Nodes.size());
-        TVector<TResponse> responses(Nodes.size());
-        for (ui32 i = 0; i < Nodes.size(); ++i) {
+        TVector<silk::FiberFuture> futures(Devices.size());
+        TVector<TResponse> responses(Devices.size());
+        for (ui32 i = 0; i < Devices.size(); ++i) {
             int r = silk::FiberScheduler::run(
                 fiberMain,
                 TParams{
-                    .Node = Nodes[i],
+                    .Device = Devices[i],
                     .Request = &request,
                     .Response = &responses[i]},
                 &futures[i]);
             Y_ABORT_UNLESS(r == 0, "failed to spawn fiber: %s", ::strerror(r));
         }
 
-        TResponse response;
-        for (ui32 i = 0; i < Nodes.size(); ++i) {
+        NProto::TError error;
+        for (ui32 i = 0; i < Devices.size(); ++i) {
             int r = futures[i].wait();
             if (r) {
                 SILK_ERROR("future error: %s", ::strerror(r));
-                if (!HasError(response.GetError())) {
-                    *response.MutableError() = MakeError(MAKE_SYSTEM_ERROR(r));
+                if (!HasError(error)) {
+                    error = MakeError(MAKE_SYSTEM_ERROR(r));
                 }
 
                 continue;
@@ -143,14 +201,13 @@ private:
                 SILK_ERROR(
                     "node error: %s",
                     FormatError(nodeResponse.GetError()).c_str());
-                if (!HasError(response.GetError())) {
-                    *response.MutableError() =
-                        std::move(*nodeResponse.MutableError());
+                if (!HasError(error)) {
+                    error = std::move(*nodeResponse.MutableError());
                 }
             }
         }
 
-        return response;
+        return error;
     }
 };
 
@@ -159,9 +216,9 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 IStorageGroupPtr CreateNaiveMirroredStorageGroup(
-    TVector<IStorageNodePtr> nodes)
+    TVector<TStorageDevice> devices)
 {
-    return std::make_shared<TStorageGroupImpl>(std::move(nodes));
+    return std::make_shared<TStorageGroupImpl>(std::move(devices));
 }
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h
@@ -2,18 +2,33 @@
 
 #include <cloud/filestore/libs/storage/fastshard/sn/iface/storage_node.h>
 
+#include <util/generic/vector.h>
+
 #include <memory>
 
 namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TPageGroupRef
+{
+    ui64 FirstPageNo = 0;
+    ui64 PageCount = 0;
+    ui64 PageSize = 0;
+};
+
+struct TPageGroup
+{
+    ui64 FirstPageNo = 0;
+    TVector<TString> Content;
+};
+
 /**
- * Storage group iface. Right now it's basically the same iface as IStorageNode
- * but it's better to keep a separate declaration to highlight that these things
- * are actually different entities. Storage groups are supposed to provide
- * some extra non-functional features on top of multiple storage nodes - like
- * redundancy or hedged requests.
+ * Storage group iface. Storage groups are supposed to provide some extra
+ * non-functional features on top of multiple storage devices - like redundancy
+ * or hedged requests. Storage groups are also responsible for locking the
+ * devices, replaying the tail of the log, maintaining log-sequence-number and
+ * in general for the relative consistency of the devices.
  *
  * The interface is synchronous and is supposed to be used from a fiber.
  */
@@ -21,17 +36,24 @@ struct IStorageGroup
 {
     virtual ~IStorageGroup() = default;
 
-#define SN_DECLARE_METHOD(name, ...)                                           \
-    virtual NProto::T##name##Response name(                                    \
-        NProto::T##name##Request request) = 0;                                 \
-// SN_DECLARE_METHOD
-
-    SN_METHODS(SN_DECLARE_METHOD)
-
-#undef SN_DECLARE_METHOD
+    virtual NProto::TError AcquireDevices() = 0;
+    virtual NProto::TError ReleaseDevices() = 0;
+    virtual NProto::TError WriteLogRecord(
+        NProto::TDeviceRequestHeaders headers,
+        TVector<TPageGroup> pageGroups) = 0;
+    virtual NProto::TError ReadPages(
+        NProto::TDeviceRequestHeaders headers,
+        const TVector<TPageGroupRef>& pageGroupRefs,
+        TVector<TPageGroup>* pageGroups) = 0;
 };
 
 using IStorageGroupPtr = std::shared_ptr<IStorageGroup>;
+
+struct TStorageDevice
+{
+    IStorageNodePtr Node;
+    TString DeviceUUID;
+};
 
 /**
  * Returns an IStorageGroup which mirrors each write into all storage nodes and
@@ -44,6 +66,6 @@ using IStorageGroupPtr = std::shared_ptr<IStorageGroup>;
  * @return - The constructed group.
  */
 IStorageGroupPtr CreateNaiveMirroredStorageGroup(
-    TVector<IStorageNodePtr> nodes);
+    TVector<TStorageDevice> devices);
 
 }   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_stub.cpp
@@ -13,20 +13,32 @@ namespace {
 class TStorageGroupStub: public IStorageGroup
 {
 public:
-#define SN_STUB_METHOD(name, ...)                                              \
-    NCloud::NProto::T##name##Response name(                                    \
-        NCloud::NProto::T##name##Request request) override                     \
-    {                                                                          \
-        Y_UNUSED(request);                                                     \
-        NProto::T##name##Response response;                                    \
-        *response.MutableError() = MakeError(E_NOT_IMPLEMENTED);               \
-        return response;                                                       \
-    }                                                                          \
-// SN_STUB_METHOD
+    NProto::TError AcquireDevices() override
+    {
+        return MakeError(E_NOT_IMPLEMENTED);
+    }
 
-    SN_METHODS(SN_STUB_METHOD)
+    NProto::TError ReleaseDevices() override
+    {
+        return MakeError(E_NOT_IMPLEMENTED);
+    }
 
-#undef SN_STUB_METHOD
+    NProto::TError WriteLogRecord(
+        NProto::TDeviceRequestHeaders headers,
+        TVector<TPageGroup> pageGroups) override
+    {
+        Y_UNUSED(headers, pageGroups);
+        return MakeError(E_NOT_IMPLEMENTED);
+    }
+
+    NProto::TError ReadPages(
+        NProto::TDeviceRequestHeaders headers,
+        const TVector<TPageGroupRef>& pageGroupRefs,
+        TVector<TPageGroup>* pageGroups) override
+    {
+        Y_UNUSED(headers, pageGroupRefs, pageGroups);
+        return MakeError(E_NOT_IMPLEMENTED);
+    }
 };
 
 }   // namespace
@@ -34,9 +46,9 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 IStorageGroupPtr CreateNaiveMirroredStorageGroup(
-    TVector<IStorageNodePtr> nodes)
+    TVector<TStorageDevice> devices)
 {
-    Y_UNUSED(nodes);
+    Y_UNUSED(devices);
 
     return std::make_shared<TStorageGroupStub>();
 }

--- a/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group_ut.cpp
@@ -25,6 +25,8 @@ namespace {
 [[maybe_unused]] auto* const gEnv =
     ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
 
+const NProto::TDeviceRequestHeaders defaultHeaders;
+
 ////////////////////////////////////////////////////////////////////////////////
 // Test fixture: builds a set of fake storage nodes. And that's it.
 
@@ -32,18 +34,26 @@ struct TStorageFixture
 {
     static constexpr ui32 NodeCount = 3;
     TVector<std::shared_ptr<TFakeStorageNode>> StorageNodes;
+    const TVector<TString> DeviceUUIDs = {
+        "dev-a",
+        "dev-b",
+        "dev-c",
+    };
     IStorageGroupPtr Group;
 
     TStorageFixture()
         : StorageNodes(NodeCount)
     {
-        TVector<IStorageNodePtr> nodes(NodeCount);
+        TVector<TStorageDevice> devices(NodeCount);
         for (ui32 i = 0; i < NodeCount; ++i) {
             StorageNodes[i] = std::make_shared<TFakeStorageNode>();
-            nodes[i] = StorageNodes[i];
+            devices[i] = {
+                .Node = StorageNodes[i],
+                .DeviceUUID = DeviceUUIDs[i],
+            };
         }
 
-        Group = CreateNaiveMirroredStorageGroup(std::move(nodes));
+        Group = CreateNaiveMirroredStorageGroup(std::move(devices));
     }
 };
 
@@ -58,13 +68,8 @@ TEST(NaiveGroupTest, MirrorsAcquireReleaseRequests)
             TStorageFixture fx;
 
             {
-                NProto::TAcquireDevicesRequest request;
-                request.AddDeviceUUIDs("dev-a");
-                request.AddDeviceUUIDs("dev-b");
-
-                auto response = fx.Group->AcquireDevices(request);
-                EXPECT_EQ(S_OK, response.GetError().GetCode())
-                    << response.GetError().GetMessage();
+                auto error = fx.Group->AcquireDevices();
+                EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
             }
 
             //
@@ -72,21 +77,18 @@ TEST(NaiveGroupTest, MirrorsAcquireReleaseRequests)
             // release requests.
             //
 
-            for (auto& sn: fx.StorageNodes) {
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                auto& sn = fx.StorageNodes[i];
                 EXPECT_EQ(1U, sn->AcquireCalls.size());
-                EXPECT_EQ(2U, sn->AcquireCalls[0].DeviceUUIDsSize());
-                EXPECT_EQ("dev-a", sn->AcquireCalls[0].GetDeviceUUIDs(0));
-                EXPECT_EQ("dev-b", sn->AcquireCalls[0].GetDeviceUUIDs(1));
+                EXPECT_EQ(1U, sn->AcquireCalls[0].DeviceUUIDsSize());
+                EXPECT_EQ(
+                    fx.DeviceUUIDs[i],
+                    sn->AcquireCalls[0].GetDeviceUUIDs(0));
             }
 
             {
-                NProto::TReleaseDevicesRequest request;
-                request.AddDeviceUUIDs("dev-a");
-                request.AddDeviceUUIDs("dev-b");
-
-                auto response = fx.Group->ReleaseDevices(request);
-                EXPECT_EQ(S_OK, response.GetError().GetCode())
-                    << response.GetError().GetMessage();
+                auto error = fx.Group->ReleaseDevices();
+                EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
             }
 
             //
@@ -94,11 +96,13 @@ TEST(NaiveGroupTest, MirrorsAcquireReleaseRequests)
             // release requests.
             //
 
-            for (auto& sn: fx.StorageNodes) {
+            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                auto& sn = fx.StorageNodes[i];
                 EXPECT_EQ(1U, sn->ReleaseCalls.size());
-                EXPECT_EQ(2U, sn->ReleaseCalls[0].DeviceUUIDsSize());
-                EXPECT_EQ("dev-a", sn->ReleaseCalls[0].GetDeviceUUIDs(0));
-                EXPECT_EQ("dev-b", sn->ReleaseCalls[0].GetDeviceUUIDs(1));
+                EXPECT_EQ(1U, sn->ReleaseCalls[0].DeviceUUIDsSize());
+                EXPECT_EQ(
+                    fx.DeviceUUIDs[i],
+                    sn->ReleaseCalls[0].GetDeviceUUIDs(0));
             }
 
             return 0;
@@ -114,49 +118,27 @@ TEST(NaiveGroupTest, MirrorsWrites)
             TStorageFixture fx;
 
             {
-                NProto::TWriteLogRecordRequest request;
-                request.SetDeviceUUID("dev");
-                auto* pg = request.AddPageGroups();
-                pg->AddContent("page1");
-                pg->AddContent("page2");
-                pg->SetFirstPageNo(111);
+                TVector<TPageGroup> pageGroups = {{
+                    .FirstPageNo = 111,
+                    .Content = {"page1", "page2"},
+                }};
 
-                auto response = fx.Group->WriteLogRecord(request);
-                EXPECT_EQ(S_OK, response.GetError().GetCode())
-                    << response.GetError().GetMessage();
+                auto error = fx.Group->WriteLogRecord(
+                    defaultHeaders,
+                    std::move(pageGroups));
+                EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
             }
 
-            for (auto& sn: fx.StorageNodes) {
+            for (ui64 i = 0; i < TStorageFixture::NodeCount; ++i) {
+                auto& sn = fx.StorageNodes[i];
                 EXPECT_EQ(1U, sn->WriteCalls.size());
-                EXPECT_EQ("dev", sn->WriteCalls[0].GetDeviceUUID());
+                EXPECT_EQ(fx.DeviceUUIDs[i], sn->WriteCalls[0].GetDeviceUUID());
                 EXPECT_EQ(1U, sn->WriteCalls[0].PageGroupsSize());
                 const auto& pg = sn->WriteCalls[0].GetPageGroups(0);
                 EXPECT_EQ(111U, pg.GetFirstPageNo());
                 EXPECT_EQ(2U, pg.ContentSize());
                 EXPECT_EQ("page1", pg.GetContent(0));
                 EXPECT_EQ("page2", pg.GetContent(1));
-            }
-
-            {
-                NProto::TReleaseDevicesRequest request;
-                request.AddDeviceUUIDs("dev-a");
-                request.AddDeviceUUIDs("dev-b");
-
-                auto response = fx.Group->ReleaseDevices(request);
-                EXPECT_EQ(S_OK, response.GetError().GetCode())
-                    << response.GetError().GetMessage();
-            }
-
-            //
-            // We expect naive group impl to do dumb mirroring for acquire and
-            // release requests.
-            //
-
-            for (auto& sn: fx.StorageNodes) {
-                EXPECT_EQ(1U, sn->ReleaseCalls.size());
-                EXPECT_EQ(2U, sn->ReleaseCalls[0].DeviceUUIDsSize());
-                EXPECT_EQ("dev-a", sn->ReleaseCalls[0].GetDeviceUUIDs(0));
-                EXPECT_EQ("dev-b", sn->ReleaseCalls[0].GetDeviceUUIDs(1));
             }
 
             return 0;
@@ -173,37 +155,55 @@ TEST(NaiveGroupTest, RoundRobinsRead)
 
             TVector<NProto::TReadPagesResponse> readResponses(
                 TStorageFixture::NodeCount);
-            for (ui32 i = 0; i < TStorageFixture::NodeCount; ++i) {
+            for (ui64 i = 0; i < TStorageFixture::NodeCount; ++i) {
                 auto* pg = readResponses[i].AddPageGroups();
                 pg->SetFirstPageNo(111);
                 pg->AddContent(TStringBuilder() << "aaa" << i);
                 fx.StorageNodes[i]->ReadResp = readResponses[i];
             }
 
-            for (ui32 i = 0; i < 10 * TStorageFixture::NodeCount; ++i) {
+            for (ui64 i = 0; i < 10 * TStorageFixture::NodeCount; ++i) {
                 const ui32 snIndex = i % TStorageFixture::NodeCount;
 
                 {
-                    NProto::TReadPagesRequest request;
-                    request.SetDeviceUUID("dev");
+                    TVector<TPageGroupRef> pageGroupRefs = {{
+                        .FirstPageNo = 111,
+                        .PageCount = 100,
+                        .PageSize = 4_KB,
+                    }};
 
-                    auto* pg = request.AddPageGroupRefs();
-                    pg->SetPageSize(4_KB);
-                    pg->SetPageCount(100);
-                    pg->SetFirstPageNo(111);
+                    TVector<TPageGroup> pageGroups;
 
-                    auto response = fx.Group->ReadPages(request);
-                    EXPECT_EQ(S_OK, response.GetError().GetCode())
-                        << response.GetError().GetMessage();
-                    EXPECT_STREQ(
-                        readResponses[snIndex].ShortUtf8DebugString().c_str(),
-                        response.ShortUtf8DebugString().c_str());
+                    auto error = fx.Group->ReadPages(
+                        defaultHeaders,
+                        pageGroupRefs,
+                        &pageGroups);
+                    EXPECT_EQ(S_OK, error.GetCode()) << error.GetMessage();
+                    EXPECT_EQ(
+                        readResponses[snIndex].PageGroupsSize(),
+                        pageGroups.size());
+                    for (ui64 j = 0; j < pageGroups.size(); ++j) {
+                        const auto& epg = readResponses[snIndex].GetPageGroups(j);
+                        EXPECT_EQ(
+                            epg.GetFirstPageNo(),
+                            pageGroups[j].FirstPageNo);
+                        EXPECT_EQ(
+                            epg.ContentSize(),
+                            pageGroups[j].Content.size());
+                        for (ui64 k = 0; k < pageGroups[j].Content.size(); ++k) {
+                            EXPECT_STREQ(
+                                epg.GetContent(k).c_str(),
+                                pageGroups[j].Content[k].c_str());
+                        }
+                    }
                 }
 
                 auto& sn = fx.StorageNodes[snIndex];
                 const ui32 cnt = 1 + i / TStorageFixture::NodeCount;
                 EXPECT_EQ(cnt, sn->ReadCalls.size());
-                EXPECT_EQ("dev", sn->ReadCalls[cnt - 1].GetDeviceUUID());
+                EXPECT_EQ(
+                    fx.DeviceUUIDs[snIndex],
+                    sn->ReadCalls[cnt - 1].GetDeviceUUID());
                 EXPECT_EQ(1U, sn->ReadCalls[cnt - 1].PageGroupRefsSize());
                 const auto& pg = sn->ReadCalls[cnt - 1].GetPageGroupRefs(0);
                 EXPECT_EQ(4_KB, pg.GetPageSize());


### PR DESCRIPTION
### Notes
_This PR is a part of https://github.com/ydb-platform/nbs/pull/6606 - the end result is described there_

Changing `IStorageGroup` interface to be able to properly (and automatically) set `DeviceUUIDs` in the group implementation.

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895
