### PR TITLE
issue-3781: TFileRingBuffer: introduce TFileRingBufferAccessor

### DIFF
--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -1,4 +1,5 @@
 #include "file_ring_buffer.h"
+#include "file_ring_buffer_accessor.h"
 #include "file_ring_buffer_format.h"
 
 #include <cloud/storage/core/libs/diagnostics/critical_events.h>
@@ -127,10 +128,7 @@ class TFileRingBuffer::TImpl
 {
 private:
     const TFileRingBufferArgs Args;
-    TFileMap Map;
-
-    std::unique_ptr<IFileRingBufferDataProcessor> Data;
-    TFileRingBufferCapabilities Capabilities;
+    TFileMapFileRingBufferAccessor Accessor;
     bool Corrupted = false;
 
     TEntryInfo CurrentAllocation = TEntryInfo::CreateInvalid();
@@ -142,12 +140,27 @@ private:
 private:
     THeader* Header()
     {
-        return reinterpret_cast<THeader*>(Map.Ptr());
+        return Accessor.GetHeader();
     }
 
     const THeader* Header() const
     {
-        return reinterpret_cast<THeader*>(Map.Ptr());
+        return Accessor.GetHeader();
+    }
+
+    IFileRingBufferDataProcessor* Data()
+    {
+        return Accessor.GetDataProcessor();
+    }
+
+    const IFileRingBufferDataProcessor* Data() const
+    {
+        return Accessor.GetDataProcessor();
+    }
+
+    const TFileRingBufferCapabilities& Capabilities() const
+    {
+        return Accessor.GetCapabilities();
     }
 
     TEntryInfo GetEntry(ui64 pos) const
@@ -162,15 +175,15 @@ private:
                 return TEntryInfo::CreateInvalid();
             }
 
-            const auto eh = Data->ReadEntryHeader(pos);
+            const auto eh = Data()->ReadEntryHeader(pos);
             if (eh.DataSize != 0) {
-                const auto* data = Data->GetEntryDataPtr(pos, eh.DataSize);
+                const auto* data = Data()->GetEntryDataPtr(pos, eh.DataSize);
                 if (data == nullptr) {
                     return TEntryInfo::CreateInvalid();
                 }
 
                 if (eh.FreeFlag && eh.DataChecksum != 0 &&
-                    Capabilities.EntryHeaderIsCoveredByChecksum)
+                    Capabilities().EntryHeaderIsCoveredByChecksum)
                 {
                     return TEntryInfo::CreateInvalid();
                 }
@@ -192,22 +205,22 @@ private:
             return TEntryInfo::CreateInvalid();
         }
 
-        const auto eh = Data->ReadEntryHeader(pos);
+        const auto eh = Data()->ReadEntryHeader(pos);
         if (eh.DataSize == 0) {
             return TEntryInfo::CreateInvalid();
         }
 
-        const auto* data = Data->GetEntryDataPtr(pos, eh.DataSize);
+        const auto* data = Data()->GetEntryDataPtr(pos, eh.DataSize);
         if (data == nullptr) {
             return TEntryInfo::CreateInvalid();
         }
 
-        if (pos + Data->GetEntrySize(eh.DataSize) > Header()->WritePos) {
+        if (pos + Data()->GetEntrySize(eh.DataSize) > Header()->WritePos) {
             return TEntryInfo::CreateInvalid();
         }
 
         if (eh.FreeFlag && eh.DataChecksum != 0 &&
-            Capabilities.EntryHeaderIsCoveredByChecksum)
+            Capabilities().EntryHeaderIsCoveredByChecksum)
         {
             return TEntryInfo::CreateInvalid();
         }
@@ -223,111 +236,29 @@ private:
     TEntryInfo GetNextEntry(const TEntryInfo& e) const
     {
         return e.HasValue()
-            ? GetEntry(e.ActualPos + Data->GetEntrySize(e.Header.DataSize))
+            ? GetEntry(e.ActualPos + Data()->GetEntrySize(e.Header.DataSize))
             : TEntryInfo::CreateInvalid();
-    }
-
-    void CreateDataProcessor(EVersion version)
-    {
-        Data = CreateFileRingBufferDataProcessor(
-            version,
-            GetMappedData(Header()->DataOffset, Header()->DataCapacity));
-
-        Capabilities = Data->GetCapabilities(true);
-    }
-
-    void ValidateStructure()
-    {
-        const ui64 mapLength = static_cast<ui64>(Map.Length());
-        const auto& h = *Header();
-
-        Y_ABORT_UNLESS(sizeof(THeader) == h.HeaderSize);
-        Y_ABORT_UNLESS(h.HeaderSize <= h.MetadataOffset);
-        Y_ABORT_UNLESS(h.MetadataOffset <= h.DataOffset);
-        Y_ABORT_UNLESS(h.MetadataCapacity <= h.DataOffset - h.MetadataOffset);
-        Y_ABORT_UNLESS(h.DataOffset <= mapLength);
-        Y_ABORT_UNLESS(h.DataCapacity <= mapLength - h.DataOffset);
-    }
-
-    void ValidateDataStructure()
-    {
-        TEntryInfo cur = GetFrontEntry();
-
-        if (cur.IsInvalid()) {
-            SetCorrupted();
-            return;
-        }
-
-        if (cur.ActualPos != Header()->ReadPos) {
-            if (cur.ActualPos == 0 && Header()->WritePos == 0) {
-                // Valid situation when Alloc was interrupted for empty buffer
-                Header()->ReadPos = 0;
-            } else {
-                SetCorrupted();
-                return;
-            }
-        }
-
-        while (cur.HasValue()) {
-            cur = GetNextEntry(cur);
-        }
-
-        if (cur.IsInvalid() || cur.ActualPos != Header()->WritePos) {
-            SetCorrupted();
-        }
-    }
-
-    void ValidateMetadata()
-    {
-        auto data =
-            GetMappedData(Header()->MetadataOffset, Header()->MetadataCapacity);
-
-        if (Header()->MetadataSize > data.size() ||
-            Crc32c(data.data(), Header()->MetadataSize) !=
-                Header()->MetadataChecksum)
-        {
-            SetCorrupted();
-        }
-    }
-
-    void ValidateEntriesChecksums()
-    {
-        Visit(
-            [&](ui32 checksum, ui32 tag, TStringBuf entry)
-            {
-                Y_UNUSED(tag);
-                const ui32 actualChecksum = Crc32c(entry.data(), entry.size());
-                if (actualChecksum != checksum) {
-                    SetCorrupted();
-                }
-            });
-    }
-
-    void ResizeAndRemap(ui64 fileSize)
-    {
-        Map.ResizeAndRemap(0, fileSize);
-        // File can be mapped to a different address - we should invalidate
-        // the data processor working with the old address range
-        Data.reset();
-    }
-
-    std::span<char> GetMappedData(ui64 offset, ui64 size) const
-    {
-        const ui64 mapLength = static_cast<ui64>(Map.Length());
-        Y_ABORT_UNLESS(offset <= mapLength);
-        Y_ABORT_UNLESS(size <= mapLength - offset);
-        return {static_cast<char*>(Map.Ptr()) + offset, size};
     }
 
     void CopyMappedData(ui64 destPos, ui64 srcPos, ui64 size)
     {
-        auto src = GetMappedData(srcPos, size);
-        auto dst = GetMappedData(destPos, size);
+        auto src = Accessor.GetRawData(srcPos, size);
+        auto dst = Accessor.GetRawData(destPos, size);
 
         // Copied data regions cannot overlap
         Y_ABORT_UNLESS(destPos + size <= srcPos || srcPos + size <= destPos);
 
         MemCopy(dst.data(), src.data(), size);
+    }
+
+    bool ResizeAndRemap(size_t newSize)
+    {
+        auto status = Accessor.ResizeAndRemap(newSize);
+        if (HasError(status)) {
+            SetCorrupted(FormatError(status));
+            return false;
+        }
+        return true;
     }
 
     bool IsMigrationNeeded() const
@@ -343,13 +274,13 @@ private:
 
         // Migration to any version can be performed when the buffer is empty
         if (Empty()) {
+            SetReadAndWritePosToZeroForEmptyBuffer();
             Header()->Version = Args.Version;
-            CreateDataProcessor(Args.Version);
-            return;
+            Validate();
         }
     }
 
-    void ResizeMetadata(ui64 desiredMetadataCapacity)
+    bool ResizeMetadata(ui64 desiredMetadataCapacity)
     {
         Header()->MetadataCapacity =
             Min(Header()->MetadataCapacity,
@@ -371,7 +302,9 @@ private:
             const ui64 tempDataOffset =
                 Max(newFileSize, Header()->DataOffset + Header()->DataCapacity);
 
-            ResizeAndRemap(tempDataOffset + Header()->DataCapacity);
+            if (!ResizeAndRemap(tempDataOffset) || !Validate()) {
+                return false;
+            }
 
             CopyMappedData(
                 tempDataOffset,
@@ -391,9 +324,13 @@ private:
             Header()->DataOffset = newDataOffset;
         }
 
-        ResizeAndRemap(newFileSize);
+        if (!ResizeAndRemap(newFileSize) || !Validate()) {
+            return false;
+        }
 
         Header()->MetadataCapacity = newMetadataCapacity;
+
+        return Validate();
     }
 
     void VisitEntries(auto&& visitor)
@@ -406,7 +343,7 @@ private:
         }
 
         if (e.IsInvalid()) {
-            SetCorrupted();
+            SetCorrupted("Invalid entry detected at VisitEntries");
         }
     }
 
@@ -418,7 +355,7 @@ private:
         }
 
         if (front.IsInvalid()) {
-            SetCorrupted();
+            SetCorrupted("Invalid front entry");
         } else {
             Header()->ReadPos = front.ActualPos;
         }
@@ -430,15 +367,31 @@ private:
 
     void WriteSlackSpaceMarker(ui64 pos)
     {
-        Data->WriteEntryHeader(pos, {});
+        Data()->WriteEntryHeader(pos, {});
+    }
+
+    void SetReadAndWritePosToZeroForEmptyBuffer()
+    {
+        Y_ABORT_UNLESS(Header()->ReadPos == Header()->WritePos);
+        if (Header()->WritePos != 0) {
+            // Ensure that the state can be restored from the intermediate state
+            WriteSlackSpaceMarker(Header()->WritePos);
+            // A compiler-only fence is sufficient here because there is no
+            // concurrent access to the memory and we just need to ensure
+            // that a compiler does not reorder writes.
+            std::atomic_signal_fence(std::memory_order_seq_cst);
+            Header()->WritePos = 0;
+            std::atomic_signal_fence(std::memory_order_seq_cst);
+            Header()->ReadPos = 0;
+        }
     }
 
     bool ValidateAccess(const char* name) const
     {
-        if (IsCorrupted()) {
+        if (IsCorrupted() || Header() == nullptr || Data() == nullptr) {
             ReportAccessToCorruptedFileRingBufferError(Sprintf(
-                "An attempt to access an entry in a corrupted TFileRingBuffer "
-                "from %s has been made",
+                "An attempt to access an entry in a corrupted or "
+                "non-initialized TFileRingBuffer from %s has been made",
                 name));
             return false;
         }
@@ -448,39 +401,58 @@ private:
 public:
     explicit TImpl(const TFileRingBufferArgs& args)
         : Args(args)
-        , Map(args.FilePath, TMemoryMapCommon::oRdWr)
+        , Accessor(
+              args.FilePath,
+              EFileRingBufferAccessorValidationMode::Normal,
+              TMemoryMapCommon::EOpenModeFlag::oRdWr)
     {
         Y_ABORT_UNLESS(
             IsSupportedFileRingBufferVersion(args.Version),
             "Unsupported requested FileRingBuffer version - %u",
             static_cast<ui32>(args.Version));
 
-        if (static_cast<ui64>(Map.Length()) < sizeof(THeader)) {
-            auto header = InitHeader(args);
-            Map.ResizeAndRemap(0, header.DataOffset + header.DataCapacity);
-            *Header() = header;
-        } else {
-            Map.Map(0, Map.Length());
+        auto mapResult = Accessor.Map();
+        if (HasError(mapResult)) {
+            SetCorrupted(FormatError(mapResult));
+            return;
         }
 
-        Y_ABORT_UNLESS(
-            IsSupportedFileRingBufferVersion(
-                static_cast<EVersion>(Header()->Version)),
-            "Unsupported current FileRingBuffer version - %u, file: %s",
-            static_cast<ui32>(Header()->Version),
-            args.FilePath.c_str());
+        auto status = Accessor.ValidateAndInitialize();
 
-        ValidateStructure();
+        switch (status) {
+            case EFileRingBufferAccessorValidationStatus::NotInitialized: {
+                auto header = InitHeader(args);
+
+                if (!ResizeAndRemap(header.DataOffset + header.DataCapacity)) {
+                    return;
+                }
+
+                Y_ABORT_UNLESS(
+                    sizeof(TFileRingBufferHeader) <=
+                    Accessor.GetRawData().size());
+
+                *reinterpret_cast<TFileRingBufferHeader*>(
+                    Accessor.GetRawData().data()) = header;
+
+                if (!Validate()) {
+                    return;
+                }
+                break;
+            }
+            case EFileRingBufferAccessorValidationStatus::Failed:
+                SetCorrupted(FormatError(Accessor.GetLastValidationError()));
+                return;
+
+            case EFileRingBufferAccessorValidationStatus::Success:
+                break;
+        }
 
         if (Header()->MetadataCapacity != Args.MetadataCapacity) {
-            ResizeMetadata(Args.MetadataCapacity);
+            if (!ResizeMetadata(Args.MetadataCapacity)) {
+                // Corruption happened
+                return;
+            }
         }
-
-        CreateDataProcessor(Header()->Version);
-
-        ValidateDataStructure();
-        ValidateMetadata();
-        ValidateEntriesChecksums();
 
         VisitEntries(
             [&](const TEntryInfo& e)
@@ -540,15 +512,16 @@ public:
             return nullptr;
         }
 
-        if (size > Capabilities.MaxAllocationByteCount) {
+        if (size > Capabilities().MaxAllocationByteCount) {
             return MakeError(
                 E_ARGUMENT,
-                TStringBuilder() << "Allocation data size (" << size
-                                 << ") exceeds maximum allowed size ("
-                                 << Capabilities.MaxAllocationByteCount << ")");
+                TStringBuilder()
+                    << "Allocation data size (" << size
+                    << ") exceeds maximum allowed size ("
+                    << Capabilities().MaxAllocationByteCount << ")");
         }
 
-        const auto sz = Data->GetEntrySize(size);
+        const auto sz = Data()->GetEntrySize(size);
         if (sz > Header()->DataCapacity) {
             return MakeError(
                 E_ARGUMENT,
@@ -561,17 +534,8 @@ public:
         if (Empty()) {
             if (Header()->WritePos != 0) {
                 // In order to fully utilize space when the buffer is empty,
-                // we need to reset read and write positions and ensure that
-                // the state can be restored from the intermediate state
-                WriteSlackSpaceMarker(Header()->WritePos);
-
-                // A compiler-only fence is sufficient here because there is no
-                // concurrent access to the memory and we just need to ensure
-                // that a compiler does not reorder writes.
-                std::atomic_signal_fence(std::memory_order_seq_cst);
-                Header()->WritePos = 0;
-                std::atomic_signal_fence(std::memory_order_seq_cst);
-                Header()->ReadPos = 0;
+                // we need to reset read and write positions
+                SetReadAndWritePosToZeroForEmptyBuffer();
                 writePos = 0;
             }
         } else {
@@ -603,7 +567,7 @@ public:
         MaxObservedEntryByteCount =
             Max(MaxObservedEntryByteCount, size);
 
-        char* ptr = Data->GetEntryDataPtr(writePos, size);
+        char* ptr = Data()->GetEntryDataPtr(writePos, size);
         Y_ABORT_UNLESS(ptr != nullptr);
 
         CurrentAllocation = TEntryInfo::Create(
@@ -623,7 +587,7 @@ public:
         CurrentAllocation.Header.DataChecksum =
             Crc32c(CurrentAllocation.Data, CurrentAllocation.Header.DataSize);
 
-        bool written = Data->WriteEntryHeader(
+        bool written = Data()->WriteEntryHeader(
             CurrentAllocation.ActualPos,
             CurrentAllocation.Header);
 
@@ -636,7 +600,7 @@ public:
 
         Header()->WritePos =
             CurrentAllocation.ActualPos +
-            Data->GetEntrySize(CurrentAllocation.Header.DataSize);
+            Data()->GetEntrySize(CurrentAllocation.Header.DataSize);
 
         EntryMap[CurrentAllocation.Data] = CurrentAllocation.ActualPos;
 
@@ -655,10 +619,10 @@ public:
             return false;
         }
 
-        auto eh = Data->ReadEntryHeader(it->second);
+        auto eh = Data()->ReadEntryHeader(it->second);
         eh.DataChecksum = 0;
         eh.FreeFlag = true;
-        Data->WriteEntryHeader(it->second, eh);
+        Data()->WriteEntryHeader(it->second, eh);
 
         EntryMap.erase(it);
 
@@ -669,7 +633,7 @@ public:
 
     ui32 GetMaxTag() const
     {
-        return Capabilities.MaxTag;
+        return Capabilities().MaxTag;
     }
 
     ui32 GetTag(const void* ptr) const
@@ -683,7 +647,7 @@ public:
             return 0;
         }
 
-        auto eh = Data->ReadEntryHeader(it->second);
+        auto eh = Data()->ReadEntryHeader(it->second);
         return eh.Tag;
     }
 
@@ -698,9 +662,9 @@ public:
             return;
         }
 
-        auto eh = Data->ReadEntryHeader(it->second);
+        auto eh = Data()->ReadEntryHeader(it->second);
         eh.Tag = tag;
-        Data->WriteEntryHeader(it->second, eh);
+        Data()->WriteEntryHeader(it->second, eh);
     }
 
     TStringBuf Front()
@@ -712,7 +676,7 @@ public:
         auto e = GetFrontEntry();
 
         if (e.IsInvalid()) {
-            SetCorrupted();
+            SetCorrupted("Invalid front entry");
             return {};
         }
 
@@ -740,6 +704,10 @@ public:
 
     bool Empty() const
     {
+        if (Header() == nullptr) {
+            return true;
+        }
+
         const bool result = Header()->ReadPos == Header()->WritePos;
         Y_DEBUG_ABORT_UNLESS(result == (EntryMap.size() == 0));
         return result;
@@ -747,10 +715,11 @@ public:
 
     bool Validate()
     {
-        ValidateStructure();
-        ValidateDataStructure();
-        ValidateMetadata();
-        ValidateEntriesChecksums();
+        auto status = Accessor.ValidateAndInitialize();
+        if (status != EFileRingBufferAccessorValidationStatus::Success) {
+            SetCorrupted(FormatError(Accessor.GetLastValidationError()));
+            return false;
+        }
         return !IsCorrupted();
     }
 
@@ -774,23 +743,27 @@ public:
         return Corrupted;
     }
 
-    void SetCorrupted()
+    void SetCorrupted(const TString& message)
     {
         if (!Corrupted) {
             Corrupted = true;
             ReportFileRingBufferCorruptionDetectedError(
                 "Corruption detected in FileRingBuffer, path: " +
-                Map.GetFile().GetName());
+                Args.FilePath + ", message: " + message);
         }
     }
 
     ui64 GetRawCapacity() const
     {
-        return Header()->DataCapacity;
+        return Header() != nullptr ? Header()->DataCapacity : 0;
     }
 
     ui64 GetRawUsedBytesCount() const
     {
+        if (Header() == nullptr) {
+            return 0;
+        }
+
         ui64 res =
             Header()->ReadPos > Header()->WritePos ? Header()->DataCapacity : 0;
 
@@ -799,7 +772,7 @@ public:
 
     ui32 GetVersion() const
     {
-        return static_cast<ui32>(Header()->Version);
+        return Header() != nullptr ? static_cast<ui32>(Header()->Version) : 0;
     }
 
     ui64 GetMaxObservedEntryByteCount() const
@@ -829,7 +802,7 @@ public:
             maxRawSize = Header()->ReadPos - Header()->WritePos - 1;
         }
 
-        return Data->GetMaxAllocationByteCount(maxRawSize);
+        return Data()->GetMaxAllocationByteCount(maxRawSize);
     }
 
     ui64 GetMaxSupportedAllocationByteCount() const
@@ -838,19 +811,21 @@ public:
             return 0;
         }
 
-        return Capabilities.MaxAllocationByteCount;
+        return Capabilities().MaxAllocationByteCount;
     }
 
-    TStringBuf GetMetadata() const
+    TStringBuf GetMetadata()
     {
         if (!ValidateAccess("GetMetadata")) {
             return {};
         }
 
-        auto data =
-            GetMappedData(Header()->MetadataOffset, Header()->MetadataCapacity);
+        auto data = Accessor.GetRawMetadata();
 
-        Y_ABORT_UNLESS(Header()->MetadataSize <= data.size());
+        if (Header()->MetadataSize > data.size()) {
+            SetCorrupted("Invalid MetadataSize");
+            return {};
+        }
 
         return {data.data(), Header()->MetadataSize};
     }
@@ -861,12 +836,11 @@ public:
             return false;
         }
 
-        if (buf.size() > Header()->MetadataCapacity) {
+        auto data = Accessor.GetRawMetadata();
+
+        if (buf.size() > data.size()) {
             return false;
         }
-
-        auto data =
-            GetMappedData(Header()->MetadataOffset, Header()->MetadataCapacity);
 
         Header()->MetadataSize = buf.size();
         Header()->MetadataChecksum = Crc32c(buf.data(), buf.size());
@@ -963,7 +937,7 @@ bool TFileRingBuffer::IsCorrupted() const
 
 void TFileRingBuffer::SetCorrupted()
 {
-    Impl->SetCorrupted();
+    Impl->SetCorrupted("");
 }
 
 ui64 TFileRingBuffer::GetRawCapacity() const

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -263,12 +263,12 @@ private:
 
     bool IsMigrationNeeded() const
     {
-        return Header()->Version != Args.Version;
+        return !IsCorrupted() && Header()->Version != Args.Version;
     }
 
     void TryMigrate()
     {
-        if (!IsMigrationNeeded() || IsCorrupted()) {
+        if (!IsMigrationNeeded()) {
             return;
         }
 
@@ -386,6 +386,7 @@ private:
             Header()->WritePos = 0;
             std::atomic_signal_fence(std::memory_order_seq_cst);
             Header()->ReadPos = 0;
+            std::atomic_signal_fence(std::memory_order_seq_cst);
         }
     }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -299,8 +299,9 @@ private:
             Header()->DataOffset < newFileSize)
         {
             // Move data to the temporary place
-            const ui64 tempDataOffset =
-                Max(newFileSize, Header()->DataOffset + Header()->DataCapacity);
+            const ui64 tempDataOffset = AlignUp(
+                Max(newFileSize, Header()->DataOffset + Header()->DataCapacity),
+                sizeof(ui64));
 
             const ui64 tempFileSize = tempDataOffset + Header()->DataCapacity;
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -182,8 +182,10 @@ private:
                     return TEntryInfo::CreateInvalid();
                 }
 
+                // When entry header is not written atomically, we cannot be
+                // sure that the checksum is not stale
                 if (eh.FreeFlag && eh.DataChecksum != 0 &&
-                    Capabilities().EntryHeaderIsCoveredByChecksum)
+                    Capabilities().EntryHeaderIsProcessedAtomically)
                 {
                     return TEntryInfo::CreateInvalid();
                 }
@@ -219,8 +221,10 @@ private:
             return TEntryInfo::CreateInvalid();
         }
 
+        // When entry header is not written atomically, we cannot be
+        // sure that the checksum is not stale
         if (eh.FreeFlag && eh.DataChecksum != 0 &&
-            Capabilities().EntryHeaderIsCoveredByChecksum)
+            Capabilities().EntryHeaderIsProcessedAtomically)
         {
             return TEntryInfo::CreateInvalid();
         }
@@ -282,12 +286,16 @@ private:
 
     bool ResizeMetadata(ui64 desiredMetadataCapacity)
     {
-        Header()->MetadataCapacity =
-            Min(Header()->MetadataCapacity,
+        // We cannot shrink below the existing metadata size
+        const ui64 newMetadataCapacity =
+            Max(desiredMetadataCapacity,
                 static_cast<ui64>(Header()->MetadataSize));
 
-        const ui64 newMetadataCapacity =
-            Max(desiredMetadataCapacity, Header()->MetadataCapacity);
+        if (Header()->MetadataCapacity == newMetadataCapacity) {
+            return true;
+        }
+
+        Header()->MetadataCapacity = static_cast<ui64>(Header()->MetadataSize);
 
         const ui64 newDataOffset = AlignUp(
             Header()->MetadataOffset + newMetadataCapacity,

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -302,7 +302,9 @@ private:
             const ui64 tempDataOffset =
                 Max(newFileSize, Header()->DataOffset + Header()->DataCapacity);
 
-            if (!ResizeAndRemap(tempDataOffset) || !Validate()) {
+            const ui64 tempFileSize = tempDataOffset + Header()->DataCapacity;
+
+            if (!ResizeAndRemap(tempFileSize) || !Validate()) {
                 return false;
             }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -79,7 +79,7 @@ public:
     ui64 Size() const;
     bool Empty() const;
 
-    // Checks data and structure integrity
+    // Checks data and structure integrity including data checksum validation
     // Sets IsCorrupted flag if any issues are found and returns false
     // Returns true if everything is valid
     // Fires a critical event and doesn't visit entries if a buffer is corrupted

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -82,10 +82,8 @@ public:
     // Checks data and structure integrity
     // Sets IsCorrupted flag if any issues are found and returns false
     // Returns true if everything is valid
+    // Fires a critical event and doesn't visit entries if a buffer is corrupted
     bool Validate();
-
-    // Calls visitor for each entry in the buffer
-    // Fires a critical event doesn't visit entries if a buffer is corrupted
     void Visit(const TVisitor& visitor);
     bool IsCorrupted() const;
     void SetCorrupted();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -84,6 +84,9 @@ public:
     // Returns true if everything is valid
     // Fires a critical event and doesn't visit entries if a buffer is corrupted
     bool Validate();
+
+    // Calls visitor for each entry in the buffer
+    // Fires a critical event doesn't visit entries if a buffer is corrupted
     void Visit(const TVisitor& visitor);
     bool IsCorrupted() const;
     void SetCorrupted();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
@@ -1,0 +1,487 @@
+#include "file_ring_buffer_accessor.h"
+
+#include <cloud/storage/core/libs/common/error.h>
+
+#include <library/cpp/digest/crc32c/crc32c.h>
+
+#include <util/generic/algorithm.h>
+#include <util/string/printf.h>
+
+namespace NCloud {
+
+using EValidationMode = EFileRingBufferAccessorValidationMode;
+using EValidationStatus = EFileRingBufferAccessorValidationStatus;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NProto::TError MakeError(TString message)
+{
+    return MakeError(E_FAIL, std::move(message));
+}
+
+NProto::TError ValidateHeader(
+    const TFileRingBufferHeader& header,
+    size_t rawDataSize)
+{
+    if (!IsSupportedFileRingBufferVersion(header.Version)) {
+        return MakeError(Sprintf(
+            "Unsupported file ring buffer version %u",
+            static_cast<ui32>(header.Version)));
+    }
+
+    if (header.HeaderSize != sizeof(TFileRingBufferHeader)) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer header size %u (expected %lu)",
+            header.HeaderSize,
+            sizeof(TFileRingBufferHeader)));
+    }
+
+    if (header.MetadataOffset < header.HeaderSize) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer metadata offset %lu (expected >= %lu)",
+            header.MetadataOffset,
+            sizeof(TFileRingBufferHeader)));
+    }
+
+    if (header.MetadataOffset % sizeof(ui64) != 0) {
+        // Note: metadata offset aligned is enforced regardless of whether
+        // entries are aligned
+        return MakeError(Sprintf(
+            "Invalid file ring buffer metadata offset %lu (expected to be "
+            "aligned to %lu)",
+            header.MetadataOffset,
+            sizeof(ui64)));
+    }
+
+    if (header.MetadataSize > header.MetadataCapacity) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer metadata size %u (expected <= %lu)",
+            header.MetadataSize,
+            header.MetadataCapacity));
+    }
+
+    if (header.DataOffset < header.MetadataOffset) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer data offset %lu (expected >= %lu)",
+            header.DataOffset,
+            header.MetadataOffset));
+    }
+
+    if (rawDataSize < header.DataOffset) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer data offset %lu (expected <= %lu)",
+            header.DataOffset,
+            rawDataSize));
+    }
+
+    if (header.DataOffset % sizeof(ui64) != 0) {
+        // Note: data offset alignment is enforced regardless of whether entries
+        // are aligned
+        return MakeError(Sprintf(
+            "Invalid file ring buffer data offset %lu (expected to be aligned "
+            "to %lu)",
+            header.DataOffset,
+            sizeof(ui64)));
+    }
+
+    if (header.MetadataCapacity > header.DataOffset - header.MetadataOffset) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer metadata capacity %lu (expected <= %lu)",
+            header.MetadataCapacity,
+            header.DataOffset - header.MetadataOffset));
+    }
+
+    if (header.DataCapacity > rawDataSize - header.DataOffset) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer data capacity %lu (expected <= %lu)",
+            header.DataCapacity,
+            rawDataSize - header.DataOffset));
+    }
+
+    if (header.ReadPos > header.DataCapacity) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer read position %lu (expected <= %lu)",
+            header.ReadPos,
+            header.DataCapacity));
+    }
+
+    if (header.WritePos > header.DataCapacity) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer write position %lu (expected <= %lu)",
+            header.WritePos,
+            header.DataCapacity));
+    }
+
+    return {};
+}
+
+TResultOrError<TFileRingBufferEntryHeader> ReadAndValidateEntry(
+    IFileRingBufferDataProcessor& dataProcessor,
+    ui64 pos,
+    const TFileRingBufferCapabilities& capabilities)
+{
+    if (capabilities.Alignment > 0 && pos % capabilities.Alignment != 0) {
+        return MakeError(Sprintf(
+            "Invalid file ring buffer entry header position %lu (expected to "
+            "be aligned to %lu)",
+            pos,
+            capabilities.Alignment));
+    }
+
+    auto eh = dataProcessor.ReadEntryHeader(pos);
+
+    if (eh.DataSize == 0) {
+        if (eh.FreeFlag) {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer entry header at position %lu "
+                "(data size is zero and free flag is set)",
+                pos));
+        }
+
+        if (eh.Tag != 0) {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer entry header at position %lu "
+                "(data size is zero and tag is non-zero)",
+                pos));
+        }
+
+        if (capabilities.EntryHeaderIsProcessedAtomically &&
+            eh.DataChecksum != 0)
+        {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer entry header at position %lu "
+                "(data size is zero and data checksum is non-zero)",
+                pos));
+        }
+    } else {
+        const char* payload = dataProcessor.GetEntryDataPtr(pos, eh.DataSize);
+        if (payload == nullptr) {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer entry header at position %lu "
+                "(data size %u exceeds data capacity)",
+                pos,
+                eh.DataSize));
+        }
+
+        if (eh.FreeFlag) {
+            if (capabilities.EntryHeaderIsProcessedAtomically &&
+                eh.DataChecksum != 0)
+            {
+                return MakeError(Sprintf(
+                    "Invalid file ring buffer entry header at position %lu "
+                    "(free flag is set and data checksum is non-zero)",
+                    pos));
+            }
+        } else {
+            auto actualCrc = Crc32c(payload, eh.DataSize);
+            if (actualCrc != eh.DataChecksum) {
+                return MakeError(Sprintf(
+                    "Checksum mismatch for entry at position %lu "
+                    "(header crc %u, actual data crc %u)",
+                    pos,
+                    eh.DataChecksum,
+                    actualCrc));
+            }
+        }
+    }
+    return eh;
+}
+
+NProto::TError ValidateData(
+    IFileRingBufferDataProcessor& dataProcessor,
+    ui64 readPos,
+    ui64 writePos)
+{
+    auto capabilities = dataProcessor.GetCapabilities(false);
+
+    if (capabilities.Alignment > 0) {
+        if (readPos % capabilities.Alignment != 0) {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer read position %lu (expected to be "
+                "aligned to %lu)",
+                readPos,
+                capabilities.Alignment));
+        }
+
+        if (writePos % capabilities.Alignment != 0) {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer write position %lu (expected to be "
+                "aligned to %lu)",
+                writePos,
+                capabilities.Alignment));
+        }
+    }
+
+    // For an empty buffer, one of the following conditions should be met:
+    // - readPos == writePos;
+    // - writePos == 0 and readPos points to a slack space.
+    //
+    // For a non-empty buffer, all the following conditions should be met:
+    // - readPos points to the first entry;
+    // - writePos points to the next byte after the last entry.
+
+    if (readPos == writePos) {
+        // Empty buffer
+        return {};
+    }
+
+    if (writePos == 0) {
+        // Valid only when readPos points to a slack space
+        // This may happen if Alloc was interrupted
+        auto ehResultOrError =
+            ReadAndValidateEntry(dataProcessor, readPos, capabilities);
+
+        if (HasError(ehResultOrError)) {
+            return ehResultOrError.GetError();
+        }
+
+        const auto& eh = ehResultOrError.GetResult();
+        if (eh.DataSize == 0) {
+            return {};
+        }
+
+        return MakeError(Sprintf(
+            "Invalid file ring buffer read position %lu (expected to point to "
+            "a slack space when WritePos == 0)",
+            readPos));
+    }
+
+    auto pos = readPos;
+
+    while (pos > writePos) {
+        auto ehResultOrError =
+            ReadAndValidateEntry(dataProcessor, pos, capabilities);
+
+        if (HasError(ehResultOrError)) {
+            return ehResultOrError.GetError();
+        }
+
+        const auto& eh = ehResultOrError.GetResult();
+
+        if (eh.DataSize != 0) {
+            pos += dataProcessor.GetEntrySize(eh.DataSize);
+        } else if (pos != readPos) {
+            pos = 0;
+        } else {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer read position %lu (expected to point "
+                "to an entry when ReadPos != WritePos and WritePos != 0)",
+                pos));
+        }
+    }
+
+    while (pos < writePos) {
+        auto ehResultOrError =
+            ReadAndValidateEntry(dataProcessor, pos, capabilities);
+
+        if (HasError(ehResultOrError)) {
+            return ehResultOrError.GetError();
+        }
+
+        const auto& eh = ehResultOrError.GetResult();
+
+        if (eh.DataSize == 0) {
+            return MakeError(Sprintf(
+                "Invalid file ring buffer entry header at read position %lu "
+                "(unexpected slack space marker)",
+                pos));
+        }
+
+        pos += dataProcessor.GetEntrySize(eh.DataSize);
+    }
+
+    if (pos > writePos) {
+        return MakeError(Sprintf(
+            "Last entry ends at position %lu (expected to be = write position "
+            "%lu)",
+            pos,
+            writePos));
+    }
+
+    return {};
+}
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TFileRingBufferAccessor::TFileRingBufferAccessor(
+    EFileRingBufferAccessorValidationMode mode)
+    : ValidationMode(mode)
+{}
+
+void TFileRingBufferAccessor::UpdateRawData(std::span<char> rawData)
+{
+    RawData = rawData;
+    ResetValidationState();
+}
+
+std::span<char> TFileRingBufferAccessor::GetRawData(ui64 offset, ui64 byteCount)
+{
+    return RawData.subspan(offset, byteCount);
+}
+
+EValidationStatus TFileRingBufferAccessor::ValidateAndInitialize()
+{
+    auto status = DoValidateAndInitialize();
+
+    if (status == EValidationStatus::Failed &&
+        ValidationMode != EValidationMode::Debug)
+    {
+        // Prevent from accessing internal structures on validation failure
+        auto lastError = std::move(LastValidationError);
+        ResetValidationState();
+        LastValidationError = std::move(lastError);
+    }
+
+    return status;
+}
+
+EValidationStatus TFileRingBufferAccessor::DoValidateAndInitialize()
+{
+    ResetValidationState();
+
+    if (RawData.empty()) {
+        LastValidationError = MakeError("File is empty");
+        return EValidationStatus::NotInitialized;
+    }
+
+    if (RawData.size() < sizeof(TFileRingBufferHeader)) {
+        LastValidationError = MakeError(Sprintf(
+            "File is too small (%lu bytes) to contain a valid header",
+            RawData.size()));
+        return EValidationStatus::Failed;
+    }
+
+    Header = reinterpret_cast<TFileRingBufferHeader*>(RawData.data());
+
+    const bool allZeros = AllOf(RawData, [](char c) { return c == 0; });
+    if (allZeros) {
+        LastValidationError = MakeError("File is not initialized");
+        return EValidationStatus::NotInitialized;
+    }
+
+    LastValidationError = ValidateHeader(*Header, RawData.size());
+    if (HasError(LastValidationError)) {
+        return EValidationStatus::Failed;
+    }
+
+    RawMetadata = GetRawData(Header->MetadataOffset, Header->MetadataCapacity);
+
+    DataProcessor = CreateFileRingBufferDataProcessor(
+        Header->Version,
+        GetRawData(Header->DataOffset, Header->DataCapacity));
+
+    Capabilities = DataProcessor->GetCapabilities(true);
+
+    LastValidationError =
+        ValidateData(*DataProcessor, Header->ReadPos, Header->WritePos);
+
+    if (HasError(LastValidationError)) {
+        return EValidationStatus::Failed;
+    }
+
+    auto metadata = RawMetadata.subspan(0, Header->MetadataSize);
+
+    auto actualMetadataCrc = Crc32c(metadata.data(), metadata.size());
+    if (actualMetadataCrc != Header->MetadataChecksum) {
+        LastValidationError = MakeError(Sprintf(
+            "Checksum mismatch for metadata "
+            "(header crc %u, actual data crc %u)",
+            Header->MetadataChecksum,
+            actualMetadataCrc));
+        return EValidationStatus::Failed;
+    }
+
+    return EValidationStatus::Success;
+}
+
+void TFileRingBufferAccessor::ResetValidationState()
+{
+    Header = nullptr;
+    DataProcessor.reset();
+    RawMetadata = {};
+    Capabilities = {};
+    LastValidationError = {};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TFileMapFileRingBufferAccessor::TFileMapFileRingBufferAccessor(
+    TString fileName,
+    EFileRingBufferAccessorValidationMode validationMode,
+    TMemoryMapCommon::EOpenModeFlag openModeFlags)
+    : TFileRingBufferAccessor(validationMode)
+    , FileName(std::move(fileName))
+    , OpenModeFlags(openModeFlags)
+{}
+
+NProto::TError TFileMapFileRingBufferAccessor::Map()
+{
+    try {
+        if (!FileMap) {
+            FileMap.emplace(FileName, OpenModeFlags);
+        }
+        FileMap->Map(0, FileMap->Length());
+    } catch (...) {
+        return MakeError(
+            E_IO,
+            Sprintf(
+                "Failed to map file %s: %s",
+                FileName.c_str(),
+                CurrentExceptionMessage().c_str()));
+    }
+
+    return ProcessMap();
+}
+
+NProto::TError TFileMapFileRingBufferAccessor::ResizeAndRemap(size_t newSize)
+{
+    try {
+        if (!FileMap) {
+            FileMap.emplace(FileName, OpenModeFlags);
+        }
+        FileMap->ResizeAndRemap(0, newSize);
+    } catch (...) {
+        return MakeError(
+            E_IO,
+            Sprintf(
+                "Failed to map file %s: %s",
+                FileName.c_str(),
+                CurrentExceptionMessage().c_str()));
+    }
+
+    return ProcessMap();
+}
+
+void TFileMapFileRingBufferAccessor::Close()
+{
+    UpdateRawData({});
+    FileMap.reset();
+}
+
+NProto::TError TFileMapFileRingBufferAccessor::ProcessMap()
+{
+    auto fileSize = static_cast<ui64>(FileMap->Length());
+
+    auto rawData = std::span<char>(
+        static_cast<char*>(FileMap->Ptr()),
+        FileMap->MappedSize());
+
+    UpdateRawData(rawData);
+
+    if (rawData.size() != fileSize) {
+        return MakeError(
+            E_IO,
+            Sprintf(
+                "Failed to map the entire file (fileSize=%lu, mappedSize=%zu)",
+                fileSize,
+                rawData.size()));
+    }
+
+    return {};
+}
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
@@ -148,6 +148,8 @@ TResultOrError<TFileRingBufferEntryHeader> ReadAndValidateEntry(
                 pos));
         }
 
+        // When entry header is not written atomically, we cannot be sure that
+        // the checksum is not stale so we skip this check
         if (capabilities.EntryHeaderIsProcessedAtomically &&
             eh.DataChecksum != 0)
         {
@@ -167,6 +169,8 @@ TResultOrError<TFileRingBufferEntryHeader> ReadAndValidateEntry(
         }
 
         if (eh.FreeFlag) {
+            // When entry header is not written atomically, we cannot be sure
+            // that the checksum is not slate so we skip this check
             if (capabilities.EntryHeaderIsProcessedAtomically &&
                 eh.DataChecksum != 0)
             {
@@ -355,7 +359,7 @@ EValidationStatus TFileRingBufferAccessor::DoValidateAndInitialize()
     if (AlignDown(RawData.data(), sizeof(ui64)) != RawData.data()) {
         // Memory mapping is done in multiples of the page size, which is a
         // multiple of 8 bytes on all supported platforms.
-        // Therefore, the raw data size should be aligned to 8 bytes.
+        // Therefore, the raw data address should be aligned to 8 bytes.
         LastValidationError =
             MakeError("Buffer is not aligned to 8 bytes");
         return EValidationStatus::Failed;
@@ -463,7 +467,7 @@ NProto::TError TFileMapFileRingBufferAccessor::ResizeAndRemap(size_t newSize)
         return MakeError(
             E_IO,
             Sprintf(
-                "Failed to map file %s: %s",
+                "Failed to resize and remap file %s: %s",
                 FileName.c_str(),
                 CurrentExceptionMessage().c_str()));
     }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
@@ -6,6 +6,7 @@
 
 #include <util/generic/algorithm.h>
 #include <util/string/printf.h>
+#include <util/system/align.h>
 
 namespace NCloud {
 
@@ -46,7 +47,7 @@ NProto::TError ValidateHeader(
     }
 
     if (header.MetadataOffset % sizeof(ui64) != 0) {
-        // Note: metadata offset aligned is enforced regardless of whether
+        // Note: metadata offset alignment is enforced regardless of whether
         // entries are aligned
         return MakeError(Sprintf(
             "Invalid file ring buffer metadata offset %lu (expected to be "
@@ -312,12 +313,6 @@ TFileRingBufferAccessor::TFileRingBufferAccessor(
     : ValidationMode(mode)
 {}
 
-void TFileRingBufferAccessor::UpdateRawData(std::span<char> rawData)
-{
-    RawData = rawData;
-    ResetValidationState();
-}
-
 std::span<char> TFileRingBufferAccessor::GetRawData(ui64 offset, ui64 byteCount)
 {
     Y_ABORT_UNLESS(offset <= RawData.size());
@@ -342,6 +337,12 @@ EValidationStatus TFileRingBufferAccessor::ValidateAndInitialize()
     return status;
 }
 
+void TFileRingBufferAccessor::UpdateRawData(std::span<char> rawData)
+{
+    RawData = rawData;
+    ResetValidationState();
+}
+
 EValidationStatus TFileRingBufferAccessor::DoValidateAndInitialize()
 {
     ResetValidationState();
@@ -349,6 +350,15 @@ EValidationStatus TFileRingBufferAccessor::DoValidateAndInitialize()
     if (RawData.empty()) {
         LastValidationError = MakeError("File is empty");
         return EValidationStatus::NotInitialized;
+    }
+
+    if (AlignDown(RawData.data(), sizeof(ui64)) != RawData.data()) {
+        // Memory mapping is done in multiples of the page size, which is a
+        // multiple of 8 bytes on all supported platforms.
+        // Therefore, the raw data size should be aligned to 8 bytes.
+        LastValidationError =
+            MakeError("Buffer is not aligned to 8 bytes");
+        return EValidationStatus::Failed;
     }
 
     if (RawData.size() < sizeof(TFileRingBufferHeader)) {
@@ -475,9 +485,8 @@ NProto::TError TFileMapFileRingBufferAccessor::ProcessMap()
         static_cast<char*>(FileMap->Ptr()),
         FileMap->MappedSize());
 
-    UpdateRawData(rawData);
-
     if (rawData.size() != fileSize) {
+        UpdateRawData({});
         return MakeError(
             E_IO,
             Sprintf(
@@ -485,6 +494,8 @@ NProto::TError TFileMapFileRingBufferAccessor::ProcessMap()
                 fileSize,
                 rawData.size()));
     }
+
+    UpdateRawData(rawData);
 
     return {};
 }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
@@ -429,6 +429,7 @@ NProto::TError TFileMapFileRingBufferAccessor::Map()
         }
         FileMap->Map(0, FileMap->Length());
     } catch (...) {
+        UpdateRawData({});
         return MakeError(
             E_IO,
             Sprintf(
@@ -448,6 +449,7 @@ NProto::TError TFileMapFileRingBufferAccessor::ResizeAndRemap(size_t newSize)
         }
         FileMap->ResizeAndRemap(0, newSize);
     } catch (...) {
+        UpdateRawData({});
         return MakeError(
             E_IO,
             Sprintf(

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.cpp
@@ -320,6 +320,9 @@ void TFileRingBufferAccessor::UpdateRawData(std::span<char> rawData)
 
 std::span<char> TFileRingBufferAccessor::GetRawData(ui64 offset, ui64 byteCount)
 {
+    Y_ABORT_UNLESS(offset <= RawData.size());
+    Y_ABORT_UNLESS(byteCount <= RawData.size() - offset);
+
     return RawData.subspan(offset, byteCount);
 }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "file_ring_buffer_format.h"
+
+#include <cloud/storage/core/protos/error.pb.h>
+
+#include <util/generic/function_ref.h>
+#include <util/system/filemap.h>
+
+#include <optional>
+#include <span>
+
+namespace NCloud {
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EFileRingBufferAccessorValidationMode
+{
+    // Header and DataProcessor will be initialized only after successful
+    // validation
+    Normal,
+
+    // Header and DataProcessor will be initialzed even if validation fails.
+    // This mode is intended for repairing corrupted state.
+    Debug
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+enum class EFileRingBufferAccessorValidationStatus
+{
+    // State file is either empty or contains zeroed data:
+    // - Header will be accessible if file length >= header size;
+    // - DataProcessor, RawMetadata and Capabilities will not be initialized.
+    NotInitialized,
+
+    // Successful validation of both header and data:
+    // - Header will be accessible;
+    // - DataProcessor, RawMetadata and Capabilities will be initialized.
+    Success,
+
+    // Validation failed.
+    // When EFileRingBufferAccessorValidationMode == Normal:
+    // - Header will not be accessible;
+    // - DataProcessor, RawMetadata and Capabilities will not be initialized.
+    // When EFileRingBufferAccessorValidationMode == Debug:
+    // - Header will be accessible if file length >= header size
+    // - DataProcessor, RawMetadata, Capabilities will be initialized if header
+    //   is successfully validated (but data may be corrupted)
+    Failed
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileRingBufferAccessor
+{
+private:
+    const EFileRingBufferAccessorValidationMode ValidationMode;
+
+    std::span<char> RawData;
+    TFileRingBufferHeader* Header = nullptr;
+    std::unique_ptr<IFileRingBufferDataProcessor> DataProcessor;
+    std::span<char> RawMetadata;
+    TFileRingBufferCapabilities Capabilities = {};
+    NProto::TError LastValidationError;
+
+public:
+    explicit TFileRingBufferAccessor(
+        EFileRingBufferAccessorValidationMode validationMode);
+
+    // Updating raw data invalidates memory references.
+    // The object must be re-initialized by calling ValidateAndInitialize()
+    void UpdateRawData(std::span<char> rawData);
+
+    // Validates raw data and initializes Header, DataProcessor, RawMetadata and
+    // Capabilities depending on the validation result and mode
+    EFileRingBufferAccessorValidationStatus ValidateAndInitialize();
+
+    const NProto::TError& GetLastValidationError() const
+    {
+        return LastValidationError;
+    }
+
+    std::span<char> GetRawData()
+    {
+        return RawData;
+    }
+
+    std::span<const char> GetRawData() const
+    {
+        return RawData;
+    }
+
+    std::span<char> GetRawData(ui64 offset, ui64 byteCount);
+
+    TFileRingBufferHeader* GetHeader()
+    {
+        return Header;
+    }
+
+    const TFileRingBufferHeader* GetHeader() const
+    {
+        return Header;
+    }
+
+    IFileRingBufferDataProcessor* GetDataProcessor()
+    {
+        return DataProcessor.get();
+    }
+
+    const IFileRingBufferDataProcessor* GetDataProcessor() const
+    {
+        return DataProcessor.get();
+    }
+
+    std::span<char> GetRawMetadata()
+    {
+        return RawMetadata;
+    }
+
+    std::span<const char> GetRawMetadata() const
+    {
+        return RawMetadata;
+    }
+
+    const TFileRingBufferCapabilities& GetCapabilities() const
+    {
+        return Capabilities;
+    }
+
+private:
+    EFileRingBufferAccessorValidationStatus DoValidateAndInitialize();
+
+    void ResetValidationState();
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFileMapFileRingBufferAccessor: public TFileRingBufferAccessor
+{
+private:
+    const TString FileName;
+    const TMemoryMapCommon::EOpenModeFlag OpenModeFlags;
+
+    std::optional<TFileMap> FileMap;
+
+public:
+    TFileMapFileRingBufferAccessor(
+        TString fileName,
+        EFileRingBufferAccessorValidationMode validationMode,
+        TMemoryMapCommon::EOpenModeFlag openModeFlags);
+
+    NProto::TError Map();
+    NProto::TError ResizeAndRemap(size_t newSize);
+    void Close();
+
+private:
+    NProto::TError ProcessMap();
+};
+
+}   // namespace NCloud

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.h
@@ -137,7 +137,7 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TFileMapFileRingBufferAccessor: public TFileRingBufferAccessor
+class TFileMapFileRingBufferAccessor final: public TFileRingBufferAccessor
 {
 private:
     const TString FileName;

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor.h
@@ -20,7 +20,7 @@ enum class EFileRingBufferAccessorValidationMode
     // validation
     Normal,
 
-    // Header and DataProcessor will be initialzed even if validation fails.
+    // Header and DataProcessor will be initialized even if validation fails.
     // This mode is intended for repairing corrupted state.
     Debug
 };
@@ -67,10 +67,6 @@ private:
 public:
     explicit TFileRingBufferAccessor(
         EFileRingBufferAccessorValidationMode validationMode);
-
-    // Updating raw data invalidates memory references.
-    // The object must be re-initialized by calling ValidateAndInitialize()
-    void UpdateRawData(std::span<char> rawData);
 
     // Validates raw data and initializes Header, DataProcessor, RawMetadata and
     // Capabilities depending on the validation result and mode
@@ -127,6 +123,11 @@ public:
     {
         return Capabilities;
     }
+
+protected:
+    // Updating raw data invalidates memory references.
+    // The object must be re-initialized by calling ValidateAndInitialize()
+    void UpdateRawData(std::span<char> rawData);
 
 private:
     EFileRingBufferAccessorValidationStatus DoValidateAndInitialize();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
@@ -15,16 +15,16 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define FILE_RING_BUFFER_TEST(name)                  \
-    void TestImpl##name(EFileRingBufferVersion ver); \
-    Y_UNIT_TEST(name##V5)                            \
-    {                                                \
-        TestImpl##name(EFileRingBufferVersion::V5);  \
-    }                                                \
-    Y_UNIT_TEST(name##V6)                            \
-    {                                                \
-        TestImpl##name(EFileRingBufferVersion::V6);  \
-    }                                                \
+#define FILE_RING_BUFFER_TEST(name)                                            \
+    void TestImpl##name(EFileRingBufferVersion ver);                           \
+    Y_UNIT_TEST(name##V5)                                                      \
+    {                                                                          \
+        TestImpl##name(EFileRingBufferVersion::V5);                            \
+    }                                                                          \
+    Y_UNIT_TEST(name##V6)                                                      \
+    {                                                                          \
+        TestImpl##name(EFileRingBufferVersion::V6);                            \
+    }                                                                          \
     void TestImpl##name(EFileRingBufferVersion ver)   // FILE_RING_BUFFER_TEST
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -438,6 +438,50 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
         b.AssertValidateFailed("Invalid file ring buffer read position");
     }
 
+    FILE_RING_BUFFER_TEST(ShouldNotValidateUnalignedReadPos)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = 0;
+        header.MetadataSize = 0;
+        header.DataOffset = sizeof(TFileRingBufferHeader);
+        header.DataCapacity = sizeof(ui64);
+        header.ReadPos = 0;
+
+        b.AssertValidateSuccess();
+
+        const auto alignment = b.Accessor.GetCapabilities().Alignment;
+        if (alignment == 1) {
+            return;
+        }
+
+        b.RawDataHeader().ReadPos = 1;
+
+        if (alignment > 1) {
+            b.AssertValidateFailed(
+                "Invalid file ring buffer read position 1 (expected to be "
+                "aligned");
+        } else {
+            b.AssertValidateSuccess();
+        }
+
+        b.RawDataHeader().ReadPos = 0;
+        b.RawDataHeader().WritePos = 1;
+
+        if (alignment > 1) {
+            b.AssertValidateFailed(
+                "Invalid file ring buffer write position 1 (expected to be "
+                "aligned");
+        } else {
+            b.AssertValidateSuccess();
+        }
+    }
+
     FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidWritePos)
     {
         TBootstrap b;
@@ -491,6 +535,51 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
             ver);
 
         b.AssertValidateSuccess();
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldValidateWrappedFileWithAllocWithoutCommit)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb)
+            {
+                while (rb.PushBack("ABCD")) {
+                    // Add elements until the buffer is full
+                }
+
+                rb.PopFront();
+                rb.PopFront();
+
+                rb.Alloc(4);
+            },
+            ver);
+
+        b.AssertValidateSuccess();
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldValidateWrappedFileWithAbortedAlloc)
+    {
+        TBootstrap b;
+
+        // Initialize empty file
+        b.Execute([](TFileRingBuffer&) {}, ver);
+
+        b.AssertValidateSuccess();
+        const auto alignment = b.Accessor.GetCapabilities().Alignment;
+
+        auto& header = b.RawDataHeader();
+        header.ReadPos = alignment > 0 ? alignment : 1;
+
+        b.Accessor.GetDataProcessor()->WriteEntryHeader(header.ReadPos, {});
+
+        b.AssertValidateSuccess();
+
+        b.Accessor.GetDataProcessor()->WriteEntryHeader(
+            header.ReadPos,
+            {.DataSize = 4, .FreeFlag = true});
+
+        b.AssertValidateFailed(
+            "expected to point to a slack space when WritePos == 0)");
     }
 
     FILE_RING_BUFFER_TEST(ShouldNotValidateFileWithZeroDataSizeAndSkipFlag)

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
@@ -1,0 +1,615 @@
+#include "file_ring_buffer.h"
+
+#include "file_ring_buffer_accessor.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/stream/output.h>
+#include <util/system/tempfile.h>
+
+namespace NCloud {
+
+using EValidationStatus = EFileRingBufferAccessorValidationStatus;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define FILE_RING_BUFFER_TEST(name)                  \
+    void TestImpl##name(EFileRingBufferVersion ver); \
+    Y_UNIT_TEST(name##V5)                            \
+    {                                                \
+        TestImpl##name(EFileRingBufferVersion::V5);  \
+    }                                                \
+    Y_UNIT_TEST(name##V6)                            \
+    {                                                \
+        TestImpl##name(EFileRingBufferVersion::V6);  \
+    }                                                \
+    void TestImpl##name(EFileRingBufferVersion ver)   // FILE_RING_BUFFER_TEST
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TBootstrap
+{
+    const bool Debug;
+
+    ui64 DataCapacity = 64;
+    ui64 MetadataCapacity = 8;
+
+    TTempFileHandle TempFileHandle;
+    TFileMapFileRingBufferAccessor Accessor;
+    std::span<char> RawData;
+
+    explicit TBootstrap(bool debug = false)
+        : Debug(debug)
+        , Accessor(
+              TempFileHandle.Name(),
+              debug ? EFileRingBufferAccessorValidationMode::Debug
+                    : EFileRingBufferAccessorValidationMode::Normal,
+              TMemoryMapCommon::EOpenModeFlag::oRdWr)
+    {
+        Remap();
+    }
+
+    void Execute(
+        const TFunctionRef<void(TFileRingBuffer&)>& fn,
+        EFileRingBufferVersion version)
+    {
+        {
+            TFileRingBuffer rb(
+                TempFileHandle.Name(),
+                DataCapacity,
+                MetadataCapacity,
+                version);
+
+            fn(rb);
+        }
+
+        // TFileRingBuffer may resize the file
+        // TFileMap does not update its mapping automatically - need to reopen
+        Accessor.Close();
+        Remap();
+    }
+
+    void AssertValidateSuccess()
+    {
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            EValidationStatus::Success,
+            Accessor.ValidateAndInitialize(),
+            FormatError(Accessor.GetLastValidationError()));
+        UNIT_ASSERT(!HasError(Accessor.GetLastValidationError()));
+        UNIT_ASSERT(Accessor.GetHeader() != nullptr);
+        UNIT_ASSERT(Accessor.GetDataProcessor() != nullptr);
+    }
+
+    void AssertValidateFailed(
+        const TString& expectedErrorSubstring,
+        EValidationStatus expectedStatus = EValidationStatus::Failed)
+    {
+        auto actualStatus = Accessor.ValidateAndInitialize();
+
+        UNIT_ASSERT_VALUES_EQUAL(expectedStatus, actualStatus);
+
+        UNIT_ASSERT(HasError(Accessor.GetLastValidationError()));
+
+        UNIT_ASSERT_STRING_CONTAINS(
+            Accessor.GetLastValidationError().GetMessage(),
+            expectedErrorSubstring);
+
+        if (!Debug && actualStatus == EValidationStatus::Failed) {
+            UNIT_ASSERT(Accessor.GetHeader() == nullptr);
+            UNIT_ASSERT(Accessor.GetDataProcessor() == nullptr);
+            UNIT_ASSERT(Accessor.GetRawMetadata().empty());
+        }
+    }
+
+    void ResizeAndRemap(size_t size)
+    {
+        auto error = Accessor.ResizeAndRemap(size);
+        UNIT_ASSERT_C(!HasError(error), FormatError(error));
+        RawData = Accessor.GetRawData();
+    }
+
+    TFileRingBufferHeader& RawDataHeader()
+    {
+        UNIT_ASSERT_LE(sizeof(TFileRingBufferHeader), RawData.size());
+        return *reinterpret_cast<TFileRingBufferHeader*>(RawData.data());
+    }
+
+private:
+    void Remap()
+    {
+        auto error = Accessor.Map();
+        UNIT_ASSERT_C(!HasError(error), FormatError(error));
+        RawData = Accessor.GetRawData();
+    }
+};
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
+{
+    Y_UNIT_TEST(ShouldValidateEmptyFile)
+    {
+        TBootstrap b;
+
+        b.AssertValidateFailed(
+            "File is empty",
+            EValidationStatus::NotInitialized);
+
+        UNIT_ASSERT(b.Accessor.GetHeader() == nullptr);
+        UNIT_ASSERT(b.Accessor.GetDataProcessor() == nullptr);
+    }
+
+    Y_UNIT_TEST(ShouldValidateFileWithZeroHeader)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader));
+
+        b.AssertValidateFailed(
+            "File is not initialized",
+            EValidationStatus::NotInitialized);
+
+        UNIT_ASSERT(b.Accessor.GetHeader() != nullptr);
+        UNIT_ASSERT(b.Accessor.GetDataProcessor() == nullptr);
+    }
+
+    Y_UNIT_TEST(ShouldNotValidateFileWithZeroVersionAndNonZeroContents)
+    {
+        TBootstrap b(false);
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader));
+        b.RawDataHeader().DataCapacity = 1;
+
+        b.AssertValidateFailed("Unsupported file ring buffer version 0");
+    }
+
+    Y_UNIT_TEST(ShouldNotValidateTooSmallFile)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(1);
+        b.RawData[0] = 1;
+
+        b.AssertValidateFailed("File is too small");
+    }
+
+    Y_UNIT_TEST(ShouldNotValidateUnsupportedVersion)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader));
+
+        auto& header = b.RawDataHeader();
+        header.Version = static_cast<EFileRingBufferVersion>(11111);
+
+        b.AssertValidateFailed("Unsupported file ring buffer version");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldValidateCorrectHeader)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(
+            sizeof(TFileRingBufferHeader) + b.MetadataCapacity +
+            b.DataCapacity);
+
+        TFileRingBufferHeader header;
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = b.MetadataCapacity;
+        header.MetadataSize = 0;
+        header.MetadataChecksum = 0;
+        header.DataOffset = sizeof(TFileRingBufferHeader) + b.MetadataCapacity;
+        header.DataCapacity = b.DataCapacity;
+        header.ReadPos = 16;
+        header.WritePos = 16;
+
+        b.RawDataHeader() = header;
+
+        b.AssertValidateSuccess();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui32>(header.Version),
+            static_cast<ui32>(b.Accessor.GetHeader()->Version));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.HeaderSize,
+            b.Accessor.GetHeader()->HeaderSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.MetadataOffset,
+            b.Accessor.GetHeader()->MetadataOffset);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.MetadataCapacity,
+            b.Accessor.GetHeader()->MetadataCapacity);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.MetadataSize,
+            b.Accessor.GetHeader()->MetadataSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.MetadataChecksum,
+            b.Accessor.GetHeader()->MetadataChecksum);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.DataOffset,
+            b.Accessor.GetHeader()->DataOffset);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.DataCapacity,
+            b.Accessor.GetHeader()->DataCapacity);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.ReadPos,
+            b.Accessor.GetHeader()->ReadPos);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            header.WritePos,
+            b.Accessor.GetHeader()->WritePos);
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidHeaderSize)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader) + 1;
+
+        b.AssertValidateFailed("Invalid file ring buffer header size");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidMetadataOffset)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader) - 1;
+
+        b.AssertValidateFailed("Invalid file ring buffer metadata offset");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateUnalignedMetadataOffset)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader) + 1;
+
+        b.AssertValidateFailed("Invalid file ring buffer metadata offset");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidMetadataSize)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = sizeof(ui64);
+        header.MetadataSize = sizeof(ui64) + 1;
+
+        b.AssertValidateFailed("Invalid file ring buffer metadata size");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidDataOffset)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + (2 * sizeof(ui64)));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader) + sizeof(ui64);
+        header.MetadataCapacity = sizeof(ui64);
+        header.MetadataSize = 0;
+
+        // Overlap with metadata
+        header.DataOffset = sizeof(TFileRingBufferHeader);
+        header.DataCapacity = sizeof(ui64);
+
+        b.AssertValidateFailed("Invalid file ring buffer data offset");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateOutOfRangeDataOffset)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = sizeof(ui64);
+        header.MetadataSize = 0;
+
+        // Outside file size
+        header.DataOffset = sizeof(TFileRingBufferHeader) + (2 * sizeof(ui64));
+        header.DataCapacity = sizeof(ui64);
+
+        b.AssertValidateFailed("Invalid file ring buffer data offset");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateUnalignedDataOffset)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + (3 * sizeof(ui64)));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = sizeof(ui64);
+        header.MetadataSize = 0;
+
+        // Outside file size
+        header.DataOffset = sizeof(TFileRingBufferHeader) + sizeof(ui64) + 1;
+        header.DataCapacity = sizeof(ui64);
+
+        b.AssertValidateFailed("Invalid file ring buffer data offset");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidMetadataCapacity)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = sizeof(ui64);
+        header.MetadataSize = 0;
+        header.DataOffset = sizeof(TFileRingBufferHeader);
+        header.DataCapacity = sizeof(ui64);
+
+        b.AssertValidateFailed("Invalid file ring buffer metadata capacity");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidDataCapacity)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = 0;
+        header.MetadataSize = 0;
+        header.DataOffset = sizeof(TFileRingBufferHeader);
+        header.DataCapacity = sizeof(ui64) * 2;
+
+        b.AssertValidateFailed("Invalid file ring buffer data capacity");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidReadPos)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = 0;
+        header.MetadataSize = 0;
+        header.DataOffset = sizeof(TFileRingBufferHeader);
+        header.DataCapacity = sizeof(ui64);
+        header.ReadPos = sizeof(ui64) + 1;
+
+        b.AssertValidateFailed("Invalid file ring buffer read position");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateInvalidWritePos)
+    {
+        TBootstrap b;
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader) + sizeof(ui64));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader);
+        header.MetadataOffset = sizeof(TFileRingBufferHeader);
+        header.MetadataCapacity = 0;
+        header.MetadataSize = 0;
+        header.DataOffset = sizeof(TFileRingBufferHeader);
+        header.DataCapacity = sizeof(ui64);
+        header.WritePos = sizeof(ui64) + 1;
+
+        b.AssertValidateFailed("Invalid file ring buffer write position");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldValidateNormalFile)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb)
+            {
+                UNIT_ASSERT(rb.PushBack("ABC"));
+                UNIT_ASSERT(rb.PushBack("123"));
+                UNIT_ASSERT(rb.SetMetadata("meta"));
+            },
+            ver);
+
+        b.AssertValidateSuccess();
+
+        UNIT_ASSERT(!b.Accessor.GetRawMetadata().empty());
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldValidateWrappedFile)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb)
+            {
+                while (rb.PushBack("ABCD")) {
+                    // Add elements until the buffer is full
+                }
+
+                rb.PopFront();
+                rb.PopFront();
+
+                UNIT_ASSERT(rb.PushBack("wrap"));
+            },
+            ver);
+
+        b.AssertValidateSuccess();
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateFileWithZeroDataSizeAndSkipFlag)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            ver);
+
+        b.AssertValidateSuccess();
+
+        b.Accessor.GetDataProcessor()->WriteEntryHeader(
+            0,
+            {.DataSize = 0, .FreeFlag = true});
+
+        b.AssertValidateFailed("data size is zero and free flag is set");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateFileWithZeroDataSizeAndNonZeroTag)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            ver);
+
+        b.AssertValidateSuccess();
+
+        b.Accessor.GetDataProcessor()->WriteEntryHeader(
+            0,
+            {.DataSize = 0, .Tag = 1});
+
+        b.AssertValidateFailed("data size is zero and tag is non-zero");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateFileWithDataSizeExceedsCapacity)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            ver);
+
+        b.AssertValidateSuccess();
+
+        b.Accessor.GetDataProcessor()->WriteEntryHeader(0, {.DataSize = 1000});
+
+        b.AssertValidateFailed("data size 1000 exceeds data capacity");
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldNotValidateFileWithNonZeroChecksumAndFreeFlag)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb) { UNIT_ASSERT(rb.PushBack("ABC")); },
+            ver);
+
+        b.AssertValidateSuccess();
+
+        b.Accessor.GetDataProcessor()->WriteEntryHeader(
+            0,
+            {.DataSize = 3, .DataChecksum = 1, .FreeFlag = true});
+
+        if (b.Accessor.GetCapabilities().EntryHeaderIsProcessedAtomically) {
+            b.AssertValidateFailed(
+                "free flag is set and data checksum is non-zero");
+        } else {
+            b.AssertValidateSuccess();
+        }
+    }
+
+    FILE_RING_BUFFER_TEST(
+        ShouldNotValidateFileWithNonZeroChecksumAndZeroDataSize)
+    {
+        TBootstrap b;
+        b.Execute(
+            [](TFileRingBuffer& rb)
+            {
+                UNIT_ASSERT(rb.PushBack("01234567"));
+                UNIT_ASSERT(rb.PushBack("ABC"));
+            },
+            ver);
+
+        b.AssertValidateSuccess();
+
+        b.Accessor.GetDataProcessor()->WriteEntryHeader(
+            16,
+            {.DataSize = 0, .DataChecksum = 1});
+
+        if (b.Accessor.GetCapabilities().EntryHeaderIsProcessedAtomically) {
+            b.AssertValidateFailed(
+                "data size is zero and data checksum is non-zero");
+        } else {
+            b.AssertValidateFailed("unexpected slack space marker");
+        }
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldInitializeHeaderOnValidationFailureInDebugMode)
+    {
+        TBootstrap b(true);
+        b.ResizeAndRemap(sizeof(TFileRingBufferHeader));
+
+        auto& header = b.RawDataHeader();
+        header.Version = ver;
+        header.HeaderSize = sizeof(TFileRingBufferHeader) + 1;
+
+        b.AssertValidateFailed("Invalid file ring buffer header size");
+
+        UNIT_ASSERT(b.Accessor.GetHeader() != nullptr);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui32>(ver),
+            static_cast<ui32>(b.Accessor.GetHeader()->Version));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            sizeof(TFileRingBufferHeader) + 1,
+            b.Accessor.GetHeader()->HeaderSize);
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldInitializeDataOnValidationFailureInDebugMode)
+    {
+        TBootstrap b(true);
+        b.Execute(
+            [](TFileRingBuffer& rb)
+            {
+                UNIT_ASSERT(rb.PushBack("ABC"));
+                UNIT_ASSERT(rb.SetMetadata("123"));
+            },
+            ver);
+
+        b.AssertValidateSuccess();
+
+        *b.Accessor.GetDataProcessor()->GetEntryDataPtr(0, 1) = 'X';
+
+        b.AssertValidateFailed("Checksum mismatch");
+
+        UNIT_ASSERT(b.Accessor.GetHeader() != nullptr);
+        UNIT_ASSERT(b.Accessor.GetDataProcessor() != nullptr);
+        UNIT_ASSERT(!b.Accessor.GetRawMetadata().empty());
+    }
+}
+
+}   // namespace NCloud
+
+template <>
+void Out<NCloud::EFileRingBufferAccessorValidationStatus>(
+    IOutputStream& out,
+    NCloud::EFileRingBufferAccessorValidationStatus value)
+{
+    out << static_cast<ui32>(value);
+}

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_accessor_ut.cpp
@@ -125,6 +125,19 @@ private:
     }
 };
 
+struct TTestFileRingBufferAccessor: public TFileRingBufferAccessor
+{
+public:
+    TTestFileRingBufferAccessor()
+        : TFileRingBufferAccessor(EFileRingBufferAccessorValidationMode::Debug)
+    {}
+
+    void SetRawData(std::span<char> rawData)
+    {
+        UpdateRawData(rawData);
+    }
+};
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,6 +154,20 @@ Y_UNIT_TEST_SUITE(TFileRingBufferAccessorTest)
 
         UNIT_ASSERT(b.Accessor.GetHeader() == nullptr);
         UNIT_ASSERT(b.Accessor.GetDataProcessor() == nullptr);
+    }
+
+    Y_UNIT_TEST(ShouldNotValidateNonAlignedBuffer)
+    {
+        TTestFileRingBufferAccessor accessor;
+        ui64 value = 0;
+        auto span = std::span(reinterpret_cast<char*>(&value) + 1, 2);
+
+        accessor.SetRawData(span);
+        auto status = accessor.ValidateAndInitialize();
+        UNIT_ASSERT_VALUES_EQUAL(status, EValidationStatus::Failed);
+        UNIT_ASSERT_STRING_CONTAINS(
+            accessor.GetLastValidationError().GetMessage(),
+            "Buffer is not aligned");
     }
 
     Y_UNIT_TEST(ShouldValidateFileWithZeroHeader)

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -142,7 +142,6 @@ public:
                     : MaxDataSize,
             .MaxTag = MaxTag,
             .Alignment = 1,
-            .EntryHeaderIsCoveredByChecksum = false,
             .EntryHeaderIsProcessedAtomically = false,
         };
     }
@@ -228,7 +227,6 @@ public:
                     : MaxDataSize,
             .MaxTag = MaxTag,
             .Alignment = sizeof(ui64),
-            .EntryHeaderIsCoveredByChecksum = true,
             .EntryHeaderIsProcessedAtomically = true,
         };
     }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -143,6 +143,7 @@ public:
             .MaxTag = MaxTag,
             .Alignment = 1,
             .EntryHeaderIsCoveredByChecksum = false,
+            .EntryHeaderIsProcessedAtomically = false,
         };
     }
 
@@ -228,6 +229,7 @@ public:
             .MaxTag = MaxTag,
             .Alignment = sizeof(ui64),
             .EntryHeaderIsCoveredByChecksum = true,
+            .EntryHeaderIsProcessedAtomically = true,
         };
     }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -98,6 +98,7 @@ struct TFileRingBufferCapabilities
     ui64 MaxTag = 0;
     ui64 Alignment = 0;
     bool EntryHeaderIsCoveredByChecksum = false;
+    bool EntryHeaderIsProcessedAtomically = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -97,7 +97,6 @@ struct TFileRingBufferCapabilities
     ui64 MaxAllocationByteCount = 0;
     ui64 MaxTag = 0;
     ui64 Alignment = 0;
-    bool EntryHeaderIsCoveredByChecksum = false;
     bool EntryHeaderIsProcessedAtomically = false;
 };
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -792,8 +792,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     FILE_RING_BUFFER_TEST(ShouldResizeMetadata)
     {
         const auto f = TTempFileHandle();
-        // entry header (8) + max entry data (4 or 8 depending on alignment)
-        const ui32 len = 17;
+        const ui32 len = 19;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 1, ver);
         UNIT_ASSERT(rb->PushBack("ABCD"));

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -888,19 +888,20 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         const auto f2 = TTempFileHandle();
         {
             TFileMap m(f2.GetName(), TMemoryMapCommon::oRdWr);
-            m.ResizeAndRemap(0, resized.length() + len);
+            auto dataOffset = AlignUp(resized.length(), sizeof(ui64));
+            m.ResizeAndRemap(0, dataOffset + len);
             auto* data = static_cast<char*>(m.Ptr());
             MemCopy(data, initial.data(), initial.length());
             const auto* entryData = initial.data() + initial.length() - len;
-            MemCopy(data + resized.length(), entryData, len);
-            MemCopy(data + resized.length() - len, entryData, 3);
-            *reinterpret_cast<ui64*>(data + 40) = resized.length();
+            MemCopy(data + dataOffset, entryData, len);
+            MemCopy(data + dataOffset - len, entryData, 3);
+            *reinterpret_cast<ui64*>(data + 40) = dataOffset;
         }
         {
             TFileRingBuffer rb(f2.GetName(), len, 100, ver);
         }
         {
-            TFileMap m(f1.GetName(), TMemoryMapCommon::oRdWr);
+            TFileMap m(f2.GetName(), TMemoryMapCommon::oRdWr);
             m.Map(0, m.Length());
             UNIT_ASSERT_STRINGS_EQUAL(
                 resized,

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -748,7 +748,9 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb->SetMetadata("1234"));
 
         {
-            // Corrupt metadata
+            // Corrupt metadata contents
+            // Header validation will pass - it will be possible to change
+            // metadata
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.Map(0, 256);
             char* data = static_cast<char*>(m.Ptr());
@@ -771,7 +773,9 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb->SetMetadata("1234"));
 
         {
-            // Corrupt metadata Length
+            // Corrupt metadata length (set length > capacity)
+            // Header validation will fail - setting metadata will not be
+            // possible
             TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
             m.Map(0, 256);
             char* data = static_cast<char*>(m.Ptr());

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -793,7 +793,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     {
         const auto f = TTempFileHandle();
         // entry header (8) + max entry data (4 or 8 depending on alignment)
-        const ui32 len = ver >= EVersion::V6 ? 16 : 12;
+        const ui32 len = 17;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 1, ver);
         UNIT_ASSERT(rb->PushBack("ABCD"));
@@ -811,6 +811,11 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT_STRINGS_EQUAL("123", rb->GetMetadata());
         UNIT_ASSERT(rb->SetMetadata("123456789"));
         UNIT_ASSERT(!rb->SetMetadata("1234567890abcdef!"));
+
+        rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 17, ver);
+        UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());
+        UNIT_ASSERT_STRINGS_EQUAL("123456789", rb->GetMetadata());
+        UNIT_ASSERT(!rb->SetMetadata("1234567890abcdefg!"));
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 100, ver);
         UNIT_ASSERT_STRINGS_EQUAL("ABCD", rb->Front());

--- a/cloud/storage/core/libs/file_backed_containers/ut/ya.make
+++ b/cloud/storage/core/libs/file_backed_containers/ut/ya.make
@@ -15,6 +15,7 @@ SRCS(
     dynamic_persistent_table_ut.cpp
     file_map_memory_limiter_ut.cpp
     file_ring_buffer_ut.cpp
+    file_ring_buffer_accessor_ut.cpp
     file_ring_buffer_format_ut.cpp
     persistent_table_ut.cpp
 )

--- a/cloud/storage/core/libs/file_backed_containers/ya.make
+++ b/cloud/storage/core/libs/file_backed_containers/ya.make
@@ -5,6 +5,7 @@ SRCS(
     dynamic_persistent_table_counters.cpp
     file_map_memory_limiter.cpp
     file_ring_buffer.cpp
+    file_ring_buffer_accessor.cpp
     file_ring_buffer_format.cpp
     persistent_table.cpp
 )


### PR DESCRIPTION
### Notes
Extracted from https://github.com/ydb-platform/nbs/pull/6563

Introduce `TFileRingBufferAccessor` to access memory mapped file from `TFileRingBuffer`:
- Extract common code that will be used in https://github.com/ydb-platform/nbs/pull/6563;
- Strengthen data validation and give verbose messages;
- Replace `Y_ABORT_UNLESS` and throwing exceptions with `NProto::TError`.

Also:
- Fixed the test `TFileRingBufferTest::ShouldMigrate` when migrating to V6 (test was passed because validation was not complete).

### Issue
https://github.com/ydb-platform/nbs/issues/1751
https://github.com/ydb-platform/nbs/issues/3781
