### PR TITLE
fixed imprecise comment

### DIFF
--- a/cloud/storage/core/tools/testing/codec_bench/main.cpp
+++ b/cloud/storage/core/tools/testing/codec_bench/main.cpp
@@ -167,9 +167,7 @@ int Run(const TOptions& opts)
          << originalSize << " bytes)" << Endl;
 
     //
-    // Pre-size compress and decompress destination buffers so no
-    // allocation happens inside the timed loop. TBuffer::Reserve/Resize
-    // does no zero-init, unlike TString::ReserveAndResize.
+    // Prealloc buffers.
     //
 
     const size_t maxCompressed = codec->MaxCompressedLength(input);


### PR DESCRIPTION
### Notes
`TString::ReserveAndResize()` actually doesn't do zero-init, so the comment is inaccurate. Fixed this.

### Issue
None