### PR TITLE
issue-6608: implement quota propagation to shards for set and delete operations

### DIFF
--- a/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
+++ b/cloud/filestore/libs/storage/service/service_ut_sharding.cpp
@@ -565,6 +565,61 @@ Y_UNIT_TEST_SUITE(TStorageServiceShardingTest)
         }
     }
 
+    SERVICE_TEST(ShouldPropagateQuotasToShards)
+    {
+        TShardedFileSystemConfig fsConfig;
+        CREATE_ENV_AND_SHARDED_FILESYSTEM();
+
+        auto listQuotas = [&](const TString& fileSystemId)
+        {
+            NProtoPrivate::TListQuotasRequest request;
+            request.SetFileSystemId(fileSystemId);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            auto jsonResponse = service.ExecuteAction("listquotas", buf);
+            NProtoPrivate::TListQuotasResponse response;
+            UNIT_ASSERT(google::protobuf::util::JsonStringToMessage(
+                jsonResponse->Record.GetOutput(), &response).ok());
+
+            return response.GetQuotas();
+        };
+
+        {
+            NProtoPrivate::TSetQuotaRequest request;
+            request.SetFileSystemId(fsConfig.FsId);
+            request.SetQuotaId(42);
+            request.SetMaxBytes(1_GB);
+            request.SetMaxNodes(100);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("setquota", buf);
+        }
+
+        for (const auto& id: fsConfig.MainAndShardIds()) {
+            const auto quotas = listQuotas(id);
+            UNIT_ASSERT_VALUES_EQUAL_C(1, quotas.size(), id);
+            UNIT_ASSERT_VALUES_EQUAL_C(42u, quotas[0].GetQuotaId(), id);
+            UNIT_ASSERT_VALUES_EQUAL_C(1_GB, quotas[0].GetMaxBytes(), id);
+            UNIT_ASSERT_VALUES_EQUAL_C(100u, quotas[0].GetMaxNodes(), id);
+        }
+
+        {
+            NProtoPrivate::TDeleteQuotaRequest request;
+            request.SetFileSystemId(fsConfig.FsId);
+            request.SetQuotaId(42);
+
+            TString buf;
+            google::protobuf::util::MessageToJsonString(request, &buf);
+            service.ExecuteAction("deletequota", buf);
+        }
+
+        for (const auto& id: fsConfig.MainAndShardIds()) {
+            UNIT_ASSERT_VALUES_EQUAL_C(0, listQuotas(id).size(), id);
+        }
+    }
+
     SERVICE_TEST(ShouldCheckForShardsInAdapterModeUponSessionCreationInShards)
     {
         //

--- a/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
+++ b/cloud/filestore/libs/storage/tablet/tablet_actor_quota.cpp
@@ -1,5 +1,9 @@
 #include "tablet_actor.h"
 
+#include "shard_request_actor.h"
+
+#include <util/string/join.h>
+
 namespace NCloud::NFileStore::NStorage {
 
 using namespace NActors;
@@ -29,16 +33,6 @@ void TIndexTabletActor::HandleSetQuota(
         ev->Cookie,
         MakeIntrusive<TCallContext>());
     requestInfo->StartedTs = ctx.Now();
-
-    if (!IsMainTablet()) {
-        // TODO(6608): propagate knowledge of the quota to all shards
-        auto response =
-            std::make_unique<TEvIndexTablet::TEvSetQuotaResponse>(MakeError(
-                E_ARGUMENT,
-                "quotas can only be set on the main tablet"));
-        NCloud::Reply(ctx, *requestInfo, std::move(response));
-        return;
-    }
 
     if (!msg->Record.GetQuotaId()) {
         auto response =
@@ -104,7 +98,42 @@ void TIndexTabletActor::CompleteTx_SetQuota(
         *response->Record.MutableQuota() = args.Quota;
     }
 
-    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+    if (HasError(args.Error) ||
+        GetFileSystem().GetShardFileSystemIds().empty() || !IsMainTablet())
+    {
+        NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+        return;
+    }
+
+    TVector<TString> shardIds;
+    for (const auto& shardId: GetFileSystem().GetShardFileSystemIds()) {
+        shardIds.push_back(shardId);
+    }
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s Propagating SetQuota to shards (%s)",
+        LogTag.c_str(),
+        JoinSeq(",", shardIds).c_str());
+
+    NProtoPrivate::TSetQuotaRequest request;
+    request.SetQuotaId(args.QuotaId);
+    request.SetMaxBytes(args.MaxBytes);
+    request.SetMaxNodes(args.MaxNodes);
+
+    auto actor = std::make_unique<TShardRequestActor<
+        TEvIndexTablet::TEvSetQuotaRequest,
+        TEvIndexTablet::TEvSetQuotaResponse>>(
+        LogTag,
+        SelfId(),
+        std::move(args.RequestInfo),
+        std::move(request),
+        std::move(shardIds),
+        std::move(response));
+
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -127,16 +156,6 @@ void TIndexTabletActor::HandleDeleteQuota(
         ev->Cookie,
         MakeIntrusive<TCallContext>());
     requestInfo->StartedTs = ctx.Now();
-
-    if (!IsMainTablet()) {
-        // TODO(6608): propagate deletion of the quota to all shards
-        auto response =
-            std::make_unique<TEvIndexTablet::TEvDeleteQuotaResponse>(MakeError(
-                E_ARGUMENT,
-                "quotas can only be deleted on the main tablet"));
-        NCloud::Reply(ctx, *requestInfo, std::move(response));
-        return;
-    }
 
     AddInFlightRequest<TEvIndexTablet::TDeleteQuotaMethod>(*requestInfo);
 
@@ -183,7 +202,40 @@ void TIndexTabletActor::CompleteTx_DeleteQuota(
     auto response =
         std::make_unique<TEvIndexTablet::TEvDeleteQuotaResponse>(args.Error);
 
-    NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+    if (HasError(args.Error) ||
+        GetFileSystem().GetShardFileSystemIds().empty() || !IsMainTablet())
+    {
+        NCloud::Reply(ctx, *args.RequestInfo, std::move(response));
+        return;
+    }
+
+    TVector<TString> shardIds;
+    for (const auto& shardId: GetFileSystem().GetShardFileSystemIds()) {
+        shardIds.push_back(shardId);
+    }
+
+    LOG_INFO(
+        ctx,
+        TFileStoreComponents::TABLET,
+        "%s Propagating DeleteQuota to shards (%s)",
+        LogTag.c_str(),
+        JoinSeq(",", shardIds).c_str());
+
+    NProtoPrivate::TDeleteQuotaRequest request;
+    request.SetQuotaId(args.QuotaId);
+
+    auto actor = std::make_unique<TShardRequestActor<
+        TEvIndexTablet::TEvDeleteQuotaRequest,
+        TEvIndexTablet::TEvDeleteQuotaResponse>>(
+        LogTag,
+        SelfId(),
+        std::move(args.RequestInfo),
+        std::move(request),
+        std::move(shardIds),
+        std::move(response));
+
+    auto actorId = NCloud::Register(ctx, std::move(actor));
+    WorkerActors.insert(actorId);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes
With this PR, quotas should be propagated from the main tablet to all shards upon creation

### Issue
#6608