### PR TITLE
[Filestore] mute tsan data race between iov_copy_to_iov and iov_iter_to_buf in vfs_fuse/vhost/fuse_virtio.c

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
+++ b/cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c
@@ -21,12 +21,36 @@
 #define Y_UNUSED(x) (void)x;
 #endif
 
+// Each fuse request comes with an iovec that is split into in and out iovecs.
+// The in iovec is read in iov_iter_to_buf to copy its content to an allocated
+// buffer. The out iovec is written in iov_copy_to_iov to send the data
+// response. Both point into guest memory.
+//
+// Tsan cannot see the synchronization that actually orders these accesses,
+// because it happens in the guest via the virtqueue. The guest reuses the
+// pages of an already completed request as the in iovec of the next one, so
+// tsan shadow memory still thinks the memory is read while it is written.
+//
+// Per-buffer __tsan_acquire/__tsan_release do not help here: the address the
+// response was written at and the address the next request is read from are
+// almost never the same, and these annotations only match when the addresses
+// are equal. Use a single sync token for the whole guest memory instead, taken
+// and released around each copy, and annotate both directions, so that neither
+// ordering is reported.
+//
+// See https://github.com/ydb-platform/nbs/pull/6611
 #if __has_feature(thread_sanitizer)
-#define TSAN_ACQUIRE(x) __tsan_acquire(x)
-#define TSAN_RELEASE(x) __tsan_release(x)
+
+static char guest_memory_sync_token;
+
+void __tsan_acquire(void* addr);
+void __tsan_release(void* addr);
+
+#define TSAN_ACQUIRE_GUEST_MEMORY() __tsan_acquire(&guest_memory_sync_token)
+#define TSAN_RELEASE_GUEST_MEMORY() __tsan_release(&guest_memory_sync_token)
 #else
-#define TSAN_ACQUIRE(x)
-#define TSAN_RELEASE(x)
+#define TSAN_ACQUIRE_GUEST_MEMORY()
+#define TSAN_RELEASE_GUEST_MEMORY()
 #endif
 
 struct fuse_virtio_dev
@@ -115,20 +139,11 @@ static void iov_copy_to_iov(
             if (src_iov[0].iov_base) {
                 void* dst = dst_iov[0].iov_base + dst_offset;
                 void* src = src_iov[0].iov_base + src_offset;
+                // dst points into guest memory, see the comment near
+                // TSAN_ACQUIRE_GUEST_MEMORY
+                TSAN_ACQUIRE_GUEST_MEMORY();
                 memcpy(dst, src, dst_len);
-                // Each fuse requests comes with iovec that is splitted into in
-                // and out iovecs. The in iovec is read in iov_iter_to_buf to
-                // copy it's content to allocated buffer. The out iovec is
-                // written in iov_copy_to_iov to send data response.
-                //
-                // It looks like tsan is not tracking the memory access well
-                // across guest vm. The guest may resend new request with in
-                // iovec containing out iovec address from previously responded
-                // request and tsan shadow memory still thinks that the memory
-                // is read during write.
-                //
-                // See https://github.com/ydb-platform/nbs/pull/4600
-                TSAN_RELEASE(dst);
+                TSAN_RELEASE_GUEST_MEMORY();
             }
             src_len -= dst_len;
             to_copy -= dst_len;
@@ -212,20 +227,11 @@ static size_t iov_iter_to_buf(struct iov_iter *it, void *buf, size_t len)
         size_t cplen = MIN(len, iov->iov_len - it->off);
 
         void* src = iov->iov_base + it->off;
-        // Each fuse requests comes with iovec that is splitted into in
-        // and out iovecs. The in iovec is read in iov_iter_to_buf to
-        // copy it's content to allocated buffer. The out iovec is
-        // written in iov_copy_to_iov to send data response.
-        //
-        // It looks like tsan is not tracking the memory access well
-        // across guest vm. The guest may resend new request with in
-        // iovec containing out iovec address from previously responded
-        // request and tsan shadow memory still thinks that the memory
-        // is read during write.
-        //
-        // See https://github.com/ydb-platform/nbs/pull/4600
-        TSAN_ACQUIRE(src);
+        // src points into guest memory, see the comment near
+        // TSAN_ACQUIRE_GUEST_MEMORY
+        TSAN_ACQUIRE_GUEST_MEMORY();
         memcpy(ptr, src, cplen);
+        TSAN_RELEASE_GUEST_MEMORY();
 
         ptr += cplen;
         len -= cplen;


### PR DESCRIPTION
### Notes

The annotations added in #4600 did not work. The nightly tsan build reports the same pair again, at the same two memcpy calls, with the annotations compiled in: a read in `iov_iter_to_buf` against a previous write in `iov_copy_to_iov`, both landing in guest memory backed by `memfd:memory-backend-memfd`.

The reason is that `__tsan_acquire` and `__tsan_release` key the sync object on the exact address. `MetaMap::GetSync` looks it up with `s->addr == addr`, so a release and an acquire only meet when both name the same byte. #4600 released on the destination chunk start in `iov_copy_to_iov` and acquired on the source chunk start in `iov_iter_to_buf`, and those two addresses are almost never equal. The virtio-fs driver lays a request out as one allocation holding the in header and args followed by the out header and args, so when the guest recycles those pages the buffer the response was written at and the buffer the next request is read from are offset from each other. No happens-before edge gets created and the race is reported as soon as the recycled ranges overlap.

This PR replaces the per-buffer annotation with a single sync token for the whole guest memory. Since the token no longer depends on the buffer address the two sides always meet, and the annotation can sit directly on the memcpy calls rather than around the enclosing loop, which keeps the window where two threads are inside the token short. Both directions are annotated now, so neither a write after a read nor a read after a write is reported.

Report from the nightly tsan run, trimmed to the top frames of both stacks:

```
data race (pid=246293)
  Read of size 8 at 0x7f3b00e0f728 by thread T153:
    #0 __tsan_memcpy contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:3165:3
    #1 iov_iter_to_buf cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:228:9
    #2 process_request cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:278:20
    #3 virtio_session_loop cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:544:19
    #4 fuse_session_loop cloud/contrib/virtiofsd/fuse_lowlevel.c:2859:12
    #5 NCloud::NFileStore::NFuse::(anonymous namespace)::TFuseLoopThread::ThreadProc() cloud/filestore/libs/vfs_fuse/loop.cpp:612:9

  Previous write of size 8 at 0x7f3b00e0f728 by thread T88:
    #0 __tsan_memcpy contrib/libs/clang16-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:3165:3
    #1 iov_copy_to_iov cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:118:17
    #2 virtio_send_msg cloud/filestore/libs/vfs_fuse/vhost/fuse_virtio.c:574:9
    #3 fuse_send_msg cloud/contrib/virtiofsd/fuse_lowlevel.c:234:16
    #4 fuse_send_reply_iov_nofree cloud/contrib/virtiofsd/fuse_lowlevel.c:258:12
    #5 send_reply_iov cloud/contrib/virtiofsd/fuse_lowlevel.c:266:11
    #6 send_reply cloud/contrib/virtiofsd/fuse_lowlevel.c:281:12
    #7 send_reply_ok cloud/contrib/virtiofsd/fuse_lowlevel.c:353:12
    #8 fuse_reply_write cloud/contrib/virtiofsd/fuse_lowlevel.c:520:12
    #9 NCloud::NFileStore::NFuse::ReplyWrite(...) cloud/filestore/libs/vfs_fuse/fs.cpp:254:15
    ...
    #29 NCloud::NFileStore::NFuse::TWriteBackCache::TImpl::ExecuteRequestUnderBarrier<...> cloud/filestore/libs/vfs_fuse/write_back_cache/write_back_cache.cpp:600:25

  Location is global '??' at 0x7f3a40000000 (memfd:memory-backend-memfd (deleted)+0xc0e0f728)
```

Full log: https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/Nightly-build-(tsan)/29546143985/1/nebius-x86-64-tsan/summary/1/ya-test.html

Failing suite: `cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test`,
chunk6, `SANITIZER_TYPE=thread`.

### Issue

#6610 