### PR TITLE
Don't requests statistics from partition on volume destruction

### DIFF
--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -764,7 +764,11 @@ void TVolumeActor::HandleGetServiceStatistics(
     StatisticRequestInfo =
         CreateRequestInfo(ev->Sender, ev->Cookie, ev->Get()->CallContext);
 
-    if (GetVolumeStatus() == EStatus::STATUS_INACTIVE) {
+    if (!CanRequestStatisticsFromPartitions())
+    {
+        // The partitions are not running: either they have not been started
+        // yet, or they have already been stopped. Reply with the cached
+        // counters.
         UpdateCounters(ctx);
         return;
     }

--- a/cloud/blockstore/libs/storage/volume/volume_actor.h
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.h
@@ -718,6 +718,8 @@ private:
     void SendStatisticRequestForDiskRegistryBasedPartition(
         const NActors::TActorContext& ctx);
 
+    bool CanRequestStatisticsFromPartitions() const;
+
     void CleanupHistory(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo);

--- a/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp
@@ -9,6 +9,7 @@
 #include <cloud/storage/core/libs/common/format.h>
 #include <cloud/storage/core/libs/common/media.h>
 #include <cloud/storage/core/libs/common/verify.h>
+#include <cloud/storage/core/libs/diagnostics/critical_events.h>
 
 #include <util/generic/hash_set.h>
 #include <util/system/hostname.h>
@@ -829,6 +830,21 @@ void TVolumeActor::CleanupHistory(
         std::move(requestInfo),
         oldestEntry,
         Config->GetVolumeHistoryCleanupItemCount());
+}
+
+bool TVolumeActor::CanRequestStatisticsFromPartitions() const
+{
+    STORAGE_CHECK_PRECONDITION(Config->GetUsePullSchemeForVolumeStatistics());
+
+    if (!State || GetVolumeStatus() == EStatus::STATUS_INACTIVE) {
+        return false;
+    }
+
+    if (State->IsDiskRegistryMediaKind()) {
+        return static_cast<bool>(State->GetDiskRegistryBasedPartitionActor());
+    }
+
+    return !State->GetPartitions().empty();
 }
 
 void TVolumeActor::SendStatisticRequestsForYDBBasedPartitions(

--- a/cloud/blockstore/libs/storage/volume/volume_ut_stats.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_ut_stats.cpp
@@ -2024,6 +2024,84 @@ Y_UNIT_TEST_SUITE(TVolumeStatsTest)
         runtime->DispatchEvents(options);
 
     }
+
+    Y_UNIT_TEST(ShouldPullStatisticsAfterPartitionStopped)
+    {
+        NProto::TStorageServiceConfig config;
+        config.SetUsePullSchemeForVolumeStatistics(true);
+
+        auto state = MakeIntrusive<TDiskRegistryState>();
+
+        auto runtime = PrepareTestActorRuntime(config, state);
+        TVolumeClient volume(*runtime);
+
+        volume.UpdateVolumeConfig(
+            0,
+            0,
+            0,
+            0,
+            false,
+            1,
+            NCloud::NProto::STORAGE_MEDIA_SSD_NONREPLICATED,
+            1024,
+            "vol0",
+            "cloud",
+            "folder",
+            1   // partitionCount
+        );
+
+        volume.WaitReady();
+
+        auto pullStatistics = [&](TAutoPtr<IEventHandle>& handle)
+        {
+            volume.SendToPipe(
+                std::make_unique<
+                    TEvStatsService::TEvGetServiceStatisticsRequest>());
+
+            auto* response = runtime->GrabEdgeEventRethrow<
+                TEvStatsService::TEvGetServiceStatisticsResponse>(
+                handle,
+                TDuration::Seconds(5));
+            UNIT_ASSERT(handle);
+            return response;
+        };
+
+        ui32 partCountersRequestCount = 0;
+        auto observer = runtime->AddObserver<
+            TEvNonreplPartitionPrivate::
+                TEvGetDiskRegistryBasedPartCountersRequest>(
+            [&](TEvNonreplPartitionPrivate::
+                    TEvGetDiskRegistryBasedPartCountersRequest::TPtr& ev)
+            {
+                Y_UNUSED(ev);
+                ++partCountersRequestCount;
+            });
+
+        // Warm up the cached counters.
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto* response = pullStatistics(handle);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(1, response->PartsCounters.size());
+            UNIT_ASSERT_VALUES_EQUAL(1, partCountersRequestCount);
+        }
+
+        // The partition gets stopped before the volume destruction.
+        volume.GracefulShutdown();
+
+        partCountersRequestCount = 0;
+
+        // The volume should reply with the cached counters instead of asking
+        // the already stopped partition.
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto* response = pullStatistics(handle);
+            UNIT_ASSERT_VALUES_EQUAL(S_OK, response->GetStatus());
+            UNIT_ASSERT_VALUES_EQUAL(1, response->PartsCounters.size());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(0, partCountersRequestCount);
+    }
 }
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
### Notes
`HandleGracefulShutdown()` (sent by the service before the volume is destroyed) calls `StopPartitions()` → `StopDiskRegistryBasedPartition()`, which poisons the partition and clears the actor id. The volume tablet itself stays alive in `StateWork`. 
So on the next stats pull, NBS encounters verify which is false:
https://github.com/ydb-platform/nbs/blob/138da331854eb4ad25b206c476549cbd9b7fb1d8/cloud/blockstore/libs/storage/volume/volume_actor_stats.cpp#L876-L880

The fix is simply checks for presence of the partition actor. 

### Issue
#3154
