### PR TITLE
THandleOpsQueue: do not process handles when the queue is corrupted

### DIFF
--- a/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl.cpp
@@ -414,6 +414,15 @@ void TFileSystem::CompleteAsyncDestroyHandle(
 void TFileSystem::ProcessHandleOpsQueue()
 {
     TGuard g{HandleOpsQueueLock};
+
+    if (HandleOpsQueue->IsCorrupted()) {
+        ReportHandleOpsQueueProcessError(
+            TStringBuilder()
+            << "HandleOpsQueue is corrupted, filesystem: "
+            << Config->GetFileSystemId());
+        return;
+    }
+
     if (HandleOpsQueue->Empty()) {
         ScheduleProcessHandleOpsQueue();
         return;

--- a/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
+++ b/cloud/filestore/libs/vfs_fuse/fs_impl_data.cpp
@@ -240,6 +240,16 @@ bool TFileSystem::ProcessAsyncRelease(
 {
     with_lock (HandleOpsQueueLock) {
         const auto res = HandleOpsQueue->AddDestroyRequest(ino, fh);
+        if (res == THandleOpsQueue::EResult::QueueIsCorrupted) {
+            TStringBuilder msg;
+            msg << "HandleOpsQueue is corrupted, can't add destroy handle "
+                   "request to queue #"
+                << ino << " @" << fh;
+
+            ReportHandleOpsQueueProcessError(msg);
+            return false;
+        }
+
         if (res == THandleOpsQueue::EResult::QueueOverflow) {
             STORAGE_DEBUG(
                 "HandleOpsQueue overflow, can't add destroy handle request to "

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.cpp
@@ -22,6 +22,10 @@ THandleOpsQueue::EResult THandleOpsQueue::AddDestroyRequest(
     ui64 nodeId,
     ui64 handle)
 {
+    if (RequestsToProcess.IsCorrupted()) {
+        return THandleOpsQueue::EResult::QueueIsCorrupted;
+    }
+
     NProto::TQueueEntry request;
     request.MutableDestroyHandleRequest()->SetHandle(handle);
     request.MutableDestroyHandleRequest()->SetNodeId(nodeId);
@@ -57,6 +61,11 @@ std::optional<NProto::TQueueEntry> THandleOpsQueue::Front()
 bool THandleOpsQueue::Empty() const
 {
     return RequestsToProcess.Empty();
+}
+
+bool THandleOpsQueue::IsCorrupted() const
+{
+    return RequestsToProcess.IsCorrupted();
 }
 
 void THandleOpsQueue::PopFront()

--- a/cloud/filestore/libs/vfs_fuse/handle_ops_queue.h
+++ b/cloud/filestore/libs/vfs_fuse/handle_ops_queue.h
@@ -23,6 +23,7 @@ public:
         Ok,
         QueueOverflow,
         SerializationError,
+        QueueIsCorrupted,
     };
 
     explicit THandleOpsQueue(const TString& filePath, ui32 size);
@@ -34,6 +35,7 @@ public:
     void PopFront();
     ui64 Size() const;
     bool Empty() const;
+    bool IsCorrupted() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
If `TFileRingBuffer` becomes corrupted, all operations with it starts to fail.
It means that neither `PopFront` or `PushBack` will work, and `ProcessHandleOpsQueue` will enter the infinite cycle.
Proposed behavior: stop any processing and wait for a manual resolution.

### Issue
Put links to the related issues here
