### PR TITLE
issue-1559: [Disk Manager]  Add MainFileSystemId to TGetFileSystemTopologyResponse

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -2711,7 +2711,7 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
             UNIT_ASSERT(response.GetStrictFileSystemSizeEnforcementEnabled());
         };
 
-        testFileSystemTopology(0, fsConfig.FsId, {});
+        testFileSystemTopology(0, fsConfig.FsId, fsConfig.FsId);
         testFileSystemTopology(1, fsConfig.Shard1Id, fsConfig.FsId);
         testFileSystemTopology(2, fsConfig.Shard2Id, fsConfig.FsId);
     }

--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -2695,20 +2695,25 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         service.WriteData(headers, fsConfig.FsId, nodeId2, handle2, 0, data2);
 
         auto testFileSystemTopology =
-            [&](const ui32 shardNo, const TString& shardId)
+            [&] (const ui32 shardNo,
+                 const TString& shardId,
+                 const TString& mainFileSystemId)
         {
             const auto response = GetFileSystemTopology(service, shardId);
             const auto& shardIds = response.GetShardFileSystemIds();
             UNIT_ASSERT_EQUAL(shardNo, response.GetShardNo());
+            UNIT_ASSERT_EQUAL(
+                mainFileSystemId,
+                response.GetMainFileSystemId());
             UNIT_ASSERT_EQUAL(2, shardIds.size());
             UNIT_ASSERT_EQUAL(fsConfig.Shard1Id, shardIds[0]);
             UNIT_ASSERT_EQUAL(fsConfig.Shard2Id, shardIds[1]);
             UNIT_ASSERT(response.GetStrictFileSystemSizeEnforcementEnabled());
         };
 
-        testFileSystemTopology(0, fsConfig.FsId);
-        testFileSystemTopology(1, fsConfig.Shard1Id);
-        testFileSystemTopology(2, fsConfig.Shard2Id);
+        testFileSystemTopology(0, fsConfig.FsId, {});
+        testFileSystemTopology(1, fsConfig.Shard1Id, fsConfig.FsId);
+        testFileSystemTopology(2, fsConfig.Shard2Id, fsConfig.FsId);
     }
 
     SERVICE_TEST(ShouldGetStorageStatsInDifferentModes)

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -987,6 +987,8 @@ void TIndexTabletActor::HandleGetFileSystemTopology(
         GetFileSystem().GetStrictFileSystemSizeEnforcementEnabled());
     response->Record.SetMaxShardCount(Config->GetMaxShardCount());
     response->Record.SetCompressNodeRef(GetCompressNodeRef());
+    response->Record.SetMainFileSystemId(
+        GetFileSystem().GetMainFileSystemId());
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET,

--- a/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor.cpp
@@ -987,8 +987,7 @@ void TIndexTabletActor::HandleGetFileSystemTopology(
         GetFileSystem().GetStrictFileSystemSizeEnforcementEnabled());
     response->Record.SetMaxShardCount(Config->GetMaxShardCount());
     response->Record.SetCompressNodeRef(GetCompressNodeRef());
-    response->Record.SetMainFileSystemId(
-        GetFileSystem().GetMainFileSystemId());
+    response->Record.SetMainFileSystemId(GetMainFileSystemId());
     LOG_INFO(
         ctx,
         TFileStoreComponents::TABLET,

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -883,6 +883,9 @@ message TGetFileSystemTopologyResponse
     repeated string FileShardFileSystemIds = 8;
 
     bool CompressNodeRef = 9;
+
+    // Main FileSystem identifier (if this fs is a shard itself).
+    string MainFileSystemId = 10;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/private/api/protos/tablet.proto
+++ b/cloud/filestore/private/api/protos/tablet.proto
@@ -884,7 +884,7 @@ message TGetFileSystemTopologyResponse
 
     bool CompressNodeRef = 9;
 
-    // Main FileSystem identifier (if this fs is a shard itself).
+    // Main FileSystem identifier.
     string MainFileSystemId = 10;
 }
 

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_enable_directory_creation_in_shards/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_enable_directory_creation_in_shards/results.txt
@@ -25,4 +25,3 @@ FileStore {
 {"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":1,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
 {"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":2,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
 {"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":3,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
-

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_enable_directory_creation_in_shards/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_enable_directory_creation_in_shards/results.txt
@@ -20,9 +20,9 @@ FileStore {
   ShardFileSystemIds: "fs0_s1"
 }
 
-{"ShardFileSystemIds":["fs0_s1"],"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":1,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":2,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":3,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254}
+{"ShardFileSystemIds":["fs0_s1"],"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":1,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":2,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":3,"DirectoryCreationInShardsEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
 

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_enable_strict/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_enable_strict/results.txt
@@ -20,9 +20,9 @@ FileStore {
   ShardFileSystemIds: "fs0_s1"
 }
 
-{"ShardFileSystemIds":["fs0_s1"],"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":1,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":2,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254}
-{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":3,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254}
+{"ShardFileSystemIds":["fs0_s1"],"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":1,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":2,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
+{"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":3,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
 

--- a/cloud/filestore/tests/client_sharded/canondata/test.test_enable_strict/results.txt
+++ b/cloud/filestore/tests/client_sharded/canondata/test.test_enable_strict/results.txt
@@ -25,4 +25,3 @@ FileStore {
 {"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":1,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
 {"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":2,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
 {"ShardFileSystemIds":["fs0_s1","fs0_s2","fs0_s3"],"ShardNo":3,"StrictFileSystemSizeEnforcementEnabled":true,"MaxShardCount":254,"MainFileSystemId":"fs0"}
-

--- a/cloud/filestore/tests/client_sharded/test.py
+++ b/cloud/filestore/tests/client_sharded/test.py
@@ -174,7 +174,7 @@ def test_enable_strict():
         "getfilesystemtopology", {"FileSystemId": "fs0_s2"})
     out += client.execute_action(
         "getfilesystemtopology", {"FileSystemId": "fs0_s3"})
-    out += client.destroy_session("fs0", "session0", "client0")
+    client.destroy_session("fs0", "session0", "client0")
 
     out += client.destroy("fs0")
     out += client.destroy("fs0_s1")
@@ -211,7 +211,7 @@ def test_enable_directory_creation_in_shards():
         "getfilesystemtopology", {"FileSystemId": "fs0_s2"})
     out += client.execute_action(
         "getfilesystemtopology", {"FileSystemId": "fs0_s3"})
-    out += client.destroy_session("fs0", "session0", "client0")
+    client.destroy_session("fs0", "session0", "client0")
 
     out += client.destroy("fs0")
     out += client.destroy("fs0_s1")


### PR DESCRIPTION
We need to get main filesystem id from shard. This can be used for various purposes e.g. to freeze all filesystem shards during filesystem shards restoration.