### PR TITLE
issue-6658: [Blockstore] check if blob is needed for checkpoint in cleanup transaction

### DIFF
--- a/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_actor_cleanup.cpp
@@ -181,7 +181,10 @@ void TPartitionActor::HandleCleanup(
         commitId,
         IsUseRecreatedBlobMetasOnCleanupEnabled(),
         IsVerifyRecreatedBlobMetasOnCleanupEnabled(),
-        std::move(cleanupQueue));
+        std::move(cleanupQueue),
+        false,              // withCheckpoint
+        InvalidCommitId,    // minCheckpointCommitId
+        InvalidCommitId);   // maxCheckpointCommitId
 
     ExecuteTx(ctx, std::move(tx));
 }

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -340,8 +340,8 @@ void ExecuteCleanupTransaction(
     size_t mixedBlobsCount = 0;
     size_t mergedBlobsCount = 0;
 
-    TVector<TCleanupQueueItem> deletedItems;
-    deletedItems.reserve(args.CleanupQueue.size());
+    TVector<TCleanupQueueItem> filteredCleanupQueue;
+    filteredCleanupQueue.reserve(args.CleanupQueue.size());
 
     Y_ABORT_UNLESS(args.CleanupQueue.size() == args.BlobsMeta.size());
     for (size_t i = 0; i < args.CleanupQueue.size(); ++i) {
@@ -444,13 +444,13 @@ void ExecuteCleanupTransaction(
             db.WriteGarbageBlob(item.BlobId);
         }
 
-        deletedItems.push_back(item);
+        filteredCleanupQueue.push_back(item);
     }
 
     if (args.WithCheckpoint) {
-        args.CleanupQueue = std::move(deletedItems);
+        args.CleanupQueue = std::move(filteredCleanupQueue);
     } else {
-        Y_DEBUG_ABORT_UNLESS(deletedItems.size() == args.CleanupQueue.size());
+        Y_DEBUG_ABORT_UNLESS(filteredCleanupQueue.size() == args.CleanupQueue.size());
     }
 
     // Updating counters

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -287,6 +287,44 @@ bool PrepareCleanupTransaction(
     return ready;
 }
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool ShouldSkipCleanupDueToCheckpoint(
+    const TCleanupQueueItem& item,
+    const NProto::TBlobMeta& blobMeta,
+    ui64 minCheckpointCommitId,
+    ui64 maxCheckpointCommitId)
+{
+    if (item.CommitId < minCheckpointCommitId) {
+        // Blob was added to the cleanup queue before any checkpoint.
+        return false;
+    }
+
+    ui64 minCommitIdInBlob = Max<ui64>();
+    if (blobMeta.HasMixedBlocks()) {
+        const auto& mixedBlocks = blobMeta.GetMixedBlocks();
+        if (mixedBlocks.CommitIdsSize() == 0) {
+            // Every block shares the same commitId.
+            minCommitIdInBlob = item.BlobId.CommitId();
+        } else {
+            // Each block has its own commitId.
+            for (ui64 commitId: mixedBlocks.GetCommitIds()) {
+                minCommitIdInBlob = Min(minCommitIdInBlob, commitId);
+            }
+        }
+    } else if (blobMeta.HasMergedBlocks()) {
+        minCommitIdInBlob = item.BlobId.CommitId();
+    }
+
+    return minCommitIdInBlob <= maxCheckpointCommitId;
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
 void ExecuteCleanupTransaction(
     const NActors::TActorSystem* actorSystem,
     const TLogTitle& logTitle,
@@ -300,10 +338,33 @@ void ExecuteCleanupTransaction(
     size_t mixedBlobsCount = 0;
     size_t mergedBlobsCount = 0;
 
+    TVector<TCleanupQueueItem> deletedItems;
+    deletedItems.reserve(args.CleanupQueue.size());
+
     Y_ABORT_UNLESS(args.CleanupQueue.size() == args.BlobsMeta.size());
     for (size_t i = 0; i < args.CleanupQueue.size(); ++i) {
         const auto& item = args.CleanupQueue[i];
         const auto& blobMeta = args.BlobsMeta[i];
+
+        if (args.WithCheckpoint &&
+            ShouldSkipCleanupDueToCheckpoint(
+                item,
+                blobMeta,
+                args.MinCheckpointCommitId,
+                args.MaxCheckpointCommitId))
+        {
+            LOG_DEBUG(
+                *actorSystem,
+                TBlockStoreComponents::PARTITION,
+                "%s ExecuteCleanupTransaction: skipping blob=%s: deletionCommitId=%lu "
+                "minCheckpointCommitId=%lu maxCheckpointCommitId=%lu",
+                logTitle.GetWithTime().c_str(),
+                ToString(MakeBlobId(tabletId, item.BlobId)).Quote().c_str(),
+                item.CommitId,
+                args.MinCheckpointCommitId,
+                args.MaxCheckpointCommitId);
+            continue;
+        }
 
         if (blobMeta.HasMixedBlocks()) {
             const auto& mixedBlocks = blobMeta.GetMixedBlocks();
@@ -380,6 +441,14 @@ void ExecuteCleanupTransaction(
         if (!IsDeletionMarker(item.BlobId)) {
             db.WriteGarbageBlob(item.BlobId);
         }
+
+        deletedItems.push_back(item);
+    }
+
+    if (args.WithCheckpoint) {
+        args.CleanupQueue = std::move(deletedItems);
+    } else {
+        Y_DEBUG_ABORT_UNLESS(deletedItems.size() == args.CleanupQueue.size());
     }
 
     // Updating counters

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic.cpp
@@ -298,7 +298,9 @@ bool ShouldSkipCleanupDueToCheckpoint(
     ui64 maxCheckpointCommitId)
 {
     if (item.CommitId < minCheckpointCommitId) {
-        // Blob was added to the cleanup queue before any checkpoint.
+        // The blob was added to the cleanup queue before any checkpoint.
+        // Therefore, it is covered by one or more blobs visible to all
+        // checkpoints.
         return false;
     }
 
@@ -346,17 +348,17 @@ void ExecuteCleanupTransaction(
         const auto& item = args.CleanupQueue[i];
         const auto& blobMeta = args.BlobsMeta[i];
 
-        if (args.WithCheckpoint &&
-            ShouldSkipCleanupDueToCheckpoint(
-                item,
-                blobMeta,
-                args.MinCheckpointCommitId,
-                args.MaxCheckpointCommitId))
+        if (args.WithCheckpoint && ShouldSkipCleanupDueToCheckpoint(
+                                       item,
+                                       blobMeta,
+                                       args.MinCheckpointCommitId,
+                                       args.MaxCheckpointCommitId))
         {
             LOG_DEBUG(
                 *actorSystem,
                 TBlockStoreComponents::PARTITION,
-                "%s ExecuteCleanupTransaction: skipping blob=%s: deletionCommitId=%lu "
+                "%s ExecuteCleanupTransaction: skipping blob=%s: "
+                "deletionCommitId=%lu "
                 "minCheckpointCommitId=%lu maxCheckpointCommitId=%lu",
                 logTitle.GetWithTime().c_str(),
                 ToString(MakeBlobId(tabletId, item.BlobId)).Quote().c_str(),

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -256,14 +256,20 @@ TTxPartition::TCleanup MakeCleanupArgs(
     const TVector<TCleanupQueueItem>& cleanupQueue,
     ui64 cleanupCommitId,
     bool useRecreatedBlobMeta,
-    bool verifyRecreatedBlobMetasOnCleanup)
+    bool verifyRecreatedBlobMetasOnCleanup,
+    bool withCheckpoint = false,
+    ui64 minCheckpointCommitId = InvalidCommitId,
+    ui64 maxCheckpointCommitId = InvalidCommitId)
 {
     return TTxPartition::TCleanup(
         MakeIntrusive<TRequestInfo>(),
         cleanupCommitId,
         useRecreatedBlobMeta,
         verifyRecreatedBlobMetasOnCleanup,
-        cleanupQueue);
+        cleanupQueue,
+        withCheckpoint,
+        minCheckpointCommitId,
+        maxCheckpointCommitId);
 }
 
 void RunPrepareAndExecute(
@@ -791,6 +797,276 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
                 UNIT_ASSERT(!HasMergedBlob(db, setup.MergedBlobId, 10, 13));
                 UNIT_ASSERT(HasGarbageBlob(db, setup.MixedBlobId));
                 UNIT_ASSERT(HasGarbageBlob(db, setup.MergedBlobId));
+            });
+    }
+
+    Y_UNIT_TEST(ShouldRespectCheckpointCommitIdBoundsDuringCleanup)
+    {
+        auto state = MakeState();
+        TTestExecutor executor;
+        TTestEnv env;
+
+        executor.WriteTx([](TPartitionDatabase db) { db.InitSchema(); });
+
+        const ui64 minCheckpointCommitId = MakeCommitId(0, 40);
+        const ui64 maxCheckpointCommitId = MakeCommitId(0, 60);
+        const ui64 cleanupCommitId = MakeCommitId(0, 100);
+
+        // earlyDeletionCommitId < minCheckpointCommitId => blobs with such
+        // deletion commit id should be cleaned up.
+        const ui64 earlyDeletionCommitId = MakeCommitId(0, 30);
+        // deletionCommitId > minCheckpointCommitId => blobs with such deletion
+        // commit id might be still needed. We should check blob's commit id.
+        const ui64 deletionCommitId = MakeCommitId(0, 80);
+
+        struct TMergedTestCase
+        {
+            ui64 DeletionCommitId = 0;
+            ui64 BlobCommitId = 0;
+            ui32 StartIndex = 0;
+            ui32 EndIndex = 0;
+            bool ShouldBeCleanedUp = false;
+        };
+
+        struct TMixedTestCase
+        {
+            ui64 DeletionCommitId = 0;
+            ui64 BlobCommitId = 0;
+            TVector<ui64> CommitIds;
+            TVector<ui32> BlockIndices;
+            bool ShouldBeCleanedUp = false;
+        };
+
+        const TVector<TMergedTestCase> mergedTestCases = {
+            // DeletionCommitId < minCheckpointCommitId
+            {
+                .DeletionCommitId = earlyDeletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 20),
+                .StartIndex = 0,
+                .EndIndex = 3,
+                .ShouldBeCleanedUp = true,
+            },
+            // BlobCommitId > maxCheckpointCommitId
+            {
+                .DeletionCommitId = deletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 70),
+                .StartIndex = 10,
+                .EndIndex = 13,
+                .ShouldBeCleanedUp = true,
+            },
+            // BlobCommitId < maxCheckpointCommitId
+            {
+                .DeletionCommitId = deletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 50),
+                .StartIndex = 20,
+                .EndIndex = 23,
+                .ShouldBeCleanedUp = false,
+            },
+        };
+
+        const TVector<TMixedTestCase> mixedTestCases = {
+            // DeletionCommitId < minCheckpointCommitId.
+            {
+                .DeletionCommitId = earlyDeletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 25),
+                .CommitIds =
+                    {MakeCommitId(0, 20), MakeCommitId(0, 21)},
+                .BlockIndices = {4, 5},
+                .ShouldBeCleanedUp = true,
+            },
+            // BlobCommitId > maxCheckpointCommitId.
+            {
+                .DeletionCommitId = deletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 75),
+                .CommitIds = {},
+                .BlockIndices = {14, 15},
+                .ShouldBeCleanedUp = true,
+            },
+            // BlobCommitId < maxCheckpointCommitId.
+            {
+                .DeletionCommitId = deletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 55),
+                .CommitIds = {},
+                .BlockIndices = {24, 25},
+                .ShouldBeCleanedUp = false,
+            },
+            // Commit ids of all blocks > maxCheckpointCommitId.
+            {
+                .DeletionCommitId = deletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 76),
+                .CommitIds =
+                    {MakeCommitId(0, 70), MakeCommitId(0, 71)},
+                .BlockIndices = {16, 17},
+                .ShouldBeCleanedUp = true,
+            },
+            // Commit id of some block < maxCheckpointCommitId.
+            {
+                .DeletionCommitId = deletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 77),
+                .CommitIds =
+                    {MakeCommitId(0, 50), MakeCommitId(0, 70)},
+                .BlockIndices = {26, 27},
+                .ShouldBeCleanedUp = false,
+            },
+        };
+
+        TVector<TPartialBlobId> mergedBlobIds;
+        TVector<TPartialBlobId> mixedBlobIds;
+
+        for (const auto& tc: mergedTestCases) {
+            mergedBlobIds.push_back(executor.MakeBlobIdWithCommitId(
+                tc.BlobCommitId,
+                tc.EndIndex - tc.StartIndex + 1));
+        }
+        for (const auto& tc: mixedTestCases) {
+            mixedBlobIds.push_back(executor.MakeBlobIdWithCommitId(
+                tc.BlobCommitId,
+                tc.BlockIndices.size()));
+        }
+
+        executor.WriteTx(
+            [&](TPartitionDatabase db)
+            {
+                for (size_t i = 0; i < mergedTestCases.size(); ++i) {
+                    const auto& tc = mergedTestCases[i];
+                    const auto& blobId = mergedBlobIds[i];
+                    db.WriteMergedBlocks(
+                        blobId,
+                        TBlockRange32::MakeClosedInterval(
+                            tc.StartIndex,
+                            tc.EndIndex),
+                        TBlockMask{});
+                    db.WriteBlobMeta(
+                        blobId,
+                        MakeMergedBlobMeta(tc.StartIndex, tc.EndIndex));
+                    db.WriteCleanupQueue(blobId, tc.DeletionCommitId);
+                }
+
+                for (size_t i = 0; i < mixedTestCases.size(); ++i) {
+                    const auto& tc = mixedTestCases[i];
+                    const auto& blobId = mixedBlobIds[i];
+                    if (tc.CommitIds.empty()) {
+                        state.WriteMixedBlocks(db, blobId, tc.BlockIndices, 1);
+                    } else {
+                        Y_ABORT_UNLESS(
+                            tc.CommitIds.size() == tc.BlockIndices.size());
+                        for (size_t j = 0; j < tc.BlockIndices.size(); ++j) {
+                            db.WriteMixedBlock(TMixedBlock(
+                                blobId,
+                                tc.CommitIds[j],
+                                tc.BlockIndices[j],
+                                j,
+                                1));
+                        }
+                    }
+                    db.WriteBlobMeta(
+                        blobId,
+                        MakeMixedBlobMeta(tc.BlockIndices, tc.CommitIds));
+                    db.WriteCleanupQueue(blobId, tc.DeletionCommitId);
+                }
+            });
+
+        ui64 mergedBlocksCount = 0;
+        ui64 mixedBlocksCount = 0;
+        size_t cleanedUpCount = 0;
+        size_t remainingMergedBlobs = 0;
+        size_t remainingMixedBlobs = 0;
+
+        for (size_t i = 0; i < mergedTestCases.size(); ++i) {
+            const auto& tc = mergedTestCases[i];
+            state.GetCleanupQueue().Add(
+                {mergedBlobIds[i], tc.DeletionCommitId, {}});
+            mergedBlocksCount += tc.EndIndex - tc.StartIndex + 1;
+            if (tc.ShouldBeCleanedUp) {
+                ++cleanedUpCount;
+            } else {
+                ++remainingMergedBlobs;
+            }
+        }
+        for (size_t i = 0; i < mixedTestCases.size(); ++i) {
+            const auto& tc = mixedTestCases[i];
+            state.GetCleanupQueue().Add(
+                {mixedBlobIds[i], tc.DeletionCommitId, {}});
+            mixedBlocksCount += tc.BlockIndices.size();
+            if (tc.ShouldBeCleanedUp) {
+                ++cleanedUpCount;
+            } else {
+                ++remainingMixedBlobs;
+            }
+        }
+
+        state.IncrementMergedBlocksCount(mergedBlocksCount);
+        state.IncrementMergedBlobsCount(mergedTestCases.size());
+        state.IncrementMixedBlocksCount(mixedBlocksCount);
+        state.IncrementMixedBlobsCount(mixedTestCases.size());
+
+        auto args = MakeCleanupArgs(
+            state.GetCleanupQueue().GetItems(cleanupCommitId),
+            cleanupCommitId,
+            false,   // useRecreatedBlobMeta
+            false,   // verifyRecreatedBlobMetasOnCleanup
+            true,    // withCheckpoint
+            minCheckpointCommitId,
+            maxCheckpointCommitId);
+
+        RunPrepareAndExecute(executor, env, state, args);
+
+        const size_t remainingCount = remainingMergedBlobs + remainingMixedBlobs;
+        UNIT_ASSERT_VALUES_EQUAL(cleanedUpCount, args.CleanupQueue.size());
+        UNIT_ASSERT_VALUES_EQUAL(remainingCount, state.GetCleanupQueue().GetCount());
+        UNIT_ASSERT_VALUES_EQUAL(remainingMergedBlobs, state.GetMergedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(remainingMixedBlobs, state.GetMixedBlobsCount());
+
+        executor.ReadTx(
+            [&](TPartitionDatabase db)
+            {
+                for (size_t i = 0; i < mergedTestCases.size(); ++i) {
+                    const auto& tc = mergedTestCases[i];
+                    const auto& blobId = mergedBlobIds[i];
+                    if (tc.ShouldBeCleanedUp) {
+                        UNIT_ASSERT(!HasMergedBlob(
+                            db,
+                            blobId,
+                            tc.StartIndex,
+                            tc.EndIndex));
+                        UNIT_ASSERT(HasGarbageBlob(db, blobId));
+                    } else {
+                        UNIT_ASSERT(HasMergedBlob(
+                            db,
+                            blobId,
+                            tc.StartIndex,
+                            tc.EndIndex));
+                        UNIT_ASSERT(!HasGarbageBlob(db, blobId));
+
+                        TMaybe<NProto::TBlobMeta> blobMeta;
+                        UNIT_ASSERT(db.ReadBlobMeta(blobId, blobMeta));
+                        UNIT_ASSERT(blobMeta.Defined());
+                    }
+                }
+
+                for (size_t i = 0; i < mixedTestCases.size(); ++i) {
+                    std::cerr << "CHECK: " << i << std::endl;
+                    const auto& tc = mixedTestCases[i];
+                    const auto& blobId = mixedBlobIds[i];
+                    const ui64 commitId = tc.CommitIds.empty() ? blobId.CommitId() : tc.CommitIds[0];
+                    if (tc.ShouldBeCleanedUp) {
+                        UNIT_ASSERT(
+                            !HasMixedBlock(db, tc.BlockIndices[0], commitId));
+                        UNIT_ASSERT(HasGarbageBlob(db, blobId));
+                    } else {
+                        UNIT_ASSERT(
+                            HasMixedBlock(db, tc.BlockIndices[0], commitId));
+                        UNIT_ASSERT(!HasGarbageBlob(db, blobId));
+
+                        TMaybe<NProto::TBlobMeta> blobMeta;
+                        UNIT_ASSERT(db.ReadBlobMeta(blobId, blobMeta));
+                        UNIT_ASSERT(blobMeta.Defined());
+                    }
+                }
+
+                TVector<TCleanupQueueItem> cleanupQueueItems;
+                UNIT_ASSERT(db.ReadCleanupQueue(cleanupQueueItems));
+                UNIT_ASSERT_VALUES_EQUAL(remainingCount, cleanupQueueItems.size());
             });
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
+++ b/cloud/blockstore/libs/storage/partition/part_cleanup_logic_ut.cpp
@@ -257,9 +257,9 @@ TTxPartition::TCleanup MakeCleanupArgs(
     ui64 cleanupCommitId,
     bool useRecreatedBlobMeta,
     bool verifyRecreatedBlobMetasOnCleanup,
-    bool withCheckpoint = false,
-    ui64 minCheckpointCommitId = InvalidCommitId,
-    ui64 maxCheckpointCommitId = InvalidCommitId)
+    bool withCheckpoint,
+    ui64 minCheckpointCommitId,
+    ui64 maxCheckpointCommitId)
 {
     return TTxPartition::TCleanup(
         MakeIntrusive<TRequestInfo>(),
@@ -605,8 +605,10 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             state.GetCleanupQueue().GetItems(cleanupCommitId),
             cleanupCommitId,
             false,   // useRecreatedBlobMeta
-            false    // verifyRecreatedBlobMetasOnCleanup
-        );
+            false,   // verifyRecreatedBlobMetasOnCleanup
+            false,   // withCheckpoint
+            InvalidCommitId,
+            InvalidCommitId);
 
         executor.ReadTx(
             [&](TPartitionDatabase db)
@@ -678,8 +680,10 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             cleanupQueue,
             cleanupCommitId,
             false,   // useRecreatedBlobMeta
-            true     // verifyRecreatedBlobMetasOnCleanup
-        );
+            true,    // verifyRecreatedBlobMetasOnCleanup
+            false,   // withCheckpoint
+            InvalidCommitId,
+            InvalidCommitId);
 
         RunPrepareAndExecute(executor, env, state, args);
 
@@ -723,9 +727,11 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         auto args = MakeCleanupArgs(
             cleanupQueue,
             cleanupCommitId,
-            true,   // useRecreatedBlobMeta
-            false   // verifyRecreatedBlobMetasOnCleanup
-        );
+            true,    // useRecreatedBlobMeta
+            false,   // verifyRecreatedBlobMetasOnCleanup
+            false,   // withCheckpoint
+            InvalidCommitId,
+            InvalidCommitId);
         RunPrepareAndExecute(executor, env, state, args);
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
@@ -776,9 +782,11 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         auto args = MakeCleanupArgs(
             cleanupQueue,
             cleanupCommitId,
-            true,   // useRecreatedBlobMeta
-            false   // verifyRecreatedBlobMetasOnCleanup
-        );
+            true,    // useRecreatedBlobMeta
+            false,   // verifyRecreatedBlobMetasOnCleanup
+            false,   // withCheckpoint
+            InvalidCommitId,
+            InvalidCommitId);
         RunPrepareAndExecute(executor, env, state, args);
 
         UNIT_ASSERT_VALUES_EQUAL(2, args.CleanupQueue.size());
@@ -812,12 +820,13 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         const ui64 maxCheckpointCommitId = MakeCommitId(0, 60);
         const ui64 cleanupCommitId = MakeCommitId(0, 100);
 
-        // earlyDeletionCommitId < minCheckpointCommitId => blobs with such
+        // deletionCommitId < minCheckpointCommitId => blobs with such
         // deletion commit id should be cleaned up.
-        const ui64 earlyDeletionCommitId = MakeCommitId(0, 30);
+        const ui64 beforeCheckpointsDeletionCommitId = MakeCommitId(0, 30);
         // deletionCommitId > minCheckpointCommitId => blobs with such deletion
         // commit id might be still needed. We should check blob's commit id.
-        const ui64 deletionCommitId = MakeCommitId(0, 80);
+        const ui64 afterCheckpointsdeletionCommitId = MakeCommitId(0, 80);
+        const ui64 betweenCheckpointsdeletionCommitId = MakeCommitId(0, 50);
 
         struct TMergedTestCase
         {
@@ -840,7 +849,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         const TVector<TMergedTestCase> mergedTestCases = {
             // DeletionCommitId < minCheckpointCommitId
             {
-                .DeletionCommitId = earlyDeletionCommitId,
+                .DeletionCommitId = beforeCheckpointsDeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 20),
                 .StartIndex = 0,
                 .EndIndex = 3,
@@ -848,7 +857,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             },
             // BlobCommitId > maxCheckpointCommitId
             {
-                .DeletionCommitId = deletionCommitId,
+                .DeletionCommitId = afterCheckpointsdeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 70),
                 .StartIndex = 10,
                 .EndIndex = 13,
@@ -856,10 +865,20 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             },
             // BlobCommitId < maxCheckpointCommitId
             {
-                .DeletionCommitId = deletionCommitId,
+                .DeletionCommitId = afterCheckpointsdeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 50),
                 .StartIndex = 20,
                 .EndIndex = 23,
+                .ShouldBeCleanedUp = false,
+            },
+            // This blob is not needed neither for minCheckpoint nor for
+            // maxCheckpoint. But it might be needed if some other checkpoints
+            // exist.
+            {
+                .DeletionCommitId = betweenCheckpointsdeletionCommitId,
+                .BlobCommitId = MakeCommitId(0, 45),
+                .StartIndex = 30,
+                .EndIndex = 33,
                 .ShouldBeCleanedUp = false,
             },
         };
@@ -867,16 +886,15 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
         const TVector<TMixedTestCase> mixedTestCases = {
             // DeletionCommitId < minCheckpointCommitId.
             {
-                .DeletionCommitId = earlyDeletionCommitId,
+                .DeletionCommitId = beforeCheckpointsDeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 25),
-                .CommitIds =
-                    {MakeCommitId(0, 20), MakeCommitId(0, 21)},
+                .CommitIds = {MakeCommitId(0, 20), MakeCommitId(0, 21)},
                 .BlockIndices = {4, 5},
                 .ShouldBeCleanedUp = true,
             },
             // BlobCommitId > maxCheckpointCommitId.
             {
-                .DeletionCommitId = deletionCommitId,
+                .DeletionCommitId = afterCheckpointsdeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 75),
                 .CommitIds = {},
                 .BlockIndices = {14, 15},
@@ -884,7 +902,7 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             },
             // BlobCommitId < maxCheckpointCommitId.
             {
-                .DeletionCommitId = deletionCommitId,
+                .DeletionCommitId = afterCheckpointsdeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 55),
                 .CommitIds = {},
                 .BlockIndices = {24, 25},
@@ -892,19 +910,17 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
             },
             // Commit ids of all blocks > maxCheckpointCommitId.
             {
-                .DeletionCommitId = deletionCommitId,
+                .DeletionCommitId = afterCheckpointsdeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 76),
-                .CommitIds =
-                    {MakeCommitId(0, 70), MakeCommitId(0, 71)},
+                .CommitIds = {MakeCommitId(0, 70), MakeCommitId(0, 71)},
                 .BlockIndices = {16, 17},
                 .ShouldBeCleanedUp = true,
             },
             // Commit id of some block < maxCheckpointCommitId.
             {
-                .DeletionCommitId = deletionCommitId,
+                .DeletionCommitId = afterCheckpointsdeletionCommitId,
                 .BlobCommitId = MakeCommitId(0, 77),
-                .CommitIds =
-                    {MakeCommitId(0, 50), MakeCommitId(0, 70)},
+                .CommitIds = {MakeCommitId(0, 50), MakeCommitId(0, 70)},
                 .BlockIndices = {26, 27},
                 .ShouldBeCleanedUp = false,
             },
@@ -1011,11 +1027,18 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
 
         RunPrepareAndExecute(executor, env, state, args);
 
-        const size_t remainingCount = remainingMergedBlobs + remainingMixedBlobs;
+        const size_t remainingCount =
+            remainingMergedBlobs + remainingMixedBlobs;
         UNIT_ASSERT_VALUES_EQUAL(cleanedUpCount, args.CleanupQueue.size());
-        UNIT_ASSERT_VALUES_EQUAL(remainingCount, state.GetCleanupQueue().GetCount());
-        UNIT_ASSERT_VALUES_EQUAL(remainingMergedBlobs, state.GetMergedBlobsCount());
-        UNIT_ASSERT_VALUES_EQUAL(remainingMixedBlobs, state.GetMixedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            remainingCount,
+            state.GetCleanupQueue().GetCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            remainingMergedBlobs,
+            state.GetMergedBlobsCount());
+        UNIT_ASSERT_VALUES_EQUAL(
+            remainingMixedBlobs,
+            state.GetMixedBlobsCount());
 
         executor.ReadTx(
             [&](TPartitionDatabase db)
@@ -1045,10 +1068,11 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
                 }
 
                 for (size_t i = 0; i < mixedTestCases.size(); ++i) {
-                    std::cerr << "CHECK: " << i << std::endl;
                     const auto& tc = mixedTestCases[i];
                     const auto& blobId = mixedBlobIds[i];
-                    const ui64 commitId = tc.CommitIds.empty() ? blobId.CommitId() : tc.CommitIds[0];
+                    const ui64 commitId = tc.CommitIds.empty()
+                                              ? blobId.CommitId()
+                                              : tc.CommitIds[0];
                     if (tc.ShouldBeCleanedUp) {
                         UNIT_ASSERT(
                             !HasMixedBlock(db, tc.BlockIndices[0], commitId));
@@ -1066,7 +1090,9 @@ Y_UNIT_TEST_SUITE(TCleanupTransactionTest)
 
                 TVector<TCleanupQueueItem> cleanupQueueItems;
                 UNIT_ASSERT(db.ReadCleanupQueue(cleanupQueueItems));
-                UNIT_ASSERT_VALUES_EQUAL(remainingCount, cleanupQueueItems.size());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    remainingCount,
+                    cleanupQueueItems.size());
             });
     }
 }

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -651,18 +651,19 @@ struct TTxPartition
         ui64 ReadBlobMetasCount = 0;
 
         TCleanup(
-                TRequestInfoPtr requestInfo,
-                ui64 commitId,
-                bool useRecreatedBlobMeta,
-                bool verifyRecreatedBlobMetasOnCleanup,
-                TVector<TCleanupQueueItem> cleanupQueue,
-                bool withCheckpoint = false,
-                ui64 minCheckpointCommitId = InvalidCommitId,
-                ui64 maxCheckpointCommitId = InvalidCommitId)
+            TRequestInfoPtr requestInfo,
+            ui64 commitId,
+            bool useRecreatedBlobMeta,
+            bool verifyRecreatedBlobMetasOnCleanup,
+            TVector<TCleanupQueueItem> cleanupQueue,
+            bool withCheckpoint,
+            ui64 minCheckpointCommitId,
+            ui64 maxCheckpointCommitId)
             : RequestInfo(std::move(requestInfo))
             , CommitId(commitId)
             , UseRecreatedBlobMeta(useRecreatedBlobMeta)
-            , VerifyRecreatedBlobMetasOnCleanup(verifyRecreatedBlobMetasOnCleanup)
+            , VerifyRecreatedBlobMetasOnCleanup(
+                  verifyRecreatedBlobMetasOnCleanup)
             , CleanupQueue(std::move(cleanupQueue))
             , WithCheckpoint(withCheckpoint)
             , MinCheckpointCommitId(minCheckpointCommitId)

--- a/cloud/blockstore/libs/storage/partition/part_tx.h
+++ b/cloud/blockstore/libs/storage/partition/part_tx.h
@@ -642,6 +642,10 @@ struct TTxPartition
 
         TVector<TCleanupQueueItem> CleanupQueue;
 
+        const bool WithCheckpoint;
+        const ui64 MinCheckpointCommitId;
+        const ui64 MaxCheckpointCommitId;
+
         TVector<NProto::TBlobMeta> BlobsMeta;
 
         ui64 ReadBlobMetasCount = 0;
@@ -651,12 +655,18 @@ struct TTxPartition
                 ui64 commitId,
                 bool useRecreatedBlobMeta,
                 bool verifyRecreatedBlobMetasOnCleanup,
-                TVector<TCleanupQueueItem> cleanupQueue)
+                TVector<TCleanupQueueItem> cleanupQueue,
+                bool withCheckpoint = false,
+                ui64 minCheckpointCommitId = InvalidCommitId,
+                ui64 maxCheckpointCommitId = InvalidCommitId)
             : RequestInfo(std::move(requestInfo))
             , CommitId(commitId)
             , UseRecreatedBlobMeta(useRecreatedBlobMeta)
             , VerifyRecreatedBlobMetasOnCleanup(verifyRecreatedBlobMetasOnCleanup)
             , CleanupQueue(std::move(cleanupQueue))
+            , WithCheckpoint(withCheckpoint)
+            , MinCheckpointCommitId(minCheckpointCommitId)
+            , MaxCheckpointCommitId(maxCheckpointCommitId)
         {}
 
         void Clear()

--- a/cloud/blockstore/libs/storage/testlib/test_executor.h
+++ b/cloud/blockstore/libs/storage/testlib/test_executor.h
@@ -57,6 +57,18 @@ struct TTestExecutor
             Cookie++,
             0);
     }
+
+    TPartialBlobId MakeBlobIdWithCommitId(ui64 commitId, ui32 blocksCount)
+    {
+        const auto [gen, step] = ParseCommitId(commitId);
+        return TPartialBlobId(
+            gen,
+            step,
+            Channel,
+            blocksCount * DefaultBlockSize,
+            Cookie++,
+            0);
+    }
 };
 
 }   // namespace NCloud::NBlockStore::NStorage


### PR DESCRIPTION
### Notes

In this PR we introduce a new mode for the cleanup transaction (see the `withCheckpoint` flag in the transaction arguments).

Currently, when the cleanup transaction is executed, it removes all blobs passed in the transaction arguments. Therefore, the deletion commit ID of every blob passed to the transaction must not exceed the commit ID of any checkpoint (in other words, the blob must have been added to the cleanup queue after the checkpoint was created).

In this PR, we add the ability to remove blobs more accurately based on the blob’s commit ID. If a blob’s commit ID is greater than the commit ID of any checkpoint, the blob is not needed and can be removed regardless of its deletion commit ID.

See the issue description for the exapple: https://github.com/ydb-platform/nbs/issues/6658. 

Note that we do not run the transaction in the new mode yet, so the behavior does not change. The new mode will be used in the next PR.

After the next PR, the cleanup queue will no longer grow without bound during snapshot creation.

### Issue
#6658
