### PR TITLE
Filestore: enable bs errors injection for py tests that use new features config

### DIFF
--- a/cloud/filestore/tests/async_close_test/ya.make
+++ b/cloud/filestore/tests/async_close_test/ya.make
@@ -18,7 +18,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 1)

--- a/cloud/filestore/tests/async_close_test/ya.make
+++ b/cloud/filestore/tests/async_close_test/ya.make
@@ -18,7 +18,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 1)

--- a/cloud/filestore/tests/async_close_test/ya.make
+++ b/cloud/filestore/tests/async_close_test/ya.make
@@ -18,6 +18,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 1)

--- a/cloud/filestore/tests/close_to_open_consistency/ya.make
+++ b/cloud/filestore/tests/close_to_open_consistency/ya.make
@@ -17,7 +17,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 2)

--- a/cloud/filestore/tests/close_to_open_consistency/ya.make
+++ b/cloud/filestore/tests/close_to_open_consistency/ya.make
@@ -17,6 +17,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 2)

--- a/cloud/filestore/tests/close_to_open_consistency/ya.make
+++ b/cloud/filestore/tests/close_to_open_consistency/ya.make
@@ -17,7 +17,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 2)

--- a/cloud/filestore/tests/directory_handles/ya.make
+++ b/cloud/filestore/tests/directory_handles/ya.make
@@ -22,7 +22,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 1)

--- a/cloud/filestore/tests/directory_handles/ya.make
+++ b/cloud/filestore/tests/directory_handles/ya.make
@@ -22,7 +22,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 1)

--- a/cloud/filestore/tests/directory_handles/ya.make
+++ b/cloud/filestore/tests/directory_handles/ya.make
@@ -22,6 +22,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 SET(QEMU_VIRTIO fs)
 SET(QEMU_INSTANCE_COUNT 1)

--- a/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
@@ -19,7 +19,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 SET(
     NFS_SERVICE_CONFIG_PATCH

--- a/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
@@ -19,6 +19,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 SET(
     NFS_SERVICE_CONFIG_PATCH

--- a/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/fio/qemu-kikimr-newfeatures-test/ya.make
@@ -19,7 +19,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 SET(
     NFS_SERVICE_CONFIG_PATCH

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
@@ -29,7 +29,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 SET(NFS_FORCE_VERBOSE 1)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
@@ -29,6 +29,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 SET(NFS_FORCE_VERBOSE 1)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-nemesis-test/ya.make
@@ -29,7 +29,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 SET(NFS_FORCE_VERBOSE 1)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
@@ -21,7 +21,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 SET(NFS_FORCE_VERBOSE 1)
 

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
@@ -21,7 +21,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 SET(NFS_FORCE_VERBOSE 1)
 

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-tablets-restart-test/ya.make
@@ -21,6 +21,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 SET(NFS_FORCE_VERBOSE 1)
 

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
@@ -21,6 +21,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
@@ -21,7 +21,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)

--- a/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fio_index/qemu-kikimr-multishard-test/ya.make
@@ -21,7 +21,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)

--- a/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
@@ -19,6 +19,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)

--- a/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
@@ -19,7 +19,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)

--- a/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
+++ b/cloud/filestore/tests/fs_posix_compliance/qemu-kikimr-multishard-test/ya.make
@@ -19,7 +19,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.001)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/vhost-kikimr.inc)

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
@@ -24,7 +24,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
+SET(NFS_BS_FAILURE_PROBABILITY 0.01)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
@@ -24,6 +24,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 

--- a/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
+++ b/cloud/filestore/tests/loadtest/service-kikimr-newfeatures-test/ya.make
@@ -24,7 +24,7 @@ SET(
     NFS_STORAGE_CONFIG_PATCH
     cloud/filestore/tests/common_configs/nfs-storage-newfeatures-patch.txt
 )
-SET(NFS_BS_FAILURE_PROBABILITY 0.01)
+SET(NFS_BS_FAILURE_PROBABILITY 0.0001)
 
 INCLUDE(${ARCADIA_ROOT}/cloud/filestore/tests/recipes/service-kikimr.inc)
 

--- a/cloud/filestore/tests/recipes/service-kikimr.inc
+++ b/cloud/filestore/tests/recipes/service-kikimr.inc
@@ -49,6 +49,10 @@ IF (USE_FAST_SHARD_PORT)
     SET_APPEND(RECIPE_ARGS --use-fast-shard-port)
 ENDIF()
 
+IF (NFS_BS_FAILURE_PROBABILITY)
+    SET_APPEND(RECIPE_ARGS --bs-failure-probability $NFS_BS_FAILURE_PROBABILITY)
+ENDIF()
+
 USE_RECIPE(
     cloud/filestore/tests/recipes/service-kikimr/service-kikimr-recipe
     ${RECIPE_ARGS}

--- a/cloud/filestore/tests/recipes/service-kikimr/__main__.py
+++ b/cloud/filestore/tests/recipes/service-kikimr/__main__.py
@@ -50,6 +50,7 @@ def start(argv):
     parser.add_argument("--use-unix-socket", action="store_true", default=False)
     parser.add_argument("--trace-sampling-rate", action="store", default=None, type=int)
     parser.add_argument("--use-fast-shard-port", action="store_true", default=False)
+    parser.add_argument("--bs-failure-probability", action="store", default=None, type=float)
     args = parser.parse_args(argv)
 
     kikimr_binary_path = common.binary_path("cloud/storage/core/tools/testing/ydb/bin/ydbd")
@@ -163,6 +164,7 @@ def start(argv):
         secure=secure,
         access_service_type=access_service_type,
         trace_sampling_rate=args.trace_sampling_rate,
+        bs_failure_probability=args.bs_failure_probability,
     )
     filestore_configurator.generate_configs(kikimr_configurator.domains_txt, kikimr_configurator.names_txt)
 

--- a/cloud/filestore/tests/recipes/vhost-kikimr.inc
+++ b/cloud/filestore/tests/recipes/vhost-kikimr.inc
@@ -39,6 +39,10 @@ IF (NFS_TRACE_SAMPLING_RATE)
     SET_APPEND(RECIPE_ARGS --trace-sampling-rate $NFS_TRACE_SAMPLING_RATE)
 ENDIF()
 
+IF (NFS_BS_FAILURE_PROBABILITY)
+    SET_APPEND(RECIPE_ARGS --bs-failure-probability $NFS_BS_FAILURE_PROBABILITY)
+ENDIF()
+
 USE_RECIPE(
     cloud/filestore/tests/recipes/vhost/vhost-recipe
     ${RECIPE_ARGS}

--- a/cloud/filestore/tests/recipes/vhost/__main__.py
+++ b/cloud/filestore/tests/recipes/vhost/__main__.py
@@ -49,6 +49,7 @@ def start(argv):
     parser.add_argument("--local-service-config-patch", action="append", default=[])
     parser.add_argument("--use-unix-socket", action="store_true", default=False)
     parser.add_argument("--trace-sampling-rate", action="store", default=None, type=int)
+    parser.add_argument("--bs-failure-probability", action="store", default=None, type=float)
 
     args = parser.parse_args(argv)
 
@@ -172,6 +173,7 @@ def start(argv):
         storage_config=storage_config,
         access_service_type=access_service_type,
         trace_sampling_rate=args.trace_sampling_rate,
+        bs_failure_probability=args.bs_failure_probability,
     )
 
     filestore_vhost = FilestoreVhost(vhost_configurator)


### PR DESCRIPTION


### Notes
Enable bs errors injection for py tests that use new features config

### Issue
#6467
