### PR TITLE
[Filestore] issue-4547: fake DescribeData should report metrics

### DIFF
--- a/cloud/filestore/libs/storage/tablet/bench/ya.make
+++ b/cloud/filestore/libs/storage/tablet/bench/ya.make
@@ -1,5 +1,8 @@
 Y_BENCHMARK()
 
+SIZE(medium)
+TIMEOUT(300)
+
 IF (SANITIZER_TYPE)
     TAG(ya:manual)
 ENDIF()

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_readdata.cpp
@@ -1194,6 +1194,12 @@ void TIndexTabletActor::HandleFakeDescribeData(
 
     ReportFakeDescribeDataHappened();
 
+    const TByteRange byteRange(
+        msg->Record.GetOffset(),
+        msg->Record.GetLength(),
+        GetBlockSize()
+    );
+
     auto requestInfo = CreateRequestInfo(
         ev->Sender,
         ev->Cookie,
@@ -1237,11 +1243,6 @@ void TIndexTabletActor::HandleFakeDescribeData(
         std::make_unique<TEvIndexTablet::TEvDescribeDataResponse>();
     response->Record = std::move(result);
 
-    CompleteResponse<TEvIndexTablet::TDescribeDataMethod>(
-        response->Record,
-        requestInfo->CallContext,
-        ctx);
-
     constexpr ui32 MaxLatencyUs = 100;
     const ui32 latencyUs = ClampVal(
         Config->GetFakeDescribeDataLatencyUs(),
@@ -1254,7 +1255,17 @@ void TIndexTabletActor::HandleFakeDescribeData(
     // Spin until deadline
     while (GetCycleCount() < deadlineCycles) {}
 
+    CompleteResponse<TEvIndexTablet::TDescribeDataMethod>(
+        response->Record,
+        requestInfo->CallContext,
+        ctx);
+
     NCloud::Reply(ctx, *requestInfo, std::move(response));
+
+    Metrics.DescribeData.Update(
+        1,
+        byteRange.Length,
+        ctx.Now() - requestInfo->StartedTs);
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_data.cpp
@@ -5751,6 +5751,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
             fakeDescribeDataLatencyUs);
 
         TTestEnv env(testEnvConfig, std::move(storageConfig));
+        auto registry = env.GetRegistry();
 
         ui32 nodeIdx = env.AddDynamicNode();
         ui64 tabletId = env.BootIndexTablet(nodeIdx);
@@ -5779,6 +5780,39 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Data)
         UNIT_ASSERT_VALUES_EQUAL(4, blobPieces.size());
 
         UNIT_ASSERT_VALUES_EQUAL(1, fakeDescribeDataHappened->Val());
+
+        // an unaligned request - RequestBytes should report the requested
+        // length, not the block-aligned one
+        tablet.DescribeData(0, 1, 100);
+
+        UNIT_ASSERT_VALUES_EQUAL(2, fakeDescribeDataHappened->Val());
+
+        tablet.SendRequest(tablet.CreateUpdateCounters());
+        env.GetRuntime().DispatchEvents({}, TDuration::Seconds(1));
+
+        {
+            TTestRegistryVisitor visitor;
+            // clang-format off
+            registry->Visit(TInstant::Zero(), visitor);
+            visitor.ValidateExpectedCounters({
+                {{
+                    {"sensor", "Count"},
+                    {"request", "DescribeData"},
+                    {"filesystem", "test"}
+                }, 2},
+                {{
+                    {"sensor", "RequestBytes"},
+                    {"request", "DescribeData"},
+                    {"filesystem", "test"}
+                }, static_cast<i64>(256_KB + 100)},
+                // fake responses are not served from the read-ahead cache
+                {{
+                    {"sensor", "ReadAheadCacheHitCount"},
+                    {"filesystem", "test"}
+                }, 0},
+            });
+            // clang-format on
+        }
     }
 
     TABLET_TEST_16K(ShouldHandleFakeDescribeData)


### PR DESCRIPTION
### Notes
Follow-up for #4930

`HandleFakeDescribeData` replied without touching `Metrics.DescribeData`, so fake DescribeData responses were invisible in the tablet request metrics. A load test running with `FakeDescribeDataEnabled` reported zero DescribeData RPS and zero throughput, which makes the fake path hard to use for performance modeling because its numbers cannot be compared against the real path.

### Issue
#4547 