### PR TITLE
issue-6608: Add tabs to the tablet monpage + separate tab for quotas

### DIFF
--- a/cloud/filestore/libs/storage/tablet/quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/quota.cpp
@@ -25,7 +25,7 @@ TVector<NProto::TQuota> TQuotaStore::GetQuotas() const
 {
     TVector<NProto::TQuota> quotas;
     quotas.reserve(QuotaById.size());
-    for (const auto& [quotaId, quota]: QuotaById) {
+    for (const auto& [_, quota]: QuotaById) {
         quotas.push_back(quota);
     }
     // Make sure the quotas are returned in a deterministic order

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.h
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.h
@@ -644,6 +644,11 @@ private:
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,
         TRequestInfoPtr requestInfo);
+    void RenderHttpInfo_OverviewTab(
+        const NActors::TActorContext& ctx,
+        const TCgiParameters& params,
+        IOutputStream& out);
+    void RenderHttpInfo_QuotasTab(IOutputStream& out);
     void HandleHttpInfo_ForceOperation(
         const NActors::TActorContext& ctx,
         const TCgiParameters& params,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_monitoring.cpp
@@ -1049,13 +1049,11 @@ void TIndexTabletActor::HandleHttpInfo(
         std::make_unique<NMon::TEvRemoteHttpInfoRes>(std::move(out.Str())));
 }
 
-void TIndexTabletActor::HandleHttpInfo_Default(
+void TIndexTabletActor::RenderHttpInfo_OverviewTab(
     const NActors::TActorContext& ctx,
     const TCgiParameters& params,
-    TRequestInfoPtr requestInfo)
+    IOutputStream& out)
 {
-    TStringStream out;
-
     HTML(out) {
         DumpDefaultHeader(out, TabletID(), SelfId().NodeId());
 
@@ -1335,6 +1333,84 @@ void TIndexTabletActor::HandleHttpInfo_Default(
         DumpSessionHistory(out, GetSessionHistoryList());
 
         GenerateActionsJS(out);
+    }
+}
+
+void TIndexTabletActor::RenderHttpInfo_QuotasTab(IOutputStream& out)
+{
+    HTML(out) {
+        const auto quotas = GetQuotas();
+        TAG(TH3) { out << "Quotas"; }
+        if (quotas.size()) {
+            TABLE_SORTABLE_CLASS("table table-bordered") {
+                TABLEHEAD() {
+                    TABLER() {
+                        TABLEH() { out << "QuotaId"; }
+                        TABLEH() { out << "MaxBytes"; }
+                        TABLEH() { out << "MaxNodes"; }
+                        TABLEH() { out << "CreatedAt"; }
+                    }
+                }
+
+                for (const auto& quota: quotas) {
+                    TABLER() {
+                        TABLED() { out << quota.GetQuotaId(); }
+                        TABLED() { out << FormatByteSize(quota.GetMaxBytes()); }
+                        TABLED() { out << quota.GetMaxNodes(); }
+                        TABLED() {
+                            out << TInstant::MicroSeconds(
+                                quota.GetCreationTimestampUs());
+                        }
+                    }
+                }
+            }
+        } else {
+            out << "No quotas defined.";
+        }
+    }
+}
+
+void TIndexTabletActor::HandleHttpInfo_Default(
+    const NActors::TActorContext& ctx,
+    const TCgiParameters& params,
+    TRequestInfoPtr requestInfo)
+{
+    TStringStream out;
+
+    const char* overviewTabName = "Overview";
+    const char* quotasTabName = "Quotas";
+
+    const char* activeTabClass = "tab-pane active";
+    const char* inactiveTabClass = "tab-pane";
+
+    const char* overviewTab = activeTabClass;
+    const char* quotasTab = inactiveTabClass;
+
+    if (params.Get("tab") == quotasTabName) {
+        overviewTab = inactiveTabClass;
+        quotasTab = activeTabClass;
+    }
+
+    HTML(out) {
+        DIV_CLASS_ID("container-fluid", "tabs") {
+            out << "<ul class='nav nav-tabs' id='Tabs'>"
+                << "<li class='active'>"
+                << "<a href='#" << overviewTabName << "' data-toggle='tab'>"
+                << overviewTabName << "</a></li>"
+                << "<li><a href='#" << quotasTabName << "' data-toggle='tab'>"
+                << quotasTabName << "</a></li>"
+                << "</ul>";
+
+            DIV_CLASS("tab-content") {
+                DIV_CLASS_ID(overviewTab, overviewTabName) {
+                    RenderHttpInfo_OverviewTab(ctx, params, out);
+                }
+
+                DIV_CLASS_ID(quotasTab, quotasTabName) {
+                    RenderHttpInfo_QuotasTab(out);
+                }
+            }
+        }
     }
 
     NCloud::Reply(


### PR DESCRIPTION
### Notes
Small tablet monpage change to include quotas + adding tabs (same as it is already done for the volume tablet)

This is how it will look: 
<img width="986" height="489" alt="image" src="https://github.com/user-attachments/assets/cabcbbaf-5055-43c9-9dbb-f1323b7485a4" />


### Issue
#6608