### PR TITLE
Switch subset of per-host AppCriticalEvents to per-disk VolumeCriticalEvents (metrics and logging)

### DIFF
--- a/cloud/blockstore/libs/common/volume_id.cpp
+++ b/cloud/blockstore/libs/common/volume_id.cpp
@@ -1,0 +1,18 @@
+#include "volume_id.h"
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVolumeIdPtr MakeVolumeId(
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId)
+{
+    return std::make_shared<TVolumeId>(TVolumeId{
+        .DiskId = diskId,
+        .CloudId = cloudId,
+        .FolderId = folderId});
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/common/volume_id.h
+++ b/cloud/blockstore/libs/common/volume_id.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/str_stl.h>
+
+#include <memory>
+#include <type_traits>
+
+namespace NCloud::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TVolumeId
+{
+    TString DiskId;
+    TString CloudId;
+    TString FolderId;
+};
+
+using TVolumeIdPtr = std::shared_ptr<TVolumeId>;
+using TVolumeIdConstPtr = std::shared_ptr<const TVolumeId>;
+
+inline bool operator==(const TVolumeId& lhs, const TVolumeId& rhs)
+{
+    return std::tie(lhs.DiskId, lhs.CloudId, lhs.FolderId) ==
+           std::tie(rhs.DiskId, rhs.CloudId, rhs.FolderId);
+}
+
+inline bool operator<(const TVolumeId& lhs, const TVolumeId& rhs)
+{
+    return std::tie(lhs.DiskId, lhs.CloudId, lhs.FolderId) <
+           std::tie(rhs.DiskId, rhs.CloudId, rhs.FolderId);
+}
+
+TVolumeIdPtr MakeVolumeId(
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId);
+
+}   // namespace NCloud::NBlockStore
+
+template <>
+struct THash<NCloud::NBlockStore::TVolumeId>
+{
+    size_t operator()(const NCloud::NBlockStore::TVolumeId& val) const
+    {
+        auto a = std::tie(val.DiskId, val.CloudId, val.FolderId);
+        return THash<std::decay_t<decltype(a)>>{}(a);
+    }
+};

--- a/cloud/blockstore/libs/common/ya.make
+++ b/cloud/blockstore/libs/common/ya.make
@@ -15,6 +15,7 @@ SRCS(
     safe_debug_print.cpp
     split_request_helpers.cpp
     typeinfo.cpp
+    volume_id.cpp
 )
 
 PEERDIR(

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -1032,6 +1032,7 @@ void TBootstrapBase::Start()
     START_COMMON_COMPONENT(GrpcEndpointListener);
     START_COMMON_COMPONENT(Executor);
     START_COMMON_COMPONENT(Server);
+    START_COMMON_COMPONENT(CriticalEventsStatsUpdater);
     START_COMMON_COMPONENT(ServerStatsUpdater);
     START_COMMON_COMPONENT(BackgroundThreadPool);
     START_COMMON_COMPONENT(RdmaClient);
@@ -1103,6 +1104,7 @@ void TBootstrapBase::Stop()
     STOP_COMMON_COMPONENT(GetTraceServiceClient());
     STOP_COMMON_COMPONENT(RdmaClient);
     STOP_COMMON_COMPONENT(BackgroundThreadPool);
+    STOP_COMMON_COMPONENT(CriticalEventsStatsUpdater);
     STOP_COMMON_COMPONENT(ServerStatsUpdater);
     STOP_COMMON_COMPONENT(Server);
     STOP_COMMON_COMPONENT(CertificateProvider);

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -309,6 +309,15 @@ void TBootstrapBase::Init()
     InitCriticalEventsCounter(serverGroup);
     InitVolumeCriticalEventsCounter(serviceVolumeGroup);
 
+    STORAGE_INFO("CriticalEvents counters initialized");
+
+    CriticalEventsStatsUpdater = CreateStatsUpdater(
+        Timer,
+        BackgroundScheduler,
+        CreateCriticalEventsStatsHandler());
+
+    STORAGE_INFO("CriticalEventsStatsUpdater initialized");
+
     TVector<TCertificateFiles> certPathList;
     for (const auto& cert: Configs->ServerConfig->GetCertsWithLegacyFallback())
     {

--- a/cloud/blockstore/libs/daemon/common/bootstrap.cpp
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.cpp
@@ -297,6 +297,8 @@ void TBootstrapBase::Init()
         ->GetSubgroup("counters", "blockstore");
 
     auto serverGroup = rootGroup->GetSubgroup("component", "server");
+    auto serviceVolumeGroup =
+        rootGroup->GetSubgroup("component", "service_volume");
     auto revisionGroup = serverGroup->GetSubgroup("revision", GetFullVersionString());
 
     auto versionCounter = revisionGroup->GetCounter(
@@ -305,6 +307,7 @@ void TBootstrapBase::Init()
     *versionCounter = 1;
 
     InitCriticalEventsCounter(serverGroup);
+    InitVolumeCriticalEventsCounter(serviceVolumeGroup);
 
     TVector<TCertificateFiles> certPathList;
     for (const auto& cert: Configs->ServerConfig->GetCertsWithLegacyFallback())

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -55,6 +55,7 @@ protected:
     IVolumeStatsPtr VolumeStats;
     IServerStatsPtr ServerStats;
     IStatsUpdaterPtr ServerStatsUpdater;
+    IStatsUpdaterPtr CriticalEventsStatsUpdater;
     TVector<ITraceReaderPtr> TraceReaders;
     ITraceProcessorPtr TraceProcessor;
     NDiscovery::IDiscoveryServicePtr DiscoveryService;

--- a/cloud/blockstore/libs/daemon/common/bootstrap.h
+++ b/cloud/blockstore/libs/daemon/common/bootstrap.h
@@ -54,8 +54,8 @@ protected:
     IRequestStatsPtr RequestStats;
     IVolumeStatsPtr VolumeStats;
     IServerStatsPtr ServerStats;
-    IStatsUpdaterPtr ServerStatsUpdater;
     IStatsUpdaterPtr CriticalEventsStatsUpdater;
+    IStatsUpdaterPtr ServerStatsUpdater;
     TVector<ITraceReaderPtr> TraceReaders;
     ITraceProcessorPtr TraceProcessor;
     NDiscovery::IDiscoveryServicePtr DiscoveryService;

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -151,7 +151,8 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 
 #undef BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER
 
-// deprecated: keeps existing AppCriticalEvents/ metrics alive
+// deprecated: keeps existing AppCriticalEvents/ * for new
+// VolumeCriticalEvents/ * metrics alive
 #define BLOCKSTORE_INIT_DEPRECATED_CRITICAL_EVENT_COUNTER(name) \
     *counters->GetCounter(GetDeprecatedCriticalEventFor##name(), true) = 0;
 
@@ -172,6 +173,14 @@ void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler()
 {
     return std::make_shared<TCriticalEventsStatsHandler>();
+}
+
+// For unit test purposes
+void ResetVolumeCriticalEventsCounter()
+{
+    TWriteGuard guard(VolumeCriticalEvents.Lock);
+    VolumeCriticalEvents.Counters.clear();
+    VolumeCriticalEvents.CountersRoot.Reset();
 }
 
 #define BLOCKSTORE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                         \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -23,11 +23,51 @@ namespace {
 // VolumeCriticalEvents
 ////////////////////////////////////////////////////////////////////////////////
 
+/*
+TVolumeCriticalEventCounter - per-interval CriticalEvent counter with
+deferred export
+
+Writing the number of CritEvents for an interval directly into the monitoring
+counter (Exported) can lead to registered CriticalEvents being missed in
+monitoring, because the 15s intervals (cycles) - the internal one and the
+monitoring one - generally do not coincide:
+
+1. End of the next monitoring interval - monitoring reads the current counter
+   value (including 0, if no CriticalEvents have been registered in this
+   internal interval yet)
+
+2. End of the next internal interval -
+   WriteVolumeCriticalEventCounters() resets the counter to 0.
+
+3. If a CriticalEvent was registered between (1) and (2) (Report...() was
+   called with an increment of the counter), that event will be lost and
+   not reflected in monitoring
+
+To exclude such a scenario:
+
+- CriticalEvents for the current interval are accumulated in the Internal
+  counter
+
+- at the end of the interval, the Internal value is written into the Exported
+  counter and held there until the end of the next interval, allowing
+  monitoring to read the value in its own read cycle
+
+Additionally:
+
+- the separate use of Internal and Exported counters avoids losing
+  CriticalEvents registered before module initialization (before
+  TVolumeCriticalEvents::CountersRoot is set) - the value accumulated in
+  Internal is not reset at the end of an interval when writing to Exported
+  is not possible. At the end of the first interval after CountersRoot
+  initialization, the value accumulated since startup in the Internal counter
+  will be written into Exported
+*/
 struct TVolumeCriticalEventCounter
 {
-    // Hot-path accumulator, not exported
+    // Per-interval CriticalEvents counter, not exported
     std::atomic<i64> Internal{0};
-    // Metrics counter, GAUGE, derivative=false. Constructed lazily
+    // Per-interval CriticalEvents metrics counter, GAUGE.
+    // Constructed lazily
     NMonitoring::TDynamicCounters::TCounterPtr Exported;
 };
 

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -14,6 +14,8 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+NMonitoring::TDynamicCountersPtr VolumeCriticalEvents;
+
 template <typename... Ts>
 TStringBuilder& operator<<(TStringBuilder& sb, const std::variant<Ts...>& v)
 {
@@ -50,6 +52,11 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 #undef BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER
 
     NCloud::InitCriticalEventsCounter(std::move(counters));
+}
+
+void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
+{
+    VolumeCriticalEvents = counters->GetSubgroup("host", "cluster");
 }
 
 #define BLOCKSTORE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                         \
@@ -173,7 +180,7 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
         const TString& message,                                                \
         const TCritEventParams& keyValues)                                     \
     {                                                                          \
-        /* deprecated: keeps existing AppCriticalEvents/ * metrics alive */    \
+        /* deprecated: keeps existing AppCriticalEvents/ metrics alive */      \
         ReportCriticalEvent(                                                   \
             GetDeprecatedCriticalEventFor##name(), message, false);            \
                                                                                \
@@ -208,6 +215,7 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
             {"folder", folderId}};                                             \
                                                                                \
         return ReportCriticalEvent(                                            \
+            VolumeCriticalEvents,                                              \
             GetCriticalEventFor##name(),                                       \
             labels,                                                            \
             msg,                                                               \

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -152,4 +152,92 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE
 
+#define BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE(name)                  \
+    TString Report##name(                                                         \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TString& message)                                                \
+    {                                                                          \
+        return Report##name(                                                   \
+            diskId,                                                            \
+            cloudId,                                                           \
+            folderId,                                                          \
+            message,                                                           \
+            {});                                                               \
+    }                                                                          \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TString& message,                                                \
+        const TCritEventParams& keyValues)                                     \
+    {                                                                          \
+        /* deprecated: keeps existing AppCriticalEvents/ * metrics alive */    \
+        ReportCriticalEvent(                                                   \
+            GetDeprecatedCriticalEventFor##name(), message, false);            \
+                                                                               \
+        auto prefix = TCritEventParams{                                        \
+            {"disk", diskId},                                                  \
+            {"cloud", cloudId},                                                \
+            {"folder", folderId}};                                             \
+                                                                               \
+        TString submsg;                                                        \
+                                                                               \
+        if (message.size() && keyValues.size()) {                              \
+            submsg = ComposeMessageWithSuffix(message, PrintParams(keyValues));\
+        }                                                                      \
+        else if (message.size() && !keyValues.size()) {                        \
+            submsg = message;                                                  \
+        }                                                                      \
+        else if (!message.size() && keyValues.size()) {                        \
+            submsg = PrintParams(keyValues);                                   \
+        }                                                                      \
+        else {                                                                 \
+            /* leave submsg empty */                                           \
+        }                                                                      \
+                                                                               \
+        TString msg =                                                          \
+            !submsg.empty()                                                    \
+                ? ComposeMessageWithSuffix(PrintParams(prefix), submsg)        \
+                : PrintParams(prefix);                                         \
+                                                                               \
+        auto labels = TCritEventLabels{                                        \
+            {"volume", diskId},                                                \
+            {"cloud", cloudId},                                                \
+            {"folder", folderId}};                                             \
+                                                                               \
+        return ReportCriticalEvent(                                            \
+            GetCriticalEventFor##name(),                                       \
+            labels,                                                            \
+            msg,                                                               \
+            false);                                                            \
+    }                                                                          \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TCritEventParams& keyValues)                                     \
+    {                                                                          \
+        return Report##name(                                                   \
+            diskId,                                                            \
+            cloudId,                                                           \
+            folderId,                                                          \
+            {},                                                                \
+            keyValues);                                                        \
+    }                                                                          \
+    const TString GetCriticalEventFor##name()                                  \
+    {                                                                          \
+        return "VolumeCriticalEvents/"#name;                                   \
+    }                                                                          \
+    const TString GetDeprecatedCriticalEventFor##name()                        \
+    {                                                                          \
+        return "AppCriticalEvents/"#name;                                      \
+    }                                                                          \
+// BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
+
+    BLOCKSTORE_VOLUME_CRITICAL_EVENTS(\
+        BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE)
+#undef BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
+
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -3,18 +3,117 @@
 #include "public.h"
 
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
+#include <cloud/storage/core/libs/diagnostics/stats_handler.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
+#include <util/generic/hash.h>
+#include <util/str_stl.h>
 #include <util/string/builder.h>
+
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
 
 namespace NCloud::NBlockStore {
 
 namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
+// VolumeCriticalEvents
+////////////////////////////////////////////////////////////////////////////////
 
-NMonitoring::TDynamicCountersPtr VolumeCriticalEvents;
+struct TVolumeCriticalEventCounter
+{
+    // Hot-path accumulator, not exported
+    std::atomic<i64> Internal{0};
+    // Metrics counter, GAUGE, derivative=false. Constructed lazily
+    NMonitoring::TDynamicCounters::TCounterPtr Exported;
+};
+
+struct TVolumeCriticalEventKey
+{
+    TString Event;      // "VolumeCriticalEvent/<event>"
+    TString DiskId;     // exported as the `volume` metric label
+    TString CloudId;    // exported as the `cloud` metric label
+    TString FolderId;   // exported as the `folder` metric label
+
+    bool operator==(const TVolumeCriticalEventKey& rhs) const
+    {
+        return std::tie(Event, DiskId, CloudId, FolderId) ==
+               std::tie(rhs.Event, rhs.DiskId, rhs.CloudId, rhs.FolderId);
+    }
+};
+
+}   // namespace
+}   // namespace NCloud::NBlockStore
+
+template <>
+struct THash<NCloud::NBlockStore::TVolumeCriticalEventKey>
+{
+    size_t operator()(
+        const NCloud::NBlockStore::TVolumeCriticalEventKey& val) const
+    {
+        auto a = std::tie(val.Event, val.DiskId, val.CloudId, val.FolderId);
+        return THash<std::decay_t<decltype(a)>>{}(a);
+    }
+};
+
+namespace NCloud::NBlockStore {
+namespace {
+
+using TVolumeCriticalEventCounterMap = THashMap<
+    TVolumeCriticalEventKey,
+    std::shared_ptr<TVolumeCriticalEventCounter>>;
+
+struct TVolumeCriticalEvents
+{
+    TRWMutex Lock;
+    TVolumeCriticalEventCounterMap Counters;
+    NMonitoring::TDynamicCountersPtr CountersRoot;
+};
+
+TVolumeCriticalEvents VolumeCriticalEvents;
+
+void WriteVolumeCriticalEventCounters()
+{
+    TReadGuard guard(VolumeCriticalEvents.Lock);
+
+    for (auto& [k, e]: VolumeCriticalEvents.Counters) {
+        // NOTE: a single instance of TCriticalEventsStatsHandler is expected
+        // (as the sole writer of e->Exported). This simplifies Lock usage
+        // (e->Exported can be written under the read guard only).
+        if (!e->Exported) {
+            if (!VolumeCriticalEvents.CountersRoot) {
+                // Root not initialized yet; keep accumulating in Internal,
+                // see the first-fire branch in Report##name().
+                continue;
+            }
+            // Root became available after the first fire (e.g. Report ran
+            // before InitVolumeCriticalEventsCounter) - materialize the
+            // exported GAUGE now so the accumulated Internal can be flushed.
+            e->Exported = VolumeCriticalEvents.CountersRoot
+                              ->GetSubgroup("volume", k.DiskId)
+                              ->GetSubgroup("cloud", k.CloudId)
+                              ->GetSubgroup("folder", k.FolderId)
+                              ->GetCounter(k.Event, /*derivative=*/false);
+        }
+        auto v = e->Internal.exchange(0);
+        *e->Exported = v;   // GAUGE set; sticky until next write
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCriticalEventsStatsHandler: public NCloud::IStatsHandler
+{
+    void UpdateStats(bool updateIntervalFinished) override
+    {
+        if (updateIntervalFinished) {
+            WriteVolumeCriticalEventCounters();
+        }
+    }
+};
 
 template <typename... Ts>
 TStringBuilder& operator<<(TStringBuilder& sb, const std::variant<Ts...>& v)
@@ -49,14 +148,30 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
     BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(
         BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER)
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER)
+
 #undef BLOCKSTORE_INIT_CRITICAL_EVENT_COUNTER
+
+// deprecated: keeps existing AppCriticalEvents/ metrics alive
+#define BLOCKSTORE_INIT_DEPRECATED_CRITICAL_EVENT_COUNTER(name) \
+    *counters->GetCounter(GetDeprecatedCriticalEventFor##name(), true) = 0;
+
+    BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
+        BLOCKSTORE_INIT_DEPRECATED_CRITICAL_EVENT_COUNTER)
+
+#undef BLOCKSTORE_INIT_DEPRECATED_CRITICAL_EVENT_COUNTER
 
     NCloud::InitCriticalEventsCounter(std::move(counters));
 }
 
 void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
 {
-    VolumeCriticalEvents = counters->GetSubgroup("host", "cluster");
+    TWriteGuard wguard(VolumeCriticalEvents.Lock);
+    VolumeCriticalEvents.CountersRoot = counters;
+}
+
+NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler()
+{
+    return std::make_shared<TCriticalEventsStatsHandler>();
 }
 
 #define BLOCKSTORE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                         \
@@ -159,93 +274,111 @@ void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters)
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DEFINE_IMPOSSIBLE_EVENT_ROUTINE
 
+    // clang-format off
 #define BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE(name)                  \
-    TString Report##name(                                                         \
-        const TString& diskId,                                                 \
-        const TString& cloudId,                                                \
-        const TString& folderId,                                               \
-        const TString& message)                                                \
-    {                                                                          \
-        return Report##name(                                                   \
-            diskId,                                                            \
-            cloudId,                                                           \
-            folderId,                                                          \
-            message,                                                           \
-            {});                                                               \
-    }                                                                          \
-    TString Report##name(                                                      \
-        const TString& diskId,                                                 \
-        const TString& cloudId,                                                \
-        const TString& folderId,                                               \
-        const TString& message,                                                \
-        const TCritEventParams& keyValues)                                     \
-    {                                                                          \
-        /* deprecated: keeps existing AppCriticalEvents/ metrics alive */      \
-        ReportCriticalEvent(                                                   \
-            GetDeprecatedCriticalEventFor##name(), message, false);            \
-                                                                               \
-        auto prefix = TCritEventParams{                                        \
-            {"disk", diskId},                                                  \
-            {"cloud", cloudId},                                                \
-            {"folder", folderId}};                                             \
-                                                                               \
-        TString submsg;                                                        \
-                                                                               \
-        if (message.size() && keyValues.size()) {                              \
-            submsg = ComposeMessageWithSuffix(message, PrintParams(keyValues));\
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TString& message)                                            \
+        {                                                                      \
+            return Report##name(diskId, cloudId, folderId, message, {});       \
         }                                                                      \
-        else if (message.size() && !keyValues.size()) {                        \
-            submsg = message;                                                  \
-        }                                                                      \
-        else if (!message.size() && keyValues.size()) {                        \
-            submsg = PrintParams(keyValues);                                   \
-        }                                                                      \
-        else {                                                                 \
-            /* leave submsg empty */                                           \
-        }                                                                      \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TString& message,                                            \
+            const TCritEventParams& keyValues)                                 \
+        {                                                                      \
+            /* deprecated: keeps existing AppCriticalEvents/ metrics alive */  \
+            ReportCriticalEvent(                                               \
+                GetDeprecatedCriticalEventFor##name(),                         \
+                message,                                                       \
+                false);                                                        \
                                                                                \
-        TString msg =                                                          \
-            !submsg.empty()                                                    \
-                ? ComposeMessageWithSuffix(PrintParams(prefix), submsg)        \
-                : PrintParams(prefix);                                         \
+            auto prefix = TCritEventParams{                                    \
+                {"disk", diskId},                                              \
+                {"cloud", cloudId},                                            \
+                {"folder", folderId}};                                         \
                                                                                \
-        auto labels = TCritEventLabels{                                        \
-            {"volume", diskId},                                                \
-            {"cloud", cloudId},                                                \
-            {"folder", folderId}};                                             \
+            TString submsg;                                                    \
                                                                                \
-        return ReportCriticalEvent(                                            \
-            VolumeCriticalEvents,                                              \
-            GetCriticalEventFor##name(),                                       \
-            labels,                                                            \
-            msg,                                                               \
-            false);                                                            \
-    }                                                                          \
-    TString Report##name(                                                      \
-        const TString& diskId,                                                 \
-        const TString& cloudId,                                                \
-        const TString& folderId,                                               \
-        const TCritEventParams& keyValues)                                     \
-    {                                                                          \
-        return Report##name(                                                   \
-            diskId,                                                            \
-            cloudId,                                                           \
-            folderId,                                                          \
-            {},                                                                \
-            keyValues);                                                        \
-    }                                                                          \
-    const TString GetCriticalEventFor##name()                                  \
-    {                                                                          \
-        return "VolumeCriticalEvents/"#name;                                   \
-    }                                                                          \
-    const TString GetDeprecatedCriticalEventFor##name()                        \
-    {                                                                          \
-        return "AppCriticalEvents/"#name;                                      \
-    }                                                                          \
-// BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
+            if (message.size() && keyValues.size()) {                          \
+                submsg =                                                       \
+                    ComposeMessageWithSuffix(message, PrintParams(keyValues)); \
+            } else if (message.size() && !keyValues.size()) {                  \
+                submsg = message;                                              \
+            } else if (!message.size() && keyValues.size()) {                  \
+                submsg = PrintParams(keyValues);                               \
+            } else {                                                           \
+                /* leave submsg empty */                                       \
+            }                                                                  \
+                                                                               \
+            TString logMessage =                                               \
+                !submsg.empty()                                                \
+                    ? ComposeMessageWithSuffix(PrintParams(prefix), submsg)    \
+                    : PrintParams(prefix);                                     \
+                                                                               \
+            /* Log immediatly */                                               \
+            auto retMessage =                                                  \
+                LogCriticalEvent(GetCriticalEventFor##name(), logMessage);     \
+                                                                               \
+            auto key = TVolumeCriticalEventKey{                                \
+                .Event    = GetCriticalEventFor##name(),                       \
+                .DiskId   = diskId,                                            \
+                .CloudId  = cloudId,                                           \
+                .FolderId = folderId                                           \
+            };                                                                 \
+                                                                               \
+            /* Hot path - counter already exists */                            \
+            {                                                                  \
+                TReadGuard guard(VolumeCriticalEvents.Lock);                   \
+                if (auto it = VolumeCriticalEvents.Counters.find(key);         \
+                    it != VolumeCriticalEvents.Counters.end())                 \
+                {                                                              \
+                    it->second->Internal++;                                    \
+                    return retMessage;                                         \
+                }                                                              \
+            }                                                                  \
+                                                                               \
+            /* First fire - create the entry.                                  \
+               The Exported GAUGE counter is materialized lazily               \
+               by WriteVolumeCriticalEventCounters() on the publish tick.      \
+               Here we only create and bump the Internal accumulator.          \
+            */                                                                 \
+            {                                                                  \
+                TWriteGuard guard(VolumeCriticalEvents.Lock);                  \
+                auto& e = VolumeCriticalEvents.Counters[key];                  \
+                if (!e) {                                                      \
+                    e = std::make_shared<TVolumeCriticalEventCounter>();       \
+                }                                                              \
+                e->Internal++;                                                 \
+            }                                                                  \
+                                                                               \
+            return retMessage;                                                 \
+        }                                                                      \
+        TString Report##name(                                                  \
+            const TString& diskId,                                             \
+            const TString& cloudId,                                            \
+            const TString& folderId,                                           \
+            const TCritEventParams& keyValues)                                 \
+        {                                                                      \
+            return Report##name(diskId, cloudId, folderId, {}, keyValues);     \
+        }                                                                      \
+        const TString GetCriticalEventFor##name()                              \
+        {                                                                      \
+            return "VolumeCriticalEvents/" #name;                              \
+        }                                                                      \
+        const TString GetDeprecatedCriticalEventFor##name()                    \
+        {                                                                      \
+            return "AppCriticalEvents/" #name;                                 \
+        }                                                                      \
+        // BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
 
     BLOCKSTORE_VOLUME_CRITICAL_EVENTS(\
         BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE)
 #undef BLOCKSTORE_DEFINE_VOLUME_CRITICAL_EVENT_ROUTINE
+    // clang-format on
 
-}   // namespace NCloud::NBlockStore
+    }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events.cpp
@@ -33,15 +33,13 @@ struct TVolumeCriticalEventCounter
 
 struct TVolumeCriticalEventKey
 {
-    TString Event;      // "VolumeCriticalEvent/<event>"
-    TString DiskId;     // exported as the `volume` metric label
-    TString CloudId;    // exported as the `cloud` metric label
-    TString FolderId;   // exported as the `folder` metric label
+    TString Event;        // "VolumeCriticalEvent/<event>"
+    TVolumeId VolumeId;   // exported as the 'volume', 'cloud' and 'folder'
+                          // metric labels
 
     bool operator==(const TVolumeCriticalEventKey& rhs) const
     {
-        return std::tie(Event, DiskId, CloudId, FolderId) ==
-               std::tie(rhs.Event, rhs.DiskId, rhs.CloudId, rhs.FolderId);
+        return std::tie(Event, VolumeId) == std::tie(rhs.Event, rhs.VolumeId);
     }
 };
 
@@ -54,7 +52,7 @@ struct THash<NCloud::NBlockStore::TVolumeCriticalEventKey>
     size_t operator()(
         const NCloud::NBlockStore::TVolumeCriticalEventKey& val) const
     {
-        auto a = std::tie(val.Event, val.DiskId, val.CloudId, val.FolderId);
+        const auto& a = std::tie(val.Event, val.VolumeId);
         return THash<std::decay_t<decltype(a)>>{}(a);
     }
 };
@@ -93,9 +91,9 @@ void WriteVolumeCriticalEventCounters()
             // before InitVolumeCriticalEventsCounter) - materialize the
             // exported GAUGE now so the accumulated Internal can be flushed.
             e->Exported = VolumeCriticalEvents.CountersRoot
-                              ->GetSubgroup("volume", k.DiskId)
-                              ->GetSubgroup("cloud", k.CloudId)
-                              ->GetSubgroup("folder", k.FolderId)
+                              ->GetSubgroup("volume", k.VolumeId.DiskId)
+                              ->GetSubgroup("cloud", k.VolumeId.CloudId)
+                              ->GetSubgroup("folder", k.VolumeId.FolderId)
                               ->GetCounter(k.Event, /*derivative=*/false);
         }
         auto v = e->Internal.exchange(0);
@@ -335,9 +333,10 @@ void ResetVolumeCriticalEventsCounter()
                                                                                \
             auto key = TVolumeCriticalEventKey{                                \
                 .Event    = GetCriticalEventFor##name(),                       \
-                .DiskId   = diskId,                                            \
-                .CloudId  = cloudId,                                           \
-                .FolderId = folderId                                           \
+                .VolumeId = {                                                  \
+                    .DiskId   = diskId,                                        \
+                    .CloudId  = cloudId,                                       \
+                    .FolderId = folderId}                                      \
             };                                                                 \
                                                                                \
             /* Hot path - counter already exists */                            \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -13,40 +13,17 @@ using TCritEventParams =
 ////////////////////////////////////////////////////////////////////////////////
 
 #define BLOCKSTORE_CRITICAL_EVENTS(xxx)                                        \
-    xxx(InvalidTabletConfig)                                                   \
-    xxx(ReassignTablet)                                                        \
-    xxx(TabletBSFailure)                                                       \
-    xxx(DiskAllocationFailure)                                                 \
-    xxx(CollectGarbageError)                                                   \
     xxx(VhostQueueRunningError)                                                \
-    xxx(MigrationFailed)                                                       \
-    xxx(BadMigrationConfig)                                                    \
-    xxx(InitFreshBlocksError)                                                  \
-    xxx(TrimFreshLogError)                                                     \
-    xxx(NrdDestructionError)                                                   \
-    xxx(FailedToStartVolumeLocally)                                            \
     xxx(PublishDiskStateError)                                                 \
     xxx(EndpointRestoringError)                                                \
     xxx(HangingYdbStatsRequest)                                                \
     xxx(UserNotificationError)                                                 \
     xxx(BackupPathDescriptionsFailure)                                         \
     xxx(RdmaError)                                                             \
-    xxx(MirroredDiskAllocationCleanupFailure)                                  \
-    xxx(MirroredDiskAllocationPlacementGroupCleanupFailure)                    \
-    xxx(MirroredDiskDeviceReplacementForbidden)                                \
-    xxx(MirroredDiskDeviceReplacementFailure)                                  \
-    xxx(MirroredDiskDeviceReplacementRateLimitExceeded)                        \
-    xxx(MirroredDiskMinorityChecksumMismatch)                                  \
-    xxx(MirroredDiskMajorityChecksumMismatch)                                  \
-    xxx(MirroredDiskChecksumMismatchUponRead)                                  \
-    xxx(MirroredDiskAddTagFailed)                                              \
     xxx(CounterUpdateRace)                                                     \
     xxx(EndpointStartingError)                                                 \
-    xxx(ResyncFailed)                                                          \
     xxx(DiskRegistryBackupFailed)                                              \
     xxx(RegisterAgentWithEmptyRackName)                                        \
-    xxx(AddConfirmedBlobsError)                                                \
-    xxx(ConfirmBlobsError)                                                     \
     xxx(ManuallyPreemptedVolumesFileError)                                     \
     xxx(ServiceProxyWakeupTimerHit)                                            \
     xxx(ReceivedUnknownTaskId)                                                 \
@@ -57,24 +34,14 @@ using TCritEventParams =
     xxx(DiskRegistrySourceDiskNotFound)                                        \
     xxx(EndpointSwitchFailure)                                                 \
     xxx(ExternalEndpointUnexpectedExit)                                        \
-    xxx(BlockDigestMismatchInBlob)                                             \
     xxx(DiskRegistryResumeDeviceFailed)                                        \
     xxx(DiskRegistryAgentDevicePoolConfigMismatch)                             \
     xxx(DiskRegistryPurgeHostError)                                            \
     xxx(DiskRegistryOccupiedDeviceConfigurationHasChanged)                     \
     xxx(DiskRegistryWrongMigratedDeviceOwnership)                              \
     xxx(DiskRegistryInitialAgentRejectionThresholdExceeded)                    \
-    xxx(ErrorWasSentToTheGuestForReliableDisk)                                 \
-    xxx(ErrorWasSentToTheGuestForNonReliableDisk)                              \
-    xxx(MirroredDiskResyncChecksumMismatch)                                    \
     xxx(DiskAgentInconsistentMultiWriteResponse)                               \
-    xxx(ReleaseShadowDiskError)                                                \
-    xxx(WrongCellIdInDescribeVolume)                                           \
-    xxx(TrimFreshLogTimeout)                                                   \
     xxx(DiskRegistryStateIntegrityBroken)                                      \
-    xxx(AddFreshBlocksResultedInError)                                         \
-    xxx(OverlappingRequestsDetected)                                           \
-    xxx(CrossPartitionRequestDetected)                                         \
 // BLOCKSTORE_CRITICAL_EVENTS
 
 #define BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(xxx)                             \
@@ -135,6 +102,42 @@ using TCritEventParams =
     xxx(CleanupBlobMetaBlocksMismatch)                                         \
 // BLOCKSTORE_IMPOSSIBLE_EVENTS
 
+#define BLOCKSTORE_VOLUME_CRITICAL_EVENTS(xxx)                                 \
+    xxx(InvalidTabletConfig)                                                   \
+    xxx(ReassignTablet)                                                        \
+    xxx(TabletBSFailure)                                                       \
+    xxx(DiskAllocationFailure)                                                 \
+    xxx(CollectGarbageError)                                                   \
+    xxx(MigrationFailed)                                                       \
+    xxx(BadMigrationConfig)                                                    \
+    xxx(InitFreshBlocksError)                                                  \
+    xxx(TrimFreshLogError)                                                     \
+    xxx(NrdDestructionError)                                                   \
+    xxx(FailedToStartVolumeLocally)                                            \
+    xxx(MirroredDiskAllocationCleanupFailure)                                  \
+    xxx(MirroredDiskAllocationPlacementGroupCleanupFailure)                    \
+    xxx(MirroredDiskDeviceReplacementForbidden)                                \
+    xxx(MirroredDiskDeviceReplacementFailure)                                  \
+    xxx(MirroredDiskDeviceReplacementRateLimitExceeded)                        \
+    xxx(MirroredDiskMinorityChecksumMismatch)                                  \
+    xxx(MirroredDiskMajorityChecksumMismatch)                                  \
+    xxx(MirroredDiskChecksumMismatchUponRead)                                  \
+    xxx(MirroredDiskAddTagFailed)                                              \
+    xxx(ResyncFailed)                                                          \
+    xxx(AddConfirmedBlobsError)                                                \
+    xxx(ConfirmBlobsError)                                                     \
+    xxx(BlockDigestMismatchInBlob)                                             \
+    xxx(ErrorWasSentToTheGuestForReliableDisk)                                 \
+    xxx(ErrorWasSentToTheGuestForNonReliableDisk)                              \
+    xxx(MirroredDiskResyncChecksumMismatch)                                    \
+    xxx(ReleaseShadowDiskError)                                                \
+    xxx(WrongCellIdInDescribeVolume)                                           \
+    xxx(TrimFreshLogTimeout)                                                   \
+    xxx(AddFreshBlocksResultedInError)                                         \
+    xxx(OverlappingRequestsDetected)                                           \
+    xxx(CrossPartitionRequestDetected)                                         \
+// BLOCKSTORE_VOLUME_CRITICAL_EVENTS
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
@@ -177,5 +180,30 @@ void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 // BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
     BLOCKSTORE_IMPOSSIBLE_EVENTS(BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE)
 #undef BLOCKSTORE_DECLARE_IMPOSSIBLE_EVENT_ROUTINE
+
+#define BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE(name)                 \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TString& message = "");                                          \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TString& message,                                                \
+        const TCritEventParams& keyValues);                                    \
+    TString Report##name(                                                      \
+        const TString& diskId,                                                 \
+        const TString& cloudId,                                                \
+        const TString& folderId,                                               \
+        const TCritEventParams& keyValues);                                    \
+    const TString GetCriticalEventFor##name();                                 \
+    const TString GetDeprecatedCriticalEventFor##name();                       \
+// BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
+
+    BLOCKSTORE_VOLUME_CRITICAL_EVENTS(\
+        BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE)
+#undef BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
 
 }   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -4,6 +4,9 @@
 
 #include <cloud/blockstore/libs/common/block_range.h>
 #include <cloud/blockstore/libs/common/printable_params.h>
+#include <cloud/blockstore/libs/common/volume_id.h>
+
+#include <utility>
 
 namespace NCloud::NBlockStore {
 
@@ -204,9 +207,26 @@ void ResetVolumeCriticalEventsCounter();
         const TString& cloudId,                                                \
         const TString& folderId,                                               \
         const TCritEventParams& keyValues);                                    \
+    template <typename... TArgs>                                               \
+    TString Report##name(const TVolumeId& volumeId, TArgs&&... args)           \
+    {                                                                          \
+        return Report##name(                                                   \
+            volumeId.DiskId,                                                   \
+            volumeId.CloudId,                                                  \
+            volumeId.FolderId,                                                 \
+            std::forward<TArgs>(args)...);                                     \
+    }                                                                          \
+    template <typename... TArgs>                                               \
+    TString Report##name(                                                      \
+        const TVolumeIdConstPtr& volumeId,                                     \
+        TArgs&&... args)                                                       \
+    {                                                                          \
+        Y_DEBUG_ABORT_UNLESS(volumeId);                                        \
+        return Report##name(*volumeId, std::forward<TArgs>(args)...);          \
+    }                                                                          \
     const TString GetCriticalEventFor##name();                                 \
     const TString GetDeprecatedCriticalEventFor##name();                       \
-// BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
+    // BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE
 
     BLOCKSTORE_VOLUME_CRITICAL_EVENTS(\
         BLOCKSTORE_DECLARE_VOLUME_CRITICAL_EVENT_ROUTINE)

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -143,6 +143,8 @@ using TCritEventParams =
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 
+NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler();
+
 #define BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                        \
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -145,6 +145,9 @@ void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 
 NCloud::IStatsHandlerPtr CreateCriticalEventsStatsHandler();
 
+// For unit test purposes
+void ResetVolumeCriticalEventsCounter();
+
 #define BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                        \
     TString Report##name(const TString& message = "");                         \
     TString Report##name(                                                      \

--- a/cloud/blockstore/libs/diagnostics/critical_events.h
+++ b/cloud/blockstore/libs/diagnostics/critical_events.h
@@ -141,6 +141,7 @@ using TCritEventParams =
 ////////////////////////////////////////////////////////////////////////////////
 
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
+void InitVolumeCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 
 #define BLOCKSTORE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                        \
     TString Report##name(const TString& message = "");                         \

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -1,0 +1,81 @@
+#include "critical_events.h"
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NCloud::NBlockStore {
+
+namespace {
+
+using namespace NMonitoring;
+
+TIntrusivePtr<TDynamicCounters> FindNestedGroup(
+    TDynamicCountersPtr root,
+    std::initializer_list<std::pair<TString, TString>> path)
+{
+    auto group = root;
+    for (const auto& [key, value] : path) {
+        group = group->FindSubgroup(key, value);
+        if (!group) {
+            return nullptr;
+        }
+    }
+    return group;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TCriticalEventsTest)
+{
+    Y_UNIT_TEST(ShouldEmitPerDiskCountersForVolumeCriticalEvents)
+    {
+        auto root = MakeIntrusive<TDynamicCounters>();
+
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(root);
+
+        const auto sensorName =
+            GetCriticalEventForMirroredDiskChecksumMismatchUponRead();
+        const auto deprecatedSensorName =
+            GetDeprecatedCriticalEventForMirroredDiskChecksumMismatchUponRead();
+
+        // Fire the report twice with a specific disk.
+        ReportMirroredDiskChecksumMismatchUponRead(
+            "disk-1",
+            "cloud-1",
+            "folder-1",
+            "msg");
+        ReportMirroredDiskChecksumMismatchUponRead(
+            "disk-1",
+            "cloud-1",
+            "folder-1",
+            "msg");
+
+        // Per-disk counter reads 2.
+        auto perDiskGroup = FindNestedGroup(
+            root,
+            {{"component", "service_volume"},
+             {"host", "cluster"},
+             {"volume", "disk-1"},
+             {"cloud", "cloud-1"},
+             {"folder", "folder-1"}});
+        UNIT_ASSERT(perDiskGroup);
+        auto perDiskCounter = perDiskGroup->FindCounter(sensorName);
+        UNIT_ASSERT(perDiskCounter);
+        UNIT_ASSERT_VALUES_EQUAL(2, perDiskCounter->Val());
+
+        // Deprecated counter under component=server reads 2.
+        auto deprecatedCounter =
+            serverGroup->FindCounter(deprecatedSensorName);
+        UNIT_ASSERT(deprecatedCounter);
+        UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
+    }
+}
+
+}   // namespace NCloud::NBlockStore

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -1,5 +1,7 @@
 #include "critical_events.h"
 
+#include <cloud/storage/core/libs/diagnostics/stats_handler.h>
+
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -23,58 +25,359 @@ TIntrusivePtr<TDynamicCounters> FindNestedGroup(
     return group;
 }
 
+struct TVolumePath
+{
+    TString DiskId;
+    TString CloudId;
+    TString FolderId;
+};
+
+// Resolves the per-disk counter group under component=service_volume.
+TIntrusivePtr<TDynamicCounters> FindVolumeGroup(
+    TDynamicCountersPtr serviceVolumeGroup,
+    const TVolumePath& p)
+{
+    return FindNestedGroup(
+        serviceVolumeGroup,
+        {{"volume", p.DiskId}, {"cloud", p.CloudId}, {"folder", p.FolderId}});
+}
+
+TString GetSensorName()
+{
+    return GetCriticalEventForBlockDigestMismatchInBlob();
+}
+
+TString GetDeprecatedSensorName()
+{
+    return GetDeprecatedCriticalEventForBlockDigestMismatchInBlob();
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Y_UNIT_TEST_SUITE(TCriticalEventsTest)
 {
-    Y_UNIT_TEST(ShouldEmitPerDiskCountersForVolumeCriticalEvents)
+    // InitCriticalEventsCounter eagerly initializes the deprecated
+    // AppCriticalEvents/<event> counters (value 0) so they keep show up in
+    // monitoring before any event is reported.
+    Y_UNIT_TEST(ShouldEagerlyInitCriticalEventsCounters)
     {
         auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
 
+        // No Report has been called yet.
+        InitCriticalEventsCounter(serverGroup);
+
+        auto assertInitialized = [&](const TString& sensorName)
+        {
+            auto counter = serverGroup->FindCounter(sensorName);
+            UNIT_ASSERT_C(counter, sensorName);
+            UNIT_ASSERT_VALUES_EQUAL_C(0, counter->Val(), sensorName);
+        };
+
+#define ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED(name) \
+    assertInitialized(GetCriticalEventFor##name());
+        // ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED
+
+        BLOCKSTORE_CRITICAL_EVENTS(ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED)
+        BLOCKSTORE_DISK_AGENT_CRITICAL_EVENTS(
+            ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED)
+        BLOCKSTORE_IMPOSSIBLE_EVENTS(ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED)
+
+#undef ASSERT_CRITICAL_EVENT_COUNTER_INITIALIZED
+
+#define ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED(name) \
+    assertInitialized(GetDeprecatedCriticalEventFor##name());
+        // ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED
+
+        // deprecated: keeps existing AppCriticalEvents/ * for new
+        // VolumeCriticalEvents/ * metrics alive
+        BLOCKSTORE_VOLUME_CRITICAL_EVENTS(
+            ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED)
+
+#undef ASSERT_DEPRECATED_CRITICAL_EVENT_COUNTER_INITIALIZED
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
+{
+    // Per-disk GAUGE counters are emitted by the shadow-swap flush,
+    // while the deprecated AppCriticalEvents/* counter (under
+    // component=server) is bumped synchronously
+    Y_UNIT_TEST(ShouldEmitPerDiskCountersForVolumeCriticalEvents)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
         auto serverGroup = root->GetSubgroup("component", "server");
         auto serviceVolumeGroup =
             root->GetSubgroup("component", "service_volume");
 
         InitCriticalEventsCounter(serverGroup);
-        InitVolumeCriticalEventsCounter(root);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
 
-        const auto sensorName =
-            GetCriticalEventForMirroredDiskChecksumMismatchUponRead();
-        const auto deprecatedSensorName =
-            GetDeprecatedCriticalEventForMirroredDiskChecksumMismatchUponRead();
+        auto handler = CreateCriticalEventsStatsHandler();
 
-        // Fire the report twice with a specific disk.
-        ReportMirroredDiskChecksumMismatchUponRead(
-            "disk-1",
-            "cloud-1",
-            "folder-1",
-            "msg");
-        ReportMirroredDiskChecksumMismatchUponRead(
-            "disk-1",
-            "cloud-1",
-            "folder-1",
-            "msg");
+        const TVolumePath p{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
 
-        // Per-disk counter reads 2.
-        auto perDiskGroup = FindNestedGroup(
-            root,
-            {{"component", "service_volume"},
-             {"host", "cluster"},
-             {"volume", "disk-1"},
-             {"cloud", "cloud-1"},
-             {"folder", "folder-1"}});
-        UNIT_ASSERT(perDiskGroup);
-        auto perDiskCounter = perDiskGroup->FindCounter(sensorName);
-        UNIT_ASSERT(perDiskCounter);
-        UNIT_ASSERT_VALUES_EQUAL(2, perDiskCounter->Val());
+        auto ret1 = ReportBlockDigestMismatchInBlob(
+            p.DiskId,
+            p.CloudId,
+            p.FolderId,
+            "some msg");
 
-        // Deprecated counter under component=server reads 2.
+        ReportBlockDigestMismatchInBlob(
+            p.DiskId,
+            p.CloudId,
+            p.FolderId,
+            "some msg");
+
+        // The returned log line carries the per-disk prefix.
+        UNIT_ASSERT_STRING_CONTAINS(ret1, "disk-1");
+        UNIT_ASSERT_STRING_CONTAINS(ret1, "cloud-1");
+        UNIT_ASSERT_STRING_CONTAINS(ret1, "folder-1");
+
+        // Before the flush the per-disk GAUGE is not yet materialized:
+        // the hot path only bumps the Internal accumulator.
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        UNIT_ASSERT(!volumeGroup || !volumeGroup->FindCounter(GetSensorName()));
+
+        // Deprecated counter is bumped synchronously.
         auto deprecatedCounter =
-            serverGroup->FindCounter(deprecatedSensorName);
+            serverGroup->FindCounter(GetDeprecatedSensorName());
         UNIT_ASSERT(deprecatedCounter);
         UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
+
+        // Flush materializes and writes the GAUGE.
+        handler->UpdateStats(true);
+
+        volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        UNIT_ASSERT(volumeGroup);
+        auto volumeCounter = volumeGroup->FindCounter(GetSensorName());
+        UNIT_ASSERT(volumeCounter);
+        UNIT_ASSERT_VALUES_EQUAL(2, volumeCounter->Val());
+
+        // Deprecated counter is not changed after update/flush.
+        UNIT_ASSERT_VALUES_EQUAL(2, deprecatedCounter->Val());
+    }
+
+    // The flush only runs when updateIntervalFinished is true
+    Y_UNIT_TEST(ShouldFlushOnlyOnIntervalFinished)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumePath p{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(
+            p.DiskId,
+            p.CloudId,
+            p.FolderId,
+            "some msg");
+
+        // Tick without the interval finished -> no flush.
+        handler->UpdateStats(false);
+
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        UNIT_ASSERT(!volumeGroup || !volumeGroup->FindCounter(GetSensorName()));
+
+        // Interval finished -> flush writes 1.
+        handler->UpdateStats(true);
+
+        volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        UNIT_ASSERT(volumeGroup);
+        auto volumeCounter = volumeGroup->FindCounter(GetSensorName());
+        UNIT_ASSERT(volumeCounter);
+        UNIT_ASSERT_VALUES_EQUAL(1, volumeCounter->Val());
+    }
+
+    // GAUGE semantics: with no new events the next flush resets to 0
+    Y_UNIT_TEST(ShouldResetToZeroAfterFlushWithNoNewEvents)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumePath p{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(
+            p.DiskId,
+            p.CloudId,
+            p.FolderId,
+            "some msg");
+
+        ReportBlockDigestMismatchInBlob(
+            p.DiskId,
+            p.CloudId,
+            p.FolderId,
+            "some msg");
+
+        handler->UpdateStats(true);
+
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        UNIT_ASSERT(volumeGroup);
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            volumeGroup->FindCounter(GetSensorName())->Val());
+
+        // No new events -> Internal is 0 -> GAUGE set back to 0.
+        handler->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            0,
+            volumeGroup->FindCounter(GetSensorName())->Val());
+    }
+
+    // Counters are distinct per disk
+    Y_UNIT_TEST(ShouldKeepDistinctCountersPerDisk)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumePath p1{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        const TVolumePath p2{
+            .DiskId = "disk-2",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        ReportBlockDigestMismatchInBlob(
+            p1.DiskId,
+            p1.CloudId,
+            p1.FolderId,
+            "some msg 1");
+
+        ReportBlockDigestMismatchInBlob(
+            p1.DiskId,
+            p1.CloudId,
+            p1.FolderId,
+            "some msg 1");
+
+        ReportBlockDigestMismatchInBlob(
+            p2.DiskId,
+            p2.CloudId,
+            p2.FolderId,
+            "some msg 2");
+
+        handler->UpdateStats(true);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            2,
+            FindVolumeGroup(serviceVolumeGroup, p1)
+                ->FindCounter(GetSensorName())
+                ->Val());
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            FindVolumeGroup(serviceVolumeGroup, p2)
+                ->FindCounter(GetSensorName())
+                ->Val());
+
+        // Deprecated counter should contain summary
+        auto deprecatedCounter =
+            serverGroup->FindCounter(GetDeprecatedSensorName());
+        UNIT_ASSERT(deprecatedCounter);
+        UNIT_ASSERT_VALUES_EQUAL(3, deprecatedCounter->Val());
+    }
+
+    // Events fired before CountersRoot is set must accumulate in
+    // Internal and be flushed once the root becomes available
+    Y_UNIT_TEST(ShouldAccumulateEventsBeforeCountersRootInitialized)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        // NOTE: InitVolumeCriticalEventsCounter is intentionally deferred.
+        InitCriticalEventsCounter(serverGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TVolumePath p{
+            .DiskId = "disk-1",
+            .CloudId = "cloud-1",
+            .FolderId = "folder-1"};
+
+        // CountersRoot is null -> entry created with Exported=null,
+        // Internal accumulates to 3.
+        for (int i = 0; i < 3; ++i) {
+            ReportBlockDigestMismatchInBlob(
+                p.DiskId,
+                p.CloudId,
+                p.FolderId,
+                "some msg");
+        }
+
+        // Root becomes available -> the next flush lazily materializes
+        // Exported and writes the accumulated value.
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+        handler->UpdateStats(true);
+
+        auto voluemGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        UNIT_ASSERT(voluemGroup);
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            voluemGroup->FindCounter(GetSensorName())->Val());
+
+        // Deprecated counter reflects the dual emission (3 synchronous
+        // Inc()'s).
+        UNIT_ASSERT_VALUES_EQUAL(
+            3,
+            serverGroup->FindCounter(GetDeprecatedSensorName())->Val());
+
+        // One more event on the hot path (Exported is now non-null,
+        // Internal -> 1) is flushed on the next tick.
+        ReportBlockDigestMismatchInBlob(
+            p.DiskId,
+            p.CloudId,
+            p.FolderId,
+            "some msg");
+        handler->UpdateStats(true);
+        UNIT_ASSERT_VALUES_EQUAL(
+            1,
+            voluemGroup->FindCounter(GetSensorName())->Val());
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
+++ b/cloud/blockstore/libs/diagnostics/critical_events_ut.cpp
@@ -25,21 +25,14 @@ TIntrusivePtr<TDynamicCounters> FindNestedGroup(
     return group;
 }
 
-struct TVolumePath
-{
-    TString DiskId;
-    TString CloudId;
-    TString FolderId;
-};
-
 // Resolves the per-disk counter group under component=service_volume.
 TIntrusivePtr<TDynamicCounters> FindVolumeGroup(
     TDynamicCountersPtr serviceVolumeGroup,
-    const TVolumePath& p)
+    const TVolumeId& v)
 {
     return FindNestedGroup(
         serviceVolumeGroup,
-        {{"volume", p.DiskId}, {"cloud", p.CloudId}, {"folder", p.FolderId}});
+        {{"volume", v.DiskId}, {"cloud", v.CloudId}, {"folder", v.FolderId}});
 }
 
 TString GetSensorName()
@@ -121,22 +114,14 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumePath p{
+        const TVolumeId v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
 
-        auto ret1 = ReportBlockDigestMismatchInBlob(
-            p.DiskId,
-            p.CloudId,
-            p.FolderId,
-            "some msg");
+        auto ret1 = ReportBlockDigestMismatchInBlob(v, "some msg");
 
-        ReportBlockDigestMismatchInBlob(
-            p.DiskId,
-            p.CloudId,
-            p.FolderId,
-            "some msg");
+        ReportBlockDigestMismatchInBlob(v, "some msg");
 
         // The returned log line carries the per-disk prefix.
         UNIT_ASSERT_STRING_CONTAINS(ret1, "disk-1");
@@ -145,7 +130,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         // Before the flush the per-disk GAUGE is not yet materialized:
         // the hot path only bumps the Internal accumulator.
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
         UNIT_ASSERT(!volumeGroup || !volumeGroup->FindCounter(GetSensorName()));
 
         // Deprecated counter is bumped synchronously.
@@ -157,7 +142,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         // Flush materializes and writes the GAUGE.
         handler->UpdateStats(true);
 
-        volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
         UNIT_ASSERT(volumeGroup);
         auto volumeCounter = volumeGroup->FindCounter(GetSensorName());
         UNIT_ASSERT(volumeCounter);
@@ -182,27 +167,23 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumePath p{
+        const TVolumeId v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
 
-        ReportBlockDigestMismatchInBlob(
-            p.DiskId,
-            p.CloudId,
-            p.FolderId,
-            "some msg");
+        ReportBlockDigestMismatchInBlob(v, "some msg");
 
         // Tick without the interval finished -> no flush.
         handler->UpdateStats(false);
 
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
         UNIT_ASSERT(!volumeGroup || !volumeGroup->FindCounter(GetSensorName()));
 
         // Interval finished -> flush writes 1.
         handler->UpdateStats(true);
 
-        volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
         UNIT_ASSERT(volumeGroup);
         auto volumeCounter = volumeGroup->FindCounter(GetSensorName());
         UNIT_ASSERT(volumeCounter);
@@ -224,26 +205,18 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumePath p{
+        const TVolumeId v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
 
-        ReportBlockDigestMismatchInBlob(
-            p.DiskId,
-            p.CloudId,
-            p.FolderId,
-            "some msg");
+        ReportBlockDigestMismatchInBlob(v, "some msg");
 
-        ReportBlockDigestMismatchInBlob(
-            p.DiskId,
-            p.CloudId,
-            p.FolderId,
-            "some msg");
+        ReportBlockDigestMismatchInBlob(v, "some msg");
 
         handler->UpdateStats(true);
 
-        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, p);
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
         UNIT_ASSERT(volumeGroup);
         UNIT_ASSERT_VALUES_EQUAL(
             2,
@@ -271,44 +244,32 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumePath p1{
+        const TVolumeId v1{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
 
-        const TVolumePath p2{
+        const TVolumeId v2{
             .DiskId = "disk-2",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
 
-        ReportBlockDigestMismatchInBlob(
-            p1.DiskId,
-            p1.CloudId,
-            p1.FolderId,
-            "some msg 1");
+        ReportBlockDigestMismatchInBlob(v1, "some msg 1");
 
-        ReportBlockDigestMismatchInBlob(
-            p1.DiskId,
-            p1.CloudId,
-            p1.FolderId,
-            "some msg 1");
+        ReportBlockDigestMismatchInBlob(v1, "some msg 1");
 
-        ReportBlockDigestMismatchInBlob(
-            p2.DiskId,
-            p2.CloudId,
-            p2.FolderId,
-            "some msg 2");
+        ReportBlockDigestMismatchInBlob(v2, "some msg 2");
 
         handler->UpdateStats(true);
 
         UNIT_ASSERT_VALUES_EQUAL(
             2,
-            FindVolumeGroup(serviceVolumeGroup, p1)
+            FindVolumeGroup(serviceVolumeGroup, v1)
                 ->FindCounter(GetSensorName())
                 ->Val());
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            FindVolumeGroup(serviceVolumeGroup, p2)
+            FindVolumeGroup(serviceVolumeGroup, v2)
                 ->FindCounter(GetSensorName())
                 ->Val());
 
@@ -335,7 +296,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         auto handler = CreateCriticalEventsStatsHandler();
 
-        const TVolumePath p{
+        const TVolumeId v{
             .DiskId = "disk-1",
             .CloudId = "cloud-1",
             .FolderId = "folder-1"};
@@ -343,11 +304,7 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         // CountersRoot is null -> entry created with Exported=null,
         // Internal accumulates to 3.
         for (int i = 0; i < 3; ++i) {
-            ReportBlockDigestMismatchInBlob(
-                p.DiskId,
-                p.CloudId,
-                p.FolderId,
-                "some msg");
+            ReportBlockDigestMismatchInBlob(v, "some msg");
         }
 
         // Root becomes available -> the next flush lazily materializes
@@ -355,11 +312,11 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
         InitVolumeCriticalEventsCounter(serviceVolumeGroup);
         handler->UpdateStats(true);
 
-        auto voluemGroup = FindVolumeGroup(serviceVolumeGroup, p);
-        UNIT_ASSERT(voluemGroup);
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(volumeGroup);
         UNIT_ASSERT_VALUES_EQUAL(
             3,
-            voluemGroup->FindCounter(GetSensorName())->Val());
+            volumeGroup->FindCounter(GetSensorName())->Val());
 
         // Deprecated counter reflects the dual emission (3 synchronous
         // Inc()'s).
@@ -369,15 +326,91 @@ Y_UNIT_TEST_SUITE(TVolumeCriticalEventsTest)
 
         // One more event on the hot path (Exported is now non-null,
         // Internal -> 1) is flushed on the next tick.
-        ReportBlockDigestMismatchInBlob(
-            p.DiskId,
-            p.CloudId,
-            p.FolderId,
-            "some msg");
+        ReportBlockDigestMismatchInBlob(v, "some msg");
         handler->UpdateStats(true);
         UNIT_ASSERT_VALUES_EQUAL(
             1,
-            voluemGroup->FindCounter(GetSensorName())->Val());
+            volumeGroup->FindCounter(GetSensorName())->Val());
+    }
+
+    // All Report...() overloads works
+    Y_UNIT_TEST(ShouldProperlyImplementAllReportOverloads)
+    {
+        ResetVolumeCriticalEventsCounter();
+
+        auto root = MakeIntrusive<TDynamicCounters>();
+        auto serverGroup = root->GetSubgroup("component", "server");
+        auto serviceVolumeGroup =
+            root->GetSubgroup("component", "service_volume");
+
+        InitCriticalEventsCounter(serverGroup);
+        InitVolumeCriticalEventsCounter(serviceVolumeGroup);
+
+        auto handler = CreateCriticalEventsStatsHandler();
+
+        const TString diskId = "disk-1";
+        const TString cloudId = "cloud-1";
+        const TString folderId = "folder-1";
+
+        const TString msg = "some msg";
+        const auto params = TCritEventParams{{"a", "1"}, {"b", "2"}};
+
+        // Report...(TString, TString, TString, ...)
+        {
+            ReportBlockDigestMismatchInBlob(diskId, cloudId, folderId);
+            ReportBlockDigestMismatchInBlob(diskId, cloudId, folderId, msg);
+            ReportBlockDigestMismatchInBlob(diskId, cloudId, folderId, params);
+            ReportBlockDigestMismatchInBlob(
+                diskId,
+                cloudId,
+                folderId,
+                msg,
+                params);
+        }
+
+        // Report...(TVolumeId, ...)
+        {
+            const auto v = TVolumeId{
+                .DiskId = diskId,
+                .CloudId = cloudId,
+                .FolderId = folderId};
+
+            ReportBlockDigestMismatchInBlob(v);
+            ReportBlockDigestMismatchInBlob(v, msg);
+            ReportBlockDigestMismatchInBlob(v, params);
+            ReportBlockDigestMismatchInBlob(v, msg, params);
+        }
+
+        // Report...(TVolumeIdConstPtr, ...)
+        {
+            const auto v = MakeVolumeId(diskId, cloudId, folderId);
+
+            ReportBlockDigestMismatchInBlob(v);
+            ReportBlockDigestMismatchInBlob(v, msg);
+            ReportBlockDigestMismatchInBlob(v, params);
+            ReportBlockDigestMismatchInBlob(v, msg, params);
+        }
+
+        const auto v = TVolumeId{
+            .DiskId = diskId,
+            .CloudId = cloudId,
+            .FolderId = folderId};
+
+        auto deprecatedCounter =
+            serverGroup->FindCounter(GetDeprecatedSensorName());
+        UNIT_ASSERT(deprecatedCounter);
+        // Deprecated counter should contain summary immediatly
+        UNIT_ASSERT_VALUES_EQUAL(12, deprecatedCounter->Val());
+
+        handler->UpdateStats(true);
+
+        auto volumeGroup = FindVolumeGroup(serviceVolumeGroup, v);
+        UNIT_ASSERT(volumeGroup);
+        UNIT_ASSERT_VALUES_EQUAL(
+            12,
+            volumeGroup->FindCounter(GetSensorName())->Val());
+
+        UNIT_ASSERT_VALUES_EQUAL(12, deprecatedCounter->Val());
     }
 }
 

--- a/cloud/blockstore/libs/diagnostics/ut/ya.make
+++ b/cloud/blockstore/libs/diagnostics/ut/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
 SRCS(
     config_ut.cpp
     block_digest_ut.cpp
+    critical_events_ut.cpp
     fault_injection_ut.cpp
     hostname_ut.cpp
     profile_log_ut.cpp

--- a/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
+++ b/cloud/blockstore/libs/endpoints_nbd/nbd_server.cpp
@@ -54,6 +54,8 @@ public:
     {
         NBD::TStorageOptions options;
         options.DiskId = request.GetDiskId();
+        options.CloudId = volume.GetCloudId();
+        options.FolderId = volume.GetFolderId();
         options.ClientId = request.GetClientId();
         options.BlockSize = volume.GetBlockSize();
         options.BlocksCount = volume.GetBlocksCount();

--- a/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
+++ b/cloud/blockstore/libs/endpoints_vhost/vhost_server.cpp
@@ -52,6 +52,8 @@ public:
         NVhost::TStorageOptions options;
         options.DeviceName = request.GetDeviceName();
         options.DiskId = request.GetDiskId();
+        options.CloudId = volume.GetCloudId();
+        options.FolderId = volume.GetFolderId();
         options.ClientId = request.GetClientId();
         options.BlockSize = volume.GetBlockSize();
         options.BlocksCount = volume.GetBlocksCount();

--- a/cloud/blockstore/libs/nbd/server_handler.cpp
+++ b/cloud/blockstore/libs/nbd/server_handler.cpp
@@ -952,6 +952,8 @@ IServerHandlerFactoryPtr CreateServerHandlerFactory(
     TDeviceHandlerParams params{
         .Storage = std::move(storage),
         .DiskId = options.DiskId,
+        .CloudId = options.CloudId,
+        .FolderId = options.FolderId,
         .ClientId = options.ClientId,
         .BlockSize = options.BlockSize,
         .MaxZeroBlocksSubRequestSize = options.MaxZeroBlocksSubRequestSize,

--- a/cloud/blockstore/libs/nbd/server_handler.h
+++ b/cloud/blockstore/libs/nbd/server_handler.h
@@ -120,6 +120,8 @@ struct IServerHandlerFactory
 struct TStorageOptions
 {
     TString DiskId;
+    TString CloudId;
+    TString FolderId;
     TString ClientId;
     ui32 BlockSize = 0;
     ui64 BlocksCount = 0;

--- a/cloud/blockstore/libs/server/server.cpp
+++ b/cloud/blockstore/libs/server/server.cpp
@@ -711,6 +711,9 @@ private:
             if (cellId && cellId != AppCtx.CellId) {
                 const auto* msg = "DescribeVolume response cell id mismatch";
                 ReportWrongCellIdInDescribeVolume(
+                    Request->GetDiskId(),
+                    "",   // cloudId — not available at this point
+                    "",   // folderId — not available at this point
                     msg,
                     {{"expected", AppCtx.CellId}, {"actual", cellId}});
 

--- a/cloud/blockstore/libs/service/aligned_device_handler.cpp
+++ b/cloud/blockstore/libs/service/aligned_device_handler.cpp
@@ -95,6 +95,8 @@ TAlignedDeviceHandler::TAlignedDeviceHandler(
         ui32 maxSubRequestSize)
     : Storage(std::move(params.Storage))
     , DiskId(std::move(params.DiskId))
+    , CloudId(std::move(params.CloudId))
+    , FolderId(std::move(params.FolderId))
     , ClientId(std::move(params.ClientId))
     , BlockSize(params.BlockSize)
     , MaxBlockCount(maxSubRequestSize / BlockSize)
@@ -467,12 +469,20 @@ void TAlignedDeviceHandler::ReportCriticalError(
     }
 
     auto message = TStringBuilder()
-                   << "disk: " << DiskId.Quote() << ", op: " << operation
+                   << "op: " << operation
                    << ", range: " << range << ", error: " << FormatError(error);
     if (IsReliableMediaKind(StorageMediaKind)) {
-        ReportErrorWasSentToTheGuestForReliableDisk(message);
+        ReportErrorWasSentToTheGuestForReliableDisk(
+            DiskId,
+            CloudId,
+            FolderId,
+            message);
     } else {
-        ReportErrorWasSentToTheGuestForNonReliableDisk(message);
+        ReportErrorWasSentToTheGuestForNonReliableDisk(
+            DiskId,
+            CloudId,
+            FolderId,
+            message);
     }
 }
 

--- a/cloud/blockstore/libs/service/aligned_device_handler.h
+++ b/cloud/blockstore/libs/service/aligned_device_handler.h
@@ -19,6 +19,8 @@ class TAlignedDeviceHandler final
 private:
     const IStoragePtr Storage;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TString ClientId;
     const ui32 BlockSize;
     const ui32 MaxBlockCount;

--- a/cloud/blockstore/libs/service/device_handler.h
+++ b/cloud/blockstore/libs/service/device_handler.h
@@ -41,6 +41,8 @@ struct TDeviceHandlerParams
 {
     IStoragePtr Storage;
     TString DiskId;
+    TString CloudId;
+    TString FolderId;
     TString ClientId;
     ui32 BlockSize = 0;
     ui32 MaxZeroBlocksSubRequestSize = 0;

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.cpp
@@ -1398,6 +1398,7 @@ void TDiskRegistryState::TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
     if (!CheckIfDeviceReplacementIsAllowed(
             timestamp,
             disk.MasterDiskId,
+            diskId,
             deviceId))
     {
         return;
@@ -1416,7 +1417,12 @@ void TDiskRegistryState::TryToReplaceDeviceIfAllowedWithoutDiskStateUpdate(
         false);   // manual
 
     if (HasError(error)) {
-        ReportMirroredDiskDeviceReplacementFailure(FormatError(error));
+        ReportMirroredDiskDeviceReplacementFailure(
+            disk.MasterDiskId ? disk.MasterDiskId : diskId,
+            disk.CloudId,
+            disk.FolderId,
+            FormatError(error),
+            {{"replica", diskId}, {"device", deviceId}});
     }
 }
 
@@ -2620,7 +2626,9 @@ void TDiskRegistryState::CleanupMirroredDisk(
 
     if (affectedDisks.size()) {
         ReportMirroredDiskAllocationPlacementGroupCleanupFailure(
-            {{"disk", diskId}});
+            diskId,
+            params.CloudId,
+            params.FolderId);
     }
 
     AddToBrokenDisks(now, db, diskId);
@@ -2745,7 +2753,9 @@ NProto::TError TDiskRegistryState::AllocateMirroredDisk(
             // TODO (NBS-3419):
             // support automatic cleanup after a failed resize
             ReportMirroredDiskAllocationCleanupFailure(
-                {{"disk", params.DiskId}});
+                params.DiskId,
+                params.CloudId,
+                params.FolderId);
         }
 
         onError();
@@ -3072,7 +3082,10 @@ NProto::TError TDiskRegistryState::DeallocateDisk(
     }
 
     if (!IsReadyForCleanup(diskId)) {
-        auto message = ReportNrdDestructionError({{"disk", diskId}});
+        auto message = ReportNrdDestructionError(
+            diskId,
+            disk->CloudId,
+            disk->FolderId);
 
         return MakeError(E_INVALID_STATE, std::move(message));
     }
@@ -7951,6 +7964,7 @@ void TDiskRegistryState::DeleteAutomaticallyReplacedDevice(
 bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
     TInstant now,
     const TDiskId& masterDiskId,
+    const TDiskId& replicaDiskId,
     const TDeviceId& deviceId)
 {
     while (AutomaticReplacementTimestamps) {
@@ -7965,10 +7979,16 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
 
     const auto rateLimit =
         StorageConfig->GetMaxAutomaticDeviceReplacementsPerHour();
-    if (rateLimit
-            && rateLimit <= AutomaticReplacementTimestamps.size()) {
+
+    if (rateLimit && rateLimit <= AutomaticReplacementTimestamps.size()) {
+        const auto* masterDisk = Disks.FindPtr(masterDiskId);
+        const TString& cloudId = masterDisk ? masterDisk->CloudId : TString();
+        const TString& folderId = masterDisk ? masterDisk->FolderId : TString();
         ReportMirroredDiskDeviceReplacementRateLimitExceeded(
-            {{"disk", masterDiskId}, {"device", deviceId}});
+            masterDiskId,
+            cloudId,
+            folderId,
+            {{"replica", replicaDiskId}, {"device", deviceId}});
         return false;
     }
 
@@ -7977,8 +7997,14 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
         deviceId);
 
     if (!canReplaceDevice) {
+        const auto* masterDisk = Disks.FindPtr(masterDiskId);
+        const TString& cloudId = masterDisk ? masterDisk->CloudId : TString();
+        const TString& folderId = masterDisk ? masterDisk->FolderId : TString();
         ReportMirroredDiskDeviceReplacementForbidden(
-            {{"disk", masterDiskId}, {"device", deviceId}});
+            masterDiskId,
+            cloudId,
+            folderId,
+            {{"replica", replicaDiskId}, {"device", deviceId}});
         return false;
     }
 
@@ -7986,10 +8012,11 @@ bool TDiskRegistryState::CheckIfDeviceReplacementIsAllowed(
         ReplicaTable.IsRecentlyReplacedDevice(masterDiskId, deviceId))
     {
         STORAGE_WARN(
-            "DiskId=%s, DeviceId=%s, automatic device replacement is postponed "
+            "DiskId=%s, ReplicaId=%s, DeviceId=%s, automatic device replacement is postponed "
             "due to replacements in "
             "other replicas.",
             masterDiskId.c_str(),
+            replicaDiskId.c_str(),
             deviceId.c_str());
         return false;
     }

--- a/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
+++ b/cloud/blockstore/libs/storage/disk_registry/disk_registry_state.h
@@ -857,6 +857,7 @@ public:
     bool CheckIfDeviceReplacementIsAllowed(
         TInstant now,
         const TDiskId& masterDiskId,
+        const TDiskId& replicaDiskId,
         const TDeviceId& deviceId);
 
     NProto::TError CreateDiskFromDevices(

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.cpp
@@ -78,6 +78,10 @@ TFreshBlocksWriterActor::TFreshBlocksWriterActor(
         IProfileLogPtr profileLog)
     : Config(std::move(config))
     , PartitionConfig(std::move(partitionConfig))
+    , VolumeId(MakeVolumeId(
+          PartitionConfig.GetDiskId(),
+          PartitionConfig.GetCloudId(),
+          PartitionConfig.GetFolderId()))
     , StorageAccessMode(storageAccessMode)
     , PartitionTabletID(partitionTabletId)
     , PartitionActorId(partitionActorId)

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/common/volume_id.h>
 #include <cloud/blockstore/libs/storage/api/fresh_blocks_writer.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
@@ -36,6 +37,7 @@ class TFreshBlocksWriterActor final
 private:
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
+    const TVolumeIdConstPtr VolumeId;
     const EStorageAccessMode StorageAccessMode;
     const ui64 PartitionTabletID;
     const NActors::TActorId PartitionActorId;

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -133,6 +133,9 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
         BlockDigestGenerator,
         false,   // waitForAddFreshBlocksResponseBeforeResponse
         PartitionTabletID,
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         SharedState);
 
     Actors.Insert(actor);
@@ -219,6 +222,9 @@ void TFreshBlocksWriterActor::ZeroFreshBlocks(
         BlockDigestGenerator,
         false,   // waitForAddFreshBlocksResponseBeforeResponse
         PartitionTabletID,
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         SharedState);
 
     Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/fresh_blocks_writer/fresh_blocks_writer_actor_writefreshblocks.cpp
@@ -133,9 +133,7 @@ void TFreshBlocksWriterActor::WriteFreshBlocks(
         BlockDigestGenerator,
         false,   // waitForAddFreshBlocksResponseBeforeResponse
         PartitionTabletID,
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         SharedState);
 
     Actors.Insert(actor);
@@ -222,9 +220,7 @@ void TFreshBlocksWriterActor::ZeroFreshBlocks(
         BlockDigestGenerator,
         false,   // waitForAddFreshBlocksResponseBeforeResponse
         PartitionTabletID,
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         SharedState);
 
     Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -341,8 +341,10 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
         std::move(channels));
 
     ReportReassignTablet(
-        {{"disk", PartitionConfig.GetDiskId()},
-         {"tablet_id", TabletID()},
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
+        {{"tablet_id", TabletID()},
          {"channels", sb}});
     ReassignRequestSentTs = ctx.Now();
 }
@@ -1390,7 +1392,9 @@ NProto::TError VerifyBlockChecksum(
     const ui64 blockIndex,
     const ui16 blobOffset,
     const ui32 expectedChecksum,
-    const TString& diskId)
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId)
 {
     if (expectedChecksum == 0) {
         // 0 is a special case - block digest calculation can be
@@ -1404,8 +1408,10 @@ NProto::TError VerifyBlockChecksum(
 
     if (actualChecksum != expectedChecksum) {
         ReportBlockDigestMismatchInBlob(
-            {{"disk", diskId},
-             {"BlockIndex", blockIndex},
+            diskId,
+            cloudId,
+            folderId,
+            {{"BlockIndex", blockIndex},
              {"blobOffset", blobOffset},
              {"blob", blobID.ToString()}});
         // we might read proper data upon retry - let's give it a chance

--- a/cloud/blockstore/libs/storage/partition/part_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor.cpp
@@ -69,6 +69,10 @@ TPartitionActor::TPartitionActor(
     , TTabletBase(owner, std::move(storage), &TransactionTimeTracker)
     , Config(std::move(config))
     , PartitionConfig(std::move(partitionConfig))
+    , VolumeId(MakeVolumeId(
+          PartitionConfig.GetDiskId(),
+          PartitionConfig.GetCloudId(),
+          PartitionConfig.GetFolderId()))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , BlockDigestGenerator(std::move(blockDigestGenerator))

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -9,6 +9,7 @@
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/common/volume_id.h>
 #include <cloud/blockstore/libs/storage/api/partition.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -121,6 +122,7 @@ private:
     const ui64 StartTime = GetCycleCount();
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
+    const TVolumeIdConstPtr VolumeId;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;

--- a/cloud/blockstore/libs/storage/partition/part_actor.h
+++ b/cloud/blockstore/libs/storage/partition/part_actor.h
@@ -834,6 +834,8 @@ NProto::TError VerifyBlockChecksum(
     const ui64 blockIndex,
     const ui16 blobOffset,
     const ui32 expectedChecksum,
-    const TString& diskId);
+    const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId);
 
 }   // namespace NCloud::NBlockStore::NStorage::NPartition

--- a/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_addconfirmedblobs.cpp
@@ -345,8 +345,10 @@ void TPartitionActor::HandleAddConfirmedBlobsCompleted(
             FormatError(msg->GetError()).c_str());
 
         ReportAddConfirmedBlobsError(
-            FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
+            FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
@@ -38,6 +38,8 @@ private:
 
     const TActorId Tablet;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 LastGCCommitId;
     const ui64 CollectCommitId;
@@ -63,6 +65,8 @@ public:
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -108,6 +112,8 @@ TCollectGarbageActor::TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -123,6 +129,8 @@ TCollectGarbageActor::TCollectGarbageActor(
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , TabletInfo(std::move(tabletInfo))
     , LastGCCommitId(lastGCCommitId)
     , CollectCommitId(collectCommitId)
@@ -248,9 +256,11 @@ void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            DiskId,
+            CloudId,
+            FolderId,
             TStringBuilder()
-                << "Garbage collection error: " << FormatError(error),
-            {{"disk", DiskId}});
+                << "Garbage collection error: " << FormatError(error));
 
         Error = std::move(error);
     }
@@ -346,6 +356,8 @@ private:
 
     const TActorId Tablet;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 CollectCommitId;
     const ui32 RecordGeneration;
@@ -365,6 +377,8 @@ public:
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -402,6 +416,8 @@ TCollectGarbageHardActor::TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -413,6 +429,8 @@ TCollectGarbageHardActor::TCollectGarbageHardActor(
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , TabletInfo(std::move(tabletInfo))
     , CollectCommitId(collectCommitId)
     , RecordGeneration(recordGeneration)
@@ -499,9 +517,11 @@ void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            DiskId,
+            CloudId,
+            FolderId,
             TStringBuilder()
-                << "Hard garbage collection error: " << FormatError(error),
-            {{"disk", DiskId}});
+                << "Hard garbage collection error: " << FormatError(error));
         Error = std::move(error);
     }
 }
@@ -736,6 +756,8 @@ void TPartitionActor::HandleCollectGarbage(
         requestInfo,
         SelfId(),
         PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         Info(),
         State->GetLastCollectCommitId(),
         commitId,
@@ -853,6 +875,8 @@ void TPartitionActor::CompleteCollectGarbage(
         args.RequestInfo,
         SelfId(),
         PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         Info(),
         args.CollectCommitId,
         Executor()->Generation(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_collectgarbage.cpp
@@ -37,9 +37,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 LastGCCommitId;
     const ui64 CollectCommitId;
@@ -64,9 +62,7 @@ public:
     TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -111,9 +107,7 @@ private:
 TCollectGarbageActor::TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -128,9 +122,7 @@ TCollectGarbageActor::TCollectGarbageActor(
         bool passTraceIdToBlobstorage)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
-    , DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    , VolumeId(std::move(volumeId))
     , TabletInfo(std::move(tabletInfo))
     , LastGCCommitId(lastGCCommitId)
     , CollectCommitId(collectCommitId)
@@ -256,9 +248,7 @@ void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
-            DiskId,
-            CloudId,
-            FolderId,
+            VolumeId,
             TStringBuilder()
                 << "Garbage collection error: " << FormatError(error));
 
@@ -355,9 +345,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 CollectCommitId;
     const ui32 RecordGeneration;
@@ -376,9 +364,7 @@ public:
     TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -415,9 +401,7 @@ private:
 TCollectGarbageHardActor::TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -428,9 +412,7 @@ TCollectGarbageHardActor::TCollectGarbageHardActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
-    , DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    , VolumeId(std::move(volumeId))
     , TabletInfo(std::move(tabletInfo))
     , CollectCommitId(collectCommitId)
     , RecordGeneration(recordGeneration)
@@ -517,9 +499,7 @@ void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
-            DiskId,
-            CloudId,
-            FolderId,
+            VolumeId,
             TStringBuilder()
                 << "Hard garbage collection error: " << FormatError(error));
         Error = std::move(error);
@@ -755,9 +735,7 @@ void TPartitionActor::HandleCollectGarbage(
         ctx,
         requestInfo,
         SelfId(),
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         Info(),
         State->GetLastCollectCommitId(),
         commitId,
@@ -874,9 +852,7 @@ void TPartitionActor::CompleteCollectGarbage(
         ctx,
         args.RequestInfo,
         SelfId(),
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         Info(),
         args.CollectCommitId,
         Executor()->Generation(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -143,9 +143,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const ui64 TabletId;
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
     const TActorId Tablet;
     const ui32 BlockSize;
     const ui32 MaxAffectedBlocksPerCompaction;
@@ -201,9 +199,7 @@ public:
     TCompactionActor(
         TRequestInfoPtr requestInfo,
         ui64 tabletId,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         const TActorId& tablet,
         ui32 blockSize,
         ui32 maxAffectedBlocksPerCompaction,
@@ -279,9 +275,7 @@ private:
 TCompactionActor::TCompactionActor(
         TRequestInfoPtr requestInfo,
         ui64 tabletId,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         const TActorId& tablet,
         ui32 blockSize,
         ui32 maxAffectedBlocksPerCompaction,
@@ -299,9 +293,7 @@ TCompactionActor::TCompactionActor(
         TVector<TPartialBlobId> blobsToReadBlobMetas)
     : RequestInfo(std::move(requestInfo))
     , TabletId(tabletId)
-    , DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    , VolumeId(std::move(volumeId))
     , Tablet(tablet)
     , BlockSize(blockSize)
     , MaxAffectedBlocksPerCompaction(maxAffectedBlocksPerCompaction)
@@ -392,9 +384,9 @@ NProto::TError TCompactionActor::VerifyBlockChecksums()
                 r->BlockIndex,
                 r->BlobOffset,
                 expectedChecksum,
-                DiskId,
-                CloudId,
-                FolderId);
+                VolumeId->DiskId,
+                VolumeId->CloudId,
+                VolumeId->FolderId);
 
             if (HasError(error)) {
                 return error;
@@ -2268,9 +2260,7 @@ void TPartitionActor::CompleteCompaction(
         ctx,
         args.RequestInfo,
         TabletID(),
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         SelfId(),
         State->GetBlockSize(),
         Config->GetMaxAffectedBlocksPerCompaction(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_compaction.cpp
@@ -144,6 +144,8 @@ private:
 
     const ui64 TabletId;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TActorId Tablet;
     const ui32 BlockSize;
     const ui32 MaxAffectedBlocksPerCompaction;
@@ -200,6 +202,8 @@ public:
         TRequestInfoPtr requestInfo,
         ui64 tabletId,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         const TActorId& tablet,
         ui32 blockSize,
         ui32 maxAffectedBlocksPerCompaction,
@@ -276,6 +280,8 @@ TCompactionActor::TCompactionActor(
         TRequestInfoPtr requestInfo,
         ui64 tabletId,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         const TActorId& tablet,
         ui32 blockSize,
         ui32 maxAffectedBlocksPerCompaction,
@@ -294,6 +300,8 @@ TCompactionActor::TCompactionActor(
     : RequestInfo(std::move(requestInfo))
     , TabletId(tabletId)
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , Tablet(tablet)
     , BlockSize(blockSize)
     , MaxAffectedBlocksPerCompaction(maxAffectedBlocksPerCompaction)
@@ -384,7 +392,9 @@ NProto::TError TCompactionActor::VerifyBlockChecksums()
                 r->BlockIndex,
                 r->BlobOffset,
                 expectedChecksum,
-                DiskId);
+                DiskId,
+                CloudId,
+                FolderId);
 
             if (HasError(error)) {
                 return error;
@@ -2259,6 +2269,8 @@ void TPartitionActor::CompleteCompaction(
         args.RequestInfo,
         TabletID(),
         PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         SelfId(),
         State->GetBlockSize(),
         Config->GetMaxAffectedBlocksPerCompaction(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_confirmblobs.cpp
@@ -231,8 +231,10 @@ void TPartitionActor::HandleConfirmBlobsCompleted(
             msg->GetStatus(),
             FormatError(msg->GetError()).c_str());
         ReportConfirmBlobsError(
-            FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
+            FormatError(msg->GetError()));
         Suicide(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_loadstate.cpp
@@ -169,6 +169,9 @@ void TPartitionActor::CompleteLoadState(
         // either a race or a bug (if this situation occurs again after tablet restart)
         // example: CLOUDINC-2027
         ReportInvalidTabletConfig(
+            partitionConfig.GetDiskId(),
+            partitionConfig.GetCloudId(),
+            partitionConfig.GetFolderId(),
             TStringBuilder()
             << LogTitle.GetWithTime()
             << " tablet info differs from config: tabletChannelCount < "

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -265,6 +265,8 @@ public:
 
 private:
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
 
     const TRequestInfoPtr RequestInfo;
 
@@ -298,6 +300,8 @@ private:
 public:
     TReadBlocksActor(
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TRequestInfoPtr requestInfo,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui32 blockSize,
@@ -362,6 +366,8 @@ private:
 
 TReadBlocksActor::TReadBlocksActor(
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TRequestInfoPtr requestInfo,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui32 blockSize,
@@ -377,6 +383,8 @@ TReadBlocksActor::TReadBlocksActor(
         TVector<IProfileLog::TBlockInfo> blockInfos,
         bool waitBaseDiskRequests)
     : DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , RequestInfo(std::move(requestInfo))
     , BlockDigestGenerator(blockDigestGenerator)
     , BlockSize(blockSize)
@@ -578,7 +586,9 @@ bool TReadBlocksActor::VerifyChecksums(
             batch.Requests[i],
             batch.BlobOffsets[i],
             batch.Checksums[i],
-            DiskId);
+            DiskId,
+            CloudId,
+            FolderId);
 
         if (HasError(error)) {
             HandleError(ctx, error);
@@ -1218,7 +1228,9 @@ void TPartitionActor::CompleteReadBlocks(
     if (describeBlocksRange.Defined() || requests) {
         const auto readBlocksActorId = NCloud::Register<TReadBlocksActor>(
             ctx,
-            PartitionConfig.diskid(),
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             args.RequestInfo,
             BlockDigestGenerator,
             State->GetBlockSize(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_readblocks.cpp
@@ -264,9 +264,7 @@ public:
     };
 
 private:
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
 
     const TRequestInfoPtr RequestInfo;
 
@@ -299,9 +297,7 @@ private:
 
 public:
     TReadBlocksActor(
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TRequestInfoPtr requestInfo,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui32 blockSize,
@@ -365,9 +361,7 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 TReadBlocksActor::TReadBlocksActor(
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TRequestInfoPtr requestInfo,
         IBlockDigestGeneratorPtr blockDigestGenerator,
         ui32 blockSize,
@@ -382,9 +376,7 @@ TReadBlocksActor::TReadBlocksActor(
         TReadBlocksRequests ownRequests,
         TVector<IProfileLog::TBlockInfo> blockInfos,
         bool waitBaseDiskRequests)
-    : DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    : VolumeId(std::move(volumeId))
     , RequestInfo(std::move(requestInfo))
     , BlockDigestGenerator(blockDigestGenerator)
     , BlockSize(blockSize)
@@ -586,9 +578,9 @@ bool TReadBlocksActor::VerifyChecksums(
             batch.Requests[i],
             batch.BlobOffsets[i],
             batch.Checksums[i],
-            DiskId,
-            CloudId,
-            FolderId);
+            VolumeId->DiskId,
+            VolumeId->CloudId,
+            VolumeId->FolderId);
 
         if (HasError(error)) {
             HandleError(ctx, error);
@@ -1228,9 +1220,7 @@ void TPartitionActor::CompleteReadBlocks(
     if (describeBlocksRange.Defined() || requests) {
         const auto readBlocksActorId = NCloud::Register<TReadBlocksActor>(
             ctx,
-            PartitionConfig.GetDiskId(),
-            PartitionConfig.GetCloudId(),
-            PartitionConfig.GetFolderId(),
+            VolumeId,
             args.RequestInfo,
             BlockDigestGenerator,
             State->GetBlockSize(),

--- a/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
@@ -145,6 +145,8 @@ void TPartitionActor::HandleTrimFreshLog(
         nextPerGenerationCounter,
         std::move(freshChannels),
         PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         Config->GetTrimFreshLogTimeout());
 
     Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_trimfreshlog.cpp
@@ -144,9 +144,7 @@ void TPartitionActor::HandleTrimFreshLog(
         Executor()->Generation(),
         nextPerGenerationCounter,
         std::move(freshChannels),
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         Config->GetTrimFreshLogTimeout());
 
     Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -135,6 +135,9 @@ void TPartitionActor::WriteFreshBlocks(
             BlockDigestGenerator,
             true,   // waitForAddFreshBlocksResponseBeforeResponse
             TabletID(),
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             nullptr);   // sharedState
 
         Actors.Insert(actor);
@@ -521,6 +524,9 @@ void TPartitionActor::ZeroFreshBlocks(
             BlockDigestGenerator,
             true,   // waitForAddFreshBlocksResponseBeforeResponse
             TabletID(),
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             nullptr);   // sharedState
 
         Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_writefreshblocks.cpp
@@ -135,9 +135,7 @@ void TPartitionActor::WriteFreshBlocks(
             BlockDigestGenerator,
             true,   // waitForAddFreshBlocksResponseBeforeResponse
             TabletID(),
-            PartitionConfig.GetDiskId(),
-            PartitionConfig.GetCloudId(),
-            PartitionConfig.GetFolderId(),
+            VolumeId,
             nullptr);   // sharedState
 
         Actors.Insert(actor);
@@ -524,9 +522,7 @@ void TPartitionActor::ZeroFreshBlocks(
             BlockDigestGenerator,
             true,   // waitForAddFreshBlocksResponseBeforeResponse
             TabletID(),
-            PartitionConfig.GetDiskId(),
-            PartitionConfig.GetCloudId(),
-            PartitionConfig.GetFolderId(),
+            VolumeId,
             nullptr);   // sharedState
 
         Actors.Insert(actor);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -52,6 +52,10 @@ TPartitionActor::TPartitionActor(
     , TTabletBase(owner, std::move(storage), nullptr)
     , Config(std::move(config))
     , PartitionConfig(std::move(partitionConfig))
+    , VolumeId(MakeVolumeId(
+          PartitionConfig.GetDiskId(),
+          PartitionConfig.GetCloudId(),
+          PartitionConfig.GetFolderId()))
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , BlockDigestGenerator(std::move(blockDigestGenerator))

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.cpp
@@ -260,6 +260,9 @@ void TPartitionActor::ReassignChannelsIfNeeded(const NActors::TActorContext& ctx
         std::move(channels));
 
     ReportReassignTablet(
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         TStringBuilder() << TabletID()
                          << " Reassign request sent for channels: " << sb);
     ReassignRequestSentTs = ctx.Now();

--- a/cloud/blockstore/libs/storage/partition2/part2_actor.h
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor.h
@@ -11,6 +11,7 @@
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
 #include <cloud/blockstore/libs/diagnostics/public.h>
 #include <cloud/blockstore/libs/kikimr/helpers.h>
+#include <cloud/blockstore/libs/common/volume_id.h>
 #include <cloud/blockstore/libs/storage/api/partition2.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
@@ -99,6 +100,7 @@ private:
     const ui64 StartTime = GetCycleCount();
     const TStorageConfigPtr Config;
     const NProto::TPartitionConfig PartitionConfig;
+    const TVolumeIdConstPtr VolumeId;
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
@@ -36,6 +36,9 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
+    const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 LastGCCommitId;
     const ui64 CollectCommitId;
@@ -57,6 +60,9 @@ public:
     TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -99,6 +105,9 @@ private:
 TCollectGarbageActor::TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -111,6 +120,9 @@ TCollectGarbageActor::TCollectGarbageActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
+    , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , TabletInfo(std::move(tabletInfo))
     , LastGCCommitId(lastGCCommitId)
     , CollectCommitId(collectCommitId)
@@ -223,6 +235,9 @@ void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            DiskId,
+            CloudId,
+            FolderId,
             TStringBuilder()
             << "Garbage collection failed: " << FormatError(error));
         Error = std::move(error);
@@ -318,6 +333,9 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
+    const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 CollectCommitId;
     const ui32 RecordGeneration;
@@ -335,6 +353,9 @@ public:
     TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -369,6 +390,9 @@ private:
 TCollectGarbageHardActor::TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
+        TString diskId,
+        TString cloudId,
+        TString folderId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -378,6 +402,9 @@ TCollectGarbageHardActor::TCollectGarbageHardActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
+    , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , TabletInfo(std::move(tabletInfo))
     , CollectCommitId(collectCommitId)
     , RecordGeneration(recordGeneration)
@@ -461,6 +488,9 @@ void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
+            DiskId,
+            CloudId,
+            FolderId,
             TStringBuilder()
             << "Hard garbage collection failed: " << FormatError(error));
         Error = std::move(error);
@@ -680,6 +710,9 @@ void TPartitionActor::HandleCollectGarbage(
         ctx,
         requestInfo,
         SelfId(),
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         Info(),
         State->GetLastCollectCommitId(),
         commitId,
@@ -779,6 +812,9 @@ void TPartitionActor::CompleteCollectGarbage(
         ctx,
         args.RequestInfo,
         SelfId(),
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         Info(),
         args.CollectCommitId,
         Executor()->Generation(),

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_collectgarbage.cpp
@@ -36,9 +36,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 LastGCCommitId;
     const ui64 CollectCommitId;
@@ -60,9 +58,7 @@ public:
     TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -105,9 +101,7 @@ private:
 TCollectGarbageActor::TCollectGarbageActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 lastGCCommitId,
         ui64 collectCommitId,
@@ -120,9 +114,7 @@ TCollectGarbageActor::TCollectGarbageActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
-    , DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    , VolumeId(std::move(volumeId))
     , TabletInfo(std::move(tabletInfo))
     , LastGCCommitId(lastGCCommitId)
     , CollectCommitId(collectCommitId)
@@ -235,9 +227,7 @@ void TCollectGarbageActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
-            DiskId,
-            CloudId,
-            FolderId,
+            VolumeId,
             TStringBuilder()
             << "Garbage collection failed: " << FormatError(error));
         Error = std::move(error);
@@ -333,9 +323,7 @@ private:
     const TRequestInfoPtr RequestInfo;
 
     const TActorId Tablet;
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
     const TTabletStorageInfoPtr TabletInfo;
     const ui64 CollectCommitId;
     const ui32 RecordGeneration;
@@ -353,9 +341,7 @@ public:
     TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -390,9 +376,7 @@ private:
 TCollectGarbageHardActor::TCollectGarbageHardActor(
         TRequestInfoPtr requestInfo,
         const TActorId& tablet,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TTabletStorageInfoPtr tabletInfo,
         ui64 collectCommitId,
         ui32 recordGeneration,
@@ -402,9 +386,7 @@ TCollectGarbageHardActor::TCollectGarbageHardActor(
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , Tablet(tablet)
-    , DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    , VolumeId(std::move(volumeId))
     , TabletInfo(std::move(tabletInfo))
     , CollectCommitId(collectCommitId)
     , RecordGeneration(recordGeneration)
@@ -488,9 +470,7 @@ void TCollectGarbageHardActor::HandleError(NProto::TError error)
 {
     if (FAILED(error.GetCode())) {
         ReportCollectGarbageError(
-            DiskId,
-            CloudId,
-            FolderId,
+            VolumeId,
             TStringBuilder()
             << "Hard garbage collection failed: " << FormatError(error));
         Error = std::move(error);
@@ -710,9 +690,7 @@ void TPartitionActor::HandleCollectGarbage(
         ctx,
         requestInfo,
         SelfId(),
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         Info(),
         State->GetLastCollectCommitId(),
         commitId,
@@ -812,9 +790,7 @@ void TPartitionActor::CompleteCollectGarbage(
         ctx,
         args.RequestInfo,
         SelfId(),
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         Info(),
         args.CollectCommitId,
         Executor()->Generation(),

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_initfreshblocks.cpp
@@ -133,6 +133,9 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
             << " reason: " << msg->GetError().GetMessage().Quote());
 
         ReportInitFreshBlocksError(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder()
             << "[" << TabletID()
             << "] LoadFreshBlobs failed: " << msg->GetStatus());
@@ -166,6 +169,9 @@ void TPartitionActor::HandleLoadFreshBlobsCompleted(
                 << FormatError(error));
 
             ReportInitFreshBlocksError(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                 << "[" << TabletID() << "] Failed to parse fresh blob "
                 << "(blob commitId: " << blob.CommitId << ")");

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_loadstate.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_loadstate.cpp
@@ -156,6 +156,9 @@ void TPartitionActor::CompleteLoadState(
 
     if (tabletChannelCount != configChannelCount) {
         ReportInvalidTabletConfig(
+            args.Meta->GetConfig().GetDiskId(),
+            args.Meta->GetConfig().GetCloudId(),
+            args.Meta->GetConfig().GetFolderId(),
             TStringBuilder()
             << "[" << TabletID() << "] "
             << "tablet info differs from config: "

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_readblob.cpp
@@ -438,6 +438,9 @@ void TPartitionActor::HandleReadBlobCompleted(
                 >= Config->GetMaxReadBlobErrorsBeforeSuicide())
         {
             ReportTabletBSFailure(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                 << TabletID()
                 << " Stop tablet because of too many ReadBlob errors (actor "

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
@@ -131,7 +131,9 @@ void TPartitionActor::HandleTrimFreshLog(
         ParseCommitId(State->GetLastCommitId()).first,
         nextPerGenerationCounter,
         std::move(freshChannels),
-        "",
+        PartitionConfig.GetDiskId(),
+        PartitionConfig.GetCloudId(),
+        PartitionConfig.GetFolderId(),
         Config->GetTrimFreshLogTimeout());
 
     Actors.insert(actor);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_trimfreshlog.cpp
@@ -131,9 +131,7 @@ void TPartitionActor::HandleTrimFreshLog(
         ParseCommitId(State->GetLastCommitId()).first,
         nextPerGenerationCounter,
         std::move(freshChannels),
-        PartitionConfig.GetDiskId(),
-        PartitionConfig.GetCloudId(),
-        PartitionConfig.GetFolderId(),
+        VolumeId,
         Config->GetTrimFreshLogTimeout());
 
     Actors.insert(actor);

--- a/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition2/part2_actor_writeblob.cpp
@@ -380,6 +380,9 @@ void TPartitionActor::HandleWriteBlobCompleted(
 
     if (FAILED(msg->GetStatus())) {
         ReportTabletBSFailure(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder()
             << TabletID() << " Stop tablet because of WriteBlob error (actor "
             << ev->Sender.ToString() << " group " << group

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
@@ -26,9 +26,7 @@ TTrimFreshLogActor::TTrimFreshLogActor(
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , PartitionActorId(partitionActorId)
@@ -37,9 +35,7 @@ TTrimFreshLogActor::TTrimFreshLogActor(
     , RecordGeneration(recordGeneration)
     , PerGenerationCounter(perGenerationCounter)
     , FreshChannels(std::move(freshChannels))
-    , DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    , VolumeId(std::move(volumeId))
     , Timeout(timeout)
 {}
 
@@ -145,16 +141,12 @@ void TTrimFreshLogActor::HandleCollectGarbageResult(
              {{"TabletId", TabletInfo->TabletID}};
         if (msg->Status == NKikimrProto::EReplyStatus::DEADLINE) {
             ReportTrimFreshLogTimeout(
-                DiskId,
-                CloudId,
-                FolderId,
+                VolumeId,
                 FormatError(error),
                 critEventParams);
         } else {
             ReportTrimFreshLogError(
-                DiskId,
-                CloudId,
-                FolderId,
+                VolumeId,
                 FormatError(error),
                 critEventParams);
         }

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.cpp
@@ -27,6 +27,8 @@ TTrimFreshLogActor::TTrimFreshLogActor(
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TDuration timeout)
     : RequestInfo(std::move(requestInfo))
     , PartitionActorId(partitionActorId)
@@ -36,6 +38,8 @@ TTrimFreshLogActor::TTrimFreshLogActor(
     , PerGenerationCounter(perGenerationCounter)
     , FreshChannels(std::move(freshChannels))
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , Timeout(timeout)
 {}
 
@@ -138,11 +142,21 @@ void TTrimFreshLogActor::HandleCollectGarbageResult(
         HasError(error))
     {
         TCritEventParams critEventParams =
-             {{"disk", DiskId}, {"TabletId", TabletInfo->TabletID}};
+             {{"TabletId", TabletInfo->TabletID}};
         if (msg->Status == NKikimrProto::EReplyStatus::DEADLINE) {
-            ReportTrimFreshLogTimeout(FormatError(error), critEventParams);
+            ReportTrimFreshLogTimeout(
+                DiskId,
+                CloudId,
+                FolderId,
+                FormatError(error),
+                critEventParams);
         } else {
-            ReportTrimFreshLogError(FormatError(error), critEventParams);
+            ReportTrimFreshLogError(
+                DiskId,
+                CloudId,
+                FolderId,
+                FormatError(error),
+                critEventParams);
         }
         Error = std::move(error);
     }

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
+#include <cloud/blockstore/libs/common/volume_id.h>
 #include <cloud/storage/core/libs/common/error.h>
 
 #include <contrib/ydb/core/base/blobstorage.h>
@@ -26,9 +27,7 @@ private:
     const ui32 RecordGeneration;
     const ui32 PerGenerationCounter;
     const TVector<ui32> FreshChannels;
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
     const TDuration Timeout;
 
     ui32 RequestsInFlight = 0;
@@ -43,9 +42,7 @@ public:
         ui32 recordGeneration,
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TDuration timeout);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_trimfreshlog.h
@@ -27,6 +27,8 @@ private:
     const ui32 PerGenerationCounter;
     const TVector<ui32> FreshChannels;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TDuration Timeout;
 
     ui32 RequestsInFlight = 0;
@@ -42,6 +44,8 @@ public:
         ui32 perGenerationCounter,
         TVector<ui32> freshChannels,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TDuration timeout);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.cpp
@@ -31,9 +31,7 @@ TWriteFreshBlocksActor::TWriteFreshBlocksActor(
         IBlockDigestGeneratorPtr blockDigestGenerator,
         bool waitForAddFreshBlocksResponseBeforeResponse,
         ui64 tabletId,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TPartitionThreadSafeStatePtr sharedState)
     : Owner(owner)
     , ActorToAddFreshBlocks(actorToAddFreshBlocks)
@@ -50,9 +48,7 @@ TWriteFreshBlocksActor::TWriteFreshBlocksActor(
     , WaitForAddFreshBlocksResponseBeforeResponse(
           waitForAddFreshBlocksResponseBeforeResponse)
     , TabletId(tabletId)
-    , DiskId(std::move(diskId))
-    , CloudId(std::move(cloudId))
-    , FolderId(std::move(folderId))
+    , VolumeId(std::move(volumeId))
     , SharedState(std::move(sharedState))
 {
     if (!IsZeroRequest) {
@@ -376,12 +372,10 @@ void TWriteFreshBlocksActor::HandleAddFreshBlocksResponse(
         error.GetCode() != E_CANCELLED)
     {
         ReportAddFreshBlocksResultedInError(
-            DiskId,
-            CloudId,
-            FolderId,
+            VolumeId,
             "unexpected error in AddFreshBlocksResponse",
-            {{"error", FormatError(ev->Get()->GetError())},
-             {"tabletId", TabletId}});
+            TCritEventParams{{"error", FormatError(ev->Get()->GetError())},
+                             {"tabletId", TabletId}});
 
         // If WaitForAddFreshBlocksResponseBeforeResponse is false, this means
         // that we responded to the client with success before adding the blocks

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.cpp
@@ -31,6 +31,9 @@ TWriteFreshBlocksActor::TWriteFreshBlocksActor(
         IBlockDigestGeneratorPtr blockDigestGenerator,
         bool waitForAddFreshBlocksResponseBeforeResponse,
         ui64 tabletId,
+        TString diskId,
+        TString cloudId,
+        TString folderId,
         TPartitionThreadSafeStatePtr sharedState)
     : Owner(owner)
     , ActorToAddFreshBlocks(actorToAddFreshBlocks)
@@ -47,6 +50,9 @@ TWriteFreshBlocksActor::TWriteFreshBlocksActor(
     , WaitForAddFreshBlocksResponseBeforeResponse(
           waitForAddFreshBlocksResponseBeforeResponse)
     , TabletId(tabletId)
+    , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , SharedState(std::move(sharedState))
 {
     if (!IsZeroRequest) {
@@ -370,6 +376,9 @@ void TWriteFreshBlocksActor::HandleAddFreshBlocksResponse(
         error.GetCode() != E_CANCELLED)
     {
         ReportAddFreshBlocksResultedInError(
+            DiskId,
+            CloudId,
+            FolderId,
             "unexpected error in AddFreshBlocksResponse",
             {{"error", FormatError(ev->Get()->GetError())},
              {"tabletId", TabletId}});

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
@@ -3,6 +3,7 @@
 #include "events_private.h"
 
 #include <cloud/blockstore/libs/diagnostics/profile_log.h>
+#include <cloud/blockstore/libs/common/volume_id.h>
 #include <cloud/blockstore/libs/storage/api/service.h>
 #include <cloud/blockstore/libs/storage/core/request_info.h>
 
@@ -59,9 +60,7 @@ private:
     const bool IsZeroRequest;
     const bool WaitForAddFreshBlocksResponseBeforeResponse;
     const ui64 TabletId;
-    const TString DiskId;
-    const TString CloudId;
-    const TString FolderId;
+    const TVolumeIdConstPtr VolumeId;
 
     TPartitionThreadSafeStatePtr SharedState;
 
@@ -88,9 +87,7 @@ public:
         IBlockDigestGeneratorPtr blockDigestGenerator,
         bool waitForAddFreshBlocksResponseBeforeResponse,
         ui64 tabletId,
-        TString diskId,
-        TString cloudId,
-        TString folderId,
+        TVolumeIdConstPtr volumeId,
         TPartitionThreadSafeStatePtr sharedState);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
+++ b/cloud/blockstore/libs/storage/partition_common/actor_writefreshblocks.h
@@ -59,6 +59,9 @@ private:
     const bool IsZeroRequest;
     const bool WaitForAddFreshBlocksResponseBeforeResponse;
     const ui64 TabletId;
+    const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
 
     TPartitionThreadSafeStatePtr SharedState;
 
@@ -85,6 +88,9 @@ public:
         IBlockDigestGeneratorPtr blockDigestGenerator,
         bool waitForAddFreshBlocksResponseBeforeResponse,
         ui64 tabletId,
+        TString diskId,
+        TString cloudId,
+        TString folderId,
         TPartitionThreadSafeStatePtr sharedState);
 
     void Bootstrap(const NActors::TActorContext& ctx);

--- a/cloud/blockstore/libs/storage/partition_common/fresh_blocks_companion_initfreshblocks.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/fresh_blocks_companion_initfreshblocks.cpp
@@ -40,9 +40,11 @@ void TFreshBlocksCompanion::HandleLoadFreshBlobsCompleted(
 
     if (FAILED(msg->GetStatus())) {
         ReportInitFreshBlocksError(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder() << "LoadFreshBlobs failed, error: "
-                             << FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+                             << FormatError(msg->GetError()));
         Client.Poison(ctx);
         return;
     }
@@ -66,10 +68,12 @@ void TFreshBlocksCompanion::HandleLoadFreshBlobsCompleted(
 
         if (FAILED(error.GetCode())) {
             ReportInitFreshBlocksError(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder() << "Failed to parse fresh blob error: "
                                  << FormatError(error),
-                {{"disk", PartitionConfig.GetDiskId()},
-                 {"commit_id", blob.CommitId}});
+                {{"commit_id", blob.CommitId}});
             Client.Poison(ctx);
             return;
         }

--- a/cloud/blockstore/libs/storage/partition_common/io_companion_patchblob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/io_companion_patchblob.cpp
@@ -351,9 +351,11 @@ void TIOCompanion::HandlePatchBlobCompleted(
 
     if (FAILED(msg->GetStatus())) {
         ReportTabletBSFailure(
+            PartitionConfig.GetDiskId(),
+            PartitionConfig.GetCloudId(),
+            PartitionConfig.GetFolderId(),
             TStringBuilder() << "Stop tablet because of PatchBlob error: "
-                             << FormatError(msg->GetError()),
-            {{"disk", PartitionConfig.GetDiskId()}});
+                             << FormatError(msg->GetError()));
         Client.Poison(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/partition_common/io_companion_readblob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/io_companion_readblob.cpp
@@ -182,11 +182,13 @@ void TIOCompanion::HandleReadBlobCompleted(
         if (++ReadBlobErrorCount >= Config->GetMaxReadBlobErrorsBeforeSuicide())
         {
             ReportTabletBSFailure(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                     << "Stop tablet because of too many ReadBlob errors"
                     << FormatError(msg->GetError()),
-                {{"disk", PartitionConfig.GetDiskId()},
-                 {"actor", ev->Sender.ToString()},
+                {{"actor", ev->Sender.ToString()},
                  {"group", groupId}});
             Client.Poison(ctx);
             return;

--- a/cloud/blockstore/libs/storage/partition_common/io_companion_writeblob.cpp
+++ b/cloud/blockstore/libs/storage/partition_common/io_companion_writeblob.cpp
@@ -469,11 +469,13 @@ void TIOCompanion::HandleWriteBlobCompleted(
             Config->GetMaxWriteBlobErrorsBeforeSuicide())
         {
             ReportTabletBSFailure(
+                PartitionConfig.GetDiskId(),
+                PartitionConfig.GetCloudId(),
+                PartitionConfig.GetFolderId(),
                 TStringBuilder()
                     << "Stop tablet because of too many WriteBlob errors"
                     << FormatError(msg->GetError()),
-                {{"disk", PartitionConfig.GetDiskId()},
-                 {"actor", ev->Sender.ToString()},
+                {{"actor", ev->Sender.ToString()},
                  {"group", groupId}});
             Client.Poison(ctx);
             return;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/config.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/config.h
@@ -55,6 +55,8 @@ public:
         TInstant CreationTs;
         NProto::EStorageMediaKind MediaKind;
         NProto::EEncryptionMode EncryptionMode;
+        TString CloudId;
+        TString FolderId;
     };
 
     struct TNonreplicatedPartitionConfigInitParams
@@ -186,6 +188,16 @@ public:
     const TVolumeInfo& GetVolumeInfo() const
     {
         return VolumeInfo;
+    }
+
+    const TString& GetCloudId() const
+    {
+        return VolumeInfo.CloudId;
+    }
+
+    const TString& GetFolderId() const
+    {
+        return VolumeInfo.FolderId;
     }
 
     NActors::TActorId GetParentActorId() const

--- a/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/lagging_agent_migration_actor.cpp
@@ -28,6 +28,8 @@ TLaggingAgentMigrationActor::TLaggingAgentMigrationActor(
           config,
           std::move(diagnosticsConfig),
           partConfig->GetName(),
+          partConfig->GetCloudId(),
+          partConfig->GetFolderId(),
           partConfig->GetBlockCount(),
           partConfig->GetBlockSize(),
           std::move(profileLog),

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.cpp
@@ -69,6 +69,8 @@ TMirrorPartitionActor::TMirrorPartitionActor(
     , RdmaClient(std::move(rdmaClient))
     , PartitionBudgetManager(std::move(partitionBudgetManager))
     , DiskId(partConfig->GetName())
+    , CloudId(partConfig->GetCloudId())
+    , FolderId(partConfig->GetFolderId())
     , VolumeActorId(volumeActorId)
     , StatActorId(statActorId)
     , ResyncActorId(resyncActorId)
@@ -256,10 +258,16 @@ void TMirrorPartitionActor::CompareChecksums(const TActorContext& ctx)
         const bool hasQuorum = majorCount > checksums.size() / 2;
         if (hasQuorum) {
             ReportMirroredDiskMinorityChecksumMismatch(
-                {{"disk", DiskId}, {"range", GetScrubbingRange()}});
+                DiskId,
+                CloudId,
+                FolderId,
+                {{"range", GetScrubbingRange()}});
         } else {
             ReportMirroredDiskMajorityChecksumMismatch(
-                {{"disk", DiskId}, {"range", GetScrubbingRange()}});
+                DiskId,
+                CloudId,
+                FolderId,
+                {{"range", GetScrubbingRange()}});
         }
         if (Config->GetResyncRangeAfterScrubbing() &&
             CanFixMismatch(hasQuorum, Config->GetScrubbingResyncPolicy()))
@@ -714,8 +722,11 @@ void TMirrorPartitionActor::HandleAddTagsResponse(
 
     if (HasError(error)) {
         ReportMirroredDiskAddTagFailed(
+            DiskId,
+            CloudId,
+            FolderId,
             FormatError(error),
-            {{"disk", DiskId}, {"tag", IntermediateWriteBufferTagName}});
+            {{"tag", IntermediateWriteBufferTagName}});
         return;
     }
     LOG_WARN(

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor.h
@@ -75,6 +75,8 @@ private:
     NCloud::NStorage::NRdma::IClientPtr RdmaClient;
     const TPartitionBudgetManagerPtr PartitionBudgetManager;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const NActors::TActorId VolumeActorId;
     const NActors::TActorId StatActorId;
     const NActors::TActorId ResyncActorId;

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_actor_mirror.cpp
@@ -66,8 +66,10 @@ void TMirrorPartitionActor::HandleMirroredReadCompleted(
     if (it == DirtyReadRequestIds.end()) {
         if (ev->Get()->ChecksumMismatchObserved) {
             ReportMirroredDiskChecksumMismatchUponRead(
-                {{"disk", DiskId},
-                 {"range", (requestCtx ? requestCtx->Range.Print() : "")}});
+                DiskId,
+                CloudId,
+                FolderId,
+                {{"range", (requestCtx ? requestCtx->Range.Print() : "")}});
         }
     } else {
         DirtyReadRequestIds.erase(it);

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_mirror_resync_actor_resync.cpp
@@ -245,9 +245,11 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
             ScheduleRetryResyncNextRange(ctx);
         } else {
             ReportResyncFailed(
+                PartConfig->GetName(),
+                PartConfig->GetCloudId(),
+                PartConfig->GetFolderId(),
                 FormatError(msg->GetError()),
-                {{"disk", PartConfig->GetName()},
-                 {"range", DescribeRange(range)}});
+                {{"range", DescribeRange(range)}});
         }
 
         TDeque<TPostponedRead> postponedReads;
@@ -276,7 +278,10 @@ void TMirrorPartitionResyncActor::HandleRangeResynced(
 
     if (CritOnChecksumMismatch && msg->WriteStartTs > TInstant()) {
         ReportMirroredDiskResyncChecksumMismatch(
-            {{"disk", PartConfig->GetName()}, {"range", range}});
+            PartConfig->GetName(),
+            PartConfig->GetCloudId(),
+            PartConfig->GetFolderId(),
+            {{"range", range}});
     }
 
     auto resyncRange = State.BuildResyncRange();

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_actor.cpp
@@ -325,7 +325,10 @@ bool TNonreplicatedPartitionActor::InitRequests(
             NProto::ERequestSplitterPolicy::RSP_ENABLE_WITH_CRIT_EVENT)
     {
         ReportCrossPartitionRequestDetected(
-            {{"disk", PartConfig->GetName()}, {"range", blockRange}});
+            PartConfig->GetName(),
+            PartConfig->GetCloudId(),
+            PartConfig->GetFolderId(),
+            {{"range", blockRange}});
     }
 
     if (deviceRequests->empty()) {

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_actor.cpp
@@ -33,6 +33,8 @@ TNonreplicatedPartitionMigrationActor::TNonreplicatedPartitionMigrationActor(
           config,
           std::move(diagnosticsConfig),
           srcConfig->GetName(),
+          srcConfig->GetCloudId(),
+          srcConfig->GetFolderId(),
           srcConfig->GetBlockCount(),
           srcConfig->GetBlockSize(),
           std::move(profileLog),
@@ -233,9 +235,11 @@ NActors::TActorId TNonreplicatedPartitionMigrationActor::CreateDstActor(
 
             if (device.GetBlocksCount() != target.GetBlocksCount()) {
                 ReportBadMigrationConfig(
+                    SrcConfig->GetName(),
+                    SrcConfig->GetCloudId(),
+                    SrcConfig->GetFolderId(),
                     "source != target blocks count",
-                    {{"disk", SrcConfig->GetName()},
-                     {"source", device.GetDeviceUUID()},
+                    {{"source", device.GetDeviceUUID()},
                      {"source_blocks_count", device.GetBlocksCount()},
                      {"target", target.GetDeviceUUID()},
                      {"target_blocks_count", target.GetBlocksCount()}});
@@ -293,8 +297,10 @@ void TNonreplicatedPartitionMigrationActor::HandleFinishMigrationResponse(
 
         if (GetErrorKind(error) != EErrorKind::ErrorRetriable) {
             ReportMigrationFailed(
-                "Finish migration failed",
-                {{"disk", SrcConfig->GetName()}});
+                SrcConfig->GetName(),
+                SrcConfig->GetCloudId(),
+                SrcConfig->GetFolderId(),
+                "Finish migration failed");
             return;
         }
     }

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.cpp
@@ -22,6 +22,8 @@ TNonreplicatedPartitionMigrationCommonActor::
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,
@@ -37,6 +39,8 @@ TNonreplicatedPartitionMigrationCommonActor::
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , BlockSize(blockSize)
     , BlockCount(blockCount)
     , BlockDigestGenerator(std::move(digestGenerator))
@@ -63,6 +67,8 @@ TNonreplicatedPartitionMigrationCommonActor::
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,
@@ -77,6 +83,8 @@ TNonreplicatedPartitionMigrationCommonActor::
     , DiagnosticsConfig(std::move(diagnosticsConfig))
     , ProfileLog(std::move(profileLog))
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , BlockSize(blockSize)
     , BlockCount(blockCount)
     , BlockDigestGenerator(std::move(digestGenerator))

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor.h
@@ -131,6 +131,8 @@ private:
     const TDiagnosticsConfigPtr DiagnosticsConfig;
     const IProfileLogPtr ProfileLog;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const ui64 BlockSize;
     const ui64 BlockCount;
     const IBlockDigestGeneratorPtr BlockDigestGenerator;
@@ -212,6 +214,8 @@ public:
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,
@@ -228,6 +232,8 @@ public:
         TStorageConfigPtr config,
         TDiagnosticsConfigPtr diagnosticsConfig,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         ui64 blockCount,
         ui64 blockSize,
         IProfileLogPtr profileLog,

--- a/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
+++ b/cloud/blockstore/libs/storage/partition_nonrepl/part_nonrepl_migration_common_actor_migration.cpp
@@ -447,8 +447,10 @@ void TNonreplicatedPartitionMigrationCommonActor::OnMigrationNonRetriableError(
     const NActors::TActorContext& ctx)
 {
     ReportMigrationFailed(
-        "Non-retriable migration error occurred",
-        {{"disk", DiskId}});
+        DiskId,
+        CloudId,
+        FolderId,
+        "Non-retriable migration error occurred");
     MigrationOwner->OnMigrationError(ctx);
     MigrationEnabled = false;
 }

--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.cpp
@@ -50,6 +50,8 @@ TFollowerDiskActor::TFollowerDiskActor(
           config,
           std::move(diagnosticConfig),
           params.LeaderDiskId,
+          params.LeaderCloudId,
+          params.LeaderFolderId,
           params.LeaderBlockCount,
           params.LeaderBlockSize,
           std::move(profileLog),

--- a/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/follower_disk_actor.h
@@ -15,6 +15,8 @@ struct TFollowerDiskActorParams
     const NProto::EStorageMediaKind LeaderMediaKind =
         NProto::EStorageMediaKind::STORAGE_MEDIA_DEFAULT;
     const TString LeaderDiskId;
+    const TString LeaderCloudId;
+    const TString LeaderFolderId;
     const ui64 LeaderBlockCount = 0;
     const ui32 LeaderBlockSize = 0;
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.cpp
@@ -38,12 +38,16 @@ TMultiPartitionWrapperActor::TMultiPartitionWrapperActor(
     TChildLogTitle logTitle,
     ITraceSerializerPtr traceSerializer,
     const TString& diskId,
+    const TString& cloudId,
+    const TString& folderId,
     ui32 blockSize,
     ui32 blocksPerStripe,
     NProto::ERequestSplitterPolicy splitterPolicy,
     const TVector<NActors::TActorId>& partitionActors)
     : LogTitle(std::move(logTitle))
     , TraceSerializer(std::move(traceSerializer))
+    , CloudId(cloudId)
+    , FolderId(folderId)
     , BlockSize(blockSize)
     , BlocksPerStripe(blocksPerStripe)
     , SplitterPolicy(splitterPolicy)
@@ -187,7 +191,10 @@ void TMultiPartitionWrapperActor::HandleRequest(
             isCrossPartitionRequest)
         {
             ReportCrossPartitionRequestDetected(
-                {{"disk", Partitions.front().DiskId}, {"range", blockRange}});
+                Partitions.front().DiskId,
+                CloudId,
+                FolderId,
+                {{"range", blockRange}});
         }
     }
 

--- a/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.h
+++ b/cloud/blockstore/libs/storage/volume/actors/multi_partition_wrapper_actor.h
@@ -24,6 +24,8 @@ class TMultiPartitionWrapperActor final
 private:
     const TChildLogTitle LogTitle;
     const ITraceSerializerPtr TraceSerializer;
+    const TString CloudId;
+    const TString FolderId;
     const ui32 BlockSize = 0;
     const ui32 BlocksPerStripe = 0;
     const NProto::ERequestSplitterPolicy SplitterPolicy =
@@ -35,6 +37,8 @@ public:
         TChildLogTitle logTitle,
         ITraceSerializerPtr traceSerializer,
         const TString& diskId,
+        const TString& cloudId,
+        const TString& folderId,
         ui32 blockSize,
         ui32 blocksPerStripe,
         NProto::ERequestSplitterPolicy splitterPolicy,

--- a/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/actors/shadow_disk_actor.cpp
@@ -562,6 +562,8 @@ TShadowDiskActor::TShadowDiskActor(
           config,
           std::move(diagnosticConfig),
           srcConfig->GetName(),
+          srcConfig->GetCloudId(),
+          srcConfig->GetFolderId(),
           srcConfig->GetBlockCount(),
           srcConfig->GetBlockSize(),
           std::move(profileLog),
@@ -822,7 +824,9 @@ void TShadowDiskActor::CreateShadowDiskConfig()
         .CreationTs = TInstant(),
         .MediaKind =
             GetCheckpointShadowDiskType(SrcConfig->GetVolumeInfo().MediaKind),
-        .EncryptionMode = SrcConfig->GetVolumeInfo().EncryptionMode};
+        .EncryptionMode = SrcConfig->GetVolumeInfo().EncryptionMode,
+        .CloudId = SrcConfig->GetVolumeInfo().CloudId,
+        .FolderId = SrcConfig->GetVolumeInfo().FolderId};
 
     TNonreplicatedPartitionConfig::TNonreplicatedPartitionConfigInitParams
         params{

--- a/cloud/blockstore/libs/storage/volume/model/helpers.cpp
+++ b/cloud/blockstore/libs/storage/volume/model/helpers.cpp
@@ -95,9 +95,11 @@ std::optional<TDeviceLocation> FindTargetMigrationDeviceLocation(
             FindReplicaDeviceLocation(meta, migration.GetSourceDeviceId());
         if (!sourceLocation) {
             ReportDiskAllocationFailure(
+                meta.GetConfig().GetDiskId(),
+                meta.GetConfig().GetCloudId(),
+                meta.GetConfig().GetFolderId(),
                 "Migration source device not found",
-                {{"disk", meta.GetConfig().GetDiskId()},
-                 {"target_device", migration.GetTargetDevice().GetDeviceUUID()},
+                {{"target_device", migration.GetTargetDevice().GetDeviceUUID()},
                  {"source_device", migration.GetSourceDeviceId()}});
             continue;
         }
@@ -192,9 +194,11 @@ TVector<NProto::TLaggingDevice> CollectLaggingDevices(
                 FindReplicaDeviceLocation(meta, migration.GetSourceDeviceId());
             if (!deviceLocation) {
                 ReportDiskAllocationFailure(
+                    meta.GetConfig().GetDiskId(),
+                    meta.GetConfig().GetCloudId(),
+                    meta.GetConfig().GetFolderId(),
                     "Migration inconsistency detected",
-                    {{"disk", meta.GetConfig().GetDiskId()},
-                     {"target_device", targetDevice.GetDeviceUUID()},
+                    {{"target_device", targetDevice.GetDeviceUUID()},
                      {"source_device", migration.GetSourceDeviceId()}});
                 continue;
             }

--- a/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_allocatedisk.cpp
@@ -379,8 +379,10 @@ void TVolumeActor::HandleAllocateDiskError(
     if (error.GetCode() != E_BS_RESOURCE_EXHAUSTED && !localDiskAllocationRetry)
     {
         ReportDiskAllocationFailure(
-            "allocation failed",
-            {{"disk", GetNewestConfig().GetDiskId()}});
+            GetNewestConfig().GetDiskId(),
+            GetNewestConfig().GetCloudId(),
+            GetNewestConfig().GetFolderId(),
+            "allocation failed");
     }
     LOG_ERROR(
         ctx,
@@ -615,8 +617,10 @@ bool TVolumeActor::CheckAllocationResult(
 
     if (!ok) {
         ReportDiskAllocationFailure(
-            "invalid disk allocation response received",
-            {{"disk", State->GetDiskId()}});
+            State->GetDiskId(),
+            State->GetMeta().GetVolumeConfig().GetCloudId(),
+            State->GetMeta().GetVolumeConfig().GetFolderId(),
+            "invalid disk allocation response received");
 
         if (State->GetAcceptInvalidDiskAllocationResponse()) {
             LOG_WARN(

--- a/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_checkpoint.cpp
@@ -177,6 +177,8 @@ private:
     const TRequestInfoPtr RequestInfo;
     const ui64 RequestId;
     const TString DiskId;
+    const TString CloudId;
+    const TString FolderId;
     const TString CheckpointId;
     const ui64 VolumeTabletId;
     const TActorId VolumeActorId;
@@ -203,6 +205,8 @@ public:
         TRequestInfoPtr requestInfo,
         ui64 requestId,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TString checkpointId,
         ui64 volumeTabletId,
         TActorId volumeActorId,
@@ -297,6 +301,8 @@ TCheckpointActor<TMethod>::TCheckpointActor(
         TRequestInfoPtr requestInfo,
         ui64 requestId,
         TString diskId,
+        TString cloudId,
+        TString folderId,
         TString checkpointId,
         ui64 volumeTabletId,
         TActorId volumeActorId,
@@ -311,6 +317,8 @@ TCheckpointActor<TMethod>::TCheckpointActor(
     : RequestInfo(std::move(requestInfo))
     , RequestId(requestId)
     , DiskId(std::move(diskId))
+    , CloudId(std::move(cloudId))
+    , FolderId(std::move(folderId))
     , CheckpointId(std::move(checkpointId))
     , VolumeTabletId(volumeTabletId)
     , VolumeActorId(volumeActorId)
@@ -779,6 +787,9 @@ void TCheckpointActor<TMethod>::HandleReleaseDiskResponse(
         }
 
         ReportReleaseShadowDiskError(
+            DiskId,
+            CloudId,
+            FolderId,
             FormatError(record.GetError()),
             {{"ShadowDiskId", ShadowDiskId}});
     }
@@ -1555,6 +1566,8 @@ void TVolumeActor::ExecuteCheckpointRequest(const TActorContext& ctx, ui64 reque
                     requestInfo->RequestInfo,
                     request.RequestId,
                     State->GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     request.CheckpointId,
                     TabletID(),
                     SelfId(),
@@ -1586,6 +1599,8 @@ void TVolumeActor::ExecuteCheckpointRequest(const TActorContext& ctx, ui64 reque
                     requestInfo->RequestInfo,
                     request.RequestId,
                     State->GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     request.CheckpointId,
                     TabletID(),
                     SelfId(),
@@ -1611,6 +1626,8 @@ void TVolumeActor::ExecuteCheckpointRequest(const TActorContext& ctx, ui64 reque
                     requestInfo->RequestInfo,
                     request.RequestId,
                     State->GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     request.CheckpointId,
                     TabletID(),
                     SelfId(),

--- a/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_forward.cpp
@@ -999,8 +999,10 @@ void TVolumeActor::ForwardRequest(
                                   ORP_ENABLE_WITH_CRIT_EVENT)
                 {
                     ReportOverlappingRequestsDetected(
-                        {{"disk", State->GetDiskId()},
-                         {"Inflight", *addResult.InflightRange},
+                        State->GetDiskId(),
+                        State->GetMeta().GetVolumeConfig().GetCloudId(),
+                        State->GetMeta().GetVolumeConfig().GetFolderId(),
+                        {{"Inflight", *addResult.InflightRange},
                          {"New", blockRange}});
                 }
 

--- a/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_startstop.cpp
@@ -158,6 +158,8 @@ void TVolumeActor::OnPartitionStateChanged(
                     LogTitle.GetChild(GetCycleCount()),
                     TraceSerializer,
                     GetDiskId(),
+                    State->GetMeta().GetVolumeConfig().GetCloudId(),
+                    State->GetMeta().GetVolumeConfig().GetFolderId(),
                     State->GetMeta().GetVolumeConfig().GetBlockSize(),
                     State->GetMeta().GetVolumeConfig().GetBlocksPerStripe(),
                     Config->GetRequestSplitterPolicy(),
@@ -246,7 +248,9 @@ void TVolumeActor::SetupDiskRegistryBasedPartitions(const TActorContext& ctx)
                 .CreationTs = State->GetCreationTs(),
                 .MediaKind = mediaKind,
                 .EncryptionMode = static_cast<NProto::EEncryptionMode>(
-                    volumeConfig.GetEncryptionDesc().GetMode())},
+                    volumeConfig.GetEncryptionDesc().GetMode()),
+                .CloudId = volumeConfig.GetCloudId(),
+                .FolderId = volumeConfig.GetFolderId()},
             State->GetDiskId(),
             State->GetMeta().GetConfig().GetBlockSize(),
             SelfId(),
@@ -441,6 +445,10 @@ TActorsStack TVolumeActor::WrapWithFollowerActorIfNeeded(
                     TFollowerDiskActorParams{
                         .LeaderMediaKind = State->GetStorageMediaKind(),
                         .LeaderDiskId = State->GetDiskId(),
+                        .LeaderCloudId =
+                            State->GetConfig().GetCloudId(),
+                        .LeaderFolderId =
+                            State->GetConfig().GetFolderId(),
                         .LeaderBlockCount = State->GetBlocksCount(),
                         .LeaderBlockSize = State->GetBlockSize(),
                         .LeaderVolumeActorId = SelfId(),

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -455,6 +455,8 @@ public:
         TDeviceHandlerParams params{
             .Storage = std::move(storage),
             .DiskId = options.DiskId,
+            .CloudId = options.CloudId,
+            .FolderId = options.FolderId,
             .ClientId = options.ClientId,
             .BlockSize = options.BlockSize,
             .MaxZeroBlocksSubRequestSize = options.MaxZeroBlocksSubRequestSize,

--- a/cloud/blockstore/libs/vhost/server.h
+++ b/cloud/blockstore/libs/vhost/server.h
@@ -23,6 +23,8 @@ struct TStorageOptions
 {
     TString DeviceName;
     TString DiskId;
+    TString CloudId;
+    TString FolderId;
     TString ClientId;
     ui32 BlockSize = 0;
     ui64 BlocksCount = 0;

--- a/cloud/blockstore/vhost-server/critical_event.cpp
+++ b/cloud/blockstore/vhost-server/critical_event.cpp
@@ -30,7 +30,7 @@ void ReportCriticalEvent(TString sensorName, TString message)
         TStringBuilder fullMessage;
         fullMessage << "CRITICAL_EVENT:" << sensorName;
         if (message) {
-            fullMessage << ":" << message;
+            fullMessage << ": " << message;
         }
         STORAGE_ERROR(fullMessage);
     }

--- a/cloud/storage/core/libs/diagnostics/critical_events.cpp
+++ b/cloud/storage/core/libs/diagnostics/critical_events.cpp
@@ -72,22 +72,7 @@ TString ReportCriticalEvent(
 
     ReportCriticalEventWithoutLogging(root, sensorName, labels);
 
-    TStringBuilder fullMessage;
-    fullMessage << "CRITICAL_EVENT:" << sensorName;
-    if (message) {
-        fullMessage << ": " << message;
-    }
-
-    if (Log.IsNotNullLog()) {
-        Log.AddLog("%s", fullMessage.c_str());
-    } else {
-        // Write message and \n in one call. This will reduce the chance of
-        // shuffling with writings of other threads.
-        Cerr << fullMessage + '\n';
-        Cerr.Flush();
-    }
-
-    return fullMessage;
+    return LogCriticalEvent(sensorName, message);
 }
 
 TString ReportCriticalEvent(
@@ -139,6 +124,26 @@ void ReportCriticalEventWithoutLogging(
 void ReportCriticalEventWithoutLogging(const TString& sensorName)
 {
     ReportCriticalEventWithoutLogging(sensorName, {});
+}
+
+TString LogCriticalEvent(const TString& sensorName, const TString& message)
+{
+    TStringBuilder fullMessage;
+    fullMessage << "CRITICAL_EVENT:" << sensorName;
+    if (message) {
+        fullMessage << ": " << message;
+    }
+
+    if (Log.IsNotNullLog()) {
+        Log.AddLog("%s", fullMessage.c_str());
+    } else {
+        // Write message and \n in one call. This will reduce the chance of
+        // shuffling with writings of other threads.
+        Cerr << fullMessage + '\n';
+        Cerr.Flush();
+    }
+
+    return fullMessage;
 }
 
 #define STORAGE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                            \

--- a/cloud/storage/core/libs/diagnostics/critical_events.cpp
+++ b/cloud/storage/core/libs/diagnostics/critical_events.cpp
@@ -56,6 +56,7 @@ TString GetImpossibleEventFullName(const TString& name)
 }
 
 TString ReportCriticalEvent(
+    NMonitoring::TDynamicCountersPtr root,
     const TString& sensorName,
     const TCritEventLabels& labels,
     const TString& message,
@@ -69,7 +70,7 @@ TString ReportCriticalEvent(
             message.c_str());
     }
 
-    ReportCriticalEventWithoutLogging(sensorName, labels);
+    ReportCriticalEventWithoutLogging(root, sensorName, labels);
 
     TStringBuilder fullMessage;
     fullMessage << "CRITICAL_EVENT:" << sensorName;
@@ -91,6 +92,20 @@ TString ReportCriticalEvent(
 
 TString ReportCriticalEvent(
     const TString& sensorName,
+    const TCritEventLabels& labels,
+    const TString& message,
+    bool verifyDebug)
+{
+    return ReportCriticalEvent(
+        CriticalEvents,
+        sensorName,
+        labels,
+        message,
+        verifyDebug);
+}
+
+TString ReportCriticalEvent(
+    const TString& sensorName,
     const TString& message,
     bool verifyDebug)
 {
@@ -98,26 +113,27 @@ TString ReportCriticalEvent(
 }
 
 void ReportCriticalEventWithoutLogging(
+    NMonitoring::TDynamicCountersPtr root,
     const TString& sensorName,
     const TCritEventLabels& labels)
 {
-    if (!CriticalEvents) {
+    if (!root) {
         return;
     }
 
-    auto subgroup = CriticalEvents;
+    auto subgroup = root;
     for (const auto& label : labels) {
         subgroup = subgroup->GetSubgroup(label.first, label.second);
     }
 
-    bool initialized = !!subgroup->FindCounter(sensorName);
-    auto counter = subgroup->GetCounter(sensorName, true);
-    // TODO: will it work for derivative counter with simultaneous init + increment?
-    if (!initialized) {
-        *counter = 0;
-    }
+    subgroup->GetCounter(sensorName, true)->Inc();
+}
 
-    counter->Inc();
+void ReportCriticalEventWithoutLogging(
+    const TString& sensorName,
+    const TCritEventLabels& labels)
+{
+    ReportCriticalEventWithoutLogging(CriticalEvents, sensorName, labels);
 }
 
 void ReportCriticalEventWithoutLogging(const TString& sensorName)

--- a/cloud/storage/core/libs/diagnostics/critical_events.cpp
+++ b/cloud/storage/core/libs/diagnostics/critical_events.cpp
@@ -57,6 +57,7 @@ TString GetImpossibleEventFullName(const TString& name)
 
 TString ReportCriticalEvent(
     const TString& sensorName,
+    const TCritEventLabels& labels,
     const TString& message,
     bool verifyDebug)
 {
@@ -68,17 +69,12 @@ TString ReportCriticalEvent(
             message.c_str());
     }
 
-    if (CriticalEvents) {
-        auto counter = CriticalEvents->GetCounter(
-            sensorName,
-            true);
-        counter->Inc();
-    }
+    ReportCriticalEventWithoutLogging(sensorName, labels);
 
     TStringBuilder fullMessage;
     fullMessage << "CRITICAL_EVENT:" << sensorName;
     if (message) {
-        fullMessage << ":" << message;
+        fullMessage << ": " << message;
     }
 
     if (Log.IsNotNullLog()) {
@@ -93,14 +89,40 @@ TString ReportCriticalEvent(
     return fullMessage;
 }
 
+TString ReportCriticalEvent(
+    const TString& sensorName,
+    const TString& message,
+    bool verifyDebug)
+{
+    return ReportCriticalEvent(sensorName, {}, message, verifyDebug);
+}
+
+void ReportCriticalEventWithoutLogging(
+    const TString& sensorName,
+    const TCritEventLabels& labels)
+{
+    if (!CriticalEvents) {
+        return;
+    }
+
+    auto subgroup = CriticalEvents;
+    for (const auto& label : labels) {
+        subgroup = subgroup->GetSubgroup(label.first, label.second);
+    }
+
+    bool initialized = !!subgroup->FindCounter(sensorName);
+    auto counter = subgroup->GetCounter(sensorName, true);
+    // TODO: will it work for derivative counter with simultaneous init + increment?
+    if (!initialized) {
+        *counter = 0;
+    }
+
+    counter->Inc();
+}
+
 void ReportCriticalEventWithoutLogging(const TString& sensorName)
 {
-    if (CriticalEvents) {
-        auto counter = CriticalEvents->GetCounter(
-            sensorName,
-            true);
-        counter->Inc();
-    }
+    ReportCriticalEventWithoutLogging(sensorName, {});
 }
 
 #define STORAGE_DEFINE_CRITICAL_EVENT_ROUTINE(name)                            \

--- a/cloud/storage/core/libs/diagnostics/critical_events.h
+++ b/cloud/storage/core/libs/diagnostics/critical_events.h
@@ -29,6 +29,10 @@ namespace NCloud {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TCritEventLabels = std::vector<std::pair<TString, TString>>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 void SetCriticalEventsLog(TLog log);
 void InitCriticalEventsCounter(NMonitoring::TDynamicCountersPtr counters);
 
@@ -37,9 +41,18 @@ TString GetImpossibleEventFullName(const TString& name);
 
 TString ReportCriticalEvent(
     const TString& sensorName,
+    const TCritEventLabels& labels,
     const TString& message,
     bool verifyDebug);
 
+TString ReportCriticalEvent(
+    const TString& sensorName,
+    const TString& message,
+    bool verifyDebug);
+
+void ReportCriticalEventWithoutLogging(
+    const TString& sensorName,
+    const TCritEventLabels& labels);
 void ReportCriticalEventWithoutLogging(const TString& sensorName);
 
 #define STORAGE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                           \

--- a/cloud/storage/core/libs/diagnostics/critical_events.h
+++ b/cloud/storage/core/libs/diagnostics/critical_events.h
@@ -40,6 +40,13 @@ TString GetCriticalEventFullName(const TString& name);
 TString GetImpossibleEventFullName(const TString& name);
 
 TString ReportCriticalEvent(
+    NMonitoring::TDynamicCountersPtr root,
+    const TString& sensorName,
+    const TCritEventLabels& labels,
+    const TString& message,
+    bool verifyDebug);
+
+TString ReportCriticalEvent(
     const TString& sensorName,
     const TCritEventLabels& labels,
     const TString& message,
@@ -50,6 +57,10 @@ TString ReportCriticalEvent(
     const TString& message,
     bool verifyDebug);
 
+void ReportCriticalEventWithoutLogging(
+    NMonitoring::TDynamicCountersPtr root,
+    const TString& sensorName,
+    const TCritEventLabels& labels);
 void ReportCriticalEventWithoutLogging(
     const TString& sensorName,
     const TCritEventLabels& labels);

--- a/cloud/storage/core/libs/diagnostics/critical_events.h
+++ b/cloud/storage/core/libs/diagnostics/critical_events.h
@@ -66,6 +66,8 @@ void ReportCriticalEventWithoutLogging(
     const TCritEventLabels& labels);
 void ReportCriticalEventWithoutLogging(const TString& sensorName);
 
+TString LogCriticalEvent(const TString& sensorName, const TString& message);
+
 #define STORAGE_DECLARE_CRITICAL_EVENT_ROUTINE(name)                           \
     TString Report##name(const TString& message = "");                         \
     const TString GetCriticalEventFor##name();                                 \


### PR DESCRIPTION
### Notes

1. Per-disk critical events are separated form **AppCriticalEvent/*** into **VolumeCriticalEvent/***
2. Introduce **VolumeCriticalEvent** reporting API with required **diskId**, **cloudId**, **folderId**, which are put into corresponding metrics and log messages
3. New **VolumeCriticalEvent/*** metrics has next shape:
```
  { project = "nbs",
    cluster = "...",
    host    = <FQDN>,
    service = "service_volume",
    sensor  = "VolumeCriticalEvent/...",
    volume  = "<diskId>",
    cloud   = "<cloudId>",
    folder  = "<folderId>" }
```
4. New **VolumeCriticalEvent/*** are created lazily upon the first occurrence of a specific CriticalEvent for a specific disk due to large amount of disks per cluster. The metric type has been changed to GAUGE and is now reset to 0 after each 15-second scrape interval. This (in constrast to RATE metric) prevents missing the first event (alert) after metric creation or during monitoring scrape gaps / NO_DATA intervals. Consequently, the metric reflects the event count per scrape interval.
5. Keep forming deprecated **AppCriticalEvent/*** metrics within **VolumeCriticalEvent** API calls until all alerts are reconfigured for new **VolumeCriticalEvent/*** metrics
6. Per-request actors are now populated with `TVolumeIdConstPtr VolumeId` instead of the old single `TString DiskId` or the three new `TString` fields (`DiskId`, `CloudId`, `FolderId`) to avoid performance overhead from string copying.
7. `‎cloud/storage/core/libs/diagnostics/critical_events.{h,cpp‎}` module refactored at earlier implementation steps. Though some new capabilities are not used in the final solution, changes are kept (may be challenged by reviewers if considered excessive). 

### Issue
#6582 (detailed analysis and implementation description)
