### PR TITLE
issue-5894, issue-5895: NaiveMirroredFileSystemShard - future<->fiber bridge, FiberShardImpl stub, ut stub, usage in tablet code

### DIFF
--- a/cloud/filestore/config/storage.proto
+++ b/cloud/filestore/config/storage.proto
@@ -855,4 +855,8 @@ message TStorageConfig
     // When this flag is enabled, TAggregateStatsActor does not poll all shards.
     // Instead, it requests aggregate statistics only from the main tablet.
     optional bool FanoutStatsCollectionInShardsDisabled = 528;
+
+    // Enable silk regardless of other config parameters. Required for
+    // persistent fastshard to work.
+    optional bool FastShardRuntimeEnabled = 529;
 }

--- a/cloud/filestore/libs/daemon/server/bootstrap.cpp
+++ b/cloud/filestore/libs/daemon/server/bootstrap.cpp
@@ -69,7 +69,9 @@ TBootstrapServer::~TBootstrapServer()
 
 void TBootstrapServer::StartComponents()
 {
-    if (FastShardServer) {
+    if (FastShardServer
+            || Configs->StorageConfig->GetFastShardRuntimeEnabled())
+    {
         NStorage::NFastShard::Init();
     }
     FILESTORE_LOG_START_COMPONENT(FastShardServer);
@@ -87,7 +89,9 @@ void TBootstrapServer::StopComponents()
     FILESTORE_LOG_STOP_COMPONENT(Service);
     FILESTORE_LOG_STOP_COMPONENT(ThreadPool);
     FILESTORE_LOG_STOP_COMPONENT(FastShardServer);
-    if (FastShardServer) {
+    if (FastShardServer
+            || Configs->StorageConfig->GetFastShardRuntimeEnabled())
+    {
         NStorage::NFastShard::Destroy();
     }
 }

--- a/cloud/filestore/libs/storage/core/config.cpp
+++ b/cloud/filestore/libs/storage/core/config.cpp
@@ -363,6 +363,7 @@ using TAliases = NProto::TStorageConfig::TFilestoreAliases;
     xxx(UseSchemeCache,                         bool,   false                 )\
                                                                                \
     xxx(FastShardServerPort,                    ui32,   0                     )\
+    xxx(FastShardRuntimeEnabled,                bool,   false                 )\
                                                                                \
     xxx(EnableNodeRefCompression,               bool,   false                 )\
                                                                                \

--- a/cloud/filestore/libs/storage/core/config.h
+++ b/cloud/filestore/libs/storage/core/config.h
@@ -420,6 +420,7 @@ public:
     [[nodiscard]] bool GetUseSchemeCache() const;
 
     [[nodiscard]] ui32 GetFastShardServerPort() const;
+    [[nodiscard]] bool GetFastShardRuntimeEnabled() const;
 
     [[nodiscard]] bool GetEnableNodeRefCompression() const;
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -1,0 +1,270 @@
+#include "shard.h"
+
+#include <cloud/filestore/libs/service/error.h>
+#include <cloud/filestore/libs/service/filestore.h>
+#include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
+
+#include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <silk/fibers/fiber.h>
+
+#include <util/string/builder.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFiberShardImpl
+{
+private:
+    const ui32 ShardNo;
+    const NProtoPrivate::TPersistentFastShardConfig Config;
+
+    IStorageGroupPtr Storage;
+
+public:
+    TFiberShardImpl(
+            ui32 shardNo,
+            NProtoPrivate::TPersistentFastShardConfig config)
+        : ShardNo(shardNo)
+        , Config(std::move(config))
+    {
+        Y_UNUSED(ShardNo);
+        Y_UNUSED(Config);
+        Y_UNUSED(Storage);
+    }
+
+public:
+    NProtoPrivate::TGetNodeAttrBatchResponse
+    GetNodeAttrBatch(NProtoPrivate::TGetNodeAttrBatchRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TGetNodeAttrResponse
+    GetNodeAttr(NProto::TGetNodeAttrRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TSetNodeAttrResponse
+    SetNodeAttr(NProto::TSetNodeAttrRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TCreateNodeResponse
+    CreateNode(NProto::TCreateNodeRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TUnlinkNodeResponse
+    UnlinkNode(NProto::TUnlinkNodeRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TCreateHandleResponse
+    CreateHandle(NProto::TCreateHandleRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TDestroyHandleResponse
+    DestroyHandle(NProto::TDestroyHandleRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TWriteDataResponse WriteData(NProto::TWriteDataRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TReadDataResponse ReadData(NProto::TReadDataRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    //
+    // Access/Allocate API is deliberately no-op in prototype.
+    //
+
+    NProto::TAccessNodeResponse
+    AccessNode(NProto::TAccessNodeRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    NProto::TAllocateDataResponse
+    AllocateData(NProto::TAllocateDataRequest request)
+    {
+        Y_UNUSED(request);
+        return {};
+    }
+
+    //
+    // Ok to keep locks API unsupported in prototype.
+    //
+
+    NProto::TAcquireLockResponse
+    AcquireLock(NProto::TAcquireLockRequest request)
+    {
+        return NotImplemented<NProto::TAcquireLockResponse>(std::move(request));
+    }
+
+    NProto::TReleaseLockResponse
+    ReleaseLock(NProto::TReleaseLockRequest request)
+    {
+        return NotImplemented<NProto::TReleaseLockResponse>(std::move(request));
+    }
+
+    NProto::TTestLockResponse
+    TestLock(NProto::TTestLockRequest request)
+    {
+        return NotImplemented<NProto::TTestLockResponse>(std::move(request));
+    }
+
+    //
+    // Ok to keep xattr API unsupported in prototype.
+    //
+
+    NProto::TRemoveNodeXAttrResponse
+    RemoveNodeXAttr(NProto::TRemoveNodeXAttrRequest request)
+    {
+        return NotImplemented<NProto::TRemoveNodeXAttrResponse>(request);
+    }
+
+    NProto::TGetNodeXAttrResponse
+    GetNodeXAttr(NProto::TGetNodeXAttrRequest request)
+    {
+        return NotImplemented<NProto::TGetNodeXAttrResponse>(request);
+    }
+
+    NProto::TSetNodeXAttrResponse
+    SetNodeXAttr(NProto::TSetNodeXAttrRequest request)
+    {
+        return NotImplemented<NProto::TSetNodeXAttrResponse>(request);
+    }
+
+    NProto::TListNodeXAttrResponse
+    ListNodeXAttr(NProto::TListNodeXAttrRequest request)
+    {
+        return NotImplemented<NProto::TListNodeXAttrResponse>(request);
+    }
+
+private:
+    template <typename TResponse, typename TRequest>
+    TResponse NotImplemented(TRequest request)
+    {
+        Y_UNUSED(request);
+
+        TResponse response;
+        *response.MutableError() = MakeError(E_NOT_IMPLEMENTED);
+        return response;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
+    struct TFiberShard##name##Params                                           \
+    {                                                                          \
+        std::shared_ptr<TFiberShardImpl> FiberShard;                           \
+        std::shared_ptr<ns::T##name##Request> Request;                         \
+        NThreading::TPromise<ns::T##name##Response> Promise;                   \
+    };                                                                         \
+                                                                               \
+    int name##FiberMain(TFiberShard##name##Params* params) noexcept            \
+    {                                                                          \
+        auto response = params->FiberShard->name(std::move(*params->Request)); \
+        params->Promise.SetValue(std::move(response));                         \
+        return 0;                                                              \
+    }                                                                          \
+// FAST_SHARD_DEFINE_METHOD
+
+    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
+    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
+
+#undef FAST_SHARD_DEFINE_METHOD
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+using namespace NThreading;
+
+class TNaiveMirroredFileSystemShard: public IFileSystemShard
+{
+private:
+    std::shared_ptr<TFiberShardImpl> FiberShard;
+
+public:
+    TNaiveMirroredFileSystemShard(
+            ui32 shardNo,
+            NProtoPrivate::TPersistentFastShardConfig config)
+        : FiberShard(
+            std::make_shared<TFiberShardImpl>(shardNo, std::move(config)))
+    {
+    }
+
+public:
+#define FAST_SHARD_DEFINE_METHOD(name, ns, ...)                                \
+    NThreading::TFuture<ns::T##name##Response> name(                           \
+        ns::T##name##Request request) override                                 \
+    {                                                                          \
+        auto promise = NThreading::NewPromise<ns::T##name##Response>();        \
+        auto future = promise.GetFuture();                                     \
+                                                                               \
+        int r = silk::FiberScheduler::run(                                     \
+            name##FiberMain,                                                   \
+            TFiberShard##name##Params{                                         \
+                .FiberShard = FiberShard,                                      \
+                .Request =                                                     \
+                    std::make_shared<ns::T##name##Request>(std::move(request)),\
+                .Promise = promise,                                            \
+            },                                                                 \
+            nullptr /* future */);                                             \
+        if (r) {                                                               \
+            ns::T##name##Response response;                                    \
+            *response.MutableError() = MakeError(E_FAIL, TStringBuilder()      \
+                << "failed to spawn fiber: " << ::strerror(r));                \
+            promise.SetValue(std::move(response));                             \
+        }                                                                      \
+                                                                               \
+        return future;                                                         \
+    }                                                                          \
+// FAST_SHARD_DEFINE_METHOD
+
+    FAST_SHARD_PRIVATE_METHODS(FAST_SHARD_DEFINE_METHOD, NProtoPrivate)
+    FAST_SHARD_PUBLIC_METHODS(FAST_SHARD_DEFINE_METHOD, NProto)
+
+#undef FAST_SHARD_DEFINE_METHOD
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+IFileSystemShardPtr CreateNaiveMirroredFileSystemShard(
+    ui32 shardNo,
+    const NProtoPrivate::TPersistentFastShardConfig& config)
+{
+    return std::make_shared<TNaiveMirroredFileSystemShard>(shardNo, config);
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cloud/filestore/libs/storage/fastshard/iface/public.h>
+
+namespace NCloud::NFileStore::NProtoPrivate {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TPersistentFastShardConfig;
+
+}   // namespace NCloud::NFileStore::NProtoPrivate
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+IFileSystemShardPtr CreateNaiveMirroredFileSystemShard(
+    ui32 shardNo,
+    const NProtoPrivate::TPersistentFastShardConfig& config);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_stub.cpp
@@ -1,0 +1,16 @@
+#include "shard.h"
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+IFileSystemShardPtr CreateMirrorUnsafeFileSystemShard(
+    ui32 shardNo,
+    const NProtoPrivate::TPersistentFastShardConfig& config)
+{
+    Y_UNUSED(shardNo, config);
+
+    return nullptr;
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_stub.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_stub.cpp
@@ -4,7 +4,7 @@ namespace NCloud::NFileStore::NStorage::NFastShard {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IFileSystemShardPtr CreateMirrorUnsafeFileSystemShard(
+IFileSystemShardPtr CreateNaiveMirroredFileSystemShard(
     ui32 shardNo,
     const NProtoPrivate::TPersistentFastShardConfig& config)
 {

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
@@ -1,0 +1,156 @@
+#include <cloud/filestore/libs/service/filestore.h>
+#include <cloud/filestore/libs/storage/fastshard/iface/fs.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/impl/storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/server/server.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/fake_storage_node.h>
+#include <cloud/filestore/libs/storage/fastshard/testlib/silk_env.h>
+#include <cloud/filestore/private/api/unsafe_protos/unsafe.pb.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <library/cpp/testing/common/network.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/logger.h>
+
+#include <gtest/gtest.h>
+
+#include <util/system/tempfile.h>
+
+using namespace NCloud;
+using namespace NFileStore;
+using namespace NFileStore::NProto;
+using namespace NStorage::NFastShard;
+using silk::FiberScheduler;
+
+////////////////////////////////////////////////////////////////////////////////
+// This is deliberately not a unit test now. This test deliberately bootstraps
+// the whole stack:
+// * several storage nodes on top of files
+// * storage node server
+// * storage node clients
+// * storage group
+// * shard implementation on top of this group
+//
+// This could've been an integration pytest but that would require adding a
+// storage node daemon as well and also it's less convenient to debug pytests
+// than to debug gtests.
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+[[maybe_unused]] auto* const gEnv =
+    ::testing::AddGlobalTestEnvironment(MakeSilkTestEnv());
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui32 ShardNo = 1;
+constexpr size_t PageSize = 4_KB;
+constexpr size_t PageCount = 128_MB / PageSize;
+constexpr size_t FileSize = PageSize * PageCount;
+constexpr size_t NodesPerGroup = 64;
+
+////////////////////////////////////////////////////////////////////////////////
+// Test fixture:
+// * allocates a file
+// * allocates a port
+// * runs a storage node on top of that file
+// * and a storage node server on top of that node
+
+struct TStorageNodeFixture
+{
+    TTempFileHandle File;
+    NTesting::TPortHolder Port;
+    IStorageNodePtr Node;
+    IServerPtr Server;
+
+    TStorageNodeFixture()
+        : File(TTempFileHandle::InCurrentDir("impl-naive_mirrored-ut"))
+        , Port(NTesting::GetFreePort())
+    {
+        File.Resize(FileSize);
+        File.Close();
+        Node = CreateNaiveFileStorageNode(File.Name());
+        Server = CreateServer(Port, Node);
+        Server->Start();
+    }
+
+    ~TStorageNodeFixture()
+    {
+        Server->Stop();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Test fixture:
+// * creates N storage node fixtures
+// * sets up shard config using the endpoints of those storage nodes
+
+struct TStorageFixture
+{
+    static constexpr ui32 NodeCount = 3;
+    TVector<TStorageNodeFixture> Nodes;
+    NProtoPrivate::TPersistentFastShardConfig Config;
+
+    TStorageFixture()
+        : Nodes(NodeCount)
+    {
+        auto* sg = Config.AddStorageGroups();
+        for (auto& node: Nodes) {
+            auto* d = sg->AddDevices();
+            d->SetHost("localhost");
+            d->SetPort(node.Port);
+            d->SetDeviceId("doesn't-matter");
+        }
+
+        Config.SetNodesPerGroup(NodesPerGroup);
+        Config.SetExpectedGroupCapacity(FileSize / 2);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(NaiveMirroredShardTest, CreatesFiles)
+{
+    silk::Logger::setLevel(silk::LogLevel::DEBUG);
+
+    TStorageFixture fx;
+
+    auto shard = CreateNaiveMirroredFileSystemShard(ShardNo, fx.Config);
+
+    const TString file1 = "file1";
+    const ui32 mode = 0644;
+    const ui64 uid = 111;
+    const ui64 gid = 222;
+
+    ui64 nodeId = 0;
+    {
+        TCreateNodeRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        request.SetUid(uid);
+        request.SetGid(gid);
+        request.MutableFile()->SetMode(mode);
+        auto f = shard->CreateNode(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        nodeId = response.GetNode().GetId();
+    }
+    Y_UNUSED(nodeId);
+
+    {
+        TUnlinkNodeRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        auto f = shard->UnlinkNode(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+}

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ut/ya.make
@@ -1,0 +1,22 @@
+GTEST()
+
+SRCS(
+    ../shard_ut.cpp
+)
+
+PEERDIR(
+    cloud/filestore/libs/storage/fastshard/impl/naive_mirrored
+    cloud/filestore/libs/storage/fastshard/sn/impl
+    cloud/filestore/libs/storage/fastshard/sn/server
+    cloud/filestore/libs/storage/fastshard/sn/quorum
+    cloud/filestore/libs/storage/fastshard/testlib
+
+    cloud/storage/core/libs/common
+    cloud/storage/core/protos
+
+    contrib/libs/silk/src/fibers
+
+    contrib/restricted/googletest/googletest
+)
+
+END()

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ya.make
@@ -1,0 +1,36 @@
+LIBRARY()
+
+INCLUDE(${ARCADIA_ROOT}/cloud/storage/deny_ydb_dependency.inc)
+
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
+    SRCS(
+        shard.cpp
+    )
+
+    PEERDIR(
+        cloud/filestore/libs/storage/fastshard/ipc
+
+        contrib/libs/silk/src/fibers
+    )
+ELSE()
+    SRCS(
+        shard_stub.cpp
+    )
+ENDIF()
+
+PEERDIR(
+    cloud/filestore/libs/service
+    cloud/filestore/libs/storage/fastshard/iface
+    cloud/filestore/libs/storage/fastshard/sn/quorum
+
+    cloud/filestore/private/api/unsafe_protos
+)
+
+END()
+
+# TODO(#5895): fix silk bootstrap/shutdown under msan
+IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB AND SANITIZER_TYPE != "memory")
+    RECURSE_FOR_TESTS(
+        ut
+    )
+ENDIF()

--- a/cloud/filestore/libs/storage/fastshard/impl/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/ya.make
@@ -1,3 +1,4 @@
 RECURSE(
     mem
+    naive_mirrored
 )

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -4,6 +4,7 @@
 #include "tablet_schema.h"
 
 #include <cloud/filestore/libs/storage/fastshard/impl/mem/memshard.h>
+#include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.h>
 
 #include <cloud/filestore/libs/diagnostics/critical_events.h>
 #include <cloud/filestore/libs/diagnostics/metrics/operations.h>
@@ -271,8 +272,9 @@ void TIndexTabletActor::CompleteAdapterLoadState(
 
     const auto& fastShardConfig = GetFileSystem().GetFastShardConfig();
     if (fastShardConfig.HasPersistentConfig()) {
-        // not supported yet
-        FastShard = NFastShard::CreateFileSystemShardStub();
+        FastShard = NFastShard::CreateNaiveMirroredFileSystemShard(
+            GetFileSystem().GetShardNo(),
+            fastShardConfig.GetPersistentConfig());
     } else {
         FastShard = NFastShard::CreateMemFileSystemShard(
             GetFileSystem().GetShardNo(),

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -272,9 +272,16 @@ void TIndexTabletActor::CompleteAdapterLoadState(
 
     const auto& fastShardConfig = GetFileSystem().GetFastShardConfig();
     if (fastShardConfig.HasPersistentConfig()) {
-        FastShard = NFastShard::CreateNaiveMirroredFileSystemShard(
-            GetFileSystem().GetShardNo(),
-            fastShardConfig.GetPersistentConfig());
+        if (Config->GetFastShardRuntimeEnabled()) {
+            FastShard = NFastShard::CreateNaiveMirroredFileSystemShard(
+                GetFileSystem().GetShardNo(),
+                fastShardConfig.GetPersistentConfig());
+        } else {
+            LOG_ERROR_S(ctx, TFileStoreComponents::TABLET,
+                LogTag << " FastShardRuntime not enabled, persistent fastshard"
+                " can't be initialized");
+            FastShard = NFastShard::CreateFileSystemShardStub();
+        }
     } else {
         FastShard = NFastShard::CreateMemFileSystemShard(
             GetFileSystem().GetShardNo(),

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -112,6 +112,7 @@ PEERDIR(
     cloud/filestore/libs/storage/core
     cloud/filestore/libs/storage/fastshard/iface
     cloud/filestore/libs/storage/fastshard/impl/mem
+    cloud/filestore/libs/storage/fastshard/impl/naive_mirrored
     cloud/filestore/libs/storage/model
     cloud/filestore/libs/storage/tablet/actors
     cloud/filestore/libs/storage/tablet/events

--- a/cloud/filestore/private/api/unsafe_protos/unsafe.proto
+++ b/cloud/filestore/private/api/unsafe_protos/unsafe.proto
@@ -101,6 +101,8 @@ message TStorageGroup
 message TPersistentFastShardConfig
 {
     repeated TStorageGroup StorageGroups = 1;
+    uint64 NodesPerGroup = 2;
+    uint64 ExpectedGroupCapacity = 3;
 }
 
 message TMemFastShardConfig


### PR DESCRIPTION
### Notes
_This PR is a part of https://github.com/ydb-platform/nbs/pull/6606 - the end result is described there_

Adding:
* `TFiberShardImpl` stub - this class is supposed to implement the shard, the methods are called from fibers, so the logic itself is fully synchronous
* `TNaiveMirroredFileSystemShard` - it's just a bridge between the `TFuture`-based interface and `TFiberShardImpl`
* a unit test stub for this

Also using this new shard impl in tablet code. Added `FastShardRuntimeEnabled` storage config flag to allow fast-shard-runtime (i.e. silk) to be explicitly initialized (needed for persistent fastshard impl to work).

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895