### PR TITLE
[Filestore] issue-4547: add 512 KiB, fresh blocks and read ahead benchmarks to tablet_bench.cpp

### DIFF
--- a/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
+++ b/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
@@ -29,7 +29,28 @@ constexpr ui64 MixedBlocksOffloadedRangesCapacity = 1000000;
 // multi-overwrite mixed file.
 constexpr ui32 MaxOverwrites = 4;
 
-struct TTabletSetup
+// Write size used to build the fresh file. It must stay below
+// WriteBlobThreshold (128KiB by default) so that the data lands in the fresh
+// blocks table instead of going down the blob write path.
+constexpr ui64 FreshWriteSize = 64_KB;
+
+// The read ahead file is separate from the 1MiB files above: read ahead only
+// does anything across *consecutive* requests, and with a 1MiB file the very
+// first window would already cover the whole file, so every later request
+// would be a cache hit and nothing would ever be described again.
+constexpr ui64 ReadAheadFileSize = 16_MB;
+
+// ReadAheadRangeSize == 0 leaves the read ahead cache disabled, which is what
+// the non-read-ahead benchmarks use.
+//
+// Read ahead is deliberately NOT enabled in the shared setup:
+// IsCloseToSequential accepts a run of identical 1MiB describes as sequential
+// (their spanned length is exactly 1MiB), so any RangeSize above 1MiB would
+// make the existing 1MiB benchmarks start populating and then hitting the read
+// ahead cache, silently changing what they measure. The read ahead benchmarks
+// get their own tablets.
+template <ui32 ReadAheadRangeSize>
+struct TTabletSetupT
 {
     TTestEnv Env;
     std::unique_ptr<TIndexTabletClient> TabletClient;
@@ -58,7 +79,18 @@ struct TTabletSetup
     ui64 OverwriteFileHandle = 0;
     ui64 OverwriteNodeId = 0;
 
-    TTabletSetup()
+    // A file whose blocks are all still in the fresh blocks table: it is
+    // written in sub-WriteBlobThreshold chunks and never flushed, so nothing
+    // is backed by a blob. Describing it has to ship every block's content
+    // inline in the response, unlike blob-backed files which are described by
+    // reference.
+    ui64 FreshFileHandle = 0;
+
+    // A ReadAheadFileSize long blob-backed file used only by the read ahead
+    // benchmarks.
+    ui64 ReadAheadFileHandle = 0;
+
+    TTabletSetupT()
         : Env(TTestEnvConfig{
             // Turn off logging in order to reduce performance overhead
             .LogPriority_NFS = NActors::NLog::PRI_ALERT,
@@ -97,6 +129,10 @@ struct TTabletSetup
         storageConfig.SetFlushThreshold(Max<ui32>());
         storageConfig.SetFlushBytesThreshold(Max<ui64>());
 
+        if (ReadAheadRangeSize) {
+            storageConfig.SetReadAheadCacheRangeSize(ReadAheadRangeSize);
+        }
+
         Env.UpdateStorageConfig(std::move(storageConfig));
 
         Env.GetRuntime().SetDispatchedEventsLimit(Max<ui64>());
@@ -115,7 +151,7 @@ struct TTabletSetup
         // the first time each benchmark runs.
     }
 
-    ~TTabletSetup()
+    ~TTabletSetupT()
     {
         // HACK(svartmetal): awful hack to prevent a crash in 'verify' during
         // process cleanup:
@@ -260,19 +296,92 @@ struct TTabletSetup
         }
     }
 
-    void DescribeData(ui64 handle, ui64 offset, ui64 length)
+    // Writes the file in sub-WriteBlobThreshold chunks and does not flush, so
+    // every block stays in the fresh blocks table.
+    void EnsureFreshFileCreated()
+    {
+        if (FreshFileHandle) {
+            return;
+        }
+
+        auto nodeId = CreateNode(
+            *TabletClient,
+            TCreateNodeArgs::File(RootNodeId, "fresh"));
+
+        auto handle = CreateHandle(*TabletClient, nodeId);
+
+        static_assert(FreshWriteSize < FileSize);
+
+        for (ui64 offset = 0; offset < FileSize; offset += FreshWriteSize) {
+            TabletClient->WriteData(handle, offset, FreshWriteSize, '3');
+        }
+
+        FreshFileHandle = handle;
+    }
+
+    void EnsureReadAheadFileCreated()
+    {
+        if (ReadAheadFileHandle) {
+            return;
+        }
+
+        auto nodeId = CreateNode(
+            *TabletClient,
+            TCreateNodeArgs::File(RootNodeId, "read_ahead"));
+
+        auto handle = CreateHandle(*TabletClient, nodeId);
+
+        static_assert(FileSize < ReadAheadFileSize);
+
+        for (ui64 offset = 0; offset < ReadAheadFileSize; offset += FileSize) {
+            TabletClient->WriteData(handle, offset, FileSize, '4');
+        }
+        TabletClient->Flush();
+
+        ReadAheadFileHandle = handle;
+    }
+
+    void DescribeData(
+        ui64 handle,
+        ui64 offset,
+        ui64 length,
+        ui64 expectedFileSize = FileSize)
     {
         auto response = TabletClient->DescribeData(handle, offset, length);
-        Y_ABORT_UNLESS(FileSize == response->Record.GetFileSize());
+        Y_ABORT_UNLESS(expectedFileSize == response->Record.GetFileSize());
     }
 };
 
+using TTabletSetup = TTabletSetupT<0>;
+
+// A 1MiB window is the smallest one that a 512KiB request can trigger:
+// RegisterDescribeImpl only widens a request shorter than RangeSize.
+using TReadAheadTabletSetup512KiB = TTabletSetupT<1_MB>;
+
+// A 1MiB request needs a window wider than 1MiB to be widened at all.
+using TReadAheadTabletSetup1MiB = TTabletSetupT<4_MB>;
+
+// Ensure these singletons are destroyed before any other singletons or static
+// variables to avoid a crash
+constexpr ui64 SingletonPriority = Max<ui64>();
+
 TTabletSetup* GetOrCreateTablet()
 {
-    // Ensure this singleton is destroyed before any other singletons or static
-    // variables to avoid a crash
-    constexpr ui64 Priority = Max<ui64>();
-    return SingletonWithPriority<TTabletSetup, Priority>();
+    return SingletonWithPriority<TTabletSetup, SingletonPriority>();
+}
+
+TReadAheadTabletSetup512KiB* GetOrCreateReadAheadTablet512KiB()
+{
+    return SingletonWithPriority<
+        TReadAheadTabletSetup512KiB,
+        SingletonPriority>();
+}
+
+TReadAheadTabletSetup1MiB* GetOrCreateReadAheadTablet1MiB()
+{
+    return SingletonWithPriority<
+        TReadAheadTabletSetup1MiB,
+        SingletonPriority>();
 }
 
 }   // namespace
@@ -287,6 +396,17 @@ Y_CPU_BENCHMARK(TTablet_DescribeData_Merged_1MiB_RequestSize, iface)
 
     for (size_t i = 0; i < iface.Iterations(); ++i) {
         tablet->DescribeData(tablet->MergedFileHandle, 0, 1_MB);
+    }
+}
+
+Y_CPU_BENCHMARK(TTablet_DescribeData_Merged_512KiB_RequestSize, iface)
+{
+    auto* tablet = GetOrCreateTablet();
+
+    tablet->EnsureMergedFileCreated();
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(tablet->MergedFileHandle, 0, 512_KB);
     }
 }
 
@@ -309,6 +429,17 @@ Y_CPU_BENCHMARK(TTablet_DescribeData_Mixed_1MiB_RequestSize, iface)
 
     for (size_t i = 0; i < iface.Iterations(); ++i) {
         tablet->DescribeData(tablet->MixedFileHandle, 0, 1_MB);
+    }
+}
+
+Y_CPU_BENCHMARK(TTablet_DescribeData_Mixed_512KiB_RequestSize, iface)
+{
+    auto* tablet = GetOrCreateTablet();
+
+    tablet->EnsureMixedFileCreated();
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(tablet->MixedFileHandle, 0, 512_KB);
     }
 }
 
@@ -336,6 +467,19 @@ Y_CPU_BENCHMARK(TTablet_DescribeData_MixedMultiOverwrite_1MiB_RequestSize, iface
     }
 }
 
+Y_CPU_BENCHMARK(
+    TTablet_DescribeData_MixedMultiOverwrite_512KiB_RequestSize,
+    iface)
+{
+    auto* tablet = GetOrCreateTablet();
+
+    tablet->EnsureMixedMultiOverwriteFileCreated();
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(tablet->OverwriteFileHandle, 0, 512_KB);
+    }
+}
+
 Y_CPU_BENCHMARK(TTablet_DescribeData_MixedMultiOverwrite_4KiB_RequestSize, iface)
 {
     auto* tablet = GetOrCreateTablet();
@@ -346,5 +490,86 @@ Y_CPU_BENCHMARK(TTablet_DescribeData_MixedMultiOverwrite_4KiB_RequestSize, iface
 
     for (size_t i = 0; i < iface.Iterations(); ++i) {
         tablet->DescribeData(tablet->OverwriteFileHandle, startOffset, 4_KB);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Fresh blocks. Nothing is blob backed, so the whole described range is
+// returned inline as fresh data ranges instead of by blob reference.
+
+Y_CPU_BENCHMARK(TTablet_DescribeData_Fresh_1MiB_RequestSize, iface)
+{
+    auto* tablet = GetOrCreateTablet();
+
+    tablet->EnsureFreshFileCreated();
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(tablet->FreshFileHandle, 0, 1_MB);
+    }
+}
+
+Y_CPU_BENCHMARK(TTablet_DescribeData_Fresh_512KiB_RequestSize, iface)
+{
+    auto* tablet = GetOrCreateTablet();
+
+    tablet->EnsureFreshFileCreated();
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(tablet->FreshFileHandle, 0, 512_KB);
+    }
+}
+
+Y_CPU_BENCHMARK(TTablet_DescribeData_Fresh_4KiB_RequestSize, iface)
+{
+    auto* tablet = GetOrCreateTablet();
+
+    tablet->EnsureFreshFileCreated();
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(tablet->FreshFileHandle, 0, 4_KB);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Read ahead. The file is scanned sequentially so that the access pattern
+// stays close to sequential and read ahead keeps firing: a request that
+// triggers it describes the whole widened window and clips the response down,
+// and the requests that fall inside that window are served from the cache.
+// With a window of RangeSize and requests of RequestSize, one request out of
+// every RangeSize / RequestSize describes, the rest hit the cache.
+
+Y_CPU_BENCHMARK(TTablet_DescribeData_ReadAhead_512KiB_RequestSize, iface)
+{
+    auto* tablet = GetOrCreateReadAheadTablet512KiB();
+
+    tablet->EnsureReadAheadFileCreated();
+
+    constexpr ui64 RequestSize = 512_KB;
+    constexpr ui64 PositionCount = ReadAheadFileSize / RequestSize;
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(
+            tablet->ReadAheadFileHandle,
+            (i % PositionCount) * RequestSize,
+            RequestSize,
+            ReadAheadFileSize);
+    }
+}
+
+Y_CPU_BENCHMARK(TTablet_DescribeData_ReadAhead_1MiB_RequestSize, iface)
+{
+    auto* tablet = GetOrCreateReadAheadTablet1MiB();
+
+    tablet->EnsureReadAheadFileCreated();
+
+    constexpr ui64 RequestSize = 1_MB;
+    constexpr ui64 PositionCount = ReadAheadFileSize / RequestSize;
+
+    for (size_t i = 0; i < iface.Iterations(); ++i) {
+        tablet->DescribeData(
+            tablet->ReadAheadFileHandle,
+            (i % PositionCount) * RequestSize,
+            RequestSize,
+            ReadAheadFileSize);
     }
 }

--- a/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
+++ b/cloud/filestore/libs/storage/tablet/bench/tablet_bench.cpp
@@ -131,6 +131,16 @@ struct TTabletSetupT
 
         if (ReadAheadRangeSize) {
             storageConfig.SetReadAheadCacheRangeSize(ReadAheadRangeSize);
+
+            // Keep only the most recent widened window. The benchmarks scan
+            // the same file over and over, and with the default of 32 retained
+            // results the cache would hold every window of the file after the
+            // first pass, so every later pass would be served entirely from
+            // the cache and nothing would be described again. Retaining one
+            // window makes wrapping around behave like moving forward into a
+            // not yet described region, so the steady state stays at one
+            // describe per window.
+            storageConfig.SetReadAheadCacheMaxResultsPerNode(1);
         }
 
         Env.UpdateStorageConfig(std::move(storageConfig));


### PR DESCRIPTION
### Notes

Adds benchmark cases for parts of the DescribeData path that are currently not measured.

**512 KiB request size** for the existing merged, mixed and multi-overwrite files, in between the existing 4 KiB and 1 MiB cases.

**Fresh blocks.** A new `fresh` file is written in 64 KiB chunks and never flushed, so every block stays in the fresh blocks table. Describing such a file returns every block's content inline as fresh data ranges.

**Read ahead.** Two cases scan a 16 MiB file sequentially so that read ahead keeps firing. One request out of every `RangeSize / RequestSize` describes the widened window and clips the response down to the requested range, the rest are served from the read ahead cache.

Enabling read ahead in the shared setup with any `RangeSize` above 1 MiB would therefore make the existing `_1MiB_RequestSize` benchmarks start widening, populating and hitting the cache, silently changing what they measure. `TTabletSetup` is now `TTabletSetupT<ReadAheadRangeSize>`, the existing benchmarks use `TTabletSetupT<0>` and keep the previous configuration. The two read ahead instantiations use 1 MiB for 512 KiB requests and 4 MiB for 1 MiB requests, because `RegisterDescribeImpl` only widens a request shorter than `RangeSize`. 

The read ahead file is separate from the 1 MiB files because with a 1 MiB file the first window would already cover the whole file and every later request would be a cache hit.

```
svartmetal@svartmetal-ivm:~/nbs-github2/cloud/filestore/libs/storage/tablet/bench$ ./bench -b 280
tablet_helpers.cpp: SetPath # /tmp/tmpM8L9Nx/pdisk_1.dat
----------- TTablet_DescribeData_Merged_1MiB_RequestSize ---------------
 samples:       1364
 iterations:    1149886
 iterations hr:    1.15M
 run time:      20.0127606
 per iteration: 41149.17325 (41.1K) cycles
----------- TTablet_DescribeData_Merged_512KiB_RequestSize ---------------
 samples:       1561
 iterations:    1505980
 iterations hr:    1.51M
 run time:      20.02088577
 per iteration: 31847.94172 (31.8K) cycles
----------- TTablet_DescribeData_Merged_4KiB_RequestSize ---------------
 samples:       1820
 iterations:    2047276
 iterations hr:    2.05M
 run time:      20.01502419
 per iteration: 23425.73391 (23.4K) cycles
----------- TTablet_DescribeData_Mixed_1MiB_RequestSize ---------------
 samples:       1120
 iterations:    775635
 iterations hr:    776K
 run time:      20.01016201
 per iteration: 61645.14788 (61.6K) cycles
----------- TTablet_DescribeData_Mixed_512KiB_RequestSize ---------------
 samples:       1192
 iterations:    878475
 iterations hr:    878K
 run time:      20.01839368
 per iteration: 54580.93795 (54.6K) cycles
----------- TTablet_DescribeData_Mixed_4KiB_RequestSize ---------------
 samples:       1266
 iterations:    990528
 iterations hr:    991K
 run time:      20.01041652
 per iteration: 48401.30302 (48.4K) cycles
----------- TTablet_DescribeData_MixedMultiOverwrite_1MiB_RequestSize ---------------
 samples:       677
 iterations:    283881
 iterations hr:    284K
 run time:      20.03633891
 per iteration: 167247.5912 (167K) cycles
----------- TTablet_DescribeData_MixedMultiOverwrite_512KiB_RequestSize ---------------
 samples:       736
 iterations:    334971
 iterations hr:    335K
 run time:      20.00363033
 per iteration: 143107.3738 (143K) cycles
----------- TTablet_DescribeData_MixedMultiOverwrite_4KiB_RequestSize ---------------
 samples:       844
 iterations:    440391
 iterations hr:    440K
 run time:      20.04230477
 per iteration: 108981.111 (109K) cycles
----------- TTablet_DescribeData_Fresh_1MiB_RequestSize ---------------
 samples:       466
 iterations:    134421
 iterations hr:    134K
 run time:      20.07546086
 per iteration: 357575.3845 (358K) cycles
----------- TTablet_DescribeData_Fresh_512KiB_RequestSize ---------------
 samples:       563
 iterations:    196251
 iterations hr:    196K
 run time:      20.02131526
 per iteration: 244508.9786 (245K) cycles
----------- TTablet_DescribeData_Fresh_4KiB_RequestSize ---------------
 samples:       834
 iterations:    430128
 iterations hr:    430K
 run time:      20.000073
 per iteration: 111404.7204 (111K) cycles
tablet_helpers.cpp: SetPath # /tmp/tmpxHgTsy/pdisk_1.dat
----------- TTablet_DescribeData_ReadAhead_512KiB_RequestSize ---------------
 samples:       1242
 iterations:    952890
 iterations hr:    953K
 run time:      20.02720149
 per iteration: 49580.19058 (49.6K) cycles
tablet_helpers.cpp: SetPath # /tmp/tmpwJj7mT/pdisk_1.dat
----------- TTablet_DescribeData_ReadAhead_1MiB_RequestSize ---------------
 samples:       1142
 iterations:    805815
 iterations hr:    806K
 run time:      20.02262181
 per iteration: 58668.22664 (58.7K) cycles
```

### Issue

#4547 