### PR TITLE
[Tasks] fix flaky TestTasksShouldFailRunningAfterRetriableErrorCount* tests

### DIFF
--- a/cloud/tasks/tasks_tests/tasks_test.go
+++ b/cloud/tasks/tasks_tests/tasks_test.go
@@ -1210,10 +1210,21 @@ func TestTasksShouldFailRunningAfterRetriableErrorCountExceeded(t *testing.T) {
 	require.NoError(t, err)
 
 	reqCtx := getRequestContext(t, ctx)
+	// NOTE: the task must never succeed on its own, it has to be terminated by
+	// the retry limit.
+	//
+	// TaskState.RetriableErrorCount is a best-effort counter: it can lag behind
+	// the real number of failed runs, because the task persists its own state
+	// (via execCtx.SaveState) and the runner increments RetriableErrorCount in
+	// two separate transactions. If the run context is cancelled in between
+	// (e.g. by a failed ping), the increment is skipped while the task state is
+	// already persisted.
+	// failed runs, see the comment in
+	// TestTasksShouldFailRunningAfterRetriableErrorCountForTaskTypeExceeded.
 	id, err := scheduleUnstableTask(
 		reqCtx,
 		s.scheduler,
-		newDefaultConfig().GetMaxRetriableErrorCount()+1,
+		10*newDefaultConfig().GetMaxRetriableErrorCount(), // failuresUntilSuccess
 	)
 	require.NoError(t, err)
 
@@ -1264,10 +1275,19 @@ func TestTasksShouldFailRunningAfterRetriableErrorCountForTaskTypeExceeded(
 	require.NoError(t, err)
 
 	reqCtx := getRequestContext(t, ctx)
+	// NOTE: the task must never succeed on its own, it has to be terminated by
+	// the retry limit.
+	//
+	// TaskState.RetriableErrorCount is a best-effort counter: it can lag behind
+	// the real number of failed runs, because the task persists its own state
+	// (via execCtx.SaveState) and the runner increments RetriableErrorCount in
+	// two separate transactions. If the run context is cancelled in between
+	// (e.g. by a failed ping), the increment is skipped while the task state is
+	// already persisted.
 	id, err := scheduleUnstableTask(
 		reqCtx,
 		s.scheduler,
-		unstableTaskMaxRetriesCount+1, // failuresUntilSuccess
+		defaultMaxRetriesCount+1, // failuresUntilSuccess
 	)
 	require.NoError(t, err)
 
@@ -1282,7 +1302,11 @@ func TestTasksShouldFailRunningAfterRetriableErrorCountForTaskTypeExceeded(
 
 	failsCount, err := getTaskMetadata(ctx, s.scheduler, id)
 	require.NoError(t, err)
-	require.EqualValues(t, unstableTaskMaxRetriesCount+1, failsCount)
+	// The task type limit must be the one in effect, not the (much bigger)
+	// default one. The exact number of runs is not deterministic, see the note
+	// above.
+	require.GreaterOrEqual(t, failsCount, unstableTaskMaxRetriesCount+1)
+	require.Less(t, failsCount, defaultMaxRetriesCount)
 }
 
 func TestTasksShouldNotRestoreRunningAfterNonRetriableError(t *testing.T) {


### PR DESCRIPTION
### Notes
`TestTasksShouldFailRunningAfterRetriableErrorCountForTaskTypeExceeded` and
`TestTasksShouldFailRunningAfterRetriableErrorCountExceeded` are flaky.

```
    tasks_test.go:1275: 
        	Error Trace:	/-S/cloud/tasks/tasks_tests/tasks_test.go:1275
        	Error:      	An error is expected but got nil.
        	Test:       	TestTasksShouldFailRunningAfterRetriableErrorCountForTaskTypeExceeded
```
https://github-actions-s3.storage.eu-north2.nebius.cloud/ydb-platform/nbs/Nightly-build/30054501916/1/nebius-x86-64/logs/1/cloud/tasks/tasks_tests/test-results/tasks_tests/testing_out_stuff/tasks_tests.TestTasksShouldFailRunningAfterRetriableErrorCountForTaskTypeExceeded.log

Both tests schedule an `unstableTask` that fails exactly `maxRetries + 1` times and then assert that the task was terminated by the retry limit. This assumes that `TaskState.RetriableErrorCount` is always equal to the number of failed runs, which is not guaranteed.

The task persists its own failure counter via `execCtx.SaveState` inside `Run`, and the runner increments `RetriableErrorCount` afterwards, in a separate transaction. If `runCtx` is cancelled in between, `executeTask`
returns early and skips `incrementRetriableErrorCount`:

```go
err := r.run(ctx, execCtx, task)

if ctx.Err() != nil {
    // If context was cancelled, just return.
    return
}
```

`runCtx` is cancelled by `taskPinger` through `onError` whenever a ping fails, which happens on a transient YDB error, on a ping exceeding `pingTimeout`, or when the lock is taken over by a stalling runner (`TaskStallingTimeout` is 1s in the test config, which is easy to miss on a loaded CI agent). The result is that the task state says N failures while `RetriableErrorCount` is N - 1. The task then reaches `state.Value == request.Value` on the next run, returns nil,
and finishes successfully, so `require.Error` fails with `An error is expected but got nil`.

`RetriableErrorCount` is a best effort counter that can only undercount, so the tests must not assume it moves in lockstep with the task's own counter.
