### PR TITLE
[DM] Add TTL mechanism for idle base disks in pools

### DIFF
--- a/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/config/config.proto
@@ -45,4 +45,10 @@ message PoolsConfig {
     //  * Reducing this number also increases the total size of the base disks
     //    that need to be allocated.
     optional uint32 BaseDiskOverSubscription = 24 [default = 2];
+    // TTL for idle base disks in pools. Base disks with zero overlay disks
+    // for longer than this duration will be retired (ejected from pool and deleted).
+    // Set to "0s" to disable.
+    optional string BaseDiskIdleTTL = 25 [default = "0s"];
+    // Maximum number of idle base disks to process in a single cleanup run.
+    optional uint64 CleanupIdleBaseDisksLimit = 26 [default = 100];
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task.go
@@ -22,39 +22,39 @@ type optimizeBaseDisksTask struct {
 	convertToImageSizedBaseDisksThreshold   uint64
 	convertToDefaultSizedBaseDisksThreshold uint64
 	minPoolAge                              time.Duration
+	baseDiskIdleTTL                         time.Duration
+	cleanupIdleBaseDisksLimit               uint64
 	state                                   *protos.OptimizeBaseDisksTaskState
 }
 
-func (t *optimizeBaseDisksTask) Save() ([]byte, error) {
-	return proto.Marshal(t.state)
-}
-
-func (t *optimizeBaseDisksTask) Load(_, state []byte) error {
-	t.state = &protos.OptimizeBaseDisksTaskState{}
-	return proto.Unmarshal(state, t.state)
-}
-
-func (t *optimizeBaseDisksTask) Run(
+func (t *optimizeBaseDisksTask) ensureResourcesToOptimizeCollected(
 	ctx context.Context,
 	execCtx tasks.ExecutionContext,
+	sizeOptimizationEnabled bool,
+	idleCleanupEnabled bool,
 ) error {
 
-	t1 := t.convertToDefaultSizedBaseDisksThreshold
-	t2 := t.convertToImageSizedBaseDisksThreshold
-	common.Assert(t1 > t2, `ConvertToDefaultSizedBaseDisksThreshold should be greater 
-		than convertToImageSizedBaseDisksThreshold`)
-
-	if t1 == 0 && t2 == 0 {
+	if t.state.CollectedResourcesToOptimize {
 		return nil
 	}
 
-	if len(t.state.ConfigurePoolRequests) == 0 {
-		poolInfos, err := t.storage.GetReadyPoolInfos(ctx)
-		if err != nil {
-			return err
-		}
+	poolInfos, err := t.storage.GetReadyPoolInfos(ctx)
+	if err != nil {
+		return err
+	}
 
-		now := time.Now()
+	now := time.Now()
+
+	type poolKey struct {
+		imageID string
+		zoneID  string
+	}
+
+	optimizedPools := make(map[poolKey]bool)
+
+	if sizeOptimizationEnabled {
+		t1 := t.convertToDefaultSizedBaseDisksThreshold
+		t2 := t.convertToImageSizedBaseDisksThreshold
 
 		for _, poolInfo := range poolInfos {
 			dateThreshold := poolInfo.CreatedAt.Add(t.minPoolAge)
@@ -75,8 +75,8 @@ func (t *optimizeBaseDisksTask) Run(
 				continue
 			}
 
-			t.state.ConfigurePoolRequests = append(
-				t.state.ConfigurePoolRequests,
+			t.state.ConfigurePoolForImageSizeRequests = append(
+				t.state.ConfigurePoolForImageSizeRequests,
 				&protos.ConfigurePoolRequest{
 					ZoneId:       poolInfo.ZoneID,
 					ImageId:      poolInfo.ImageID,
@@ -84,17 +84,115 @@ func (t *optimizeBaseDisksTask) Run(
 					UseImageSize: newUseImageSize,
 				},
 			)
-		}
 
-		err = execCtx.SaveState(ctx)
-		if err != nil {
-			return err
+			// Pools selected for size optimization will have all their base disks retired,
+			// including idle ones, so there is no need to run idle cleanup for them.
+			optimizedPools[poolKey{poolInfo.ImageID, poolInfo.ZoneID}] = true
 		}
 	}
 
+	if idleCleanupEnabled {
+		for _, poolInfo := range poolInfos {
+			key := poolKey{poolInfo.ImageID, poolInfo.ZoneID}
+			if optimizedPools[key] {
+				continue
+			}
+
+			idleDisks, err := t.storage.GetIdleBaseDisks(
+				ctx,
+				poolInfo.ImageID,
+				poolInfo.ZoneID,
+				t.baseDiskIdleTTL,
+				t.cleanupIdleBaseDisksLimit,
+			)
+			if err != nil {
+				return err
+			}
+
+			if len(idleDisks) == 0 {
+				continue
+			}
+
+			var reduction uint32
+			for _, disk := range idleDisks {
+				reduction += uint32(disk.FreeSlots)
+				t.state.IdleBaseDiskIds = append(
+					t.state.IdleBaseDiskIds,
+					disk.ID,
+				)
+			}
+
+			// TODO(https://github.com/ydb-platform/nbs/issues/6684):
+			// setting capacity to 0 may cause a race. If a slot is acquired
+			// on an idle disk between ConfigurePool and RetireBaseDisk, the
+			// retire triggers a rebase that creates a new base disk with srcDisk=nil.
+			// The scheduler (takeBaseDisksToSchedule) never picks it up: no SrcDisk
+			// for the global path, and capacity=0 excludes the pool from the per-pool
+			// path. The rebase task retries indefinitely, hanging the optimization.
+			newCapacity := uint32(0)
+			if poolInfo.Capacity > reduction {
+				newCapacity = poolInfo.Capacity - reduction
+			}
+
+			t.state.PoolReductionRequests = append(
+				t.state.PoolReductionRequests,
+				&protos.ConfigurePoolRequest{
+					ZoneId:       key.zoneID,
+					ImageId:      key.imageID,
+					Capacity:     newCapacity,
+					UseImageSize: poolInfo.ImageSize > 0,
+				},
+			)
+		}
+	}
+
+	t.state.CollectedResourcesToOptimize = true
+	return execCtx.SaveState(ctx)
+}
+
+func (t *optimizeBaseDisksTask) Save() ([]byte, error) {
+	return proto.Marshal(t.state)
+}
+
+func (t *optimizeBaseDisksTask) Load(_, state []byte) error {
+	t.state = &protos.OptimizeBaseDisksTaskState{}
+	return proto.Unmarshal(state, t.state)
+}
+
+func (t *optimizeBaseDisksTask) Run(
+	ctx context.Context,
+	execCtx tasks.ExecutionContext,
+) error {
+
+	t1 := t.convertToDefaultSizedBaseDisksThreshold
+	t2 := t.convertToImageSizedBaseDisksThreshold
+
+	sizeOptimizationEnabled := t1 > 0 || t2 > 0
+	if sizeOptimizationEnabled {
+		common.Assert(t1 > t2, `ConvertToDefaultSizedBaseDisksThreshold should be greater
+			than convertToImageSizedBaseDisksThreshold`)
+	}
+
+	idleCleanupEnabled := t.baseDiskIdleTTL > 0
+
+	if !sizeOptimizationEnabled && !idleCleanupEnabled {
+		return nil
+	}
+
+	err := t.ensureResourcesToOptimizeCollected(
+		ctx,
+		execCtx,
+		sizeOptimizationEnabled,
+		idleCleanupEnabled,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Execute optimization: ConfigurePool + RetireBaseDisks for each pool.
 	var configurePoolTaskIDs []string
 
-	for _, request := range t.state.ConfigurePoolRequests {
+	for _, request := range t.state.ConfigurePoolForImageSizeRequests {
 		taskID, err := t.scheduler.ScheduleTask(
 			headers.SetIncomingIdempotencyKey(
 				ctx,
@@ -124,7 +222,7 @@ func (t *optimizeBaseDisksTask) Run(
 			return err
 		}
 
-		request := t.state.ConfigurePoolRequests[i]
+		request := t.state.ConfigurePoolForImageSizeRequests[i]
 
 		taskID, err = t.scheduler.ScheduleTask(
 			headers.SetIncomingIdempotencyKey(
@@ -138,6 +236,57 @@ func (t *optimizeBaseDisksTask) Run(
 				ZoneId:           request.GetZoneId(),
 				ImageId:          request.GetImageId(),
 				UseBaseDiskAsSrc: true,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		_, err = t.scheduler.WaitTask(ctx, execCtx, taskID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Execute idle cleanup: reduce pool capacities, then retire idle base disks.
+	for _, request := range t.state.PoolReductionRequests {
+		taskID, err := t.scheduler.ScheduleTask(
+			headers.SetIncomingIdempotencyKey(
+				ctx,
+				"idle_configure_pool_"+execCtx.GetTaskID()+
+					":"+request.GetZoneId()+":"+request.GetImageId(),
+			),
+			"pools.ConfigurePool",
+			"",
+			request,
+		)
+		if err != nil {
+			return err
+		}
+
+		_, err = t.scheduler.WaitTask(ctx, execCtx, taskID)
+		if err != nil {
+			if !errors.CanRetry(err) {
+				// Ignore non-retriable (fatal) error, because image might be already
+				// deleted.
+				continue
+			}
+
+			return err
+		}
+	}
+
+	for _, baseDiskID := range t.state.IdleBaseDiskIds {
+		taskID, err := t.scheduler.ScheduleTask(
+			headers.SetIncomingIdempotencyKey(
+				ctx,
+				"retire_idle_base_disk_"+execCtx.GetTaskID()+
+					":"+baseDiskID,
+			),
+			"pools.RetireBaseDisk",
+			"",
+			&protos.RetireBaseDiskRequest{
+				BaseDiskId: baseDiskID,
 			},
 		)
 		if err != nil {

--- a/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/optimize_base_disks_task_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/pools/protos"
 	pools_storage "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/pools/storage"
 	storage_mocks "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg/services/pools/storage/mocks"
+	task_errors "github.com/ydb-platform/nbs/cloud/tasks/errors"
 	tasks_mocks "github.com/ydb-platform/nbs/cloud/tasks/mocks"
 )
 
@@ -174,4 +175,439 @@ func TestOptimizeBaseDisksTaskShouldPanicOnIncorrectConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Panics(t, func() { _ = task.Run(ctx, execCtx) }, "This task should panic")
+}
+
+func TestOptimizeBaseDisksTaskIdleCleanup(t *testing.T) {
+	ctx := newContext()
+	scheduler := tasks_mocks.NewSchedulerMock()
+	storage := storage_mocks.NewStorageMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	execCtx.On("GetTaskID").Return("1")
+	execCtx.On("SaveState", mock.Anything).Return(nil)
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	storage.On("GetReadyPoolInfos", ctx).Return([]pools_storage.PoolInfo{
+		{
+			ImageID:       "image1",
+			ZoneID:        "zone1",
+			FreeUnits:     640,
+			AcquiredUnits: 0,
+			Capacity:      1280,
+			ImageSize:     0,
+			CreatedAt:     yesterday,
+		},
+	}, nil)
+
+	idleTTL := 24 * time.Hour
+
+	storage.On(
+		"GetIdleBaseDisks",
+		ctx,
+		"image1",
+		"zone1",
+		idleTTL,
+		uint64(100),
+	).Return([]pools_storage.BaseDisk{
+		{
+			ID:        "baseDisk1",
+			ImageID:   "image1",
+			ZoneID:    "zone1",
+			FreeSlots: 80,
+		},
+	}, nil)
+
+	// ConfigurePool to reduce capacity by min(units, maxActiveSlots) (80, 640) = 80.
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.ConfigurePool",
+		"",
+		&protos.ConfigurePoolRequest{
+			ImageId:      "image1",
+			ZoneId:       "zone1",
+			Capacity:     1200,
+			UseImageSize: false,
+		},
+	).Return("idle_configure_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"idle_configure_task1",
+	).Return(nil, nil)
+
+	// RetireBaseDisk for idle disk.
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.RetireBaseDisk",
+		"",
+		&protos.RetireBaseDiskRequest{
+			BaseDiskId: "baseDisk1",
+		},
+	).Return("idle_retire_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"idle_retire_task1",
+	).Return(nil, nil)
+
+	task := &optimizeBaseDisksTask{
+		scheduler:                 scheduler,
+		storage:                   storage,
+		baseDiskIdleTTL:           idleTTL,
+		cleanupIdleBaseDisksLimit: 100,
+	}
+
+	err := task.Load(nil, nil)
+	require.NoError(t, err)
+
+	err = task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, scheduler, storage, execCtx)
+}
+
+func TestOptimizeBaseDisksTaskIdleCleanupSkipsOptimizedPools(t *testing.T) {
+	ctx := newContext()
+	scheduler := tasks_mocks.NewSchedulerMock()
+	storage := storage_mocks.NewStorageMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	execCtx.On("GetTaskID").Return("1")
+	execCtx.On("SaveState", mock.Anything).Return(nil)
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	storage.On("GetReadyPoolInfos", ctx).Return([]pools_storage.PoolInfo{
+		{
+			ImageID:       "image1",
+			ZoneID:        "zone1",
+			FreeUnits:     640,
+			AcquiredUnits: 2,
+			Capacity:      1280,
+			ImageSize:     0,
+			CreatedAt:     yesterday,
+		},
+	}, nil)
+
+	// Pool is optimized (AcquiredUnits=2 < threshold=5 => switch to image size).
+	// GetIdleBaseDisks is NOT called — pool is skipped before the query.
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.ConfigurePool",
+		"",
+		&protos.ConfigurePoolRequest{
+			ImageId:      "image1",
+			ZoneId:       "zone1",
+			Capacity:     1280,
+			UseImageSize: true,
+		},
+	).Return("optimize_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"optimize_task1",
+	).Return(nil, nil)
+
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.RetireBaseDisks",
+		"",
+		&protos.RetireBaseDisksRequest{
+			ImageId:          "image1",
+			ZoneId:           "zone1",
+			UseBaseDiskAsSrc: true,
+		},
+	).Return("optimize_retire_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"optimize_retire_task1",
+	).Return(nil, nil)
+
+	// No idle cleanup tasks should be scheduled for this pool.
+
+	task := &optimizeBaseDisksTask{
+		scheduler:                               scheduler,
+		storage:                                 storage,
+		convertToImageSizedBaseDisksThreshold:   5,
+		convertToDefaultSizedBaseDisksThreshold: 15,
+		minPoolAge:                              12 * time.Hour,
+		baseDiskIdleTTL:                         24 * time.Hour,
+		cleanupIdleBaseDisksLimit:               100,
+	}
+
+	err := task.Load(nil, nil)
+	require.NoError(t, err)
+
+	err = task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, scheduler, storage, execCtx)
+}
+
+func TestOptimizeBaseDisksTaskIdleCleanupMultipleDisks(t *testing.T) {
+	ctx := newContext()
+	scheduler := tasks_mocks.NewSchedulerMock()
+	storage := storage_mocks.NewStorageMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	execCtx.On("GetTaskID").Return("1")
+	execCtx.On("SaveState", mock.Anything).Return(nil)
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	storage.On("GetReadyPoolInfos", ctx).Return([]pools_storage.PoolInfo{
+		{
+			ImageID:       "image1",
+			ZoneID:        "zone1",
+			FreeUnits:     1920,
+			AcquiredUnits: 0,
+			Capacity:      1920,
+			ImageSize:     0,
+			CreatedAt:     yesterday,
+		},
+	}, nil)
+
+	idleTTL := 24 * time.Hour
+
+	storage.On(
+		"GetIdleBaseDisks",
+		ctx,
+		"image1",
+		"zone1",
+		idleTTL,
+		uint64(100),
+	).Return([]pools_storage.BaseDisk{
+		{
+			ID:        "baseDisk1",
+			ImageID:   "image1",
+			ZoneID:    "zone1",
+			FreeSlots: 100,
+		},
+		{
+			ID:        "baseDisk2",
+			ImageID:   "image1",
+			ZoneID:    "zone1",
+			FreeSlots: 120,
+		},
+	}, nil)
+
+	// Capacity reduced by 100 + 120 = 220.
+	// New capacity = 1920 - 220 = 1700.
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.ConfigurePool",
+		"",
+		&protos.ConfigurePoolRequest{
+			ImageId:      "image1",
+			ZoneId:       "zone1",
+			Capacity:     1700,
+			UseImageSize: false,
+		},
+	).Return("idle_configure_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"idle_configure_task1",
+	).Return(nil, nil)
+
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.RetireBaseDisk",
+		"",
+		&protos.RetireBaseDiskRequest{
+			BaseDiskId: "baseDisk1",
+		},
+	).Return("idle_retire_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"idle_retire_task1",
+	).Return(nil, nil)
+
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.RetireBaseDisk",
+		"",
+		&protos.RetireBaseDiskRequest{
+			BaseDiskId: "baseDisk2",
+		},
+	).Return("idle_retire_task2", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"idle_retire_task2",
+	).Return(nil, nil)
+
+	task := &optimizeBaseDisksTask{
+		scheduler:                 scheduler,
+		storage:                   storage,
+		baseDiskIdleTTL:           idleTTL,
+		cleanupIdleBaseDisksLimit: 100,
+	}
+
+	err := task.Load(nil, nil)
+	require.NoError(t, err)
+
+	err = task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, scheduler, storage, execCtx)
+}
+
+func TestOptimizeBaseDisksTaskIdleCleanupContinuesOnConfigurePoolFailure(
+	t *testing.T,
+) {
+	ctx := newContext()
+	scheduler := tasks_mocks.NewSchedulerMock()
+	storage := storage_mocks.NewStorageMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	execCtx.On("GetTaskID").Return("1")
+	execCtx.On("SaveState", mock.Anything).Return(nil)
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	storage.On("GetReadyPoolInfos", ctx).Return([]pools_storage.PoolInfo{
+		{
+			ImageID:       "image1",
+			ZoneID:        "zone1",
+			FreeUnits:     640,
+			AcquiredUnits: 0,
+			Capacity:      1280,
+			ImageSize:     0,
+			CreatedAt:     yesterday,
+		},
+	}, nil)
+
+	idleTTL := 24 * time.Hour
+
+	storage.On(
+		"GetIdleBaseDisks",
+		ctx,
+		"image1",
+		"zone1",
+		idleTTL,
+		uint64(100),
+	).Return([]pools_storage.BaseDisk{
+		{
+			ID:        "baseDisk1",
+			ImageID:   "image1",
+			ZoneID:    "zone1",
+			FreeSlots: 80,
+		},
+	}, nil)
+
+	// ConfigurePool fails with non-retriable error (e.g. image deleted).
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.ConfigurePool",
+		"",
+		&protos.ConfigurePoolRequest{
+			ImageId:      "image1",
+			ZoneId:       "zone1",
+			Capacity:     1200,
+			UseImageSize: false,
+		},
+	).Return("idle_configure_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"idle_configure_task1",
+	).Return(nil, task_errors.NewNonRetriableErrorf("image deleted"))
+
+	// RetireBaseDisk still runs — it is idempotent and handles deleted disks.
+	scheduler.On(
+		"ScheduleTask",
+		mock.Anything,
+		"pools.RetireBaseDisk",
+		"",
+		&protos.RetireBaseDiskRequest{
+			BaseDiskId: "baseDisk1",
+		},
+	).Return("idle_retire_task1", nil)
+
+	scheduler.On(
+		"WaitTask",
+		mock.Anything,
+		execCtx,
+		"idle_retire_task1",
+	).Return(nil, nil)
+
+	task := &optimizeBaseDisksTask{
+		scheduler:                 scheduler,
+		storage:                   storage,
+		baseDiskIdleTTL:           idleTTL,
+		cleanupIdleBaseDisksLimit: 100,
+	}
+
+	err := task.Load(nil, nil)
+	require.NoError(t, err)
+
+	err = task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, scheduler, storage, execCtx)
+}
+
+func TestOptimizeBaseDisksTaskNoCleanupWhenTTLZero(t *testing.T) {
+	ctx := newContext()
+	scheduler := tasks_mocks.NewSchedulerMock()
+	storage := storage_mocks.NewStorageMock()
+	execCtx := tasks_mocks.NewExecutionContextMock()
+
+	execCtx.On("SaveState", mock.Anything).Return(nil)
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	storage.On("GetReadyPoolInfos", ctx).Return([]pools_storage.PoolInfo{
+		{
+			ImageID:       "image1",
+			ZoneID:        "zone1",
+			FreeUnits:     640,
+			AcquiredUnits: 20,
+			Capacity:      640,
+			ImageSize:     0,
+			CreatedAt:     yesterday,
+		},
+	}, nil)
+
+	// GetIdleBaseDisks should NOT be called when baseDiskIdleTTL is 0.
+
+	task := &optimizeBaseDisksTask{
+		scheduler:                               scheduler,
+		storage:                                 storage,
+		convertToImageSizedBaseDisksThreshold:   5,
+		convertToDefaultSizedBaseDisksThreshold: 15,
+		minPoolAge:                              12 * time.Hour,
+		baseDiskIdleTTL:                         0,
+	}
+
+	err := task.Load(nil, nil)
+	require.NoError(t, err)
+
+	err = task.Run(ctx, execCtx)
+	require.NoError(t, err)
+	mock.AssertExpectationsForObjects(t, scheduler, storage, execCtx)
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/protos/optimize_base_disks_task.proto
+++ b/cloud/disk_manager/internal/pkg/services/pools/protos/optimize_base_disks_task.proto
@@ -9,5 +9,8 @@ option go_package = "github.com/ydb-platform/nbs/cloud/disk_manager/internal/pkg
 ////////////////////////////////////////////////////////////////////////////////
 
 message OptimizeBaseDisksTaskState {
-    repeated ConfigurePoolRequest ConfigurePoolRequests = 1;
+    repeated ConfigurePoolRequest ConfigurePoolForImageSizeRequests = 1;
+    repeated ConfigurePoolRequest PoolReductionRequests = 2;
+    repeated string IdleBaseDiskIds = 3;
+    bool CollectedResourcesToOptimize = 4;
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/register.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/register.go
@@ -79,6 +79,13 @@ func RegisterForExecution(
 		return err
 	}
 
+	baseDiskIdleTTL, err := time.ParseDuration(
+		config.GetBaseDiskIdleTTL(),
+	)
+	if err != nil {
+		return err
+	}
+
 	err = taskRegistry.RegisterForExecution("pools.AcquireBaseDisk", func() tasks.Task {
 		return &acquireBaseDiskTask{
 			scheduler: taskScheduler,
@@ -189,6 +196,8 @@ func RegisterForExecution(
 			convertToImageSizedBaseDisksThreshold:   config.GetConvertToImageSizedBaseDiskThreshold(),
 			convertToDefaultSizedBaseDisksThreshold: config.GetConvertToDefaultSizedBaseDiskThreshold(),
 			minPoolAge:                              minOptimizedPoolAge,
+			baseDiskIdleTTL:                         baseDiskIdleTTL,
+			cleanupIdleBaseDisksLimit:               config.GetCleanupIdleBaseDisksLimit(),
 		}
 	})
 	if err != nil {

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common.go
@@ -86,6 +86,15 @@ func baseDiskStatusToString(status baseDiskStatus) string {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// It checks whether a timestamp is effectively zero.
+// Go's time.Time{} is 0001-01-01, but after a YDB round-trip it becomes
+// time.Unix(0, 0) (1970-01-01), so t.IsZero() alone is insufficient.
+func isTimestampUnset(t time.Time) bool {
+	return !t.After(time.Unix(0, 0))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 type baseDisk struct {
 	id                  string
 	imageID             string
@@ -105,6 +114,7 @@ type baseDisk struct {
 	fromPool       bool
 	retiring       bool
 	deletedAt      time.Time
+	idleSince      time.Time // zero if disk has at least one active unit
 	status         baseDiskStatus
 }
 
@@ -128,6 +138,7 @@ func (d *baseDisk) toBaseDisk() BaseDisk {
 		CreateTaskID:        d.createTaskID,
 		Size:                d.size,
 		Units:               d.units,
+		FreeSlots:           d.freeSlots(),
 		Ready:               d.status == baseDiskStatusReady,
 	}
 }
@@ -152,6 +163,13 @@ func (d *baseDisk) applyInvariants() {
 		if !d.isDoomed() && !d.fromPool {
 			d.status = baseDiskStatusDeleting
 		}
+
+		if isTimestampUnset(d.idleSince) {
+			d.idleSince = time.Now()
+		}
+	} else {
+		// Disk is no longer idle.
+		d.idleSince = time.Time{}
 	}
 }
 
@@ -205,6 +223,7 @@ func (d *baseDisk) structValue() persistence.Value {
 		persistence.StructFieldValue("from_pool", persistence.BoolValue(d.fromPool)),
 		persistence.StructFieldValue("retiring", persistence.BoolValue(d.retiring)),
 		persistence.StructFieldValue("deleted_at", persistence.TimestampValue(d.deletedAt)),
+		persistence.StructFieldValue("idle_since", persistence.TimestampValue(d.idleSince)),
 		persistence.StructFieldValue("status", persistence.Int64Value(int64(d.status))),
 	)
 }
@@ -229,6 +248,7 @@ func baseDiskStructTypeString() string {
 		from_pool: Bool,
 		retiring: Bool,
 		deleted_at: Timestamp,
+		idle_since: Timestamp,
 		status: Int64>`
 }
 
@@ -252,6 +272,7 @@ func baseDisksTableDescription() persistence.CreateTableDescription {
 		persistence.WithColumn("from_pool", persistence.Optional(persistence.TypeBool)),
 		persistence.WithColumn("retiring", persistence.Optional(persistence.TypeBool)),
 		persistence.WithColumn("deleted_at", persistence.Optional(persistence.TypeTimestamp)),
+		persistence.WithColumn("idle_since", persistence.Optional(persistence.TypeTimestamp)),
 		persistence.WithColumn("status", persistence.Optional(persistence.TypeInt64)),
 
 		persistence.WithPrimaryKeyColumn("id"),
@@ -278,6 +299,7 @@ func scanBaseDisk(res persistence.Result) (baseDisk baseDisk, err error) {
 		persistence.OptionalWithDefault("from_pool", &baseDisk.fromPool),
 		persistence.OptionalWithDefault("retiring", &baseDisk.retiring),
 		persistence.OptionalWithDefault("deleted_at", &baseDisk.deletedAt),
+		persistence.OptionalWithDefault("idle_since", &baseDisk.idleSince),
 		persistence.OptionalWithDefault("status", &baseDisk.status),
 	)
 	return

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/common_test.go
@@ -283,3 +283,104 @@ func TestCommonAcquireAndReleaseUnitsAndSlots(t *testing.T) {
 	require.Equal(t, uint64(4), baseDisk.freeSlots())
 	require.True(t, baseDisk.hasFreeSlots())
 }
+
+func TestCommonIdleSinceTracking(t *testing.T) {
+	ctx := newContext()
+
+	disk := &baseDisk{
+		maxActiveSlots: 4,
+		units:          6,
+		fromPool:       true,
+		status:         baseDiskStatusReady,
+	}
+
+	require.True(t, isTimestampUnset(disk.idleSince))
+
+	slot1 := &slot{}
+	err := acquireUnitsAndSlots(ctx, nil, disk, slot1)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.True(t, isTimestampUnset(disk.idleSince))
+
+	slot2 := &slot{}
+	err = acquireUnitsAndSlots(ctx, nil, disk, slot2)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.True(t, isTimestampUnset(disk.idleSince))
+
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot1)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), disk.activeUnits)
+	require.True(t, isTimestampUnset(disk.idleSince))
+
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot2)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), disk.activeUnits)
+	require.False(t, isTimestampUnset(disk.idleSince))
+
+	firstUnusedAt := disk.idleSince
+
+	slot3 := &slot{}
+	err = acquireUnitsAndSlots(ctx, nil, disk, slot3)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.True(t, isTimestampUnset(disk.idleSince))
+
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot3)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), disk.activeUnits)
+	require.False(t, isTimestampUnset(disk.idleSince))
+	require.True(t, disk.idleSince.After(firstUnusedAt) || disk.idleSince.Equal(firstUnusedAt))
+}
+
+func TestCommonIdleSinceSetOncePerIdlePeriod(t *testing.T) {
+	ctx := newContext()
+
+	disk := &baseDisk{
+		maxActiveSlots: 4,
+		units:          6,
+		fromPool:       true,
+		status:         baseDiskStatusReady,
+	}
+
+	slot1 := &slot{}
+	slot2 := &slot{}
+
+	err := acquireUnitsAndSlots(ctx, nil, disk, slot1)
+	require.NoError(t, err)
+	err = acquireUnitsAndSlots(ctx, nil, disk, slot2)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), disk.activeUnits)
+
+	// Releasing first slot: activeUnits goes to 1, idleSince stays zero.
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot1)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), disk.activeUnits)
+	require.True(t, isTimestampUnset(disk.idleSince))
+
+	// Releasing second slot: activeUnits goes to 0, idleSince gets set.
+	err = releaseUnitsAndSlots(ctx, nil, disk, *slot2)
+	disk.applyInvariants()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), disk.activeUnits)
+	require.False(t, isTimestampUnset(disk.idleSince))
+}
+
+func TestCommonApplyInvariantsIdlePoolDisk(t *testing.T) {
+	disk := &baseDisk{
+		activeUnits: 0,
+		fromPool:    true,
+		status:      baseDiskStatusReady,
+	}
+
+	disk.applyInvariants()
+	require.Equal(t, baseDiskStatusReady, disk.status)
+
+	disk.fromPool = false
+	disk.applyInvariants()
+	require.Equal(t, baseDiskStatusDeleting, disk.status)
+}

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/mocks/storage_mock.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/mocks/storage_mock.go
@@ -280,6 +280,23 @@ func (s *StorageMock) CheckConsistency(ctx context.Context) error {
 	return args.Error(0)
 }
 
+func (s *StorageMock) GetIdleBaseDisks(
+	ctx context.Context,
+	imageID string,
+	zoneID string,
+	idleDuration time.Duration,
+	limit uint64,
+) ([]storage.BaseDisk, error) {
+
+	args := s.Called(ctx, imageID, zoneID, idleDuration, limit)
+	return args.Get(0).([]storage.BaseDisk), args.Error(1)
+}
+
+func (s *StorageMock) InitializeIdleTimestamps(ctx context.Context) error {
+	args := s.Called(ctx)
+	return args.Error(0)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewStorageMock() *StorageMock {

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage.go
@@ -23,6 +23,7 @@ type BaseDisk struct {
 	CreateTaskID        string
 	Size                uint64
 	Units               uint64
+	FreeSlots           uint64
 	Ready               bool
 }
 
@@ -192,4 +193,16 @@ type Storage interface {
 	// Used in tests and SRE tools.
 	// Executes both CheckPoolsConsistency and CheckBaseDisksConsistency.
 	CheckConsistency(ctx context.Context) error
+
+	// Returns base disks with imageID and zoneID that belong to a pool,
+	// have zero active units, have been idle longer than |idleDuration|.
+	GetIdleBaseDisks(
+		ctx context.Context,
+		imageID string,
+		zoneID string,
+		idleDuration time.Duration,
+		limit uint64,
+	) ([]BaseDisk, error)
+
+	InitializeIdleTimestamps(ctx context.Context) error
 }

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb.go
@@ -476,6 +476,43 @@ func (s *storageYDB) CheckConsistency(ctx context.Context) error {
 	)
 }
 
+func (s *storageYDB) GetIdleBaseDisks(
+	ctx context.Context,
+	imageID string,
+	zoneID string,
+	idleDuration time.Duration,
+	limit uint64,
+) ([]BaseDisk, error) {
+
+	var baseDisks []BaseDisk
+
+	err := s.db.Execute(
+		ctx,
+		func(ctx context.Context, session *persistence.Session) error {
+			var err error
+			baseDisks, err = s.getIdleBaseDisks(
+				ctx,
+				imageID,
+				zoneID,
+				session,
+				idleDuration,
+				limit,
+			)
+			return err
+		},
+	)
+	return baseDisks, err
+}
+
+func (s *storageYDB) InitializeIdleTimestamps(ctx context.Context) error {
+	return s.db.Execute(
+		ctx,
+		func(ctx context.Context, session *persistence.Session) error {
+			return s.initializeIdleTimestamps(ctx, session)
+		},
+	)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewStorage(

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_impl.go
@@ -3602,3 +3602,88 @@ func (s *storageYDB) unlockPool(
 
 	return tx.Commit(ctx)
 }
+
+func (s *storageYDB) getIdleBaseDisks(
+	ctx context.Context,
+	imageID string,
+	zoneID string,
+	session *persistence.Session,
+	idleDuration time.Duration,
+	limit uint64,
+) ([]BaseDisk, error) {
+
+	idleBefore := time.Now().Add(-idleDuration)
+
+	res, err := session.ExecuteRO(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $image_id as Utf8;
+		declare $zone_id as Utf8;
+		declare $idle_before as Timestamp;
+		declare $status as Int64;
+		declare $limit as Uint64;
+
+		select bd.*
+		from free as f
+		join base_disks as bd
+			on f.image_id = bd.image_id
+			and f.zone_id = bd.zone_id
+			and f.base_disk_id = bd.id
+		where bd.image_id = $image_id
+			and bd.zone_id = $zone_id
+			and bd.active_units = 0
+			and bd.status = $status
+			and bd.idle_since IS NOT NULL
+			and bd.idle_since != cast(0 as Timestamp)
+			and bd.idle_since < $idle_before
+		limit $limit
+	`, s.tablesPath),
+		persistence.ValueParam("$image_id", persistence.UTF8Value(imageID)),
+		persistence.ValueParam("$zone_id", persistence.UTF8Value(zoneID)),
+		persistence.ValueParam("$idle_before", persistence.TimestampValue(idleBefore)),
+		persistence.ValueParam("$status", persistence.Int64Value(int64(baseDiskStatusReady))),
+		persistence.ValueParam("$limit", persistence.Uint64Value(limit)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Close()
+
+	baseDisks, err := scanBaseDisks(ctx, res)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []BaseDisk
+	for _, d := range baseDisks {
+		result = append(result, d.toBaseDisk())
+	}
+
+	return result, nil
+}
+
+func (s *storageYDB) initializeIdleTimestamps(
+	ctx context.Context,
+	session *persistence.Session,
+) error {
+
+	now := time.Now()
+
+	_, err := session.ExecuteRW(ctx, fmt.Sprintf(`
+		--!syntax_v1
+		pragma TablePathPrefix = "%v";
+		declare $now as Timestamp;
+		declare $status as Int64;
+
+		update base_disks
+		set idle_since = $now
+		where from_pool = true
+			and active_units = 0
+			and status = $status
+			and (idle_since IS NULL OR idle_since = cast(0 as Timestamp))
+	`, s.tablesPath),
+		persistence.ValueParam("$now", persistence.TimestampValue(now)),
+		persistence.ValueParam("$status", persistence.Int64Value(int64(baseDiskStatusReady))),
+	)
+	return err
+}

--- a/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
+++ b/cloud/disk_manager/internal/pkg/services/pools/storage/storage_ydb_test.go
@@ -151,6 +151,20 @@ func relocateOverlayDisk(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+func normalizeBaseDisk(disk BaseDisk) BaseDisk {
+	disk.FreeSlots = 0
+	return disk
+}
+
+func normalizeBaseDisks(disks []BaseDisk) []BaseDisk {
+	for i := range disks {
+		disks[i].FreeSlots = 0
+	}
+	return disks
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 func TestStorageYDBReleaseNonExistent(t *testing.T) {
 	ctx, cancel := context.WithCancel(newContext())
 	defer cancel()
@@ -299,6 +313,17 @@ func TestStorageYDBCreateBaseDisksPool(t *testing.T) {
 	require.Equal(t, uint64(0), poolInfos[0].ImageSize)
 	require.NotZero(t, poolInfos[0].CreatedAt)
 
+	disks := make([]BaseDisk, 0)
+	disks, err = storage.GetIdleBaseDisks(
+		ctx,
+		poolInfos[0].ImageID,
+		poolInfos[0].ZoneID,
+		0,
+		100,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(disks))
+
 	for _, disk := range baseDisks[2:5] {
 		err = storage.BaseDiskCreated(ctx, disk)
 		require.NoError(t, err)
@@ -308,6 +333,19 @@ func TestStorageYDBCreateBaseDisksPool(t *testing.T) {
 	for i := 0; i < len(scheduled); i++ {
 		scheduled[i].CreateTaskID = "create"
 	}
+
+	disks, err = storage.GetIdleBaseDisks(
+		ctx,
+		poolInfos[0].ImageID,
+		poolInfos[0].ZoneID,
+		0,
+		100,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(disks))
+	require.Equal(t, baseDisks[2].ImageID, disks[0].ImageID)
+	require.Equal(t, baseDisks[3].ImageID, disks[1].ImageID)
+	require.Equal(t, baseDisks[4].ImageID, disks[2].ImageID)
 
 	err = storage.BaseDisksScheduled(ctx, scheduled)
 	require.NoError(t, err)
@@ -437,22 +475,22 @@ func TestStorageYDBPoolReusage1(t *testing.T) {
 
 	actual, err := storage.AcquireBaseDiskSlot(ctx, "image", slot1)
 	require.NoError(t, err)
-	require.Equal(t, baseDisks[0], actual)
+	require.Equal(t, normalizeBaseDisk(baseDisks[0]), normalizeBaseDisk(actual))
 
 	actual, err = storage.ReleaseBaseDiskSlot(ctx, slot1.OverlayDisk)
 	require.NoError(t, err)
-	require.Equal(t, baseDisks[0], actual)
+	require.Equal(t, normalizeBaseDisk(baseDisks[0]), normalizeBaseDisk(actual))
 	require.False(t, baseDiskShouldBeDeletedSoon(t, ctx, storage, actual))
 
 	// Check idempotency.
 	actual, err = storage.ReleaseBaseDiskSlot(ctx, slot1.OverlayDisk)
 	require.NoError(t, err)
-	require.Equal(t, baseDisks[0], actual)
+	require.Equal(t, normalizeBaseDisk(baseDisks[0]), normalizeBaseDisk(actual))
 	require.False(t, baseDiskShouldBeDeletedSoon(t, ctx, storage, actual))
 
 	actual, err = storage.AcquireBaseDiskSlot(ctx, "image", slot2)
 	require.NoError(t, err)
-	require.Equal(t, baseDisks[0], actual)
+	require.Equal(t, normalizeBaseDisk(baseDisks[0]), normalizeBaseDisk(actual))
 
 	err = storage.CheckConsistency(ctx)
 	require.NoError(t, err)
@@ -495,13 +533,17 @@ func TestStorageYDBPoolReusage2(t *testing.T) {
 			Slot{OverlayDisk: overlayDisks[i]},
 		)
 		require.NoError(t, err)
-		require.Equal(t, baseDisks[0], actual)
+		require.Equal(
+			t,
+			normalizeBaseDisk(baseDisks[0]),
+			normalizeBaseDisk(actual),
+		)
 	}
 
 	// Release one slot.
 	actual, err := storage.ReleaseBaseDiskSlot(ctx, overlayDisks[0])
 	require.NoError(t, err)
-	require.Equal(t, baseDisks[0], actual)
+	require.Equal(t, normalizeBaseDisk(baseDisks[0]), normalizeBaseDisk(actual))
 	require.False(t, baseDiskShouldBeDeletedSoon(t, ctx, storage, actual))
 
 	// Acquire slot for last overlay disk.
@@ -511,7 +553,7 @@ func TestStorageYDBPoolReusage2(t *testing.T) {
 		Slot{OverlayDisk: overlayDisks[len(overlayDisks)-1]},
 	)
 	require.NoError(t, err)
-	require.Equal(t, baseDisks[0], actual)
+	require.Equal(t, normalizeBaseDisk(baseDisks[0]), normalizeBaseDisk(actual))
 
 	err = storage.CheckConsistency(ctx)
 	require.NoError(t, err)
@@ -570,7 +612,11 @@ func TestStorageYDBDeletePool(t *testing.T) {
 	toDelete, err := storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(toDelete))
-	require.Equal(t, baseDiskFromZone1, toDelete[0])
+	require.Equal(
+		t,
+		normalizeBaseDisk(baseDiskFromZone1),
+		normalizeBaseDisk(toDelete[0]),
+	)
 
 	// Check idempotency.
 	err = storage.DeletePool(ctx, "image", "zone1")
@@ -579,7 +625,11 @@ func TestStorageYDBDeletePool(t *testing.T) {
 	toDelete, err = storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(toDelete))
-	require.Equal(t, baseDiskFromZone1, toDelete[0])
+	require.Equal(
+		t,
+		normalizeBaseDisk(baseDiskFromZone1),
+		normalizeBaseDisk(toDelete[0]),
+	)
 
 	toSchedule, err := storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
@@ -639,7 +689,7 @@ func TestStorageYDBImageDeleting(t *testing.T) {
 
 	actual, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Equal(t, scheduled[0], actual)
+	require.Equal(t, normalizeBaseDisk(scheduled[0]), normalizeBaseDisk(actual))
 
 	err = storage.ImageDeleting(ctx, "image")
 	require.NoError(t, err)
@@ -651,7 +701,11 @@ func TestStorageYDBImageDeleting(t *testing.T) {
 	toDelete, err := storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(toDelete))
-	require.Equal(t, baseDisks[1], toDelete[0])
+	require.Equal(
+		t,
+		normalizeBaseDisk(baseDisks[1]),
+		normalizeBaseDisk(toDelete[0]),
+	)
 
 	// Check idempotency.
 	err = storage.ImageDeleting(ctx, "image")
@@ -660,7 +714,11 @@ func TestStorageYDBImageDeleting(t *testing.T) {
 	toDelete, err = storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(toDelete))
-	require.Equal(t, baseDisks[1], toDelete[0])
+	require.Equal(
+		t,
+		normalizeBaseDisk(baseDisks[1]),
+		normalizeBaseDisk(toDelete[0]),
+	)
 
 	toSchedule, err := storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
@@ -731,7 +789,7 @@ func TestStorageYDBBaseDisksDeleted(t *testing.T) {
 
 	actual, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Equal(t, scheduled[0], actual)
+	require.Equal(t, normalizeBaseDisk(scheduled[0]), normalizeBaseDisk(actual))
 
 	err = storage.ImageDeleting(ctx, "image")
 	require.NoError(t, err)
@@ -739,13 +797,21 @@ func TestStorageYDBBaseDisksDeleted(t *testing.T) {
 	toDelete, err := storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(toDelete))
-	require.ElementsMatch(t, []BaseDisk{baseDisks[1], baseDisks[2]}, toDelete)
+	require.ElementsMatch(
+		t,
+		normalizeBaseDisks([]BaseDisk{baseDisks[1], baseDisks[2]}),
+		normalizeBaseDisks(toDelete),
+	)
 
 	// Check idempotency.
 	toDelete, err = storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(toDelete))
-	require.ElementsMatch(t, []BaseDisk{baseDisks[1], baseDisks[2]}, toDelete)
+	require.ElementsMatch(
+		t,
+		normalizeBaseDisks([]BaseDisk{baseDisks[1], baseDisks[2]}),
+		normalizeBaseDisks(toDelete),
+	)
 
 	err = storage.BaseDisksDeleted(ctx, toDelete)
 	require.NoError(t, err)
@@ -813,7 +879,11 @@ func TestStorageYDBBaseDiskCreationFailed(t *testing.T) {
 	actual, err := storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(actual))
-	require.Equal(t, baseDisks1[0], actual[0])
+	require.Equal(
+		t,
+		normalizeBaseDisk(baseDisks1[0]),
+		normalizeBaseDisk(actual[0]),
+	)
 
 	baseDisks2, err := storage.TakeBaseDisksToSchedule(ctx)
 	require.NoError(t, err)
@@ -841,7 +911,11 @@ func TestStorageYDBBaseDiskCreationFailed(t *testing.T) {
 	actual, err = storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(actual))
-	require.Equal(t, baseDisks1[0], actual[0])
+	require.Equal(
+		t,
+		normalizeBaseDisk(baseDisks1[0]),
+		normalizeBaseDisk(actual[0]),
+	)
 
 	err = storage.CheckConsistency(ctx)
 	require.NoError(t, err)
@@ -972,7 +1046,7 @@ func TestStorageYDBRebaseOverlayDisk1(t *testing.T) {
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(t, normalizeBaseDisks(baseDisks), normalizeBaseDisk(source))
 
 	var target BaseDisk
 
@@ -1052,11 +1126,11 @@ func TestStorageYDBRebaseOverlayDisk1(t *testing.T) {
 
 	actual, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Equal(t, target, actual)
+	require.Equal(t, normalizeBaseDisk(target), normalizeBaseDisk(actual))
 
 	actual, err = storage.ReleaseBaseDiskSlot(ctx, slot.OverlayDisk)
 	require.NoError(t, err)
-	require.Equal(t, target, actual)
+	require.Equal(t, normalizeBaseDisk(target), normalizeBaseDisk(actual))
 
 	err = storage.OverlayDiskRebasing(ctx, RebaseInfo{
 		OverlayDisk:      slot.OverlayDisk,
@@ -1113,7 +1187,7 @@ func TestStorageYDBRebaseOverlayDisk2(t *testing.T) {
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(t, normalizeBaseDisks(baseDisks), normalizeBaseDisk(source))
 
 	var target BaseDisk
 	for _, baseDisk := range baseDisks {
@@ -1131,7 +1205,7 @@ func TestStorageYDBRebaseOverlayDisk2(t *testing.T) {
 	// Release slot before rebase is finished.
 	actual, err := storage.ReleaseBaseDiskSlot(ctx, slot.OverlayDisk)
 	require.NoError(t, err)
-	require.Equal(t, source, actual)
+	require.Equal(t, normalizeBaseDisk(source), normalizeBaseDisk(actual))
 
 	err = storage.OverlayDiskRebased(ctx, RebaseInfo{
 		OverlayDisk:      slot.OverlayDisk,
@@ -1198,7 +1272,7 @@ func TestStorageYDBRelocateOverlayDisk(t *testing.T) {
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(t, normalizeBaseDisks(baseDisks), normalizeBaseDisk(source))
 
 	for _, baseDisk := range baseDisks {
 		err = storage.BaseDiskCreated(ctx, baseDisk)
@@ -1304,7 +1378,7 @@ func TestStorageYDBRelocateOverlayDiskWithoutPool(t *testing.T) {
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(t, normalizeBaseDisks(baseDisks), normalizeBaseDisk(source))
 
 	for _, baseDisk := range baseDisks {
 		err = storage.BaseDiskCreated(ctx, baseDisk)
@@ -1373,7 +1447,7 @@ func TestStorageYDBRebaseOverlayDiskDuringRelocating(t *testing.T) {
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(t, normalizeBaseDisks(baseDisks), normalizeBaseDisk(source))
 
 	for _, baseDisk := range baseDisks {
 		err = storage.BaseDiskCreated(ctx, baseDisk)
@@ -1480,7 +1554,11 @@ func TestStorageYDBRetiringOverlayDiskDuringRelocating(t *testing.T) {
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(
+		t,
+		normalizeBaseDisks(baseDisks),
+		normalizeBaseDisk(source),
+	)
 
 	for _, baseDisk := range baseDisks {
 		err = storage.BaseDiskCreated(ctx, baseDisk)
@@ -1596,7 +1674,11 @@ func TestStorageYDBRelocatingOverlayDiskAfterRelocatingToAnotherZone(
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(
+		t,
+		normalizeBaseDisks(baseDisks),
+		normalizeBaseDisk(source),
+	)
 
 	for _, baseDisk := range baseDisks {
 		err = storage.BaseDiskCreated(ctx, baseDisk)
@@ -1724,7 +1806,11 @@ func TestStorageYDBAbortOverlayDiskRebasing(t *testing.T) {
 
 	source, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 	require.NoError(t, err)
-	require.Contains(t, baseDisks, source)
+	require.Contains(
+		t,
+		normalizeBaseDisks(baseDisks),
+		normalizeBaseDisk(source),
+	)
 
 	var target BaseDisk
 	var anotherTarget BaseDisk
@@ -1906,7 +1992,11 @@ func TestStorageYDBRetireBaseDisks(t *testing.T) {
 
 		for i := 0; i < len(toSchedule); i++ {
 			toSchedule[i].CreateTaskID = "create"
-			require.NotContains(t, oldBaseDisks, toSchedule[i])
+			require.NotContains(
+				t,
+				normalizeBaseDisks(oldBaseDisks),
+				normalizeBaseDisk(toSchedule[i]),
+			)
 		}
 
 		err = storage.BaseDisksScheduled(ctx, toSchedule)
@@ -1937,13 +2027,21 @@ func TestStorageYDBRetireBaseDisks(t *testing.T) {
 
 	toDelete, err := storage.GetBaseDisksToDelete(ctx, 100500)
 	require.NoError(t, err)
-	require.ElementsMatch(t, oldBaseDisks, toDelete)
+	require.ElementsMatch(
+		t,
+		normalizeBaseDisks(oldBaseDisks),
+		normalizeBaseDisks(toDelete),
+	)
 
 	for _, slot := range slots {
 		baseDisk, err := storage.AcquireBaseDiskSlot(ctx, "image", slot)
 		require.NoError(t, err)
 		require.NotEmpty(t, baseDisk.ID)
-		require.Contains(t, newBaseDisks, baseDisk)
+		require.Contains(
+			t,
+			normalizeBaseDisks(newBaseDisks),
+			normalizeBaseDisk(baseDisk),
+		)
 
 		id, ok := baseDiskIDs[slot.OverlayDisk.DiskId]
 		require.True(t, ok)
@@ -2727,4 +2825,19 @@ func TestStorageYDBBaseDisksShouldHavePrefix(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(baseDisks))
 	require.True(t, strings.HasPrefix(baseDisks[0].ID, prefix))
+}
+
+func TestStorageYDBGetIdleBaseDisksEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(newContext())
+	defer cancel()
+
+	db, err := newYDB(ctx)
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	storage := newStorage(t, ctx, db)
+
+	idleDisks, err := storage.GetIdleBaseDisks(ctx, "image", "zone", time.Hour, 100)
+	require.NoError(t, err)
+	require.Empty(t, idleDisks)
 }


### PR DESCRIPTION
### Notes
Add automatic cleanup of idle base disks in pools via the existing `OptimizeBaseDisks` periodic task. Base disks with zero active overlay disks for longer than a configurable TTL are retired and their pool capacity is reduced to prevent the scheduler from recreating them.
