### PR TITLE
Cached rdma memory windows

### DIFF
--- a/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/bootstrap.cpp
@@ -103,6 +103,7 @@ void TBootstrap::Init()
         config->QpRnrRetryCount = Options->QpRnrRetryCount;
         config->QpTimeout = Options->QpTimeout;
         config->QpMinRnrTimer = Options->QpMinRnrTimer;
+        config->UseMemoryWindows = Options->UseMemoryWindows;
 
         Client = NCloud::NBlockStore::NRdma::CreateRdmaClient(
             Logging,

--- a/cloud/blockstore/tools/testing/rdma-test/options.cpp
+++ b/cloud/blockstore/tools/testing/rdma-test/options.cpp
@@ -115,6 +115,9 @@ void TOptions::Parse(int argc, char** argv)
         .DefaultValue(QpMinRnrTimer)
         .StoreResult(&QpMinRnrTimer);
 
+    opts.AddLongOption("memory-windows")
+        .StoreTrue(&UseMemoryWindows);
+
     // device geometry
     opts.AddLongOption("storage")
         .RequiredArgument("{" + GetEnumAllNames<EStorageKind>() + "}")

--- a/cloud/blockstore/tools/testing/rdma-test/options.h
+++ b/cloud/blockstore/tools/testing/rdma-test/options.h
@@ -64,6 +64,7 @@ struct TOptions
     ui8 QpRnrRetryCount = 7;
     ui8 QpTimeout = 0;
     ui8 QpMinRnrTimer = 0;
+    bool UseMemoryWindows = false;
 
     // storage options
     EStorageKind StorageKind = EStorageKind::Null;

--- a/cloud/storage/core/libs/rdma/iface/client.cpp
+++ b/cloud/storage/core/libs/rdma/iface/client.cpp
@@ -86,6 +86,7 @@ void TClientConfig::DumpHtml(IOutputStream& out) const
                 ENTRY(QpRnrRetryCount, static_cast<ui32>(QpRnrRetryCount));
                 ENTRY(QpTimeout, static_cast<ui32>(QpTimeout));
                 ENTRY(QpMinRnrTimer, static_cast<ui32>(QpMinRnrTimer));
+                ENTRY(UseMemoryWindows, UseMemoryWindows);
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/iface/client.h
+++ b/cloud/storage/core/libs/rdma/iface/client.h
@@ -48,6 +48,7 @@ struct TClientConfig
     ui8 QpRnrRetryCount = 7;
     ui8 QpTimeout = 0;
     ui8 QpMinRnrTimer = 0;
+    bool UseMemoryWindows = false;
 
     TClientConfig();
 

--- a/cloud/storage/core/libs/rdma/iface/config.h
+++ b/cloud/storage/core/libs/rdma/iface/config.h
@@ -66,6 +66,7 @@ inline TClientConfig CreateClientConfig(const NProto::TRdmaClient& config)
     SET(QpRnrRetryCount);
     SET(QpTimeout);
     SET(QpMinRnrTimer);
+    SET(UseMemoryWindows);
 
     SET_NESTED(BufferPool, ChunkSize);
     SET_NESTED(BufferPool, MaxChunkAlloc);

--- a/cloud/storage/core/libs/rdma/iface/probes.h
+++ b/cloud/storage/core/libs/rdma/iface/probes.h
@@ -63,6 +63,22 @@
         GROUPS("StorageRequest"),                                              \
         TYPES(),                                                               \
         NAMES())                                                               \
+    PROBE(BindInBufferStarted,                                                 \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindInBufferCompleted,                                               \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindOutBufferStarted,                                                \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
+    PROBE(BindOutBufferCompleted,                                              \
+        GROUPS("StorageRequest"),                                              \
+        TYPES(ui64),                                                           \
+        NAMES("requestId"))                                                    \
 // STORAGE_RDMA_PROVIDER
 
 LWTRACE_DECLARE_PROVIDER(STORAGE_RDMA_PROVIDER)

--- a/cloud/storage/core/libs/rdma/iface/protocol.h
+++ b/cloud/storage/core/libs/rdma/iface/protocol.h
@@ -62,6 +62,16 @@ enum {
     RDMA_PROTO_FLAG_DATA_AT_THE_END = 1,
 };
 
+enum {
+    RDMA_REQUEST_FLAG_NONE = 0,
+    RDMA_REQUEST_FLAG_USE_MEMORY_WINDOWS = 1,
+};
+
+enum {
+    RDMA_ACCEPT_FLAG_NONE = 0,
+    RDMA_ACCEPT_FLAG_SEND_WITH_INV = 1,
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Y_PACKED TMessageHeader

--- a/cloud/storage/core/libs/rdma/impl/buffer.cpp
+++ b/cloud/storage/core/libs/rdma/impl/buffer.cpp
@@ -9,13 +9,6 @@ namespace NCloud::NStorage::NRdma {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TPooledBuffer::operator TStringBuf() const
-{
-    return {reinterpret_cast<char*>(Address), Length};
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 class TBufferPool::TChunk
     : public TIntrusiveListItem<TChunk>
 {
@@ -100,7 +93,24 @@ public:
         AllocatedBytes = 0;
         FreedBytes = 0;
     }
+
+    ibv_mr* GetMemoryRegion() const
+    {
+        return MemoryRegion.get();
+    }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+TPooledBuffer::operator TStringBuf() const
+{
+    return {reinterpret_cast<char*>(Address), Length};
+}
+
+ibv_mr* TPooledBuffer::GetMemoryRegion() const
+{
+    return Chunk->GetMemoryRegion();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/cloud/storage/core/libs/rdma/impl/buffer.h
+++ b/cloud/storage/core/libs/rdma/impl/buffer.h
@@ -39,6 +39,9 @@ public:
     {
         TChunk* Chunk;
         ui32 LKey;
+        ui32 WindowRKey;
+
+        ibv_mr* GetMemoryRegion() const;
 
         explicit operator TStringBuf() const;
     };

--- a/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
@@ -83,7 +83,11 @@ public:
         (ibv_cq * cq, NVerbs::ICompletionHandler* handler),
         (override));
 
-    MOCK_METHOD(void, PostSend, (ibv_qp * qp, ibv_send_wr* wr), (override));
+    MOCK_METHOD(
+        void,
+        PostSend,
+        (ibv_qp * qp, ibv_send_wr* wr, ibv_send_wr** badWr),
+        (override));
     MOCK_METHOD(void, PostRecv, (ibv_qp * qp, ibv_recv_wr* wr), (override));
 
     MOCK_METHOD(

--- a/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/buffer_ut.cpp
@@ -44,6 +44,11 @@ public:
         RegisterMemoryRegion,
         (ibv_pd * pd, void* addr, size_t length, int flags),
         (override));
+    MOCK_METHOD(
+        NVerbs::TMemoryWindowPtr,
+        CreateMemoryWindow,
+        (ibv_pd * pd),
+        (override));
 
     MOCK_METHOD(
         NVerbs::TCompletionChannelPtr,

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -461,6 +461,11 @@ struct TRequestResources
     ui64 BufferPoolGeneration = 0;
     NProto::TError Error;
 
+    // Cleanup is performed only after the user releases TRequest and every
+    // posted WR chain has either completed or been destroyed with its QP.
+    bool UserReleased = false;
+    ui32 HardwareOwners = 0;
+
     ui32 Status = RDMA_PROTO_FAIL;
     ui32 ResponseBytes = 0;
 };
@@ -565,12 +570,18 @@ private:
     TEventHandle DisconnectEvent;
 
     TSimpleList<TRequest> QueuedRequests;
+    TSimpleList<TRequest> PartiallyPostedRequests;
+    // Send slots whose terminal CQE is no longer required because the current
+    // QP is committed to destruction.
+    std::atomic<size_t> QpOwnedSendSlots = 0;
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
         PendingInvalidationRequests;
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
         InflightInvalidationRequests;
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
         RetiredInvalidationRequests;
+    TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
+        PartiallyPostedInvalidationRequests;
     TActiveRequests ActiveRequests;
 
     std::atomic<ui64> ReqIdPool{0};
@@ -664,6 +675,7 @@ private:
         TRequestPtr& req,
         NProto::TError error) noexcept;
     void AbortRequest(ui32 reqId) noexcept;
+    void AbortRequest(ui32 reqId, NProto::TError error) noexcept;
     void AbortRequest(TRequestPtr req, const NProto::TError& error) noexcept;
     void AbortRequest(
         TRequestPtr req,
@@ -690,6 +702,9 @@ private:
 
     // Resource lifetime and allocation helpers.
     void ReleaseRequestResources(TRequestResourcesPtr resources) noexcept;
+    void AcquireHardwareResources(const TRequestResourcesPtr& resources) noexcept;
+    void ReleaseHardwareResources(const TRequestResourcesPtr& resources) noexcept;
+    void CleanupRequestResourcesLocked(TRequestResources& resources) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     NVerbs::TMemoryWindowPtr AcquireMemoryWindowLocked();
     void RecycleMemoryWindowLocked(NVerbs::TMemoryWindowPtr& memoryWindow);
@@ -912,13 +927,8 @@ void TClientEndpoint::SetupQP()
 
 void TClientEndpoint::DestroyQP() noexcept
 {
-    RetiredInvalidationRequests.Clear();
-
-    with_lock (AllocationLock) {
-        MaxFreeMemoryWindows = 0;
-        FreeMemoryWindows.clear();
-    }
-
+    // QP destruction is the lifetime boundary for every MW which may have
+    // been referenced by a posted WQE.
     if (Connection && Connection->qp) {
         if (Config.VerbsQP) {
             Verbs->DestroyQP(Connection->qp);
@@ -927,6 +937,34 @@ void TClientEndpoint::DestroyQP() noexcept
             Verbs->RdmaDestroyQP(Connection.get());
             Connection->qp = nullptr;
         }
+    }
+
+    while (RetiredInvalidationRequests) {
+        auto* req = RetiredInvalidationRequests.PopFront();
+        Y_ABORT_UNLESS(req);
+        ReleaseHardwareResources(req->Resources);
+        delete req;
+    }
+
+    while (auto req = PartiallyPostedRequests.Dequeue()) {
+        AbortRequest(
+            std::move(req),
+            EAbortCounter::Aborted,
+            MakeError(E_RDMA_UNAVAILABLE, "failed to post complete send chain"));
+    }
+
+    while (PartiallyPostedInvalidationRequests) {
+        auto* req = PartiallyPostedInvalidationRequests.PopFront();
+        Y_ABORT_UNLESS(req);
+        ReleaseHardwareResources(req->Resources);
+        FinalizeInvalidationRequest(req, false);
+    }
+    QpOwnedSendSlots = 0;
+
+    // No WQE can reference windows from the endpoint-local pool anymore.
+    with_lock (AllocationLock) {
+        MaxFreeMemoryWindows = 0;
+        FreeMemoryWindows.clear();
     }
 
     CompletionQueue.reset();
@@ -1283,15 +1321,19 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
     if (id.Magic == SendMagic && id.Index < SendWrs.size()) {
         auto* send = &SendWrs[id.Index];
         auto handleLocalInvalidationCompletion = [&] {
+            if (!send->context) {
+                RDMA_TRACE(send << " local invalidate completion already handled");
+                return;
+            }
             send->context = nullptr;
             SendQueue.Push(send);
         };
-        auto handleRequestSendCompletion = [&] {
+        auto handleRequestSendCompletion = [&] (NProto::TError error) {
             const ui32 reqId =
                 SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
             Counters->SendRequestCompleted();
             SendQueue.Push(send);
-            AbortRequest(reqId);
+            AbortRequest(reqId, std::move(error));
         };
 
         switch (wc->status) {
@@ -1302,7 +1344,11 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
                         handleLocalInvalidationCompletion();
                         break;
                     case IBV_WC_SEND:
-                        handleRequestSendCompletion();
+                        handleRequestSendCompletion(MakeError(
+                            E_RDMA_UNAVAILABLE,
+                            TStringBuilder()
+                                << "send request flushed: "
+                                << NVerbs::GetStatusString(wc->status)));
                         break;
                     default:
                         break;
@@ -1333,7 +1379,11 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
                         handleLocalInvalidationCompletion();
                         break;
                     case IBV_WC_SEND:
-                        handleRequestSendCompletion();
+                        handleRequestSendCompletion(MakeError(
+                            E_RDMA_UNAVAILABLE,
+                            TStringBuilder()
+                                << "send request failed: "
+                                << NVerbs::GetStatusString(wc->status)));
                         break;
                     default:
                         break;
@@ -1520,25 +1570,37 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
     }
 
     if (tail) {
+        // BIND_MW is asynchronous on HCA, SEND must be fenced to ensure
+        // memory window bindings become visible before request delivery.
+        send->wr.send_flags |= IBV_SEND_FENCE;
         tail->next = &send->wr;
     }
 
+    ibv_send_wr* badWr = nullptr;
     try {
-        Verbs->PostSend(Connection->qp, head);
+        Verbs->PostSend(Connection->qp, head, &badWr);
         RDMA_TRACE(send << " posted");
     }
     catch (const TServiceError& e) {
         RDMA_ERROR(send << " " << e.what());
-        SendQueue.Push(send);
-        // PostSend failed synchronously before any CQE could be produced.
-        // Roll back ActiveSend and complete request locally: no WQE was posted,
-        // so no completion/flush can arrive for this request.
         Counters->SendRequestCompleted();
         if (auto failedReq = ActiveRequests.Pop(req->ReqId)) {
-            AbortRequest(
-                std::move(failedReq),
-                EAbortCounter::Aborted,
-                MakeError(E_RDMA_UNAVAILABLE, "failed to post send request"));
+            if (badWr == head) {
+                // The first WR was rejected, hence nothing from this chain can
+                // still reference the request resources.
+                SendQueue.Push(send);
+                AbortRequest(
+                    std::move(failedReq),
+                    EAbortCounter::Aborted,
+                    MakeError(E_RDMA_UNAVAILABLE, "failed to post send request"));
+            } else {
+                // ibv_post_send may accept a prefix of a linked list. Keep all
+                // resources alive until the QP has been destroyed.
+                failedReq->Resources->RecyclePolicy =
+                    TRequestResources::ERecyclePolicy::Drop;
+                PartiallyPostedRequests.Enqueue(std::move(failedReq));
+                ++QpOwnedSendSlots;
+            }
         }
         Counters->Error();
         Disconnect();
@@ -1663,9 +1725,21 @@ void TClientEndpoint::TryAbortRequest(
 
 void TClientEndpoint::AbortRequest(ui32 reqId) noexcept
 {
+    AbortRequest(reqId, NProto::TError());
+}
+
+void TClientEndpoint::AbortRequest(ui32 reqId, NProto::TError error) noexcept
+{
     auto* req = ActiveRequests.Get(reqId);
-    if (!req || !req->Resources || !HasError(req->Resources->Error)) {
+    if (!req || !req->Resources) {
         return;
+    }
+
+    if (!HasError(req->Resources->Error)) {
+        if (!HasError(error)) {
+            return;
+        }
+        req->Resources->Error = std::move(error);
     }
 
     auto abortedReq = ActiveRequests.Pop(reqId);
@@ -1674,15 +1748,22 @@ void TClientEndpoint::AbortRequest(ui32 reqId) noexcept
     }
 
     if (!HasError(abortedReq->Resources->Error)) {
+        if (!HasError(error)) {
+            return;
+        }
+        abortedReq->Resources->Error = std::move(error);
+    }
+
+    if (!HasError(abortedReq->Resources->Error)) {
         return;
     }
-    auto error = std::move(abortedReq->Resources->Error);
+    auto abortError = std::move(abortedReq->Resources->Error);
     abortedReq->Resources->Error = NProto::TError();
 
     AbortRequest(
         std::move(abortedReq),
         EAbortCounter::Aborted,
-        error);
+        abortError);
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1899,7 +1980,8 @@ bool TClientEndpoint::ClientRequestsFlushed() const
 
 bool TClientEndpoint::WorkRequestsFlushed() const
 {
-    return SendQueue.Size() == Config.SendQueueSize
+    return SendQueue.Size() + QpOwnedSendSlots.load() ==
+            Config.SendQueueSize
         && RecvQueue.Size() == Config.RecvQueueSize
         && !PendingInvalidationRequests
         && !InflightInvalidationRequests;
@@ -1919,34 +2001,68 @@ void TClientEndpoint::ReleaseRequestResources(TRequestResourcesPtr resources) no
     }
 
     with_lock (AllocationLock) {
-        const ui64 currentBufferPoolGeneration = BufferPoolGeneration.load();
-        const bool sameBufferPoolGeneration =
-            resources->BufferPoolGeneration == currentBufferPoolGeneration;
+        resources->UserReleased = true;
+        if (resources->HardwareOwners == 0) {
+            CleanupRequestResourcesLocked(*resources);
+        }
+    }
+}
 
-        if (sameBufferPoolGeneration) {
-            if (Config.UseMemoryWindows &&
-                resources->RecyclePolicy == TRequestResources::ERecyclePolicy::Recycle &&
-                CheckState(EEndpointState::Connected))
-            {
-                RecycleMemoryWindowLocked(resources->InMemoryWindow);
-                RecycleMemoryWindowLocked(resources->OutMemoryWindow);
-            } else {
-                resources->InMemoryWindow = NVerbs::NullPtr;
-                resources->OutMemoryWindow = NVerbs::NullPtr;
-            }
+void TClientEndpoint::AcquireHardwareResources(
+    const TRequestResourcesPtr& resources) noexcept
+{
+    Y_ABORT_UNLESS(resources);
+    with_lock (AllocationLock) {
+        ++resources->HardwareOwners;
+    }
+}
 
-            SendBuffers.ReleaseBuffer(resources->InBuffer);
-            RecvBuffers.ReleaseBuffer(resources->OutBuffer);
-            return;
+void TClientEndpoint::ReleaseHardwareResources(
+    const TRequestResourcesPtr& resources) noexcept
+{
+    if (!resources) {
+        return;
+    }
+
+    with_lock (AllocationLock) {
+        Y_ABORT_UNLESS(resources->HardwareOwners > 0);
+        --resources->HardwareOwners;
+        if (resources->HardwareOwners == 0 && resources->UserReleased) {
+            CleanupRequestResourcesLocked(*resources);
+        }
+    }
+}
+
+void TClientEndpoint::CleanupRequestResourcesLocked(
+    TRequestResources& resources) noexcept
+{
+    const ui64 currentBufferPoolGeneration = BufferPoolGeneration.load();
+    const bool sameBufferPoolGeneration =
+        resources.BufferPoolGeneration == currentBufferPoolGeneration;
+
+    if (sameBufferPoolGeneration) {
+        if (Config.UseMemoryWindows &&
+            resources.RecyclePolicy == TRequestResources::ERecyclePolicy::Recycle &&
+            CheckState(EEndpointState::Connected))
+        {
+            RecycleMemoryWindowLocked(resources.InMemoryWindow);
+            RecycleMemoryWindowLocked(resources.OutMemoryWindow);
+        } else {
+            resources.InMemoryWindow = NVerbs::NullPtr;
+            resources.OutMemoryWindow = NVerbs::NullPtr;
         }
 
-        // Late request destruction after reconnect: buffers belong to an older
-        // pool generation and cannot be safely released via current pool.
-        resources->InMemoryWindow = NVerbs::NullPtr;
-        resources->OutMemoryWindow = NVerbs::NullPtr;
-        resources->InBuffer = {};
-        resources->OutBuffer = {};
+        SendBuffers.ReleaseBuffer(resources.InBuffer);
+        RecvBuffers.ReleaseBuffer(resources.OutBuffer);
+        return;
     }
+
+    // Late cleanup after reconnect: buffers belong to an older pool generation
+    // and cannot be released through the current pool.
+    resources.InMemoryWindow = NVerbs::NullPtr;
+    resources.OutMemoryWindow = NVerbs::NullPtr;
+    resources.InBuffer = {};
+    resources.OutBuffer = {};
 }
 
 void TClientEndpoint::FinalizeRequest(TRequestPtr req) noexcept
@@ -1979,12 +2095,13 @@ void TClientEndpoint::FinalizeInvalidationRequest(
     if (req->Resources) {
         req->Resources->RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
     }
-    FinalizeRequest(std::move(req->Request));
-
     if (keepAlive) {
         req->Stage = TInvalidationRequest::EStage::Retired;
         RetiredInvalidationRequests.PushBack(req);
+        ++QpOwnedSendSlots;
+        FinalizeRequest(std::move(req->Request));
     } else {
+        FinalizeRequest(std::move(req->Request));
         delete req;
     }
 }
@@ -2062,17 +2179,34 @@ void TClientEndpoint::PostLocalInvalidation(
     req->Stage = TInvalidationRequest::EStage::Inflight;
     InflightInvalidationRequests.PushBack(req);
     send->context = req;
+    Y_ABORT_UNLESS(tail);
+    tail->send_flags |= IBV_SEND_SIGNALED;
+    AcquireHardwareResources(req->Resources);
 
+    ibv_send_wr* badWr = nullptr;
     try {
-        Verbs->PostSend(Connection->qp, head);
+        Verbs->PostSend(Connection->qp, head, &badWr);
         RDMA_TRACE(send << " local invalidate posted");
     } catch (const TServiceError& e) {
         RDMA_ERROR(send << " " << e.what());
         send->context = nullptr;
-        SendQueue.Push(send);
         Counters->Error();
         InflightInvalidationRequests.Remove(req);
-        FinalizeInvalidationRequest(req, true);
+        if (badWr == head) {
+            ReleaseHardwareResources(req->Resources);
+            SendQueue.Push(send);
+            FinalizeInvalidationRequest(req, false);
+        } else {
+            // At least one invalidation was accepted. Its MW must remain alive
+            // until QP destruction even though no terminal WR was posted.
+            req->Stage = TInvalidationRequest::EStage::Retired;
+            if (req->Resources) {
+                req->Resources->RecyclePolicy =
+                    TRequestResources::ERecyclePolicy::Drop;
+            }
+            PartiallyPostedInvalidationRequests.PushBack(req);
+            ++QpOwnedSendSlots;
+        }
         Disconnect();
     }
 }
@@ -2092,17 +2226,18 @@ void TClientEndpoint::HandlePendingInvalidationRequests() noexcept
 void TClientEndpoint::LocalInvalidationCompleted(TSendWr* send) noexcept
 {
     auto* rawReq = static_cast<TInvalidationRequest*>(send->context);
-    send->context = nullptr;
-    SendQueue.Push(send);
-
     if (!rawReq) {
-        RDMA_WARN(send << " local invalidation request not found");
+        RDMA_TRACE(send << " duplicate local invalidation completion");
         return;
     }
+
+    send->context = nullptr;
+    SendQueue.Push(send);
 
     switch (rawReq->Stage) {
         case TInvalidationRequest::EStage::Inflight:
             InflightInvalidationRequests.Remove(rawReq);
+            ReleaseHardwareResources(rawReq->Resources);
             if (!rawReq->Finalized) {
                 FinalizeRequest(std::move(rawReq->Request));
             }
@@ -2112,6 +2247,9 @@ void TClientEndpoint::LocalInvalidationCompleted(TSendWr* send) noexcept
 
         case TInvalidationRequest::EStage::Retired:
             RetiredInvalidationRequests.Remove(rawReq);
+            Y_ABORT_UNLESS(QpOwnedSendSlots.load() > 0);
+            --QpOwnedSendSlots;
+            ReleaseHardwareResources(rawReq->Resources);
             delete rawReq;
             return;
 

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -464,7 +464,7 @@ struct TRequestResources
     // Cleanup is performed only after the user releases TRequest and every
     // posted WR chain has either completed or been destroyed with its QP.
     bool UserReleased = false;
-    ui32 HardwareOwners = 0;
+    bool HardwareOwned = false;
 
     ui32 Status = RDMA_PROTO_FAIL;
     ui32 ResponseBytes = 0;
@@ -475,17 +475,10 @@ struct TRequestResources
 struct TInvalidationRequest
     : TIntrusiveListItem<TInvalidationRequest>
 {
-    enum class EStage
-    {
-        Pending,
-        Inflight,
-        Retired,
-    };
-
     TRequestPtr Request;
     TRequestResourcesPtr Resources;
-    EStage Stage = EStage::Pending;
-    bool Finalized = false;
+    bool UserCompleted = false;
+    bool QpOwnedSendSlot = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -574,14 +567,14 @@ private:
     // Send slots whose terminal CQE is no longer required because the current
     // QP is committed to destruction.
     std::atomic<size_t> QpOwnedSendSlots = 0;
+    // Invalidations have only two ownership states: waiting for a send slot or
+    // already visible to hardware. Posted entries stay in one list until their
+    // terminal CQE or QP destruction; flags record whether the user callback
+    // and send-slot bookkeeping have already been completed.
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
         PendingInvalidationRequests;
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
-        InflightInvalidationRequests;
-    TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
-        RetiredInvalidationRequests;
-    TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
-        PartiallyPostedInvalidationRequests;
+        PostedInvalidationRequests;
     TActiveRequests ActiveRequests;
 
     std::atomic<ui64> ReqIdPool{0};
@@ -683,7 +676,8 @@ private:
         const NProto::TError& error) noexcept;
 
     // Invalidation flow.
-    void FinalizeInvalidationRequest(TInvalidationRequest* req, bool keepAlive) noexcept;
+    void CompleteInvalidationRequest(TInvalidationRequest* req) noexcept;
+    void MarkInvalidationAsQpOwned(TInvalidationRequest* req) noexcept;
     void DrainInvalidationRequests() noexcept;
     void PostNextPendingInvalidation(TSendWr* send) noexcept;
     void PostLocalInvalidation(TInvalidationRequest* req, TSendWr* send) noexcept;
@@ -939,13 +933,6 @@ void TClientEndpoint::DestroyQP() noexcept
         }
     }
 
-    while (RetiredInvalidationRequests) {
-        auto* req = RetiredInvalidationRequests.PopFront();
-        Y_ABORT_UNLESS(req);
-        ReleaseHardwareResources(req->Resources);
-        delete req;
-    }
-
     while (auto req = PartiallyPostedRequests.Dequeue()) {
         AbortRequest(
             std::move(req),
@@ -953,11 +940,14 @@ void TClientEndpoint::DestroyQP() noexcept
             MakeError(E_RDMA_UNAVAILABLE, "failed to post complete send chain"));
     }
 
-    while (PartiallyPostedInvalidationRequests) {
-        auto* req = PartiallyPostedInvalidationRequests.PopFront();
+    while (PostedInvalidationRequests) {
+        auto* req = PostedInvalidationRequests.PopFront();
         Y_ABORT_UNLESS(req);
         ReleaseHardwareResources(req->Resources);
-        FinalizeInvalidationRequest(req, false);
+        if (!req->UserCompleted) {
+            CompleteInvalidationRequest(req);
+        }
+        delete req;
     }
     QpOwnedSendSlots = 0;
 
@@ -1325,8 +1315,11 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
                 RDMA_TRACE(send << " local invalidate completion already handled");
                 return;
             }
+            auto* req = static_cast<TInvalidationRequest*>(send->context);
             send->context = nullptr;
-            SendQueue.Push(send);
+            // A failed LOCAL_INV may be followed by another WQE from the same
+            // chain. Quarantine the slot and retain resources until QP destroy.
+            MarkInvalidationAsQpOwned(req);
         };
         auto handleRequestSendCompletion = [&] (NProto::TError error) {
             const ui32 reqId =
@@ -1888,7 +1881,6 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept
         auto* invalidationRequest = new TInvalidationRequest();
         invalidationRequest->Resources = req->Resources;
         invalidationRequest->Request = std::move(req);
-        invalidationRequest->Stage = TInvalidationRequest::EStage::Pending;
         PendingInvalidationRequests.PushBack(invalidationRequest);
         HandlePendingInvalidationRequests();
         return;
@@ -1974,8 +1966,7 @@ bool TClientEndpoint::ClientRequestsFlushed() const
         && !InputRequests
         && !QueuedRequests
         && !CancelRequests
-        && !PendingInvalidationRequests
-        && !InflightInvalidationRequests;
+        && !PendingInvalidationRequests;
 }
 
 bool TClientEndpoint::WorkRequestsFlushed() const
@@ -1983,8 +1974,7 @@ bool TClientEndpoint::WorkRequestsFlushed() const
     return SendQueue.Size() + QpOwnedSendSlots.load() ==
             Config.SendQueueSize
         && RecvQueue.Size() == Config.RecvQueueSize
-        && !PendingInvalidationRequests
-        && !InflightInvalidationRequests;
+        && !PendingInvalidationRequests;
 }
 
 bool TClientEndpoint::FlushHanging() const
@@ -2002,7 +1992,7 @@ void TClientEndpoint::ReleaseRequestResources(TRequestResourcesPtr resources) no
 
     with_lock (AllocationLock) {
         resources->UserReleased = true;
-        if (resources->HardwareOwners == 0) {
+        if (!resources->HardwareOwned) {
             CleanupRequestResourcesLocked(*resources);
         }
     }
@@ -2013,7 +2003,8 @@ void TClientEndpoint::AcquireHardwareResources(
 {
     Y_ABORT_UNLESS(resources);
     with_lock (AllocationLock) {
-        ++resources->HardwareOwners;
+        Y_ABORT_UNLESS(!resources->HardwareOwned);
+        resources->HardwareOwned = true;
     }
 }
 
@@ -2025,9 +2016,9 @@ void TClientEndpoint::ReleaseHardwareResources(
     }
 
     with_lock (AllocationLock) {
-        Y_ABORT_UNLESS(resources->HardwareOwners > 0);
-        --resources->HardwareOwners;
-        if (resources->HardwareOwners == 0 && resources->UserReleased) {
+        Y_ABORT_UNLESS(resources->HardwareOwned);
+        resources->HardwareOwned = false;
+        if (resources->UserReleased) {
             CleanupRequestResourcesLocked(*resources);
         }
     }
@@ -2086,23 +2077,25 @@ void TClientEndpoint::FinalizeRequest(TRequestPtr req) noexcept
         responseBytes);
 }
 
-void TClientEndpoint::FinalizeInvalidationRequest(
-    TInvalidationRequest* req,
-    bool keepAlive) noexcept
+void TClientEndpoint::CompleteInvalidationRequest(
+    TInvalidationRequest* req) noexcept
 {
     Y_ABORT_UNLESS(req);
-    req->Finalized = true;
+    Y_ABORT_UNLESS(!req->UserCompleted);
+    req->UserCompleted = true;
     if (req->Resources) {
         req->Resources->RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
     }
-    if (keepAlive) {
-        req->Stage = TInvalidationRequest::EStage::Retired;
-        RetiredInvalidationRequests.PushBack(req);
+    FinalizeRequest(std::move(req->Request));
+}
+
+void TClientEndpoint::MarkInvalidationAsQpOwned(
+    TInvalidationRequest* req) noexcept
+{
+    Y_ABORT_UNLESS(req);
+    if (!req->QpOwnedSendSlot) {
+        req->QpOwnedSendSlot = true;
         ++QpOwnedSendSlots;
-        FinalizeRequest(std::move(req->Request));
-    } else {
-        FinalizeRequest(std::move(req->Request));
-        delete req;
     }
 }
 
@@ -2111,13 +2104,15 @@ void TClientEndpoint::DrainInvalidationRequests() noexcept
     while (PendingInvalidationRequests) {
         auto* req = PendingInvalidationRequests.PopFront();
         Y_ABORT_UNLESS(req);
-        FinalizeInvalidationRequest(req, false);
+        CompleteInvalidationRequest(req);
+        delete req;
     }
 
-    while (InflightInvalidationRequests) {
-        auto* req = InflightInvalidationRequests.PopFront();
-        Y_ABORT_UNLESS(req);
-        FinalizeInvalidationRequest(req, true);
+    for (auto& req: PostedInvalidationRequests) {
+        MarkInvalidationAsQpOwned(&req);
+        if (!req.UserCompleted) {
+            CompleteInvalidationRequest(&req);
+        }
     }
 }
 
@@ -2176,8 +2171,7 @@ void TClientEndpoint::PostLocalInvalidation(
         return;
     }
 
-    req->Stage = TInvalidationRequest::EStage::Inflight;
-    InflightInvalidationRequests.PushBack(req);
+    PostedInvalidationRequests.PushBack(req);
     send->context = req;
     Y_ABORT_UNLESS(tail);
     tail->send_flags |= IBV_SEND_SIGNALED;
@@ -2191,21 +2185,21 @@ void TClientEndpoint::PostLocalInvalidation(
         RDMA_ERROR(send << " " << e.what());
         send->context = nullptr;
         Counters->Error();
-        InflightInvalidationRequests.Remove(req);
+        PostedInvalidationRequests.Remove(req);
         if (badWr == head) {
             ReleaseHardwareResources(req->Resources);
             SendQueue.Push(send);
-            FinalizeInvalidationRequest(req, false);
+            CompleteInvalidationRequest(req);
+            delete req;
         } else {
             // At least one invalidation was accepted. Its MW must remain alive
             // until QP destruction even though no terminal WR was posted.
-            req->Stage = TInvalidationRequest::EStage::Retired;
             if (req->Resources) {
                 req->Resources->RecyclePolicy =
                     TRequestResources::ERecyclePolicy::Drop;
             }
-            PartiallyPostedInvalidationRequests.PushBack(req);
-            ++QpOwnedSendSlots;
+            PostedInvalidationRequests.PushBack(req);
+            MarkInvalidationAsQpOwned(req);
         }
         Disconnect();
     }
@@ -2234,29 +2228,17 @@ void TClientEndpoint::LocalInvalidationCompleted(TSendWr* send) noexcept
     send->context = nullptr;
     SendQueue.Push(send);
 
-    switch (rawReq->Stage) {
-        case TInvalidationRequest::EStage::Inflight:
-            InflightInvalidationRequests.Remove(rawReq);
-            ReleaseHardwareResources(rawReq->Resources);
-            if (!rawReq->Finalized) {
-                FinalizeRequest(std::move(rawReq->Request));
-            }
-            delete rawReq;
-            HandlePendingInvalidationRequests();
-            return;
-
-        case TInvalidationRequest::EStage::Retired:
-            RetiredInvalidationRequests.Remove(rawReq);
-            Y_ABORT_UNLESS(QpOwnedSendSlots.load() > 0);
-            --QpOwnedSendSlots;
-            ReleaseHardwareResources(rawReq->Resources);
-            delete rawReq;
-            return;
-
-        case TInvalidationRequest::EStage::Pending:
-            RDMA_WARN(send << " local invalidation request in pending stage");
-            return;
+    PostedInvalidationRequests.Remove(rawReq);
+    if (rawReq->QpOwnedSendSlot) {
+        Y_ABORT_UNLESS(QpOwnedSendSlots.load() > 0);
+        --QpOwnedSendSlots;
     }
+    ReleaseHardwareResources(rawReq->Resources);
+    if (!rawReq->UserCompleted) {
+        FinalizeRequest(std::move(rawReq->Request));
+    }
+    delete rawReq;
+    HandlePendingInvalidationRequests();
 }
 
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -458,6 +458,7 @@ struct TRequestResources
     ERecyclePolicy RecyclePolicy = ERecyclePolicy::Recycle;
     EOutInvalidationMode OutInvalidationMode = EOutInvalidationMode::None;
     ui32 ExpectedInvalidatedRKey = 0;
+    ui64 BufferPoolGeneration = 0;
     bool AbortPending = false;
     ui32 AbortError = RDMA_PROTO_FAIL;
     TString AbortMessage;
@@ -492,14 +493,6 @@ struct TInvalidationRequestDelete
     {
         delete req;
     }
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-struct TCompletedRequestResources
-    : TListNode<TCompletedRequestResources>
-{
-    TRequestResourcesPtr Resources;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -546,6 +539,7 @@ private:
 
     TBufferPool SendBuffers;
     TBufferPool RecvBuffers;
+    std::atomic<ui64> BufferPoolGeneration = 0;
     TMutex AllocationLock;
     TVector<NVerbs::TMemoryWindowPtr> FreeMemoryWindows;
     size_t MaxFreeMemoryWindows = 0;
@@ -579,8 +573,6 @@ private:
         InflightInvalidationRequests;
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
         RetiredInvalidationRequests;
-    TLockFreeList<TCompletedRequestResources> CompletedRequestResources;
-    TSimpleList<TCompletedRequestResources> CompletedRequestResourcesQueue;
     TActiveRequests ActiveRequests;
 
     std::atomic<ui64> ReqIdPool{0};
@@ -651,13 +643,14 @@ public:
 private:
     // called from CQ thread
     void HandleQueuedRequests() noexcept;
-    void DrainCompletedRequestResources() noexcept;
     void ReleaseRequestResources(TRequestResourcesPtr resources) noexcept;
     void SendRequest(TRequestPtr req, TSendWr* send) noexcept;
     void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
     void FinalizeRequest(TRequestPtr req) noexcept;
     void FinalizeInvalidationRequest(TInvalidationRequest* req, bool keepAlive) noexcept;
+    void DrainInvalidationRequestsOnDisconnect() noexcept;
+    void PostNextPendingInvalidation(TSendWr* send) noexcept;
     void PostLocalInvalidation(TInvalidationRequest* req, TSendWr* send) noexcept;
     void HandlePendingInvalidationRequests() noexcept;
     void LocalInvalidationCompleted(TSendWr* send) noexcept;
@@ -672,7 +665,23 @@ private:
         ibv_wc* wc,
         TRequestResources& resources) noexcept;
     bool NeedLocalInvalidation(const TRequestResources& resources) const noexcept;
-    bool DeferAbortUntilSendCompletion(
+    bool ConsumeDeferredAbortIfAny(
+        TRequestResources& resources,
+        ui32& err,
+        TString& msg) noexcept;
+    void AbortRequestWithAccounting(
+        TRequestPtr req,
+        ui32 err,
+        TString msg) noexcept;
+    void AbortDequeuedRequest(
+        TRequestPtr req,
+        ui32 err,
+        TString msg) noexcept;
+    bool TryDeferAbortUntilSendCompletion(
+        TRequestPtr& req,
+        ui32 err,
+        TString msg) noexcept;
+    void AbortActiveRequestOrDefer(
         TRequestPtr& req,
         ui32 err,
         TString msg) noexcept;
@@ -768,6 +777,8 @@ void TClientEndpoint::ChangeState(
 
 void TClientEndpoint::CreateQP()
 {
+    ++BufferPoolGeneration;
+
     CompletionChannel = Verbs->CreateCompletionChannel(Connection->verbs);
     SetNonBlock(CompletionChannel->fd, true);
 
@@ -970,6 +981,7 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         std::move(handler),
         std::move(context));
     req->Resources = MakeIntrusive<TRequestResources>();
+    req->Resources->BufferPoolGeneration = BufferPoolGeneration.load();
 
     try {
         with_lock (AllocationLock) {
@@ -1051,8 +1063,6 @@ bool TClientEndpoint::HandleInputRequests() noexcept
         RequestEvent.Clear();
     }
 
-    DrainCompletedRequestResources();
-
     auto requests = InputRequests.DequeueAll();
     if (!requests) {
         return false;
@@ -1065,8 +1075,6 @@ bool TClientEndpoint::HandleInputRequests() noexcept
 
 void TClientEndpoint::HandleQueuedRequests() noexcept
 {
-    DrainCompletedRequestResources();
-
     while (QueuedRequests || PendingInvalidationRequests) {
         if (CheckState(EEndpointState::Connected)) {
             auto* send = SendQueue.Pop();
@@ -1076,9 +1084,7 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
             }
 
             if (PendingInvalidationRequests) {
-                auto* req = PendingInvalidationRequests.PopFront();
-                Y_ABORT_UNLESS(req);
-                PostLocalInvalidation(req, send);
+                PostNextPendingInvalidation(send);
                 continue;
             }
 
@@ -1089,25 +1095,17 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
             SendRequest(std::move(req), send);
         }
         else {
-            while (PendingInvalidationRequests) {
-                auto* req = PendingInvalidationRequests.PopFront();
-                Y_ABORT_UNLESS(req);
-                FinalizeInvalidationRequest(req, false);
-            }
-
-            while (InflightInvalidationRequests) {
-                auto* req = InflightInvalidationRequests.PopFront();
-                Y_ABORT_UNLESS(req);
-                FinalizeInvalidationRequest(req, true);
-            }
+            DrainInvalidationRequestsOnDisconnect();
 
             auto req = QueuedRequests.Dequeue();
             if (!req) {
                 break;
             }
 
-            Counters->RequestDequeued();
-            AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
+            AbortDequeuedRequest(
+                std::move(req),
+                E_RDMA_UNAVAILABLE,
+                "endpoint is unavailable");
         }
     }
 }
@@ -1167,24 +1165,20 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
     cancelled.Append(QueuedRequests.DequeueIf(wasCancelled));
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
-        Counters->RequestDequeued();
-        AbortRequest(std::move(req), E_CANCELLED, "request was cancelled");
+        AbortDequeuedRequest(
+            std::move(req),
+            E_CANCELLED,
+            "request was cancelled");
     }
 
     // cancel active requests
     cancelled.Append(ActiveRequests.PopCancelledRequests(clientRequestIdToCancel));
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
-        if (DeferAbortUntilSendCompletion(
-                req,
-                E_CANCELLED,
-                "request was cancelled"))
-        {
-            continue;
-        }
-
-        Counters->RequestAborted();
-        AbortRequest(std::move(req), E_CANCELLED, "request was cancelled");
+        AbortActiveRequestOrDefer(
+            req,
+            E_CANCELLED,
+            "request was cancelled");
     }
 
     if (!requests) {
@@ -1202,8 +1196,6 @@ void TClientEndpoint::AbortRequests() noexcept
         AbortRequestsEvent.Clear();
     }
 
-    DrainCompletedRequestResources();
-
     if (!CheckState(EEndpointState::Disconnecting)) {
         return;
     }
@@ -1217,8 +1209,10 @@ void TClientEndpoint::AbortRequests() noexcept
         auto req = QueuedRequests.Dequeue();
         Y_ABORT_UNLESS(req);
         RDMA_DEBUG("abort request " << req->ReqId);
-        Counters->RequestDequeued();
-        AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
+        AbortDequeuedRequest(
+            std::move(req),
+            E_RDMA_UNAVAILABLE,
+            "endpoint is unavailable");
     }
 
     TSimpleList<TRequest> activeRequests;
@@ -1228,29 +1222,13 @@ void TClientEndpoint::AbortRequests() noexcept
 
     while (auto req = activeRequests.Dequeue()) {
         RDMA_DEBUG("abort request " << req->ReqId);
-        if (DeferAbortUntilSendCompletion(
-                req,
-                E_RDMA_UNAVAILABLE,
-                "endpoint is unavailable"))
-        {
-            continue;
-        }
-
-        Counters->RequestAborted();
-        AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
+        AbortActiveRequestOrDefer(
+            req,
+            E_RDMA_UNAVAILABLE,
+            "endpoint is unavailable");
     }
 
-    while (PendingInvalidationRequests) {
-        auto* req = PendingInvalidationRequests.PopFront();
-        Y_ABORT_UNLESS(req);
-        FinalizeInvalidationRequest(req, false);
-    }
-
-    while (InflightInvalidationRequests) {
-        auto* req = InflightInvalidationRequests.PopFront();
-        Y_ABORT_UNLESS(req);
-        FinalizeInvalidationRequest(req, true);
-    }
+    DrainInvalidationRequestsOnDisconnect();
 }
 
 void TClientEndpoint::AbortRequest(
@@ -1537,8 +1515,7 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
         // so no completion/flush can arrive for this request.
         Counters->SendRequestCompleted();
         if (auto failedReq = ActiveRequests.Pop(req->ReqId)) {
-            Counters->RequestAborted();
-            AbortRequest(
+            AbortRequestWithAccounting(
                 std::move(failedReq),
                 E_RDMA_UNAVAILABLE,
                 "failed to post send request");
@@ -1625,7 +1602,51 @@ bool TClientEndpoint::NeedLocalInvalidation(
           resources.OutBuffer.Length));
 }
 
-bool TClientEndpoint::DeferAbortUntilSendCompletion(
+// Deferred-abort helpers for requests still in SendRequest stage.
+bool TClientEndpoint::ConsumeDeferredAbortIfAny(
+    TRequestResources& resources,
+    ui32& err,
+    TString& msg) noexcept
+{
+    if (!resources.AbortPending) {
+        return false;
+    }
+
+    err = resources.AbortError;
+    msg = std::move(resources.AbortMessage);
+    resources.AbortPending = false;
+    resources.AbortMessage.clear();
+    resources.AbortError = RDMA_PROTO_FAIL;
+    return true;
+}
+
+void TClientEndpoint::AbortRequestWithAccounting(
+    TRequestPtr req,
+    ui32 err,
+    TString msg) noexcept
+{
+    if (!req) {
+        return;
+    }
+
+    Counters->RequestAborted();
+    AbortRequest(std::move(req), err, msg);
+}
+
+void TClientEndpoint::AbortDequeuedRequest(
+    TRequestPtr req,
+    ui32 err,
+    TString msg) noexcept
+{
+    if (!req) {
+        return;
+    }
+
+    Counters->RequestDequeued();
+    AbortRequest(std::move(req), err, msg);
+}
+
+bool TClientEndpoint::TryDeferAbortUntilSendCompletion(
     TRequestPtr& req,
     ui32 err,
     TString msg) noexcept
@@ -1649,6 +1670,18 @@ bool TClientEndpoint::DeferAbortUntilSendCompletion(
     return true;
 }
 
+void TClientEndpoint::AbortActiveRequestOrDefer(
+    TRequestPtr& req,
+    ui32 err,
+    TString msg) noexcept
+{
+    if (TryDeferAbortUntilSendCompletion(req, err, msg)) {
+        return;
+    }
+
+    AbortRequestWithAccounting(std::move(req), err, std::move(msg));
+}
+
 void TClientEndpoint::FinalizeDeferredAbort(ui32 reqId) noexcept
 {
     auto* req = ActiveRequests.Get(reqId);
@@ -1661,14 +1694,13 @@ void TClientEndpoint::FinalizeDeferredAbort(ui32 reqId) noexcept
         return;
     }
 
-    ui32 err = abortedReq->Resources->AbortError;
-    TString msg = std::move(abortedReq->Resources->AbortMessage);
-    abortedReq->Resources->AbortPending = false;
-    abortedReq->Resources->AbortMessage.clear();
-    abortedReq->Resources->AbortError = RDMA_PROTO_FAIL;
+    ui32 err = RDMA_PROTO_FAIL;
+    TString msg;
+    if (!ConsumeDeferredAbortIfAny(*abortedReq->Resources, err, msg)) {
+        return;
+    }
 
-    Counters->RequestAborted();
-    AbortRequest(std::move(abortedReq), err, msg);
+    AbortRequestWithAccounting(std::move(abortedReq), err, std::move(msg));
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1765,16 +1797,13 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept
         return;
     }
 
-    if (req->Resources && req->Resources->AbortPending) {
-        ui32 err = req->Resources->AbortError;
-        TString msg = std::move(req->Resources->AbortMessage);
-        req->Resources->AbortPending = false;
-        req->Resources->AbortMessage.clear();
-        req->Resources->AbortError = RDMA_PROTO_FAIL;
-
+    ui32 abortErr = RDMA_PROTO_FAIL;
+    TString abortMsg;
+    if (req->Resources &&
+        ConsumeDeferredAbortIfAny(*req->Resources, abortErr, abortMsg))
+    {
         RecvResponse(recv);
-        Counters->RequestAborted();
-        AbortRequest(std::move(req), err, msg);
+        AbortRequestWithAccounting(std::move(req), abortErr, std::move(abortMsg));
         return;
     }
 
@@ -1880,9 +1909,7 @@ bool TClientEndpoint::ClientRequestsFlushed() const
         && !QueuedRequests
         && !CancelRequests
         && !PendingInvalidationRequests
-        && !InflightInvalidationRequests
-        && !CompletedRequestResources
-        && !CompletedRequestResourcesQueue;
+        && !InflightInvalidationRequests;
 }
 
 bool TClientEndpoint::WorkRequestsFlushed() const
@@ -1890,9 +1917,7 @@ bool TClientEndpoint::WorkRequestsFlushed() const
     return SendQueue.Size() == Config.SendQueueSize
         && RecvQueue.Size() == Config.RecvQueueSize
         && !PendingInvalidationRequests
-        && !InflightInvalidationRequests
-        && !CompletedRequestResources
-        && !CompletedRequestResourcesQueue;
+        && !InflightInvalidationRequests;
 }
 
 bool TClientEndpoint::FlushHanging() const
@@ -1909,31 +1934,33 @@ void TClientEndpoint::ReleaseRequestResources(TRequestResourcesPtr resources) no
     }
 
     with_lock (AllocationLock) {
-        if (Config.UseMemoryWindows &&
-            resources->RecyclePolicy == TRequestResources::ERecyclePolicy::Recycle &&
-            Connection &&
-            Connection->qp)
-        {
-            RecycleMemoryWindowLocked(resources->InMemoryWindow);
-            RecycleMemoryWindowLocked(resources->OutMemoryWindow);
-        } else {
-            resources->InMemoryWindow = NVerbs::NullPtr;
-            resources->OutMemoryWindow = NVerbs::NullPtr;
+        const ui64 currentBufferPoolGeneration = BufferPoolGeneration.load();
+        const bool sameBufferPoolGeneration =
+            resources->BufferPoolGeneration == currentBufferPoolGeneration;
+
+        if (sameBufferPoolGeneration) {
+            if (Config.UseMemoryWindows &&
+                resources->RecyclePolicy == TRequestResources::ERecyclePolicy::Recycle &&
+                CheckState(EEndpointState::Connected))
+            {
+                RecycleMemoryWindowLocked(resources->InMemoryWindow);
+                RecycleMemoryWindowLocked(resources->OutMemoryWindow);
+            } else {
+                resources->InMemoryWindow = NVerbs::NullPtr;
+                resources->OutMemoryWindow = NVerbs::NullPtr;
+            }
+
+            SendBuffers.ReleaseBuffer(resources->InBuffer);
+            RecvBuffers.ReleaseBuffer(resources->OutBuffer);
+            return;
         }
 
-        SendBuffers.ReleaseBuffer(resources->InBuffer);
-        RecvBuffers.ReleaseBuffer(resources->OutBuffer);
-    }
-}
-
-void TClientEndpoint::DrainCompletedRequestResources() noexcept
-{
-    CompletedRequestResourcesQueue.Append(CompletedRequestResources.DequeueAll());
-
-    while (CompletedRequestResourcesQueue) {
-        auto completed = CompletedRequestResourcesQueue.Dequeue();
-        Y_ABORT_UNLESS(completed);
-        ReleaseRequestResources(std::move(completed->Resources));
+        // Late request destruction after reconnect: buffers belong to an older
+        // pool generation and cannot be safely released via current pool.
+        resources->InMemoryWindow = NVerbs::NullPtr;
+        resources->OutMemoryWindow = NVerbs::NullPtr;
+        resources->InBuffer = {};
+        resources->OutBuffer = {};
     }
 }
 
@@ -1975,6 +2002,29 @@ void TClientEndpoint::FinalizeInvalidationRequest(
     } else {
         delete req;
     }
+}
+
+void TClientEndpoint::DrainInvalidationRequestsOnDisconnect() noexcept
+{
+    while (PendingInvalidationRequests) {
+        auto* req = PendingInvalidationRequests.PopFront();
+        Y_ABORT_UNLESS(req);
+        FinalizeInvalidationRequest(req, false);
+    }
+
+    while (InflightInvalidationRequests) {
+        auto* req = InflightInvalidationRequests.PopFront();
+        Y_ABORT_UNLESS(req);
+        FinalizeInvalidationRequest(req, true);
+    }
+}
+
+void TClientEndpoint::PostNextPendingInvalidation(TSendWr* send) noexcept
+{
+    Y_ABORT_UNLESS(send);
+    auto* req = PendingInvalidationRequests.PopFront();
+    Y_ABORT_UNLESS(req);
+    PostLocalInvalidation(req, send);
 }
 
 void TClientEndpoint::PostLocalInvalidation(
@@ -2051,9 +2101,7 @@ void TClientEndpoint::HandlePendingInvalidationRequests() noexcept
             return;
         }
 
-        auto* req = PendingInvalidationRequests.PopFront();
-        Y_ABORT_UNLESS(req);
-        PostLocalInvalidation(req, send);
+        PostNextPendingInvalidation(send);
     }
 }
 
@@ -2095,13 +2143,7 @@ void TClientEndpoint::FreeRequest(TRequest* req) noexcept
         return;
     }
 
-    auto completed = std::make_unique<TCompletedRequestResources>();
-    completed->Resources = std::move(req->Resources);
-    CompletedRequestResources.Enqueue(std::move(completed));
-
-    if (WaitMode == EWaitMode::Poll) {
-        RequestEvent.Set();
-    }
+    ReleaseRequestResources(std::move(req->Resources));
 }
 
 NVerbs::TMemoryWindowPtr TClientEndpoint::AcquireMemoryWindowLocked()
@@ -2538,7 +2580,7 @@ private:
                     << "[peer=" << endpoint->Host << ":"
                     << endpoint->Port << "]";
 
-                if (endpoint->DeferAbortUntilSendCompletion(
+                if (endpoint->TryDeferAbortUntilSendCompletion(
                         request,
                         E_TIMEOUT,
                         timeoutMessage))
@@ -2546,11 +2588,10 @@ private:
                     continue;
                 }
 
-                endpoint->Counters->RequestAborted();
-                endpoint->AbortRequest(
+                endpoint->AbortRequestWithAccounting(
                     std::move(request),
                     E_TIMEOUT,
-                    timeoutMessage);
+                    std::move(timeoutMessage));
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -64,7 +64,7 @@ struct TRequest;
 using TRequestPtr = std::unique_ptr<TRequest>;
 
 struct TRequestResources;
-using TRequestResourcesPtr = TIntrusivePtr<TRequestResources>;
+using TRequestResourcesPtr = std::unique_ptr<TRequestResources>;
 
 struct TEndpointCounters;
 using TEndpointCountersPtr = std::shared_ptr<TEndpointCounters>;
@@ -434,7 +434,6 @@ struct TClientRequestId: TListNode<TClientRequestId>
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TRequestResources
-    : TAtomicRefCount<TRequestResources>
 {
     enum class ERecyclePolicy
     {
@@ -461,11 +460,6 @@ struct TRequestResources
     ui64 BufferPoolGeneration = 0;
     NProto::TError Error;
 
-    // Cleanup is performed only after the user releases TRequest and every
-    // posted WR chain has either completed or been destroyed with its QP.
-    bool UserReleased = false;
-    bool HardwareOwned = false;
-
     ui32 Status = RDMA_PROTO_FAIL;
     ui32 ResponseBytes = 0;
 };
@@ -476,8 +470,6 @@ struct TInvalidationRequest
     : TIntrusiveListItem<TInvalidationRequest>
 {
     TRequestPtr Request;
-    TRequestResourcesPtr Resources;
-    bool UserCompleted = false;
     bool QpOwnedSendSlot = false;
 };
 
@@ -696,8 +688,6 @@ private:
 
     // Resource lifetime and allocation helpers.
     void ReleaseRequestResources(TRequestResourcesPtr resources) noexcept;
-    void AcquireHardwareResources(const TRequestResourcesPtr& resources) noexcept;
-    void ReleaseHardwareResources(const TRequestResourcesPtr& resources) noexcept;
     void CleanupRequestResourcesLocked(TRequestResources& resources) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     NVerbs::TMemoryWindowPtr AcquireMemoryWindowLocked();
@@ -943,10 +933,7 @@ void TClientEndpoint::DestroyQP() noexcept
     while (PostedInvalidationRequests) {
         auto* req = PostedInvalidationRequests.PopFront();
         Y_ABORT_UNLESS(req);
-        ReleaseHardwareResources(req->Resources);
-        if (!req->UserCompleted) {
-            CompleteInvalidationRequest(req);
-        }
+        CompleteInvalidationRequest(req);
         delete req;
     }
     QpOwnedSendSlots = 0;
@@ -1010,7 +997,7 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         shared_from_this(),
         std::move(handler),
         std::move(context));
-    req->Resources = MakeIntrusive<TRequestResources>();
+    req->Resources = std::make_unique<TRequestResources>();
     req->Resources->BufferPoolGeneration = BufferPoolGeneration.load();
 
     try {
@@ -1879,7 +1866,6 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept
 
     if (needsLocalInvalidate) {
         auto* invalidationRequest = new TInvalidationRequest();
-        invalidationRequest->Resources = req->Resources;
         invalidationRequest->Request = std::move(req);
         PendingInvalidationRequests.PushBack(invalidationRequest);
         HandlePendingInvalidationRequests();
@@ -1991,36 +1977,7 @@ void TClientEndpoint::ReleaseRequestResources(TRequestResourcesPtr resources) no
     }
 
     with_lock (AllocationLock) {
-        resources->UserReleased = true;
-        if (!resources->HardwareOwned) {
-            CleanupRequestResourcesLocked(*resources);
-        }
-    }
-}
-
-void TClientEndpoint::AcquireHardwareResources(
-    const TRequestResourcesPtr& resources) noexcept
-{
-    Y_ABORT_UNLESS(resources);
-    with_lock (AllocationLock) {
-        Y_ABORT_UNLESS(!resources->HardwareOwned);
-        resources->HardwareOwned = true;
-    }
-}
-
-void TClientEndpoint::ReleaseHardwareResources(
-    const TRequestResourcesPtr& resources) noexcept
-{
-    if (!resources) {
-        return;
-    }
-
-    with_lock (AllocationLock) {
-        Y_ABORT_UNLESS(resources->HardwareOwned);
-        resources->HardwareOwned = false;
-        if (resources->UserReleased) {
-            CleanupRequestResourcesLocked(*resources);
-        }
+        CleanupRequestResourcesLocked(*resources);
     }
 }
 
@@ -2081,10 +2038,10 @@ void TClientEndpoint::CompleteInvalidationRequest(
     TInvalidationRequest* req) noexcept
 {
     Y_ABORT_UNLESS(req);
-    Y_ABORT_UNLESS(!req->UserCompleted);
-    req->UserCompleted = true;
-    if (req->Resources) {
-        req->Resources->RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
+    Y_ABORT_UNLESS(req->Request);
+    if (req->Request->Resources) {
+        req->Request->Resources->RecyclePolicy =
+            TRequestResources::ERecyclePolicy::Drop;
     }
     FinalizeRequest(std::move(req->Request));
 }
@@ -2110,8 +2067,9 @@ void TClientEndpoint::DrainInvalidationRequests() noexcept
 
     for (auto& req: PostedInvalidationRequests) {
         MarkInvalidationAsQpOwned(&req);
-        if (!req.UserCompleted) {
-            CompleteInvalidationRequest(&req);
+        if (req.Request && req.Request->Resources) {
+            req.Request->Resources->RecyclePolicy =
+                TRequestResources::ERecyclePolicy::Drop;
         }
     }
 }
@@ -2129,8 +2087,9 @@ void TClientEndpoint::PostLocalInvalidation(
     TSendWr* send) noexcept
 {
     Y_ABORT_UNLESS(req);
-    Y_ABORT_UNLESS(req->Resources);
-    auto* resources = req->Resources.Get();
+    Y_ABORT_UNLESS(req->Request);
+    Y_ABORT_UNLESS(req->Request->Resources);
+    auto* resources = req->Request->Resources.get();
     const bool needLocalInvalidateOut =
         resources->OutMode ==
         TRequestResources::EOutMode::LocalInvalidate;
@@ -2175,7 +2134,6 @@ void TClientEndpoint::PostLocalInvalidation(
     send->context = req;
     Y_ABORT_UNLESS(tail);
     tail->send_flags |= IBV_SEND_SIGNALED;
-    AcquireHardwareResources(req->Resources);
 
     ibv_send_wr* badWr = nullptr;
     try {
@@ -2187,15 +2145,14 @@ void TClientEndpoint::PostLocalInvalidation(
         Counters->Error();
         PostedInvalidationRequests.Remove(req);
         if (badWr == head) {
-            ReleaseHardwareResources(req->Resources);
             SendQueue.Push(send);
             CompleteInvalidationRequest(req);
             delete req;
         } else {
             // At least one invalidation was accepted. Its MW must remain alive
             // until QP destruction even though no terminal WR was posted.
-            if (req->Resources) {
-                req->Resources->RecyclePolicy =
+            if (req->Request && req->Request->Resources) {
+                req->Request->Resources->RecyclePolicy =
                     TRequestResources::ERecyclePolicy::Drop;
             }
             PostedInvalidationRequests.PushBack(req);
@@ -2233,10 +2190,7 @@ void TClientEndpoint::LocalInvalidationCompleted(TSendWr* send) noexcept
         Y_ABORT_UNLESS(QpOwnedSendSlots.load() > 0);
         --QpOwnedSendSlots;
     }
-    ReleaseHardwareResources(rawReq->Resources);
-    if (!rawReq->UserCompleted) {
-        FinalizeRequest(std::move(rawReq->Request));
-    }
+    FinalizeRequest(std::move(rawReq->Request));
     delete rawReq;
     HandlePendingInvalidationRequests();
 }

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -716,15 +716,15 @@ void TClientEndpoint::CreateQP()
         Verbs->RdmaCreateQP(Connection.get(), &qp_attrs);
     }
 
-    int sendAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
-    int recvAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
-    if (Config.UseMemoryWindows) {
-        sendAccessFlags |= IBV_ACCESS_MW_BIND;
-        recvAccessFlags |= IBV_ACCESS_MW_BIND;
-    }
+    SendBuffers.Init(
+        Verbs,
+        Connection->pd,
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
 
-    SendBuffers.Init(Verbs, Connection->pd, sendAccessFlags);
-    RecvBuffers.Init(Verbs, Connection->pd, recvAccessFlags);
+    RecvBuffers.Init(
+        Verbs,
+        Connection->pd,
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
 
     SendBuffer = SendBuffers.AcquireBuffer(
         Config.SendQueueSize * sizeof(TRequestMessage), true);
@@ -860,16 +860,12 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         with_lock (AllocationLock) {
             if (requestBytes) {
                 req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
-                if (Config.UseMemoryWindows) {
-                    req->InMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
-                }
+                req->InMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
             }
 
             if (responseBytes) {
                 req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
-                if (Config.UseMemoryWindows) {
-                    req->OutMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
-                }
+                req->OutMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
             }
         }
     } catch (...) {
@@ -1265,7 +1261,7 @@ void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
 
     try {
         Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE("bind request " << req->ReqId << " input buffer");
+        RDMA_TRACE("bind request " << reqId << " input buffer");
         RDMA_TRACE(wr << "[request=" << req->ReqId << "]" << " posted");
     }
     catch (const TServiceError& e) {
@@ -1361,13 +1357,9 @@ void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
                 RDMA_ERROR(
                     "bind " << send->wr << " completed in unexpected state "
                             << req->State);
-                SendQueue.Push(send);
-                Disconnect();
         }
-        return;
     }
-    // request has been cancelled/aborted before bind completed
-    SendQueue.Push(send);
+    // request has been cancelled before bind completed
 }
 
 void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
@@ -1575,11 +1567,6 @@ bool TClientEndpoint::FlushHanging() const
 
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
-    // Memory windows must be deallocated before releasing pooled buffers/MRs
-    // they were bound to.
-    req->InMemoryWindow = NVerbs::NullPtr;
-    req->OutMemoryWindow = NVerbs::NullPtr;
-
     with_lock (AllocationLock) {
         SendBuffers.ReleaseBuffer(req->InBuffer);
         RecvBuffers.ReleaseBuffer(req->OutBuffer);

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -75,6 +75,32 @@ using TCompletionPollerPtr = std::unique_ptr<TCompletionPoller>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum class ERequestState
+{
+    BindInBuffer,
+    BindOutBuffer,
+    SendRequest,
+    RecvResponse,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+inline IOutputStream& operator<<(IOutputStream& out, ERequestState state)
+{
+    static const char* string[] = {
+        "BindInBuffer",
+        "BindOutBuffer",
+        "SendRequest",
+        "RecvResponse",
+    };
+    if (static_cast<size_t>(state) < Y_ARRAY_SIZE(string)) {
+        return out << string[static_cast<size_t>(state)];
+    }
+    return out << "Undefined";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TRequest
     : TClientRequest
     , TListNode<TRequest>
@@ -89,6 +115,11 @@ struct TRequest
 
     TPooledBuffer InBuffer{};
     TPooledBuffer OutBuffer{};
+
+    NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
+    NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
+
+    ERequestState State;
 
     TRequest(
             std::weak_ptr<TClientEndpoint> endpoint,
@@ -472,14 +503,11 @@ private:
     TWorkQueue<TSendWr> SendQueue;
     TWorkQueue<TRecvWr> RecvQueue;
 
-    union {
-        const ui64 Id = RandomNumber(Max<ui64>());
-        struct {
-            const ui32 RecvMagic;
-            const ui32 SendMagic;
-        };
-    };
+    const ui64 Id = RandomNumber(Max<ui64>());
     ui16 Generation = Max<ui16>();
+
+    const ui32 RecvMagic = RandomNumber(Max<ui32>());
+    const ui32 SendMagic = RecvMagic ^ (1u << 31);
 
     TLockFreeList<TRequest> InputRequests;
     TLockFreeList<TClientRequestId> CancelRequests;
@@ -559,7 +587,11 @@ private:
     // called from CQ thread
     void HandleQueuedRequests() noexcept;
     void SendRequest(TRequestPtr req, TSendWr* send) noexcept;
+    void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
+    void BindInBuffer(TRequest* req, TSendWr* send) noexcept;
+    void BindOutBuffer(TRequest* req, TSendWr* send) noexcept;
+    void BindCompleted(TSendWr* send) noexcept;
     void RecvResponse(TRecvWr* recv) noexcept;
     void RecvResponseCompleted(TRecvWr* recv) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
@@ -828,9 +860,12 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         with_lock (AllocationLock) {
             if (requestBytes) {
                 req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
+                req->InMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
             }
+
             if (responseBytes) {
                 req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
+                req->OutMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
             }
         }
     } catch (...) {
@@ -1088,7 +1123,7 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
             SendQueue.Push(send);
             return -1;
         }
-        if (wc->opcode != IBV_WC_SEND) {
+        if (wc->opcode != IBV_WC_SEND && wc->opcode != IBV_WC_BIND_MW) {
             RDMA_ERROR(
                 send << " unexpected opcode "
                      << NVerbs::GetOpcodeName(wc->opcode));
@@ -1144,6 +1179,13 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
     }
 
     switch (wc->opcode) {
+        case IBV_WC_BIND_MW: {
+            TSendWr* send = &SendWrs[id.Index];
+            RDMA_TRACE(wc->opcode << " " << id << " completed")
+            BindCompleted(send);
+            break;
+        }
+
         case IBV_WC_SEND: {
             TSendWr* send = &SendWrs[id.Index];
             RDMA_TRACE(send << " completed");
@@ -1164,29 +1206,165 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
     }
 }
 
-void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send) noexcept
+void TClientEndpoint::SendRequest(TRequestPtr request, TSendWr* send) noexcept
 {
-    req->ReqId = ActiveRequests.CreateId();
+    // hand request over to simplify error handling
+    auto* req = request.get();
+    request->ReqId = ActiveRequests.CreateId();
+    ActiveRequests.Push(std::move(request));
 
-    auto* requestMsg = send->Message();
-    Zero(*requestMsg);
+    send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
 
-    InitMessageHeader(requestMsg, NegotiatedProtocolVersion);
+    auto* msg = send->Message();
+    Zero(*msg);
 
-    requestMsg->ReqId = req->ReqId;
-    requestMsg->In = req->InBuffer;
-    requestMsg->Out = req->OutBuffer;
+    InitMessageHeader(msg, NegotiatedProtocolVersion);
+
+    msg->ReqId = req->ReqId;
+    msg->In = req->InBuffer;
+    msg->Out = req->OutBuffer;
+
+    if (Config.UseMemoryWindows) {
+        BindInBuffer(req, send);
+    } else {
+        SendRequest(req, send);
+    }
+}
+
+void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::BindInBuffer;
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_BIND_MW,
+        .bind_mw = {
+            .mw = req->InMemoryWindow.get(),
+            .rkey = req->InMemoryWindow->rkey,
+            .bind_info = {
+                .mr = req->InBuffer.GetMemoryRegion(),
+                .addr = req->InBuffer.Address,
+                .length = req->InBuffer.Length,
+                .mw_access_flags = IBV_ACCESS_REMOTE_READ,
+            },
+        },
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE("bind request " << reqId << " input buffer");
+        RDMA_TRACE(wr << "[request=" << req->ReqId << "]" << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        BindInBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::BindOutBuffer(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::BindOutBuffer;
+
+    ibv_send_wr wr = {
+        .wr_id = send->wr.wr_id,
+        .opcode = IBV_WR_BIND_MW,
+        .bind_mw = {
+            .mw = req->OutMemoryWindow.get(),
+            .rkey = req->OutMemoryWindow->rkey,
+            .bind_info = {
+                .mr = req->OutBuffer.GetMemoryRegion(),
+                .addr = req->OutBuffer.Address,
+                .length = req->OutBuffer.Length,
+                .mw_access_flags = IBV_ACCESS_REMOTE_WRITE,
+            },
+        },
+    };
+
+    try {
+        Verbs->PostSend(Connection->qp, &wr);
+        RDMA_TRACE(wr << " posted");
+    }
+    catch (const TServiceError& e) {
+        RDMA_ERROR(wr << " " << e.what());
+        SendQueue.Push(send);
+        Counters->Error();
+        Disconnect();
+        return;
+    }
+
+    LWTRACK(
+        BindOutBufferStarted,
+        req->CallContext->LWOrbit,
+        req->CallContext->RequestId);
+}
+
+void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
+{
+    const ui32 reqId =
+        SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
+
+    if (auto* req = ActiveRequests.Get(reqId)) {
+        switch (req->State) {
+            case ERequestState::BindInBuffer:
+                LWTRACK(
+                    BindInBufferCompleted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
+
+                RDMA_DEBUG(
+                    "change request #" << req->ReqId << " input buffer rkey: "
+                                       << req->InBuffer.RKey << " -> "
+                                       << req->InMemoryWindow->rkey);
+
+                send->Message()->In.RKey = req->InMemoryWindow->rkey;
+                BindOutBuffer(req, send);
+                break;
+
+            case ERequestState::BindOutBuffer:
+                LWTRACK(
+                    BindOutBufferCompleted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
+
+                RDMA_DEBUG(
+                    "change request #" << req->ReqId << " output buffer rkey: "
+                                       << req->OutBuffer.RKey << " -> "
+                                       << req->OutMemoryWindow->rkey);
+
+                send->Message()->Out.RKey = req->OutMemoryWindow->rkey;
+                SendRequest(req, send);
+                break;
+
+            default:
+                Counters->Error();
+                RDMA_ERROR(
+                    "bind " << send->wr << " completed in unexpected state "
+                            << req->State);
+        }
+    }
+    // request has been cancelled before bind completed
+}
+
+void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
+{
+    req->State = ERequestState::SendRequest;
 
     try {
         Verbs->PostSend(Connection->qp, &send->wr);
         RDMA_TRACE(send << " posted");
-
-    } catch (const TServiceError& e) {
+    }
+    catch (const TServiceError& e) {
         RDMA_ERROR(send << " " << e.what());
         SendQueue.Push(send);
         Counters->Error();
-        Counters->RequestEnqueued();
-        QueuedRequests.Enqueue(std::move(req));
         Disconnect();
         return;
     }
@@ -1197,9 +1375,6 @@ void TClientEndpoint::SendRequest(TRequestPtr req, TSendWr* send) noexcept
         req->CallContext->RequestId);
 
     Counters->SendRequestStarted();
-
-    send->context = reinterpret_cast<void*>(static_cast<uintptr_t>(req->ReqId));
-    ActiveRequests.Push(std::move(req));
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1215,6 +1390,8 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
             SendRequestCompleted,
             req->CallContext->LWOrbit,
             req->CallContext->RequestId);
+
+        req->State = ERequestState::RecvResponse;
     }
     // request has already been completed
 }

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -28,7 +28,9 @@
 #include <util/datetime/base.h>
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
+#include <util/generic/intrlist.h>
 #include <util/generic/map.h>
+#include <util/generic/ptr.h>
 #include <util/generic/vector.h>
 #include <util/network/interface.h>
 #include <util/random/random.h>
@@ -61,6 +63,9 @@ constexpr TDuration INSTANT_RECONNECT_DELAY = TDuration::MicroSeconds(1);
 struct TRequest;
 using TRequestPtr = std::unique_ptr<TRequest>;
 
+struct TRequestResources;
+using TRequestResourcesPtr = TIntrusivePtr<TRequestResources>;
+
 struct TEndpointCounters;
 using TEndpointCountersPtr = std::shared_ptr<TEndpointCounters>;
 
@@ -77,27 +82,9 @@ using TCompletionPollerPtr = std::unique_ptr<TCompletionPoller>;
 
 enum class ERequestState
 {
-    BindInBuffer,
-    BindOutBuffer,
     SendRequest,
     RecvResponse,
 };
-
-////////////////////////////////////////////////////////////////////////////////
-
-inline IOutputStream& operator<<(IOutputStream& out, ERequestState state)
-{
-    static const char* string[] = {
-        "BindInBuffer",
-        "BindOutBuffer",
-        "SendRequest",
-        "RecvResponse",
-    };
-    if (static_cast<size_t>(state) < Y_ARRAY_SIZE(string)) {
-        return out << string[static_cast<size_t>(state)];
-    }
-    return out << "Undefined";
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -113,11 +100,7 @@ struct TRequest
     ui32 ReqId = 0;   // 16-bit RDMA request id
     ui64 ClientReqId = 0;
 
-    TPooledBuffer InBuffer{};
-    TPooledBuffer OutBuffer{};
-
-    NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
-    NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
+    TRequestResourcesPtr Resources;
 
     ERequestState State;
 
@@ -450,6 +433,77 @@ struct TClientRequestId: TListNode<TClientRequestId>
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TRequestResources
+    : TAtomicRefCount<TRequestResources>
+{
+    enum class ERecyclePolicy
+    {
+        Recycle,
+        Drop,
+    };
+
+    enum class EOutInvalidationMode
+    {
+        None,
+        Remote,
+        Local,
+    };
+
+    TPooledBuffer InBuffer{};
+    TPooledBuffer OutBuffer{};
+
+    NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
+    NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
+
+    ERecyclePolicy RecyclePolicy = ERecyclePolicy::Recycle;
+    EOutInvalidationMode OutInvalidationMode = EOutInvalidationMode::None;
+    ui32 ExpectedInvalidatedRKey = 0;
+    bool AbortPending = false;
+    ui32 AbortError = RDMA_PROTO_FAIL;
+    TString AbortMessage;
+
+    ui32 Status = RDMA_PROTO_FAIL;
+    ui32 ResponseBytes = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TInvalidationRequest
+    : TIntrusiveListItem<TInvalidationRequest>
+{
+    enum class EStage
+    {
+        Pending,
+        Inflight,
+        Retired,
+    };
+
+    TRequestPtr Request;
+    TRequestResourcesPtr Resources;
+    EStage Stage = EStage::Pending;
+    bool Finalized = false;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TInvalidationRequestDelete
+{
+    static void Destroy(TInvalidationRequest* req)
+    {
+        delete req;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCompletedRequestResources
+    : TListNode<TCompletedRequestResources>
+{
+    TRequestResourcesPtr Resources;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TClientEndpoint final
     : public IClientEndpoint
     , public NVerbs::ICompletionHandler
@@ -493,6 +547,8 @@ private:
     TBufferPool SendBuffers;
     TBufferPool RecvBuffers;
     TMutex AllocationLock;
+    TVector<NVerbs::TMemoryWindowPtr> FreeMemoryWindows;
+    size_t MaxFreeMemoryWindows = 0;
 
     TPooledBuffer SendBuffer {};
     TPooledBuffer RecvBuffer {};
@@ -517,11 +573,20 @@ private:
     TEventHandle DisconnectEvent;
 
     TSimpleList<TRequest> QueuedRequests;
+    TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
+        PendingInvalidationRequests;
+    TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
+        InflightInvalidationRequests;
+    TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
+        RetiredInvalidationRequests;
+    TLockFreeList<TCompletedRequestResources> CompletedRequestResources;
+    TSimpleList<TCompletedRequestResources> CompletedRequestResourcesQueue;
     TActiveRequests ActiveRequests;
 
     std::atomic<ui64> ReqIdPool{0};
 
     int NegotiatedProtocolVersion = RDMA_PROTO_VERSION;
+    bool PeerSupportsSendWithInvalidate = false;
 
 public:
     static TClientEndpoint* FromEvent(rdma_cm_event* event)
@@ -586,16 +651,39 @@ public:
 private:
     // called from CQ thread
     void HandleQueuedRequests() noexcept;
+    void DrainCompletedRequestResources() noexcept;
+    void ReleaseRequestResources(TRequestResourcesPtr resources) noexcept;
     void SendRequest(TRequestPtr req, TSendWr* send) noexcept;
     void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
-    void BindInBuffer(TRequest* req, TSendWr* send) noexcept;
-    void BindOutBuffer(TRequest* req, TSendWr* send) noexcept;
-    void BindCompleted(TSendWr* send) noexcept;
+    void FinalizeRequest(TRequestPtr req) noexcept;
+    void FinalizeInvalidationRequest(TInvalidationRequest* req, bool keepAlive) noexcept;
+    void PostLocalInvalidation(TInvalidationRequest* req, TSendWr* send) noexcept;
+    void HandlePendingInvalidationRequests() noexcept;
+    void LocalInvalidationCompleted(TSendWr* send) noexcept;
+    void ResetInvalidationState(TRequestResources& resources) noexcept;
+    void ConfigureOutInvalidation(
+        TRequestResources& resources,
+        TRequestMessage* msg,
+        ui32 outRKey) noexcept;
+    bool ValidateRemoteInvalidation(
+        TRecvWr* recv,
+        ui32 reqId,
+        ibv_wc* wc,
+        TRequestResources& resources) noexcept;
+    bool NeedLocalInvalidation(const TRequestResources& resources) const noexcept;
+    bool DeferAbortUntilSendCompletion(
+        TRequestPtr& req,
+        ui32 err,
+        TString msg) noexcept;
+    void FinalizeDeferredAbort(ui32 reqId) noexcept;
     void RecvResponse(TRecvWr* recv) noexcept;
-    void RecvResponseCompleted(TRecvWr* recv) noexcept;
+    void RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept;
     void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
+    NVerbs::TMemoryWindowPtr AcquireMemoryWindowLocked();
+    void RecycleMemoryWindowLocked(NVerbs::TMemoryWindowPtr& memoryWindow);
+    static ui32 GetNextMemoryWindowRKey(ibv_mw* memoryWindow);
     int ValidateCompletion(ibv_wc* wc) noexcept;
     ui64 GetNewReqId() noexcept;
 };
@@ -688,9 +776,12 @@ void TClientEndpoint::CreateQP()
         ResetConfig = false;
     }
 
+    const ui32 sendWrPerRequest = Config.UseMemoryWindows ? 3 : 1;
+    const ui32 maxSendWr = Config.SendQueueSize * sendWrPerRequest;
+
     CompletionQueue = Verbs->CreateCompletionQueue(
         Connection->verbs,
-        Config.SendQueueSize + Config.RecvQueueSize,   // send + recv
+        maxSendWr + Config.RecvQueueSize,
         this,
         CompletionChannel.get(),
         0);   // comp_vector
@@ -700,14 +791,14 @@ void TClientEndpoint::CreateQP()
         .send_cq = CompletionQueue.get(),
         .recv_cq = CompletionQueue.get(),
         .cap = {
-            .max_send_wr = Config.SendQueueSize,
+            .max_send_wr = maxSendWr,
             .max_recv_wr = Config.RecvQueueSize,
             .max_send_sge = RDMA_MAX_SEND_SGE,
             .max_recv_sge = RDMA_MAX_RECV_SGE,
             .max_inline_data = 16,
         },
         .qp_type = IBV_QPT_RC,
-        .sq_sig_all = 1,
+        .sq_sig_all = 0,
     };
 
     if (Config.VerbsQP) {
@@ -716,15 +807,28 @@ void TClientEndpoint::CreateQP()
         Verbs->RdmaCreateQP(Connection.get(), &qp_attrs);
     }
 
-    SendBuffers.Init(
-        Verbs,
-        Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
+    int sendAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
+    int recvAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
+    if (Config.UseMemoryWindows) {
+        sendAccessFlags |= IBV_ACCESS_MW_BIND;
+        recvAccessFlags |= IBV_ACCESS_MW_BIND;
+    }
 
-    RecvBuffers.Init(
-        Verbs,
-        Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    SendBuffers.Init(Verbs, Connection->pd, sendAccessFlags);
+    RecvBuffers.Init(Verbs, Connection->pd, recvAccessFlags);
+
+    if (Config.UseMemoryWindows) {
+        // Endpoint-local pool: windows are reused only inside this endpoint/QP
+        // flow (Type 2A semantics at application level).
+        MaxFreeMemoryWindows = static_cast<size_t>(Config.SendQueueSize) * 2;
+        FreeMemoryWindows.reserve(MaxFreeMemoryWindows);
+        for (size_t i = 0; i < MaxFreeMemoryWindows; ++i) {
+            FreeMemoryWindows.push_back(Verbs->CreateMemoryWindow(Connection->pd));
+        }
+    } else {
+        MaxFreeMemoryWindows = 0;
+        FreeMemoryWindows.clear();
+    }
 
     SendBuffer = SendBuffers.AcquireBuffer(
         Config.SendQueueSize * sizeof(TRequestMessage), true);
@@ -749,6 +853,8 @@ void TClientEndpoint::CreateQP()
         wr.wr.wr_id = TWorkRequestId(SendMagic, Generation, i++).Id;
         wr.wr.sg_list = wr.sg_list;
         wr.wr.num_sge = 1;
+        wr.wr.send_flags = IBV_SEND_SIGNALED;
+        wr.wr.next = nullptr;
 
         wr.sg_list[0].lkey = SendBuffer.LKey;
         wr.sg_list[0].addr = requestMsg;
@@ -793,12 +899,20 @@ void TClientEndpoint::SetupQP()
 
 void TClientEndpoint::DestroyQP() noexcept
 {
+    RetiredInvalidationRequests.Clear();
+
+    with_lock (AllocationLock) {
+        MaxFreeMemoryWindows = 0;
+        FreeMemoryWindows.clear();
+    }
+
     if (Connection && Connection->qp) {
         if (Config.VerbsQP) {
             Verbs->DestroyQP(Connection->qp);
             Connection->qp = nullptr;
         } else {
             Verbs->RdmaDestroyQP(Connection.get());
+            Connection->qp = nullptr;
         }
     }
 
@@ -855,17 +969,22 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         shared_from_this(),
         std::move(handler),
         std::move(context));
+    req->Resources = MakeIntrusive<TRequestResources>();
 
     try {
         with_lock (AllocationLock) {
             if (requestBytes) {
-                req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
-                req->InMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
+                req->Resources->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
+                if (Config.UseMemoryWindows) {
+                    req->Resources->InMemoryWindow = AcquireMemoryWindowLocked();
+                }
             }
 
             if (responseBytes) {
-                req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
-                req->OutMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
+                req->Resources->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
+                if (Config.UseMemoryWindows) {
+                    req->Resources->OutMemoryWindow = AcquireMemoryWindowLocked();
+                }
             }
         }
     } catch (...) {
@@ -882,12 +1001,12 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
     }
 
     req->RequestBuffer = TStringBuf {
-        reinterpret_cast<char*>(req->InBuffer.Address),
-        req->InBuffer.Length,
+        reinterpret_cast<char*>(req->Resources->InBuffer.Address),
+        req->Resources->InBuffer.Length,
     };
     req->ResponseBuffer = TStringBuf {
-        reinterpret_cast<char*>(req->OutBuffer.Address),
-        req->OutBuffer.Length,
+        reinterpret_cast<char*>(req->Resources->OutBuffer.Address),
+        req->Resources->OutBuffer.Length,
     };
 
     return TClientRequestPtr(std::move(req));
@@ -909,10 +1028,12 @@ ui64 TClientEndpoint::SendRequest(
         return clientReqId;
     }
 
-    LWTRACK(
-        RequestEnqueued,
-        req->CallContext->LWOrbit,
-        req->CallContext->RequestId);
+    if (req->CallContext) {
+        LWTRACK(
+            RequestEnqueued,
+            req->CallContext->LWOrbit,
+            req->CallContext->RequestId);
+    }
 
     Counters->RequestEnqueued();
     InputRequests.Enqueue(std::move(req));
@@ -930,6 +1051,8 @@ bool TClientEndpoint::HandleInputRequests() noexcept
         RequestEvent.Clear();
     }
 
+    DrainCompletedRequestResources();
+
     auto requests = InputRequests.DequeueAll();
     if (!requests) {
         return false;
@@ -942,12 +1065,21 @@ bool TClientEndpoint::HandleInputRequests() noexcept
 
 void TClientEndpoint::HandleQueuedRequests() noexcept
 {
-    while (QueuedRequests) {
+    DrainCompletedRequestResources();
+
+    while (QueuedRequests || PendingInvalidationRequests) {
         if (CheckState(EEndpointState::Connected)) {
             auto* send = SendQueue.Pop();
             if (!send) {
                 // no more WRs available
                 break;
+            }
+
+            if (PendingInvalidationRequests) {
+                auto* req = PendingInvalidationRequests.PopFront();
+                Y_ABORT_UNLESS(req);
+                PostLocalInvalidation(req, send);
+                continue;
             }
 
             auto req = QueuedRequests.Dequeue();
@@ -957,8 +1089,22 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
             SendRequest(std::move(req), send);
         }
         else {
+            while (PendingInvalidationRequests) {
+                auto* req = PendingInvalidationRequests.PopFront();
+                Y_ABORT_UNLESS(req);
+                FinalizeInvalidationRequest(req, false);
+            }
+
+            while (InflightInvalidationRequests) {
+                auto* req = InflightInvalidationRequests.PopFront();
+                Y_ABORT_UNLESS(req);
+                FinalizeInvalidationRequest(req, true);
+            }
+
             auto req = QueuedRequests.Dequeue();
-            Y_ABORT_UNLESS(req);
+            if (!req) {
+                break;
+            }
 
             Counters->RequestDequeued();
             AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
@@ -1029,6 +1175,14 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
     cancelled.Append(ActiveRequests.PopCancelledRequests(clientRequestIdToCancel));
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
+        if (DeferAbortUntilSendCompletion(
+                req,
+                E_CANCELLED,
+                "request was cancelled"))
+        {
+            continue;
+        }
+
         Counters->RequestAborted();
         AbortRequest(std::move(req), E_CANCELLED, "request was cancelled");
     }
@@ -1048,6 +1202,8 @@ void TClientEndpoint::AbortRequests() noexcept
         AbortRequestsEvent.Clear();
     }
 
+    DrainCompletedRequestResources();
+
     if (!CheckState(EEndpointState::Disconnecting)) {
         return;
     }
@@ -1065,10 +1221,35 @@ void TClientEndpoint::AbortRequests() noexcept
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
     }
 
+    TSimpleList<TRequest> activeRequests;
     while (auto req = ActiveRequests.Pop()) {
+        activeRequests.Enqueue(std::move(req));
+    }
+
+    while (auto req = activeRequests.Dequeue()) {
         RDMA_DEBUG("abort request " << req->ReqId);
+        if (DeferAbortUntilSendCompletion(
+                req,
+                E_RDMA_UNAVAILABLE,
+                "endpoint is unavailable"))
+        {
+            continue;
+        }
+
         Counters->RequestAborted();
         AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
+    }
+
+    while (PendingInvalidationRequests) {
+        auto* req = PendingInvalidationRequests.PopFront();
+        Y_ABORT_UNLESS(req);
+        FinalizeInvalidationRequest(req, false);
+    }
+
+    while (InflightInvalidationRequests) {
+        auto* req = InflightInvalidationRequests.PopFront();
+        Y_ABORT_UNLESS(req);
+        FinalizeInvalidationRequest(req, true);
     }
 }
 
@@ -1077,10 +1258,14 @@ void TClientEndpoint::AbortRequest(
     ui32 err, const
     TString& msg) noexcept
 {
+    // For timed out/cancelled/aborted requests we cannot guarantee that remote
+    // peer invalidated keys, so force MW deallocation instead of recycling.
+    req->Resources->RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
+
     auto len = SerializeError(
         err,
         msg,
-        static_cast<TStringBuf>(req->OutBuffer));
+        static_cast<TStringBuf>(req->Resources->OutBuffer));
 
     auto* handler = req->Handler.get();
     handler->HandleResponse(std::move(req), RDMA_PROTO_FAIL, len);
@@ -1118,21 +1303,42 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
 
     if (id.Magic == SendMagic && id.Index < SendWrs.size()) {
         auto* send = &SendWrs[id.Index];
+        const bool isRequestSend = wc->opcode == IBV_WC_SEND;
+        const bool isLocalInvalidate = wc->opcode == IBV_WC_LOCAL_INV;
+        const bool isBindMw = wc->opcode == IBV_WC_BIND_MW;
 
         if (wc->status == IBV_WC_WR_FLUSH_ERR) {
             RDMA_TRACE(send << " " << NVerbs::GetStatusString(wc->status));
-            Counters->SendRequestCompleted();
-            SendQueue.Push(send);
+            if (isLocalInvalidate) {
+                send->context = nullptr;
+                SendQueue.Push(send);
+            }
+            if (isRequestSend) {
+                const ui32 reqId =
+                    SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
+                Counters->SendRequestCompleted();
+                SendQueue.Push(send);
+                FinalizeDeferredAbort(reqId);
+            }
             return -1;
         }
         if (wc->status != IBV_WC_SUCCESS) {
             RDMA_ERROR(send << " " << NVerbs::GetStatusString(wc->status));
             Counters->Error();
-            Counters->SendRequestCompleted();
-            SendQueue.Push(send);
+            if (isLocalInvalidate) {
+                send->context = nullptr;
+                SendQueue.Push(send);
+            }
+            if (isRequestSend) {
+                const ui32 reqId =
+                    SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
+                Counters->SendRequestCompleted();
+                SendQueue.Push(send);
+                FinalizeDeferredAbort(reqId);
+            }
             return -1;
         }
-        if (wc->opcode != IBV_WC_SEND && wc->opcode != IBV_WC_BIND_MW) {
+        if (!isRequestSend && !isBindMw && !isLocalInvalidate) {
             RDMA_ERROR(
                 send << " unexpected opcode "
                      << NVerbs::GetOpcodeName(wc->opcode));
@@ -1188,13 +1394,6 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
     }
 
     switch (wc->opcode) {
-        case IBV_WC_BIND_MW: {
-            TSendWr* send = &SendWrs[id.Index];
-            RDMA_TRACE(wc->opcode << " " << id << " completed")
-            BindCompleted(send);
-            break;
-        }
-
         case IBV_WC_SEND: {
             TSendWr* send = &SendWrs[id.Index];
             RDMA_TRACE(send << " completed");
@@ -1202,10 +1401,22 @@ void TClientEndpoint::HandleCompletionEvent(ibv_wc* wc) noexcept
             break;
         }
 
+        case IBV_WC_LOCAL_INV: {
+            TSendWr* send = &SendWrs[id.Index];
+            RDMA_TRACE(send << " local invalidate completed");
+            LocalInvalidationCompleted(send);
+            break;
+        }
+
+        case IBV_WC_BIND_MW:
+            // Auxiliary completions for bind WRs in a SEND chain.
+            // Send WR slot is returned by terminal SEND/LOCAL_INV completion.
+            break;
+
         case IBV_WC_RECV: {
             TRecvWr* recv = &RecvWrs[id.Index];
             RDMA_TRACE(recv << " completed");
-            RecvResponseCompleted(recv);
+            RecvResponseCompleted(recv, wc);
             break;
         }
 
@@ -1230,160 +1441,234 @@ void TClientEndpoint::SendRequest(TRequestPtr request, TSendWr* send) noexcept
     InitMessageHeader(msg, NegotiatedProtocolVersion);
 
     msg->ReqId = req->ReqId;
-    msg->In = req->InBuffer;
-    msg->Out = req->OutBuffer;
+    msg->Unused = RDMA_REQUEST_FLAG_NONE;
+    msg->In = req->Resources->InBuffer;
+    msg->Out = req->Resources->OutBuffer;
 
-    if (Config.UseMemoryWindows) {
-        BindInBuffer(req, send);
-    } else {
-        SendRequest(req, send);
-    }
-}
-
-void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
-{
-    req->State = ERequestState::BindInBuffer;
-
-    ibv_send_wr wr = {
-        .wr_id = send->wr.wr_id,
-        .opcode = IBV_WR_BIND_MW,
-        .bind_mw = {
-            .mw = req->InMemoryWindow.get(),
-            .rkey = req->InMemoryWindow->rkey,
-            .bind_info = {
-                .mr = req->InBuffer.GetMemoryRegion(),
-                .addr = req->InBuffer.Address,
-                .length = req->InBuffer.Length,
-                .mw_access_flags = IBV_ACCESS_REMOTE_READ,
-            },
-        },
-    };
-
-    try {
-        Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE("bind request " << reqId << " input buffer");
-        RDMA_TRACE(wr << "[request=" << req->ReqId << "]" << " posted");
-    }
-    catch (const TServiceError& e) {
-        RDMA_ERROR(wr << " " << e.what());
-        SendQueue.Push(send);
-        Counters->Error();
-        Disconnect();
-        return;
-    }
-
-    LWTRACK(
-        BindInBufferStarted,
-        req->CallContext->LWOrbit,
-        req->CallContext->RequestId);
-}
-
-void TClientEndpoint::BindOutBuffer(TRequest* req, TSendWr* send) noexcept
-{
-    req->State = ERequestState::BindOutBuffer;
-
-    ibv_send_wr wr = {
-        .wr_id = send->wr.wr_id,
-        .opcode = IBV_WR_BIND_MW,
-        .bind_mw = {
-            .mw = req->OutMemoryWindow.get(),
-            .rkey = req->OutMemoryWindow->rkey,
-            .bind_info = {
-                .mr = req->OutBuffer.GetMemoryRegion(),
-                .addr = req->OutBuffer.Address,
-                .length = req->OutBuffer.Length,
-                .mw_access_flags = IBV_ACCESS_REMOTE_WRITE,
-            },
-        },
-    };
-
-    try {
-        Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE(wr << " posted");
-    }
-    catch (const TServiceError& e) {
-        RDMA_ERROR(wr << " " << e.what());
-        SendQueue.Push(send);
-        Counters->Error();
-        Disconnect();
-        return;
-    }
-
-    LWTRACK(
-        BindOutBufferStarted,
-        req->CallContext->LWOrbit,
-        req->CallContext->RequestId);
-}
-
-void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
-{
-    const ui32 reqId =
-        SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
-
-    if (auto* req = ActiveRequests.Get(reqId)) {
-        switch (req->State) {
-            case ERequestState::BindInBuffer:
-                LWTRACK(
-                    BindInBufferCompleted,
-                    req->CallContext->LWOrbit,
-                    req->CallContext->RequestId);
-
-                RDMA_DEBUG(
-                    "change request #" << req->ReqId << " input buffer rkey: "
-                                       << req->InBuffer.RKey << " -> "
-                                       << req->InMemoryWindow->rkey);
-
-                send->Message()->In.RKey = req->InMemoryWindow->rkey;
-                BindOutBuffer(req, send);
-                break;
-
-            case ERequestState::BindOutBuffer:
-                LWTRACK(
-                    BindOutBufferCompleted,
-                    req->CallContext->LWOrbit,
-                    req->CallContext->RequestId);
-
-                RDMA_DEBUG(
-                    "change request #" << req->ReqId << " output buffer rkey: "
-                                       << req->OutBuffer.RKey << " -> "
-                                       << req->OutMemoryWindow->rkey);
-
-                send->Message()->Out.RKey = req->OutMemoryWindow->rkey;
-                SendRequest(req, send);
-                break;
-
-            default:
-                Counters->Error();
-                RDMA_ERROR(
-                    "bind " << send->wr << " completed in unexpected state "
-                            << req->State);
-        }
-    }
-    // request has been cancelled before bind completed
+    SendRequest(req, send);
 }
 
 void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
 {
     req->State = ERequestState::SendRequest;
+    auto* msg = send->Message();
+    ResetInvalidationState(*req->Resources);
+    Counters->SendRequestStarted();
+
+    // We only expect SEND completion with sq_sig_all=0.
+    send->wr.send_flags = IBV_SEND_SIGNALED;
+    send->wr.next = nullptr;
+
+    ibv_send_wr* head = &send->wr;
+    ibv_send_wr* tail = nullptr;
+    ibv_send_wr bindIn = {};
+    ibv_send_wr bindOut = {};
+
+    if (Config.UseMemoryWindows) {
+        if (req->Resources->InMemoryWindow && req->Resources->InBuffer.Length) {
+            if (req->CallContext) {
+                LWTRACK(
+                    BindInBufferStarted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
+            }
+
+            const ui32 inRKey = GetNextMemoryWindowRKey(
+                req->Resources->InMemoryWindow.get());
+            msg->In.RKey = inRKey;
+
+            bindIn.wr_id = send->wr.wr_id;
+            bindIn.opcode = IBV_WR_BIND_MW;
+            bindIn.bind_mw.mw = req->Resources->InMemoryWindow.get();
+            bindIn.bind_mw.rkey = inRKey;
+            bindIn.bind_mw.bind_info.mr = req->Resources->InBuffer.GetMemoryRegion();
+            bindIn.bind_mw.bind_info.addr = req->Resources->InBuffer.Address;
+            bindIn.bind_mw.bind_info.length = req->Resources->InBuffer.Length;
+            bindIn.bind_mw.bind_info.mw_access_flags = IBV_ACCESS_REMOTE_READ;
+
+            head = &bindIn;
+            tail = &bindIn;
+        }
+
+        if (req->Resources->OutMemoryWindow && req->Resources->OutBuffer.Length) {
+            if (req->CallContext) {
+                LWTRACK(
+                    BindOutBufferStarted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
+            }
+
+            const ui32 outRKey = GetNextMemoryWindowRKey(
+                req->Resources->OutMemoryWindow.get());
+            msg->Out.RKey = outRKey;
+            ConfigureOutInvalidation(*req->Resources, msg, outRKey);
+
+            bindOut.wr_id = send->wr.wr_id;
+            bindOut.opcode = IBV_WR_BIND_MW;
+            bindOut.bind_mw.mw = req->Resources->OutMemoryWindow.get();
+            bindOut.bind_mw.rkey = outRKey;
+            bindOut.bind_mw.bind_info.mr = req->Resources->OutBuffer.GetMemoryRegion();
+            bindOut.bind_mw.bind_info.addr = req->Resources->OutBuffer.Address;
+            bindOut.bind_mw.bind_info.length = req->Resources->OutBuffer.Length;
+            bindOut.bind_mw.bind_info.mw_access_flags = IBV_ACCESS_REMOTE_WRITE;
+
+            if (tail) {
+                tail->next = &bindOut;
+            } else {
+                head = &bindOut;
+            }
+            tail = &bindOut;
+        }
+    }
+
+    if (tail) {
+        tail->next = &send->wr;
+    }
 
     try {
-        Verbs->PostSend(Connection->qp, &send->wr);
+        Verbs->PostSend(Connection->qp, head);
         RDMA_TRACE(send << " posted");
     }
     catch (const TServiceError& e) {
         RDMA_ERROR(send << " " << e.what());
         SendQueue.Push(send);
+        // PostSend failed synchronously before any CQE could be produced.
+        // Roll back ActiveSend and complete request locally: no WQE was posted,
+        // so no completion/flush can arrive for this request.
+        Counters->SendRequestCompleted();
+        if (auto failedReq = ActiveRequests.Pop(req->ReqId)) {
+            Counters->RequestAborted();
+            AbortRequest(
+                std::move(failedReq),
+                E_RDMA_UNAVAILABLE,
+                "failed to post send request");
+        }
         Counters->Error();
         Disconnect();
         return;
     }
 
-    LWTRACK(
-        SendRequestStarted,
-        req->CallContext->LWOrbit,
-        req->CallContext->RequestId);
+    if (req->CallContext) {
+        LWTRACK(
+            SendRequestStarted,
+            req->CallContext->LWOrbit,
+            req->CallContext->RequestId);
+    }
 
-    Counters->SendRequestStarted();
+}
+
+void TClientEndpoint::ResetInvalidationState(
+    TRequestResources& resources) noexcept
+{
+    resources.OutInvalidationMode = TRequestResources::EOutInvalidationMode::None;
+    resources.ExpectedInvalidatedRKey = 0;
+}
+
+void TClientEndpoint::ConfigureOutInvalidation(
+    TRequestResources& resources,
+    TRequestMessage* msg,
+    ui32 outRKey) noexcept
+{
+    if (PeerSupportsSendWithInvalidate) {
+        msg->Unused |= RDMA_REQUEST_FLAG_USE_MEMORY_WINDOWS;
+        resources.OutInvalidationMode =
+            TRequestResources::EOutInvalidationMode::Remote;
+        resources.ExpectedInvalidatedRKey = outRKey;
+    } else {
+        resources.OutInvalidationMode =
+            TRequestResources::EOutInvalidationMode::Local;
+    }
+}
+
+bool TClientEndpoint::ValidateRemoteInvalidation(
+    TRecvWr* recv,
+    ui32 reqId,
+    ibv_wc* wc,
+    TRequestResources& resources) noexcept
+{
+    if (resources.OutInvalidationMode !=
+        TRequestResources::EOutInvalidationMode::Remote)
+    {
+        return true;
+    }
+
+    const bool hasInv = wc && (wc->wc_flags & IBV_WC_WITH_INV);
+    if (!hasInv) {
+        RDMA_WARN(recv << " missing remote invalidate for request " << reqId);
+        resources.RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
+        Counters->Error();
+        return false;
+    }
+
+    if (wc->invalidated_rkey != resources.ExpectedInvalidatedRKey) {
+        RDMA_WARN(
+            recv << " unexpected invalidated rkey for request " << reqId
+                 << ", expected " << resources.ExpectedInvalidatedRKey
+                 << ", got " << wc->invalidated_rkey);
+        resources.RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
+        Counters->Error();
+        return false;
+    }
+
+    return true;
+}
+
+bool TClientEndpoint::NeedLocalInvalidation(
+    const TRequestResources& resources) const noexcept
+{
+    return Config.UseMemoryWindows &&
+        resources.RecyclePolicy == TRequestResources::ERecyclePolicy::Recycle &&
+        ((resources.InMemoryWindow && resources.InBuffer.Length) ||
+         (resources.OutInvalidationMode ==
+              TRequestResources::EOutInvalidationMode::Local &&
+          resources.OutMemoryWindow &&
+          resources.OutBuffer.Length));
+}
+
+bool TClientEndpoint::DeferAbortUntilSendCompletion(
+    TRequestPtr& req,
+    ui32 err,
+    TString msg) noexcept
+{
+    if (!req ||
+        !Config.UseMemoryWindows ||
+        req->State != ERequestState::SendRequest ||
+        !req->Resources)
+    {
+        return false;
+    }
+
+    auto& resources = *req->Resources;
+    if (!resources.AbortPending) {
+        resources.AbortPending = true;
+        resources.AbortError = err;
+        resources.AbortMessage = std::move(msg);
+    }
+
+    ActiveRequests.Push(std::move(req));
+    return true;
+}
+
+void TClientEndpoint::FinalizeDeferredAbort(ui32 reqId) noexcept
+{
+    auto* req = ActiveRequests.Get(reqId);
+    if (!req || !req->Resources || !req->Resources->AbortPending) {
+        return;
+    }
+
+    auto abortedReq = ActiveRequests.Pop(reqId);
+    if (!abortedReq || !abortedReq->Resources) {
+        return;
+    }
+
+    ui32 err = abortedReq->Resources->AbortError;
+    TString msg = std::move(abortedReq->Resources->AbortMessage);
+    abortedReq->Resources->AbortPending = false;
+    abortedReq->Resources->AbortMessage.clear();
+    abortedReq->Resources->AbortError = RDMA_PROTO_FAIL;
+
+    Counters->RequestAborted();
+    AbortRequest(std::move(abortedReq), err, msg);
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1395,14 +1680,37 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
     SendQueue.Push(send);
 
     if (auto* req = ActiveRequests.Get(reqId)) {
-        LWTRACK(
-            SendRequestCompleted,
-            req->CallContext->LWOrbit,
-            req->CallContext->RequestId);
+        if (Config.UseMemoryWindows) {
+            if (req->Resources->InMemoryWindow && req->Resources->InBuffer.Length) {
+                if (req->CallContext) {
+                    LWTRACK(
+                        BindInBufferCompleted,
+                        req->CallContext->LWOrbit,
+                        req->CallContext->RequestId);
+                }
+            }
+            if (req->Resources->OutMemoryWindow && req->Resources->OutBuffer.Length) {
+                if (req->CallContext) {
+                    LWTRACK(
+                        BindOutBufferCompleted,
+                        req->CallContext->LWOrbit,
+                        req->CallContext->RequestId);
+                }
+            }
+        }
+
+        if (req->CallContext) {
+            LWTRACK(
+                SendRequestCompleted,
+                req->CallContext->LWOrbit,
+                req->CallContext->RequestId);
+        }
 
         req->State = ERequestState::RecvResponse;
+        FinalizeDeferredAbort(reqId);
     }
     // request has already been completed
+    HandlePendingInvalidationRequests();
 }
 
 void TClientEndpoint::RecvResponse(TRecvWr* recv) noexcept
@@ -1425,7 +1733,7 @@ void TClientEndpoint::RecvResponse(TRecvWr* recv) noexcept
     Counters->RecvResponseStarted();
 }
 
-void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv) noexcept
+void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept
 {
     auto* msg = recv->Message();
 
@@ -1456,21 +1764,42 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv) noexcept
         RecvResponse(recv);
         return;
     }
-    Counters->RequestCompleted();
+
+    if (req->Resources && req->Resources->AbortPending) {
+        ui32 err = req->Resources->AbortError;
+        TString msg = std::move(req->Resources->AbortMessage);
+        req->Resources->AbortPending = false;
+        req->Resources->AbortMessage.clear();
+        req->Resources->AbortError = RDMA_PROTO_FAIL;
+
+        RecvResponse(recv);
+        Counters->RequestAborted();
+        AbortRequest(std::move(req), err, msg);
+        return;
+    }
+
+    auto& resources = *req->Resources;
+    ValidateRemoteInvalidation(recv, reqId, wc, resources);
+
+    resources.Status = status;
+    resources.ResponseBytes = responseBytes;
     RecvResponse(recv);
 
     RDMA_TRACE("request " << reqId << " completed");
 
-    LWTRACK(
-        RecvResponseCompleted,
-        req->CallContext->LWOrbit,
-        req->CallContext->RequestId);
+    const bool needsLocalInvalidate = NeedLocalInvalidation(resources);
 
-    auto* handler = req->Handler.get();
-    handler->HandleResponse(
-        std::move(req),
-        status,
-        responseBytes);
+    if (needsLocalInvalidate) {
+        auto* invalidationRequest = new TInvalidationRequest();
+        invalidationRequest->Resources = req->Resources;
+        invalidationRequest->Request = std::move(req);
+        invalidationRequest->Stage = TInvalidationRequest::EStage::Pending;
+        PendingInvalidationRequests.PushBack(invalidationRequest);
+        HandlePendingInvalidationRequests();
+        return;
+    }
+
+    FinalizeRequest(std::move(req));
 }
 
 TFuture<void> TClientEndpoint::Stop() noexcept
@@ -1549,13 +1878,21 @@ bool TClientEndpoint::ClientRequestsFlushed() const
     return ActiveRequests.Empty()
         && !InputRequests
         && !QueuedRequests
-        && !CancelRequests;
+        && !CancelRequests
+        && !PendingInvalidationRequests
+        && !InflightInvalidationRequests
+        && !CompletedRequestResources
+        && !CompletedRequestResourcesQueue;
 }
 
 bool TClientEndpoint::WorkRequestsFlushed() const
 {
     return SendQueue.Size() == Config.SendQueueSize
-        && RecvQueue.Size() == Config.RecvQueueSize;
+        && RecvQueue.Size() == Config.RecvQueueSize
+        && !PendingInvalidationRequests
+        && !InflightInvalidationRequests
+        && !CompletedRequestResources
+        && !CompletedRequestResourcesQueue;
 }
 
 bool TClientEndpoint::FlushHanging() const
@@ -1565,12 +1902,242 @@ bool TClientEndpoint::FlushHanging() const
            CyclesToDurationSafe(GetCycleCount() - start) >= Config.FlushTimeout;
 }
 
+void TClientEndpoint::ReleaseRequestResources(TRequestResourcesPtr resources) noexcept
+{
+    if (!resources) {
+        return;
+    }
+
+    with_lock (AllocationLock) {
+        if (Config.UseMemoryWindows &&
+            resources->RecyclePolicy == TRequestResources::ERecyclePolicy::Recycle &&
+            Connection &&
+            Connection->qp)
+        {
+            RecycleMemoryWindowLocked(resources->InMemoryWindow);
+            RecycleMemoryWindowLocked(resources->OutMemoryWindow);
+        } else {
+            resources->InMemoryWindow = NVerbs::NullPtr;
+            resources->OutMemoryWindow = NVerbs::NullPtr;
+        }
+
+        SendBuffers.ReleaseBuffer(resources->InBuffer);
+        RecvBuffers.ReleaseBuffer(resources->OutBuffer);
+    }
+}
+
+void TClientEndpoint::DrainCompletedRequestResources() noexcept
+{
+    CompletedRequestResourcesQueue.Append(CompletedRequestResources.DequeueAll());
+
+    while (CompletedRequestResourcesQueue) {
+        auto completed = CompletedRequestResourcesQueue.Dequeue();
+        Y_ABORT_UNLESS(completed);
+        ReleaseRequestResources(std::move(completed->Resources));
+    }
+}
+
+void TClientEndpoint::FinalizeRequest(TRequestPtr req) noexcept
+{
+    const ui32 status = req->Resources ? req->Resources->Status : RDMA_PROTO_FAIL;
+    const ui32 responseBytes = req->Resources ? req->Resources->ResponseBytes : 0;
+
+    Counters->RequestCompleted();
+
+    if (req->CallContext) {
+        LWTRACK(
+            RecvResponseCompleted,
+            req->CallContext->LWOrbit,
+            req->CallContext->RequestId);
+    }
+
+    auto* handler = req->Handler.get();
+    handler->HandleResponse(
+        std::move(req),
+        status,
+        responseBytes);
+}
+
+void TClientEndpoint::FinalizeInvalidationRequest(
+    TInvalidationRequest* req,
+    bool keepAlive) noexcept
+{
+    Y_ABORT_UNLESS(req);
+    req->Finalized = true;
+    if (req->Resources) {
+        req->Resources->RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
+    }
+    FinalizeRequest(std::move(req->Request));
+
+    if (keepAlive) {
+        req->Stage = TInvalidationRequest::EStage::Retired;
+        RetiredInvalidationRequests.PushBack(req);
+    } else {
+        delete req;
+    }
+}
+
+void TClientEndpoint::PostLocalInvalidation(
+    TInvalidationRequest* req,
+    TSendWr* send) noexcept
+{
+    Y_ABORT_UNLESS(req);
+    Y_ABORT_UNLESS(req->Resources);
+    auto* resources = req->Resources.Get();
+    const bool needLocalInvalidateOut =
+        resources->OutInvalidationMode ==
+        TRequestResources::EOutInvalidationMode::Local;
+
+    ibv_send_wr* head = nullptr;
+    ibv_send_wr* tail = nullptr;
+    ibv_send_wr invIn = {};
+    ibv_send_wr invOut = {};
+
+    if (resources->InMemoryWindow && resources->InBuffer.Length) {
+        invIn.wr_id = send->wr.wr_id;
+        invIn.opcode = IBV_WR_LOCAL_INV;
+        invIn.invalidate_rkey = resources->InMemoryWindow->rkey;
+
+        head = &invIn;
+        tail = &invIn;
+    }
+
+    if (needLocalInvalidateOut &&
+        resources->OutMemoryWindow &&
+        resources->OutBuffer.Length)
+    {
+        invOut.wr_id = send->wr.wr_id;
+        invOut.opcode = IBV_WR_LOCAL_INV;
+        invOut.invalidate_rkey = resources->OutMemoryWindow->rkey;
+
+        if (tail) {
+            tail->next = &invOut;
+        } else {
+            head = &invOut;
+        }
+        tail = &invOut;
+    }
+
+    if (!head) {
+        SendQueue.Push(send);
+        FinalizeRequest(std::move(req->Request));
+        delete req;
+        return;
+    }
+
+    req->Stage = TInvalidationRequest::EStage::Inflight;
+    InflightInvalidationRequests.PushBack(req);
+    send->context = req;
+
+    try {
+        Verbs->PostSend(Connection->qp, head);
+        RDMA_TRACE(send << " local invalidate posted");
+    } catch (const TServiceError& e) {
+        RDMA_ERROR(send << " " << e.what());
+        send->context = nullptr;
+        SendQueue.Push(send);
+        Counters->Error();
+        InflightInvalidationRequests.Remove(req);
+        FinalizeInvalidationRequest(req, true);
+        Disconnect();
+    }
+}
+
+void TClientEndpoint::HandlePendingInvalidationRequests() noexcept
+{
+    while (PendingInvalidationRequests && CheckState(EEndpointState::Connected)) {
+        auto* send = SendQueue.Pop();
+        if (!send) {
+            return;
+        }
+
+        auto* req = PendingInvalidationRequests.PopFront();
+        Y_ABORT_UNLESS(req);
+        PostLocalInvalidation(req, send);
+    }
+}
+
+void TClientEndpoint::LocalInvalidationCompleted(TSendWr* send) noexcept
+{
+    auto* rawReq = static_cast<TInvalidationRequest*>(send->context);
+    send->context = nullptr;
+    SendQueue.Push(send);
+
+    if (!rawReq) {
+        RDMA_WARN(send << " local invalidation request not found");
+        return;
+    }
+
+    switch (rawReq->Stage) {
+        case TInvalidationRequest::EStage::Inflight:
+            InflightInvalidationRequests.Remove(rawReq);
+            if (!rawReq->Finalized) {
+                FinalizeRequest(std::move(rawReq->Request));
+            }
+            delete rawReq;
+            HandlePendingInvalidationRequests();
+            return;
+
+        case TInvalidationRequest::EStage::Retired:
+            RetiredInvalidationRequests.Remove(rawReq);
+            delete rawReq;
+            return;
+
+        case TInvalidationRequest::EStage::Pending:
+            RDMA_WARN(send << " local invalidation request in pending stage");
+            return;
+    }
+}
+
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
-    with_lock (AllocationLock) {
-        SendBuffers.ReleaseBuffer(req->InBuffer);
-        RecvBuffers.ReleaseBuffer(req->OutBuffer);
+    if (!req->Resources) {
+        return;
     }
+
+    auto completed = std::make_unique<TCompletedRequestResources>();
+    completed->Resources = std::move(req->Resources);
+    CompletedRequestResources.Enqueue(std::move(completed));
+
+    if (WaitMode == EWaitMode::Poll) {
+        RequestEvent.Set();
+    }
+}
+
+NVerbs::TMemoryWindowPtr TClientEndpoint::AcquireMemoryWindowLocked()
+{
+    if (!FreeMemoryWindows.empty()) {
+        auto memoryWindow = std::move(FreeMemoryWindows.back());
+        FreeMemoryWindows.pop_back();
+        return memoryWindow;
+    }
+
+    // Slow path for request spikes over the preallocated pool size.
+    return Verbs->CreateMemoryWindow(Connection->pd);
+}
+
+void TClientEndpoint::RecycleMemoryWindowLocked(
+    NVerbs::TMemoryWindowPtr& memoryWindow)
+{
+    if (!memoryWindow) {
+        return;
+    }
+
+    if (FreeMemoryWindows.size() < MaxFreeMemoryWindows) {
+        FreeMemoryWindows.push_back(std::move(memoryWindow));
+    } else {
+        memoryWindow = NVerbs::NullPtr;
+    }
+}
+
+ui32 TClientEndpoint::GetNextMemoryWindowRKey(ibv_mw* memoryWindow)
+{
+    Y_ABORT_UNLESS(memoryWindow);
+
+    const ui32 current = memoryWindow->rkey;
+    const ui32 next = (current & 0xFFFFFF00u) | ((current + 1u) & 0x000000FFu);
+    memoryWindow->rkey = next;
+    return next;
 }
 
 ui64 TClientEndpoint::GetNewReqId() noexcept
@@ -1961,14 +2528,29 @@ private:
 
             for (auto& request: requests) {
                 const ui32 reqId = request->ReqId;
-                RDMA_DEBUG(endpoint->Log, "request " << reqId << " timed out");
+                const bool alreadyPendingAbort =
+                    request->Resources && request->Resources->AbortPending;
+                if (!alreadyPendingAbort) {
+                    RDMA_DEBUG(endpoint->Log, "request " << reqId << " timed out");
+                }
+                TString timeoutMessage = TStringBuilder()
+                    << "request " << reqId << " timed out "
+                    << "[peer=" << endpoint->Host << ":"
+                    << endpoint->Port << "]";
+
+                if (endpoint->DeferAbortUntilSendCompletion(
+                        request,
+                        E_TIMEOUT,
+                        timeoutMessage))
+                {
+                    continue;
+                }
+
                 endpoint->Counters->RequestAborted();
                 endpoint->AbortRequest(
                     std::move(request),
                     E_TIMEOUT,
-                    TStringBuilder() << "request " << reqId << " timed out "
-                                     << "[peer=" << endpoint->Host << ":"
-                                     << endpoint->Port << "]");
+                    timeoutMessage);
             }
         }
     }
@@ -2447,6 +3029,7 @@ void TClient::BeginConnect(TClientEndpoint* endpoint) noexcept
 
     try {
         RDMA_INFO(endpoint->Log, "connect to " << endpoint->Host);
+        endpoint->PeerSupportsSendWithInvalidate = false;
 
         endpoint->ChangeState(
             EEndpointState::ResolvingRoute,
@@ -2507,6 +3090,11 @@ void TClient::HandleConnected(
         endpoint->Disconnect();
         return;
     }
+
+    const auto* acceptMsg =
+        static_cast<const TAcceptMessage*>(param->private_data);
+    endpoint->PeerSupportsSendWithInvalidate =
+        (acceptMsg->Unused & RDMA_ACCEPT_FLAG_SEND_WITH_INV) != 0;
 
     endpoint->SetNegotiatedProtocolVersion(version);
     endpoint->ChangeState(

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -3111,6 +3111,9 @@ void TClient::HandleConnected(
         static_cast<const TAcceptMessage*>(param->private_data);
     endpoint->PeerSupportsSendWithInvalidate =
         (acceptMsg->Unused & RDMA_ACCEPT_FLAG_SEND_WITH_INV) != 0;
+    if (endpoint->PeerSupportsSendWithInvalidate) {
+        RDMA_INFO(endpoint->Log, "send with invalidate enabled");
+    }
 
     endpoint->SetNegotiatedProtocolVersion(version);
     endpoint->ChangeState(

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -716,15 +716,15 @@ void TClientEndpoint::CreateQP()
         Verbs->RdmaCreateQP(Connection.get(), &qp_attrs);
     }
 
-    SendBuffers.Init(
-        Verbs,
-        Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
+    int sendAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
+    int recvAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
+    if (Config.UseMemoryWindows) {
+        sendAccessFlags |= IBV_ACCESS_MW_BIND;
+        recvAccessFlags |= IBV_ACCESS_MW_BIND;
+    }
 
-    RecvBuffers.Init(
-        Verbs,
-        Connection->pd,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    SendBuffers.Init(Verbs, Connection->pd, sendAccessFlags);
+    RecvBuffers.Init(Verbs, Connection->pd, recvAccessFlags);
 
     SendBuffer = SendBuffers.AcquireBuffer(
         Config.SendQueueSize * sizeof(TRequestMessage), true);
@@ -860,12 +860,16 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         with_lock (AllocationLock) {
             if (requestBytes) {
                 req->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
-                req->InMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
+                if (Config.UseMemoryWindows) {
+                    req->InMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
+                }
             }
 
             if (responseBytes) {
                 req->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
-                req->OutMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
+                if (Config.UseMemoryWindows) {
+                    req->OutMemoryWindow = Verbs->CreateMemoryWindow(Connection->pd);
+                }
             }
         }
     } catch (...) {
@@ -1261,7 +1265,7 @@ void TClientEndpoint::BindInBuffer(TRequest* req, TSendWr* send) noexcept
 
     try {
         Verbs->PostSend(Connection->qp, &wr);
-        RDMA_TRACE("bind request " << reqId << " input buffer");
+        RDMA_TRACE("bind request " << req->ReqId << " input buffer");
         RDMA_TRACE(wr << "[request=" << req->ReqId << "]" << " posted");
     }
     catch (const TServiceError& e) {
@@ -1357,9 +1361,13 @@ void TClientEndpoint::BindCompleted(TSendWr* send) noexcept
                 RDMA_ERROR(
                     "bind " << send->wr << " completed in unexpected state "
                             << req->State);
+                SendQueue.Push(send);
+                Disconnect();
         }
+        return;
     }
-    // request has been cancelled before bind completed
+    // request has been cancelled/aborted before bind completed
+    SendQueue.Push(send);
 }
 
 void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
@@ -1567,6 +1575,11 @@ bool TClientEndpoint::FlushHanging() const
 
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
+    // Memory windows must be deallocated before releasing pooled buffers/MRs
+    // they were bound to.
+    req->InMemoryWindow = NVerbs::NullPtr;
+    req->OutMemoryWindow = NVerbs::NullPtr;
+
     with_lock (AllocationLock) {
         SendBuffers.ReleaseBuffer(req->InBuffer);
         RecvBuffers.ReleaseBuffer(req->OutBuffer);

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -60,11 +60,41 @@ constexpr TDuration INSTANT_RECONNECT_DELAY = TDuration::MicroSeconds(1);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TRequestResources
+{
+    enum class ERecyclePolicy
+    {
+        Recycle,
+        Drop,
+    };
+
+    enum class EOutMode
+    {
+        None,
+        RemoteInvalidate,
+        LocalInvalidate,
+    };
+
+    TPooledBuffer InBuffer{};
+    TPooledBuffer OutBuffer{};
+
+    NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
+    NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
+
+    ERecyclePolicy RecyclePolicy = ERecyclePolicy::Recycle;
+    EOutMode OutMode = EOutMode::None;
+    ui32 RKey = 0;
+    ui64 BufferPoolGeneration = 0;
+    NProto::TError Error;
+
+    ui32 Status = RDMA_PROTO_FAIL;
+    ui32 ResponseBytes = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TRequest;
 using TRequestPtr = std::unique_ptr<TRequest>;
-
-struct TRequestResources;
-using TRequestResourcesPtr = std::unique_ptr<TRequestResources>;
 
 struct TEndpointCounters;
 using TEndpointCountersPtr = std::shared_ptr<TEndpointCounters>;
@@ -100,7 +130,7 @@ struct TRequest
     ui32 ReqId = 0;   // 16-bit RDMA request id
     ui64 ClientReqId = 0;
 
-    TRequestResourcesPtr Resources;
+    TRequestResources Resources;
 
     ERequestState State;
 
@@ -433,39 +463,6 @@ struct TClientRequestId: TListNode<TClientRequestId>
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TRequestResources
-{
-    enum class ERecyclePolicy
-    {
-        Recycle,
-        Drop,
-    };
-
-    enum class EOutMode
-    {
-        None,
-        RemoteInvalidate,
-        LocalInvalidate,
-    };
-
-    TPooledBuffer InBuffer{};
-    TPooledBuffer OutBuffer{};
-
-    NVerbs::TMemoryWindowPtr InMemoryWindow = NVerbs::NullPtr;
-    NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
-
-    ERecyclePolicy RecyclePolicy = ERecyclePolicy::Recycle;
-    EOutMode OutMode = EOutMode::None;
-    ui32 RKey = 0;
-    ui64 BufferPoolGeneration = 0;
-    NProto::TError Error;
-
-    ui32 Status = RDMA_PROTO_FAIL;
-    ui32 ResponseBytes = 0;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
 struct TInvalidationRequest
     : TIntrusiveListItem<TInvalidationRequest>
 {
@@ -561,8 +558,8 @@ private:
     std::atomic<size_t> QpOwnedSendSlots = 0;
     // Invalidations have only two ownership states: waiting for a send slot or
     // already visible to hardware. Posted entries stay in one list until their
-    // terminal CQE or QP destruction; flags record whether the user callback
-    // and send-slot bookkeeping have already been completed.
+    // terminal CQE or QP destruction. QpOwnedSendSlot tracks send-slot
+    // bookkeeping while the QP is committed to destruction.
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
         PendingInvalidationRequests;
     TIntrusiveListWithAutoDelete<TInvalidationRequest, TInvalidationRequestDelete>
@@ -637,7 +634,6 @@ public:
 private:
     enum class EAbortCounter
     {
-        None,
         Dequeued,
         Aborted,
     };
@@ -657,7 +653,7 @@ private:
 
     // Abort/defer flow.
     void TryAbortRequest(
-        TRequestPtr& req,
+        TRequestPtr req,
         NProto::TError error) noexcept;
     void AbortRequest(ui32 reqId) noexcept;
     void AbortRequest(ui32 reqId, NProto::TError error) noexcept;
@@ -687,7 +683,6 @@ private:
     bool NeedLocalInvalidation(const TRequestResources& resources) const noexcept;
 
     // Resource lifetime and allocation helpers.
-    void ReleaseRequestResources(TRequestResourcesPtr resources) noexcept;
     void CleanupRequestResourcesLocked(TRequestResources& resources) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     NVerbs::TMemoryWindowPtr AcquireMemoryWindowLocked();
@@ -997,22 +992,21 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
         shared_from_this(),
         std::move(handler),
         std::move(context));
-    req->Resources = std::make_unique<TRequestResources>();
-    req->Resources->BufferPoolGeneration = BufferPoolGeneration.load();
+    req->Resources.BufferPoolGeneration = BufferPoolGeneration.load();
 
     try {
         with_lock (AllocationLock) {
             if (requestBytes) {
-                req->Resources->InBuffer = SendBuffers.AcquireBuffer(requestBytes);
+                req->Resources.InBuffer = SendBuffers.AcquireBuffer(requestBytes);
                 if (Config.UseMemoryWindows) {
-                    req->Resources->InMemoryWindow = AcquireMemoryWindowLocked();
+                    req->Resources.InMemoryWindow = AcquireMemoryWindowLocked();
                 }
             }
 
             if (responseBytes) {
-                req->Resources->OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
+                req->Resources.OutBuffer = RecvBuffers.AcquireBuffer(responseBytes);
                 if (Config.UseMemoryWindows) {
-                    req->Resources->OutMemoryWindow = AcquireMemoryWindowLocked();
+                    req->Resources.OutMemoryWindow = AcquireMemoryWindowLocked();
                 }
             }
         }
@@ -1030,12 +1024,12 @@ TResultOrError<TClientRequestPtr> TClientEndpoint::AllocateRequest(
     }
 
     req->RequestBuffer = TStringBuf {
-        reinterpret_cast<char*>(req->Resources->InBuffer.Address),
-        req->Resources->InBuffer.Length,
+        reinterpret_cast<char*>(req->Resources.InBuffer.Address),
+        req->Resources.InBuffer.Length,
     };
     req->ResponseBuffer = TStringBuf {
-        reinterpret_cast<char*>(req->Resources->OutBuffer.Address),
-        req->Resources->OutBuffer.Length,
+        reinterpret_cast<char*>(req->Resources.OutBuffer.Address),
+        req->Resources.OutBuffer.Length,
     };
 
     return TClientRequestPtr(std::move(req));
@@ -1195,7 +1189,7 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
         TryAbortRequest(
-            req,
+            std::move(req),
             MakeError(E_CANCELLED, "request was cancelled"));
     }
 
@@ -1241,7 +1235,7 @@ void TClientEndpoint::AbortRequests() noexcept
     while (auto req = activeRequests.Dequeue()) {
         RDMA_DEBUG("abort request " << req->ReqId);
         TryAbortRequest(
-            req,
+            std::move(req),
             MakeError(E_RDMA_UNAVAILABLE, "endpoint is unavailable"));
     }
 
@@ -1254,12 +1248,12 @@ void TClientEndpoint::AbortRequest(
 {
     // For timed out/cancelled/aborted requests we cannot guarantee that remote
     // peer invalidated keys, so force MW deallocation instead of recycling.
-    req->Resources->RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
+    req->Resources.RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
 
     auto len = SerializeError(
         error.GetCode(),
         error.GetMessage(),
-        static_cast<TStringBuf>(req->Resources->OutBuffer));
+        static_cast<TStringBuf>(req->Resources.OutBuffer));
 
     auto* handler = req->Handler.get();
     handler->HandleResponse(std::move(req), RDMA_PROTO_FAIL, len);
@@ -1469,8 +1463,8 @@ void TClientEndpoint::SendRequest(TRequestPtr request, TSendWr* send) noexcept
 
     msg->ReqId = req->ReqId;
     msg->Unused = RDMA_REQUEST_FLAG_NONE;
-    msg->In = req->Resources->InBuffer;
-    msg->Out = req->Resources->OutBuffer;
+    msg->In = req->Resources.InBuffer;
+    msg->Out = req->Resources.OutBuffer;
 
     SendRequest(req, send);
 }
@@ -1479,8 +1473,6 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
 {
     req->State = ERequestState::SendRequest;
     auto* msg = send->Message();
-    req->Resources->OutMode = TRequestResources::EOutMode::None;
-    req->Resources->RKey = 0;
     Counters->SendRequestStarted();
 
     // We only expect SEND completion with sq_sig_all=0.
@@ -1493,7 +1485,7 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
     ibv_send_wr bindOut = {};
 
     if (Config.UseMemoryWindows) {
-        if (req->Resources->InMemoryWindow) {
+        if (req->Resources.InMemoryWindow) {
             if (req->CallContext) {
                 LWTRACK(
                     BindInBufferStarted,
@@ -1502,23 +1494,23 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
             }
 
             const ui32 inRKey = GetNextMemoryWindowRKey(
-                req->Resources->InMemoryWindow.get());
+                req->Resources.InMemoryWindow.get());
             msg->In.RKey = inRKey;
 
             bindIn.wr_id = send->wr.wr_id;
             bindIn.opcode = IBV_WR_BIND_MW;
-            bindIn.bind_mw.mw = req->Resources->InMemoryWindow.get();
+            bindIn.bind_mw.mw = req->Resources.InMemoryWindow.get();
             bindIn.bind_mw.rkey = inRKey;
-            bindIn.bind_mw.bind_info.mr = req->Resources->InBuffer.GetMemoryRegion();
-            bindIn.bind_mw.bind_info.addr = req->Resources->InBuffer.Address;
-            bindIn.bind_mw.bind_info.length = req->Resources->InBuffer.Length;
+            bindIn.bind_mw.bind_info.mr = req->Resources.InBuffer.GetMemoryRegion();
+            bindIn.bind_mw.bind_info.addr = req->Resources.InBuffer.Address;
+            bindIn.bind_mw.bind_info.length = req->Resources.InBuffer.Length;
             bindIn.bind_mw.bind_info.mw_access_flags = IBV_ACCESS_REMOTE_READ;
 
             head = &bindIn;
             tail = &bindIn;
         }
 
-        if (req->Resources->OutMemoryWindow) {
+        if (req->Resources.OutMemoryWindow) {
             if (req->CallContext) {
                 LWTRACK(
                     BindOutBufferStarted,
@@ -1527,17 +1519,17 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
             }
 
             const ui32 outRKey = GetNextMemoryWindowRKey(
-                req->Resources->OutMemoryWindow.get());
+                req->Resources.OutMemoryWindow.get());
             msg->Out.RKey = outRKey;
-            ConfigureOutInvalidation(*req->Resources, msg, outRKey);
+            ConfigureOutInvalidation(req->Resources, msg, outRKey);
 
             bindOut.wr_id = send->wr.wr_id;
             bindOut.opcode = IBV_WR_BIND_MW;
-            bindOut.bind_mw.mw = req->Resources->OutMemoryWindow.get();
+            bindOut.bind_mw.mw = req->Resources.OutMemoryWindow.get();
             bindOut.bind_mw.rkey = outRKey;
-            bindOut.bind_mw.bind_info.mr = req->Resources->OutBuffer.GetMemoryRegion();
-            bindOut.bind_mw.bind_info.addr = req->Resources->OutBuffer.Address;
-            bindOut.bind_mw.bind_info.length = req->Resources->OutBuffer.Length;
+            bindOut.bind_mw.bind_info.mr = req->Resources.OutBuffer.GetMemoryRegion();
+            bindOut.bind_mw.bind_info.addr = req->Resources.OutBuffer.Address;
+            bindOut.bind_mw.bind_info.length = req->Resources.OutBuffer.Length;
             bindOut.bind_mw.bind_info.mw_access_flags = IBV_ACCESS_REMOTE_WRITE;
 
             if (tail) {
@@ -1576,8 +1568,6 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
             } else {
                 // ibv_post_send may accept a prefix of a linked list. Keep all
                 // resources alive until the QP has been destroyed.
-                failedReq->Resources->RecyclePolicy =
-                    TRequestResources::ERecyclePolicy::Drop;
                 PartiallyPostedRequests.Enqueue(std::move(failedReq));
                 ++QpOwnedSendSlots;
             }
@@ -1672,23 +1662,21 @@ void TClientEndpoint::AbortRequest(
         case EAbortCounter::Aborted:
             Counters->RequestAborted();
             break;
-        case EAbortCounter::None:
-            break;
     }
 
     AbortRequest(std::move(req), error);
 }
 
 void TClientEndpoint::TryAbortRequest(
-    TRequestPtr& req,
+    TRequestPtr req,
     NProto::TError error) noexcept
 {
-    if (req &&
-        Config.UseMemoryWindows &&
-        req->State == ERequestState::SendRequest &&
-        req->Resources)
+    Y_ABORT_UNLESS(req);
+
+    if (Config.UseMemoryWindows &&
+        req->State == ERequestState::SendRequest)
     {
-        auto& resources = *req->Resources;
+        auto& resources = req->Resources;
         if (!HasError(resources.Error)) {
             resources.Error = std::move(error);
         }
@@ -1711,34 +1699,20 @@ void TClientEndpoint::AbortRequest(ui32 reqId) noexcept
 void TClientEndpoint::AbortRequest(ui32 reqId, NProto::TError error) noexcept
 {
     auto* req = ActiveRequests.Get(reqId);
-    if (!req || !req->Resources) {
+    if (!req) {
         return;
     }
-
-    if (!HasError(req->Resources->Error)) {
+    if (!HasError(req->Resources.Error)) {
         if (!HasError(error)) {
             return;
         }
-        req->Resources->Error = std::move(error);
+        req->Resources.Error = std::move(error);
     }
 
     auto abortedReq = ActiveRequests.Pop(reqId);
-    if (!abortedReq || !abortedReq->Resources) {
-        return;
-    }
+    Y_ABORT_UNLESS(abortedReq);
 
-    if (!HasError(abortedReq->Resources->Error)) {
-        if (!HasError(error)) {
-            return;
-        }
-        abortedReq->Resources->Error = std::move(error);
-    }
-
-    if (!HasError(abortedReq->Resources->Error)) {
-        return;
-    }
-    auto abortError = std::move(abortedReq->Resources->Error);
-    abortedReq->Resources->Error = NProto::TError();
+    auto abortError = std::move(abortedReq->Resources.Error);
 
     AbortRequest(
         std::move(abortedReq),
@@ -1755,22 +1729,20 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
     SendQueue.Push(send);
 
     if (auto* req = ActiveRequests.Get(reqId)) {
-        if (Config.UseMemoryWindows) {
-            if (req->Resources->InMemoryWindow) {
-                if (req->CallContext) {
-                    LWTRACK(
-                        BindInBufferCompleted,
-                        req->CallContext->LWOrbit,
-                        req->CallContext->RequestId);
-                }
+        if (req->Resources.InMemoryWindow) {
+            if (req->CallContext) {
+                LWTRACK(
+                    BindInBufferCompleted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
             }
-            if (req->Resources->OutMemoryWindow) {
-                if (req->CallContext) {
-                    LWTRACK(
-                        BindOutBufferCompleted,
-                        req->CallContext->LWOrbit,
-                        req->CallContext->RequestId);
-                }
+        }
+        if (req->Resources.OutMemoryWindow) {
+            if (req->CallContext) {
+                LWTRACK(
+                    BindOutBufferCompleted,
+                    req->CallContext->LWOrbit,
+                    req->CallContext->RequestId);
             }
         }
 
@@ -1841,10 +1813,8 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept
     }
 
     NProto::TError abortError;
-    if (req->Resources && HasError(req->Resources->Error))
-    {
-        abortError = std::move(req->Resources->Error);
-        req->Resources->Error = NProto::TError();
+    if (HasError(req->Resources.Error)) {
+        abortError = std::move(req->Resources.Error);
         RecvResponse(recv);
         AbortRequest(
             std::move(req),
@@ -1853,7 +1823,7 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept
         return;
     }
 
-    auto& resources = *req->Resources;
+    auto& resources = req->Resources;
     ValidateRemoteInvalidation(recv, reqId, wc, resources);
 
     resources.Status = status;
@@ -1970,17 +1940,6 @@ bool TClientEndpoint::FlushHanging() const
            CyclesToDurationSafe(GetCycleCount() - start) >= Config.FlushTimeout;
 }
 
-void TClientEndpoint::ReleaseRequestResources(TRequestResourcesPtr resources) noexcept
-{
-    if (!resources) {
-        return;
-    }
-
-    with_lock (AllocationLock) {
-        CleanupRequestResourcesLocked(*resources);
-    }
-}
-
 void TClientEndpoint::CleanupRequestResourcesLocked(
     TRequestResources& resources) noexcept
 {
@@ -2015,8 +1974,10 @@ void TClientEndpoint::CleanupRequestResourcesLocked(
 
 void TClientEndpoint::FinalizeRequest(TRequestPtr req) noexcept
 {
-    const ui32 status = req->Resources ? req->Resources->Status : RDMA_PROTO_FAIL;
-    const ui32 responseBytes = req->Resources ? req->Resources->ResponseBytes : 0;
+    Y_ABORT_UNLESS(req);
+
+    const ui32 status = req->Resources.Status;
+    const ui32 responseBytes = req->Resources.ResponseBytes;
 
     Counters->RequestCompleted();
 
@@ -2039,10 +2000,8 @@ void TClientEndpoint::CompleteInvalidationRequest(
 {
     Y_ABORT_UNLESS(req);
     Y_ABORT_UNLESS(req->Request);
-    if (req->Request->Resources) {
-        req->Request->Resources->RecyclePolicy =
-            TRequestResources::ERecyclePolicy::Drop;
-    }
+    req->Request->Resources.RecyclePolicy =
+        TRequestResources::ERecyclePolicy::Drop;
     FinalizeRequest(std::move(req->Request));
 }
 
@@ -2067,10 +2026,6 @@ void TClientEndpoint::DrainInvalidationRequests() noexcept
 
     for (auto& req: PostedInvalidationRequests) {
         MarkInvalidationAsQpOwned(&req);
-        if (req.Request && req.Request->Resources) {
-            req.Request->Resources->RecyclePolicy =
-                TRequestResources::ERecyclePolicy::Drop;
-        }
     }
 }
 
@@ -2088,10 +2043,9 @@ void TClientEndpoint::PostLocalInvalidation(
 {
     Y_ABORT_UNLESS(req);
     Y_ABORT_UNLESS(req->Request);
-    Y_ABORT_UNLESS(req->Request->Resources);
-    auto* resources = req->Request->Resources.get();
+    auto& resources = req->Request->Resources;
     const bool needLocalInvalidateOut =
-        resources->OutMode ==
+        resources.OutMode ==
         TRequestResources::EOutMode::LocalInvalidate;
 
     ibv_send_wr* head = nullptr;
@@ -2099,21 +2053,21 @@ void TClientEndpoint::PostLocalInvalidation(
     ibv_send_wr invIn = {};
     ibv_send_wr invOut = {};
 
-    if (resources->InMemoryWindow) {
+    if (resources.InMemoryWindow) {
         invIn.wr_id = send->wr.wr_id;
         invIn.opcode = IBV_WR_LOCAL_INV;
-        invIn.invalidate_rkey = resources->InMemoryWindow->rkey;
+        invIn.invalidate_rkey = resources.InMemoryWindow->rkey;
 
         head = &invIn;
         tail = &invIn;
     }
 
     if (needLocalInvalidateOut &&
-        resources->OutMemoryWindow)
+        resources.OutMemoryWindow)
     {
         invOut.wr_id = send->wr.wr_id;
         invOut.opcode = IBV_WR_LOCAL_INV;
-        invOut.invalidate_rkey = resources->OutMemoryWindow->rkey;
+        invOut.invalidate_rkey = resources.OutMemoryWindow->rkey;
 
         if (tail) {
             tail->next = &invOut;
@@ -2123,16 +2077,9 @@ void TClientEndpoint::PostLocalInvalidation(
         tail = &invOut;
     }
 
-    if (!head) {
-        SendQueue.Push(send);
-        FinalizeRequest(std::move(req->Request));
-        delete req;
-        return;
-    }
-
+    Y_ABORT_UNLESS(head && tail);
     PostedInvalidationRequests.PushBack(req);
     send->context = req;
-    Y_ABORT_UNLESS(tail);
     tail->send_flags |= IBV_SEND_SIGNALED;
 
     ibv_send_wr* badWr = nullptr;
@@ -2151,10 +2098,6 @@ void TClientEndpoint::PostLocalInvalidation(
         } else {
             // At least one invalidation was accepted. Its MW must remain alive
             // until QP destruction even though no terminal WR was posted.
-            if (req->Request && req->Request->Resources) {
-                req->Request->Resources->RecyclePolicy =
-                    TRequestResources::ERecyclePolicy::Drop;
-            }
             PostedInvalidationRequests.PushBack(req);
             MarkInvalidationAsQpOwned(req);
         }
@@ -2197,11 +2140,9 @@ void TClientEndpoint::LocalInvalidationCompleted(TSendWr* send) noexcept
 
 void TClientEndpoint::FreeRequest(TRequest* req) noexcept
 {
-    if (!req->Resources) {
-        return;
+    with_lock (AllocationLock) {
+        CleanupRequestResourcesLocked(req->Resources);
     }
-
-    ReleaseRequestResources(std::move(req->Resources));
 }
 
 NVerbs::TMemoryWindowPtr TClientEndpoint::AcquireMemoryWindowLocked()
@@ -2629,7 +2570,7 @@ private:
             for (auto& request: requests) {
                 const ui32 reqId = request->ReqId;
                 const bool alreadyPendingAbort =
-                    request->Resources && HasError(request->Resources->Error);
+                    HasError(request->Resources.Error);
                 if (!alreadyPendingAbort) {
                     RDMA_DEBUG(endpoint->Log, "request " << reqId << " timed out");
                 }
@@ -2639,7 +2580,7 @@ private:
                     << endpoint->Port << "]";
 
                 endpoint->TryAbortRequest(
-                    request,
+                    std::move(request),
                     MakeError(E_TIMEOUT, std::move(timeoutMessage)));
             }
         }

--- a/cloud/storage/core/libs/rdma/impl/client.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client.cpp
@@ -442,11 +442,11 @@ struct TRequestResources
         Drop,
     };
 
-    enum class EOutInvalidationMode
+    enum class EOutMode
     {
         None,
-        Remote,
-        Local,
+        RemoteInvalidate,
+        LocalInvalidate,
     };
 
     TPooledBuffer InBuffer{};
@@ -456,12 +456,10 @@ struct TRequestResources
     NVerbs::TMemoryWindowPtr OutMemoryWindow = NVerbs::NullPtr;
 
     ERecyclePolicy RecyclePolicy = ERecyclePolicy::Recycle;
-    EOutInvalidationMode OutInvalidationMode = EOutInvalidationMode::None;
-    ui32 ExpectedInvalidatedRKey = 0;
+    EOutMode OutMode = EOutMode::None;
+    ui32 RKey = 0;
     ui64 BufferPoolGeneration = 0;
-    bool AbortPending = false;
-    ui32 AbortError = RDMA_PROTO_FAIL;
-    TString AbortMessage;
+    NProto::TError Error;
 
     ui32 Status = RDMA_PROTO_FAIL;
     ui32 ResponseBytes = 0;
@@ -641,20 +639,44 @@ public:
     int GetNegotiatedProtocolVersion() const;
 
 private:
+    enum class EAbortCounter
+    {
+        None,
+        Dequeued,
+        Aborted,
+    };
+
+private:
     // called from CQ thread
+
+    // Request scheduling and completion flow.
     void HandleQueuedRequests() noexcept;
-    void ReleaseRequestResources(TRequestResourcesPtr resources) noexcept;
     void SendRequest(TRequestPtr req, TSendWr* send) noexcept;
     void SendRequest(TRequest* req, TSendWr* send) noexcept;
     void SendRequestCompleted(TSendWr* send) noexcept;
+    int ValidateCompletion(ibv_wc* wc) noexcept;
+    void RecvResponse(TRecvWr* recv) noexcept;
+    void RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept;
     void FinalizeRequest(TRequestPtr req) noexcept;
+
+    // Abort/defer flow.
+    void TryAbortRequest(
+        TRequestPtr& req,
+        NProto::TError error) noexcept;
+    void AbortRequest(ui32 reqId) noexcept;
+    void AbortRequest(TRequestPtr req, const NProto::TError& error) noexcept;
+    void AbortRequest(
+        TRequestPtr req,
+        EAbortCounter counter,
+        const NProto::TError& error) noexcept;
+
+    // Invalidation flow.
     void FinalizeInvalidationRequest(TInvalidationRequest* req, bool keepAlive) noexcept;
-    void DrainInvalidationRequestsOnDisconnect() noexcept;
+    void DrainInvalidationRequests() noexcept;
     void PostNextPendingInvalidation(TSendWr* send) noexcept;
     void PostLocalInvalidation(TInvalidationRequest* req, TSendWr* send) noexcept;
     void HandlePendingInvalidationRequests() noexcept;
     void LocalInvalidationCompleted(TSendWr* send) noexcept;
-    void ResetInvalidationState(TRequestResources& resources) noexcept;
     void ConfigureOutInvalidation(
         TRequestResources& resources,
         TRequestMessage* msg,
@@ -665,35 +687,15 @@ private:
         ibv_wc* wc,
         TRequestResources& resources) noexcept;
     bool NeedLocalInvalidation(const TRequestResources& resources) const noexcept;
-    bool ConsumeDeferredAbortIfAny(
-        TRequestResources& resources,
-        ui32& err,
-        TString& msg) noexcept;
-    void AbortRequestWithAccounting(
-        TRequestPtr req,
-        ui32 err,
-        TString msg) noexcept;
-    void AbortDequeuedRequest(
-        TRequestPtr req,
-        ui32 err,
-        TString msg) noexcept;
-    bool TryDeferAbortUntilSendCompletion(
-        TRequestPtr& req,
-        ui32 err,
-        TString msg) noexcept;
-    void AbortActiveRequestOrDefer(
-        TRequestPtr& req,
-        ui32 err,
-        TString msg) noexcept;
-    void FinalizeDeferredAbort(ui32 reqId) noexcept;
-    void RecvResponse(TRecvWr* recv) noexcept;
-    void RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept;
-    void AbortRequest(TRequestPtr req, ui32 err, const TString& msg) noexcept;
+
+    // Resource lifetime and allocation helpers.
+    void ReleaseRequestResources(TRequestResourcesPtr resources) noexcept;
     void FreeRequest(TRequest* creq) noexcept;
     NVerbs::TMemoryWindowPtr AcquireMemoryWindowLocked();
     void RecycleMemoryWindowLocked(NVerbs::TMemoryWindowPtr& memoryWindow);
     static ui32 GetNextMemoryWindowRKey(ibv_mw* memoryWindow);
-    int ValidateCompletion(ibv_wc* wc) noexcept;
+
+    // Misc.
     ui64 GetNewReqId() noexcept;
 };
 
@@ -1036,7 +1038,9 @@ ui64 TClientEndpoint::SendRequest(
     req->ClientReqId = clientReqId;
 
     if (!CheckState(EEndpointState::Connected)) {
-        AbortRequest(std::move(req), E_RDMA_UNAVAILABLE, "endpoint is unavailable");
+        AbortRequest(
+            std::move(req),
+            MakeError(E_RDMA_UNAVAILABLE, "endpoint is unavailable"));
         return clientReqId;
     }
 
@@ -1095,17 +1099,17 @@ void TClientEndpoint::HandleQueuedRequests() noexcept
             SendRequest(std::move(req), send);
         }
         else {
-            DrainInvalidationRequestsOnDisconnect();
+            DrainInvalidationRequests();
 
             auto req = QueuedRequests.Dequeue();
             if (!req) {
                 break;
             }
 
-            AbortDequeuedRequest(
+            AbortRequest(
                 std::move(req),
-                E_RDMA_UNAVAILABLE,
-                "endpoint is unavailable");
+                EAbortCounter::Dequeued,
+                MakeError(E_RDMA_UNAVAILABLE, "endpoint is unavailable"));
         }
     }
 }
@@ -1165,20 +1169,19 @@ bool TClientEndpoint::HandleCancelRequests() noexcept
     cancelled.Append(QueuedRequests.DequeueIf(wasCancelled));
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
-        AbortDequeuedRequest(
+        AbortRequest(
             std::move(req),
-            E_CANCELLED,
-            "request was cancelled");
+            EAbortCounter::Dequeued,
+            MakeError(E_CANCELLED, "request was cancelled"));
     }
 
     // cancel active requests
     cancelled.Append(ActiveRequests.PopCancelledRequests(clientRequestIdToCancel));
     while (auto req = cancelled.Dequeue()) {
         RDMA_TRACE("request " << req->ReqId << " cancelled");
-        AbortActiveRequestOrDefer(
+        TryAbortRequest(
             req,
-            E_CANCELLED,
-            "request was cancelled");
+            MakeError(E_CANCELLED, "request was cancelled"));
     }
 
     if (!requests) {
@@ -1209,10 +1212,10 @@ void TClientEndpoint::AbortRequests() noexcept
         auto req = QueuedRequests.Dequeue();
         Y_ABORT_UNLESS(req);
         RDMA_DEBUG("abort request " << req->ReqId);
-        AbortDequeuedRequest(
+        AbortRequest(
             std::move(req),
-            E_RDMA_UNAVAILABLE,
-            "endpoint is unavailable");
+            EAbortCounter::Dequeued,
+            MakeError(E_RDMA_UNAVAILABLE, "endpoint is unavailable"));
     }
 
     TSimpleList<TRequest> activeRequests;
@@ -1222,27 +1225,25 @@ void TClientEndpoint::AbortRequests() noexcept
 
     while (auto req = activeRequests.Dequeue()) {
         RDMA_DEBUG("abort request " << req->ReqId);
-        AbortActiveRequestOrDefer(
+        TryAbortRequest(
             req,
-            E_RDMA_UNAVAILABLE,
-            "endpoint is unavailable");
+            MakeError(E_RDMA_UNAVAILABLE, "endpoint is unavailable"));
     }
 
-    DrainInvalidationRequestsOnDisconnect();
+    DrainInvalidationRequests();
 }
 
 void TClientEndpoint::AbortRequest(
     TRequestPtr req,
-    ui32 err, const
-    TString& msg) noexcept
+    const NProto::TError& error) noexcept
 {
     // For timed out/cancelled/aborted requests we cannot guarantee that remote
     // peer invalidated keys, so force MW deallocation instead of recycling.
     req->Resources->RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
 
     auto len = SerializeError(
-        err,
-        msg,
+        error.GetCode(),
+        error.GetMessage(),
         static_cast<TStringBuf>(req->Resources->OutBuffer));
 
     auto* handler = req->Handler.get();
@@ -1281,79 +1282,97 @@ int TClientEndpoint::ValidateCompletion(ibv_wc* wc) noexcept
 
     if (id.Magic == SendMagic && id.Index < SendWrs.size()) {
         auto* send = &SendWrs[id.Index];
-        const bool isRequestSend = wc->opcode == IBV_WC_SEND;
-        const bool isLocalInvalidate = wc->opcode == IBV_WC_LOCAL_INV;
-        const bool isBindMw = wc->opcode == IBV_WC_BIND_MW;
-
-        if (wc->status == IBV_WC_WR_FLUSH_ERR) {
-            RDMA_TRACE(send << " " << NVerbs::GetStatusString(wc->status));
-            if (isLocalInvalidate) {
-                send->context = nullptr;
-                SendQueue.Push(send);
-            }
-            if (isRequestSend) {
-                const ui32 reqId =
-                    SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
-                Counters->SendRequestCompleted();
-                SendQueue.Push(send);
-                FinalizeDeferredAbort(reqId);
-            }
-            return -1;
-        }
-        if (wc->status != IBV_WC_SUCCESS) {
-            RDMA_ERROR(send << " " << NVerbs::GetStatusString(wc->status));
-            Counters->Error();
-            if (isLocalInvalidate) {
-                send->context = nullptr;
-                SendQueue.Push(send);
-            }
-            if (isRequestSend) {
-                const ui32 reqId =
-                    SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
-                Counters->SendRequestCompleted();
-                SendQueue.Push(send);
-                FinalizeDeferredAbort(reqId);
-            }
-            return -1;
-        }
-        if (!isRequestSend && !isBindMw && !isLocalInvalidate) {
-            RDMA_ERROR(
-                send << " unexpected opcode "
-                     << NVerbs::GetOpcodeName(wc->opcode));
-            Counters->Error();
+        auto handleLocalInvalidationCompletion = [&] {
+            send->context = nullptr;
+            SendQueue.Push(send);
+        };
+        auto handleRequestSendCompletion = [&] {
+            const ui32 reqId =
+                SafeCast<ui32>(reinterpret_cast<uintptr_t>(send->context));
             Counters->SendRequestCompleted();
             SendQueue.Push(send);
-            return -1;
+            AbortRequest(reqId);
+        };
+
+        switch (wc->status) {
+            case IBV_WC_WR_FLUSH_ERR:
+                RDMA_TRACE(send << " " << NVerbs::GetStatusString(wc->status));
+                switch (wc->opcode) {
+                    case IBV_WC_LOCAL_INV:
+                        handleLocalInvalidationCompletion();
+                        break;
+                    case IBV_WC_SEND:
+                        handleRequestSendCompletion();
+                        break;
+                    default:
+                        break;
+                }
+                return -1;
+
+            case IBV_WC_SUCCESS:
+                switch (wc->opcode) {
+                    case IBV_WC_SEND:
+                    case IBV_WC_BIND_MW:
+                    case IBV_WC_LOCAL_INV:
+                        return 0;
+                    default:
+                        RDMA_ERROR(
+                            send << " unexpected opcode "
+                                 << NVerbs::GetOpcodeName(wc->opcode));
+                        Counters->Error();
+                        Counters->SendRequestCompleted();
+                        SendQueue.Push(send);
+                        return -1;
+                }
+
+            default:
+                RDMA_ERROR(send << " " << NVerbs::GetStatusString(wc->status));
+                Counters->Error();
+                switch (wc->opcode) {
+                    case IBV_WC_LOCAL_INV:
+                        handleLocalInvalidationCompletion();
+                        break;
+                    case IBV_WC_SEND:
+                        handleRequestSendCompletion();
+                        break;
+                    default:
+                        break;
+                }
+                return -1;
         }
-        return 0;
     }
 
     if (id.Magic == RecvMagic && id.Index < RecvWrs.size()) {
         auto* recv = &RecvWrs[id.Index];
 
-        if (wc->status == IBV_WC_WR_FLUSH_ERR) {
-            RDMA_TRACE(recv << " " << NVerbs::GetStatusString(wc->status));
-            Counters->RecvResponseCompleted();
-            RecvQueue.Push(recv);
-            return -1;
+        switch (wc->status) {
+            case IBV_WC_WR_FLUSH_ERR:
+                RDMA_TRACE(recv << " " << NVerbs::GetStatusString(wc->status));
+                Counters->RecvResponseCompleted();
+                RecvQueue.Push(recv);
+                return -1;
+
+            case IBV_WC_SUCCESS:
+                switch (wc->opcode) {
+                    case IBV_WC_RECV:
+                        return 0;
+                    default:
+                        RDMA_ERROR(
+                            recv << " unexpected opcode "
+                                 << NVerbs::GetOpcodeName(wc->opcode));
+                        Counters->Error();
+                        Counters->RecvResponseCompleted();
+                        RecvQueue.Push(recv);
+                        return -1;
+                }
+
+            default:
+                RDMA_ERROR(recv << " " << NVerbs::GetStatusString(wc->status));
+                Counters->Error();
+                Counters->RecvResponseCompleted();
+                RecvQueue.Push(recv);
+                return -1;
         }
-        if (wc->status != IBV_WC_SUCCESS) {
-            RDMA_ERROR(recv << " " << NVerbs::GetStatusString(wc->status));
-            Counters->Error();
-            Counters->RecvResponseCompleted();
-            RecvQueue.Push(recv);
-            return -1;
-        }
-        if (wc->opcode != IBV_WC_RECV) {
-            RDMA_ERROR(
-                recv << " unexpected opcode "
-                     << NVerbs::GetOpcodeName(wc->opcode));
-            Counters->Error();
-            Counters->RecvResponseCompleted();
-            RecvQueue.Push(recv);
-            return -1;
-        }
-        return 0;
     }
 
     RDMA_ERROR("unexpected wr_id " << NVerbs::PrintCompletion(wc));
@@ -1430,7 +1449,8 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
 {
     req->State = ERequestState::SendRequest;
     auto* msg = send->Message();
-    ResetInvalidationState(*req->Resources);
+    req->Resources->OutMode = TRequestResources::EOutMode::None;
+    req->Resources->RKey = 0;
     Counters->SendRequestStarted();
 
     // We only expect SEND completion with sq_sig_all=0.
@@ -1443,7 +1463,7 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
     ibv_send_wr bindOut = {};
 
     if (Config.UseMemoryWindows) {
-        if (req->Resources->InMemoryWindow && req->Resources->InBuffer.Length) {
+        if (req->Resources->InMemoryWindow) {
             if (req->CallContext) {
                 LWTRACK(
                     BindInBufferStarted,
@@ -1468,7 +1488,7 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
             tail = &bindIn;
         }
 
-        if (req->Resources->OutMemoryWindow && req->Resources->OutBuffer.Length) {
+        if (req->Resources->OutMemoryWindow) {
             if (req->CallContext) {
                 LWTRACK(
                     BindOutBufferStarted,
@@ -1515,10 +1535,10 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
         // so no completion/flush can arrive for this request.
         Counters->SendRequestCompleted();
         if (auto failedReq = ActiveRequests.Pop(req->ReqId)) {
-            AbortRequestWithAccounting(
+            AbortRequest(
                 std::move(failedReq),
-                E_RDMA_UNAVAILABLE,
-                "failed to post send request");
+                EAbortCounter::Aborted,
+                MakeError(E_RDMA_UNAVAILABLE, "failed to post send request"));
         }
         Counters->Error();
         Disconnect();
@@ -1534,13 +1554,6 @@ void TClientEndpoint::SendRequest(TRequest* req, TSendWr* send) noexcept
 
 }
 
-void TClientEndpoint::ResetInvalidationState(
-    TRequestResources& resources) noexcept
-{
-    resources.OutInvalidationMode = TRequestResources::EOutInvalidationMode::None;
-    resources.ExpectedInvalidatedRKey = 0;
-}
-
 void TClientEndpoint::ConfigureOutInvalidation(
     TRequestResources& resources,
     TRequestMessage* msg,
@@ -1548,12 +1561,12 @@ void TClientEndpoint::ConfigureOutInvalidation(
 {
     if (PeerSupportsSendWithInvalidate) {
         msg->Unused |= RDMA_REQUEST_FLAG_USE_MEMORY_WINDOWS;
-        resources.OutInvalidationMode =
-            TRequestResources::EOutInvalidationMode::Remote;
-        resources.ExpectedInvalidatedRKey = outRKey;
+        resources.OutMode =
+            TRequestResources::EOutMode::RemoteInvalidate;
+        resources.RKey = outRKey;
     } else {
-        resources.OutInvalidationMode =
-            TRequestResources::EOutInvalidationMode::Local;
+        resources.OutMode =
+            TRequestResources::EOutMode::LocalInvalidate;
     }
 }
 
@@ -1563,8 +1576,8 @@ bool TClientEndpoint::ValidateRemoteInvalidation(
     ibv_wc* wc,
     TRequestResources& resources) noexcept
 {
-    if (resources.OutInvalidationMode !=
-        TRequestResources::EOutInvalidationMode::Remote)
+    if (resources.OutMode !=
+        TRequestResources::EOutMode::RemoteInvalidate)
     {
         return true;
     }
@@ -1577,10 +1590,10 @@ bool TClientEndpoint::ValidateRemoteInvalidation(
         return false;
     }
 
-    if (wc->invalidated_rkey != resources.ExpectedInvalidatedRKey) {
+    if (wc->invalidated_rkey != resources.RKey) {
         RDMA_WARN(
             recv << " unexpected invalidated rkey for request " << reqId
-                 << ", expected " << resources.ExpectedInvalidatedRKey
+                 << ", expected " << resources.RKey
                  << ", got " << wc->invalidated_rkey);
         resources.RecyclePolicy = TRequestResources::ERecyclePolicy::Drop;
         Counters->Error();
@@ -1595,97 +1608,63 @@ bool TClientEndpoint::NeedLocalInvalidation(
 {
     return Config.UseMemoryWindows &&
         resources.RecyclePolicy == TRequestResources::ERecyclePolicy::Recycle &&
-        ((resources.InMemoryWindow && resources.InBuffer.Length) ||
-         (resources.OutInvalidationMode ==
-              TRequestResources::EOutInvalidationMode::Local &&
-          resources.OutMemoryWindow &&
-          resources.OutBuffer.Length));
+        (resources.InMemoryWindow ||
+         (resources.OutMode ==
+              TRequestResources::EOutMode::LocalInvalidate &&
+          resources.OutMemoryWindow));
 }
 
-// Deferred-abort helpers for requests still in SendRequest stage.
-bool TClientEndpoint::ConsumeDeferredAbortIfAny(
-    TRequestResources& resources,
-    ui32& err,
-    TString& msg) noexcept
-{
-    if (!resources.AbortPending) {
-        return false;
-    }
-
-    err = resources.AbortError;
-    msg = std::move(resources.AbortMessage);
-    resources.AbortPending = false;
-    resources.AbortMessage.clear();
-    resources.AbortError = RDMA_PROTO_FAIL;
-    return true;
-}
-
-void TClientEndpoint::AbortRequestWithAccounting(
+void TClientEndpoint::AbortRequest(
     TRequestPtr req,
-    ui32 err,
-    TString msg) noexcept
+    EAbortCounter counter,
+    const NProto::TError& error) noexcept
 {
     if (!req) {
         return;
     }
 
-    Counters->RequestAborted();
-    AbortRequest(std::move(req), err, msg);
-}
-
-void TClientEndpoint::AbortDequeuedRequest(
-    TRequestPtr req,
-    ui32 err,
-    TString msg) noexcept
-{
-    if (!req) {
-        return;
+    switch (counter) {
+        case EAbortCounter::Dequeued:
+            Counters->RequestDequeued();
+            break;
+        case EAbortCounter::Aborted:
+            Counters->RequestAborted();
+            break;
+        case EAbortCounter::None:
+            break;
     }
 
-    Counters->RequestDequeued();
-    AbortRequest(std::move(req), err, msg);
+    AbortRequest(std::move(req), error);
 }
 
-bool TClientEndpoint::TryDeferAbortUntilSendCompletion(
+void TClientEndpoint::TryAbortRequest(
     TRequestPtr& req,
-    ui32 err,
-    TString msg) noexcept
+    NProto::TError error) noexcept
 {
-    if (!req ||
-        !Config.UseMemoryWindows ||
-        req->State != ERequestState::SendRequest ||
-        !req->Resources)
+    if (req &&
+        Config.UseMemoryWindows &&
+        req->State == ERequestState::SendRequest &&
+        req->Resources)
     {
-        return false;
-    }
+        auto& resources = *req->Resources;
+        if (!HasError(resources.Error)) {
+            resources.Error = std::move(error);
+        }
 
-    auto& resources = *req->Resources;
-    if (!resources.AbortPending) {
-        resources.AbortPending = true;
-        resources.AbortError = err;
-        resources.AbortMessage = std::move(msg);
-    }
-
-    ActiveRequests.Push(std::move(req));
-    return true;
-}
-
-void TClientEndpoint::AbortActiveRequestOrDefer(
-    TRequestPtr& req,
-    ui32 err,
-    TString msg) noexcept
-{
-    if (TryDeferAbortUntilSendCompletion(req, err, msg)) {
+        ActiveRequests.Push(std::move(req));
         return;
     }
 
-    AbortRequestWithAccounting(std::move(req), err, std::move(msg));
+    AbortRequest(
+        std::move(req),
+        EAbortCounter::Aborted,
+        std::move(error));
 }
 
-void TClientEndpoint::FinalizeDeferredAbort(ui32 reqId) noexcept
+void TClientEndpoint::AbortRequest(ui32 reqId) noexcept
 {
     auto* req = ActiveRequests.Get(reqId);
-    if (!req || !req->Resources || !req->Resources->AbortPending) {
+    if (!req || !req->Resources || !HasError(req->Resources->Error)) {
         return;
     }
 
@@ -1694,13 +1673,16 @@ void TClientEndpoint::FinalizeDeferredAbort(ui32 reqId) noexcept
         return;
     }
 
-    ui32 err = RDMA_PROTO_FAIL;
-    TString msg;
-    if (!ConsumeDeferredAbortIfAny(*abortedReq->Resources, err, msg)) {
+    if (!HasError(abortedReq->Resources->Error)) {
         return;
     }
+    auto error = std::move(abortedReq->Resources->Error);
+    abortedReq->Resources->Error = NProto::TError();
 
-    AbortRequestWithAccounting(std::move(abortedReq), err, std::move(msg));
+    AbortRequest(
+        std::move(abortedReq),
+        EAbortCounter::Aborted,
+        error);
 }
 
 void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
@@ -1713,7 +1695,7 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
 
     if (auto* req = ActiveRequests.Get(reqId)) {
         if (Config.UseMemoryWindows) {
-            if (req->Resources->InMemoryWindow && req->Resources->InBuffer.Length) {
+            if (req->Resources->InMemoryWindow) {
                 if (req->CallContext) {
                     LWTRACK(
                         BindInBufferCompleted,
@@ -1721,7 +1703,7 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
                         req->CallContext->RequestId);
                 }
             }
-            if (req->Resources->OutMemoryWindow && req->Resources->OutBuffer.Length) {
+            if (req->Resources->OutMemoryWindow) {
                 if (req->CallContext) {
                     LWTRACK(
                         BindOutBufferCompleted,
@@ -1739,7 +1721,7 @@ void TClientEndpoint::SendRequestCompleted(TSendWr* send) noexcept
         }
 
         req->State = ERequestState::RecvResponse;
-        FinalizeDeferredAbort(reqId);
+        AbortRequest(reqId);
     }
     // request has already been completed
     HandlePendingInvalidationRequests();
@@ -1797,13 +1779,16 @@ void TClientEndpoint::RecvResponseCompleted(TRecvWr* recv, ibv_wc* wc) noexcept
         return;
     }
 
-    ui32 abortErr = RDMA_PROTO_FAIL;
-    TString abortMsg;
-    if (req->Resources &&
-        ConsumeDeferredAbortIfAny(*req->Resources, abortErr, abortMsg))
+    NProto::TError abortError;
+    if (req->Resources && HasError(req->Resources->Error))
     {
+        abortError = std::move(req->Resources->Error);
+        req->Resources->Error = NProto::TError();
         RecvResponse(recv);
-        AbortRequestWithAccounting(std::move(req), abortErr, std::move(abortMsg));
+        AbortRequest(
+            std::move(req),
+            EAbortCounter::Aborted,
+            abortError);
         return;
     }
 
@@ -2004,7 +1989,7 @@ void TClientEndpoint::FinalizeInvalidationRequest(
     }
 }
 
-void TClientEndpoint::DrainInvalidationRequestsOnDisconnect() noexcept
+void TClientEndpoint::DrainInvalidationRequests() noexcept
 {
     while (PendingInvalidationRequests) {
         auto* req = PendingInvalidationRequests.PopFront();
@@ -2035,15 +2020,15 @@ void TClientEndpoint::PostLocalInvalidation(
     Y_ABORT_UNLESS(req->Resources);
     auto* resources = req->Resources.Get();
     const bool needLocalInvalidateOut =
-        resources->OutInvalidationMode ==
-        TRequestResources::EOutInvalidationMode::Local;
+        resources->OutMode ==
+        TRequestResources::EOutMode::LocalInvalidate;
 
     ibv_send_wr* head = nullptr;
     ibv_send_wr* tail = nullptr;
     ibv_send_wr invIn = {};
     ibv_send_wr invOut = {};
 
-    if (resources->InMemoryWindow && resources->InBuffer.Length) {
+    if (resources->InMemoryWindow) {
         invIn.wr_id = send->wr.wr_id;
         invIn.opcode = IBV_WR_LOCAL_INV;
         invIn.invalidate_rkey = resources->InMemoryWindow->rkey;
@@ -2053,8 +2038,7 @@ void TClientEndpoint::PostLocalInvalidation(
     }
 
     if (needLocalInvalidateOut &&
-        resources->OutMemoryWindow &&
-        resources->OutBuffer.Length)
+        resources->OutMemoryWindow)
     {
         invOut.wr_id = send->wr.wr_id;
         invOut.opcode = IBV_WR_LOCAL_INV;
@@ -2571,7 +2555,7 @@ private:
             for (auto& request: requests) {
                 const ui32 reqId = request->ReqId;
                 const bool alreadyPendingAbort =
-                    request->Resources && request->Resources->AbortPending;
+                    request->Resources && HasError(request->Resources->Error);
                 if (!alreadyPendingAbort) {
                     RDMA_DEBUG(endpoint->Log, "request " << reqId << " timed out");
                 }
@@ -2580,18 +2564,9 @@ private:
                     << "[peer=" << endpoint->Host << ":"
                     << endpoint->Port << "]";
 
-                if (endpoint->TryDeferAbortUntilSendCompletion(
-                        request,
-                        E_TIMEOUT,
-                        timeoutMessage))
-                {
-                    continue;
-                }
-
-                endpoint->AbortRequestWithAccounting(
-                    std::move(request),
-                    E_TIMEOUT,
-                    std::move(timeoutMessage));
+                endpoint->TryAbortRequest(
+                    request,
+                    MakeError(E_TIMEOUT, std::move(timeoutMessage)));
             }
         }
     }

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -571,6 +571,809 @@ TEST(TRdmaClientTest, ShouldProcessRequests)
         }
 }
 
+TEST(TRdmaClientTest, ShouldInvalidateMemoryWindowsOnSuccessButNotOnTimeout)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 1s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        testContext->HandleConnect = [&](auto* id, auto* param)
+        {
+            Y_UNUSED(param);
+
+            TAcceptMessage acceptMsg{};
+            InitMessageHeader(&acceptMsg, RDMA_PROTO_VERSION);
+            acceptMsg.Unused = RDMA_ACCEPT_FLAG_NONE;
+            NVerbs::EnqueueAcceptEvent(
+                testContext,
+                id,
+                &acceptMsg,
+                sizeof(acceptMsg));
+        };
+
+        std::atomic<size_t> localInvalidationsPosted = 0;
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            for (auto* current = wr; current; current = current->next) {
+                if (current->opcode == IBV_WR_LOCAL_INV) {
+                    localInvalidationsPosted.fetch_add(1);
+                }
+            }
+
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        struct TResponse
+        {
+            bool Received = false;
+            TStringBuf Buffer;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        auto makeContext = [](TManualEvent* ev, TResponse* response)
+        {
+            auto ctx = std::make_unique<TRequestContext>();
+            ctx->Handler = [ev, response](
+                               TStringBuf requestBuffer,
+                               TStringBuf responseBuffer,
+                               ui32 status,
+                               size_t responseBytes)
+            {
+                Y_UNUSED(requestBuffer);
+
+                response->Received = true;
+                response->Buffer = responseBuffer;
+                response->Status = status;
+                response->Bytes = responseBytes;
+
+                ev->Signal();
+            };
+            return ctx;
+        };
+
+        auto completeOneRequest = [&](ui32 status)
+        {
+            while (true) {
+                with_lock (testContext->CompletionLock) {
+                    if (testContext->RecvEvents && testContext->ReqIds) {
+                        auto* re = testContext->RecvEvents.front();
+                        auto* responseMsg = reinterpret_cast<TResponseMessage*>(
+                            re->sg_list[0].addr);
+                        Zero(*responseMsg);
+                        InitMessageHeader(responseMsg, RDMA_PROTO_VERSION);
+                        responseMsg->ReqId = testContext->ReqIds.front();
+                        responseMsg->Status = status;
+                        responseMsg->ResponseBytes = 0;
+
+                        testContext->ReqIds.pop_front();
+                        testContext->RecvEvents.pop_front();
+                        testContext->ProcessedRecvEvents.push_back(re);
+                        testContext->CompletionHandle.Set();
+                        return;
+                    }
+                }
+            }
+        };
+
+        // Happy path: request completes and local invalidation is posted for
+        // both In/Out windows before the handler is called.
+        TManualEvent ev1;
+        TResponse response1;
+        auto request1 = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            makeContext(&ev1, &response1),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request1.GetError()));
+
+        endpoint->SendRequest(
+            request1.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+        completeOneRequest(RDMA_PROTO_OK);
+
+        ASSERT_TRUE(ev1.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_TRUE(response1.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_OK), response1.Status);
+        ASSERT_EQ(2u, localInvalidationsPosted.load());
+
+        // Timeout path: request is aborted, so windows are not recycled and no
+        // local invalidation is posted for this timed out request.
+        TManualEvent ev2;
+        TResponse response2;
+        auto request2 = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            makeContext(&ev2, &response2),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request2.GetError()));
+
+        endpoint->SendRequest(
+            request2.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        ASSERT_TRUE(ev2.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_TRUE(response2.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response2.Status);
+        NProto::TError error = ParseError(response2.Buffer.Head(response2.Bytes));
+        ASSERT_EQ(E_TIMEOUT, error.GetCode());
+        ASSERT_EQ(2u, localInvalidationsPosted.load());
+
+        // Drain delayed response from test transport.
+        completeOneRequest(RDMA_PROTO_OK);
+}
+
+TEST(TRdmaClientTest, ShouldDeferCancelUntilTerminalSendCompletionWithMemoryWindows)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 1s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        TManualEvent sendPosted;
+        ibv_send_wr* delayedSend = nullptr;
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            Y_UNUSED(qp);
+
+            with_lock (testContext->CompletionLock) {
+                for (auto* current = wr; current; current = current->next) {
+                    auto* copy = new ibv_send_wr(*current);
+                    copy->next = nullptr;
+
+                    if (current->opcode == IBV_WR_SEND) {
+                        delayedSend = copy;
+                        sendPosted.Signal();
+                    } else {
+                        testContext->SendEvents.push_back(copy);
+                    }
+                }
+
+                if (testContext->SendEvents) {
+                    testContext->CompletionHandle.Set();
+                }
+            }
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        struct TResponse
+        {
+            bool Received = false;
+            TStringBuf Buffer;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        TManualEvent done;
+        TResponse response;
+        auto ctx = std::make_unique<TRequestContext>();
+        ctx->Handler = [&](TStringBuf requestBuffer,
+                           TStringBuf responseBuffer,
+                           ui32 status,
+                           size_t responseBytes)
+        {
+            Y_UNUSED(requestBuffer);
+            response = TResponse{true, responseBuffer, status, responseBytes};
+            done.Signal();
+        };
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::move(ctx),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        auto reqId = endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        ASSERT_TRUE(sendPosted.WaitT(5s));
+
+        endpoint->CancelRequest(reqId);
+        ASSERT_FALSE(done.WaitT(200ms));
+
+        {
+            with_lock (testContext->CompletionLock) {
+                ASSERT_NE(nullptr, delayedSend);
+                testContext->SendEvents.push_back(delayedSend);
+                delayedSend = nullptr;
+                testContext->CompletionHandle.Set();
+            }
+        }
+
+        ASSERT_TRUE(done.WaitT(clientConfig->MaxResponseDelay + 2s));
+        ASSERT_TRUE(response.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response.Status);
+
+        NProto::TError error = ParseError(response.Buffer.Head(response.Bytes));
+        ASSERT_EQ(E_CANCELLED, error.GetCode());
+}
+
+TEST(TRdmaClientTest, ShouldDeferTimeoutUntilTerminalSendCompletionWithMemoryWindows)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 1s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        TManualEvent sendPosted;
+        ibv_send_wr* delayedSend = nullptr;
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            Y_UNUSED(qp);
+
+            with_lock (testContext->CompletionLock) {
+                for (auto* current = wr; current; current = current->next) {
+                    auto* copy = new ibv_send_wr(*current);
+                    copy->next = nullptr;
+
+                    if (current->opcode == IBV_WR_SEND) {
+                        delayedSend = copy;
+                        sendPosted.Signal();
+                    } else {
+                        testContext->SendEvents.push_back(copy);
+                    }
+                }
+
+                if (testContext->SendEvents) {
+                    testContext->CompletionHandle.Set();
+                }
+            }
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        struct TResponse
+        {
+            bool Received = false;
+            TStringBuf Buffer;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        TManualEvent done;
+        TResponse response;
+        auto ctx = std::make_unique<TRequestContext>();
+        ctx->Handler = [&](TStringBuf requestBuffer,
+                           TStringBuf responseBuffer,
+                           ui32 status,
+                           size_t responseBytes)
+        {
+            Y_UNUSED(requestBuffer);
+            response = TResponse{true, responseBuffer, status, responseBytes};
+            done.Signal();
+        };
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::move(ctx),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        ASSERT_TRUE(sendPosted.WaitT(5s));
+
+        // Timeout should fire while the request is still in SendRequest state,
+        // but callback must stay deferred until terminal SEND completion.
+        ASSERT_FALSE(done.WaitT(clientConfig->MaxResponseDelay + 200ms));
+
+        {
+            with_lock (testContext->CompletionLock) {
+                ASSERT_NE(nullptr, delayedSend);
+                testContext->SendEvents.push_back(delayedSend);
+                delayedSend = nullptr;
+                testContext->CompletionHandle.Set();
+            }
+        }
+
+        ASSERT_TRUE(done.WaitT(clientConfig->MaxResponseDelay + 2s));
+        ASSERT_TRUE(response.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response.Status);
+
+        NProto::TError error = ParseError(response.Buffer.Head(response.Bytes));
+        ASSERT_EQ(E_TIMEOUT, error.GetCode());
+}
+
+TEST(TRdmaClientTest, ShouldUseSendWithInvalidateForOutMemoryWindow)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 1s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        testContext->HandleConnect = [&](auto* id, auto* param)
+        {
+            Y_UNUSED(param);
+
+            TAcceptMessage acceptMsg{};
+            InitMessageHeader(&acceptMsg, RDMA_PROTO_VERSION);
+            acceptMsg.Unused = RDMA_ACCEPT_FLAG_SEND_WITH_INV;
+            NVerbs::EnqueueAcceptEvent(
+                testContext,
+                id,
+                &acceptMsg,
+                sizeof(acceptMsg));
+        };
+
+        std::atomic<ui32> expectedOutRKey = 0;
+        std::atomic<size_t> localInvalidationsPosted = 0;
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            for (auto* current = wr; current; current = current->next) {
+                if (current->opcode == IBV_WR_LOCAL_INV) {
+                    localInvalidationsPosted.fetch_add(1);
+                }
+
+                if (current->opcode == IBV_WR_SEND &&
+                    current->sg_list &&
+                    current->num_sge > 0)
+                {
+                    const auto* msg = reinterpret_cast<TRequestMessage*>(
+                        current->sg_list[0].addr);
+                    expectedOutRKey.store(msg->Out.RKey);
+                }
+            }
+
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+        testContext->HandleCompletionEvent = [&](ibv_wc* wc)
+        {
+            if (wc->opcode == IBV_WC_RECV) {
+                wc->wc_flags |= IBV_WC_WITH_INV;
+                wc->invalidated_rkey = expectedOutRKey.load();
+            }
+        };
+
+        struct TResponse
+        {
+            bool Received = false;
+            TStringBuf Buffer;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        TManualEvent ev;
+        TResponse response;
+        auto makeContext = [&](TManualEvent* done, TResponse* out)
+        {
+            auto ctx = std::make_unique<TRequestContext>();
+            ctx->Handler = [done, out](
+                               TStringBuf requestBuffer,
+                               TStringBuf responseBuffer,
+                               ui32 status,
+                               size_t responseBytes)
+            {
+                Y_UNUSED(requestBuffer);
+
+                out->Received = true;
+                out->Buffer = responseBuffer;
+                out->Status = status;
+                out->Bytes = responseBytes;
+
+                done->Signal();
+            };
+            return ctx;
+        };
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            makeContext(&ev, &response),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        while (true) {
+            with_lock (testContext->CompletionLock) {
+                if (testContext->RecvEvents && testContext->ReqIds) {
+                    auto* re = testContext->RecvEvents.front();
+                    auto* responseMsg = reinterpret_cast<TResponseMessage*>(
+                        re->sg_list[0].addr);
+                    Zero(*responseMsg);
+                    InitMessageHeader(responseMsg, RDMA_PROTO_VERSION);
+                    responseMsg->ReqId = testContext->ReqIds.front();
+                    responseMsg->Status = RDMA_PROTO_OK;
+                    responseMsg->ResponseBytes = 0;
+
+                    testContext->ReqIds.pop_front();
+                    testContext->RecvEvents.pop_front();
+                    testContext->ProcessedRecvEvents.push_back(re);
+                    testContext->CompletionHandle.Set();
+                    break;
+                }
+            }
+        }
+
+        ASSERT_TRUE(ev.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_TRUE(response.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_OK), response.Status);
+
+        // With SEND_WITH_INV support: In is invalidated locally, Out remotely.
+        ASSERT_EQ(1u, localInvalidationsPosted.load());
+}
+
+TEST(TRdmaClientTest, ShouldDisableRecycleWhenSendWithInvIsMissing)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 1s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        testContext->HandleConnect = [&](auto* id, auto* param)
+        {
+            Y_UNUSED(param);
+
+            TAcceptMessage acceptMsg{};
+            InitMessageHeader(&acceptMsg, RDMA_PROTO_VERSION);
+            acceptMsg.Unused = RDMA_ACCEPT_FLAG_SEND_WITH_INV;
+            NVerbs::EnqueueAcceptEvent(
+                testContext,
+                id,
+                &acceptMsg,
+                sizeof(acceptMsg));
+        };
+
+        std::atomic<size_t> localInvalidationsPosted = 0;
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            for (auto* current = wr; current; current = current->next) {
+                if (current->opcode == IBV_WR_LOCAL_INV) {
+                    localInvalidationsPosted.fetch_add(1);
+                }
+            }
+
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+        // Intentionally do not set IBV_WC_WITH_INV on RECV completions.
+        testContext->HandleCompletionEvent = [&](ibv_wc* wc)
+        {
+            if (wc->opcode == IBV_WC_RECV) {
+                wc->wc_flags = 0;
+            }
+        };
+
+        struct TResponse
+        {
+            bool Received = false;
+            TStringBuf Buffer;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        TManualEvent ev;
+        TResponse response;
+        auto makeContext = [&](TManualEvent* done, TResponse* out)
+        {
+            auto ctx = std::make_unique<TRequestContext>();
+            ctx->Handler = [done, out](
+                               TStringBuf requestBuffer,
+                               TStringBuf responseBuffer,
+                               ui32 status,
+                               size_t responseBytes)
+            {
+                Y_UNUSED(requestBuffer);
+
+                out->Received = true;
+                out->Buffer = responseBuffer;
+                out->Status = status;
+                out->Bytes = responseBytes;
+
+                done->Signal();
+            };
+            return ctx;
+        };
+
+        auto counters = GetClientCounters(monitoring);
+        auto errors = counters->GetCounter("Errors");
+        const auto errorsBefore = errors->Val();
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            makeContext(&ev, &response),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        while (true) {
+            with_lock (testContext->CompletionLock) {
+                if (testContext->RecvEvents && testContext->ReqIds) {
+                    auto* re = testContext->RecvEvents.front();
+                    auto* responseMsg = reinterpret_cast<TResponseMessage*>(
+                        re->sg_list[0].addr);
+                    Zero(*responseMsg);
+                    InitMessageHeader(responseMsg, RDMA_PROTO_VERSION);
+                    responseMsg->ReqId = testContext->ReqIds.front();
+                    responseMsg->Status = RDMA_PROTO_OK;
+                    responseMsg->ResponseBytes = 0;
+
+                    testContext->ReqIds.pop_front();
+                    testContext->RecvEvents.pop_front();
+                    testContext->ProcessedRecvEvents.push_back(re);
+                    testContext->CompletionHandle.Set();
+                    break;
+                }
+            }
+        }
+
+        ASSERT_TRUE(ev.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_TRUE(response.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_OK), response.Status);
+
+        // Missing remote invalidation disables recycle path for this request.
+        ASSERT_EQ(0u, localInvalidationsPosted.load());
+        ASSERT_GT(errors->Val(), errorsBefore);
+}
+
+TEST(TRdmaClientTest, ShouldDisableRecycleOnUnexpectedSendWithInvRKey)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 1s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        testContext->HandleConnect = [&](auto* id, auto* param)
+        {
+            Y_UNUSED(param);
+
+            TAcceptMessage acceptMsg{};
+            InitMessageHeader(&acceptMsg, RDMA_PROTO_VERSION);
+            acceptMsg.Unused = RDMA_ACCEPT_FLAG_SEND_WITH_INV;
+            NVerbs::EnqueueAcceptEvent(
+                testContext,
+                id,
+                &acceptMsg,
+                sizeof(acceptMsg));
+        };
+
+        std::atomic<ui32> expectedOutRKey = 0;
+        std::atomic<size_t> localInvalidationsPosted = 0;
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            for (auto* current = wr; current; current = current->next) {
+                if (current->opcode == IBV_WR_LOCAL_INV) {
+                    localInvalidationsPosted.fetch_add(1);
+                }
+
+                if (current->opcode == IBV_WR_SEND &&
+                    current->sg_list &&
+                    current->num_sge > 0)
+                {
+                    const auto* msg = reinterpret_cast<TRequestMessage*>(
+                        current->sg_list[0].addr);
+                    expectedOutRKey.store(msg->Out.RKey);
+                }
+            }
+
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+        testContext->HandleCompletionEvent = [&](ibv_wc* wc)
+        {
+            if (wc->opcode == IBV_WC_RECV) {
+                wc->wc_flags |= IBV_WC_WITH_INV;
+                wc->invalidated_rkey = expectedOutRKey.load() + 1;
+            }
+        };
+
+        struct TResponse
+        {
+            bool Received = false;
+            TStringBuf Buffer;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        TManualEvent ev;
+        TResponse response;
+        auto makeContext = [&](TManualEvent* done, TResponse* out)
+        {
+            auto ctx = std::make_unique<TRequestContext>();
+            ctx->Handler = [done, out](
+                               TStringBuf requestBuffer,
+                               TStringBuf responseBuffer,
+                               ui32 status,
+                               size_t responseBytes)
+            {
+                Y_UNUSED(requestBuffer);
+
+                out->Received = true;
+                out->Buffer = responseBuffer;
+                out->Status = status;
+                out->Bytes = responseBytes;
+
+                done->Signal();
+            };
+            return ctx;
+        };
+
+        auto counters = GetClientCounters(monitoring);
+        auto errors = counters->GetCounter("Errors");
+        const auto errorsBefore = errors->Val();
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            makeContext(&ev, &response),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        while (true) {
+            with_lock (testContext->CompletionLock) {
+                if (testContext->RecvEvents && testContext->ReqIds) {
+                    auto* re = testContext->RecvEvents.front();
+                    auto* responseMsg = reinterpret_cast<TResponseMessage*>(
+                        re->sg_list[0].addr);
+                    Zero(*responseMsg);
+                    InitMessageHeader(responseMsg, RDMA_PROTO_VERSION);
+                    responseMsg->ReqId = testContext->ReqIds.front();
+                    responseMsg->Status = RDMA_PROTO_OK;
+                    responseMsg->ResponseBytes = 0;
+
+                    testContext->ReqIds.pop_front();
+                    testContext->RecvEvents.pop_front();
+                    testContext->ProcessedRecvEvents.push_back(re);
+                    testContext->CompletionHandle.Set();
+                    break;
+                }
+            }
+        }
+
+        ASSERT_TRUE(ev.WaitT(clientConfig->MaxResponseDelay + 1s));
+        ASSERT_TRUE(response.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_OK), response.Status);
+
+        // Wrong invalidated_rkey also disables recycle path.
+        ASSERT_EQ(0u, localInvalidationsPosted.load());
+        ASSERT_GT(errors->Val(), errorsBefore);
+}
+
 TEST(TRdmaClientTest, ShouldReuseChunks)
 {
         auto testContext = MakeIntrusive<NVerbs::TTestContext>();

--- a/cloud/storage/core/libs/rdma/impl/client_ut.cpp
+++ b/cloud/storage/core/libs/rdma/impl/client_ut.cpp
@@ -726,6 +726,106 @@ TEST(TRdmaClientTest, ShouldInvalidateMemoryWindowsOnSuccessButNotOnTimeout)
         completeOneRequest(RDMA_PROTO_OK);
 }
 
+TEST(TRdmaClientTest, ShouldKeepInvalidationResourcesUntilQpDestroy)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 100ms;
+        clientConfig->FlushTimeout = 5s;
+
+        auto client = CreateTestClient(
+            NVerbs::CreateTestVerbs(testContext),
+            CreateLoggingService("console", TLogSettings{TLOG_RESOURCES}),
+            CreateMonitoringServiceStub(),
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        std::atomic<ui32> invalidatedRKey1 = 0;
+        std::atomic<ui32> invalidatedRKey2 = 0;
+        std::atomic<bool> qpDestroyed = false;
+        std::atomic<size_t> prematureMwDestructions = 0;
+        TManualEvent invalidationPosted;
+        TManualEvent qpDestroyedEvent;
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            if (wr->opcode == IBV_WR_LOCAL_INV) {
+                invalidatedRKey1 = wr->invalidate_rkey;
+                if (wr->next) {
+                    invalidatedRKey2 = wr->next->invalidate_rkey;
+                }
+                // Keep LOCAL_INV in the simulated SQ without producing CQE.
+                invalidationPosted.Signal();
+                return;
+            }
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+        testContext->DestroyQP = [&](rdma_cm_id*) {
+            qpDestroyed = true;
+            qpDestroyedEvent.Signal();
+        };
+        testContext->DestroyMemoryWindow = [&](ibv_mw* mw) {
+            Y_UNUSED(mw);
+            if (!qpDestroyed.load()) {
+                ++prematureMwDestructions;
+            }
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        TManualEvent responseReceived;
+        auto ctx = std::make_unique<TRequestContext>();
+        ctx->Handler = [&](TStringBuf, TStringBuf, ui32, size_t) {
+            responseReceived.Signal();
+        };
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::move(ctx),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        while (true) {
+            with_lock (testContext->CompletionLock) {
+                if (testContext->RecvEvents && testContext->ReqIds) {
+                    auto* recv = testContext->RecvEvents.front();
+                    auto* msg = reinterpret_cast<TResponseMessage*>(
+                        recv->sg_list[0].addr);
+                    Zero(*msg);
+                    InitMessageHeader(msg, RDMA_PROTO_VERSION);
+                    msg->ReqId = testContext->ReqIds.front();
+                    msg->Status = RDMA_PROTO_OK;
+
+                    testContext->ReqIds.pop_front();
+                    testContext->RecvEvents.pop_front();
+                    testContext->ProcessedRecvEvents.push_back(recv);
+                    testContext->CompletionHandle.Set();
+                    break;
+                }
+            }
+        }
+
+        ASSERT_TRUE(invalidationPosted.WaitT(5s));
+        NVerbs::Disconnect(testContext);
+        ASSERT_TRUE(responseReceived.WaitT(5s));
+
+        // Retired LOCAL_INV owns the missing send slot, so teardown must not
+        // wait for FlushTimeout when its terminal CQE never arrives.
+        ASSERT_TRUE(qpDestroyedEvent.WaitT(1s));
+        ASSERT_EQ(0u, prematureMwDestructions.load());
+}
+
 TEST(TRdmaClientTest, ShouldDeferCancelUntilTerminalSendCompletionWithMemoryWindows)
 {
         auto testContext = MakeIntrusive<NVerbs::TTestContext>();
@@ -943,6 +1043,199 @@ TEST(TRdmaClientTest, ShouldDeferTimeoutUntilTerminalSendCompletionWithMemoryWin
 
         NProto::TError error = ParseError(response.Buffer.Head(response.Bytes));
         ASSERT_EQ(E_TIMEOUT, error.GetCode());
+}
+
+TEST(TRdmaClientTest, ShouldAbortOnFirstSendFlushCompletionWithMemoryWindows)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto verbs = NVerbs::CreateTestVerbs(testContext);
+        auto monitoring = CreateMonitoringServiceStub();
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->MaxResponseDelay = 30s;
+
+        auto logging = CreateLoggingService(
+            "console",
+            TLogSettings{TLOG_RESOURCES});
+
+        auto client = CreateTestClient(
+            verbs,
+            logging,
+            monitoring,
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        TManualEvent sendPosted;
+        ibv_send_wr* delayedSend = nullptr;
+
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            Y_UNUSED(qp);
+
+            with_lock (testContext->CompletionLock) {
+                for (auto* current = wr; current; current = current->next) {
+                    auto* copy = new ibv_send_wr(*current);
+                    copy->next = nullptr;
+
+                    if (current->opcode == IBV_WR_SEND) {
+                        delayedSend = copy;
+                        sendPosted.Signal();
+                    } else {
+                        testContext->SendEvents.push_back(copy);
+                    }
+                }
+
+                if (testContext->SendEvents) {
+                    testContext->CompletionHandle.Set();
+                }
+            }
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        struct TResponse
+        {
+            bool Received = false;
+            TStringBuf Buffer;
+            ui32 Status = 0;
+            size_t Bytes = 0;
+        };
+
+        TManualEvent done;
+        TResponse response;
+        auto ctx = std::make_unique<TRequestContext>();
+        ctx->Handler = [&](TStringBuf requestBuffer,
+                           TStringBuf responseBuffer,
+                           ui32 status,
+                           size_t responseBytes)
+        {
+            Y_UNUSED(requestBuffer);
+            response = TResponse{true, responseBuffer, status, responseBytes};
+            done.Signal();
+        };
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::move(ctx),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        ASSERT_TRUE(sendPosted.WaitT(5s));
+
+        const ui64 delayedSendWrId = delayedSend->wr_id;
+        testContext->HandleCompletionEvent = [&](ibv_wc* wc)
+        {
+            if (wc->wr_id == delayedSendWrId &&
+                wc->opcode == IBV_WC_SEND)
+            {
+                wc->status = IBV_WC_WR_FLUSH_ERR;
+            }
+        };
+
+        {
+            with_lock (testContext->CompletionLock) {
+                ASSERT_NE(nullptr, delayedSend);
+                testContext->SendEvents.push_back(delayedSend);
+                delayedSend = nullptr;
+                testContext->CompletionHandle.Set();
+            }
+        }
+
+        ASSERT_TRUE(done.WaitT(5s));
+        ASSERT_TRUE(response.Received);
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), response.Status);
+
+        NProto::TError error = ParseError(response.Buffer.Head(response.Bytes));
+        ASSERT_EQ(E_RDMA_UNAVAILABLE, error.GetCode());
+}
+
+TEST(TRdmaClientTest, ShouldKeepResourcesUntilQpDestroyOnPartialPostSend)
+{
+        auto testContext = MakeIntrusive<NVerbs::TTestContext>();
+        testContext->AllowConnect = true;
+
+        auto clientConfig = std::make_shared<TClientConfig>();
+        clientConfig->UseMemoryWindows = true;
+        clientConfig->MaxReconnectDelay = 5s;
+        clientConfig->FlushTimeout = 1s;
+
+        auto client = CreateTestClient(
+            NVerbs::CreateTestVerbs(testContext),
+            CreateLoggingService("console", TLogSettings{TLOG_RESOURCES}),
+            CreateMonitoringServiceStub(),
+            clientConfig);
+
+        client->Start();
+        Y_DEFER {
+            client->Stop();
+        };
+
+        std::atomic<bool> failPartially = true;
+        testContext->PostSend = [&](ibv_qp* qp, ibv_send_wr* wr)
+        {
+            if (failPartially.load() && wr->next) {
+                // Emulate a provider which accepted the first BIND_MW only.
+                with_lock (testContext->CompletionLock) {
+                    auto* accepted = new ibv_send_wr(*wr);
+                    accepted->next = nullptr;
+                    testContext->SendEvents.push_back(accepted);
+                    testContext->CompletionHandle.Set();
+                }
+                return;
+            }
+            PostSend<TRequestMessage>(testContext, qp, wr);
+        };
+        testContext->GetBadSendWr = [&](ibv_send_wr* wr)
+        {
+            if (failPartially.exchange(false)) {
+                return wr->next;
+            }
+            return static_cast<ibv_send_wr*>(nullptr);
+        };
+
+        auto endpoint = client->StartEndpoint("::", 10020).ExtractValueSync();
+
+        TManualEvent done;
+        ui32 status = 0;
+        NProto::TError error;
+        auto ctx = std::make_unique<TRequestContext>();
+        ctx->Handler = [&](TStringBuf requestBuffer,
+                           TStringBuf responseBuffer,
+                           ui32 responseStatus,
+                           size_t responseBytes)
+        {
+            Y_UNUSED(requestBuffer);
+            status = responseStatus;
+            error = ParseError(responseBuffer.Head(responseBytes));
+            done.Signal();
+        };
+
+        auto request = endpoint->AllocateRequest(
+            std::make_shared<TClientHandler>(),
+            std::move(ctx),
+            4096,
+            4096);
+        ASSERT_FALSE(HasError(request.GetError()));
+
+        endpoint->SendRequest(
+            request.ExtractResult(),
+            MakeIntrusive<TCallContextBase>(0u));
+
+        ASSERT_TRUE(done.WaitT(5s));
+        ASSERT_EQ(static_cast<ui32>(RDMA_PROTO_FAIL), status);
+        ASSERT_EQ(E_RDMA_UNAVAILABLE, error.GetCode());
 }
 
 TEST(TRdmaClientTest, ShouldUseSendWithInvalidateForOutMemoryWindow)

--- a/cloud/storage/core/libs/rdma/impl/server.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server.cpp
@@ -92,6 +92,7 @@ struct TRequest
     ui32 ReqId = 0;
     ui32 Status = 0;
     ui32 ResponseBytes = 0;
+    bool InvalidateResponseRKey = false;
 
     TBufferDesc In {};
     TBufferDesc Out {};
@@ -853,6 +854,8 @@ void TServerSession::RecvRequestCompleted(TRecvWr* recv) noexcept
     req->CallContext = Handler->CreateCallContext();
     Y_ABORT_UNLESS(req->CallContext);
     req->ReqId = msg->ReqId;
+    req->InvalidateResponseRKey =
+        (msg->Unused & RDMA_REQUEST_FLAG_USE_MEMORY_WINDOWS) != 0;
     req->In = msg->In;
     req->Out = msg->Out;
 
@@ -1107,6 +1110,8 @@ void TServerSession::WriteResponseDataCompleted(TSendWr* send) noexcept
 void TServerSession::SendResponse(TRequestPtr req, TSendWr* send) noexcept
 {
     req->State = ERequestState::SendResponse;
+    send->wr.opcode = IBV_WR_SEND;
+    send->wr.invalidate_rkey = 0;
 
     auto* responseMsg = send->Message();
     Zero(*responseMsg);
@@ -1116,6 +1121,11 @@ void TServerSession::SendResponse(TRequestPtr req, TSendWr* send) noexcept
     responseMsg->ReqId = req->ReqId;
     responseMsg->Status = req->Status;
     responseMsg->ResponseBytes = req->ResponseBytes;
+
+    if (req->InvalidateResponseRKey && req->Out.RKey) {
+        send->wr.opcode = IBV_WR_SEND_WITH_INV;
+        send->wr.invalidate_rkey = req->Out.RKey;
+    }
 
     try {
         auto& cc = req->CallContext;
@@ -1967,6 +1977,7 @@ void TServer::Accept(
         session->CreateQP();
 
         TAcceptMessage acceptMsg = {
+            .Unused = RDMA_ACCEPT_FLAG_SEND_WITH_INV,
             .KeepAliveTimeout =
                 SafeCast<ui16>(Config->KeepAliveTimeout.MilliSeconds()),
         };

--- a/cloud/storage/core/libs/rdma/impl/server.cpp
+++ b/cloud/storage/core/libs/rdma/impl/server.cpp
@@ -1993,6 +1993,8 @@ void TServer::Accept(
             .rnr_retry_count = Config->QpRnrRetryCount,
         };
 
+        RDMA_INFO(
+            "send with invalidate enabled for " << Verbs->GetPeer(event->id));
         RDMA_DEBUG("accept " << Verbs->GetPeer(event->id));
         Verbs->Accept(event->id, &acceptParams);
 

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -163,6 +163,12 @@ struct TTestVerbs
         };
     }
 
+    TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) override
+    {
+        Y_UNUSED(pd);
+        return NullPtr;
+    }
+
     struct TCompletionChannel
         : ibv_comp_channel
     {

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -166,7 +166,10 @@ struct TTestVerbs
     struct TMemoryWindow
         : ibv_mw
     {
-        explicit TMemoryWindow(ibv_pd* ibvPd)
+        TTestContextPtr Context;
+
+        TMemoryWindow(ibv_pd* ibvPd, TTestContextPtr context)
+            : Context(std::move(context))
         {
             static std::atomic<ui32> NextRKey{1};
 
@@ -177,7 +180,11 @@ struct TTestVerbs
 
         static int Destroy(ibv_mw* mw)
         {
-            delete static_cast<TMemoryWindow*>(mw);
+            auto* window = static_cast<TMemoryWindow*>(mw);
+            if (window->Context->DestroyMemoryWindow) {
+                window->Context->DestroyMemoryWindow(mw);
+            }
+            delete window;
             return 0;
         }
     };
@@ -185,7 +192,7 @@ struct TTestVerbs
     TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) override
     {
         return {
-            static_cast<ibv_mw*>(new TMemoryWindow(pd)),
+            static_cast<ibv_mw*>(new TMemoryWindow(pd, TestContext)),
             TMemoryWindow::Destroy,
         };
     }
@@ -276,7 +283,7 @@ struct TTestVerbs
             TestContext->ProcessedRecvEvents.clear();
         }
 
-        auto handleEvent = [&] (ui64 id, ibv_wc_opcode opcode) {
+        auto buildCompletion = [&] (ui64 id, ibv_wc_opcode opcode) {
             ibv_wc wc = {
                 .wr_id = id,
                 .status = IBV_WC_SUCCESS,
@@ -287,41 +294,66 @@ struct TTestVerbs
                     TestContext->HandleCompletionEvent(&wc);
                 }
             }
-            handler->HandleCompletionEvent(&wc);
+            return wc;
         };
 
         for (const auto& x: sends) {
+            ibv_wc_opcode opcode = IBV_WC_SEND;
             switch (x->opcode) {
                 case IBV_WR_RDMA_READ:
-                    handleEvent(x->wr_id, IBV_WC_RDMA_READ);
+                    opcode = IBV_WC_RDMA_READ;
                     break;
                 case IBV_WR_RDMA_WRITE:
-                    handleEvent(x->wr_id, IBV_WC_RDMA_WRITE);
+                    opcode = IBV_WC_RDMA_WRITE;
                     break;
                 case IBV_WR_BIND_MW:
-                    handleEvent(x->wr_id, IBV_WC_BIND_MW);
+                    opcode = IBV_WC_BIND_MW;
                     break;
                 case IBV_WR_LOCAL_INV:
-                    handleEvent(x->wr_id, IBV_WC_LOCAL_INV);
+                    opcode = IBV_WC_LOCAL_INV;
                     break;
                 default:
-                    handleEvent(x->wr_id, IBV_WC_SEND);
+                    opcode = IBV_WC_SEND;
+                    break;
+            }
+
+            auto wc = buildCompletion(x->wr_id, opcode);
+            const bool signaled = x->send_flags & IBV_SEND_SIGNALED;
+            if (signaled || wc.status != IBV_WC_SUCCESS) {
+                handler->HandleCompletionEvent(&wc);
             }
             delete x;
         }
 
         for (const auto& x: recvs) {
-            handleEvent(x->wr_id, IBV_WC_RECV);
+            auto wc = buildCompletion(x->wr_id, IBV_WC_RECV);
+            handler->HandleCompletionEvent(&wc);
         }
 
         return true;
     }
 
-    void PostSend(ibv_qp* qp, ibv_send_wr* wr) override
+    void PostSend(
+        ibv_qp* qp,
+        ibv_send_wr* wr,
+        ibv_send_wr** badWr = nullptr) override
     {
+        if (badWr) {
+            *badWr = nullptr;
+        }
+
         if (TestContext->PostSend) {
             TestContext->PostSend(qp, wr);
-            return;
+        }
+
+        if (TestContext->GetBadSendWr) {
+            auto* bad = TestContext->GetBadSendWr(wr);
+            if (bad) {
+                if (badWr) {
+                    *badWr = bad;
+                }
+                throw TServiceError(E_FAIL) << "ibv_post_send error";
+            }
         }
     }
 

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.cpp
@@ -163,10 +163,31 @@ struct TTestVerbs
         };
     }
 
+    struct TMemoryWindow
+        : ibv_mw
+    {
+        explicit TMemoryWindow(ibv_pd* ibvPd)
+        {
+            static std::atomic<ui32> NextRKey{1};
+
+            pd = ibvPd;
+            rkey = NextRKey.fetch_add(0x100u);
+            type = IBV_MW_TYPE_2;
+        }
+
+        static int Destroy(ibv_mw* mw)
+        {
+            delete static_cast<TMemoryWindow*>(mw);
+            return 0;
+        }
+    };
+
     TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) override
     {
-        Y_UNUSED(pd);
-        return NullPtr;
+        return {
+            static_cast<ibv_mw*>(new TMemoryWindow(pd)),
+            TMemoryWindow::Destroy,
+        };
     }
 
     struct TCompletionChannel
@@ -276,6 +297,12 @@ struct TTestVerbs
                     break;
                 case IBV_WR_RDMA_WRITE:
                     handleEvent(x->wr_id, IBV_WC_RDMA_WRITE);
+                    break;
+                case IBV_WR_BIND_MW:
+                    handleEvent(x->wr_id, IBV_WC_BIND_MW);
+                    break;
+                case IBV_WR_LOCAL_INV:
+                    handleEvent(x->wr_id, IBV_WC_LOCAL_INV);
                     break;
                 default:
                     handleEvent(x->wr_id, IBV_WC_SEND);

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -79,9 +79,16 @@ void PostSend(TTestContextPtr context, ibv_qp* qp, ibv_send_wr* wr)
 {
     Y_UNUSED(qp);
     with_lock (context->CompletionLock) {
-        const auto* msg = reinterpret_cast<M*>(wr->sg_list[0].addr);
-        context->ReqIds.push_back(msg->ReqId);
-        context->SendEvents.push_back(new ibv_send_wr(*wr));
+        for (auto* current = wr; current; current = current->next) {
+            if (current->opcode == IBV_WR_SEND &&
+                current->sg_list &&
+                current->num_sge > 0)
+            {
+                const auto* msg = reinterpret_cast<M*>(current->sg_list[0].addr);
+                context->ReqIds.push_back(msg->ReqId);
+            }
+            context->SendEvents.push_back(new ibv_send_wr(*current));
+        }
         context->CompletionHandle.Set();
     }
 }

--- a/cloud/storage/core/libs/rdma/impl/test_verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/test_verbs.h
@@ -39,6 +39,9 @@ struct TTestContext: TAtomicRefCount<TTestContext>
     TAtomic PostRecvCounter = 0;
 
     std::function<void(ibv_qp* qp, ibv_send_wr* wr)> PostSend;
+    // Return the first WR that was not accepted to emulate a partial
+    // ibv_post_send failure.
+    std::function<ibv_send_wr*(ibv_send_wr* wr)> GetBadSendWr;
     std::function<void(ibv_qp* qp, ibv_recv_wr* wr)> PostRecv;
     std::function<void(rdma_cm_id* id, int backlog)> Listen;
     std::function<void(ibv_wc* wc)> HandleCompletionEvent;
@@ -51,6 +54,7 @@ struct TTestContext: TAtomicRefCount<TTestContext>
     std::function<void(ibv_qp* qp, ibv_qp_attr* attr, int mask)> ModifyQP;
     std::function<void(ibv_pd* pd, void* addr, size_t length, int flags)>
         RegisterMemoryRegion;
+    std::function<void(ibv_mw* mw)> DestroyMemoryWindow;
 
     // If set, called when TTestVerbs resolves address/route.
     std::function<void(

--- a/cloud/storage/core/libs/rdma/impl/verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/verbs.cpp
@@ -80,6 +80,15 @@ struct TVerbs
         return WrapPtr(mr);
     }
 
+    TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) override
+    {
+        auto* mw = ibv_alloc_mw(pd, IBV_MW_TYPE_2);
+        if (!mw) {
+            RDMA_THROW_ERROR("ibv_alloc_mw");
+        }
+        return WrapPtr(mw);
+    }
+
     TCompletionChannelPtr CreateCompletionChannel(ibv_context* context) override
     {
         auto* channel = ibv_create_comp_channel(context);
@@ -404,6 +413,11 @@ IVerbsPtr CreateVerbs()
     return std::make_shared<TVerbs>();
 }
 
+int DestroyId(rdma_cm_id* id)
+{
+    return rdma_destroy_id(id);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 const char* GetOpcodeName(ibv_wc_opcode opcode)
@@ -540,11 +554,6 @@ TString PrintCompletion(ibv_wc* wc)
         << " status=" << GetStatusString(wc->status)
         << " vendor_err=" << wc->vendor_err
         << "]";
-}
-
-int DestroyId(rdma_cm_id* id)
-{
-    return rdma_destroy_id(id);
 }
 
 }   // namespace NCloud::NStorage::NRdma::NVerbs

--- a/cloud/storage/core/libs/rdma/impl/verbs.cpp
+++ b/cloud/storage/core/libs/rdma/impl/verbs.cpp
@@ -167,13 +167,23 @@ struct TVerbs
         return gotWorkCompletions;
     }
 
-    void PostSend(ibv_qp* qp, ibv_send_wr* wr) override
+    void PostSend(
+        ibv_qp* qp,
+        ibv_send_wr* wr,
+        ibv_send_wr** badWr = nullptr) override
     {
         ibv_send_wr* bad = nullptr;
 
         int res = rdma_seterrno(ibv_post_send(qp, wr, &bad));
         if (res < 0) {
+            if (badWr) {
+                *badWr = bad;
+            }
             RDMA_THROW_ERROR("ibv_post_send");
+        }
+
+        if (badWr) {
+            *badWr = nullptr;
         }
     }
 

--- a/cloud/storage/core/libs/rdma/impl/verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/verbs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "public.h"
+#include "work_queue.h"
 
 #include <util/datetime/base.h>
 #include <util/generic/string.h>
@@ -26,6 +27,7 @@ RDMA_DECLARE_PTR(Context, ibv_context, ibv_close_device);
 RDMA_DECLARE_PTR(DeviceList, ibv_device*, ibv_free_device_list);
 RDMA_DECLARE_PTR(ProtectionDomain, ibv_pd, ibv_dealloc_pd);
 RDMA_DECLARE_PTR(MemoryRegion, ibv_mr, ibv_dereg_mr);
+RDMA_DECLARE_PTR(MemoryWindow, ibv_mw, ibv_dealloc_mw);
 RDMA_DECLARE_PTR(CompletionChannel, ibv_comp_channel, ibv_destroy_comp_channel);
 RDMA_DECLARE_PTR(CompletionQueue, ibv_cq, ibv_destroy_cq);
 RDMA_DECLARE_PTR(AddressInfo, rdma_addrinfo, rdma_freeaddrinfo);
@@ -70,6 +72,7 @@ struct IVerbs
         void* addr,
         size_t length,
         int flags) = 0;
+    virtual TMemoryWindowPtr CreateMemoryWindow(ibv_pd* pd) = 0;
 
     virtual TCompletionChannelPtr CreateCompletionChannel(
         ibv_context* context) = 0;
@@ -149,3 +152,39 @@ TString PrintConnectionParams(const rdma_conn_param* param);
 TString PrintCompletion(ibv_wc* wc);
 
 }   // namespace NCloud::NStorage::NRdma::NVerbs
+
+inline IOutputStream& operator<<(IOutputStream& out, ibv_wr_opcode opcode)
+{
+    static const char* string[] = {
+        "RDMA_WRITE",
+        "RDMA_WRITE_WITH_IMM",
+        "SEND",
+        "SEND_WITH_IMM",
+        "RDMA_READ",
+        "ATOMIC_CMP_AND_SWP",
+        "ATOMIC_FETCH_AND_ADD",
+        "LOCAL_INV",
+        "BIND_MW",
+        "SEND_WITH_INV",
+        "TSO",
+        "DRIVER1",
+        "FLUSH",
+        "ATOMIC_WRITE",
+    };
+
+    if ((size_t)opcode < Y_ARRAY_SIZE(string)) {
+        return out << string[(size_t)opcode];
+    }
+
+    return out << "UNKNOWN";
+}
+
+inline IOutputStream& operator<<(IOutputStream& out, ibv_wc_opcode opcode)
+{
+    return out << NCloud::NStorage::NRdma::NVerbs::GetOpcodeName(opcode);
+}
+
+inline IOutputStream& operator<<(IOutputStream& out, const ibv_send_wr& send)
+{
+    return out << send.opcode << " " << NCloud::NStorage::NRdma::TWorkRequestId(send.wr_id);
+}

--- a/cloud/storage/core/libs/rdma/impl/verbs.h
+++ b/cloud/storage/core/libs/rdma/impl/verbs.h
@@ -91,7 +91,10 @@ struct IVerbs
         ibv_cq* cq,
         ICompletionHandler* handler) = 0;
 
-    virtual void PostSend(ibv_qp* qp, ibv_send_wr* wr) = 0;
+    virtual void PostSend(
+        ibv_qp* qp,
+        ibv_send_wr* wr,
+        ibv_send_wr** badWr = nullptr) = 0;
     virtual void PostRecv(ibv_qp* qp, ibv_recv_wr* wr) = 0;
 
     // connection manager

--- a/cloud/storage/core/protos/rdma.proto
+++ b/cloud/storage/core/protos/rdma.proto
@@ -107,15 +107,21 @@ message TRdmaClient
     // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 7].
     uint32 QpRetryCount = 18;
+
     // Sets the "retry_cnt" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 7].
     uint32 QpRnrRetryCount = 19;
+
     // Sets the "timeout" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 31].
     // The resulting timeout is calculated as 4096*2^{QpTimeout} microseconds.
     // 0 means infinite timeout.
     uint32 QpTimeout = 20;
+
     // Sets the "min_rnr_timer" parameter in the "ibv_qp_attr" for
     // "ibv_modify_qp()" function. Valid values are in range [0, 31].
     uint32 QpMinRnrTimer = 21;
+
+    // quick way to invalidate request buffers without heavy ibv_dereg_mr call
+    bool UseMemoryWindows = 22;
 }


### PR DESCRIPTION
### Notes
**Summary**
This PR adds optional RDMA Type 2 Memory Window support to reduce the cost of exposing request buffers and improve rkey lifecycle management.
Instead of exposing long-lived Memory Region keys directly, the client binds reusable Memory Windows to individual request buffers. These windows are invalidated after the request completes and reused only when invalidation has been confirmed.
The feature is controlled by the UseMemoryWindows client setting and the --memory-windows option in the RDMA test tool.
**How it works**
**Connection setup**
When Memory Windows are enabled, the client:
registers buffer pools with IBV_ACCESS_MW_BIND;
preallocates an endpoint-local pool of Type 2 Memory Windows;
increases the QP send queue capacity to account for BIND_MW, SEND, and LOCAL_INV work requests;
negotiates SEND_WITH_INV support with the server during connection establishment.
The server advertises SEND_WITH_INV support in the accept message.
**Request submission**
For each input and output buffer, the client allocates or reuses a Memory Window and generates a new rkey.
The request is posted as a chained sequence:
BIND_MW(input) -> BIND_MW(output) -> SEND
The terminal SEND is fenced so that the request cannot reach the server before the Memory Window bindings become visible.
The request message contains the temporary Memory Window rkeys instead of the underlying Memory Region keys.
**Memory Window invalidation**
The input window is invalidated locally after request completion.
For the output window, the client selects one of two modes:
If the server supports SEND_WITH_INV, the server invalidates the output rkey while sending the response.
Otherwise, the client posts a local invalidation for the output window as well.
Remote invalidation completions are validated against the expected rkey. A missing or unexpected invalidation prevents the affected window from being recycled.
Locally invalidated windows are returned to the endpoint cache only after the terminal LOCAL_INV completion. This guarantees that the old rkey is no longer usable before the window and its buffer are reused.
**Resource ownership**
Request resources are exclusively owned by TRequest. They include:
input and output buffers;
input and output Memory Windows;
invalidation mode and expected rkey;
deferred completion or abort state;
buffer-pool generation.
Invalidation requests have two states:
PendingInvalidationRequests: invalidation has not yet been posted.
PostedInvalidationRequests: invalidation is visible to hardware and may still reference request resources.
A posted invalidation retains the entire request until its terminal CQE is received or the QP is destroyed. This avoids separate user-side and hardware-side ownership and keeps the lifetime rules explicit.
**Cancellation and error handling**
Requests cannot be destroyed while a posted send chain may still reference their Memory Windows.
Cancellation, timeout, and disconnect handling therefore distinguish between:
requests that have not been submitted and can be completed immediately;
requests waiting for their terminal SEND completion;
requests with pending invalidations;
requests whose work chain was only partially accepted by ibv_post_send().
Errors reported by SEND completions now abort the corresponding request even when the CQE is the first place where the error is observed. This prevents requests from remaining indefinitely in ActiveRequests with SendRequest state during disconnect.
ibv_post_send() now exposes bad_wr, allowing the client to distinguish between:
a completely rejected chain, whose resources can be released immediately;
a partially posted chain, whose resources must remain alive until QP destruction.
Memory Windows associated with cancelled, timed-out, failed, or partially posted requests are dropped instead of returned to the reuse pool.
**Disconnect and teardown**
Pending invalidations that were never posted can be completed immediately.
Posted invalidations retain their requests until either:
their terminal CQE arrives; or
the QP is destroyed.
QP destruction is used as the final lifetime boundary for WQEs that may still reference Memory Windows. The teardown order ensures that Memory Windows are not deallocated while the QP may still access them:
stop polling/posting
    -> destroy QP
    -> finalize retained requests
    -> deallocate Memory Windows
    -> release buffers and remaining transport resources
Send slots owned by a QP that is committed to destruction are tracked separately, allowing disconnect flushing to finish without waiting indefinitely for invalidation completions that may never arrive.
A buffer-pool generation counter also prevents resources retained across reconnect from being returned to a newly created buffer pool.
**Additional changes**
Added Memory Window allocation support to the verbs abstraction and test implementation.
Added opcode and work-request formatting for diagnostics.
Added tracing probes for input and output Memory Window binding.
Added configuration and monitoring output for UseMemoryWindows.
Updated buffer descriptors to expose their underlying Memory Region.
Extended the RDMA protocol with request and accept capability flags.
Added comprehensive tests for:Memory Window allocation and reuse;
local and remote invalidation;
capability negotiation;
cancellation and timeout ordering;
disconnect and QP teardown;
failed and flushed completions;
partially posted send and invalidation chains;
retained resource lifetime across reconnect.

### Issue
Put links to the related issues here
