### PR TITLE
[NBS] add TFixture to test_grpc_device_provider_ut

### DIFF
--- a/cloud/blockstore/libs/local_nvme/test_grpc_device_provider_ut.cpp
+++ b/cloud/blockstore/libs/local_nvme/test_grpc_device_provider_ut.cpp
@@ -15,22 +15,43 @@ namespace NCloud::NBlockStore {
 
 using namespace std::chrono_literals;
 
+namespace {
+
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_UNIT_TEST_SUITE(TGrpcDeviceProviderTest)
+struct TFixture: NUnitTest::TBaseTestCase
+{
+    ILoggingServicePtr Logging;
+    TString SocketPath;
+
+    void SetUp(NUnitTest::TTestContext& /* context */) final
+    {
+        Logging =
+            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
+        Logging->Start();
+
+        SocketPath = GetEnv("INFRA_DEVICE_PROVIDER_SOCKET");
+        UNIT_ASSERT_UNEQUAL("", SocketPath);
+    }
+
+    void TearDown(NUnitTest::TTestContext& /* context */) final
+    {
+        Logging->Stop();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE_F(TGrpcDeviceProviderTest, TFixture)
 {
     Y_UNIT_TEST(ShouldListDevices)
     {
-        const ILoggingServicePtr logging =
-            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
-
-        const TString socketPath = GetEnv("INFRA_DEVICE_PROVIDER_SOCKET");
-        UNIT_ASSERT_UNEQUAL("", socketPath);
-
         {
             auto deviceProvider = CreateTestGrpcDeviceProvider(
-                logging,
-                "unix://nbs@" + socketPath);
+                Logging,
+                "unix://nbs@" + SocketPath);
             deviceProvider->Start();
 
             auto future = deviceProvider->ListNVMeDevices();
@@ -41,8 +62,8 @@ Y_UNIT_TEST_SUITE(TGrpcDeviceProviderTest)
         }
         {
             auto deviceProvider = CreateTestGrpcDeviceProvider(
-                logging,
-                "unix://ydb@" + socketPath);
+                Logging,
+                "unix://ydb@" + SocketPath);
             deviceProvider->Start();
 
             auto future = deviceProvider->ListNVMeDevices();
@@ -55,22 +76,19 @@ Y_UNIT_TEST_SUITE(TGrpcDeviceProviderTest)
 
     Y_UNIT_TEST(ShouldNotHangOnStopWithPendingRequest)
     {
-        const ILoggingServicePtr logging =
-            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
-
         TTempDir tempDir;
 
         const TString socketPath = tempDir.Path() / "non-existent.sock";
 
         auto deviceProvider =
-            CreateTestGrpcDeviceProvider(logging, "unix://nbs@" + socketPath);
+            CreateTestGrpcDeviceProvider(Logging, "unix://nbs@" + socketPath);
         deviceProvider->Start();
 
         {
             auto future = deviceProvider->ListNVMeDevices();
-
             deviceProvider->Stop();
 
+            future.Wait();
             auto [_, error] = ResultOrError(future);
 
             UNIT_ASSERT_VALUES_EQUAL_C(
@@ -85,6 +103,7 @@ Y_UNIT_TEST_SUITE(TGrpcDeviceProviderTest)
 
         {
             auto future = deviceProvider->ListNVMeDevices();
+            future.Wait();
             auto [_, error] = ResultOrError(future);
             UNIT_ASSERT_VALUES_EQUAL_C(
                 E_REJECTED,
@@ -97,16 +116,13 @@ Y_UNIT_TEST_SUITE(TGrpcDeviceProviderTest)
 
     Y_UNIT_TEST(ShouldNotHangOnDestruction)
     {
-        const ILoggingServicePtr logging =
-            CreateLoggingService("console", {.FiltrationLevel = TLOG_DEBUG});
-
         TTempDir tempDir;
 
         {
             const TString socketPath = tempDir.Path() / "non-existent.sock";
 
             auto deviceProvider = CreateTestGrpcDeviceProvider(
-                logging,
+                Logging,
                 "unix://nbs@" + socketPath);
 
             Y_UNUSED(deviceProvider);
@@ -117,7 +133,7 @@ Y_UNIT_TEST_SUITE(TGrpcDeviceProviderTest)
             UNIT_ASSERT_UNEQUAL("", socketPath);
 
             auto deviceProvider = CreateTestGrpcDeviceProvider(
-                logging,
+                Logging,
                 "unix://nbs@" + socketPath);
 
             Y_UNUSED(deviceProvider);

--- a/cloud/blockstore/libs/local_nvme/ut/ya.make
+++ b/cloud/blockstore/libs/local_nvme/ut/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/cloud/storage/core/tests/recipes/small.inc)
 SRCS(
     config_ut.cpp
     device_provider_ut.cpp
+    service_proxy_ut.cpp
     service_ut.cpp
 )
 
@@ -15,6 +16,8 @@ IF (OS_LINUX)
 ENDIF(OS_LINUX)
 
 PEERDIR(
+    cloud/blockstore/libs/service
+
     library/cpp/testing/unittest
 )
 

--- a/cloud/blockstore/libs/local_nvme/ut_infra/ya.make
+++ b/cloud/blockstore/libs/local_nvme/ut_infra/ya.make
@@ -10,12 +10,10 @@ SRCS(
 IF (OS_LINUX)
     SRCS(
         service_linux_ut.cpp
-        service_proxy_ut.cpp
     )
 ENDIF(OS_LINUX)
 
 PEERDIR(
-    cloud/blockstore/libs/service
     cloud/blockstore/tools/testing/infra-device-provider/protos
     cloud/storage/core/libs/grpc
 


### PR DESCRIPTION
* Add `TFixture` to `test_grpc_device_provider_ut`.
* Add `future.Wait()` to prevent possible failures in `ShouldNotHangOnStopWithPendingRequest`.
* Move `service_proxy_ut.cpp` to `ut`, since it does not depend on `infra-device-provider`.
