### PR TITLE
[NBS] Use ExactDiskIdMatch in write-path DescribeVolume calls

### DIFF
--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
@@ -78,12 +78,14 @@ void TUpdateActor::Bootstrap(const TActorContext& ctx)
     DescribeVolume(ctx, Config.GetDiskId());
 }
 
-void TUpdateActor::DescribeVolume(const TActorContext& ctx, const TString& diskId)
+void TUpdateActor::DescribeVolume(
+    const TActorContext& ctx,
+    const TString& diskId)
 {
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(diskId));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(diskId, true));
 }
 
 void TUpdateActor::HandleDescribeVolumeResponse(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_actor_volume_config.cpp
@@ -85,7 +85,9 @@ void TUpdateActor::DescribeVolume(
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(diskId, true));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
+            diskId,
+            /*exactDiskIdMatch=*/true));
 }
 
 void TUpdateActor::HandleDescribeVolumeResponse(

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_ut_config.cpp
@@ -1020,6 +1020,63 @@ Y_UNIT_TEST_SUITE(TDiskRegistryTest)
         UNIT_ASSERT_VALUES_EQUAL(0, unknownDevices->Val());
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyDevices->Val());
     }
+
+    Y_UNIT_TEST(ShouldUseExactDiskIdMatchOnUpdateVolumeConfig)
+    {
+        const auto agent1 = CreateAgentConfig(
+            "agent-1",
+            {Device("dev-1", "uuid-1", "rack-1", 10_GB),
+             Device("dev-2", "uuid-2", "rack-1", 10_GB)});
+
+        auto runtime = TTestRuntimeBuilder().WithAgents({agent1}).Build();
+
+        TDiskRegistryClient diskRegistry(*runtime);
+
+        diskRegistry.WaitReady();
+        diskRegistry.SetWritableState(true);
+        diskRegistry.UpdateConfig(CreateRegistryConfig(0, {agent1}));
+
+        RegisterAgents(*runtime, 1);
+        WaitForAgents(*runtime, 1);
+        WaitForSecureErase(*runtime, {agent1});
+
+        TSSProxyClient ssProxy(*runtime);
+        ssProxy.CreateVolume("disk-1");
+
+        diskRegistry.AllocateDisk("disk-1", 10_GB);
+
+        bool exactDiskIdMatch = false;
+
+        runtime->SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeVolumeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvDescribeVolumeRequest>();
+                        exactDiskIdMatch = msg.ExactDiskIdMatch;
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        diskRegistry.CreatePlacementGroup(
+            "group-1",
+            NProto::PLACEMENT_STRATEGY_SPREAD,
+            0);
+        diskRegistry.AlterPlacementGroupMembership(
+            "group-1",
+            1,   // version
+            TVector<TString>{"disk-1"},
+            TVector<TString>());
+
+        runtime->DispatchEvents({}, TDuration::MilliSeconds(10));
+
+        UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_finish_fill_disk.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_finish_fill_disk.cpp
@@ -118,14 +118,18 @@ void TFinishFillDiskActionActor::DescribeVolume(const TActorContext& ctx)
 {
     Become(&TThis::StateDescribeVolume);
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
         "Sending describe request for volume %s",
         Request.GetDiskId().Quote().c_str());
 
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(Request.GetDiskId()));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
+            Request.GetDiskId(),
+            true));
 }
 
 void TFinishFillDiskActionActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_finish_fill_disk.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_finish_fill_disk.cpp
@@ -129,7 +129,7 @@ void TFinishFillDiskActionActor::DescribeVolume(const TActorContext& ctx)
         MakeSSProxyServiceId(),
         std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
             Request.GetDiskId(),
-            true));
+            /*exactDiskIdMatch=*/true));
 }
 
 void TFinishFillDiskActionActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_modify_tags.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_modify_tags.cpp
@@ -168,7 +168,7 @@ void TModifyTagsActionActor::DescribeVolume(const TActorContext& ctx)
         MakeSSProxyServiceId(),
         std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
             Request.GetDiskId(),
-            true));
+            /*exactDiskIdMatch=*/true));
 }
 
 void TModifyTagsActionActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_modify_tags.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_modify_tags.cpp
@@ -146,7 +146,6 @@ void TModifyTagsActionActor::Bootstrap(const TActorContext& ctx)
         }
     }
 
-    VolumeConfig.SetDiskId(Request.GetDiskId());
     if (Request.GetConfigVersion()) {
         VolumeConfig.SetVersion(Request.GetConfigVersion());
     }
@@ -158,14 +157,18 @@ void TModifyTagsActionActor::DescribeVolume(const TActorContext& ctx)
 {
     Become(&TThis::StateDescribeVolume);
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
         "Sending describe request for volume %s",
         Request.GetDiskId().Quote().c_str());
 
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(Request.GetDiskId()));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
+            Request.GetDiskId(),
+            true));
 }
 
 void TModifyTagsActionActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_rebase_volume.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_rebase_volume.cpp
@@ -151,7 +151,7 @@ void TRebaseVolumeActionActor::DescribeVolume(const TActorContext& ctx)
         MakeSSProxyServiceId(),
         std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
             Request.GetDiskId(),
-            true));
+            /*exactDiskIdMatch=*/true));
 }
 
 void TRebaseVolumeActionActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_actions_rebase_volume.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_actions_rebase_volume.cpp
@@ -115,7 +115,6 @@ void TRebaseVolumeActionActor::Bootstrap(const TActorContext& ctx)
         return;
     }
 
-    VolumeConfig.SetDiskId(Request.GetDiskId());
     VolumeConfig.SetBaseDiskId(Request.GetTargetBaseDiskId());
     VolumeConfig.SetVersion(Request.GetConfigVersion());
     DescribeBaseVolume(ctx);
@@ -141,14 +140,18 @@ void TRebaseVolumeActionActor::DescribeVolume(const TActorContext& ctx)
 {
     Become(&TThis::StateDescribeVolume);
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
         "Sending describe request for volume %s",
         Request.GetDiskId().Quote().c_str());
 
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(Request.GetDiskId()));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
+            Request.GetDiskId(),
+            true));
 }
 
 void TRebaseVolumeActionActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
@@ -212,14 +212,16 @@ void TAlterVolumeActor::DescribeVolume(const TActorContext& ctx)
 {
     Become(&TThis::StateDescribeVolume);
 
-    LOG_DEBUG(ctx, TBlockStoreComponents::SERVICE,
+    LOG_DEBUG(
+        ctx,
+        TBlockStoreComponents::SERVICE,
         "Sending describe request for volume %s",
         DiskId.Quote().c_str());
 
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(DiskId));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(DiskId, true));
 }
 
 void TAlterVolumeActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_alter.cpp
@@ -221,7 +221,9 @@ void TAlterVolumeActor::DescribeVolume(const TActorContext& ctx)
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(DiskId, true));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
+            DiskId,
+            /*exactDiskIdMatch=*/true));
 }
 
 void TAlterVolumeActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_vhost_discard_flag.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_vhost_discard_flag.cpp
@@ -95,7 +95,6 @@ void TSetVhostDiscardFlagActor::Bootstrap(const TActorContext& ctx)
         return;
     }
 
-    VolumeConfig.SetDiskId(DiskId);
     if (ConfigVersion) {
         VolumeConfig.SetVersion(ConfigVersion);
     }
@@ -103,8 +102,7 @@ void TSetVhostDiscardFlagActor::Bootstrap(const TActorContext& ctx)
     DescribeVolume(ctx);
 }
 
-void TSetVhostDiscardFlagActor::DescribeVolume(
-    const TActorContext& ctx)
+void TSetVhostDiscardFlagActor::DescribeVolume(const TActorContext& ctx)
 {
     Become(&TThis::StateDescribeVolume);
 
@@ -117,7 +115,7 @@ void TSetVhostDiscardFlagActor::DescribeVolume(
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(DiskId));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(DiskId, true));
 }
 
 void TSetVhostDiscardFlagActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_actor_vhost_discard_flag.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor_vhost_discard_flag.cpp
@@ -115,7 +115,9 @@ void TSetVhostDiscardFlagActor::DescribeVolume(const TActorContext& ctx)
     NCloud::Send(
         ctx,
         MakeSSProxyServiceId(),
-        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(DiskId, true));
+        std::make_unique<TEvSSProxy::TEvDescribeVolumeRequest>(
+            DiskId,
+            /*exactDiskIdMatch=*/true));
 }
 
 void TSetVhostDiscardFlagActor::AlterVolume(

--- a/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_actions.cpp
@@ -7,6 +7,7 @@
 #include <cloud/blockstore/libs/storage/api/volume_proxy.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
 #include <cloud/blockstore/libs/storage/core/volume_model.h>
+#include <cloud/blockstore/libs/storage/model/volume_label.h>
 #include <cloud/blockstore/libs/storage/disk_registry/disk_registry_private.h>
 #include <cloud/blockstore/libs/storage/protos_ydb/disk.pb.h>
 #include <cloud/blockstore/libs/storage/testlib/ut_helpers.h>
@@ -2236,6 +2237,233 @@ Y_UNIT_TEST_SUITE(TServiceActionsTest)
                 &proto)
                 .ok());
         UNIT_ASSERT_VALUES_EQUAL(disk->Devices.size(), proto.DevicesSize());
+    }
+
+    Y_UNIT_TEST(ShouldUseExactDiskIdMatchOnModifyTags)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume();
+
+        bool exactDiskIdMatch = false;
+        bool hasDiskIdInVolumeConfig = true;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeVolumeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvDescribeVolumeRequest>();
+                        exactDiskIdMatch = msg.ExactDiskIdMatch;
+                        break;
+                    }
+                    case TEvSSProxy::EvModifySchemeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvModifySchemeRequest>();
+                        const auto& volumeConfig =
+                            msg.ModifyScheme.GetAlterBlockStoreVolume()
+                                .GetVolumeConfig();
+                        hasDiskIdInVolumeConfig = volumeConfig.HasDiskId();
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        {
+            NPrivateProto::TModifyTagsRequest request;
+            request.SetDiskId(DefaultDiskId);
+            *request.AddTagsToAdd() = "a";
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("ModifyTags", buf);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
+        UNIT_ASSERT_VALUES_EQUAL(false, hasDiskIdInVolumeConfig);
+    }
+
+    Y_UNIT_TEST(ShouldFailModifyTagsIfOnlySecondaryDiskExists)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        TServiceClient service(env.GetRuntime(), nodeIdx);
+        service.CreateVolume(GetSecondaryDiskId(DefaultDiskId));
+
+        {
+            NPrivateProto::TModifyTagsRequest request;
+            request.SetDiskId(DefaultDiskId);
+            *request.AddTagsToAdd() = "source-disk-id=some-disk";
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.SendExecuteActionRequest("ModifyTags", buf);
+            auto response = service.RecvExecuteActionResponse();
+            UNIT_ASSERT(FAILED(response->GetStatus()));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldUseExactDiskIdMatchOnRebaseVolume)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume(DefaultDiskId);
+        service.CreateVolume("new-base-disk");
+
+        bool exactDiskIdMatch = false;
+        int describeCount = 0;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeVolumeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvDescribeVolumeRequest>();
+                        ++describeCount;
+                        // Second describe is for the volume itself (first
+                        // is for base disk, which should not use
+                        // ExactDiskIdMatch).
+                        if (describeCount == 2) {
+                            exactDiskIdMatch = msg.ExactDiskIdMatch;
+                        }
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        {
+            NPrivateProto::TRebaseVolumeRequest rebaseReq;
+            rebaseReq.SetDiskId(DefaultDiskId);
+            rebaseReq.SetTargetBaseDiskId("new-base-disk");
+            rebaseReq.SetConfigVersion(1);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(rebaseReq, &buf);
+            service.ExecuteAction("rebasevolume", buf);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
+
+        auto volumeConfig = GetVolumeConfig(service, DefaultDiskId);
+        UNIT_ASSERT_VALUES_EQUAL("new-base-disk", volumeConfig.GetBaseDiskId());
+    }
+
+    Y_UNIT_TEST(ShouldUseExactDiskIdMatchOnFinishFillDisk)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+
+        auto request = service.CreateCreateVolumeRequest();
+        request->Record.SetFillGeneration(1);
+        service.SendRequest(MakeStorageServiceId(), std::move(request));
+
+        auto response = service.RecvCreateVolumeResponse();
+        UNIT_ASSERT_C(response->GetStatus() == S_OK, response->GetStatus());
+
+        bool exactDiskIdMatch = false;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeVolumeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvDescribeVolumeRequest>();
+                        exactDiskIdMatch = msg.ExactDiskIdMatch;
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        {
+            NPrivateProto::TFinishFillDiskRequest request;
+            request.SetDiskId(DefaultDiskId);
+            request.SetConfigVersion(1);
+            request.SetFillGeneration(1);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("finishfilldisk", buf);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
+    }
+
+    Y_UNIT_TEST(ShouldUseExactDiskIdMatchOnSetVhostDiscardFlag)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume(DefaultDiskId);
+
+        bool exactDiskIdMatch = false;
+        bool hasDiskIdInVolumeConfig = true;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeVolumeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvDescribeVolumeRequest>();
+                        exactDiskIdMatch = msg.ExactDiskIdMatch;
+                        break;
+                    }
+                    case TEvSSProxy::EvModifySchemeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvModifySchemeRequest>();
+                        const auto& volumeConfig =
+                            msg.ModifyScheme.GetAlterBlockStoreVolume()
+                                .GetVolumeConfig();
+                        hasDiskIdInVolumeConfig = volumeConfig.HasDiskId();
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        {
+            NPrivateProto::TSetVhostDiscardFlagActionRequest request;
+            request.SetDiskId(DefaultDiskId);
+            request.SetVhostDiscardEnabled(true);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("setvhostdiscardenabledflag", buf);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
+        UNIT_ASSERT_VALUES_EQUAL(false, hasDiskIdInVolumeConfig);
     }
 }
 

--- a/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
@@ -972,6 +972,45 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
             UNIT_ASSERT(response->Record.GetVolume().GetAlterTs() > 0);
         }
     }
+
+    Y_UNIT_TEST(ShouldUseExactDiskIdMatchOnAlterVolume)
+    {
+        TTestEnv env;
+        NProto::TStorageServiceConfig config;
+        config.SetAllowVersionInModifyScheme(true);
+        ui32 nodeIdx = SetupTestEnv(env, std::move(config));
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service(runtime, nodeIdx);
+        service.CreateVolume(
+            DefaultDiskId,
+            512,
+            DefaultBlockSize,
+            "test_folder",
+            "test_cloud");
+
+        bool exactDiskIdMatch = false;
+
+        runtime.SetEventFilter(
+            [&](auto& runtime, TAutoPtr<IEventHandle>& event)
+            {
+                Y_UNUSED(runtime);
+                switch (event->GetTypeRewrite()) {
+                    case TEvSSProxy::EvDescribeVolumeRequest: {
+                        auto& msg =
+                            *event->Get<TEvSSProxy::TEvDescribeVolumeRequest>();
+                        exactDiskIdMatch = msg.ExactDiskIdMatch;
+                        break;
+                    }
+                }
+
+                return false;
+            });
+
+        service.AlterVolume(DefaultDiskId, "project", "folder", "cloud");
+
+        UNIT_ASSERT_VALUES_EQUAL(true, exactDiskIdMatch);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
## Problem

After disk migration completes and the original disk is deleted, DM calls ModifyTags to remove the source-disk-id tag. ModifyTags describes the original disk, SS proxy falls back to the copy via DescribeSecondary, and sends AlterVolume to the copy's SS entry with DiskId set to the original's name. SS MergeFrom overwrites the copy's DiskId → UpdateVolumeConfig → AllocateDisk with the deallocated name → DR allocates empty devices → user gets a clean disk instead of the copied one.

## Fix

1. All Describe→Alter operations now use ExactDiskIdMatch=true, preventing silent fallback to a different disk.
2. Removed unnecessary SetDiskId in VolumeConfig for ModifyTags, RebaseVolume, and SetVhostDiscardFlag — these fields are not needed for their respective alter operations and are dangerous when combined with the DescribeSecondary fallback.

Read-path operations (VolumeProxy, mount, describe API) keep the fallback — it is by design for transparent client redirection.