### PR TITLE
issue-5894, issue-5895: NaiveMirroredFileSystemShard - implemented PageStore, PersistentHashTable, PersistentBitmap

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
@@ -1,0 +1,263 @@
+#include "page_store.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <silk/fibers/mutex.h>
+#include <silk/util/logger.h>
+
+#include <util/generic/scope.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TPageStore: public IPageStore
+{
+private:
+    IStorageGroupPtr Storage;
+
+protected:
+    const ui64 PageSize;
+
+private:
+    struct TPage
+    {
+        TString Content;
+        ui64 Lsn = 0;
+        bool Dirty = false;
+    };
+
+    // TODO(#5895): eviction strategy + size limit
+    using TPageCache = THashMap<ui64, TPage>;
+    mutable TPageCache PageCache;
+    mutable silk::FiberMutex Mutex;
+
+    // TODO(#5895): properly initialize this
+    ui64 Lsn = 0;
+
+public:
+    TPageStore(
+            IStorageGroupPtr storage,
+            ui64 pageSize)
+        : Storage(std::move(storage))
+        , PageSize(pageSize)
+    {
+    }
+
+public:
+    ui64 AllocateLsn() override;
+    void CommitPages(const TVector<ui64>& pages) override;
+    void RollbackPages(const TVector<ui64>& pages) override;
+    void WritePage(
+        ui64 lsn,
+        ui64 pageNo,
+        TString page,
+        TVector<TPageGroup>& logRecord) override;
+    NProto::TError ReadPage(
+        ui64 lsn,
+        ui64 pageNo,
+        TString* page) const override;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+ui64 TPageStore::AllocateLsn()
+{
+    std::lock_guard g(Mutex);
+    return ++Lsn;
+}
+
+void TPageStore::CommitPages(const TVector<ui64>& pages)
+{
+    std::lock_guard g(Mutex);
+    for (const ui64 pageNo: pages) {
+        auto* page = PageCache.FindPtr(pageNo);
+        Y_ABORT_UNLESS(page);
+        page->Dirty = false;
+    }
+}
+
+void TPageStore::RollbackPages(const TVector<ui64>& pages)
+{
+    std::lock_guard g(Mutex);
+    for (const ui64 pageNo: pages) {
+        auto it = PageCache.find(pageNo);
+        Y_ABORT_UNLESS(it != PageCache.end());
+        PageCache.erase(it);
+    }
+}
+
+void TPageStore::WritePage(
+    ui64 lsn,
+    ui64 pageNo,
+    TString page,
+    TVector<TPageGroup>& logRecord)
+{
+    bool found = false;
+
+    //
+    // Linear search is ok because we don't expect to have more than a couple
+    // page groups in log-record.
+    //
+
+    for (auto& pg: logRecord) {
+        const ui64 endPageNo = pg.FirstPageNo + pg.Content.size();
+        if (pg.FirstPageNo <= pageNo && endPageNo > pageNo) {
+            pg.Content[pageNo - pg.FirstPageNo] = page;
+            found = true;
+        }
+    }
+
+    if (!found) {
+        logRecord.push_back({
+            .FirstPageNo = pageNo,
+            .Content = TVector<TString>({page})
+        });
+    }
+
+    std::lock_guard g(Mutex);
+    auto& p = PageCache[pageNo];
+    Y_ABORT_UNLESS(p.Lsn <= lsn);
+    p = {
+        .Content = std::move(page),
+        .Lsn = lsn,
+        .Dirty = true
+    };
+}
+
+NProto::TError TPageStore::ReadPage(
+    ui64 lsn,
+    ui64 pageNo,
+    TString* page) const
+{
+    page->clear();
+
+    TPageCache::iterator cachedPage;
+    {
+        std::lock_guard g(Mutex);
+
+        TPageCache::insert_ctx insertCtx;
+        cachedPage = PageCache.find(pageNo, insertCtx);
+        if (cachedPage != PageCache.end()) {
+            // TODO(#5894): block reader upon dirty page read attempt instead of
+            // erroring
+            if (cachedPage->second.Dirty && cachedPage->second.Lsn != lsn) {
+                return MakeError(
+                    E_REJECTED,
+                    TStringBuilder() << "dirty page (" << pageNo
+                        << ") with non-matching lsn ("
+                        << cachedPage->second.Lsn << " != " << lsn << ")");
+            }
+
+            *page = cachedPage->second.Content;
+            return {};
+        }
+
+        cachedPage = PageCache.insert_direct(
+            std::make_pair(pageNo, TPage{.Content = {}, .Dirty = true}),
+            insertCtx);
+    }
+
+    Y_DEFER {
+        std::lock_guard g(Mutex);
+
+        if (page->empty()) {
+            PageCache.erase(cachedPage);
+        } else {
+            cachedPage->second.Content = *page;
+            cachedPage->second.Dirty = false;
+        }
+    };
+
+    if (!Storage) {
+        return MakeError(E_NOT_FOUND);
+    }
+
+    NProto::TReadPagesRequest request;
+    auto* pg = request.AddPageGroupRefs();
+    pg->SetFirstPageNo(pageNo);
+    pg->SetPageCount(1);
+    pg->SetPageSize(PageSize);
+
+    TVector<TPageGroupRef> pageGroupRefs = {{
+        .FirstPageNo = pageNo,
+        .PageCount = 1,
+        .PageSize = PageSize,
+    }};
+
+    TVector<TPageGroup> pageGroups;
+
+    auto error = Storage->ReadPages(
+        {} /* headers */,
+        pageGroupRefs,
+        &pageGroups);
+    if (HasError(error)) {
+        return error;
+    }
+
+    if (pageGroups.size() != 1) {
+        return MakeError(
+            E_BADMSG,
+            TStringBuilder() << "unexpected pg count: "
+                << pageGroups.size());
+    }
+
+    auto& rpg = pageGroups[0];
+    if (rpg.Content.size() != 1) {
+        return MakeError(
+            E_BADMSG,
+            TStringBuilder() << "unexpected page count: "
+                << rpg.Content.size());
+    }
+
+    if (rpg.Content[0].size() < PageSize) {
+        return MakeError(
+            E_BADMSG,
+            TStringBuilder() << "unexpected page size: "
+                << rpg.Content[0].size());
+    }
+
+    *page = std::move(rpg.Content[0]);
+    return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TMemPageStore: public TPageStore
+{
+public:
+    explicit TMemPageStore(ui64 pageSize)
+        : TPageStore(nullptr /* storage */, pageSize)
+    {
+    }
+
+    NProto::TError ReadPage(ui64 lsn, ui64 pageNo, TString* page) const override
+    {
+        auto error = TPageStore::ReadPage(lsn, pageNo, page);
+        if (error.GetCode() == E_NOT_FOUND) {
+            *page = TString(PageSize, 0);
+            return {};
+        }
+
+        return error;
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IPageStorePtr CreatePageStore(IStorageGroupPtr storage, ui64 pageSize)
+{
+    return std::make_shared<TPageStore>(std::move(storage), pageSize);
+}
+
+IPageStorePtr CreateMemPageStore(ui64 pageSize)
+{
+    return std::make_shared<TMemPageStore>(pageSize);
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.cpp
@@ -51,7 +51,7 @@ public:
     ui64 AllocateLsn() override;
     void CommitPages(const TVector<ui64>& pages) override;
     void RollbackPages(const TVector<ui64>& pages) override;
-    void WritePage(
+    NProto::TError WritePage(
         ui64 lsn,
         ui64 pageNo,
         TString page,
@@ -90,7 +90,7 @@ void TPageStore::RollbackPages(const TVector<ui64>& pages)
     }
 }
 
-void TPageStore::WritePage(
+NProto::TError TPageStore::WritePage(
     ui64 lsn,
     ui64 pageNo,
     TString page,
@@ -120,12 +120,31 @@ void TPageStore::WritePage(
 
     std::lock_guard g(Mutex);
     auto& p = PageCache[pageNo];
-    Y_ABORT_UNLESS(p.Lsn <= lsn);
+
+    if (p.Dirty && p.Lsn != 0 && p.Lsn != lsn) {
+        //
+        // Doing it in the simplest way possible - just rejecting concurrent ops
+        // for each page. We can implement tracking different page versions for
+        // different lsns in the future if needed.
+        //
+
+        return MakeError(
+            E_REJECTED,
+            TStringBuilder() << "dirty page (" << pageNo
+                << ") with different lsn (" << p.Lsn << " != " << lsn << ")");
+    }
+
+    if (!p.Dirty) {
+        Y_ABORT_UNLESS(p.Lsn <= lsn);
+    }
+
     p = {
         .Content = std::move(page),
         .Lsn = lsn,
         .Dirty = true
     };
+
+    return {};
 }
 
 NProto::TError TPageStore::ReadPage(
@@ -142,13 +161,15 @@ NProto::TError TPageStore::ReadPage(
         TPageCache::insert_ctx insertCtx;
         cachedPage = PageCache.find(pageNo, insertCtx);
         if (cachedPage != PageCache.end()) {
-            // TODO(#5894): block reader upon dirty page read attempt instead of
-            // erroring
+            //
+            // See the comment for WritePage() E_REJECTED error.
+            //
+
             if (cachedPage->second.Dirty && cachedPage->second.Lsn != lsn) {
                 return MakeError(
                     E_REJECTED,
                     TStringBuilder() << "dirty page (" << pageNo
-                        << ") with non-matching lsn ("
+                        << ") with different lsn ("
                         << cachedPage->second.Lsn << " != " << lsn << ")");
             }
 
@@ -157,7 +178,9 @@ NProto::TError TPageStore::ReadPage(
         }
 
         cachedPage = PageCache.insert_direct(
-            std::make_pair(pageNo, TPage{.Content = {}, .Dirty = true}),
+            std::make_pair(
+                pageNo,
+                TPage{.Content = {}, .Lsn = lsn, .Dirty = true}),
             insertCtx);
     }
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cloud/filestore/libs/service/error.h>
+#include <cloud/filestore/libs/storage/fastshard/sn/quorum/storage_group.h>
+
+#include <memory>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class IPageStore
+{
+public:
+    virtual ~IPageStore() = default;
+
+    virtual ui64 AllocateLsn() = 0;
+    virtual void CommitPages(const TVector<ui64>& pages) = 0;
+    virtual void RollbackPages(const TVector<ui64>& pages) = 0;
+    virtual void WritePage(
+        ui64 lsn,
+        ui64 pageNo,
+        TString page,
+        TVector<TPageGroup>& logRecord) = 0;
+    virtual NProto::TError ReadPage(
+        ui64 lsn,
+        ui64 pageNo,
+        TString* page) const = 0;
+};
+
+using IPageStorePtr = std::shared_ptr<IPageStore>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+IPageStorePtr CreatePageStore(IStorageGroupPtr storage, ui64 pageSize);
+IPageStorePtr CreateMemPageStore(ui64 pageSize);
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/page_store.h
@@ -17,7 +17,7 @@ public:
     virtual ui64 AllocateLsn() = 0;
     virtual void CommitPages(const TVector<ui64>& pages) = 0;
     virtual void RollbackPages(const TVector<ui64>& pages) = 0;
-    virtual void WritePage(
+    virtual NProto::TError WritePage(
         ui64 lsn,
         ui64 pageNo,
         TString page,

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
@@ -65,9 +65,25 @@ ui64 FindFirstFreeBit(const TString& bitmapPage)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool TPersistentBitmap::Validate(ui64 bit, NProto::TError* error) const
+{
+    if (bit >= PageCount * BitsPerPage) {
+        *error = MakeError(E_ARGUMENT, TStringBuilder() << "out of bounds"
+            " bitmap access: " << bit << " >= " << (PageCount * BitsPerPage));
+        return false;
+    }
+
+    return true;
+}
+
 NProto::TError TPersistentBitmap::Get(ui64 bit, bool* result) const
 {
-    auto error = InitIfNeeded();
+    NProto::TError error;
+    if (!Validate(bit, &error)) {
+        return error;
+    }
+
+    error = InitIfNeeded();
     if (HasError(error)) {
         return error;
     }
@@ -82,7 +98,12 @@ NProto::TError TPersistentBitmap::Set(
     ui64 bit,
     TVector<TPageGroup>& pageGroups)
 {
-    auto error = InitIfNeeded();
+    NProto::TError error;
+    if (!Validate(bit, &error)) {
+        return error;
+    }
+
+    error = InitIfNeeded();
     if (HasError(error)) {
         return error;
     }
@@ -91,8 +112,11 @@ NProto::TError TPersistentBitmap::Set(
     SetBit(BitmapPages[bitmapPageNo], bit % BitsPerPage, false /* isReset */);
 
     const ui64 pageNo = FirstPageNo + bitmapPageNo;
-    PageStore->WritePage(lsn, pageNo, BitmapPages[bitmapPageNo], pageGroups);
-    return {};
+    return PageStore->WritePage(
+        lsn,
+        pageNo,
+        BitmapPages[bitmapPageNo],
+        pageGroups);
 }
 
 NProto::TError TPersistentBitmap::Reset(
@@ -100,17 +124,31 @@ NProto::TError TPersistentBitmap::Reset(
     ui64 bit,
     TVector<TPageGroup>& pageGroups)
 {
-    auto error = InitIfNeeded();
+    NProto::TError error;
+    if (!Validate(bit, &error)) {
+        return error;
+    }
+
+    error = InitIfNeeded();
     if (HasError(error)) {
         return error;
     }
 
     const ui64 bitmapPageNo = bit / BitsPerPage;
-    SetBit(BitmapPages[bitmapPageNo], bit % BitsPerPage, true /* isReset */);
+    auto& page = BitmapPages[bitmapPageNo];
+    const bool wasFull = IsFull(page);
+    SetBit(page, bit % BitsPerPage, true /* isReset */);
+
+    if (wasFull) {
+        BitmapPagesWithFreeBits.push(bitmapPageNo);
+    }
 
     const ui64 pageNo = FirstPageNo + bitmapPageNo;
-    PageStore->WritePage(lsn, pageNo, BitmapPages[bitmapPageNo], pageGroups);
-    return {};
+    return PageStore->WritePage(
+        lsn,
+        pageNo,
+        BitmapPages[bitmapPageNo],
+        pageGroups);
 }
 
 NProto::TError TPersistentBitmap::Allocate(
@@ -144,8 +182,7 @@ NProto::TError TPersistentBitmap::Allocate(
         *bit = bitmapPageNo * BitsPerPage + pageBit;
 
         const ui64 pageNo = FirstPageNo + bitmapPageNo;
-        PageStore->WritePage(lsn, pageNo, page, pageGroups);
-        return {};
+        return PageStore->WritePage(lsn, pageNo, page, pageGroups);
     }
 
     return MakeError(E_FS_OUT_OF_SPACE, "bitmap full");

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.cpp
@@ -1,0 +1,180 @@
+#include "persistent_bitmap.h"
+
+#include <util/string/builder.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr ui64 InvalidBitNo = Max<ui64>();
+constexpr ui64 BitsPerWord = 64;
+
+bool IsFull(const TString& bitmapPage)
+{
+    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+
+    for (ui64 i = 0; i < bitmapPage.size(); i += sizeof(ui64)) {
+        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.data() + i);
+        if (~*word != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool GetBit(TString& bitmapPage, ui64 bit)
+{
+    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+
+    ui64* word = reinterpret_cast<ui64*>(bitmapPage.begin())
+        + bit / BitsPerWord;
+    return (*word & (1ULL << (bit % BitsPerWord))) != 0;
+}
+
+void SetBit(TString& bitmapPage, ui64 bit, bool isReset)
+{
+    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+
+    ui64* word = reinterpret_cast<ui64*>(bitmapPage.begin())
+        + bit / BitsPerWord;
+    if (isReset) {
+        *word &= ~(1ULL << (bit % BitsPerWord));
+    } else {
+        *word |= 1ULL << (bit % BitsPerWord);
+    }
+}
+
+ui64 FindFirstFreeBit(const TString& bitmapPage)
+{
+    Y_ABORT_UNLESS(bitmapPage.size() % sizeof(ui64) == 0);
+
+    for (ui64 i = 0; i < bitmapPage.size(); i += sizeof(ui64)) {
+        const ui64* word = reinterpret_cast<const ui64*>(bitmapPage.data() + i);
+        if (~*word != 0) {
+            return i * 8 + std::countr_one(*word);
+        }
+    }
+
+    return InvalidBitNo;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError TPersistentBitmap::Get(ui64 bit, bool* result) const
+{
+    auto error = InitIfNeeded();
+    if (HasError(error)) {
+        return error;
+    }
+
+    const ui64 bitmapPageNo = bit / BitsPerPage;
+    *result = GetBit(BitmapPages[bitmapPageNo], bit % BitsPerPage);
+    return {};
+}
+
+NProto::TError TPersistentBitmap::Set(
+    ui64 lsn,
+    ui64 bit,
+    TVector<TPageGroup>& pageGroups)
+{
+    auto error = InitIfNeeded();
+    if (HasError(error)) {
+        return error;
+    }
+
+    const ui64 bitmapPageNo = bit / BitsPerPage;
+    SetBit(BitmapPages[bitmapPageNo], bit % BitsPerPage, false /* isReset */);
+
+    const ui64 pageNo = FirstPageNo + bitmapPageNo;
+    PageStore->WritePage(lsn, pageNo, BitmapPages[bitmapPageNo], pageGroups);
+    return {};
+}
+
+NProto::TError TPersistentBitmap::Reset(
+    ui64 lsn,
+    ui64 bit,
+    TVector<TPageGroup>& pageGroups)
+{
+    auto error = InitIfNeeded();
+    if (HasError(error)) {
+        return error;
+    }
+
+    const ui64 bitmapPageNo = bit / BitsPerPage;
+    SetBit(BitmapPages[bitmapPageNo], bit % BitsPerPage, true /* isReset */);
+
+    const ui64 pageNo = FirstPageNo + bitmapPageNo;
+    PageStore->WritePage(lsn, pageNo, BitmapPages[bitmapPageNo], pageGroups);
+    return {};
+}
+
+NProto::TError TPersistentBitmap::Allocate(
+    ui64 lsn,
+    ui64* bit,
+    TVector<TPageGroup>& pageGroups)
+{
+    auto error = InitIfNeeded();
+    if (HasError(error)) {
+        return error;
+    }
+
+    while (!BitmapPagesWithFreeBits.empty()) {
+        const ui64 bitmapPageNo = BitmapPagesWithFreeBits.top();
+        auto& page = BitmapPages[bitmapPageNo];
+        const ui64 pageBit = FindFirstFreeBit(page);
+        if (pageBit == InvalidBitNo) {
+            //
+            // Can happen because of Set() calls.
+            //
+
+            BitmapPagesWithFreeBits.pop();
+            continue;
+        }
+
+        SetBit(page, pageBit, false /* isReset */);
+        if (IsFull(page)) {
+            BitmapPagesWithFreeBits.pop();
+        }
+
+        *bit = bitmapPageNo * BitsPerPage + pageBit;
+
+        const ui64 pageNo = FirstPageNo + bitmapPageNo;
+        PageStore->WritePage(lsn, pageNo, page, pageGroups);
+        return {};
+    }
+
+    return MakeError(E_FS_OUT_OF_SPACE, "bitmap full");
+}
+
+NProto::TError TPersistentBitmap::InitIfNeeded() const
+{
+    if (!BitmapPages.empty()) {
+        return {};
+    }
+
+    BitmapPages.resize(PageCount);
+
+    for (ui64 i = 0; i < PageCount; ++i) {
+        const ui64 pageNo = FirstPageNo + i;
+        auto error = PageStore->ReadPage(0 /* lsn */, pageNo, &BitmapPages[i]);
+        if (HasError(error)) {
+            BitmapPages.clear();
+            return error;
+        }
+
+        Y_ABORT_UNLESS(BitmapPages[i].size() == PageSize);
+
+        if (!IsFull(BitmapPages[i])) {
+            BitmapPagesWithFreeBits.push(i);
+        }
+    }
+
+    return {};
+}
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
@@ -51,6 +51,7 @@ public:
     }
 
 private:
+    bool Validate(ui64 bit, NProto::TError* error) const;
     NProto::TError InitIfNeeded() const;
 };
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "page_store.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <util/generic/stack.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TPersistentBitmap
+{
+private:
+    const ui64 FirstPageNo;
+    const ui64 PageCount;
+    const ui64 PageSize;
+    const ui64 BitsPerPage;
+    IPageStorePtr PageStore;
+
+    mutable TVector<TString> BitmapPages;
+    mutable TStack<ui64> BitmapPagesWithFreeBits;
+
+public:
+    TPersistentBitmap(
+            ui64 firstPageNo,
+            ui64 pageCount,
+            ui64 pageSize,
+            IPageStorePtr pageStore)
+        : FirstPageNo(firstPageNo)
+        , PageCount(pageCount)
+        , PageSize(pageSize)
+        , BitsPerPage(CalcBitsPerPage(pageSize))
+        , PageStore(std::move(pageStore))
+    {
+    }
+
+public:
+    NProto::TError Get(ui64 bit, bool* result) const;
+    NProto::TError Set(ui64 lsn, ui64 bit, TVector<TPageGroup>& pageGroups);
+    NProto::TError Reset(ui64 lsn, ui64 bit, TVector<TPageGroup>& pageGroups);
+    NProto::TError Allocate(
+        ui64 lsn,
+        ui64* bit,
+        TVector<TPageGroup>& pageGroups);
+
+    static ui64 CalcBitsPerPage(ui64 pageSize)
+    {
+        return pageSize * 8;
+    }
+
+private:
+    NProto::TError InitIfNeeded() const;
+};
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <util/generic/bitmap.h>
+#include <util/generic/hash_set.h>
 #include <util/random/fast.h>
 
 using namespace NCloud;
@@ -34,6 +35,12 @@ TVector<ui64> CollectPages(const TVector<TPageGroup>& groups)
 void Flush(TVector<TPageGroup>& groups, IPageStore& pageStore)
 {
     pageStore.CommitPages(CollectPages(groups));
+    groups.clear();
+}
+
+void Rollback(TVector<TPageGroup>& groups, IPageStore& pageStore)
+{
+    pageStore.RollbackPages(CollectPages(groups));
     groups.clear();
 }
 
@@ -131,6 +138,52 @@ TEST(PersistentBitmapTest, SetResetAllocate)
     Flush(pageGroups, *fx.PageStore);
     ASSERT_TRUE(bit != bit3) << bit;
     ASSERT_TRUE(bit2 != bit3) << bit;
+}
+
+TEST(PersistentBitmapTest, OutOfSpace)
+{
+    TFixture fx;
+
+    TVector<TPageGroup> pageGroups;
+
+    const ui64 cap =
+        TPersistentBitmap::CalcBitsPerPage(PageSize) * fx.PageCount;
+
+    THashSet<ui64> bitSet;
+
+    for (ui64 i = 0; i < cap; ++i) {
+        ui64 bit = 0;
+        auto error = fx.Bitmap->Allocate(
+            fx.PageStore->AllocateLsn(),
+            &bit,
+            pageGroups);
+        ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+        Flush(pageGroups, *fx.PageStore);
+
+        ASSERT_TRUE(bitSet.insert(bit).second);
+        ASSERT_LT(bit, cap);
+    }
+
+    ui64 bit = 0;
+    auto error = fx.Bitmap->Allocate(
+        fx.PageStore->AllocateLsn(),
+        &bit,
+        pageGroups);
+    ASSERT_EQ(E_FS_OUT_OF_SPACE, error.GetCode()) << FormatError(error);
+    Rollback(pageGroups, *fx.PageStore);
+
+    error = fx.Bitmap->Reset(fx.PageStore->AllocateLsn(), 1000, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    bit = 0;
+    error = fx.Bitmap->Allocate(
+        fx.PageStore->AllocateLsn(),
+        &bit,
+        pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+    ASSERT_EQ(1000ULL, bit);
 }
 
 TEST(PersistentBitmapTest, SetResetAllocateRandomized)

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap_ut.cpp
@@ -1,0 +1,228 @@
+#include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_bitmap.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <gtest/gtest.h>
+
+#include <util/generic/bitmap.h>
+#include <util/random/fast.h>
+
+using namespace NCloud;
+using namespace NFileStore;
+using namespace NStorage::NFastShard;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr size_t PageSize = 4_KB;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<ui64> CollectPages(const TVector<TPageGroup>& groups)
+{
+    TVector<ui64> res;
+    for (const auto& pg: groups) {
+        for (ui64 i = 0; i < pg.Content.size(); ++i) {
+            res.push_back(pg.FirstPageNo + i);
+        }
+    }
+
+    return res;
+}
+
+void Flush(TVector<TPageGroup>& groups, IPageStore& pageStore)
+{
+    pageStore.CommitPages(CollectPages(groups));
+    groups.clear();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture
+{
+    const ui64 FirstPageNo = 10;
+    const ui64 PageCount = 2;
+
+    IPageStorePtr PageStore = CreateMemPageStore(PageSize);
+    std::unique_ptr<TPersistentBitmap> Bitmap;
+
+    TFixture()
+    {
+        Reload();
+    }
+
+    void Reload()
+    {
+        Bitmap = std::make_unique<TPersistentBitmap>(
+            FirstPageNo,
+            PageCount,
+            PageSize,
+            PageStore);
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(PersistentBitmapTest, SetResetAllocate)
+{
+    TFixture fx;
+
+    TVector<TPageGroup> pageGroups;
+
+    bool result = false;
+    auto error = fx.Bitmap->Get(1000, &result);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_FALSE(result);
+
+    error = fx.Bitmap->Set(fx.PageStore->AllocateLsn(), 1000, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    result = false;
+    error = fx.Bitmap->Get(1000, &result);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_TRUE(result);
+
+    ui64 bit = 0;
+    error = fx.Bitmap->Allocate(fx.PageStore->AllocateLsn(), &bit, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    result = false;
+    error = fx.Bitmap->Get(bit, &result);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_TRUE(result);
+
+    ui64 bit2 = 0;
+    error = fx.Bitmap->Allocate(fx.PageStore->AllocateLsn(), &bit2, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+    ASSERT_TRUE(bit != bit2) << bit;
+
+    result = false;
+    error = fx.Bitmap->Get(bit2, &result);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_TRUE(result);
+
+    error = fx.Bitmap->Reset(fx.PageStore->AllocateLsn(), bit2, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    result = false;
+    error = fx.Bitmap->Get(bit2, &result);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_FALSE(result);
+
+    error = fx.Bitmap->Set(fx.PageStore->AllocateLsn(), bit2, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    result = false;
+    error = fx.Bitmap->Get(bit2, &result);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    ASSERT_TRUE(result);
+
+    ui64 bit3 = 0;
+    error = fx.Bitmap->Allocate(fx.PageStore->AllocateLsn(), &bit3, pageGroups);
+    ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+    ASSERT_TRUE(bit != bit3) << bit;
+    ASSERT_TRUE(bit2 != bit3) << bit;
+}
+
+TEST(PersistentBitmapTest, SetResetAllocateRandomized)
+{
+    TFixture fx;
+
+    TVector<TPageGroup> pageGroups;
+
+    const double setProb = 0.01;
+    const double resetProb = 0.5;
+    const double allocateProb = 0.6;
+    const ui64 cap =
+        TPersistentBitmap::CalcBitsPerPage(PageSize) * fx.PageCount;
+
+    TDynBitMap refImpl;
+    refImpl.Reserve(cap);
+
+    const ui64 seed = 111;
+    TFastRng64 rng(seed);
+
+    const ui64 iters = 2 * cap;
+    for (ui64 i = 0; i < iters; ++i) {
+        //
+        // Set.
+        //
+
+        if (rng.GenRandReal2() < setProb) {
+            ui64 bit = rng.Uniform(cap);
+            refImpl.Set(bit);
+            auto error =
+                fx.Bitmap->Set(fx.PageStore->AllocateLsn(), bit, pageGroups);
+            ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+            Flush(pageGroups, *fx.PageStore);
+        }
+
+        //
+        // Reset.
+        //
+
+        if (rng.GenRandReal2() < resetProb) {
+            ui64 bit = rng.Uniform(cap);
+            refImpl.Reset(bit);
+            auto error =
+                fx.Bitmap->Reset(fx.PageStore->AllocateLsn(), bit, pageGroups);
+            ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+            Flush(pageGroups, *fx.PageStore);
+        }
+
+        //
+        // Allocate.
+        //
+
+        if (rng.GenRandReal2() < allocateProb) {
+            ui64 bit = 0;
+            auto error = fx.Bitmap->Allocate(
+                fx.PageStore->AllocateLsn(),
+                &bit,
+                pageGroups);
+            ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+            Flush(pageGroups, *fx.PageStore);
+            ASSERT_FALSE(refImpl.Get(bit))
+                << "i=" << i << ", bit=" << bit << ", bits=" << refImpl.Count();
+            refImpl.Set(bit);
+        }
+
+        //
+        // Get.
+        //
+
+        ui64 bit = rng.Uniform(cap);
+        bool result = false;
+        auto error = fx.Bitmap->Get(bit, &result);
+        ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+        ASSERT_EQ(result, refImpl.Get(bit))
+            << "i=" << i << ", bit=" << bit << ", result=" << result
+            << ", bits=" << refImpl.Count();
+
+        if (i % 10'000 == 0) {
+            Cdbg << "bits: " << refImpl.Count() << "/" << cap << Endl;
+        }
+    }
+
+    //
+    // Reload and validate.
+    //
+
+    fx.Reload();
+
+    for (ui64 bit = 0; bit < cap; ++bit) {
+        bool result = false;
+        auto error = fx.Bitmap->Get(bit, &result);
+        ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+        ASSERT_EQ(refImpl.Get(bit), result);
+    }
+}

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.cpp
@@ -1,0 +1,1 @@
+#include "persistent_hash_table.h"

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
@@ -29,12 +29,14 @@ template <typename TKey, typename TValue>
 class TPersistentHashTable
 {
 private:
+    static constexpr ui64 InvalidSlotNo = Max<ui64>();
+
     const ui64 FirstPageNo;
     const ui64 PageCount;
     const ui64 PageSize;
-    const ui64 SlotCount;
     const ui64 SlotSize;
     const ui64 SlotsPerPage;
+    const ui64 SlotCount;
     const TValue Tombstone;
     const TKey TombstoneKey;
     IPageStorePtr PageStore;
@@ -149,7 +151,13 @@ private:
         void Write(const char* data)
         {
             const ui64 offsetInPage = (SlotNo % SlotsPerPage) * SlotSize;
-            memcpy(Page.begin() + offsetInPage, data, SlotSize);
+            char* dst = Page.begin() + offsetInPage;
+            memcpy(dst, data, sizeof(TValue));
+            dst += sizeof(TValue);
+            const ui64 tail = SlotSize - sizeof(TValue);
+            if (tail) {
+                memset(dst, 0, tail);
+            }
             Dirty = true;
         }
 
@@ -178,7 +186,6 @@ public:
             ui64 firstPageNo,
             ui64 pageCount,
             ui64 pageSize,
-            ui64 slotCount,
             ui64 slotSize,
             const TValue& tombstone,
             IPageStorePtr pageStore,
@@ -187,20 +194,24 @@ public:
         : FirstPageNo(firstPageNo)
         , PageCount(pageCount)
         , PageSize(pageSize)
-        , SlotCount(slotCount)
         , SlotSize(slotSize)
         , SlotsPerPage(PageSize / SlotSize)
+        , SlotCount(PageCount * SlotsPerPage)
         , Tombstone(tombstone)
         , TombstoneKey(makeKey(tombstone))
         , PageStore(std::move(pageStore))
         , MakeKey(std::move(makeKey))
         , Hash(std::move(hash))
     {
-        Y_ABORT_UNLESS(SlotCount * SlotSize <= PageCount * PageSize);
         Y_ABORT_UNLESS(sizeof(TValue) <= SlotSize);
     }
 
 public:
+    ui64 GetSlotCount() const
+    {
+        return SlotCount;
+    }
+
     NProto::TError Put(
         ui64 lsn,
         const TValue& v,
@@ -354,17 +365,32 @@ private:
             return error;
         }
 
+        ui64 candidateSlotNo = InvalidSlotNo;
         while (true) {
             bool success = LookupSlot(it.GetRaw(), v);
             if (!success) {
+                //
+                // We found an empty slot - now we can stop.
+                //
+
+                if (candidateSlotNo == InvalidSlotNo) {
+                    candidateSlotNo = it.SlotNo;
+                }
+
                 break;
             }
 
             if (TombstoneKey == MakeKey(*v)) {
-                break;
-            }
+                //
+                // This is a candidate slot. But we might have the same key
+                // somewhere after this tombstone. So we can't stop - we can
+                // just memorize this slot.
+                //
 
-            if (k == MakeKey(*v)) {
+                if (candidateSlotNo == InvalidSlotNo) {
+                    candidateSlotNo = it.SlotNo;
+                }
+            } else if (k == MakeKey(*v)) {
                 return MakeError(E_FS_EXIST);
             }
 
@@ -378,7 +404,7 @@ private:
             }
         }
 
-        *slotNo = it.SlotNo;
+        *slotNo = candidateSlotNo;
         return {};
     }
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
@@ -1,0 +1,580 @@
+#pragma once
+
+#include "page_store.h"
+
+#include <cloud/filestore/libs/service/error.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <silk/util/logger.h>
+
+#include <util/digest/city.h>
+#include <util/string/builder.h>
+
+namespace NCloud::NFileStore::NStorage::NFastShard {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TPersistentHashTableStats
+{
+    ui64 SlotCount = 0;
+    ui64 ValueCount = 0;
+    ui64 MisplacedValueCount = 0;
+    ui64 TombstoneCount = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename TKey, typename TValue>
+class TPersistentHashTable
+{
+private:
+    const ui64 FirstPageNo;
+    const ui64 PageCount;
+    const ui64 PageSize;
+    const ui64 SlotCount;
+    const ui64 SlotSize;
+    const ui64 SlotsPerPage;
+    const TValue Tombstone;
+    const TKey TombstoneKey;
+    IPageStorePtr PageStore;
+
+    using TMakeKey = std::function<TKey(const TValue&)>;
+    TMakeKey MakeKey;
+
+    using THash = std::function<ui64(const TKey&)>;
+    THash Hash;
+
+    ui64 SlotPointer = 0;
+
+private:
+    struct TSlotIterator
+    {
+        const IPageStore& PageStore;
+        const ui64 Lsn;
+        const ui64 FirstPageNo;
+        const ui64 SlotSize;
+        const ui64 SlotCount;
+        const ui64 SlotsPerPage;
+        TString Page;
+        bool Dirty = false;
+        ui64 SlotNo;
+
+        struct TDirtyPage
+        {
+            TString Content;
+            ui64 PageNo = 0;
+        };
+        TVector<TDirtyPage> DirtyPages;
+
+        TSlotIterator(
+                IPageStore& pageStore,
+                ui64 lsn,
+                ui64 firstPageNo,
+                ui64 slotSize,
+                ui64 slotCount,
+                ui64 slotsPerPage,
+                ui64 slotNo)
+            : PageStore(pageStore)
+            , Lsn(lsn)
+            , FirstPageNo(firstPageNo)
+            , SlotSize(slotSize)
+            , SlotCount(slotCount)
+            , SlotsPerPage(slotsPerPage)
+            , SlotNo(slotNo)
+        {
+        }
+
+        NProto::TError Init()
+        {
+            const ui64 pageNo = FirstPageNo + SlotNo / SlotsPerPage;
+            return PageStore.ReadPage(Lsn, pageNo, &Page);
+        }
+
+        ui64 CurrentPageNo() const
+        {
+            return FirstPageNo + SlotNo / SlotsPerPage;
+        }
+
+        NProto::TError ReloadPageIfNeeded(
+            const ui64 pageNo,
+            const ui64 newPageNo)
+        {
+            if (pageNo == newPageNo) {
+                return {};
+            }
+
+            if (Dirty) {
+                DirtyPages.push_back({
+                    .Content = std::move(Page),
+                    .PageNo = pageNo,
+                });
+            }
+
+            Dirty = false;
+            return PageStore.ReadPage(Lsn, newPageNo, &Page);
+        }
+
+        NProto::TError ToPrevSlot()
+        {
+            const ui64 pageNo = CurrentPageNo();
+            if (SlotNo == 0) {
+                SlotNo = SlotCount;
+            }
+
+            --SlotNo;
+            const ui64 newPageNo = CurrentPageNo();
+            return ReloadPageIfNeeded(pageNo, newPageNo);
+        }
+
+        NProto::TError ToNextSlot()
+        {
+            const ui64 pageNo = CurrentPageNo();
+            SlotNo = (SlotNo + 1) % SlotCount;
+            const ui64 newPageNo = CurrentPageNo();
+            return ReloadPageIfNeeded(pageNo, newPageNo);
+        }
+
+        const char* GetRaw() const
+        {
+            const ui64 offsetInPage = (SlotNo % SlotsPerPage) * SlotSize;
+            return Page.data() + offsetInPage;
+        }
+
+        const TValue& Get() const
+        {
+            return *reinterpret_cast<const TValue*>(GetRaw());
+        }
+
+        void Write(const char* data)
+        {
+            const ui64 offsetInPage = (SlotNo % SlotsPerPage) * SlotSize;
+            memcpy(Page.begin() + offsetInPage, data, SlotSize);
+            Dirty = true;
+        }
+
+        void Clear()
+        {
+            const ui64 offsetInPage = (SlotNo % SlotsPerPage) * SlotSize;
+            memset(Page.begin() + offsetInPage, 0, SlotSize);
+            Dirty = true;
+        }
+
+        TVector<TDirtyPage> Finish()
+        {
+            if (Dirty) {
+                DirtyPages.push_back({
+                    .Content = std::move(Page),
+                    .PageNo = CurrentPageNo(),
+                });
+            }
+
+            return std::move(DirtyPages);
+        }
+    };
+
+public:
+    TPersistentHashTable(
+            ui64 firstPageNo,
+            ui64 pageCount,
+            ui64 pageSize,
+            ui64 slotCount,
+            ui64 slotSize,
+            const TValue& tombstone,
+            IPageStorePtr pageStore,
+            TMakeKey makeKey,
+            THash hash)
+        : FirstPageNo(firstPageNo)
+        , PageCount(pageCount)
+        , PageSize(pageSize)
+        , SlotCount(slotCount)
+        , SlotSize(slotSize)
+        , SlotsPerPage(PageSize / SlotSize)
+        , Tombstone(tombstone)
+        , TombstoneKey(makeKey(tombstone))
+        , PageStore(std::move(pageStore))
+        , MakeKey(std::move(makeKey))
+        , Hash(std::move(hash))
+    {
+        Y_ABORT_UNLESS(SlotCount * SlotSize <= PageCount * PageSize);
+        Y_ABORT_UNLESS(sizeof(TValue) <= SlotSize);
+    }
+
+public:
+    NProto::TError Put(
+        ui64 lsn,
+        const TValue& v,
+        TVector<TPageGroup>& pageGroups)
+    {
+        auto k = MakeKey(v);
+        TValue existing{};
+        ui64 slotNo = 0;
+        auto error = AllocateSlot(lsn, k, &existing, &slotNo);
+        if (HasError(error)) {
+            return error;
+        }
+
+        return DoPut(lsn, v, slotNo, pageGroups);
+    }
+
+    NProto::TError Update(
+        ui64 lsn,
+        const TValue& v,
+        const ui64 slotNo,
+        TVector<TPageGroup>& pageGroups)
+    {
+        // TODO(#5895): verify that there's no key change
+        return DoPut(lsn, v, slotNo, pageGroups);
+    }
+
+    NProto::TError Get(ui64 lsn, const TKey& k, TValue* v, ui64* slotNo) const
+    {
+        return FindSlot(lsn, k, v, slotNo);
+    }
+
+    NProto::TError Delete(
+        ui64 lsn,
+        const TKey& k,
+        TValue* v,
+        TVector<TPageGroup>& pageGroups)
+    {
+        ui64 slotNo = 0;
+        auto error = FindSlot(lsn, k, v, &slotNo);
+        if (HasError(error)) {
+            return error;
+        }
+
+        return DoDelete(lsn, slotNo, pageGroups);
+    }
+
+    NProto::TError CollectStats(TPersistentHashTableStats* stats) const
+    {
+        TSlotIterator it(
+            *PageStore,
+            0 /* lsn */,
+            FirstPageNo,
+            SlotSize,
+            SlotCount,
+            SlotsPerPage,
+            0 /* slotNo */);
+
+        auto error = it.Init();
+        if (HasError(error)) {
+            return error;
+        }
+
+        *stats = {};
+        while (!stats->SlotCount || it.SlotNo != 0) {
+            const char* raw = it.GetRaw();
+            const bool isEmpty = IsEmpty(raw);
+            const bool isTombstone = MakeKey(it.Get()) == TombstoneKey;
+
+            ++stats->SlotCount;
+            if (!isEmpty) {
+                if (isTombstone) {
+                    ++stats->TombstoneCount;
+                } else {
+                    ++stats->ValueCount;
+
+                    if (CalcSlotNo(it.Get()) != it.SlotNo) {
+                        ++stats->MisplacedValueCount;
+                    }
+                }
+            }
+
+            error = it.ToNextSlot();
+            if (HasError(error)) {
+                return error;
+            }
+        }
+
+        return {};
+    }
+
+private:
+    void WritePage(
+        ui64 lsn,
+        ui64 slotNo,
+        TString page,
+        TVector<TPageGroup>& pageGroups)
+    {
+        const ui64 pageNo = FirstPageNo + slotNo / SlotsPerPage;
+        PageStore->WritePage(lsn, pageNo, std::move(page), pageGroups);
+    }
+
+    NProto::TError ReadPage(ui64 lsn, ui64 slotNo, TString* page) const
+    {
+        const ui64 pageNo = FirstPageNo + slotNo / SlotsPerPage;
+        return PageStore->ReadPage(lsn, pageNo, page);
+    }
+
+    bool LookupSlot(const char* slotData, TValue* v) const
+    {
+        if (IsEmpty(slotData)) {
+            return false;
+        }
+
+        memcpy(v, slotData, sizeof(TValue));
+        return true;
+    }
+
+    NProto::TError LookupSlot(ui64 lsn, ui64 slotNo, TValue* v) const
+    {
+        TString page;
+        auto error = ReadPage(lsn, slotNo, &page);
+        if (HasError(error)) {
+            return error;
+        }
+
+        const ui32 relSlotNo = slotNo % SlotsPerPage;
+        const char* ptr = page.data() + relSlotNo * SlotSize;
+        return LookupSlot(ptr, v) ? MakeError(S_OK) : MakeError(S_FALSE);
+    }
+
+    NProto::TError AllocateSlot(
+        ui64 lsn,
+        const TKey& k,
+        TValue* v,
+        ui64* slotNo) const
+    {
+        const ui64 h = Hash(k);
+        const ui64 firstSlotNo = h % SlotCount;
+
+        TSlotIterator it(
+            *PageStore,
+            lsn,
+            FirstPageNo,
+            SlotSize,
+            SlotCount,
+            SlotsPerPage,
+            firstSlotNo);
+
+        auto error = it.Init();
+        if (HasError(error)) {
+            return error;
+        }
+
+        while (true) {
+            bool success = LookupSlot(it.GetRaw(), v);
+            if (!success) {
+                break;
+            }
+
+            if (TombstoneKey == MakeKey(*v)) {
+                break;
+            }
+
+            if (k == MakeKey(*v)) {
+                return MakeError(E_FS_EXIST);
+            }
+
+            error = it.ToNextSlot();
+            if (HasError(error)) {
+                return error;
+            }
+
+            if (it.SlotNo == firstSlotNo) {
+                return MakeError(E_FS_OUT_OF_SPACE, "no free node slot");
+            }
+        }
+
+        *slotNo = it.SlotNo;
+        return {};
+    }
+
+    NProto::TError FindSlot(
+        ui64 lsn,
+        const TKey& k,
+        TValue* v,
+        ui64* slotNo) const
+    {
+        const ui64 h = Hash(k);
+        const ui64 firstSlotNo = h % SlotCount;
+
+        TSlotIterator it(
+            *PageStore,
+            lsn,
+            FirstPageNo,
+            SlotSize,
+            SlotCount,
+            SlotsPerPage,
+            firstSlotNo);
+
+        auto error = it.Init();
+        if (HasError(error)) {
+            return error;
+        }
+
+        while (true) {
+            bool success = LookupSlot(it.GetRaw(), v);
+            if (!success) {
+                break;
+            }
+
+            if (k == MakeKey(*v)) {
+                *slotNo = it.SlotNo;
+                return {};
+            }
+
+            auto error = it.ToNextSlot();
+            if (HasError(error)) {
+                return error;
+            }
+
+            if (it.SlotNo == firstSlotNo) {
+                break;
+            }
+        }
+
+        return MakeError(E_FS_NOENT);
+    }
+
+    NProto::TError DoPut(
+        ui64 lsn,
+        const TValue& v,
+        ui64 slotNo,
+        TVector<TPageGroup>& pageGroups)
+    {
+        TString page;
+        auto error = ReadPage(lsn, slotNo, &page);
+        if (HasError(error)) {
+            return error;
+        }
+
+        const ui32 relSlotNo = slotNo % SlotsPerPage;
+        char* ptr = page.begin() + relSlotNo * SlotSize;
+        memcpy(ptr, &v, sizeof(TValue));
+
+        WritePage(lsn, slotNo, std::move(page), pageGroups);
+
+        SILK_DEBUG(
+            "pht DoPut: slotNo=%lu, logRecordPGs=%lu",
+            slotNo,
+            pageGroups.size());
+
+        return {};
+    }
+
+    ui64 CalcSlotNo(const TKey& k) const
+    {
+        return Hash(k) % SlotCount;
+    }
+
+    ui64 CalcSlotNo(const TValue& v) const
+    {
+        return CalcSlotNo(MakeKey(v));
+    }
+
+    bool IsEmpty(const char* slotData) const
+    {
+        return slotData[0] == 0
+            && memcmp(slotData, slotData + 1, SlotSize - 1) == 0;
+    }
+
+    NProto::TError DoDelete(
+        ui64 lsn,
+        ui64 slotNo,
+        TVector<TPageGroup>& pageGroups)
+    {
+        const ui64 nextSlotNo = (slotNo + 1) % SlotCount;
+
+        TSlotIterator it(
+            *PageStore,
+            lsn,
+            FirstPageNo,
+            SlotSize,
+            SlotCount,
+            SlotsPerPage,
+            nextSlotNo);
+
+        //
+        // Lookup next slot page - we need to check whether it's misplaced.
+        //
+
+        auto error = it.Init();
+        if (HasError(error)) {
+            return error;
+        }
+
+        const bool isNextSlotEmpty = IsEmpty(it.GetRaw());
+
+        //
+        // Moving back to the current slot.
+        //
+
+        error = it.ToPrevSlot();
+        if (HasError(error)) {
+            return error;
+        }
+
+        if (isNextSlotEmpty) {
+            //
+            // The next slot is empty - we can clear the current slot.
+            //
+
+            it.Clear();
+
+            //
+            // Trying to remove a consecutive range of tombstones preceding this
+            // slot.
+            //
+
+            error = it.ToPrevSlot();
+            if (HasError(error)) {
+                return error;
+            }
+
+            while (true) {
+                const auto curK = MakeKey(it.Get());
+                if (curK != TombstoneKey) {
+                    // not a tombstone
+                    break;
+                }
+
+                if (CalcSlotNo(curK) == it.SlotNo) {
+                    // not misplaced
+                    break;
+                }
+
+                it.Clear();
+
+                error = it.ToPrevSlot();
+                if (HasError(error)) {
+                    return error;
+                }
+            }
+        } else {
+            //
+            // The next slot is not empty. This means that we can have a logical
+            // slot chain which contains the current slot and which is necessary
+            // to find some misplaced slots that go after this slot.
+            //
+            // TODO(#5895): implement backward-shift deletion.
+            //
+
+            it.Write(reinterpret_cast<const char*>(&Tombstone));
+        }
+
+        //
+        // Writing the changes.
+        //
+
+        auto toWrite = it.Finish();
+        for (auto& dp: toWrite) {
+            PageStore->WritePage(
+                lsn,
+                dp.PageNo,
+                std::move(dp.Content),
+                pageGroups);
+        }
+
+        SILK_DEBUG(
+            "pht DoDelete: slotNo=%lu, logRecordPGs=%lu",
+            slotNo,
+            pageGroups.size());
+
+        return {};
+    }
+};
+
+}   // namespace NCloud::NFileStore::NStorage::NFastShard

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
@@ -292,14 +292,14 @@ public:
     }
 
 private:
-    void WritePage(
+    NProto::TError WritePage(
         ui64 lsn,
         ui64 slotNo,
         TString page,
         TVector<TPageGroup>& pageGroups)
     {
         const ui64 pageNo = FirstPageNo + slotNo / SlotsPerPage;
-        PageStore->WritePage(lsn, pageNo, std::move(page), pageGroups);
+        return PageStore->WritePage(lsn, pageNo, std::move(page), pageGroups);
     }
 
     NProto::TError ReadPage(ui64 lsn, ui64 slotNo, TString* page) const
@@ -445,14 +445,12 @@ private:
         char* ptr = page.begin() + relSlotNo * SlotSize;
         memcpy(ptr, &v, sizeof(TValue));
 
-        WritePage(lsn, slotNo, std::move(page), pageGroups);
-
         SILK_DEBUG(
             "pht DoPut: slotNo=%lu, logRecordPGs=%lu",
             slotNo,
             pageGroups.size());
 
-        return {};
+        return WritePage(lsn, slotNo, std::move(page), pageGroups);
     }
 
     ui64 CalcSlotNo(const TKey& k) const
@@ -555,23 +553,31 @@ private:
             it.Write(reinterpret_cast<const char*>(&Tombstone));
         }
 
+        SILK_DEBUG(
+            "pht DoDelete: slotNo=%lu, logRecordPGs=%lu",
+            slotNo,
+            pageGroups.size());
+
         //
         // Writing the changes.
         //
 
         auto toWrite = it.Finish();
         for (auto& dp: toWrite) {
-            PageStore->WritePage(
+            auto error = PageStore->WritePage(
                 lsn,
                 dp.PageNo,
                 std::move(dp.Content),
                 pageGroups);
-        }
 
-        SILK_DEBUG(
-            "pht DoDelete: slotNo=%lu, logRecordPGs=%lu",
-            slotNo,
-            pageGroups.size());
+            if (HasError(error)) {
+                //
+                // The caller is responsible for rolling back the changes.
+                //
+
+                return error;
+            }
+        }
 
         return {};
     }

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table_ut.cpp
@@ -55,7 +55,6 @@ struct TFixture
     const ui64 FirstPageNo = 10;
     const ui64 PageCount = 1024;
     const ui64 SlotSize = sizeof(TSlot);
-    const ui64 SlotCount = (PageSize / SlotSize) * PageCount;
 
     IPageStorePtr PageStore = CreateMemPageStore(PageSize);
     TPersistentHashTable<ui64, TSlot> Ht;
@@ -65,7 +64,6 @@ struct TFixture
             FirstPageNo,
             PageCount,
             PageSize,
-            SlotCount,
             SlotSize,
             tombstone,
             PageStore,
@@ -230,7 +228,7 @@ TEST(PersistentHashTableTest, PutGetUpdateRandomized)
         };
     };
 
-    for (ui64 i = 0; i < fx.SlotCount; ++i) {
+    for (ui64 i = 0; i < fx.Ht.GetSlotCount(); ++i) {
         //
         // Put.
         //

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table_ut.cpp
@@ -1,0 +1,336 @@
+#include <cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h>
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <gtest/gtest.h>
+
+#include <util/generic/hash.h>
+#include <util/random/fast.h>
+
+using namespace NCloud;
+using namespace NFileStore;
+using namespace NStorage::NFastShard;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr size_t PageSize = 4_KB;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TSlot
+{
+    ui32 A = 0;
+    ui64 B = 0;
+    ui32 C = 0;
+};
+
+const TSlot tombstone{.B = Max<ui64>()};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TVector<ui64> CollectPages(const TVector<TPageGroup>& groups)
+{
+    TVector<ui64> res;
+    for (const auto& pg: groups) {
+        for (ui64 i = 0; i < pg.Content.size(); ++i) {
+            res.push_back(pg.FirstPageNo + i);
+        }
+    }
+
+    return res;
+}
+
+void Flush(TVector<TPageGroup>& groups, IPageStore& pageStore)
+{
+    pageStore.CommitPages(CollectPages(groups));
+    groups.clear();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFixture
+{
+    const ui64 FirstPageNo = 10;
+    const ui64 PageCount = 1024;
+    const ui64 SlotSize = sizeof(TSlot);
+    const ui64 SlotCount = (PageSize / SlotSize) * PageCount;
+
+    IPageStorePtr PageStore = CreateMemPageStore(PageSize);
+    TPersistentHashTable<ui64, TSlot> Ht;
+
+    TFixture()
+        : Ht(
+            FirstPageNo,
+            PageCount,
+            PageSize,
+            SlotCount,
+            SlotSize,
+            tombstone,
+            PageStore,
+            [] (const TSlot& slot) {
+                return slot.B;
+            },
+            [] (const ui64& key) {
+                return IntHash(key);
+            })
+    {}
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(PersistentHashTableTest, PutGetUpdate)
+{
+    TFixture fx;
+
+    TVector<TPageGroup> pageGroups;
+    ui64 lsn = fx.PageStore->AllocateLsn();
+    auto error = fx.Ht.Put(lsn, TSlot{.A = 1, .B = 100, .C = 3}, pageGroups);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+
+    TSlot slot;
+    ui64 slotNo = 0;
+    error = fx.Ht.Get(0 /* lsn */, 100, &slot, &slotNo);
+    EXPECT_EQ(E_REJECTED, error.GetCode()) << FormatError(error);
+
+    error = fx.Ht.Get(lsn, 100, &slot, &slotNo);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    EXPECT_EQ(1U, slot.A);
+    EXPECT_EQ(100U, slot.B);
+    EXPECT_EQ(3U, slot.C);
+
+    Flush(pageGroups, *fx.PageStore);
+    lsn = fx.PageStore->AllocateLsn();
+
+    error = fx.Ht.Get(lsn, 100, &slot, &slotNo);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    EXPECT_EQ(1U, slot.A);
+    EXPECT_EQ(100U, slot.B);
+    EXPECT_EQ(3U, slot.C);
+
+    fx.Ht.Update(lsn, TSlot{.A = 2, .B = 100, .C = 10}, slotNo, pageGroups);
+
+    error = fx.Ht.Get(0 /* lsn */, 100, &slot, &slotNo);
+    EXPECT_EQ(E_REJECTED, error.GetCode()) << FormatError(error);
+
+    error = fx.Ht.Get(lsn, 100, &slot, &slotNo);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    EXPECT_EQ(2U, slot.A);
+    EXPECT_EQ(100U, slot.B);
+    EXPECT_EQ(10U, slot.C);
+
+    Flush(pageGroups, *fx.PageStore);
+
+    error = fx.Ht.Get(0 /* lsn */, 100, &slot, &slotNo);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    EXPECT_EQ(2U, slot.A);
+    EXPECT_EQ(100U, slot.B);
+    EXPECT_EQ(10U, slot.C);
+}
+
+TEST(PersistentHashTableTest, Delete)
+{
+    TFixture fx;
+
+    TVector<TPageGroup> pageGroups;
+    ui64 lsn = fx.PageStore->AllocateLsn();
+    auto error = fx.Ht.Put(lsn, TSlot{.A = 1, .B = 100, .C = 3}, pageGroups);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    lsn = fx.PageStore->AllocateLsn();
+    error = fx.Ht.Put(lsn, TSlot{.A = 2, .B = 101, .C = 4}, pageGroups);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    lsn = fx.PageStore->AllocateLsn();
+    error = fx.Ht.Put(lsn, TSlot{.A = 3, .B = 102, .C = 5}, pageGroups);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    Flush(pageGroups, *fx.PageStore);
+
+    lsn = fx.PageStore->AllocateLsn();
+    TSlot slot;
+    error = fx.Ht.Delete(lsn, 101, &slot, pageGroups);
+    EXPECT_EQ(2U, slot.A);
+    EXPECT_EQ(101U, slot.B);
+    EXPECT_EQ(4U, slot.C);
+    Flush(pageGroups, *fx.PageStore);
+
+    ui64 slotNo = 0;
+    error = fx.Ht.Get(0 /* lsn */, 100, &slot, &slotNo);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    EXPECT_EQ(1U, slot.A);
+    EXPECT_EQ(100U, slot.B);
+    EXPECT_EQ(3U, slot.C);
+    error = fx.Ht.Get(0 /* lsn */, 101, &slot, &slotNo);
+    EXPECT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+    error = fx.Ht.Get(0 /* lsn */, 102, &slot, &slotNo);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    EXPECT_EQ(3U, slot.A);
+    EXPECT_EQ(102U, slot.B);
+    EXPECT_EQ(5U, slot.C);
+
+    lsn = fx.PageStore->AllocateLsn();
+    error = fx.Ht.Delete(lsn, 100, &slot, pageGroups);
+    EXPECT_EQ(1U, slot.A);
+    EXPECT_EQ(100U, slot.B);
+    EXPECT_EQ(3U, slot.C);
+    Flush(pageGroups, *fx.PageStore);
+
+    error = fx.Ht.Get(0 /* lsn */, 100, &slot, &slotNo);
+    EXPECT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+    error = fx.Ht.Get(0 /* lsn */, 101, &slot, &slotNo);
+    EXPECT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+    error = fx.Ht.Get(0 /* lsn */, 102, &slot, &slotNo);
+    EXPECT_EQ(S_OK, error.GetCode()) << FormatError(error);
+    EXPECT_EQ(3U, slot.A);
+    EXPECT_EQ(102U, slot.B);
+    EXPECT_EQ(5U, slot.C);
+
+    lsn = fx.PageStore->AllocateLsn();
+    error = fx.Ht.Delete(lsn, 102, &slot, pageGroups);
+    EXPECT_EQ(3U, slot.A);
+    EXPECT_EQ(102U, slot.B);
+    EXPECT_EQ(5U, slot.C);
+    Flush(pageGroups, *fx.PageStore);
+
+    error = fx.Ht.Get(0 /* lsn */, 100, &slot, &slotNo);
+    EXPECT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+    error = fx.Ht.Get(0 /* lsn */, 101, &slot, &slotNo);
+    EXPECT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+    error = fx.Ht.Get(0 /* lsn */, 102, &slot, &slotNo);
+    EXPECT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+}
+
+TEST(PersistentHashTableTest, PutGetUpdateRandomized)
+{
+    TFixture fx;
+
+    TVector<TPageGroup> pageGroups;
+
+    const double putProb = 0.5;
+    const double updateProb = 0.2;
+    const double deleteProb = 0.3;
+    TVector<ui64> keys;
+    THashMap<ui64, std::pair<TSlot, ui64>> refImpl;
+
+    const ui64 seed = 111;
+    TFastRng64 rng(seed);
+
+    const ui64 maxKey = 1'000'000;
+
+    auto makeSlot = [&] () {
+        return TSlot{
+            .A = static_cast<ui32>(rng.GenRand()),
+            .B = rng.Uniform(0, maxKey),
+            .C = static_cast<ui32>(rng.GenRand()),
+        };
+    };
+
+    for (ui64 i = 0; i < fx.SlotCount; ++i) {
+        //
+        // Put.
+        //
+
+        if (keys.empty() || rng.GenRandReal2() < putProb) {
+            auto slot = makeSlot();
+            if (!refImpl.contains(slot.B)) {
+                refImpl[slot.B] = {slot, keys.size()};
+
+                ui64 lsn = fx.PageStore->AllocateLsn();
+                auto error = fx.Ht.Put(lsn, slot, pageGroups);
+                Cdbg << "PUT " << slot.B << Endl;
+                ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+                Flush(pageGroups, *fx.PageStore);
+                keys.push_back(slot.B);
+            }
+        }
+
+        //
+        // Get for existing key.
+        //
+
+        TSlot slot;
+        ui64 slotNo = 0;
+        const ui64 key = keys[rng.Uniform(0, keys.size())];
+        auto error = fx.Ht.Get(0 /* lsn */, key, &slot, &slotNo);
+        Cdbg << "GET " << key << Endl;
+        ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+        auto& expectedSlot = refImpl[key].first;
+        ASSERT_EQ(expectedSlot.A, slot.A);
+        ASSERT_EQ(expectedSlot.B, slot.B);
+        ASSERT_EQ(expectedSlot.C, slot.C);
+
+        //
+        // Update.
+        //
+
+        if (rng.GenRandReal2() < updateProb) {
+            slot = makeSlot();
+            slot.B = key;
+
+            refImpl[key].first = slot;
+
+            ui64 lsn = fx.PageStore->AllocateLsn();
+            error = fx.Ht.Update(lsn, slot, slotNo, pageGroups);
+            Cdbg << "UPDATE " << key << Endl;
+            ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+            Flush(pageGroups, *fx.PageStore);
+        }
+
+        //
+        // Delete.
+        //
+
+        if (rng.GenRandReal2() < deleteProb) {
+            auto it = refImpl.find(key);
+            Y_ABORT_UNLESS(it != refImpl.end());
+            const ui64 keysArrayIndex = it->second.second;
+            if (keysArrayIndex != keys.size() - 1) {
+                refImpl[keys.back()].second = keysArrayIndex;
+                keys[keysArrayIndex] = keys.back();
+            }
+            keys.pop_back();
+            refImpl.erase(it);
+
+            ui64 lsn = fx.PageStore->AllocateLsn();
+            error = fx.Ht.Delete(lsn, key, &slot, pageGroups);
+            Cdbg << "DELETE " << key << Endl;
+            ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+            Flush(pageGroups, *fx.PageStore);
+
+            error = fx.Ht.Get(0 /* lsn */, key, &slot, &slotNo);
+            if (error.GetCode() != E_FS_NOENT) {
+                Cerr << slot.B << Endl;
+            }
+            ASSERT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+        }
+
+        //
+        // Get for missing key.
+        //
+
+        const ui64 key2 = rng.Uniform(maxKey, 1'000);
+        error = fx.Ht.Get(0 /* lsn */, key2, &slot, &slotNo);
+        ASSERT_EQ(E_FS_NOENT, error.GetCode()) << FormatError(error);
+
+        //
+        // Output stats from time to time.
+        //
+
+        if (i % 10'000 == 0) {
+            TPersistentHashTableStats stats;
+            error = fx.Ht.CollectStats(&stats);
+            ASSERT_EQ(S_OK, error.GetCode()) << FormatError(error);
+            Cerr << "values=" << stats.ValueCount << "/" << stats.SlotCount
+                << " tombstones=" << stats.TombstoneCount
+                << "/" << stats.SlotCount
+                << " misplaced=" << stats.MisplacedValueCount
+                << "/" << stats.ValueCount
+                << Endl;
+        }
+    }
+}

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ut/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ut/ya.make
@@ -1,6 +1,8 @@
 GTEST()
 
 SRCS(
+    ../persistent_bitmap_ut.cpp
+    ../persistent_hash_table_ut.cpp
     ../shard_ut.cpp
 )
 

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ya.make
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/ya.make
@@ -4,6 +4,9 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/deny_ydb_dependency.inc)
 
 IF (OPENSOURCE AND NOT FORCE_FASTSHARD_IPC_STUB)
     SRCS(
+        page_store.cpp
+        persistent_bitmap.cpp
+        persistent_hash_table.cpp
         shard.cpp
     )
 


### PR DESCRIPTION
### Notes
_This PR is a part of https://github.com/ydb-platform/nbs/pull/6606 - the end result is described there_

Implementing the following parts of that PR:
* `PersistentHashTable` - a simple open-addressed hash table with linear probing and some simple tombstone cleanup logic, will be used for `NodeTable`, `NameTable`, `HandleTable` and, in the prototype, - for `PageIndex`
* `PersistentBitmap` - will be used for `PageAllocator`
* `PageStore` - all data accesses go through it

Added both simple unit tests and randomized unit tests that validate `PersistentHashTable` via `THashMap` and `PersistentBitmap` - via `TDynBitMap`. 

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895