### PR TITLE
publish ca fingerprint in metrics

### DIFF
--- a/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
+++ b/cloud/storage/core/libs/grpc/periodic_tls_certificate_provider.cpp
@@ -13,6 +13,7 @@
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
+#include <util/digest/city.h>
 #include <util/folder/dirut.h>
 #include <util/generic/yexception.h>
 #include <util/system/mutex.h>
@@ -28,6 +29,15 @@ namespace {
 
 using grpc_core::PemKeyCertPairList;
 using grpc_core::RefCountedPtr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+ui64 RootCaFingerprint(TStringBuf rootCa)
+{
+    // Dynamic counters export gauges as double. Keep only 53 bits to avoid
+    // precision loss while preserving a high-quality fingerprint.
+    return CityHash64(rootCa) & ((1ULL << 53) - 1);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -123,6 +133,7 @@ class TPeriodicCertificateProvider final
     NTlsUtils::TRootCaPair RootCaPair;
     TVector<NTlsUtils::TCertificatePair> Certificates;
     TVector<NMonitoring::TDynamicCountersPtr> CertificateMetrics;
+    NMonitoring::TDynamicCountersPtr RootCaMetrics;
 
     mutable TMutex UpdateMutex;
     std::atomic<bool> Started = false;
@@ -238,6 +249,11 @@ public:
             CertificateMetrics[i] = std::move(certMetrics);
         }
 
+        if (tlsMetricsGroup && RootCaPair.RootCaPath) {
+            RootCaMetrics = tlsMetricsGroup
+                ->GetSubgroup("cert", GetBaseName(RootCaPair.RootCaPath));
+        }
+
         RefreshCertificates();
 
         ScheduleUpdateAt(TInstant::Now() + RefreshInterval, true);
@@ -335,8 +351,12 @@ private:
         const TString oldRootCa = RootCaPair.RootCa;
         auto result = NTlsUtils::UpdateCertificates(certPairs, RootCaPair, Log);
         RootCaPair.RootCa = result.RootCa.GetOrElse(oldRootCa);
-
         const bool rootChanged = oldRootCa != RootCaPair.RootCa;
+
+        if (RootCaMetrics) {
+            const ui64 fingerprint = RootCaFingerprint(RootCaPair.RootCa);
+            *RootCaMetrics->GetCounter("Fingerprint", false) = fingerprint;
+        }
 
         PemKeyCertPairList identityPairs;
         for (size_t i = 0; i < Certificates.size(); ++i) {

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider.cpp
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider.cpp
@@ -6,6 +6,7 @@
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
+#include <util/digest/city.h>
 #include <util/folder/dirut.h>
 #include <util/generic/yexception.h>
 #include <util/stream/file.h>
@@ -13,6 +14,15 @@
 namespace NCloud {
 
 namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+ui64 RootCaFingerprint(TStringBuf rootCa)
+{
+    // Dynamic counters export gauges as double. Keep only 53 bits to avoid
+    // precision loss while preserving a high-quality fingerprint.
+    return CityHash64(rootCa) & ((1ULL << 53) - 1);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -98,12 +108,20 @@ public:
 private:
     void InitCounters()
     {
-        if (!ServerGroup || Certificates.empty()) {
+        if (!ServerGroup) {
             return;
         }
 
         auto tlsMetricsGroup =
             ServerGroup->GetSubgroup("subsystem", "certificates");
+
+        if (RootCaPair.RootCaPath) {
+            auto rootMetrics = tlsMetricsGroup->GetSubgroup(
+                "cert",
+                GetBaseName(RootCaPair.RootCaPath));
+            *rootMetrics->GetCounter("Fingerprint", false) =
+                RootCaFingerprint(RootCaPair.RootCa);
+        }
 
         for (const auto& cert: Certificates) {
             auto certMetrics = tlsMetricsGroup->GetSubgroup(

--- a/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
+++ b/cloud/storage/core/libs/grpc/tls_certificate_provider_ut.cpp
@@ -10,6 +10,7 @@
 #include <library/cpp/resource/resource.h>
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/digest/city.h>
 #include <util/datetime/base.h>
 #include <util/folder/dirut.h>
 #include <util/folder/tempdir.h>
@@ -34,6 +35,11 @@ TString ReadCertResource(TStringBuf relativePath)
 {
     return NResource::Find(
         TStringBuilder() << "grpc/ut/certs/" << relativePath);
+}
+
+ui64 RootCaFingerprint(TStringBuf rootCa)
+{
+    return CityHash64(rootCa) & ((1ULL << 53) - 1);
 }
 
 void WriteTextFile(const TString& path, const TString& content)
@@ -239,6 +245,14 @@ struct TManualProviderContext
             ->GetSubgroup("cert", GetBaseName(certPath))
             ->GetCounter("ExpireTs", false)
             ->Val();
+    }
+
+    ui64 GetRootCaFingerprint() const
+    {
+        auto rootGroup = ServerGroup
+            ->GetSubgroup("subsystem", "certificates")
+            ->GetSubgroup("cert", GetBaseName(RootPath));
+        return rootGroup->GetCounter("Fingerprint", false)->Val();
     }
 };
 
@@ -499,7 +513,25 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
         UNIT_ASSERT_VALUES_EQUAL(initialPending + 1, scheduler->PendingCount());
     }
 
-    Y_UNIT_TEST(ShouldReportExpireTsCounters)
+    Y_UNIT_TEST(ShouldReportRootCaFingerprint)
+    {
+        TManualProviderContext context;
+        context.Provider->Start();
+        Y_DEFER {
+            context.Provider->Stop();
+        };
+
+        const auto beforeFingerprint = context.GetRootCaFingerprint();
+
+        WriteTextFile(context.RootPath, ReadCertResource("server2.crt"));
+        context.Scheduler->RunPending();
+
+        const auto afterFingerprint = context.GetRootCaFingerprint();
+
+        UNIT_ASSERT_VALUES_UNEQUAL(beforeFingerprint, afterFingerprint);
+    }
+
+    Y_UNIT_TEST(ShouldReportExpireTsCountersForStaticProvider)
     {
         TTempDir tempDir;
         const TString rootPath = tempDir.Path() / "ca.crt";
@@ -528,6 +560,13 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
                     ->GetSubgroup("cert", GetBaseName(cert.CertChainPath));
             return certGroup->GetCounter("ExpireTs", false)->Val();
         };
+        auto rootFingerprint = [&]
+        {
+            auto rootGroup =
+                serverGroup->GetSubgroup("subsystem", "certificates")
+                    ->GetSubgroup("cert", GetBaseName(rootPath));
+            return rootGroup->GetCounter("Fingerprint", false)->Val();
+        };
 
         auto provider = CreateStaticCertificateProvider(
             rootPath,
@@ -541,6 +580,9 @@ Y_UNIT_TEST_SUITE(TTlsCertificateProviderTest)
 
         UNIT_ASSERT(expireTs(certs[0]) > 0);
         UNIT_ASSERT(expireTs(certs[1]) > 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            rootFingerprint(),
+            RootCaFingerprint(ReadCertResource("ca.crt")));
 
         UNIT_ASSERT(provider->CreateSecureServerCredentials());
         UNIT_ASSERT(provider->CreateSecureClientCredentials());


### PR DESCRIPTION
### Notes
For server certificates, we publish expiration timestamps to track certificate rotations. For the root CA, expiration is less useful because a bundle may contain multiple certificates. To track root CA changes reliably, this PR adds a hash-based fingerprint metric.

### Issue
#5722
