### PR TITLE
[Disk Manager] cleanup testcommon/common.go: use require instead of returning error for YDB-related constructors

### DIFF
--- a/cloud/disk_manager/internal/pkg/facade/disk_service_max_free_bytes_policy_test/disk_service_max_free_bytes_policy_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_max_free_bytes_policy_test/disk_service_max_free_bytes_policy_test.go
@@ -28,6 +28,7 @@ func TestCreateEmptyDiskWithMaxFreeBytesPolicy(t *testing.T) {
 	deleteOlderThan := time.Now()
 
 	err := testcommon.UpdateClusterCapacities(
+		t,
 		ctx,
 		[]cells_storage.ClusterCapacity{
 			{
@@ -79,7 +80,7 @@ func TestCreateEmptyDiskWithMaxFreeBytesPolicy(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, operation.Id)
 	require.NoError(t, err)
 
-	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	diskMeta, err := testcommon.GetDiskMeta(t, ctx, diskID)
 	require.NoError(t, err)
 	require.Equal(t, cellID2, diskMeta.ZoneID)
 
@@ -115,7 +116,7 @@ func TestCreateEmptyDiskWithMaxFreeBytesPolicyFallback(t *testing.T) {
 	err = internal_client.WaitOperation(ctx, client, operation.Id)
 	require.NoError(t, err)
 
-	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	diskMeta, err := testcommon.GetDiskMeta(t, ctx, diskID)
 	require.NoError(t, err)
 	// Should fallback to the first cell in config, which is cellID1 for shardedZoneID.
 	require.Equal(t, cellID1, diskMeta.ZoneID)

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/common_test.go
@@ -111,7 +111,7 @@ func testCreateDiskFromImageWithZoneID(
 	err = internal_client.WaitOperation(ctx, client, operation.Id)
 	require.NoError(t, err)
 
-	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	diskMeta, err := testcommon.GetDiskMeta(t, ctx, diskID)
 	require.NoError(t, err)
 	// We should provide correct zone for NBS client because only unsharded
 	// zones and shards are configured in the NBS client config.
@@ -251,7 +251,7 @@ func testDiskServiceCreateDiskFromSnapshotWithZoneID(
 	err = nbsClient.ValidateCrc32(ctx, diskID1, diskContentInfo)
 	require.NoError(t, err)
 
-	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID2)
+	diskMeta, err := testcommon.GetDiskMeta(t, ctx, diskID2)
 	require.NoError(t, err)
 	// We should provide correct zone for NBS client because only unsharded
 	// zones and shards are configured in the NBS client config.

--- a/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/disk_service_test/disk_service_test.go
@@ -354,8 +354,7 @@ func TestDiskServiceDeleteDiskWhenCreationIsInFlight(t *testing.T) {
 
 	testcommon.DeleteDisk(t, ctx, client, diskID)
 
-	tasksStorage, err := testcommon.NewTaskStorage(ctx)
-	require.NoError(t, err)
+	tasksStorage := testcommon.NewTaskStorage(t, ctx)
 
 	require.Eventually(t, func() bool {
 		ended, err := tasksStorage.IsTaskEnded(ctx, createOp.Id)

--- a/cloud/disk_manager/internal/pkg/facade/filesystem_scrubbing_test/filesystem_scrubbing_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_scrubbing_test/filesystem_scrubbing_test.go
@@ -229,8 +229,7 @@ func TestRegularFilesystemScrubbing(t *testing.T) {
 		}()
 	}
 
-	taskStorage, err := testcommon.NewTaskStorage(ctx)
-	require.NoError(t, err)
+	taskStorage := testcommon.NewTaskStorage(t, ctx)
 
 	// First iteration: wait for all filesystems to be scheduled.
 	firstTaskIDs := getRegularScrubTaskIDs(t, ctx, taskStorage)

--- a/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go
@@ -58,7 +58,7 @@ func waitForFilesystemSnapshotCreationStarted(
 ) {
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		meta, err := testcommon.GetFilesystemSnapshotMeta(ctx, snapshotID)
+		meta, err := testcommon.GetFilesystemSnapshotMeta(t, ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.NotNil(collect, meta)
 		if err != nil || meta == nil {
@@ -66,7 +66,7 @@ func waitForFilesystemSnapshotCreationStarted(
 		}
 
 		dataplaneMeta, err :=
-			testcommon.GetDataplaneFilesystemSnapshotMeta(ctx, snapshotID)
+			testcommon.GetDataplaneFilesystemSnapshotMeta(t, ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.NotNil(collect, dataplaneMeta)
 	}, 30*time.Second, 100*time.Millisecond)
@@ -79,7 +79,7 @@ func waitForFilesystemSnapshotDeleted(
 ) {
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		meta, err := testcommon.GetFilesystemSnapshotMeta(ctx, snapshotID)
+		meta, err := testcommon.GetFilesystemSnapshotMeta(t, ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.Nil(collect, meta)
 		if err != nil || meta != nil {
@@ -87,7 +87,7 @@ func waitForFilesystemSnapshotDeleted(
 		}
 
 		dataplaneMeta, err :=
-			testcommon.GetDataplaneFilesystemSnapshotMeta(ctx, snapshotID)
+			testcommon.GetDataplaneFilesystemSnapshotMeta(t, ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.Nil(collect, dataplaneMeta)
 	}, 60*time.Second, 100*time.Millisecond)

--- a/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/filesystem_snapshot_service_test/filesystem_snapshot_service_test.go
@@ -57,8 +57,17 @@ func waitForFilesystemSnapshotCreationStarted(
 	snapshotID string,
 ) {
 
+	// Storages are constructed here, because the callback below runs on
+	// another goroutine and must not use require.
+	storage, closeFunc := testcommon.NewResourceStorage(t, ctx)
+	defer closeFunc()
+
+	dataplaneStorage, closeDataplaneFunc :=
+		testcommon.NewFilesystemSnapshotStorage(t, ctx)
+	defer closeDataplaneFunc()
+
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		meta, err := testcommon.GetFilesystemSnapshotMeta(t, ctx, snapshotID)
+		meta, err := storage.GetFilesystemSnapshotMeta(ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.NotNil(collect, meta)
 		if err != nil || meta == nil {
@@ -66,7 +75,7 @@ func waitForFilesystemSnapshotCreationStarted(
 		}
 
 		dataplaneMeta, err :=
-			testcommon.GetDataplaneFilesystemSnapshotMeta(t, ctx, snapshotID)
+			dataplaneStorage.GetFilesystemSnapshotMeta(ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.NotNil(collect, dataplaneMeta)
 	}, 30*time.Second, 100*time.Millisecond)
@@ -78,8 +87,17 @@ func waitForFilesystemSnapshotDeleted(
 	snapshotID string,
 ) {
 
+	// Storages are constructed here, because the callback below runs on
+	// another goroutine and must not use require.
+	storage, closeFunc := testcommon.NewResourceStorage(t, ctx)
+	defer closeFunc()
+
+	dataplaneStorage, closeDataplaneFunc :=
+		testcommon.NewFilesystemSnapshotStorage(t, ctx)
+	defer closeDataplaneFunc()
+
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		meta, err := testcommon.GetFilesystemSnapshotMeta(t, ctx, snapshotID)
+		meta, err := storage.GetFilesystemSnapshotMeta(ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.Nil(collect, meta)
 		if err != nil || meta != nil {
@@ -87,7 +105,7 @@ func waitForFilesystemSnapshotDeleted(
 		}
 
 		dataplaneMeta, err :=
-			testcommon.GetDataplaneFilesystemSnapshotMeta(t, ctx, snapshotID)
+			dataplaneStorage.GetFilesystemSnapshotMeta(ctx, snapshotID)
 		assert.NoError(collect, err)
 		assert.Nil(collect, dataplaneMeta)
 	}, 60*time.Second, 100*time.Millisecond)

--- a/cloud/disk_manager/internal/pkg/facade/image_service_test/image_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/image_service_test/image_service_test.go
@@ -216,7 +216,7 @@ func testImageServiceCreateImageFromDiskWithKind(
 	require.NoError(t, err)
 
 	// Disk cell is not determined, when creating in sharded zone.
-	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	diskMeta, err := testcommon.GetDiskMeta(t, ctx, diskID)
 	require.NoError(t, err)
 	nbsClient := testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
 	diskContentInfo, err := nbsClient.FillDisk(ctx, diskID, diskSize)

--- a/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/snapshot_service_test/snapshot_service_test.go
@@ -59,7 +59,7 @@ func testCreateSnapshotFromDiskWithZoneID(
 	require.NoError(t, err)
 
 	// Disk cell is not determined, when creating in sharded zone.
-	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	diskMeta, err := testcommon.GetDiskMeta(t, ctx, diskID)
 	require.NoError(t, err)
 	nbsClient := testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
 	_, err = nbsClient.FillDisk(ctx, diskID, 64*4096)
@@ -202,7 +202,7 @@ func TestSnapshotServiceCancelCreateSnapshotFromDisk(t *testing.T) {
 	testcommon.CancelOperation(t, ctx, client, operation.Id)
 	testcommon.WaitOperationEnded(t, ctx, operation.Id, 10*time.Second)
 
-	snapshotMeta, err := testcommon.GetSnapshotMeta(ctx, snapshotID)
+	snapshotMeta, err := testcommon.GetSnapshotMeta(t, ctx, snapshotID)
 
 	// If snapshot creation was cancelled, checkpoint should be deleted.
 	// Otherwise, there should be a checkpoint from snapshot.
@@ -748,7 +748,7 @@ func TestSnapshotServiceDeleteIncrementalSnapshotWhileCreating(t *testing.T) {
 	// TestSnapshotServiceDeleteIncrementalSnapshotBeforeCreating and
 	// TestSnapshotServiceDeleteIncrementalSnapshotAfterCreating.
 	if creationErr != nil {
-		snapshotID, _, err := testcommon.GetIncremental(ctx, &types.Disk{
+		snapshotID, _, err := testcommon.GetIncremental(t, ctx, &types.Disk{
 			ZoneId: defaultZoneID,
 			DiskId: diskID,
 		})

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -612,7 +612,7 @@ func DeleteDisk(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-func newYDB(ctx context.Context) (*persistence.YDBClient, error) {
+func newYDB(t *testing.T, ctx context.Context) *persistence.YDBClient {
 	endpoint := fmt.Sprintf(
 		"localhost:%v",
 		os.Getenv("DISK_MANAGER_RECIPE_YDB_PORT"),
@@ -622,7 +622,7 @@ func newYDB(ctx context.Context) (*persistence.YDBClient, error) {
 	database := "/Root"
 	rootPath := "disk_manager/recipe"
 
-	return persistence.NewYDBClient(
+	db, err := persistence.NewYDBClient(
 		ctx,
 		&persistence_config.PersistenceConfig{
 			Endpoint: &endpoint,
@@ -631,6 +631,8 @@ func newYDB(ctx context.Context) (*persistence.YDBClient, error) {
 		},
 		metrics.NewEmptyRegistry(),
 	)
+	require.NoError(t, err)
+	return db
 }
 
 type storageWithDB[T any] struct {
@@ -638,24 +640,18 @@ type storageWithDB[T any] struct {
 	db      *persistence.YDBClient
 }
 
-func (s *storageWithDB[T]) close(ctx context.Context) error {
-	return s.db.Close(ctx)
+func (s *storageWithDB[T]) close(ctx context.Context) {
+	s.db.Close(ctx)
 }
 
 func newResourceStorage(
+	t *testing.T,
 	ctx context.Context,
-) (*storageWithDB[resources.Storage], error) {
+) *storageWithDB[resources.Storage] {
 
-	db, err := newYDB(ctx)
-	if err != nil {
-		return nil, err
-	}
+	db := newYDB(t, ctx)
 
-	endedMigrationExpirationTimeout, err := time.ParseDuration("30m")
-	if err != nil {
-		_ = db.Close(ctx)
-		return nil, err
-	}
+	endedMigrationExpirationTimeout := 30 * time.Minute
 
 	resourcesStorage, err := resources.NewStorage(
 		"disks",
@@ -667,20 +663,18 @@ func newResourceStorage(
 		db,
 		endedMigrationExpirationTimeout,
 	)
-	if err != nil {
-		_ = db.Close(ctx)
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	return &storageWithDB[resources.Storage]{
 		storage: resourcesStorage,
 		db:      db,
-	}, nil
+	}
 }
 
 func newFilesystemSnapshotStorage(
+	t *testing.T,
 	ctx context.Context,
-) (*storageWithDB[filesystem_snapshot_storage.Storage], error) {
+) *storageWithDB[filesystem_snapshot_storage.Storage] {
 
 	endpoint := fmt.Sprintf(
 		"localhost:%v",
@@ -699,9 +693,7 @@ func newFilesystemSnapshotStorage(
 		},
 		metrics.NewEmptyRegistry(),
 	)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	// Should be in sync with FilesystemSnapshotConfig.NodesStorageFolder.
 	return &storageWithDB[filesystem_snapshot_storage.Storage]{
@@ -710,17 +702,15 @@ func newFilesystemSnapshotStorage(
 			"filesystem/snapshot/nodes",
 		),
 		db: db,
-	}, nil
+	}
 }
 
 func newPoolStorage(
+	t *testing.T,
 	ctx context.Context,
-) (*storageWithDB[pools_storage.Storage], error) {
+) *storageWithDB[pools_storage.Storage] {
 
-	db, err := newYDB(ctx)
-	if err != nil {
-		return nil, err
-	}
+	db := newYDB(t, ctx)
 
 	// Should be in sync with settings from PoolsConfig in test recipe.
 	cloudID := "cloud"
@@ -730,35 +720,31 @@ func newPoolStorage(
 		CloudId:  &cloudID,
 		FolderId: &folderID,
 	}, db, metrics.NewEmptyRegistry())
-	if err != nil {
-		_ = db.Close(ctx)
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	return &storageWithDB[pools_storage.Storage]{
 		storage: storage,
 		db:      db,
-	}, nil
+	}
 }
 
 func newCellStorage(
+	t *testing.T,
 	ctx context.Context,
-) (*storageWithDB[cells_storage.Storage], error) {
+) *storageWithDB[cells_storage.Storage] {
 
-	db, err := newYDB(ctx)
-	if err != nil {
-		return nil, err
-	}
+	db := newYDB(t, ctx)
 
 	return &storageWithDB[cells_storage.Storage]{
 		storage: cells_storage.NewStorage(&cells_config.CellsConfig{}, db),
 		db:      db,
-	}, nil
+	}
 }
 
 func newSnapshotStorage(
+	t *testing.T,
 	ctx context.Context,
-) (*storageWithDB[snapshot_storage.Storage], error) {
+) *storageWithDB[snapshot_storage.Storage] {
 
 	// Should be in sync with settings from SnapshotConfig in test recipe.
 	endpoint := fmt.Sprintf(
@@ -778,9 +764,7 @@ func newSnapshotStorage(
 		config.GetPersistenceConfig(),
 		metrics.NewEmptyRegistry(),
 	)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	storage, err := snapshot_storage.NewStorage(
 		config,
@@ -788,54 +772,46 @@ func newSnapshotStorage(
 		db,
 		nil, // do not need s3 here
 	)
-	if err != nil {
-		_ = db.Close(ctx)
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	return &storageWithDB[snapshot_storage.Storage]{
 		storage: storage,
 		db:      db,
-	}, nil
+	}
 }
 
-func NewTaskStorage(ctx context.Context) (tasks_storage.Storage, error) {
-	db, err := newYDB(ctx)
-	if err != nil {
-		return nil, err
-	}
+func NewTaskStorage(
+	t *testing.T,
+	ctx context.Context,
+) tasks_storage.Storage {
 
-	return tasks_storage.NewStorage(
+	db := newYDB(t, ctx)
+
+	storage, err := tasks_storage.NewStorage(
 		&tasks_config.TasksConfig{},
 		metrics.NewEmptyRegistry(),
 		db,
 	)
+	require.NoError(t, err)
+
+	return storage
 }
 
-func newScheduler(ctx context.Context) (tasks.Scheduler, error) {
+func newScheduler(t *testing.T, ctx context.Context) tasks.Scheduler {
 	taskRegistry := tasks.NewRegistry()
-	err := filesystem_scrubbing.Register(taskRegistry)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, filesystem_scrubbing.Register(taskRegistry))
+	require.NoError(t, filesystem_snapshot.Register(taskRegistry))
 
-	err = filesystem_snapshot.Register(taskRegistry)
-	if err != nil {
-		return nil, err
-	}
-
-	taskStorage, err := NewTaskStorage(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return tasks.NewScheduler(
+	scheduler, err := tasks.NewScheduler(
 		ctx,
 		taskRegistry,
-		taskStorage,
+		NewTaskStorage(t, ctx),
 		&tasks_config.TasksConfig{},
 		metrics.NewEmptyRegistry(),
 	)
+	require.NoError(t, err)
+
+	return scheduler
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -847,10 +823,9 @@ func WaitOperationEnded(
 	timeout time.Duration,
 ) {
 
-	scheduler, err := newScheduler(ctx)
-	require.NoError(t, err)
+	scheduler := newScheduler(t, ctx)
 
-	err = scheduler.WaitTaskEndedWithTimeout(ctx, operationID, timeout)
+	err := scheduler.WaitTaskEndedWithTimeout(ctx, operationID, timeout)
 	require.NoError(t, err)
 }
 
@@ -860,10 +835,9 @@ func RequireTaskHasNoError(
 	taskID string,
 ) {
 
-	scheduler, err := newScheduler(ctx)
-	require.NoError(t, err)
+	scheduler := newScheduler(t, ctx)
 
-	err = scheduler.GetTaskError(ctx, taskID)
+	err := scheduler.GetTaskError(ctx, taskID)
 	require.NoError(t, err)
 }
 
@@ -873,8 +847,7 @@ func GetTaskMetadata(
 	taskID string,
 ) proto.Message {
 
-	scheduler, err := newScheduler(ctx)
-	require.NoError(t, err)
+	scheduler := newScheduler(t, ctx)
 
 	metadata, err := scheduler.GetTaskMetadata(ctx, taskID)
 	require.NoError(t, err)
@@ -888,8 +861,7 @@ func ScheduleFilesystemScrubbing(
 	filesystemID string,
 ) string {
 
-	scheduler, err := newScheduler(ctx)
-	require.NoError(t, err)
+	scheduler := newScheduler(t, ctx)
 	lastReqNumber++
 	taskID, err := filesystem_scrubbing.ScheduleScrubFilesystem(
 		tasks_headers.SetIncomingIdempotencyKey(
@@ -913,7 +885,7 @@ func CheckBaseSnapshot(
 	expectedBaseSnapshotID string,
 ) {
 
-	snapshotMeta, err := GetSnapshotMeta(ctx, snapshotID)
+	snapshotMeta, err := GetSnapshotMeta(t, ctx, snapshotID)
 	require.NoError(t, err)
 	require.EqualValues(t, expectedBaseSnapshotID, snapshotMeta.BaseSnapshotID)
 }
@@ -924,13 +896,10 @@ func CheckBaseDiskSlotReleased(
 	overlayDiskID string,
 ) {
 
-	poolStorage, err := newPoolStorage(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, poolStorage.close(ctx))
-	}()
+	poolStorage := newPoolStorage(t, ctx)
+	defer poolStorage.close(ctx)
 
-	err = poolStorage.storage.CheckBaseDiskSlotReleased(ctx, overlayDiskID)
+	err := poolStorage.storage.CheckBaseDiskSlotReleased(ctx, overlayDiskID)
 	require.NoError(t, err)
 }
 
@@ -975,13 +944,10 @@ func CheckConsistency(t *testing.T, ctx context.Context) {
 		time.Sleep(time.Second)
 	}
 
-	poolStorage, err := newPoolStorage(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, poolStorage.close(ctx))
-	}()
+	poolStorage := newPoolStorage(t, ctx)
+	defer poolStorage.close(ctx)
 
-	err = poolStorage.storage.CheckConsistency(ctx)
+	err := poolStorage.storage.CheckConsistency(ctx)
 	require.NoError(t, err)
 
 	// TODO: validate internal YDB tables (tasks, pools etc.) consistency.
@@ -990,28 +956,24 @@ func CheckConsistency(t *testing.T, ctx context.Context) {
 ////////////////////////////////////////////////////////////////////////////////
 
 func GetIncremental(
+	t *testing.T,
 	ctx context.Context,
 	disk *types.Disk,
 ) (string, string, error) {
 
-	storage, err := newSnapshotStorage(ctx)
-	if err != nil {
-		return "", "", err
-	}
+	storage := newSnapshotStorage(t, ctx)
 	defer storage.close(ctx)
 
 	return storage.storage.GetIncremental(ctx, disk)
 }
 
 func GetDiskMeta(
+	t *testing.T,
 	ctx context.Context,
 	diskID string,
 ) (*resources.DiskMeta, error) {
 
-	storage, err := newResourceStorage(ctx)
-	if err != nil {
-		return nil, err
-	}
+	storage := newResourceStorage(t, ctx)
 	defer storage.close(ctx)
 
 	return storage.storage.GetDiskMeta(ctx, diskID)
@@ -1029,57 +991,49 @@ func GetEncryptionKeyHash(encryptionDesc *types.EncryptionDesc) ([]byte, error) 
 }
 
 func GetSnapshotMeta(
+	t *testing.T,
 	ctx context.Context,
 	snapshotID string,
 ) (*snapshot_storage.SnapshotMeta, error) {
 
-	storage, err := newSnapshotStorage(ctx)
-	if err != nil {
-		return nil, err
-	}
+	storage := newSnapshotStorage(t, ctx)
 	defer storage.close(ctx)
 
 	return storage.storage.GetSnapshotMeta(ctx, snapshotID)
 }
 
 func GetFilesystemSnapshotMeta(
+	t *testing.T,
 	ctx context.Context,
 	snapshotID string,
 ) (*resources.FilesystemSnapshotMeta, error) {
 
-	storage, err := newResourceStorage(ctx)
-	if err != nil {
-		return nil, err
-	}
+	storage := newResourceStorage(t, ctx)
 	defer storage.close(ctx)
 
 	return storage.storage.GetFilesystemSnapshotMeta(ctx, snapshotID)
 }
 
 func GetDataplaneFilesystemSnapshotMeta(
+	t *testing.T,
 	ctx context.Context,
 	snapshotID string,
 ) (*filesystem_snapshot_storage.FilesystemSnapshotMeta, error) {
 
-	storage, err := newFilesystemSnapshotStorage(ctx)
-	if err != nil {
-		return nil, err
-	}
+	storage := newFilesystemSnapshotStorage(t, ctx)
 	defer storage.close(ctx)
 
 	return storage.storage.GetFilesystemSnapshotMeta(ctx, snapshotID)
 }
 
 func UpdateClusterCapacities(
+	t *testing.T,
 	ctx context.Context,
 	capacities []cells_storage.ClusterCapacity,
 	deleteOlderThan time.Time,
 ) error {
 
-	cellStorage, err := newCellStorage(ctx)
-	if err != nil {
-		return err
-	}
+	cellStorage := newCellStorage(t, ctx)
 	defer cellStorage.close(ctx)
 
 	return cellStorage.storage.UpdateClusterCapacities(

--- a/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
+++ b/cloud/disk_manager/internal/pkg/facade/testcommon/common.go
@@ -635,25 +635,20 @@ func newYDB(t *testing.T, ctx context.Context) *persistence.YDBClient {
 	return db
 }
 
-type storageWithDB[T any] struct {
-	storage T
-	db      *persistence.YDBClient
-}
-
-func (s *storageWithDB[T]) close(ctx context.Context) {
-	s.db.Close(ctx)
-}
-
-func newResourceStorage(
+func NewResourceStorage(
 	t *testing.T,
 	ctx context.Context,
-) *storageWithDB[resources.Storage] {
+) (resources.Storage, func()) {
 
 	db := newYDB(t, ctx)
 
+	closeFunc := func() {
+		_ = db.Close(ctx)
+	}
+
 	endedMigrationExpirationTimeout := 30 * time.Minute
 
-	resourcesStorage, err := resources.NewStorage(
+	storage, err := resources.NewStorage(
 		"disks",
 		"images",
 		"snapshot",
@@ -665,16 +660,13 @@ func newResourceStorage(
 	)
 	require.NoError(t, err)
 
-	return &storageWithDB[resources.Storage]{
-		storage: resourcesStorage,
-		db:      db,
-	}
+	return storage, closeFunc
 }
 
-func newFilesystemSnapshotStorage(
+func NewFilesystemSnapshotStorage(
 	t *testing.T,
 	ctx context.Context,
-) *storageWithDB[filesystem_snapshot_storage.Storage] {
+) (filesystem_snapshot_storage.Storage, func()) {
 
 	endpoint := fmt.Sprintf(
 		"localhost:%v",
@@ -695,22 +687,29 @@ func newFilesystemSnapshotStorage(
 	)
 	require.NoError(t, err)
 
-	// Should be in sync with FilesystemSnapshotConfig.NodesStorageFolder.
-	return &storageWithDB[filesystem_snapshot_storage.Storage]{
-		storage: filesystem_snapshot_storage.NewStorage(
-			db,
-			"filesystem/snapshot/nodes",
-		),
-		db: db,
+	closeFunc := func() {
+		_ = db.Close(ctx)
 	}
+
+	// Should be in sync with FilesystemSnapshotConfig.NodesStorageFolder.
+	storage := filesystem_snapshot_storage.NewStorage(
+		db,
+		"filesystem/snapshot/nodes",
+	)
+
+	return storage, closeFunc
 }
 
 func newPoolStorage(
 	t *testing.T,
 	ctx context.Context,
-) *storageWithDB[pools_storage.Storage] {
+) (pools_storage.Storage, func()) {
 
 	db := newYDB(t, ctx)
+
+	closeFunc := func() {
+		_ = db.Close(ctx)
+	}
 
 	// Should be in sync with settings from PoolsConfig in test recipe.
 	cloudID := "cloud"
@@ -722,29 +721,29 @@ func newPoolStorage(
 	}, db, metrics.NewEmptyRegistry())
 	require.NoError(t, err)
 
-	return &storageWithDB[pools_storage.Storage]{
-		storage: storage,
-		db:      db,
-	}
+	return storage, closeFunc
 }
 
 func newCellStorage(
 	t *testing.T,
 	ctx context.Context,
-) *storageWithDB[cells_storage.Storage] {
+) (cells_storage.Storage, func()) {
 
 	db := newYDB(t, ctx)
 
-	return &storageWithDB[cells_storage.Storage]{
-		storage: cells_storage.NewStorage(&cells_config.CellsConfig{}, db),
-		db:      db,
+	closeFunc := func() {
+		_ = db.Close(ctx)
 	}
+
+	storage := cells_storage.NewStorage(&cells_config.CellsConfig{}, db)
+
+	return storage, closeFunc
 }
 
 func newSnapshotStorage(
 	t *testing.T,
 	ctx context.Context,
-) *storageWithDB[snapshot_storage.Storage] {
+) (snapshot_storage.Storage, func()) {
 
 	// Should be in sync with settings from SnapshotConfig in test recipe.
 	endpoint := fmt.Sprintf(
@@ -766,6 +765,10 @@ func newSnapshotStorage(
 	)
 	require.NoError(t, err)
 
+	closeFunc := func() {
+		_ = db.Close(ctx)
+	}
+
 	storage, err := snapshot_storage.NewStorage(
 		config,
 		metrics.NewEmptyRegistry(),
@@ -774,10 +777,7 @@ func newSnapshotStorage(
 	)
 	require.NoError(t, err)
 
-	return &storageWithDB[snapshot_storage.Storage]{
-		storage: storage,
-		db:      db,
-	}
+	return storage, closeFunc
 }
 
 func NewTaskStorage(
@@ -896,10 +896,10 @@ func CheckBaseDiskSlotReleased(
 	overlayDiskID string,
 ) {
 
-	poolStorage := newPoolStorage(t, ctx)
-	defer poolStorage.close(ctx)
+	poolStorage, closeFunc := newPoolStorage(t, ctx)
+	defer closeFunc()
 
-	err := poolStorage.storage.CheckBaseDiskSlotReleased(ctx, overlayDiskID)
+	err := poolStorage.CheckBaseDiskSlotReleased(ctx, overlayDiskID)
 	require.NoError(t, err)
 }
 
@@ -944,10 +944,10 @@ func CheckConsistency(t *testing.T, ctx context.Context) {
 		time.Sleep(time.Second)
 	}
 
-	poolStorage := newPoolStorage(t, ctx)
-	defer poolStorage.close(ctx)
+	poolStorage, closeFunc := newPoolStorage(t, ctx)
+	defer closeFunc()
 
-	err := poolStorage.storage.CheckConsistency(ctx)
+	err := poolStorage.CheckConsistency(ctx)
 	require.NoError(t, err)
 
 	// TODO: validate internal YDB tables (tasks, pools etc.) consistency.
@@ -961,10 +961,10 @@ func GetIncremental(
 	disk *types.Disk,
 ) (string, string, error) {
 
-	storage := newSnapshotStorage(t, ctx)
-	defer storage.close(ctx)
+	storage, closeFunc := newSnapshotStorage(t, ctx)
+	defer closeFunc()
 
-	return storage.storage.GetIncremental(ctx, disk)
+	return storage.GetIncremental(ctx, disk)
 }
 
 func GetDiskMeta(
@@ -973,10 +973,10 @@ func GetDiskMeta(
 	diskID string,
 ) (*resources.DiskMeta, error) {
 
-	storage := newResourceStorage(t, ctx)
-	defer storage.close(ctx)
+	storage, closeFunc := NewResourceStorage(t, ctx)
+	defer closeFunc()
 
-	return storage.storage.GetDiskMeta(ctx, diskID)
+	return storage.GetDiskMeta(ctx, diskID)
 }
 
 func GetEncryptionKeyHash(encryptionDesc *types.EncryptionDesc) ([]byte, error) {
@@ -996,34 +996,10 @@ func GetSnapshotMeta(
 	snapshotID string,
 ) (*snapshot_storage.SnapshotMeta, error) {
 
-	storage := newSnapshotStorage(t, ctx)
-	defer storage.close(ctx)
+	storage, closeFunc := newSnapshotStorage(t, ctx)
+	defer closeFunc()
 
-	return storage.storage.GetSnapshotMeta(ctx, snapshotID)
-}
-
-func GetFilesystemSnapshotMeta(
-	t *testing.T,
-	ctx context.Context,
-	snapshotID string,
-) (*resources.FilesystemSnapshotMeta, error) {
-
-	storage := newResourceStorage(t, ctx)
-	defer storage.close(ctx)
-
-	return storage.storage.GetFilesystemSnapshotMeta(ctx, snapshotID)
-}
-
-func GetDataplaneFilesystemSnapshotMeta(
-	t *testing.T,
-	ctx context.Context,
-	snapshotID string,
-) (*filesystem_snapshot_storage.FilesystemSnapshotMeta, error) {
-
-	storage := newFilesystemSnapshotStorage(t, ctx)
-	defer storage.close(ctx)
-
-	return storage.storage.GetFilesystemSnapshotMeta(ctx, snapshotID)
+	return storage.GetSnapshotMeta(ctx, snapshotID)
 }
 
 func UpdateClusterCapacities(
@@ -1033,10 +1009,10 @@ func UpdateClusterCapacities(
 	deleteOlderThan time.Time,
 ) error {
 
-	cellStorage := newCellStorage(t, ctx)
-	defer cellStorage.close(ctx)
+	cellStorage, closeFunc := newCellStorage(t, ctx)
+	defer closeFunc()
 
-	return cellStorage.storage.UpdateClusterCapacities(
+	return cellStorage.UpdateClusterCapacities(
 		ctx,
 		capacities,
 		deleteOlderThan,

--- a/cloud/disk_manager/internal/pkg/facade/without_shadow_disks_test/without_shadow_disks_test.go
+++ b/cloud/disk_manager/internal/pkg/facade/without_shadow_disks_test/without_shadow_disks_test.go
@@ -47,7 +47,7 @@ func TestCreateSnapshotFromSsdNonreplicatedDiskWithoutShadowDisks(
 	require.NoError(t, err)
 
 	// Disk cell is not determined, when creating in sharded zone.
-	diskMeta, err := testcommon.GetDiskMeta(ctx, diskID)
+	diskMeta, err := testcommon.GetDiskMeta(t, ctx, diskID)
 	require.NoError(t, err)
 	nbsClient := testcommon.NewNbsTestingClient(t, ctx, diskMeta.ZoneID)
 	_, err = nbsClient.FillDisk(ctx, diskID, 64*4096)


### PR DESCRIPTION
### Notes
Refactor the storage helpers in `cloud/disk_manager/internal/pkg/facade/testcommon` so they take `*testing.T` and assert with `require` instead of returning an error.

Affected helpers: `newYDB`, `newResourceStorage`, `newFilesystemSnapshotStorage`, `newPoolStorage`, `newCellStorage`, `newSnapshotStorage`, `NewTaskStorage`, `newScheduler` and `storageWithDB.close`. All of them now return only the value.

These helpers construct YDB clients and storages against the test recipe. A failure there is a broken test environment, not a condition any caller can handle, so every call site did the same `require.NoError(t, err)` immediately after.

Also replaced `time.ParseDuration("30m")` with `30 * time.Minute` in `newResourceStorage`
