### PR TITLE
issue-1751: TFileRingBuffer - remove support for V4

### DIFF
--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -321,22 +321,6 @@ private:
             CreateDataProcessor(Args.Version);
             return;
         }
-
-        // WriteBackCache needs functionality of V5+ (tags) for entries created
-        // in older version (V4) - we need to make migration immediately to
-        // at least V5 in order to provide this functionality.
-        // Transition V4 -> V5 can be made without emptying the buffer.
-        if (Header()->Version == EVersion::V4 && Args.Version > EVersion::V4) {
-            // Parse entry headers using newer version
-            CreateDataProcessor(EVersion::V5);
-
-            // In the new version, the highest bits of the entry size are
-            // treated as a tag value - need to ensure that they are not used
-            VisitEntries([](const TEntryInfo& e)
-                         { Y_ABORT_UNLESS(e.Header.Tag == 0); });
-
-            Header()->Version = EVersion::V5;
-        }
     }
 
     void ResizeMetadata(ui64 desiredMetadataCapacity)

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.cpp
@@ -98,102 +98,6 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TFileRingBufferDataProcessorV4: public IFileRingBufferDataProcessor
-{
-private:
-    // Entry header layout (lower bits come first):
-    // [ DataSize (31 bits) | FreeFlag (1 bit) ]
-    // [ Checksum (32 bits) ]
-    struct Y_PACKED TEntryHeader
-    {
-        ui32 DataSize = 0;
-        ui32 Checksum = 0;
-    };
-
-    static_assert(sizeof(TEntryHeader) == sizeof(ui64));
-
-    TData<TEntryHeader, false> Data;
-
-    static constexpr ui32 MaxDataSize = (1U << 31U) - 1U;
-    static constexpr ui32 FreeFlagMask = 1U << 31U;
-
-public:
-    explicit TFileRingBufferDataProcessorV4(std::span<char> data)
-        : Data(data)
-    {}
-
-    TFileRingBufferCapabilities GetCapabilities(
-        bool takeBufferSizeIntoAccount) const override
-    {
-        return {
-            .MaxAllocationByteCount =
-                takeBufferSizeIntoAccount
-                    ? GetMaxAllocationByteCount(Data.Size())
-                    : MaxDataSize,
-            .MaxTag = 0,
-            .Alignment = 1,
-            .EntryHeaderIsCoveredByChecksum = false,
-        };
-    }
-
-    TFileRingBufferEntryHeader ReadEntryHeader(ui64 pos) const override
-    {
-        auto* eh = Data.GetEntryHeaderPtr(pos);
-        if (eh == nullptr) {
-            return {};
-        }
-
-        return {
-            .DataSize = eh->DataSize & MaxDataSize,
-            .DataChecksum = eh->Checksum,
-            .Tag = 0,
-            .FreeFlag = (eh->DataSize & FreeFlagMask) != 0,
-        };
-    }
-
-    bool WriteEntryHeader(
-        ui64 pos,
-        const TFileRingBufferEntryHeader& header) override
-    {
-        if (header.DataSize > MaxDataSize || header.Tag != 0) {
-            return false;
-        }
-
-        auto* eh = Data.GetEntryHeaderPtr(pos);
-        if (eh == nullptr) {
-            return false;
-        }
-
-        eh->DataSize = header.DataSize | (header.FreeFlag ? FreeFlagMask : 0);
-        eh->Checksum = header.DataChecksum;
-        return true;
-    }
-
-    ui64 GetEntrySize(ui64 dataSize) const override
-    {
-        return sizeof(TEntryHeader) + dataSize;
-    }
-
-    ui64 GetMaxAllocationByteCount(ui64 maxEntrySize) const override
-    {
-        return Min(
-            Data.GetMaxDataSize(maxEntrySize),
-            static_cast<ui64>(MaxDataSize));
-    }
-
-    const char* GetEntryDataPtr(ui64 pos, ui64 dataSize) const override
-    {
-        return Data.GetEntryDataPtr(pos, dataSize);
-    }
-
-    char* GetEntryDataPtr(ui64 pos, ui64 dataSize) override
-    {
-        return Data.GetEntryDataPtr(pos, dataSize);
-    }
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TFileRingBufferDataProcessorV5Base
 {
 protected:
@@ -402,8 +306,6 @@ std::unique_ptr<IFileRingBufferDataProcessor> CreateFileRingBufferDataProcessor(
     std::span<char> data)
 {
     switch (version) {
-        case EFileRingBufferVersion::V4:
-            return std::make_unique<TFileRingBufferDataProcessorV4>(data);
         case EFileRingBufferVersion::V5:
             return std::make_unique<TFileRingBufferDataProcessorV5>(data);
         case EFileRingBufferVersion::V6:
@@ -418,8 +320,7 @@ std::unique_ptr<IFileRingBufferDataProcessor> CreateFileRingBufferDataProcessor(
 
 bool IsSupportedFileRingBufferVersion(EFileRingBufferVersion version)
 {
-    return version == EFileRingBufferVersion::V4 ||
-           version == EFileRingBufferVersion::V5 ||
+    return version == EFileRingBufferVersion::V5 ||
            version == EFileRingBufferVersion::V6;
 }
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format.h
@@ -48,13 +48,6 @@ enum class EFileRingBufferVersion : ui32
     NotInitialized = 0,
 
     // Entry headers are not aligned
-    // Maximum allocation size is 2^31-1
-    // Free flag is supported
-    // Tags are not supported
-    // Checksum is calculated over entry data only
-    V4 = 4,
-
-    // Entry headers are not aligned
     // Maximum allocation size is 2^28-1
     // Free flag is supported
     // Tags are supported - small values [0-7]

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_format_ut.cpp
@@ -13,7 +13,6 @@ namespace {
 TVector<EFileRingBufferVersion> GetVersionsForTest()
 {
     return {
-        EFileRingBufferVersion::V4,
         EFileRingBufferVersion::V5,
         EFileRingBufferVersion::V6};
 }

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -19,10 +19,6 @@ namespace {
 
 #define FILE_RING_BUFFER_TEST(name)                                            \
     void TestImpl##name(EVersion ver);                                         \
-    Y_UNIT_TEST(name##V4)                                                      \
-    {                                                                          \
-        TestImpl##name(EVersion::V4);                                          \
-    }                                                                          \
     Y_UNIT_TEST(name##V5)                                                      \
     {                                                                          \
         TestImpl##name(EVersion::V5);                                          \
@@ -809,46 +805,6 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb->ValidateMetadata());
     }
 
-    Y_UNIT_TEST(ShouldBackwardSupportFileFormat_V4_to_V5)
-    {
-        const auto f = TTempFileHandle();
-        const ui32 dataLen = 36;
-        const ui32 metadataLen = 8;
-
-        auto rb = std::make_unique<TFileRingBuffer>(
-            f.GetName(),
-            dataLen,
-            metadataLen,
-            EVersion::V4);
-
-        rb->SetMetadata("FormatV4");
-        rb->PushBack("SomeData");
-
-        {
-            TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
-            m.ResizeAndRemap(0, m.Length());
-            // Check version before migration
-            UNIT_ASSERT_VALUES_EQUAL(4, *reinterpret_cast<ui32*>(m.Ptr()));
-        }
-
-        rb = std::make_unique<TFileRingBuffer>(
-            f.GetName(),
-            dataLen,
-            metadataLen,
-            EVersion::V5);
-
-        UNIT_ASSERT(!rb->IsCorrupted());
-        UNIT_ASSERT_VALUES_EQUAL("FormatV4", rb->GetMetadata());
-        UNIT_ASSERT_VALUES_EQUAL("SomeData", rb->Front());
-
-        {
-            TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
-            m.ResizeAndRemap(0, m.Length());
-            // Check version after migration
-            UNIT_ASSERT_VALUES_EQUAL(5, *reinterpret_cast<ui32*>(m.Ptr()));
-        }
-    }
-
     FILE_RING_BUFFER_TEST(ShouldResizeMetadata)
     {
         const auto f = TTempFileHandle();
@@ -1234,8 +1190,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
     Y_UNIT_TEST(ShouldMigrate)
     {
         auto check = [](EVersion srcVersion,
-                        EVersion dstVersion,
-                        bool immediateMigration)
+                        EVersion dstVersion)
         {
             const auto f = TTempFileHandle();
             const ui32 len = 128;
@@ -1266,27 +1221,19 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
             UNIT_ASSERT_VALUES_EQUAL("123, 4, xz", Dump(*rb));
 
-            UNIT_ASSERT_VALUES_EQUAL(immediateMigration, rb->PushBack("!"));
+            // New entries can be added only after the migration is completed
+            UNIT_ASSERT(!rb->PushBack("!"));
 
-            if (immediateMigration) {
-                // Migration happened with non-empty buffer
-                UNIT_ASSERT_VALUES_EQUAL("123, 4, xz, !", Dump(*rb));
+            // Migration didn't happen - need to empty the buffer first
+            UNIT_ASSERT_VALUES_EQUAL(0, rb->GetAvailableByteCount());
 
-                rb->PopFront();
-                rb->PopFront();
-                rb->PopFront();
-            } else {
-                // Migration didn't happen - need to empty the buffer first
-                UNIT_ASSERT_VALUES_EQUAL(0, rb->GetAvailableByteCount());
+            rb->PopFront();
+            rb->PopFront();
+            rb->PopFront();
 
-                rb->PopFront();
-                rb->PopFront();
-                rb->PopFront();
+            UNIT_ASSERT_LT(0, rb->GetAvailableByteCount());
 
-                UNIT_ASSERT_LT(0, rb->GetAvailableByteCount());
-
-                UNIT_ASSERT(rb->PushBack("!"));
-            }
+            UNIT_ASSERT(rb->PushBack("!"));
 
             UNIT_ASSERT_VALUES_EQUAL("!", Dump(*rb));
             UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
@@ -1299,14 +1246,10 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         };
 
         // Version upgrade
-        check(EVersion::V4, EVersion::V5, true);
-        check(EVersion::V4, EVersion::V6, false);
-        check(EVersion::V5, EVersion::V6, false);
+        check(EVersion::V5, EVersion::V6);
 
         // Version downgrade
-        check(EVersion::V6, EVersion::V5, false);
-        check(EVersion::V6, EVersion::V4, false);
-        check(EVersion::V5, EVersion::V4, false);
+        check(EVersion::V6, EVersion::V5);
     }
 }
 


### PR DESCRIPTION
### Notes
WriteBackCache and HandleOpsQueue are no more using V4 format.
It is needed to remove support for it.

### Issue
https://github.com/ydb-platform/nbs/issues/1751
