### PR TITLE
issue-5894, issue-5895: assorted persistent shard fixes

### DIFF
--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
@@ -205,8 +205,7 @@ public:
     {
         Y_ABORT_UNLESS(sizeof(TValue) <= SlotSize);
 
-        TValue emptySlot;
-        memset(reinterpret_cast<char*>(&emptySlot), 0, SlotSize);
+        const TValue emptySlot{};
         Y_ABORT_UNLESS(TombstoneKey != MakeKey(emptySlot));
     }
 
@@ -222,6 +221,10 @@ public:
         TVector<TPageGroup>& pageGroups)
     {
         auto k = MakeKey(v);
+        if (k == TombstoneKey) {
+            return MakeError(E_ARGUMENT, "attempt to put a tombstone");
+        }
+
         TValue existing{};
         ui64 slotNo = 0;
         auto error = AllocateSlot(lsn, k, &existing, &slotNo);

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/persistent_hash_table.h
@@ -204,6 +204,10 @@ public:
         , Hash(std::move(hash))
     {
         Y_ABORT_UNLESS(sizeof(TValue) <= SlotSize);
+
+        TValue emptySlot;
+        memset(reinterpret_cast<char*>(&emptySlot), 0, SlotSize);
+        Y_ABORT_UNLESS(TombstoneKey != MakeKey(emptySlot));
     }
 
 public:

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -324,6 +324,12 @@ public:
             slot.CTime = update.GetCTime();
         }
         if (HasFlag(flags, NProto::TSetNodeAttrRequest::F_SET_ATTR_SIZE)) {
+            if (slot.Size > update.GetSize()) {
+                //
+                // TODO(#5894): deallocate pages and delete them from page index
+                //
+            }
+
             slot.Size = update.GetSize();
         }
 
@@ -381,6 +387,7 @@ private:
     static_assert(SlotsPerPage * NameSlotSize <= PageSize);
 
     using THt = TPersistentHashTable<TStringBuf, TNameTableSlot>;
+    TNameTableSlot Tombstone{};
     std::unique_ptr<THt> Slots;
 
 public:
@@ -392,16 +399,15 @@ public:
         const ui64 pageCount = Min(
             RoundUp(config.GetNodesPerGroup(), SlotsPerPage),
             (NodeTableSize / PageSize) * SlotsPerPage) / SlotsPerPage;
-        TNameTableSlot tombstone{};
-        // tombstone key needs to be different from an empty slot key
-        memset(tombstone.Name, 1, NameCapacity - 1);
-        tombstone.NodeId = Max<ui64>();
+        // Tombstone key needs to be different from an empty slot key
+        memset(Tombstone.Name, 1, NameCapacity - 1);
+        Tombstone.NodeId = Max<ui64>();
         Slots = std::make_unique<THt>(
             firstPageNo,
             pageCount,
             PageSize,
             NameSlotSize,
-            tombstone,
+            Tombstone,
             std::move(pageStore),
             [] (const TNameTableSlot& s) -> TStringBuf
             {
@@ -566,7 +572,7 @@ ui64 CalcPageClusterCount(
 {
     const ui64 dataPageCount = Min(
         config.GetExpectedGroupCapacity() / PageSize,
-        MaxNodePageClusterTableSize / PageSize);
+        MaxSpacePerStorageGroup / PageSize);
     return RoundUp(dataPageCount, PageClusterPageCount) / PageClusterPageCount;
 }
 
@@ -1285,7 +1291,9 @@ public:
                 storagePageClusterIdsToWrite.push_back(storagePageClusterId);
             }
 
-            bufferOffset += PageClusterSize;
+            const ui64 nextFileOffset =
+                RoundDown(fileOffset + PageClusterSize, PageClusterSize);
+            bufferOffset += nextFileOffset - fileOffset;
         }
 
         if (HasError(error)) {
@@ -1425,6 +1433,10 @@ public:
         }
 
         if (HasError(error)) {
+            PageAllocator.RollbackAllocation(
+                newStoragePageClusterIds,
+                writeContext);
+
             *response.MutableError() = std::move(error);
             return response;
         }
@@ -1437,6 +1449,10 @@ public:
         error = Nodes.ResizeNode(nodeId, endOffset, writeContext);
 
         if (HasError(error)) {
+            PageAllocator.RollbackAllocation(
+                newStoragePageClusterIds,
+                writeContext);
+
             *response.MutableError() = std::move(error);
             return response;
         }
@@ -1460,9 +1476,12 @@ public:
             // after that we can rollback the pages.
             //
 
+            l.lock();
             PageAllocator.RollbackAllocation(
                 newStoragePageClusterIds,
                 writeContext);
+            l.unlock();
+
             PageStore->RollbackPages(pages);
 
             return response;

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard.cpp
@@ -393,6 +393,8 @@ public:
             RoundUp(config.GetNodesPerGroup(), SlotsPerPage),
             (NodeTableSize / PageSize) * SlotsPerPage) / SlotsPerPage;
         TNameTableSlot tombstone{};
+        // tombstone key needs to be different from an empty slot key
+        memset(tombstone.Name, 1, NameCapacity - 1);
         tombstone.NodeId = Max<ui64>();
         Slots = std::make_unique<THt>(
             firstPageNo,

--- a/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
+++ b/cloud/filestore/libs/storage/fastshard/impl/naive_mirrored/shard_ut.cpp
@@ -670,3 +670,102 @@ TEST(NaiveMirroredShardTest, WritesAndReadsLongUnalignedRangesWithHoles)
             << FormatError(response.GetError());
     }
 }
+
+TEST(NaiveMirroredShardTest, UnalignedAppend)
+{
+    TStorageFixture fx;
+
+    auto shard = CreateNaiveMirroredFileSystemShard(ShardNo, fx.Config);
+
+    const TString file1 = "file1";
+    const ui32 mode = 0644;
+    const ui64 uid = 111;
+    const ui64 gid = 222;
+
+    const ui32 createHandleFlags
+        = ProtoFlag(TCreateHandleRequest::E_CREATE)
+        | ProtoFlag(TCreateHandleRequest::E_READ)
+        | ProtoFlag(TCreateHandleRequest::E_WRITE);
+
+    ui64 nodeId = 0;
+    ui64 handle = 0;
+    {
+        TCreateHandleRequest request;
+        request.SetNodeId(RootNodeId);
+        request.SetName(file1);
+        request.SetFlags(createHandleFlags);
+        request.SetMode(mode);
+        request.SetUid(uid);
+        request.SetGid(gid);
+        auto f = shard->CreateHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        handle = response.GetHandle();
+        EXPECT_TRUE(handle != 0);
+        nodeId = response.GetNodeAttr().GetId();
+        EXPECT_TRUE(nodeId != 0);
+    }
+
+    // the request should span 2 clusters but be smaller than 1 cluster
+    const auto data = GenerateValidateData(24_KB, 1 /* seed */);
+    const ui64 offset = 16_KB;
+
+    {
+        TWriteDataRequest request;
+        request.SetHandle(handle);
+        request.SetOffset(offset);
+        *request.MutableBuffer() = data;
+        auto f = shard->WriteData(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+
+    {
+        const ui64 readOffset = 0;
+        const ui64 readLength = 64_KB;
+
+        TString expectedData(readLength, 0);
+
+        memcpy(expectedData.begin() + offset, data.data(), data.size());
+
+        TReadDataRequest request;
+        request.SetHandle(handle);
+        request.SetOffset(readOffset);
+        request.SetLength(readLength);
+        auto f = shard->ReadData(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(expectedData, response.GetBuffer());
+    }
+
+    //
+    // Checking that file size is correct.
+    //
+
+    {
+        TGetNodeAttrRequest request;
+        request.SetNodeId(nodeId);
+        auto f = shard->GetNodeAttr(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+        EXPECT_EQ(nodeId, response.GetNode().GetId());
+        EXPECT_EQ(40_KB, response.GetNode().GetSize());
+    }
+
+    //
+    // Cleanup.
+    //
+
+    {
+        TDestroyHandleRequest request;
+        request.SetHandle(handle);
+        auto f = shard->DestroyHandle(request);
+        auto response = f.GetValueSync();
+        EXPECT_EQ(S_OK, response.GetError().GetCode())
+            << FormatError(response.GetError());
+    }
+}


### PR DESCRIPTION
### Notes
Assorted follow-up fixes for https://github.com/ydb-platform/nbs/pull/6630:
* `NaiveMirroredFileSystemShard` - `TNameTable` tombstone key must be different from empty slot key (and `TPersistentHashTable` should validate this)
* fixed incorrect calculation for data page count limit - will add uts for this separately - need to implement page store initialization via dependency injection to do it cleanly
* fixed broken last cluster allocation for append requests which are not `PageClusterSize`-aligned and span multiple page clusters at the same time
* deallocating pages in `TPageAllocator` in all error cases in `WriteData()` - will implement uts for PageStore error scenarios separately
* added a TODO item about page deallocation into file truncation code (the same as for `UnlinkNode()`) - will implement this logic separately 

### Issue
https://github.com/ydb-platform/nbs/issues/5894
https://github.com/ydb-platform/nbs/issues/5895