### PR TITLE
issue-6608: Implement quota management tablet-level methods: set, delete, and list quotas (for now, only in the main tablet)

### DIFF
--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -65,7 +65,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(SetHasXAttrs,               __VA_ARGS__)                               \
     xxx(MarkNodeRefsExhaustive,     __VA_ARGS__)                               \
                                                                                \
-    xxx(CreateQuota,                __VA_ARGS__)                               \
+    xxx(SetQuota,                   __VA_ARGS__)                               \
     xxx(DeleteQuota,                __VA_ARGS__)                               \
     xxx(ListQuotas,                 __VA_ARGS__)                               \
                                                                                \
@@ -230,8 +230,8 @@ struct TEvIndexTablet
         EvListNodesInternalRequest = EvBegin + 83,
         EvListNodesInternalResponse,
 
-        EvCreateQuotaRequest = EvBegin + 85,
-        EvCreateQuotaResponse,
+        EvSetQuotaRequest = EvBegin + 85,
+        EvSetQuotaResponse,
 
         EvDeleteQuotaRequest = EvBegin + 87,
         EvDeleteQuotaResponse,

--- a/cloud/filestore/libs/storage/api/tablet.h
+++ b/cloud/filestore/libs/storage/api/tablet.h
@@ -65,6 +65,10 @@ namespace NCloud::NFileStore::NStorage {
     xxx(SetHasXAttrs,               __VA_ARGS__)                               \
     xxx(MarkNodeRefsExhaustive,     __VA_ARGS__)                               \
                                                                                \
+    xxx(CreateQuota,                __VA_ARGS__)                               \
+    xxx(DeleteQuota,                __VA_ARGS__)                               \
+    xxx(ListQuotas,                 __VA_ARGS__)                               \
+                                                                               \
     FILESTORE_UNSAFE_TABLET_REQUESTS(xxx, __VA_ARGS__)                         \
 // FILESTORE_TABLET_REQUESTS
 
@@ -225,6 +229,15 @@ struct TEvIndexTablet
 
         EvListNodesInternalRequest = EvBegin + 83,
         EvListNodesInternalResponse,
+
+        EvCreateQuotaRequest = EvBegin + 85,
+        EvCreateQuotaResponse,
+
+        EvDeleteQuotaRequest = EvBegin + 87,
+        EvDeleteQuotaResponse,
+
+        EvListQuotasRequest = EvBegin + 89,
+        EvListQuotasResponse,
 
         // After the TABLET sub-namespace we have TABLET_WORKER and TABLET_PROXY
         // sub-namespaces which don't have any non-local events so if we run out

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -343,7 +343,7 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
-    NActors::IActorPtr CreateCreateQuotaActionActor(
+    NActors::IActorPtr CreateSetQuotaActionActor(
         TRequestInfoPtr requestInfo,
         TString input);
 

--- a/cloud/filestore/libs/storage/service/service_actor.h
+++ b/cloud/filestore/libs/storage/service/service_actor.h
@@ -343,6 +343,18 @@ private:
         TRequestInfoPtr requestInfo,
         TString input);
 
+    NActors::IActorPtr CreateCreateQuotaActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    NActors::IActorPtr CreateDeleteQuotaActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
+    NActors::IActorPtr CreateListQuotasActionActor(
+        TRequestInfoPtr requestInfo,
+        TString input);
+
     void PerformToggleServiceStateAction(
         const NActors::TActorContext& ctx,
         TRequestInfoPtr requestInfo,

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -160,6 +160,18 @@ void TStorageServiceActor::HandleExecuteAction(
             "listnodesinternal",
             &TStorageServiceActor::CreateListNodesInternalActor
         },
+        {
+            "createquota",
+            &TStorageServiceActor::CreateCreateQuotaActionActor
+        },
+        {
+            "deletequota",
+            &TStorageServiceActor::CreateDeleteQuotaActionActor
+        },
+        {
+            "listquotas",
+            &TStorageServiceActor::CreateListQuotasActionActor
+        },
     };
 
     using TInstantAction = void (TStorageServiceActor::*)(

--- a/cloud/filestore/libs/storage/service/service_actor_actions.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions.cpp
@@ -161,8 +161,8 @@ void TStorageServiceActor::HandleExecuteAction(
             &TStorageServiceActor::CreateListNodesInternalActor
         },
         {
-            "createquota",
-            &TStorageServiceActor::CreateCreateQuotaActionActor
+            "setquota",
+            &TStorageServiceActor::CreateSetQuotaActionActor
         },
         {
             "deletequota",

--- a/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
@@ -311,14 +311,14 @@ IActorPtr TStorageServiceActor::CreateListNodesInternalActor(
 ////////////////////////////////////////////////////////////////////////////////
 // Quotas
 
-IActorPtr TStorageServiceActor::CreateCreateQuotaActionActor(
+IActorPtr TStorageServiceActor::CreateSetQuotaActionActor(
     TRequestInfoPtr requestInfo,
     TString input)
 {
-    using TCreateQuotaActor = TTabletActionActor<
-        TEvIndexTablet::TEvCreateQuotaRequest,
-        TEvIndexTablet::TEvCreateQuotaResponse>;
-    return std::make_unique<TCreateQuotaActor>(
+    using TSetQuotaActor = TTabletActionActor<
+        TEvIndexTablet::TEvSetQuotaRequest,
+        TEvIndexTablet::TEvSetQuotaResponse>;
+    return std::make_unique<TSetQuotaActor>(
         std::move(requestInfo),
         std::move(input));
 }

--- a/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
+++ b/cloud/filestore/libs/storage/service/service_actor_actions_tablet_ops.cpp
@@ -308,4 +308,43 @@ IActorPtr TStorageServiceActor::CreateListNodesInternalActor(
         std::move(input));
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Quotas
+
+IActorPtr TStorageServiceActor::CreateCreateQuotaActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TCreateQuotaActor = TTabletActionActor<
+        TEvIndexTablet::TEvCreateQuotaRequest,
+        TEvIndexTablet::TEvCreateQuotaResponse>;
+    return std::make_unique<TCreateQuotaActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateDeleteQuotaActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TDeleteQuotaActor = TTabletActionActor<
+        TEvIndexTablet::TEvDeleteQuotaRequest,
+        TEvIndexTablet::TEvDeleteQuotaResponse>;
+    return std::make_unique<TDeleteQuotaActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
+IActorPtr TStorageServiceActor::CreateListQuotasActionActor(
+    TRequestInfoPtr requestInfo,
+    TString input)
+{
+    using TListQuotasActor = TTabletActionActor<
+        TEvIndexTablet::TEvListQuotasRequest,
+        TEvIndexTablet::TEvListQuotasResponse>;
+    return std::make_unique<TListQuotasActor>(
+        std::move(requestInfo),
+        std::move(input));
+}
+
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -6,6 +6,7 @@ import "cloud/filestore/public/api/protos/data.proto";
 import "cloud/filestore/public/api/protos/fs.proto";
 import "cloud/filestore/public/api/protos/locks.proto";
 import "cloud/filestore/public/api/protos/node.proto";
+import "cloud/filestore/public/api/protos/quota.proto";
 
 import "cloud/storage/core/protos/media.proto";
 
@@ -122,18 +123,6 @@ message TNode
     uint64 DevId = 11;
 
     bool IsPreparedForUnlink = 12;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-message TQuota
-{
-    uint32 QuotaId = 1;
-    uint64 MaxBytes = 2;
-    uint64 MaxNodes = 3;
-
-    repeated uint64 NodeId = 4;
-    uint64 CreationTimestampUs = 5;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/storage/tablet/protos/tablet.proto
+++ b/cloud/filestore/libs/storage/tablet/protos/tablet.proto
@@ -6,7 +6,6 @@ import "cloud/filestore/public/api/protos/data.proto";
 import "cloud/filestore/public/api/protos/fs.proto";
 import "cloud/filestore/public/api/protos/locks.proto";
 import "cloud/filestore/public/api/protos/node.proto";
-import "cloud/filestore/public/api/protos/quota.proto";
 
 import "cloud/storage/core/protos/media.proto";
 

--- a/cloud/filestore/libs/storage/tablet/quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/quota.cpp
@@ -16,8 +16,28 @@ void TQuotaStore::RemoveQuota(ui32 quotaId)
 
 const NProto::TQuota* TQuotaStore::FindQuota(ui32 quotaId) const
 {
-    auto it = QuotaById.find(quotaId);
-    return it != QuotaById.end() ? &it->second : nullptr;
+    return QuotaById.FindPtr(quotaId);
+}
+
+TVector<NProto::TQuota> TQuotaStore::GetQuotas() const
+{
+    TVector<NProto::TQuota> quotas;
+    quotas.reserve(QuotaById.size());
+    for (const auto& [quotaId, quota]: QuotaById) {
+        quotas.push_back(quota);
+    }
+
+    return quotas;
+}
+
+ui32 TQuotaStore::GenerateQuotaId() const
+{
+    ui32 quotaId = 1;
+    for (const auto& [id, quota]: QuotaById) {
+        quotaId = Max(quotaId, id + 1);
+    }
+
+    return quotaId;
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/quota.cpp
@@ -30,14 +30,4 @@ TVector<NProto::TQuota> TQuotaStore::GetQuotas() const
     return quotas;
 }
 
-ui32 TQuotaStore::GenerateQuotaId() const
-{
-    ui32 quotaId = 1;
-    for (const auto& [id, quota]: QuotaById) {
-        quotaId = Max(quotaId, id + 1);
-    }
-
-    return quotaId;
-}
-
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/quota.cpp
@@ -1,5 +1,7 @@
 #include "quota.h"
 
+#include <util/generic/algorithm.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -26,6 +28,10 @@ TVector<NProto::TQuota> TQuotaStore::GetQuotas() const
     for (const auto& [quotaId, quota]: QuotaById) {
         quotas.push_back(quota);
     }
+    // Make sure the quotas are returned in a deterministic order
+    Sort(quotas.begin(), quotas.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.GetQuotaId() < rhs.GetQuotaId();
+    });
 
     return quotas;
 }

--- a/cloud/filestore/libs/storage/tablet/quota.h
+++ b/cloud/filestore/libs/storage/tablet/quota.h
@@ -2,9 +2,10 @@
 
 #include "public.h"
 
-#include <cloud/filestore/libs/storage/tablet/protos/tablet.pb.h>
+#include <cloud/filestore/public/api/protos/quota.pb.h>
 
 #include <util/generic/hash.h>
+#include <util/generic/vector.h>
 
 namespace NCloud::NFileStore::NStorage {
 
@@ -20,6 +21,9 @@ public:
     void RemoveQuota(ui32 quotaId);
 
     [[nodiscard]] const NProto::TQuota* FindQuota(ui32 quotaId) const;
+    [[nodiscard]] TVector<NProto::TQuota> GetQuotas() const;
+
+    [[nodiscard]] ui32 GenerateQuotaId() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/quota.h
+++ b/cloud/filestore/libs/storage/tablet/quota.h
@@ -22,8 +22,6 @@ public:
 
     [[nodiscard]] const NProto::TQuota* FindQuota(ui32 quotaId) const;
     [[nodiscard]] TVector<NProto::TQuota> GetQuotas() const;
-
-    [[nodiscard]] ui32 GenerateQuotaId() const;
 };
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/quota_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/quota_ut.cpp
@@ -131,23 +131,6 @@ Y_UNIT_TEST_SUITE(TQuotaStoreTest)
         UNIT_ASSERT(quotaIds.contains(2));
         UNIT_ASSERT(quotaIds.contains(3));
     }
-
-    Y_UNIT_TEST(ShouldGenerateQuotaIds)
-    {
-        TQuotaStore store;
-
-        UNIT_ASSERT_VALUES_EQUAL(1u, store.GenerateQuotaId());
-
-        store.UpdateQuota(MakeQuota(1, 100, 1_GB));
-        store.UpdateQuota(MakeQuota(5, 200, 2_GB));
-        store.UpdateQuota(MakeQuota(3, 300, 3_GB));
-
-        UNIT_ASSERT_VALUES_EQUAL(6u, store.GenerateQuotaId());
-
-        store.RemoveQuota(5);
-
-        UNIT_ASSERT_VALUES_EQUAL(4u, store.GenerateQuotaId());
-    }
 }
 
 }   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/quota_ut.cpp
+++ b/cloud/filestore/libs/storage/tablet/quota_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/hash_set.h>
 #include <util/generic/size_literals.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -108,6 +109,44 @@ Y_UNIT_TEST_SUITE(TQuotaStoreTest)
 
         UNIT_ASSERT(!store.FindQuota(1));
         UNIT_ASSERT(store.FindQuota(2));
+    }
+
+    Y_UNIT_TEST(ShouldGetAllQuotas)
+    {
+        TQuotaStore store;
+
+        store.UpdateQuota(MakeQuota(1, 100, 1_GB));
+        store.UpdateQuota(MakeQuota(2, 200, 2_GB));
+        store.UpdateQuota(MakeQuota(3, 300, 3_GB));
+
+        auto quotas = store.GetQuotas();
+        UNIT_ASSERT_VALUES_EQUAL(3u, quotas.size());
+
+        THashSet<ui32> quotaIds;
+        for (const auto& quota: quotas) {
+            quotaIds.insert(quota.GetQuotaId());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(3u, quotaIds.size());
+        UNIT_ASSERT(quotaIds.contains(1));
+        UNIT_ASSERT(quotaIds.contains(2));
+        UNIT_ASSERT(quotaIds.contains(3));
+    }
+
+    Y_UNIT_TEST(ShouldGenerateQuotaIds)
+    {
+        TQuotaStore store;
+
+        UNIT_ASSERT_VALUES_EQUAL(1u, store.GenerateQuotaId());
+
+        store.UpdateQuota(MakeQuota(1, 100, 1_GB));
+        store.UpdateQuota(MakeQuota(5, 200, 2_GB));
+        store.UpdateQuota(MakeQuota(3, 300, 3_GB));
+
+        UNIT_ASSERT_VALUES_EQUAL(6u, store.GenerateQuotaId());
+
+        store.RemoveQuota(5);
+
+        UNIT_ASSERT_VALUES_EQUAL(4u, store.GenerateQuotaId());
     }
 }
 

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_loadstate.cpp
@@ -112,6 +112,7 @@ bool TIndexTabletActor::PrepareTx_LoadState(
         db->ReadNewBlobs(args.NewBlobs),
         db->ReadGarbageBlobs(args.GarbageBlobs),
         db->ReadCheckpoints(args.Checkpoints),
+        db->ReadQuotas(args.Quotas),
         db->ReadTruncateQueue(args.TruncateQueue),
         db->ReadStorageConfig(args.StorageConfig),
         db->ReadSessionHistoryEntries(args.SessionHistory),
@@ -448,6 +449,11 @@ void TIndexTabletActor::CompleteTx_LoadState(
         LogTag << " Loading tablet checkpoints: "
             << args.Checkpoints.size());
     LoadCheckpoints(args.Checkpoints);
+
+    LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
+        LogTag << " Loading tablet quotas: "
+            << args.Quotas.size());
+    LoadQuotas(args.Quotas);
 
     LOG_INFO_S(ctx, TFileStoreComponents::TABLET,
         LogTag << " Loading fresh bytes: "

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
@@ -9,8 +9,8 @@ using namespace NKikimr::NTabletFlatExecutor;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TIndexTabletActor::HandleCreateQuota(
-    const TEvIndexTablet::TEvCreateQuotaRequest::TPtr& ev,
+void TIndexTabletActor::HandleSetQuota(
+    const TEvIndexTablet::TEvSetQuotaRequest::TPtr& ev,
     const TActorContext& ctx)
 {
     auto* msg = ev->Get();
@@ -18,8 +18,9 @@ void TIndexTabletActor::HandleCreateQuota(
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET,
-        "%s CreateQuota started (maxBytes: %lu, maxNodes: %lu)",
+        "%s SetQuota started (quotaId: %u, maxBytes: %lu, maxNodes: %lu)",
         LogTag.c_str(),
+        msg->Record.GetQuotaId(),
         msg->Record.GetMaxBytes(),
         msg->Record.GetMaxNodes());
 
@@ -32,56 +33,62 @@ void TIndexTabletActor::HandleCreateQuota(
     if (!IsMainTablet()) {
         // TODO(6608): propagate knowledge of the quota to all shards
         auto response =
-            std::make_unique<TEvIndexTablet::TEvCreateQuotaResponse>(MakeError(
+            std::make_unique<TEvIndexTablet::TEvSetQuotaResponse>(MakeError(
                 E_ARGUMENT,
-                "quotas can only be created on the main tablet"));
+                "quotas can only be set on the main tablet"));
         NCloud::Reply(ctx, *requestInfo, std::move(response));
         return;
     }
 
-    AddInFlightRequest<TEvIndexTablet::TCreateQuotaMethod>(*requestInfo);
+    AddInFlightRequest<TEvIndexTablet::TSetQuotaMethod>(*requestInfo);
 
-    ExecuteTx<TCreateQuota>(
+    ExecuteTx<TSetQuota>(
         ctx,
         std::move(requestInfo),
+        msg->Record.GetQuotaId(),
         msg->Record.GetMaxBytes(),
         msg->Record.GetMaxNodes());
 }
 
-bool TIndexTabletActor::PrepareTx_CreateQuota(
+bool TIndexTabletActor::PrepareTx_SetQuota(
     const TActorContext& ctx,
     TTransactionContext& tx,
-    TTxIndexTablet::TCreateQuota& args)
+    TTxIndexTablet::TSetQuota& args)
 {
     Y_UNUSED(ctx, tx, args);
 
     return true;
 }
 
-void TIndexTabletActor::ExecuteTx_CreateQuota(
+void TIndexTabletActor::ExecuteTx_SetQuota(
     const TActorContext& ctx,
     TTransactionContext& tx,
-    TTxIndexTablet::TCreateQuota& args)
+    TTxIndexTablet::TSetQuota& args)
 {
     auto db = CreateIndexTabletDatabase(tx.DB);
-    args.Quota = CreateQuota(*db, args.MaxBytes, args.MaxNodes, ctx.Now());
+    args.Quota = SetQuota(
+        *db,
+        args.QuotaId,
+        args.MaxBytes,
+        args.MaxNodes,
+        ctx.Now());
 }
 
-void TIndexTabletActor::CompleteTx_CreateQuota(
+void TIndexTabletActor::CompleteTx_SetQuota(
     const TActorContext& ctx,
-    TTxIndexTablet::TCreateQuota& args)
+    TTxIndexTablet::TSetQuota& args)
 {
     RemoveInFlightRequest(*args.RequestInfo);
 
     LOG_DEBUG(
         ctx,
         TFileStoreComponents::TABLET,
-        "%s CreateQuota completed (%s)",
+        "%s SetQuota completed (%s)",
         LogTag.c_str(),
         FormatError(args.Error).c_str());
 
     auto response =
-        std::make_unique<TEvIndexTablet::TEvCreateQuotaResponse>(args.Error);
+        std::make_unique<TEvIndexTablet::TEvSetQuotaResponse>(args.Error);
     if (!HasError(args.Error)) {
         *response->Record.MutableQuota() = args.Quota;
     }

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
@@ -40,6 +40,17 @@ void TIndexTabletActor::HandleSetQuota(
         return;
     }
 
+    if (!msg->Record.GetQuotaId()) {
+        auto response =
+            std::make_unique<TEvIndexTablet::TEvSetQuotaResponse>(MakeError(
+                E_ARGUMENT,
+                "quotaId must be non-zero"));
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
+    }
+
+    // TODO(6608): add limit for the number of quotas per file system
+
     AddInFlightRequest<TEvIndexTablet::TSetQuotaMethod>(*requestInfo);
 
     ExecuteTx<TSetQuota>(

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
@@ -1,0 +1,194 @@
+#include "tablet_actor.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+using namespace NActors;
+
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleCreateQuota(
+    const TEvIndexTablet::TEvCreateQuotaRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s CreateQuota started (maxBytes: %lu, maxNodes: %lu)",
+        LogTag.c_str(),
+        msg->Record.GetMaxBytes(),
+        msg->Record.GetMaxNodes());
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        MakeIntrusive<TCallContext>());
+    requestInfo->StartedTs = ctx.Now();
+
+    if (!IsMainTablet()) {
+        // TODO(6608): propagate knowledge of the quota to all shards
+        auto response =
+            std::make_unique<TEvIndexTablet::TEvCreateQuotaResponse>(MakeError(
+                E_ARGUMENT,
+                "quotas can only be created on the main tablet"));
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
+    }
+
+    AddInFlightRequest<TEvIndexTablet::TCreateQuotaMethod>(*requestInfo);
+
+    ExecuteTx<TCreateQuota>(
+        ctx,
+        std::move(requestInfo),
+        msg->Record.GetMaxBytes(),
+        msg->Record.GetMaxNodes());
+}
+
+bool TIndexTabletActor::PrepareTx_CreateQuota(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCreateQuota& args)
+{
+    Y_UNUSED(ctx, tx, args);
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_CreateQuota(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TCreateQuota& args)
+{
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    args.Quota = CreateQuota(*db, args.MaxBytes, args.MaxNodes, ctx.Now());
+}
+
+void TIndexTabletActor::CompleteTx_CreateQuota(
+    const TActorContext& ctx,
+    TTxIndexTablet::TCreateQuota& args)
+{
+    RemoveInFlightRequest(*args.RequestInfo);
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s CreateQuota completed (%s)",
+        LogTag.c_str(),
+        FormatError(args.Error).c_str());
+
+    auto response =
+        std::make_unique<TEvIndexTablet::TEvCreateQuotaResponse>(args.Error);
+    if (!HasError(args.Error)) {
+        *response->Record.MutableQuota() = args.Quota;
+    }
+
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleDeleteQuota(
+    const TEvIndexTablet::TEvDeleteQuotaRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto* msg = ev->Get();
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s DeleteQuota started (quotaId: %u)",
+        LogTag.c_str(),
+        msg->Record.GetQuotaId());
+
+    auto requestInfo = CreateRequestInfo(
+        ev->Sender,
+        ev->Cookie,
+        MakeIntrusive<TCallContext>());
+    requestInfo->StartedTs = ctx.Now();
+
+    if (!IsMainTablet()) {
+        // TODO(6608): propagate deletion of the quota to all shards
+        auto response =
+            std::make_unique<TEvIndexTablet::TEvDeleteQuotaResponse>(MakeError(
+                E_ARGUMENT,
+                "quotas can only be deleted on the main tablet"));
+        NCloud::Reply(ctx, *requestInfo, std::move(response));
+        return;
+    }
+
+    AddInFlightRequest<TEvIndexTablet::TDeleteQuotaMethod>(*requestInfo);
+
+    ExecuteTx<TDeleteQuota>(
+        ctx,
+        std::move(requestInfo),
+        msg->Record.GetQuotaId());
+}
+
+bool TIndexTabletActor::PrepareTx_DeleteQuota(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDeleteQuota& args)
+{
+    Y_UNUSED(ctx, tx, args);
+
+    return true;
+}
+
+void TIndexTabletActor::ExecuteTx_DeleteQuota(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxIndexTablet::TDeleteQuota& args)
+{
+    Y_UNUSED(ctx);
+
+    auto db = CreateIndexTabletDatabase(tx.DB);
+    DeleteQuota(*db, args.QuotaId);
+}
+
+void TIndexTabletActor::CompleteTx_DeleteQuota(
+    const TActorContext& ctx,
+    TTxIndexTablet::TDeleteQuota& args)
+{
+    RemoveInFlightRequest(*args.RequestInfo);
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s DeleteQuota completed (%s)",
+        LogTag.c_str(),
+        FormatError(args.Error).c_str());
+
+    auto response =
+        std::make_unique<TEvIndexTablet::TEvDeleteQuotaResponse>(args.Error);
+
+    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletActor::HandleListQuotas(
+    const TEvIndexTablet::TEvListQuotasRequest::TPtr& ev,
+    const TActorContext& ctx)
+{
+    auto response = std::make_unique<TEvIndexTablet::TEvListQuotasResponse>();
+
+    auto quotas = GetQuotas();
+    for (auto& quota: quotas) {
+        *response->Record.AddQuotas() = std::move(quota);
+    }
+
+    LOG_DEBUG(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s ListQuotas completed (count: %lu)",
+        LogTag.c_str(),
+        quotas.size());
+
+    NCloud::Reply(ctx, *ev, std::move(response));
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1312,11 +1312,12 @@ public:
 
     const NProto::TQuota* FindQuota(ui32 quotaId) const;
 
-    const NProto::TQuota& CreateQuota(
+    const NProto::TQuota& SetQuota(
         IIndexTabletDatabase& db,
+        ui32 quotaId,
         ui64 maxBytes,
         ui64 maxNodes,
-        TInstant creationTimestamp);
+        TInstant now);
 
     void DeleteQuota(IIndexTabletDatabase& db, ui32 quotaId);
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_state.h
@@ -1302,6 +1302,25 @@ private:
         const TPartialBlobId& blobId);
 
     //
+    // Quotas
+    //
+
+public:
+    void LoadQuotas(const TVector<NProto::TQuota>& quotas);
+
+    TVector<NProto::TQuota> GetQuotas() const;
+
+    const NProto::TQuota* FindQuota(ui32 quotaId) const;
+
+    const NProto::TQuota& CreateQuota(
+        IIndexTabletDatabase& db,
+        ui64 maxBytes,
+        ui64 maxNodes,
+        TInstant creationTimestamp);
+
+    void DeleteQuota(IIndexTabletDatabase& db, ui32 quotaId);
+
+    //
     // Background operations
     //
 

--- a/cloud/filestore/libs/storage/tablet/tablet_state_quotas.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_quotas.cpp
@@ -21,19 +21,21 @@ const NProto::TQuota* TIndexTabletState::FindQuota(ui32 quotaId) const
     return Impl->Quotas.FindQuota(quotaId);
 }
 
-const NProto::TQuota& TIndexTabletState::CreateQuota(
+const NProto::TQuota& TIndexTabletState::SetQuota(
     IIndexTabletDatabase& db,
+    ui32 quotaId,
     ui64 maxBytes,
     ui64 maxNodes,
-    TInstant creationTimestamp)
+    TInstant now)
 {
-    const ui32 quotaId = Impl->Quotas.GenerateQuotaId();
+    const auto* existing = Impl->Quotas.FindQuota(quotaId);
 
     NProto::TQuota quota;
     quota.SetQuotaId(quotaId);
     quota.SetMaxBytes(maxBytes);
     quota.SetMaxNodes(maxNodes);
-    quota.SetCreationTimestampUs(creationTimestamp.MicroSeconds());
+    quota.SetCreationTimestampUs(
+        existing ? existing->GetCreationTimestampUs() : now.MicroSeconds());
 
     db.WriteQuota(quota);
     Impl->Quotas.UpdateQuota(quota);

--- a/cloud/filestore/libs/storage/tablet/tablet_state_quotas.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_quotas.cpp
@@ -1,0 +1,50 @@
+#include "tablet_state_impl.h"
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TIndexTabletState::LoadQuotas(const TVector<NProto::TQuota>& quotas)
+{
+    for (const auto& quota: quotas) {
+        Impl->Quotas.UpdateQuota(quota);
+    }
+}
+
+TVector<NProto::TQuota> TIndexTabletState::GetQuotas() const
+{
+    return Impl->Quotas.GetQuotas();
+}
+
+const NProto::TQuota* TIndexTabletState::FindQuota(ui32 quotaId) const
+{
+    return Impl->Quotas.FindQuota(quotaId);
+}
+
+const NProto::TQuota& TIndexTabletState::CreateQuota(
+    IIndexTabletDatabase& db,
+    ui64 maxBytes,
+    ui64 maxNodes,
+    TInstant creationTimestamp)
+{
+    const ui32 quotaId = Impl->Quotas.GenerateQuotaId();
+
+    NProto::TQuota quota;
+    quota.SetQuotaId(quotaId);
+    quota.SetMaxBytes(maxBytes);
+    quota.SetMaxNodes(maxNodes);
+    quota.SetCreationTimestampUs(creationTimestamp.MicroSeconds());
+
+    db.WriteQuota(quota);
+    Impl->Quotas.UpdateQuota(quota);
+
+    return *Impl->Quotas.FindQuota(quotaId);
+}
+
+void TIndexTabletState::DeleteQuota(IIndexTabletDatabase& db, ui32 quotaId)
+{
+    db.DeleteQuota(quotaId);
+    Impl->Quotas.RemoveQuota(quotaId);
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/tablet_state_quotas.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_state_quotas.cpp
@@ -34,8 +34,14 @@ const NProto::TQuota& TIndexTabletState::SetQuota(
     quota.SetQuotaId(quotaId);
     quota.SetMaxBytes(maxBytes);
     quota.SetMaxNodes(maxNodes);
-    quota.SetCreationTimestampUs(
-        existing ? existing->GetCreationTimestampUs() : now.MicroSeconds());
+    if (existing) {
+        quota.SetCreationTimestampUs(existing->GetCreationTimestampUs());
+        // TODO(6608): add a UT for NodeId preservation once AttachQuota
+        // exists and can populate it
+        *quota.MutableNodeId() = existing->GetNodeId();
+    } else {
+        quota.SetCreationTimestampUs(now.MicroSeconds());
+    }
 
     db.WriteQuota(quota);
     Impl->Quotas.UpdateQuota(quota);

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -105,7 +105,7 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CreateCheckpoint,                   __VA_ARGS__)                       \
     xxx(DeleteCheckpoint,                   __VA_ARGS__)                       \
                                                                                \
-    xxx(CreateQuota,                        __VA_ARGS__)                       \
+    xxx(SetQuota,                           __VA_ARGS__)                       \
     xxx(DeleteQuota,                        __VA_ARGS__)                       \
                                                                                \
     xxx(CreateNode,                         __VA_ARGS__)                       \
@@ -705,24 +705,27 @@ struct TTxIndexTablet
     };
 
     //
-    // CreateQuota
+    // SetQuota
     //
 
-    struct TCreateQuota
+    struct TSetQuota
         : TTxIndexTabletBase
         , TErrorAware
     {
         const TRequestInfoPtr RequestInfo;
+        const ui32 QuotaId;
         const ui64 MaxBytes;
         const ui64 MaxNodes;
 
         NProto::TQuota Quota;
 
-        TCreateQuota(
+        TSetQuota(
                 TRequestInfoPtr requestInfo,
+                ui32 quotaId,
                 ui64 maxBytes,
                 ui64 maxNodes)
             : RequestInfo(std::move(requestInfo))
+            , QuotaId(quotaId)
             , MaxBytes(maxBytes)
             , MaxNodes(maxNodes)
         {}

--- a/cloud/filestore/libs/storage/tablet/tablet_tx.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_tx.h
@@ -105,6 +105,9 @@ namespace NCloud::NFileStore::NStorage {
     xxx(CreateCheckpoint,                   __VA_ARGS__)                       \
     xxx(DeleteCheckpoint,                   __VA_ARGS__)                       \
                                                                                \
+    xxx(CreateQuota,                        __VA_ARGS__)                       \
+    xxx(DeleteQuota,                        __VA_ARGS__)                       \
+                                                                               \
     xxx(CreateNode,                         __VA_ARGS__)                       \
     xxx(UnlinkNode,                         __VA_ARGS__)                       \
     xxx(CompleteUnlinkNode,                 __VA_ARGS__)                       \
@@ -357,6 +360,7 @@ struct TTxIndexTablet
         TVector<TPartialBlobId> NewBlobs;
         TVector<TPartialBlobId> GarbageBlobs;
         TVector<NProto::TCheckpoint> Checkpoints;
+        TVector<NProto::TQuota> Quotas;
         TVector<NProto::TDupCacheEntry> DupCache;
         TVector<NProto::TTruncateEntry> TruncateQueue;
         TMaybe<NProto::TStorageConfig> StorageConfig;
@@ -383,6 +387,7 @@ struct TTxIndexTablet
             NewBlobs.clear();
             GarbageBlobs.clear();
             Checkpoints.clear();
+            Quotas.clear();
             DupCache.clear();
             TruncateQueue.clear();
             StorageConfig.Clear();
@@ -696,6 +701,61 @@ struct TTxIndexTablet
 
             Blobs.clear();
             MixedBlobs.clear();
+        }
+    };
+
+    //
+    // CreateQuota
+    //
+
+    struct TCreateQuota
+        : TTxIndexTabletBase
+        , TErrorAware
+    {
+        const TRequestInfoPtr RequestInfo;
+        const ui64 MaxBytes;
+        const ui64 MaxNodes;
+
+        NProto::TQuota Quota;
+
+        TCreateQuota(
+                TRequestInfoPtr requestInfo,
+                ui64 maxBytes,
+                ui64 maxNodes)
+            : RequestInfo(std::move(requestInfo))
+            , MaxBytes(maxBytes)
+            , MaxNodes(maxNodes)
+        {}
+
+        void Clear() override
+        {
+            TErrorAware::Clear();
+
+            Quota.Clear();
+        }
+    };
+
+    //
+    // DeleteQuota
+    //
+
+    struct TDeleteQuota
+        : TTxIndexTabletBase
+        , TErrorAware
+    {
+        const TRequestInfoPtr RequestInfo;
+        const ui32 QuotaId;
+
+        TDeleteQuota(
+                TRequestInfoPtr requestInfo,
+                ui32 quotaId)
+            : RequestInfo(std::move(requestInfo))
+            , QuotaId(quotaId)
+        {}
+
+        void Clear() override
+        {
+            TErrorAware::Clear();
         }
     };
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_quotas.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_quotas.cpp
@@ -6,6 +6,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/hash.h>
 #include <util/generic/size_literals.h>
 
 namespace NCloud::NFileStore::NStorage {
@@ -88,6 +89,18 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
         auto quota = tablet.SetQuota(1, 2_GB, 200)->Record.GetQuota();
         UNIT_ASSERT_VALUES_EQUAL(2_GB, quota.GetMaxBytes());
         UNIT_ASSERT_VALUES_EQUAL(200u, quota.GetMaxNodes());
+    }
+
+    Y_UNIT_TEST(ShouldRejectZeroQuotaId)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        tablet.AssertSetQuotaFailed(0, 1_GB, 100);
     }
 
     Y_UNIT_TEST(ShouldPersistQuotasAcrossReboot)

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_quotas.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_quotas.cpp
@@ -14,7 +14,7 @@ namespace NCloud::NFileStore::NStorage {
 
 Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
 {
-    Y_UNIT_TEST(ShouldCreateQuota)
+    Y_UNIT_TEST(ShouldSetAndListQuotas)
     {
         TTestEnv env;
 
@@ -23,41 +23,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
 
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
 
-        auto response = tablet.CreateQuota(1_GB, 100);
-        const auto& quota = response->Record.GetQuota();
+        auto quota1 = tablet.SetQuota(1, 1_GB, 10)->Record.GetQuota();
+        UNIT_ASSERT_VALUES_EQUAL(1u, quota1.GetQuotaId());
+        UNIT_ASSERT_VALUES_EQUAL(1_GB, quota1.GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(10u, quota1.GetMaxNodes());
+        UNIT_ASSERT(quota1.GetCreationTimestampUs() != 0);
 
-        UNIT_ASSERT(quota.GetQuotaId() != 0);
-        UNIT_ASSERT_VALUES_EQUAL(1_GB, quota.GetMaxBytes());
-        UNIT_ASSERT_VALUES_EQUAL(100u, quota.GetMaxNodes());
-        UNIT_ASSERT(quota.GetCreationTimestampUs() != 0);
-    }
-
-    Y_UNIT_TEST(ShouldAllocateUniqueQuotaIds)
-    {
-        TTestEnv env;
-
-        ui32 nodeIdx = env.AddDynamicNode();
-        ui64 tabletId = env.BootIndexTablet(nodeIdx);
-
-        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
-
-        auto quota1 = tablet.CreateQuota(1_GB)->Record.GetQuota();
-        auto quota2 = tablet.CreateQuota(2_GB)->Record.GetQuota();
-
-        UNIT_ASSERT(quota1.GetQuotaId() != quota2.GetQuotaId());
-    }
-
-    Y_UNIT_TEST(ShouldListQuotas)
-    {
-        TTestEnv env;
-
-        ui32 nodeIdx = env.AddDynamicNode();
-        ui64 tabletId = env.BootIndexTablet(nodeIdx);
-
-        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
-
-        auto quota1 = tablet.CreateQuota(1_GB, 10)->Record.GetQuota();
-        auto quota2 = tablet.CreateQuota(2_GB, 20)->Record.GetQuota();
+        tablet.SetQuota(2, 2_GB, 20);
 
         auto response = tablet.ListQuotas();
         UNIT_ASSERT_VALUES_EQUAL(2, response->Record.QuotasSize());
@@ -67,24 +39,13 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
             quotaById[quota.GetQuotaId()] = quota;
         }
 
-        UNIT_ASSERT(quotaById.contains(quota1.GetQuotaId()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            1_GB,
-            quotaById[quota1.GetQuotaId()].GetMaxBytes());
-        UNIT_ASSERT_VALUES_EQUAL(
-            10u,
-            quotaById[quota1.GetQuotaId()].GetMaxNodes());
-
-        UNIT_ASSERT(quotaById.contains(quota2.GetQuotaId()));
-        UNIT_ASSERT_VALUES_EQUAL(
-            2_GB,
-            quotaById[quota2.GetQuotaId()].GetMaxBytes());
-        UNIT_ASSERT_VALUES_EQUAL(
-            20u,
-            quotaById[quota2.GetQuotaId()].GetMaxNodes());
+        UNIT_ASSERT_VALUES_EQUAL(1_GB, quotaById[1].GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(10u, quotaById[1].GetMaxNodes());
+        UNIT_ASSERT_VALUES_EQUAL(2_GB, quotaById[2].GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(20u, quotaById[2].GetMaxNodes());
     }
 
-    Y_UNIT_TEST(ShouldDeleteQuota)
+    Y_UNIT_TEST(ShouldUpsertQuotaPreservingCreationTimestamp)
     {
         TTestEnv env;
 
@@ -93,15 +54,23 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
 
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
 
-        auto quota = tablet.CreateQuota(1_GB)->Record.GetQuota();
+        auto created = tablet.SetQuota(1, 1_GB, 100)->Record.GetQuota();
+        auto resetSame = tablet.SetQuota(1, 1_GB, 100)->Record.GetQuota();
+        auto updated = tablet.SetQuota(1, 2_GB, 200)->Record.GetQuota();
 
-        tablet.DeleteQuota(quota.GetQuotaId());
+        UNIT_ASSERT_VALUES_EQUAL(1_GB, resetSame.GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(2_GB, updated.GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(200u, updated.GetMaxNodes());
 
-        auto response = tablet.ListQuotas();
-        UNIT_ASSERT_VALUES_EQUAL(0, response->Record.QuotasSize());
+        UNIT_ASSERT_VALUES_EQUAL(
+            created.GetCreationTimestampUs(),
+            resetSame.GetCreationTimestampUs());
+        UNIT_ASSERT_VALUES_EQUAL(
+            created.GetCreationTimestampUs(),
+            updated.GetCreationTimestampUs());
     }
 
-    Y_UNIT_TEST(ShouldDeleteUnknownQuotaAsNoop)
+    Y_UNIT_TEST(ShouldDeleteAndReuseQuotaId)
     {
         TTestEnv env;
 
@@ -110,7 +79,15 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
 
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
 
-        tablet.DeleteQuota(42);
+        tablet.DeleteQuota(1);   // noop, nothing exists yet
+
+        tablet.SetQuota(1, 1_GB, 100);
+        tablet.DeleteQuota(1);
+        UNIT_ASSERT_VALUES_EQUAL(0, tablet.ListQuotas()->Record.QuotasSize());
+
+        auto quota = tablet.SetQuota(1, 2_GB, 200)->Record.GetQuota();
+        UNIT_ASSERT_VALUES_EQUAL(2_GB, quota.GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(200u, quota.GetMaxNodes());
     }
 
     Y_UNIT_TEST(ShouldPersistQuotasAcrossReboot)
@@ -122,7 +99,7 @@ Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
 
         TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
 
-        auto quota = tablet.CreateQuota(1_GB, 100)->Record.GetQuota();
+        auto quota = tablet.SetQuota(1, 1_GB, 100)->Record.GetQuota();
 
         tablet.RebootTablet();
 

--- a/cloud/filestore/libs/storage/tablet/tablet_ut_quotas.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_ut_quotas.cpp
@@ -1,0 +1,139 @@
+#include "tablet.h"
+
+#include <cloud/filestore/libs/storage/testlib/helpers.h>
+#include <cloud/filestore/libs/storage/testlib/tablet_client.h>
+#include <cloud/filestore/libs/storage/testlib/test_env.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+namespace NCloud::NFileStore::NStorage {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TIndexTabletTest_Quotas)
+{
+    Y_UNIT_TEST(ShouldCreateQuota)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        auto response = tablet.CreateQuota(1_GB, 100);
+        const auto& quota = response->Record.GetQuota();
+
+        UNIT_ASSERT(quota.GetQuotaId() != 0);
+        UNIT_ASSERT_VALUES_EQUAL(1_GB, quota.GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(100u, quota.GetMaxNodes());
+        UNIT_ASSERT(quota.GetCreationTimestampUs() != 0);
+    }
+
+    Y_UNIT_TEST(ShouldAllocateUniqueQuotaIds)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        auto quota1 = tablet.CreateQuota(1_GB)->Record.GetQuota();
+        auto quota2 = tablet.CreateQuota(2_GB)->Record.GetQuota();
+
+        UNIT_ASSERT(quota1.GetQuotaId() != quota2.GetQuotaId());
+    }
+
+    Y_UNIT_TEST(ShouldListQuotas)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        auto quota1 = tablet.CreateQuota(1_GB, 10)->Record.GetQuota();
+        auto quota2 = tablet.CreateQuota(2_GB, 20)->Record.GetQuota();
+
+        auto response = tablet.ListQuotas();
+        UNIT_ASSERT_VALUES_EQUAL(2, response->Record.QuotasSize());
+
+        THashMap<ui32, NProto::TQuota> quotaById;
+        for (const auto& quota: response->Record.GetQuotas()) {
+            quotaById[quota.GetQuotaId()] = quota;
+        }
+
+        UNIT_ASSERT(quotaById.contains(quota1.GetQuotaId()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            1_GB,
+            quotaById[quota1.GetQuotaId()].GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(
+            10u,
+            quotaById[quota1.GetQuotaId()].GetMaxNodes());
+
+        UNIT_ASSERT(quotaById.contains(quota2.GetQuotaId()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            2_GB,
+            quotaById[quota2.GetQuotaId()].GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(
+            20u,
+            quotaById[quota2.GetQuotaId()].GetMaxNodes());
+    }
+
+    Y_UNIT_TEST(ShouldDeleteQuota)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        auto quota = tablet.CreateQuota(1_GB)->Record.GetQuota();
+
+        tablet.DeleteQuota(quota.GetQuotaId());
+
+        auto response = tablet.ListQuotas();
+        UNIT_ASSERT_VALUES_EQUAL(0, response->Record.QuotasSize());
+    }
+
+    Y_UNIT_TEST(ShouldDeleteUnknownQuotaAsNoop)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        tablet.DeleteQuota(42);
+    }
+
+    Y_UNIT_TEST(ShouldPersistQuotasAcrossReboot)
+    {
+        TTestEnv env;
+
+        ui32 nodeIdx = env.AddDynamicNode();
+        ui64 tabletId = env.BootIndexTablet(nodeIdx);
+
+        TIndexTabletClient tablet(env.GetRuntime(), nodeIdx, tabletId);
+
+        auto quota = tablet.CreateQuota(1_GB, 100)->Record.GetQuota();
+
+        tablet.RebootTablet();
+
+        auto response = tablet.ListQuotas();
+        UNIT_ASSERT_VALUES_EQUAL(1, response->Record.QuotasSize());
+
+        const auto& reloaded = response->Record.GetQuotas(0);
+        UNIT_ASSERT_VALUES_EQUAL(quota.GetQuotaId(), reloaded.GetQuotaId());
+        UNIT_ASSERT_VALUES_EQUAL(1_GB, reloaded.GetMaxBytes());
+        UNIT_ASSERT_VALUES_EQUAL(100u, reloaded.GetMaxNodes());
+    }
+}
+
+}   // namespace NCloud::NFileStore::NStorage

--- a/cloud/filestore/libs/storage/tablet/ut/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ut/ya.make
@@ -23,6 +23,7 @@ SRCS(
     tablet_ut_nodes.cpp
     tablet_ut_nodes_filteralivenodes.cpp
     tablet_ut_nodes_internal.cpp
+    tablet_ut_quotas.cpp
     tablet_ut_sessions.cpp
     tablet_ut_subsessions.cpp
     tablet_ut_throttling.cpp

--- a/cloud/filestore/libs/storage/tablet/ya.make
+++ b/cloud/filestore/libs/storage/tablet/ya.make
@@ -58,6 +58,7 @@ SRCS(
     tablet_actor_monitoring_directory_viewer.cpp
     tablet_actor_monitoring_locks.cpp
     tablet_actor_oplog.cpp
+    tablet_actor_quota.cpp
     tablet_actor_readblob.cpp
     tablet_actor_readdata.cpp
     tablet_actor_readlink.cpp
@@ -100,6 +101,7 @@ SRCS(
     tablet_state_checkpoints.cpp
     tablet_state_data.cpp
     tablet_state_nodes.cpp
+    tablet_state_quotas.cpp
     tablet_state_sessions.cpp
     tablet_state_throttling.cpp
     tablet_tx.cpp

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -299,6 +299,28 @@ public:
         return request;
     }
 
+    auto CreateCreateQuotaRequest(ui64 maxBytes, ui64 maxNodes = 0)
+    {
+        auto request =
+            std::make_unique<TEvIndexTablet::TEvCreateQuotaRequest>();
+        request->Record.SetMaxBytes(maxBytes);
+        request->Record.SetMaxNodes(maxNodes);
+        return request;
+    }
+
+    auto CreateDeleteQuotaRequest(ui32 quotaId)
+    {
+        auto request =
+            std::make_unique<TEvIndexTablet::TEvDeleteQuotaRequest>();
+        request->Record.SetQuotaId(quotaId);
+        return request;
+    }
+
+    auto CreateListQuotasRequest()
+    {
+        return std::make_unique<TEvIndexTablet::TEvListQuotasRequest>();
+    }
+
     auto CreateDestroySessionRequest(ui64 seqNo = 0)
     {
         auto request = std::make_unique<TEvIndexTablet::TEvDestroySessionRequest>();

--- a/cloud/filestore/libs/storage/testlib/tablet_client.h
+++ b/cloud/filestore/libs/storage/testlib/tablet_client.h
@@ -299,10 +299,11 @@ public:
         return request;
     }
 
-    auto CreateCreateQuotaRequest(ui64 maxBytes, ui64 maxNodes = 0)
+    auto CreateSetQuotaRequest(ui32 quotaId, ui64 maxBytes, ui64 maxNodes = 0)
     {
         auto request =
-            std::make_unique<TEvIndexTablet::TEvCreateQuotaRequest>();
+            std::make_unique<TEvIndexTablet::TEvSetQuotaRequest>();
+        request->Record.SetQuotaId(quotaId);
         request->Record.SetMaxBytes(maxBytes);
         request->Record.SetMaxNodes(maxNodes);
         return request;

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -1239,7 +1239,7 @@ message TListNodesInternalResponse
 ////////////////////////////////////////////////////////////////////////////////
 // Quota management requests/responses
 
-message TCreateQuotaRequest
+message TSetQuotaRequest
 {
     // Optional request headers.
     NProto.THeaders Headers = 1;
@@ -1247,17 +1247,20 @@ message TCreateQuotaRequest
     // FileSystem identifier.
     string FileSystemId = 2;
 
+    // Quota identifier, chosen by the caller.
+    uint32 QuotaId = 3;
+
     // Byte and node limits, 0 means unlimited.
-    uint64 MaxBytes = 3;
-    uint64 MaxNodes = 4;
+    uint64 MaxBytes = 4;
+    uint64 MaxNodes = 5;
 }
 
-message TCreateQuotaResponse
+message TSetQuotaResponse
 {
     // Optional error, set only if error happened.
     NCloud.NProto.TError Error = 1;
 
-    // Created quota.
+    // Resulting quota.
     NProto.TQuota Quota = 2;
 }
 

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -5,6 +5,7 @@ import "cloud/storage/core/protos/media.proto";
 import "cloud/filestore/public/api/protos/fs.proto";
 import "cloud/filestore/public/api/protos/headers.proto";
 import "cloud/filestore/public/api/protos/node.proto";
+import "cloud/filestore/public/api/protos/quota.proto";
 import "cloud/filestore/config/storage.proto";
 
 import "contrib/ydb/core/protos/base.proto";
@@ -1233,4 +1234,65 @@ message TListNodesInternalResponse
 
     // Optional response headers.
     NProto.TResponseHeaders Headers = 1000;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Quota management requests/responses
+
+message TCreateQuotaRequest
+{
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // FileSystem identifier.
+    string FileSystemId = 2;
+
+    // Byte and node limits, 0 means unlimited.
+    uint64 MaxBytes = 3;
+    uint64 MaxNodes = 4;
+}
+
+message TCreateQuotaResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // Created quota.
+    NProto.TQuota Quota = 2;
+}
+
+message TDeleteQuotaRequest
+{
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // FileSystem identifier.
+    string FileSystemId = 2;
+
+    // Quota identifier.
+    uint32 QuotaId = 3;
+}
+
+message TDeleteQuotaResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+}
+
+message TListQuotasRequest
+{
+    // Optional request headers.
+    NProto.THeaders Headers = 1;
+
+    // FileSystem identifier.
+    string FileSystemId = 2;
+}
+
+message TListQuotasResponse
+{
+    // Optional error, set only if error happened.
+    NCloud.NProto.TError Error = 1;
+
+    // All quotas defined on this filesystem.
+    repeated NProto.TQuota Quotas = 2;
 }

--- a/cloud/filestore/public/api/protos/quota.proto
+++ b/cloud/filestore/public/api/protos/quota.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package NCloud.NFileStore.NProto;
+
+option go_package = "github.com/ydb-platform/nbs/cloud/filestore/public/api/protos";
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TQuota
+{
+    uint32 QuotaId = 1;
+    uint64 MaxBytes = 2;
+    uint64 MaxNodes = 3;
+
+    repeated uint64 NodeId = 4;
+    uint64 CreationTimestampUs = 5;
+}

--- a/cloud/filestore/public/api/protos/ya.make
+++ b/cloud/filestore/public/api/protos/ya.make
@@ -15,6 +15,7 @@ SRCS(
     locks.proto
     node.proto
     ping.proto
+    quota.proto
     server.proto
     session.proto
 )


### PR DESCRIPTION
### Notes
* Exposing quotas management operations in the main tablet (no support for shards for now)
* Adding executeActions for these methods
* Moving TQuota from `filestore/libs/storage/tablet/protos/tablet.proto` to `filestore/public/api/protos/quota.proto`

### Issue
#6608
