### PR TITLE
Fix ya.make reachability

### DIFF
--- a/cloud/filestore/tests/loadtest/ya.make
+++ b/cloud/filestore/tests/loadtest/ya.make
@@ -1,4 +1,5 @@
 RECURSE_FOR_TESTS(
+    max-file-count-test
     service-kikimr-auth-test
     service-kikimr-datashard-like-test
     service-kikimr-emergency-test

--- a/cloud/storage/core/tools/testing/unstable-process/tests/ya.make
+++ b/cloud/storage/core/tools/testing/unstable-process/tests/ya.make
@@ -17,3 +17,7 @@ PEERDIR(
 SIZE(MEDIUM)
 
 END()
+
+RECURSE(
+    dummy-daemon
+)


### PR DESCRIPTION
## What changed

- Added `cloud/filestore/tests/loadtest/max-file-count-test` to the loadtest `RECURSE_FOR_TESTS` list.
- Added `RECURSE(dummy-daemon)` under `cloud/storage/core/tools/testing/unstable-process/tests` so the helper program target is reachable from the Arcadia root.

## Issue

Arcadia Common Checks reported missing recurse entries for these `ya.make` targets

```
 cloud/filestore/tests/loadtest/max-file-count-test/ya.make  (not found in "cloud/filestore/tests/loadtest/ya.make")
 cloud/storage/core/tools/testing/unstable-process/tests/dummy-daemon/ya.make  (not found in "cloud/storage/core/tools/testing/unstable-process/tests/ya.make")
```