### PR TITLE
issue-3781: TFileRingBuffer: strengthen validation checks

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.cpp
@@ -50,18 +50,6 @@ public:
             return MakeError(E_FAIL, "Data structure is corrupted");
         }
 
-        if (!Storage.ValidateMetadata()) {
-            Storage.SetCorrupted();
-            SetCounters();
-            return MakeError(E_FAIL, "Metadata is corrupted");
-        }
-
-        if (Config.EnableChecksumValidation && !Storage.Validate().empty()) {
-            Storage.SetCorrupted();
-            SetCounters();
-            return MakeError(E_FAIL, "Data entries are corrupted");
-        }
-
         NJsonWriter::TBuf json;
         json.BeginObject()
             .WriteKey("FilePath")

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage.h
@@ -75,7 +75,6 @@ struct TPersistentStorageConfig
     TString FilePath;
     ui64 DataCapacity = 0;
     ui64 MetadataCapacity = 0;
-    bool EnableChecksumValidation = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
+++ b/cloud/filestore/libs/vfs_fuse/write_back_cache/persistent_storage_ut.cpp
@@ -45,8 +45,7 @@ struct TBootstrap
             Stats,
             {.FilePath = TempFile.GetName(),
              .DataCapacity = DefaultCapacity,
-             .MetadataCapacity = 0,
-             .EnableChecksumValidation = true},
+             .MetadataCapacity = 0},
             Log,
             "[tag]");
 

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.cpp
@@ -277,6 +277,32 @@ private:
         }
     }
 
+    void ValidateMetadata()
+    {
+        auto data =
+            GetMappedData(Header()->MetadataOffset, Header()->MetadataCapacity);
+
+        if (Header()->MetadataSize > data.size() ||
+            Crc32c(data.data(), Header()->MetadataSize) !=
+                Header()->MetadataChecksum)
+        {
+            SetCorrupted();
+        }
+    }
+
+    void ValidateEntriesChecksums()
+    {
+        Visit(
+            [&](ui32 checksum, ui32 tag, TStringBuf entry)
+            {
+                Y_UNUSED(tag);
+                const ui32 actualChecksum = Crc32c(entry.data(), entry.size());
+                if (actualChecksum != checksum) {
+                    SetCorrupted();
+                }
+            });
+    }
+
     void ResizeAndRemap(ui64 fileSize)
     {
         Map.ResizeAndRemap(0, fileSize);
@@ -453,6 +479,8 @@ public:
         CreateDataProcessor(Header()->Version);
 
         ValidateDataStructure();
+        ValidateMetadata();
+        ValidateEntriesChecksums();
 
         VisitEntries(
             [&](const TEntryInfo& e)
@@ -717,22 +745,13 @@ public:
         return result;
     }
 
-    auto ValidateEntriesChecksums()
+    bool Validate()
     {
-        TVector<TBrokenFileEntry> entries;
-
-        Visit([&] (ui32 checksum, ui32 tag, TStringBuf entry) {
-            Y_UNUSED(tag);
-            const ui32 actualChecksum = Crc32c(entry.data(), entry.size());
-            if (actualChecksum != checksum) {
-                entries.push_back({
-                    TString(entry),
-                    checksum,
-                    actualChecksum});
-            }
-        });
-
-        return entries;
+        ValidateStructure();
+        ValidateDataStructure();
+        ValidateMetadata();
+        ValidateEntriesChecksums();
+        return !IsCorrupted();
     }
 
     void Visit(const TVisitor& visitor)
@@ -822,18 +841,12 @@ public:
         return Capabilities.MaxAllocationByteCount;
     }
 
-    bool ValidateMetadata() const
-    {
-        auto data =
-            GetMappedData(Header()->MetadataOffset, Header()->MetadataCapacity);
-
-        return Header()->MetadataSize <= data.size() &&
-               Crc32c(data.data(), Header()->MetadataSize) ==
-                   Header()->MetadataChecksum;
-    }
-
     TStringBuf GetMetadata() const
     {
+        if (!ValidateAccess("GetMetadata")) {
+            return {};
+        }
+
         auto data =
             GetMappedData(Header()->MetadataOffset, Header()->MetadataCapacity);
 
@@ -844,6 +857,10 @@ public:
 
     bool SetMetadata(TStringBuf buf)
     {
+        if (!ValidateAccess("SetMetadata")) {
+            return false;
+        }
+
         if (buf.size() > Header()->MetadataCapacity) {
             return false;
         }
@@ -929,9 +946,9 @@ bool TFileRingBuffer::Empty() const
     return Impl->Empty();
 }
 
-TVector<TFileRingBuffer::TBrokenFileEntry> TFileRingBuffer::Validate()
+bool TFileRingBuffer::Validate()
 {
-    return Impl->ValidateEntriesChecksums();
+    return Impl->Validate();
 }
 
 void TFileRingBuffer::Visit(const TVisitor& visitor)
@@ -977,11 +994,6 @@ ui64 TFileRingBuffer::GetAvailableByteCount() const
 ui64 TFileRingBuffer::GetMaxSupportedAllocationByteCount() const
 {
     return Impl->GetMaxSupportedAllocationByteCount();
-}
-
-bool TFileRingBuffer::ValidateMetadata() const
-{
-    return Impl->ValidateMetadata();
 }
 
 TStringBuf TFileRingBuffer::GetMetadata() const

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -4,8 +4,7 @@
 
 #include <cloud/storage/core/libs/common/error.h>
 
-#include <util/generic/string.h>
-#include <util/generic/vector.h>
+#include <util/generic/strbuf.h>
 
 #include <functional>
 
@@ -79,7 +78,14 @@ public:
     void PopFront();
     ui64 Size() const;
     bool Empty() const;
+
+    // Checks data and structure integrity
+    // Sets IsCorrupted flag if any issues are found and returns false
+    // Returns true if everything is valid
     bool Validate();
+
+    // Calls visitor for each entry in the buffer
+    // Fires a critical event doesn't visit entries if a buffer is corrupted
     void Visit(const TVisitor& visitor);
     bool IsCorrupted() const;
     void SetCorrupted();

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer.h
@@ -16,13 +16,6 @@ namespace NCloud {
 class TFileRingBuffer
 {
 public:
-    struct TBrokenFileEntry
-    {
-        TString Data;
-        ui32 ExpectedChecksum = 0;
-        ui32 ActualChecksum = 0;
-    };
-
     using TVisitor =
         std::function<void(ui32 checksum, ui32 tag, TStringBuf entry)>;
 
@@ -86,7 +79,7 @@ public:
     void PopFront();
     ui64 Size() const;
     bool Empty() const;
-    TVector<TBrokenFileEntry> Validate();
+    bool Validate();
     void Visit(const TVisitor& visitor);
     bool IsCorrupted() const;
     void SetCorrupted();
@@ -105,7 +98,6 @@ public:
     // Returns zero if the buffer is corrupted.
     ui64 GetMaxSupportedAllocationByteCount() const;
 
-    bool ValidateMetadata() const;
     TStringBuf GetMetadata() const;
     bool SetMetadata(TStringBuf data);
 };

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -32,23 +32,6 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TString Dump(const TVector<TFileRingBuffer::TBrokenFileEntry>& entries)
-{
-    TStringBuilder sb;
-
-    for (ui32 i = 0; i < entries.size(); ++i) {
-        if (i) {
-            sb << ", ";
-        }
-
-        sb << "data=" << entries[i].Data
-            << " ecsum=" << entries[i].ExpectedChecksum
-            << " csum=" << entries[i].ActualChecksum;
-    }
-
-    return sb;
-}
-
 TString Dump(const TVector<TString>& entries)
 {
     TStringBuilder sb;
@@ -212,9 +195,9 @@ struct TReferenceImplementation
         return Q.size();
     }
 
-    auto Validate() const
+    bool Validate() const
     {
-        return TVector<TFileRingBuffer::TBrokenFileEntry>();
+        return true;
     }
 };
 
@@ -260,38 +243,38 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb.PushBack("petya2"));
         UNIT_ASSERT(!rb.PushBack("vasya3"));        // out of space
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(4, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya", rb.Front());
         rb.PopFront();
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(3, rb.Size());
         UNIT_ASSERT(!rb.PushBack("vasya3"));
 
         UNIT_ASSERT_VALUES_EQUAL("petya", rb.Front());
         rb.PopFront();
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
         UNIT_ASSERT(rb.PushBack("vasya3"));
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(3, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya2", rb.Front());
         rb.PopFront();
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(2, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("petya2", rb.Front());
         rb.PopFront();
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(1, rb.Size());
         UNIT_ASSERT_VALUES_EQUAL("vasya3", rb.Front());
         rb.PopFront();
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         UNIT_ASSERT_VALUES_EQUAL(0, rb.Size());
         UNIT_ASSERT(rb.Empty());
     }
@@ -330,7 +313,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 0, ver);
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb->Validate()));
+        UNIT_ASSERT(rb->Validate());
         UNIT_ASSERT_VALUES_EQUAL(4, rb->Size());
 
         UNIT_ASSERT_VALUES_EQUAL("vasya2, petya2, vasya3, xxx", PopAll(*rb));
@@ -347,22 +330,13 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT(rb.PushBack("vasya2"));
         UNIT_ASSERT(rb.PushBack("petya2"));
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
         TFileMap m(f.GetName(), TMemoryMapCommon::oRdWr);
         m.Map(0, len);
         char* data = static_cast<char*>(m.Ptr());
         data[260] = 'A';
 
-        if (ver >= EVersion::V6) {
-            // In V6, checksum is additionally XOR-ed with the header checksum
-            UNIT_ASSERT_VALUES_EQUAL(
-                "data=vasya ecsum=3387363625 csum=3387363646",
-                Dump(rb.Validate()));
-        } else {
-            UNIT_ASSERT_VALUES_EQUAL(
-                "data=vasya ecsum=3387363649 csum=3387363646",
-                Dump(rb.Validate()));
-        }
+        UNIT_ASSERT(!rb.Validate());
     }
 
     Y_UNIT_TEST(ShouldIgnoreSlackSpaceSmallerThanEntryHeader)
@@ -391,7 +365,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
          *  hhhhhhhhccccccccccccccccccccc0hhhhhhhhbbbbbbbbbbbbbbbbbbbbb00000
          */
 
-        UNIT_ASSERT_VALUES_EQUAL("", Dump(rb.Validate()));
+        UNIT_ASSERT(rb.Validate());
     }
 
     void DoRandomizedPushPopRestore(
@@ -463,7 +437,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
 
             UNIT_ASSERT_VALUES_EQUAL(ri.Size(), rb->Size());
             UNIT_ASSERT_VALUES_EQUAL(ri.Empty(), rb->Empty());
-            UNIT_ASSERT_VALUES_EQUAL("", Dump(rb->Validate()));
+            UNIT_ASSERT(rb->Validate());
             UNIT_ASSERT(!rb->IsCorrupted());
         }
     }
@@ -596,8 +570,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         for (int i = 0; i <= 32; i++) {
             TStateWithCorruptedEntryLength s(i);
             UNIT_ASSERT(!s.RingBuffer.IsCorrupted());
-            auto brokenEntries = s.RingBuffer.Validate();
-            UNIT_ASSERT_VALUES_EQUAL(i != 2, s.RingBuffer.IsCorrupted());
+            UNIT_ASSERT_VALUES_EQUAL(i == 2, s.RingBuffer.Validate());
         }
     }
 
@@ -765,14 +738,13 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
         UNIT_ASSERT_VALUES_EQUAL("AAA", rb->Front());
     }
 
-    FILE_RING_BUFFER_TEST(ShouldValidateMetadata)
+    FILE_RING_BUFFER_TEST(ShouldValidateMetadataWithCorruptedData)
     {
         const auto f = TTempFileHandle();
         const ui32 len = 36;
 
         auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
         UNIT_ASSERT(rb->SetMetadata("1234"));
-        UNIT_ASSERT(rb->ValidateMetadata());
 
         {
             // Corrupt metadata
@@ -782,12 +754,20 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             data[68] ^= 1;
         }
 
-        UNIT_ASSERT(!rb->ValidateMetadata());
+        UNIT_ASSERT(!rb->Validate());
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
-        UNIT_ASSERT(!rb->ValidateMetadata());
+        UNIT_ASSERT(rb->IsCorrupted());
+        UNIT_ASSERT(!rb->SetMetadata("1234"));
+    }
+
+    FILE_RING_BUFFER_TEST(ShouldValidateMetadataWithCorruptedSize)
+    {
+        const auto f = TTempFileHandle();
+        const ui32 len = 36;
+
+        auto rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
         UNIT_ASSERT(rb->SetMetadata("1234"));
-        UNIT_ASSERT(rb->ValidateMetadata());
 
         {
             // Corrupt metadata Length
@@ -797,12 +777,11 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             data[64] = 100;
         }
 
-        UNIT_ASSERT(!rb->ValidateMetadata());
+        UNIT_ASSERT(!rb->Validate());
 
         rb = std::make_unique<TFileRingBuffer>(f.GetName(), len, 8, ver);
-        UNIT_ASSERT(!rb->ValidateMetadata());
-        UNIT_ASSERT(rb->SetMetadata("1234"));
-        UNIT_ASSERT(rb->ValidateMetadata());
+        UNIT_ASSERT(rb->IsCorrupted());
+        UNIT_ASSERT(!rb->SetMetadata("1234"));
     }
 
     FILE_RING_BUFFER_TEST(ShouldResizeMetadata)
@@ -1216,7 +1195,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
                 8,
                 dstVersion);
 
-            UNIT_ASSERT(rb->Validate().empty());
+            UNIT_ASSERT(rb->Validate());
 
             UNIT_ASSERT_VALUES_EQUAL("abc", rb->GetMetadata());
             UNIT_ASSERT_VALUES_EQUAL("123, 4, xz", Dump(*rb));
@@ -1242,7 +1221,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
                 static_cast<ui32>(dstVersion),
                 rb->GetVersion());
 
-            UNIT_ASSERT(rb->Validate().empty());
+            UNIT_ASSERT(rb->Validate());
         };
 
         // Version upgrade

--- a/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
+++ b/cloud/storage/core/libs/file_backed_containers/file_ring_buffer_ut.cpp
@@ -571,6 +571,7 @@ Y_UNIT_TEST_SUITE(TFileRingBufferTest)
             TStateWithCorruptedEntryLength s(i);
             UNIT_ASSERT(!s.RingBuffer.IsCorrupted());
             UNIT_ASSERT_VALUES_EQUAL(i == 2, s.RingBuffer.Validate());
+            UNIT_ASSERT_VALUES_EQUAL(i != 2, s.RingBuffer.IsCorrupted());
         }
     }
 


### PR DESCRIPTION
### Notes
Strengthen validation checks in TFileRingBuffer:
- mandatory checksum validation check on startup;
- forbid reading/writing metadata in the corrupted state - the behavior is now the same as for data;
- remove redundant methods, `Validate` now rechecks everything and returns `bool`.

Validation will become more accurate in https://github.com/ydb-platform/nbs/pull/6654

### Issue
https://github.com/ydb-platform/nbs/issues/3781
