### PR TITLE
qemu should notice the block device resize

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cloud/contrib/vhost"]
 	path = cloud/contrib/vhost
-	url = https://github.com/yandex-cloud/yc-libvhost-server
+	url = https://github.com/faucct/yc-libvhost-server

--- a/cloud/blockstore/libs/endpoints/endpoint_events.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_events.cpp
@@ -17,6 +17,10 @@ public:
     TFuture<NProto::TError> SwitchEndpointIfNeeded(
         const TString& diskId,
         const TString& reason) override;
+    TFuture<NProto::TError> RefreshEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason,
+        const NProto::TVolume* volume) override;
     void Register(IEndpointEventHandlerPtr listener) override;
 };
 
@@ -28,6 +32,18 @@ TFuture<NProto::TError> TEndpointEventProxy::SwitchEndpointIfNeeded(
 {
     if (Handler) {
         return Handler->SwitchEndpointIfNeeded(diskId, reason);
+    }
+
+    return MakeFuture(MakeError(S_OK));
+}
+
+TFuture<NProto::TError> TEndpointEventProxy::RefreshEndpointIfNeeded(
+    const TString& diskId,
+    const TString& reason,
+    const NProto::TVolume* volume)
+{
+    if (Handler) {
+        return Handler->RefreshEndpointIfNeeded(diskId, reason, volume);
     }
 
     return MakeFuture(MakeError(S_OK));

--- a/cloud/blockstore/libs/endpoints/endpoint_events.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_events.h
@@ -16,6 +16,11 @@ struct IEndpointEventHandler
     virtual NThreading::TFuture<NProto::TError> SwitchEndpointIfNeeded(
         const TString& diskId,
         const TString& reason) = 0;
+
+    virtual NThreading::TFuture<NProto::TError> RefreshEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason,
+        const NProto::TVolume* volume = nullptr) = 0;
 };
 
 struct IEndpointEventProxy: public IEndpointEventHandler

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -627,7 +627,8 @@ public:
         const TString& reason) override;
     TFuture<NProto::TError> RefreshEndpointIfNeeded(
         const TString& diskId,
-        const TString& reason) override;
+        const TString& reason,
+        const NProto::TVolume* volume = nullptr) override;
 
     TFuture<void> RestoreEndpoints() override
     {
@@ -682,7 +683,8 @@ private:
 
     NProto::TRefreshEndpointResponse RefreshEndpointImpl(
         TCallContextPtr ctx,
-        std::shared_ptr<NProto::TRefreshEndpointRequest> request);
+        std::shared_ptr<NProto::TRefreshEndpointRequest> request,
+        const NProto::TVolume* volume = nullptr);
 
     NProto::TError SwitchEndpointImpl(
         TCallContextPtr ctx,
@@ -690,7 +692,8 @@ private:
 
     NProto::TError RefreshEndpointIfNeededImpl(
         const TString& diskId,
-        const TString& reason);
+        const TString& reason,
+        const NProto::TVolume* volume);
 
     NProto::TError AlterEndpoint(
         TCallContextPtr ctx,
@@ -1380,7 +1383,8 @@ NProto::TRefreshEndpointResponse TEndpointManager::DoRefreshEndpoint(
 
 NProto::TRefreshEndpointResponse TEndpointManager::RefreshEndpointImpl(
     TCallContextPtr ctx,
-    std::shared_ptr<NProto::TRefreshEndpointRequest> request)
+    std::shared_ptr<NProto::TRefreshEndpointRequest> request,
+    const NProto::TVolume* volume)
 {
     const auto& socketPath = request->GetUnixSocketPath();
     const auto& headers = request->GetHeaders();
@@ -1399,47 +1403,64 @@ NProto::TRefreshEndpointResponse TEndpointManager::RefreshEndpointImpl(
         socketPath);
     const auto& listener = listenerIt->second;
 
-    auto future = SessionManager->GetSession(std::move(ctx), socketPath, headers);
-    const auto& [sessionInfo, getSessionError] = Executor->WaitFor(future);
+    NProto::TVolume endpointVolume;
+    if (volume) {
+        endpointVolume.CopyFrom(*volume);
+    } else {
+        auto future = SessionManager->GetSession(
+            std::move(ctx),
+            socketPath,
+            headers);
+        const auto& [sessionInfo, getSessionError] = Executor->WaitFor(future);
 
-    if (HasError(getSessionError)) {
-        return TErrorResponse(getSessionError);
+        if (HasError(getSessionError)) {
+            return TErrorResponse(getSessionError);
+        }
+
+        endpointVolume.CopyFrom(sessionInfo.Volume);
     }
 
-    it->second->Volume.SetBlocksCount(sessionInfo.Volume.GetBlocksCount());
-    it->second->Volume.SetBlockSize(sessionInfo.Volume.GetBlockSize());
+    it->second->Volume.SetBlocksCount(endpointVolume.GetBlocksCount());
+    it->second->Volume.SetBlockSize(endpointVolume.GetBlockSize());
 
     auto error = it->second->Device->Resize(
-        sessionInfo.Volume.GetBlocksCount() *
-        sessionInfo.Volume.GetBlockSize()).GetValueSync();
+        endpointVolume.GetBlocksCount() *
+        endpointVolume.GetBlockSize()).GetValueSync();
     if (HasError(error)) {
         return TErrorResponse(error);
     }
 
-    const auto refreshError = listener->RefreshEndpoint(socketPath, sessionInfo.Volume);
+    const auto refreshError = listener->RefreshEndpoint(socketPath, endpointVolume);
     return TErrorResponse(refreshError);
 }
 
 TFuture<NProto::TError> TEndpointManager::RefreshEndpointIfNeeded(
     const TString& diskId,
-    const TString& reason)
+    const TString& reason,
+    const NProto::TVolume* volume)
 {
+    auto volumeCopy = volume
+        ? std::make_shared<NProto::TVolume>(*volume)
+        : nullptr;
+
     return Executor->Execute([
         weakSelf = weak_from_this(),
         diskId,
-        reason] {
+        reason,
+        volume = std::move(volumeCopy)] {
         auto self = weakSelf.lock();
         if (!self) {
             return MakeError(E_FAIL, "EndpointManager is destroyed");
         }
 
-        return self->RefreshEndpointIfNeededImpl(diskId, reason);
+        return self->RefreshEndpointIfNeededImpl(diskId, reason, volume.get());
     });
 }
 
 NProto::TError TEndpointManager::RefreshEndpointIfNeededImpl(
     const TString& diskId,
-    const TString& reason)
+    const TString& reason,
+    const NProto::TVolume* volume)
 {
     struct TEndpointToRefresh
     {
@@ -1473,7 +1494,10 @@ NProto::TError TEndpointManager::RefreshEndpointIfNeededImpl(
         request->MutableHeaders()->CopyFrom(endpoint.Headers);
 
         auto response =
-            DoRefreshEndpoint(MakeIntrusive<TCallContext>(), std::move(request));
+            RefreshEndpointImpl(
+                MakeIntrusive<TCallContext>(),
+                std::move(request),
+                volume);
         if (HasError(response.GetError())) {
             return response.GetError();
         }

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -625,6 +625,9 @@ public:
     TFuture<NProto::TError> SwitchEndpointIfNeeded(
         const TString& diskId,
         const TString& reason) override;
+    TFuture<NProto::TError> RefreshEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason) override;
 
     TFuture<void> RestoreEndpoints() override
     {
@@ -684,6 +687,10 @@ private:
     NProto::TError SwitchEndpointImpl(
         TCallContextPtr ctx,
         std::shared_ptr<TSwitchEndpointRequest> request);
+
+    NProto::TError RefreshEndpointIfNeededImpl(
+        const TString& diskId,
+        const TString& reason);
 
     NProto::TError AlterEndpoint(
         TCallContextPtr ctx,
@@ -1411,6 +1418,68 @@ NProto::TRefreshEndpointResponse TEndpointManager::RefreshEndpointImpl(
 
     const auto refreshError = listener->RefreshEndpoint(socketPath, sessionInfo.Volume);
     return TErrorResponse(refreshError);
+}
+
+TFuture<NProto::TError> TEndpointManager::RefreshEndpointIfNeeded(
+    const TString& diskId,
+    const TString& reason)
+{
+    return Executor->Execute([
+        weakSelf = weak_from_this(),
+        diskId,
+        reason] {
+        auto self = weakSelf.lock();
+        if (!self) {
+            return MakeError(E_FAIL, "EndpointManager is destroyed");
+        }
+
+        return self->RefreshEndpointIfNeededImpl(diskId, reason);
+    });
+}
+
+NProto::TError TEndpointManager::RefreshEndpointIfNeededImpl(
+    const TString& diskId,
+    const TString& reason)
+{
+    struct TEndpointToRefresh
+    {
+        TString SocketPath;
+        NProto::THeaders Headers;
+    };
+
+    TVector<TEndpointToRefresh> endpointsToRefresh;
+    for (const auto& [socketPath, endpoint]: Endpoints) {
+        if (endpoint->Request->GetDiskId() == diskId) {
+            endpointsToRefresh.push_back({
+                .SocketPath = socketPath,
+                .Headers = endpoint->Request->GetHeaders(),
+            });
+        }
+    }
+
+    if (endpointsToRefresh.empty()) {
+        return MakeError(S_OK);
+    }
+
+    STORAGE_INFO(
+        "Refreshing endpoints"
+        << ", reason=" << reason
+        << ", disk=" << diskId
+        << ", count=" << endpointsToRefresh.size());
+
+    for (const auto& endpoint: endpointsToRefresh) {
+        auto request = std::make_shared<NProto::TRefreshEndpointRequest>();
+        request->SetUnixSocketPath(endpoint.SocketPath);
+        request->MutableHeaders()->CopyFrom(endpoint.Headers);
+
+        auto response =
+            DoRefreshEndpoint(MakeIntrusive<TCallContext>(), std::move(request));
+        if (HasError(response.GetError())) {
+            return response.GetError();
+        }
+    }
+
+    return MakeError(S_OK);
 }
 
 void TEndpointManager::ProcessException(

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.cpp
@@ -179,6 +179,18 @@ bool CompareRequests(
     return left.GetUnixSocketPath() == right.GetUnixSocketPath();
 }
 
+bool IsStaleVolumeConfig(
+    const NProto::TVolume& volume,
+    const NProto::TVolume& cachedVolume)
+{
+    const auto volumeConfigVersion = volume.GetConfigVersion();
+    const auto cachedConfigVersion = cachedVolume.GetConfigVersion();
+
+    return volumeConfigVersion &&
+        cachedConfigVersion &&
+        volumeConfigVersion < cachedConfigVersion;
+}
+
 void UpdateRequest(
     NProto::TStartEndpointRequest& dstReq,
     const NProto::TStartEndpointRequest& srcReq)
@@ -1420,8 +1432,23 @@ NProto::TRefreshEndpointResponse TEndpointManager::RefreshEndpointImpl(
         endpointVolume.CopyFrom(sessionInfo.Volume);
     }
 
+    if (IsStaleVolumeConfig(endpointVolume, it->second->Volume)) {
+        STORAGE_WARN(
+            "Skip endpoint refresh with stale volume config"
+            << ", socket=" << socketPath.Quote()
+            << ", disk=" << endpointVolume.GetDiskId().Quote()
+            << ", configVersion=" << endpointVolume.GetConfigVersion()
+            << ", cachedConfigVersion="
+            << it->second->Volume.GetConfigVersion());
+
+        return TErrorResponse(S_OK);
+    }
+
     it->second->Volume.SetBlocksCount(endpointVolume.GetBlocksCount());
     it->second->Volume.SetBlockSize(endpointVolume.GetBlockSize());
+    if (endpointVolume.GetConfigVersion()) {
+        it->second->Volume.SetConfigVersion(endpointVolume.GetConfigVersion());
+    }
 
     auto error = it->second->Device->Resize(
         endpointVolume.GetBlocksCount() *

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.h
@@ -37,6 +37,10 @@ struct IEndpointManager
 #undef ENDPOINT_DECLARE_METHOD
 
     virtual NThreading::TFuture<void> RestoreEndpoints() = 0;
+
+    virtual NThreading::TFuture<NProto::TError> RefreshEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints/endpoint_manager.h
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager.h
@@ -4,6 +4,7 @@
 
 #include <cloud/blockstore/config/client.pb.h>
 #include <cloud/blockstore/public/api/protos/endpoints.pb.h>
+#include <cloud/blockstore/public/api/protos/volume.pb.h>
 
 #include <cloud/blockstore/libs/client/public.h>
 #include <cloud/blockstore/libs/common/public.h>
@@ -40,7 +41,8 @@ struct IEndpointManager
 
     virtual NThreading::TFuture<NProto::TError> RefreshEndpointIfNeeded(
         const TString& diskId,
-        const TString& reason) = 0;
+        const TString& reason,
+        const NProto::TVolume* volume = nullptr) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -220,16 +220,17 @@ private:
 
     TMap<TString, TTestEndpoint> Endpoints;
 
-public:
-    ui32 AlterEndpointCounter = 0;
-    ui32 SwitchEndpointCounter = 0;
-    NProto::TError AlterEndpointError;
-
     using TStartEndpointHandler = std::function<TFuture<NProto::TError>(
         const NProto::TStartEndpointRequest& request,
         NClient::ISessionPtr session)>;
 
 public:
+    ui32 AlterEndpointCounter = 0;
+    ui32 RefreshEndpointCounter = 0;
+    ui32 SwitchEndpointCounter = 0;
+    NProto::TError AlterEndpointError;
+    NProto::TError RefreshEndpointError;
+
     TTestEndpointListener(
             TFuture<NProto::TError> result = MakeFuture<NProto::TError>())
         : Result(std::move(result))
@@ -287,7 +288,9 @@ public:
     {
         Y_UNUSED(socketPath);
         Y_UNUSED(volume);
-        return {};
+        ++RefreshEndpointCounter;
+
+        return RefreshEndpointError;
     }
 
     TFuture<NProto::TError> SwitchEndpoint(
@@ -1429,6 +1432,63 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
                 error.GetCode(),
                 error);
             UNIT_ASSERT_VALUES_EQUAL(1, listener->SwitchEndpointCounter);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRefreshEndpointWhenEndpointStarted)
+    {
+        TBootstrap bootstrap;
+        TMap<TString, NProto::TMountVolumeRequest> mountedVolumes;
+        bootstrap.Service = CreateTestService(mountedVolumes);
+
+        auto listener = std::make_shared<TTestEndpointListener>();
+        bootstrap.EndpointListeners = {{ NProto::IPC_VHOST, listener }};
+
+        auto manager = CreateEndpointManager(bootstrap);
+        bootstrap.Start();
+        Y_DEFER {
+            bootstrap.Stop();
+        };
+        manager->RestoreEndpoints().Wait(5s);
+
+        TTempDir dir;
+        auto socketPath = (dir.Path() / "testSocket").GetPath();
+        auto diskId = "testDiskId";
+
+        {
+            auto future = manager->RefreshEndpointIfNeeded(diskId, "test");
+            auto error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                error);
+            UNIT_ASSERT_VALUES_EQUAL(0, listener->RefreshEndpointCounter);
+        }
+
+        NProto::TStartEndpointRequest startRequest;
+        SetDefaultHeaders(startRequest);
+        startRequest.SetUnixSocketPath(socketPath);
+        startRequest.SetDiskId(diskId);
+        startRequest.SetClientId(TestClientId);
+        startRequest.SetIpcType(NProto::IPC_VHOST);
+
+        {
+            auto future = StartEndpoint(*manager, startRequest);
+            auto response = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                response.GetError().GetCode(),
+                response.GetError());
+        }
+
+        {
+            auto future = manager->RefreshEndpointIfNeeded(diskId, "test");
+            auto error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                error);
+            UNIT_ASSERT_VALUES_EQUAL(1, listener->RefreshEndpointCounter);
         }
     }
 

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -1500,6 +1500,7 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
         volume.SetDiskId(diskId);
         volume.SetBlocksCount(42);
         volume.SetBlockSize(DefaultBlockSize);
+        volume.SetConfigVersion(2);
 
         {
             auto future = bootstrap.EndpointEventHandler->RefreshEndpointIfNeeded(
@@ -1518,6 +1519,34 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
             UNIT_ASSERT_VALUES_EQUAL(
                 volume.GetBlockSize(),
                 listener->LastRefreshVolume.GetBlockSize());
+            UNIT_ASSERT_VALUES_EQUAL(
+                volume.GetConfigVersion(),
+                listener->LastRefreshVolume.GetConfigVersion());
+        }
+
+        NProto::TVolume staleVolume;
+        staleVolume.SetDiskId(diskId);
+        staleVolume.SetBlocksCount(13);
+        staleVolume.SetBlockSize(DefaultBlockSize);
+        staleVolume.SetConfigVersion(1);
+
+        {
+            auto future = bootstrap.EndpointEventHandler->RefreshEndpointIfNeeded(
+                diskId,
+                "test",
+                &staleVolume);
+            auto error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                error);
+            UNIT_ASSERT_VALUES_EQUAL(2, listener->RefreshEndpointCounter);
+            UNIT_ASSERT_VALUES_EQUAL(
+                volume.GetBlocksCount(),
+                listener->LastRefreshVolume.GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                volume.GetConfigVersion(),
+                listener->LastRefreshVolume.GetConfigVersion());
         }
     }
 

--- a/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/endpoint_manager_ut.cpp
@@ -228,6 +228,7 @@ public:
     ui32 AlterEndpointCounter = 0;
     ui32 RefreshEndpointCounter = 0;
     ui32 SwitchEndpointCounter = 0;
+    NProto::TVolume LastRefreshVolume;
     NProto::TError AlterEndpointError;
     NProto::TError RefreshEndpointError;
 
@@ -287,7 +288,7 @@ public:
         const NProto::TVolume& volume) override
     {
         Y_UNUSED(socketPath);
-        Y_UNUSED(volume);
+        LastRefreshVolume.CopyFrom(volume);
         ++RefreshEndpointCounter;
 
         return RefreshEndpointError;
@@ -1456,7 +1457,9 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
         auto diskId = "testDiskId";
 
         {
-            auto future = manager->RefreshEndpointIfNeeded(diskId, "test");
+            auto future = bootstrap.EndpointEventHandler->RefreshEndpointIfNeeded(
+                diskId,
+                "test");
             auto error = future.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
@@ -1482,13 +1485,39 @@ Y_UNIT_TEST_SUITE(TEndpointManagerTest)
         }
 
         {
-            auto future = manager->RefreshEndpointIfNeeded(diskId, "test");
+            auto future = bootstrap.EndpointEventHandler->RefreshEndpointIfNeeded(
+                diskId,
+                "test");
             auto error = future.GetValue(TDuration::Seconds(5));
             UNIT_ASSERT_VALUES_EQUAL_C(
                 S_OK,
                 error.GetCode(),
                 error);
             UNIT_ASSERT_VALUES_EQUAL(1, listener->RefreshEndpointCounter);
+        }
+
+        NProto::TVolume volume;
+        volume.SetDiskId(diskId);
+        volume.SetBlocksCount(42);
+        volume.SetBlockSize(DefaultBlockSize);
+
+        {
+            auto future = bootstrap.EndpointEventHandler->RefreshEndpointIfNeeded(
+                diskId,
+                "test",
+                &volume);
+            auto error = future.GetValue(TDuration::Seconds(5));
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                S_OK,
+                error.GetCode(),
+                error);
+            UNIT_ASSERT_VALUES_EQUAL(2, listener->RefreshEndpointCounter);
+            UNIT_ASSERT_VALUES_EQUAL(
+                volume.GetBlocksCount(),
+                listener->LastRefreshVolume.GetBlocksCount());
+            UNIT_ASSERT_VALUES_EQUAL(
+                volume.GetBlockSize(),
+                listener->LastRefreshVolume.GetBlockSize());
         }
     }
 

--- a/cloud/blockstore/libs/endpoints/service_endpoint.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint.cpp
@@ -3,13 +3,10 @@
 #include "endpoint_manager.h"
 
 #include <cloud/blockstore/libs/service/context.h>
-#include <cloud/blockstore/libs/service/service_method.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
-
-#include <type_traits>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -61,10 +58,7 @@ public:
         TCallContextPtr ctx,                                                   \
         std::shared_ptr<NProto::T##name##Request> request) override            \
     {                                                                          \
-        using TMethod = TBlockStore##name##Method;                             \
-        return ExecuteStorageRequest<TMethod>(                                 \
-            std::move(ctx),                                                    \
-            std::move(request));                                               \
+        return Service->name(std::move(ctx), std::move(request));              \
     }                                                                          \
 // STORAGE_IMPLEMENT_METHOD
 
@@ -89,49 +83,6 @@ public:
 #undef ENDPOINT_IMPLEMENT_METHOD
 
 private:
-    template <typename TMethod>
-    TFuture<typename TMethod::TResponse> ExecuteStorageRequest(
-        TCallContextPtr ctx,
-        std::shared_ptr<typename TMethod::TRequest> request)
-    {
-        if constexpr (std::is_same_v<TMethod, TBlockStoreResizeVolumeMethod>) {
-            const auto diskId = request->GetDiskId();
-            const bool shouldRefreshEndpoint = request->GetBlocksCount() != 0;
-
-            auto future = TMethod::Execute(
-                Service.get(),
-                std::move(ctx),
-                std::move(request));
-
-            return future.Apply([
-                endpointManager = EndpointManager,
-                diskId,
-                shouldRefreshEndpoint] (const auto& f)
-            {
-                auto response = f.GetValue();
-                if (!shouldRefreshEndpoint ||
-                    response.GetError().GetCode() != S_OK ||
-                    !endpointManager)
-                {
-                    return MakeFuture(std::move(response));
-                }
-
-                return endpointManager
-                    ->RefreshEndpointIfNeeded(diskId, "volume resize")
-                    .Apply([response = std::move(response)] (const auto& f) mutable
-                    {
-                        Y_UNUSED(f.GetValue());
-                        return response;
-                    });
-            });
-        } else {
-            return TMethod::Execute(
-                Service.get(),
-                std::move(ctx),
-                std::move(request));
-        }
-    }
-
     template <typename T>
     TFuture<T> CreateTimeoutFuture(const TFuture<T>& future, TDuration timeout)
     {

--- a/cloud/blockstore/libs/endpoints/service_endpoint.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint.cpp
@@ -3,10 +3,13 @@
 #include "endpoint_manager.h"
 
 #include <cloud/blockstore/libs/service/context.h>
+#include <cloud/blockstore/libs/service/service_method.h>
 #include <cloud/blockstore/libs/service/service.h>
 #include <cloud/storage/core/libs/common/error.h>
 #include <cloud/storage/core/libs/common/scheduler.h>
 #include <cloud/storage/core/libs/common/timer.h>
+
+#include <type_traits>
 
 namespace NCloud::NBlockStore::NServer {
 
@@ -58,7 +61,10 @@ public:
         TCallContextPtr ctx,                                                   \
         std::shared_ptr<NProto::T##name##Request> request) override            \
     {                                                                          \
-        return Service->name(std::move(ctx), std::move(request));              \
+        using TMethod = TBlockStore##name##Method;                             \
+        return ExecuteStorageRequest<TMethod>(                                 \
+            std::move(ctx),                                                    \
+            std::move(request));                                               \
     }                                                                          \
 // STORAGE_IMPLEMENT_METHOD
 
@@ -83,6 +89,49 @@ public:
 #undef ENDPOINT_IMPLEMENT_METHOD
 
 private:
+    template <typename TMethod>
+    TFuture<typename TMethod::TResponse> ExecuteStorageRequest(
+        TCallContextPtr ctx,
+        std::shared_ptr<typename TMethod::TRequest> request)
+    {
+        if constexpr (std::is_same_v<TMethod, TBlockStoreResizeVolumeMethod>) {
+            const auto diskId = request->GetDiskId();
+            const bool shouldRefreshEndpoint = request->GetBlocksCount() != 0;
+
+            auto future = TMethod::Execute(
+                Service.get(),
+                std::move(ctx),
+                std::move(request));
+
+            return future.Apply([
+                endpointManager = EndpointManager,
+                diskId,
+                shouldRefreshEndpoint] (const auto& f)
+            {
+                auto response = f.GetValue();
+                if (!shouldRefreshEndpoint ||
+                    response.GetError().GetCode() != S_OK ||
+                    !endpointManager)
+                {
+                    return MakeFuture(std::move(response));
+                }
+
+                return endpointManager
+                    ->RefreshEndpointIfNeeded(diskId, "volume resize")
+                    .Apply([response = std::move(response)] (const auto& f) mutable
+                    {
+                        Y_UNUSED(f.GetValue());
+                        return response;
+                    });
+            });
+        } else {
+            return TMethod::Execute(
+                Service.get(),
+                std::move(ctx),
+                std::move(request));
+        }
+    }
+
     template <typename T>
     TFuture<T> CreateTimeoutFuture(const TFuture<T>& future, TDuration timeout)
     {

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -209,6 +209,60 @@ struct TTestSessionManager final
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TTestEndpointManager final
+    : public IEndpointManager
+{
+    ui32 RefreshEndpointCounter = 0;
+    TString LastDiskId;
+    TString LastRefreshReason;
+    TPromise<NProto::TError> RefreshEndpointResult = NewPromise<NProto::TError>();
+
+    void Start() override
+    {}
+
+    void Stop() override
+    {}
+
+    size_t CollectRequests(
+        const TIncompleteRequestsCollector& collector) override
+    {
+        Y_UNUSED(collector);
+        return 0;
+    }
+
+#define ENDPOINT_IMPLEMENT_METHOD(name, ...)                                   \
+    TFuture<NProto::T##name##Response> name(                                   \
+        TCallContextPtr ctx,                                                   \
+        std::shared_ptr<NProto::T##name##Request> request) override            \
+    {                                                                          \
+        Y_UNUSED(ctx);                                                         \
+        Y_UNUSED(request);                                                     \
+        return MakeFuture(NProto::T##name##Response());                        \
+    }                                                                          \
+// ENDPOINT_IMPLEMENT_METHOD
+
+    BLOCKSTORE_ENDPOINT_SERVICE(ENDPOINT_IMPLEMENT_METHOD)
+
+#undef ENDPOINT_IMPLEMENT_METHOD
+
+    TFuture<void> RestoreEndpoints() override
+    {
+        return MakeFuture();
+    }
+
+    TFuture<NProto::TError> RefreshEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason) override
+    {
+        ++RefreshEndpointCounter;
+        LastDiskId = diskId;
+        LastRefreshReason = reason;
+        return RefreshEndpointResult;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 NProto::TKickEndpointResponse KickEndpoint(
     IEndpointManager& service,
     ui32 keyringId,
@@ -313,6 +367,48 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         }
 
         executor->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldRefreshEndpointAfterResizeVolume)
+    {
+        const TString diskId = "testDiskId";
+        const ui64 blocksCount = 42;
+
+        auto service = std::make_shared<TTestService>();
+        service->ResizeVolumeHandler =
+            [&] (std::shared_ptr<NProto::TResizeVolumeRequest> request)
+            {
+                UNIT_ASSERT_VALUES_EQUAL(diskId, request->GetDiskId());
+                UNIT_ASSERT_VALUES_EQUAL(blocksCount, request->GetBlocksCount());
+                return MakeFuture(NProto::TResizeVolumeResponse());
+            };
+
+        auto endpointManager = std::make_shared<TTestEndpointManager>();
+        auto endpointService = CreateMultipleEndpointService(
+            service,
+            CreateWallClockTimer(),
+            CreateSchedulerStub(),
+            endpointManager);
+
+        auto request = std::make_shared<NProto::TResizeVolumeRequest>();
+        request->SetDiskId(diskId);
+        request->SetBlocksCount(blocksCount);
+
+        auto future = endpointService->ResizeVolume(
+            MakeIntrusive<TCallContext>(),
+            std::move(request));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, endpointManager->RefreshEndpointCounter);
+        UNIT_ASSERT_VALUES_EQUAL(diskId, endpointManager->LastDiskId);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "volume resize",
+            endpointManager->LastRefreshReason);
+        UNIT_ASSERT(!future.HasValue());
+
+        endpointManager->RefreshEndpointResult.SetValue(MakeError(S_OK));
+
+        auto response = future.GetValue(TDuration::Seconds(5));
+        UNIT_ASSERT_C(!HasError(response), response);
     }
 
     Y_UNIT_TEST(ShouldTimeoutFrozenRequest)

--- a/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
+++ b/cloud/blockstore/libs/endpoints/service_endpoint_ut.cpp
@@ -212,11 +212,6 @@ struct TTestSessionManager final
 struct TTestEndpointManager final
     : public IEndpointManager
 {
-    ui32 RefreshEndpointCounter = 0;
-    TString LastDiskId;
-    TString LastRefreshReason;
-    TPromise<NProto::TError> RefreshEndpointResult = NewPromise<NProto::TError>();
-
     void Start() override
     {}
 
@@ -252,12 +247,13 @@ struct TTestEndpointManager final
 
     TFuture<NProto::TError> RefreshEndpointIfNeeded(
         const TString& diskId,
-        const TString& reason) override
+        const TString& reason,
+        const NProto::TVolume* volume) override
     {
-        ++RefreshEndpointCounter;
-        LastDiskId = diskId;
-        LastRefreshReason = reason;
-        return RefreshEndpointResult;
+        Y_UNUSED(diskId);
+        Y_UNUSED(reason);
+        Y_UNUSED(volume);
+        return MakeFuture(MakeError(S_OK));
     }
 };
 
@@ -367,48 +363,6 @@ Y_UNIT_TEST_SUITE(TServiceEndpointTest)
         }
 
         executor->Stop();
-    }
-
-    Y_UNIT_TEST(ShouldRefreshEndpointAfterResizeVolume)
-    {
-        const TString diskId = "testDiskId";
-        const ui64 blocksCount = 42;
-
-        auto service = std::make_shared<TTestService>();
-        service->ResizeVolumeHandler =
-            [&] (std::shared_ptr<NProto::TResizeVolumeRequest> request)
-            {
-                UNIT_ASSERT_VALUES_EQUAL(diskId, request->GetDiskId());
-                UNIT_ASSERT_VALUES_EQUAL(blocksCount, request->GetBlocksCount());
-                return MakeFuture(NProto::TResizeVolumeResponse());
-            };
-
-        auto endpointManager = std::make_shared<TTestEndpointManager>();
-        auto endpointService = CreateMultipleEndpointService(
-            service,
-            CreateWallClockTimer(),
-            CreateSchedulerStub(),
-            endpointManager);
-
-        auto request = std::make_shared<NProto::TResizeVolumeRequest>();
-        request->SetDiskId(diskId);
-        request->SetBlocksCount(blocksCount);
-
-        auto future = endpointService->ResizeVolume(
-            MakeIntrusive<TCallContext>(),
-            std::move(request));
-
-        UNIT_ASSERT_VALUES_EQUAL(1, endpointManager->RefreshEndpointCounter);
-        UNIT_ASSERT_VALUES_EQUAL(diskId, endpointManager->LastDiskId);
-        UNIT_ASSERT_VALUES_EQUAL(
-            "volume resize",
-            endpointManager->LastRefreshReason);
-        UNIT_ASSERT(!future.HasValue());
-
-        endpointManager->RefreshEndpointResult.SetValue(MakeError(S_OK));
-
-        auto response = future.GetValue(TDuration::Seconds(5));
-        UNIT_ASSERT_C(!HasError(response), response);
     }
 
     Y_UNIT_TEST(ShouldTimeoutFrozenRequest)

--- a/cloud/blockstore/libs/storage/api/service.cpp
+++ b/cloud/blockstore/libs/storage/api/service.cpp
@@ -8,7 +8,12 @@ using namespace NActors;
 
 TActorId MakeStorageServiceId()
 {
-    return TActorId(0, "blk-service");
+    return MakeStorageServiceId(0);
+}
+
+TActorId MakeStorageServiceId(ui32 nodeId)
+{
+    return TActorId(nodeId, "blk-service");
 }
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/api/service.h
+++ b/cloud/blockstore/libs/storage/api/service.h
@@ -422,5 +422,6 @@ struct TEvService
 ////////////////////////////////////////////////////////////////////////////////
 
 NActors::TActorId MakeStorageServiceId();
+NActors::TActorId MakeStorageServiceId(ui32 nodeId);
 
 }   // namespace NCloud::NBlockStore::NStorage

--- a/cloud/blockstore/libs/storage/service/service_actor.cpp
+++ b/cloud/blockstore/libs/storage/service/service_actor.cpp
@@ -1,6 +1,7 @@
 #include "service_actor.h"
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/storage/api/undelivered.h>
 #include <cloud/blockstore/libs/storage/core/disk_counters.h>
 #include <cloud/storage/core/libs/common/alloc.h>
@@ -197,7 +198,24 @@ void TServiceActor::HandleVolumeConfigUpdated(
             msg->DiskId.Quote().data());
         return;
     }
+
+    const auto oldBlocksCount =
+        volume->VolumeInfo ? volume->VolumeInfo->GetBlocksCount() : 0;
+    const auto newBlocksCount = msg->Config.GetBlocksCount();
+    const auto refreshEndpoint =
+        oldBlocksCount &&
+        newBlocksCount &&
+        oldBlocksCount != newBlocksCount &&
+        volume->IsLocallyMounted();
+
     volume->VolumeInfo = msg->Config;
+
+    if (refreshEndpoint) {
+        EndpointEventHandler->RefreshEndpointIfNeeded(
+            msg->DiskId,
+            "volume config updated",
+            &msg->Config);
+    }
 }
 
 void TServiceActor::HandleUnregisterVolume(

--- a/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
+++ b/cloud/blockstore/libs/storage/service/service_ut_alter.cpp
@@ -2,6 +2,7 @@
 
 #include <cloud/blockstore/config/storage.pb.h>
 
+#include <cloud/blockstore/libs/endpoints/endpoint_events.h>
 #include <cloud/blockstore/libs/storage/api/ss_proxy.h>
 #include <cloud/blockstore/libs/storage/api/volume.h>
 #include <cloud/blockstore/libs/storage/core/config.h>
@@ -14,6 +15,63 @@ namespace NCloud::NBlockStore::NStorage {
 using namespace NActors;
 
 using namespace NKikimr;
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TTestEndpointEventHandler final
+    : public NServer::IEndpointEventHandler
+{
+    ui32 RefreshEndpointCount = 0;
+    TString LastRefreshDiskId;
+    TString LastRefreshReason;
+    bool LastRefreshHasVolume = false;
+    ui64 LastRefreshBlocksCount = 0;
+
+    NThreading::TFuture<NProto::TError> SwitchEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason) override
+    {
+        Y_UNUSED(diskId);
+        Y_UNUSED(reason);
+
+        return NThreading::MakeFuture(MakeError(S_OK));
+    }
+
+    NThreading::TFuture<NProto::TError> RefreshEndpointIfNeeded(
+        const TString& diskId,
+        const TString& reason,
+        const NProto::TVolume* volume) override
+    {
+        ++RefreshEndpointCount;
+        LastRefreshDiskId = diskId;
+        LastRefreshReason = reason;
+        LastRefreshHasVolume = volume != nullptr;
+        if (volume) {
+            LastRefreshBlocksCount = volume->GetBlocksCount();
+        }
+
+        return NThreading::MakeFuture(MakeError(S_OK));
+    }
+};
+
+ui32 SetupTestEnvWithEndpointEvents(
+    TTestEnv& env,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler)
+{
+    env.CreateSubDomain("nbs");
+
+    return env.CreateBlockStoreNode(
+        "nbs",
+        CreateTestStorageConfig({}),
+        CreateTestDiagnosticsConfig(),
+        std::move(endpointEventHandler));
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -854,6 +912,61 @@ Y_UNIT_TEST_SUITE(TServiceAlterTest)
                 NProto::VOLUME_MOUNT_REMOTE);
             UNIT_ASSERT(response->Record.GetVolume().GetBlocksCount() == newBlocksCount);
         }
+    }
+
+    Y_UNIT_TEST(ShouldRefreshEndpointOnLocalMountHostAfterResizeFromAnotherHost)
+    {
+        TTestEnv env(1, 2, 10);
+        auto endpointEvents1 = std::make_shared<TTestEndpointEventHandler>();
+        auto endpointEvents2 = std::make_shared<TTestEndpointEventHandler>();
+
+        ui32 nodeIdx1 = SetupTestEnvWithEndpointEvents(env, endpointEvents1);
+        ui32 nodeIdx2 = SetupTestEnvWithEndpointEvents(env, endpointEvents2);
+
+        auto& runtime = env.GetRuntime();
+        TServiceClient service1(runtime, nodeIdx1);
+        TServiceClient service2(runtime, nodeIdx2);
+
+        const ui64 blocksCount = 1024;
+        service1.CreateVolume(DefaultDiskId, blocksCount);
+
+        {
+            auto response = service1.MountVolume(DefaultDiskId);
+            UNIT_ASSERT_VALUES_EQUAL(
+                blocksCount,
+                response->Record.GetVolume().GetBlocksCount());
+        }
+
+        {
+            auto response = service2.MountVolume(
+                DefaultDiskId,
+                "",
+                "",
+                NProto::IPC_GRPC,
+                NProto::VOLUME_ACCESS_READ_ONLY,
+                NProto::VOLUME_MOUNT_REMOTE);
+            UNIT_ASSERT_VALUES_EQUAL(
+                blocksCount,
+                response->Record.GetVolume().GetBlocksCount());
+        }
+
+        const ui64 newBlocksCount = blocksCount * 2;
+        service2.ResizeVolume(DefaultDiskId, newBlocksCount);
+
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(2));
+
+        UNIT_ASSERT_VALUES_EQUAL(1, endpointEvents1->RefreshEndpointCount);
+        UNIT_ASSERT_VALUES_EQUAL(
+            DefaultDiskId,
+            endpointEvents1->LastRefreshDiskId);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "volume config updated",
+            endpointEvents1->LastRefreshReason);
+        UNIT_ASSERT(endpointEvents1->LastRefreshHasVolume);
+        UNIT_ASSERT_VALUES_EQUAL(
+            newBlocksCount,
+            endpointEvents1->LastRefreshBlocksCount);
+        UNIT_ASSERT_VALUES_EQUAL(0, endpointEvents2->RefreshEndpointCount);
     }
 
     Y_UNIT_TEST(ShouldAllocateFreshChannelOnAlter)

--- a/cloud/blockstore/libs/storage/testlib/test_env.cpp
+++ b/cloud/blockstore/libs/storage/testlib/test_env.cpp
@@ -207,6 +207,21 @@ ui32 TTestEnv::CreateBlockStoreNode(
     const TString& name,
     TStorageConfigPtr storageConfig,
     TDiagnosticsConfigPtr diagnosticsConfig,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler)
+{
+    return CreateBlockStoreNode(
+        name,
+        std::move(storageConfig),
+        std::move(diagnosticsConfig),
+        NYdbStats::CreateVolumesStatsUploaderStub(),
+        CreateManuallyPreemptedVolumes(),
+        std::move(endpointEventHandler));
+}
+
+ui32 TTestEnv::CreateBlockStoreNode(
+    const TString& name,
+    TStorageConfigPtr storageConfig,
+    TDiagnosticsConfigPtr diagnosticsConfig,
     TManuallyPreemptedVolumesPtr manuallyPreemptedVolumes)
 {
     return CreateBlockStoreNode(
@@ -223,6 +238,23 @@ ui32 TTestEnv::CreateBlockStoreNode(
     TDiagnosticsConfigPtr diagnosticsConfig,
     NYdbStats::IYdbVolumesStatsUploaderPtr ydbStatsUploader,
     TManuallyPreemptedVolumesPtr manuallyPreemptedVolumes)
+{
+    return CreateBlockStoreNode(
+        name,
+        std::move(storageConfig),
+        std::move(diagnosticsConfig),
+        std::move(ydbStatsUploader),
+        std::move(manuallyPreemptedVolumes),
+        NServer::CreateEndpointEventProxy());
+}
+
+ui32 TTestEnv::CreateBlockStoreNode(
+    const TString& name,
+    TStorageConfigPtr storageConfig,
+    TDiagnosticsConfigPtr diagnosticsConfig,
+    NYdbStats::IYdbVolumesStatsUploaderPtr ydbStatsUploader,
+    TManuallyPreemptedVolumesPtr manuallyPreemptedVolumes,
+    NServer::IEndpointEventHandlerPtr endpointEventHandler)
 {
     ui32 nodeIdx = NextDynamicNode++;
     UNIT_ASSERT(nodeIdx < StaticNodeCount + DynamicNodeCount);
@@ -412,7 +444,7 @@ ui32 TTestEnv::CreateBlockStoreNode(
         CreateBlockDigestGeneratorStub(),
         NDiscovery::CreateDiscoveryServiceStub(),
         TraceSerializer,
-        NServer::CreateEndpointEventProxy(),
+        std::move(endpointEventHandler),
         nullptr,   // rdmaClient
         partitionBudgetManager,
         CreateVolumeStatsStub(),

--- a/cloud/blockstore/libs/storage/testlib/test_env.h
+++ b/cloud/blockstore/libs/storage/testlib/test_env.h
@@ -5,6 +5,7 @@
 #include <cloud/blockstore/public/api/protos/volume.pb.h>
 
 #include <cloud/blockstore/libs/diagnostics/public.h>
+#include <cloud/blockstore/libs/endpoints/public.h>
 #include <cloud/blockstore/libs/kikimr/public.h>
 #include <cloud/blockstore/libs/storage/core/public.h>
 #include <cloud/blockstore/libs/storage/ss_proxy/public.h>
@@ -82,6 +83,12 @@ public:
         const TString& name,
         TStorageConfigPtr storageConfig,
         TDiagnosticsConfigPtr diagnosticsConfig,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler);
+
+    ui32 CreateBlockStoreNode(
+        const TString& name,
+        TStorageConfigPtr storageConfig,
+        TDiagnosticsConfigPtr diagnosticsConfig,
         TManuallyPreemptedVolumesPtr manuallyPreemptedVolumes);
 
     ui32 CreateBlockStoreNode(
@@ -90,6 +97,14 @@ public:
         TDiagnosticsConfigPtr diagnosticsConfig,
         NYdbStats::IYdbVolumesStatsUploaderPtr ydbStatsUploader,
         TManuallyPreemptedVolumesPtr manuallyPreemptedVolumes);
+
+    ui32 CreateBlockStoreNode(
+        const TString& name,
+        TStorageConfigPtr storageConfig,
+        TDiagnosticsConfigPtr diagnosticsConfig,
+        NYdbStats::IYdbVolumesStatsUploaderPtr ydbStatsUploader,
+        TManuallyPreemptedVolumesPtr manuallyPreemptedVolumes,
+        NServer::IEndpointEventHandlerPtr endpointEventHandler);
 
     TString UpdatePrivateCacheSize(ui64 tabletId, ui64 cacheSize);
     ui64 GetPrivateCacheSize(ui64 tabletId);

--- a/cloud/blockstore/libs/storage/volume/volume_actor.cpp
+++ b/cloud/blockstore/libs/storage/volume/volume_actor.cpp
@@ -23,6 +23,7 @@
 #include <library/cpp/lwtrace/protos/lwtrace.pb.h>
 #include <library/cpp/lwtrace/signature.h>
 
+#include <util/generic/hash_set.h>
 #include <util/stream/str.h>
 #include <util/string/builder.h>
 
@@ -44,6 +45,30 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr TInstant DRTabletIdRequestRetryInterval = TInstant::Seconds(3);
+
+THashSet<ui32> GetStorageServiceNodeIdsForConfigUpdate(
+    const TVolumeState& state,
+    ui32 localNodeId)
+{
+    THashSet<ui32> nodeIds;
+    nodeIds.insert(localNodeId);
+
+    for (const auto& [clientId, client]: state.GetClients()) {
+        Y_UNUSED(clientId);
+
+        for (const auto& [serverId, pipe]: client.GetPipes()) {
+            Y_UNUSED(serverId);
+
+            if (pipe.State != TVolumeClientState::EPipeState::DEACTIVATED &&
+                pipe.SenderNodeId != 0)
+            {
+                nodeIds.insert(pipe.SenderNodeId);
+            }
+        }
+    }
+
+    return nodeIds;
+}
 
 bool ShapingThrottlerEnabled(
     const TStorageConfigPtr& config,
@@ -555,11 +580,17 @@ void TVolumeActor::SendVolumeConfigUpdated(const TActorContext& ctx)
         State->GetMeta().GetVolumeConfig(),
         State->GetPrincipalDiskId(),
         volume);
-    {
+
+    const auto storageServiceNodeIds =
+        GetStorageServiceNodeIdsForConfigUpdate(*State, SelfId().NodeId());
+    for (const auto nodeId: storageServiceNodeIds) {
         auto request = std::make_unique<TEvService::TEvVolumeConfigUpdated>(
             State->GetDiskId(),
             volume);
-        NCloud::Send(ctx, MakeStorageServiceId(), std::move(request));
+        const auto recipient = nodeId == SelfId().NodeId()
+            ? MakeStorageServiceId()
+            : MakeStorageServiceId(nodeId);
+        NCloud::Send(ctx, recipient, std::move(request));
     }
 
     {

--- a/cloud/blockstore/libs/vhost/server.cpp
+++ b/cloud/blockstore/libs/vhost/server.cpp
@@ -219,12 +219,12 @@ public:
         return future;
     }
 
-    void Update(ui64 blocksCount)
+    NProto::TError Update(ui64 blocksCount)
     {
         TLog& Log = AppCtx.Log;
         STORAGE_INFO("Update vhost endpoint " << SocketPath.Quote()
             << " with blocks count = " << blocksCount);
-        VhostDevice->Update(blocksCount);
+        return VhostDevice->Update(blocksCount);
     }
 
     ui32 GetVhostQueuesCount() const
@@ -806,7 +806,7 @@ NProto::TError TServer::UpdateEndpoint(
     }
 
     if (endpoint) {
-        endpoint->Update(blocksCount);
+        return endpoint->Update(blocksCount);
     }
     return NProto::TError{};
 }

--- a/cloud/blockstore/libs/vhost/server_ut.cpp
+++ b/cloud/blockstore/libs/vhost/server_ut.cpp
@@ -89,6 +89,11 @@ public:
         return *VhostQueueFactory;
     }
 
+    NProto::TError UpdateEndpoint(ui64 blocksCount)
+    {
+        return VhostServer->UpdateEndpoint(SocketPath.GetPath(), blocksCount);
+    }
+
     bool DequeueRequest(TTestRequest& request)
     {
         return RequestQueue.Dequeue(&request);
@@ -304,6 +309,20 @@ Y_UNIT_TEST_SUITE(TServerTest)
         }
 
         vhostServer->Stop();
+    }
+
+    Y_UNIT_TEST(ShouldReturnErrorWhenUpdateEndpointFails)
+    {
+        TTestEnvironment env(DefaultBlockSize);
+
+        auto expectedError = MakeError(E_FAIL, "update failed");
+        env.GetVhostDevice()->SetUpdateError(expectedError);
+
+        const auto error = env.UpdateEndpoint(512);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            expectedError.GetCode(),
+            error.GetCode(),
+            error);
     }
 
     Y_UNIT_TEST(ShouldStopVhostServerWithStartedEndpoints)

--- a/cloud/blockstore/libs/vhost/vhost.cpp
+++ b/cloud/blockstore/libs/vhost/vhost.cpp
@@ -6,7 +6,10 @@
 #include <cloud/contrib/vhost/include/vhost/server.h>
 
 #include <util/generic/singleton.h>
+#include <util/string/builder.h>
 #include <util/system/mutex.h>
+
+#include <string.h>
 
 namespace NCloud::NBlockStore::NVhost {
 
@@ -213,13 +216,23 @@ public:
         return result.GetFuture();
     }
 
-    void Update(ui64 blocksCount) override
+    NProto::TError Update(ui64 blocksCount) override
     {
         with_lock (Lock) {
             if (!VhdVdev) {
-                return;
+                return MakeError(S_FALSE, "Vhost device is not started");
             }
-            vhd_blockdev_set_total_blocks(VhdVdev, blocksCount);
+
+            const auto ret = vhd_blockdev_resize(VhdVdev, blocksCount);
+            if (ret < 0) {
+                return MakeError(
+                    MAKE_SYSTEM_ERROR(-ret),
+                    TStringBuilder()
+                        << "Failed to update vhost device "
+                        << SocketPath.Quote() << ": " << strerror(-ret));
+            }
+
+            return {};
         }
     }
 };

--- a/cloud/blockstore/libs/vhost/vhost.h
+++ b/cloud/blockstore/libs/vhost/vhost.h
@@ -44,7 +44,7 @@ struct IVhostDevice
 
     virtual bool Start() = 0;
     virtual NThreading::TFuture<NProto::TError> Stop() = 0;
-    virtual void Update(ui64 blocksCount) = 0;
+    virtual NProto::TError Update(ui64 blocksCount) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cloud/blockstore/libs/vhost/vhost_test.cpp
+++ b/cloud/blockstore/libs/vhost/vhost_test.cpp
@@ -62,6 +62,7 @@ private:
 
     TMutex Lock;
     TVector<TFuture<TVhostRequest::EResult>> Futures;
+    NProto::TError UpdateError;
 
     std::atomic_flag Stopped = 0;
 
@@ -95,9 +96,12 @@ public:
         });
     }
 
-    void Update(ui64 blocksCount) override
+    NProto::TError Update(ui64 blocksCount) override
     {
         Y_UNUSED(blocksCount);
+        with_lock (Lock) {
+            return UpdateError;
+        }
     }
 
     bool IsStopped() override
@@ -112,6 +116,13 @@ public:
             Autostop.Swap(promise);
         } else {
             Autostop.SetValue();
+        }
+    }
+
+    void SetUpdateError(NProto::TError error) override
+    {
+        with_lock (Lock) {
+            UpdateError = std::move(error);
         }
     }
 

--- a/cloud/blockstore/libs/vhost/vhost_test.h
+++ b/cloud/blockstore/libs/vhost/vhost_test.h
@@ -25,6 +25,8 @@ struct ITestVhostDevice
 
     virtual void DisableAutostop(bool disable) = 0;
 
+    virtual void SetUpdateError(NProto::TError error) = 0;
+
     [[nodiscard]] virtual ui32 GetOptimalIoSize() const = 0;
 };
 

--- a/cloud/blockstore/tests/recipes/local-kikimr/__main__.py
+++ b/cloud/blockstore/tests/recipes/local-kikimr/__main__.py
@@ -22,6 +22,8 @@ import yatest.common as yatest_common
 
 PID_FILE_NAME = "local_kikimr_nbs_server_recipe.pid"
 ERR_LOG_FILE_NAMES_FILE = "local_kikimr_nbs_server_recipe.err_log_files"
+DATA_PLANE_SERVER_INDEX = 0
+CONTROL_PLANE_SERVER_INDEX = 1
 
 
 def start(argv):
@@ -30,7 +32,9 @@ def start(argv):
     parser.add_argument("--nbs-package-path", action='store', default=None)
     parser.add_argument("--use-log-files", action='store_true', default=False)
     parser.add_argument("--use-ic-version-check", action='store_true', default=False)
+    parser.add_argument("--server-count", type=int, default=1)
     args = parser.parse_args(argv)
+    assert args.server_count > 0
 
     kikimr_binary_path = yatest_common.binary_path("contrib/ydb/apps/ydbd/ydbd")
     if args.kikimr_package_path is not None:
@@ -75,51 +79,71 @@ def start(argv):
 
     pm = yatest_common.network.PortManager()
 
-    nbs_port = pm.get_port()
-    nbs_secure_port = pm.get_port()
+    nbs_ports = [pm.get_port() for _ in range(args.server_count)]
+    nbs_secure_ports = [pm.get_port() for _ in range(args.server_count)]
 
     instance_list_file = os.path.join(yatest_common.output_path(), "static_instances.txt")
     with open(instance_list_file, "w") as f:
-        print("localhost\t%s\t%s" % (nbs_port, nbs_secure_port), file=f)
+        for nbs_port, nbs_secure_port in zip(nbs_ports, nbs_secure_ports):
+            print("localhost\t%s\t%s" % (nbs_port, nbs_secure_port), file=f)
 
     discovery_config = TDiscoveryServiceConfig()
     discovery_config.InstanceListFile = instance_list_file
 
     kikimr_port = list(kikimr_cluster.nodes.values())[0].port
-    nbs = LocalNbs(
-        kikimr_port,
-        configurator.domains_txt,
-        server_app_config=server_app_config,
-        enable_tls=True,
-        load_configs_from_cms=True,
-        discovery_config=discovery_config,
-        nbs_secure_port=nbs_secure_port,
-        nbs_port=nbs_port,
-        kikimr_binary_path=kikimr_binary_path,
-        nbs_binary_path=nbs_binary_path,
-        use_ic_version_check=args.use_ic_version_check)
+    nbs_servers = [
+        LocalNbs(
+            kikimr_port,
+            configurator.domains_txt,
+            server_app_config=server_app_config,
+            enable_tls=True,
+            load_configs_from_cms=True,
+            discovery_config=discovery_config,
+            nbs_secure_port=nbs_secure_port,
+            nbs_port=nbs_port,
+            kikimr_binary_path=kikimr_binary_path,
+            nbs_binary_path=nbs_binary_path,
+            use_ic_version_check=args.use_ic_version_check)
+        for nbs_port, nbs_secure_port in zip(nbs_ports, nbs_secure_ports)
+    ]
 
-    nbs.setup_cms(kikimr_cluster.client)
+    nbs_servers[DATA_PLANE_SERVER_INDEX].setup_cms(kikimr_cluster.client)
 
-    nbs.start()
+    for nbs in nbs_servers:
+        nbs.start()
 
-    append_recipe_err_files(ERR_LOG_FILE_NAMES_FILE, nbs.stderr_file_name)
+        append_recipe_err_files(ERR_LOG_FILE_NAMES_FILE, nbs.stderr_file_name)
 
     set_env("LOCAL_KIKIMR_KIKIMR_ROOT", configurator.domain_name)
     set_env("LOCAL_KIKIMR_KIKIMR_SERVER_PORT", str(kikimr_port))
-    set_env("LOCAL_KIKIMR_SECURE_NBS_SERVER_PORT", str(nbs.nbs_secure_port))
-    set_env("LOCAL_KIKIMR_INSECURE_NBS_SERVER_PORT", str(nbs.nbs_port))
+    set_env(
+        "LOCAL_KIKIMR_SECURE_NBS_SERVER_PORT",
+        str(nbs_servers[DATA_PLANE_SERVER_INDEX].nbs_secure_port))
+    set_env(
+        "LOCAL_KIKIMR_INSECURE_NBS_SERVER_PORT",
+        str(nbs_servers[DATA_PLANE_SERVER_INDEX].nbs_port))
+
+    if args.server_count > CONTROL_PLANE_SERVER_INDEX:
+        set_env(
+            "LOCAL_KIKIMR_CONTROL_PLANE_INSECURE_NBS_SERVER_PORT",
+            str(nbs_servers[CONTROL_PLANE_SERVER_INDEX].nbs_port))
+        set_env(
+            "NBS_RESIZE_SERVER_PORT",
+            str(nbs_servers[CONTROL_PLANE_SERVER_INDEX].nbs_port))
 
     with open(PID_FILE_NAME, "w") as f:
-        f.write(str(nbs.pid))
+        for nbs in nbs_servers:
+            print(nbs.pid, file=f)
 
-    wait_for_nbs_server(nbs.nbs_port)
+    for nbs in nbs_servers:
+        wait_for_nbs_server(nbs.nbs_port)
 
 
 def stop(argv):
     with open(PID_FILE_NAME) as f:
-        pid = int(f.read())
-        os.kill(pid, signal.SIGTERM)
+        for line in f:
+            pid = int(line)
+            os.kill(pid, signal.SIGTERM)
     errors = process_recipe_err_files(ERR_LOG_FILE_NAMES_FILE)
     if errors:
         raise RuntimeError("Errors during recipe execution:\n" + "\n".join(errors))

--- a/cloud/blockstore/tests/recipes/local-kikimr/local-kikimr.inc
+++ b/cloud/blockstore/tests/recipes/local-kikimr/local-kikimr.inc
@@ -10,7 +10,12 @@ DATA(
     arcadia/cloud/blockstore/tests/certs/server.key
 )
 
-USE_RECIPE(
-    cloud/blockstore/tests/recipes/local-kikimr/local-kikimr-recipe --use-log-files
-)
+IF (NOT LOCAL_KIKIMR_SERVER_COUNT)
+    SET(LOCAL_KIKIMR_SERVER_COUNT 1)
+ENDIF()
 
+USE_RECIPE(
+    cloud/blockstore/tests/recipes/local-kikimr/local-kikimr-recipe
+    --use-log-files
+    --server-count $LOCAL_KIKIMR_SERVER_COUNT
+)

--- a/cloud/blockstore/tests/resize-disk/test.py
+++ b/cloud/blockstore/tests/resize-disk/test.py
@@ -1,19 +1,89 @@
-import subprocess
+import os
+import time
 
 import yatest.common as common
 
+from cloud.blockstore.public.sdk.python import client
+
 
 BLOCK_SIZE = 4*1024
-EXPECTED_BLOCKS_COUNT = 64*1024
+OLD_BLOCKS_COUNT = 32*1024
+NEW_BLOCKS_COUNT = 64*1024
+QEMU_HOST = "10.0.2.2"
+
+
+def _get_nbs_port():
+    for env_name in (
+            "LOCAL_KIKIMR_INSECURE_NBS_SERVER_PORT",
+            "SERVICE_LOCAL_INSECURE_NBS_SERVER_PORT",
+            "LOCAL_NULL_INSECURE_NBS_SERVER_PORT"):
+        port = os.getenv(env_name)
+        if port:
+            return port
+
+    raise RuntimeError("Cannot determine NBS port")
+
+
+def _get_nbs_host():
+    host = os.getenv("NBS_SERVER_HOST")
+    if host:
+        return host
+
+    if os.getenv("NBS_DEVICE_PATH") and os.path.exists("/run_test.sh"):
+        return QEMU_HOST
+
+    return "localhost"
+
+
+def _get_nbs_endpoint():
+    return "{}:{}".format(_get_nbs_host(), _get_nbs_port())
+
+
+def _get_device_size(device_path):
+    ex = common.execute(
+        ["sudo", "blockdev", "--getsize64", device_path])
+
+    return int(ex.stdout)
+
+
+def _wait_for_device_size(device_path, expected_size, timeout=60):
+    deadline = time.monotonic() + timeout
+    last_size = None
+
+    while time.monotonic() < deadline:
+        last_size = _get_device_size(device_path)
+        if last_size == expected_size:
+            return
+        time.sleep(1)
+
+    raise AssertionError(
+        f"{device_path} size is {last_size}, expected {expected_size}")
 
 
 def test_resize_disk():
+    device_path = os.getenv("NBS_DEVICE_PATH", "/dev/vdb")
+    disk_id = os.getenv("NBS_DISK_ID")
+
+    assert disk_id
+
     common.execute(["lsblk"])
 
-    ex = common.execute(
-        ["sudo", "blockdev", "--getsize64", "/dev/vdb"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
+    old_size = OLD_BLOCKS_COUNT * BLOCK_SIZE
+    new_size = NEW_BLOCKS_COUNT * BLOCK_SIZE
 
-    disk_size = int(ex.stdout)
-    assert disk_size == EXPECTED_BLOCKS_COUNT * BLOCK_SIZE
+    assert _get_device_size(device_path) == old_size
+
+    with client.CreateClient(_get_nbs_endpoint()) as nbs_client:
+        volume = nbs_client.describe_volume(disk_id)
+        assert volume.BlocksCount == OLD_BLOCKS_COUNT
+
+        nbs_client.resize_volume(
+            disk_id=disk_id,
+            blocks_count=NEW_BLOCKS_COUNT,
+            channels_count=0,
+            config_version=None)
+
+        volume = nbs_client.describe_volume(disk_id)
+        assert volume.BlocksCount == NEW_BLOCKS_COUNT
+
+    _wait_for_device_size(device_path, new_size)

--- a/cloud/blockstore/tests/resize-disk/test.py
+++ b/cloud/blockstore/tests/resize-disk/test.py
@@ -39,6 +39,18 @@ def _get_nbs_endpoint():
     return "{}:{}".format(_get_nbs_host(), _get_nbs_port())
 
 
+def _get_resize_endpoint():
+    endpoint = os.getenv("NBS_RESIZE_ENDPOINT")
+    if endpoint:
+        return endpoint
+
+    port = os.getenv("NBS_RESIZE_SERVER_PORT")
+    if port:
+        return "{}:{}".format(_get_nbs_host(), port)
+
+    return _get_nbs_endpoint()
+
+
 def _get_device_size(device_path):
     ex = common.execute(
         ["sudo", "blockdev", "--getsize64", device_path])
@@ -77,12 +89,17 @@ def test_resize_disk():
         volume = nbs_client.describe_volume(disk_id)
         assert volume.BlocksCount == OLD_BLOCKS_COUNT
 
+    with client.CreateClient(_get_resize_endpoint()) as nbs_client:
         nbs_client.resize_volume(
             disk_id=disk_id,
             blocks_count=NEW_BLOCKS_COUNT,
             channels_count=0,
             config_version=None)
 
+        volume = nbs_client.describe_volume(disk_id)
+        assert volume.BlocksCount == NEW_BLOCKS_COUNT
+
+    with client.CreateClient(_get_nbs_endpoint()) as nbs_client:
         volume = nbs_client.describe_volume(disk_id)
         assert volume.BlocksCount == NEW_BLOCKS_COUNT
 

--- a/cloud/blockstore/tests/resize-disk/ya.make
+++ b/cloud/blockstore/tests/resize-disk/ya.make
@@ -6,6 +6,7 @@ FORK_SUBTESTS()
 SPLIT_FACTOR(1)
 
 PEERDIR(
+    cloud/blockstore/public/sdk/python/client
     cloud/blockstore/tests/python/lib
 )
 
@@ -15,7 +16,6 @@ TEST_SRCS(
 
 INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/service-local/service-local.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/endpoint/vhost-endpoint.inc)
-INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/resize-disk/resize-disk.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/qemu.inc)
 
 END()

--- a/cloud/blockstore/tests/resize-disk/ya.make
+++ b/cloud/blockstore/tests/resize-disk/ya.make
@@ -14,7 +14,9 @@ TEST_SRCS(
     test.py
 )
 
-INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/service-local/service-local.inc)
+SET(LOCAL_KIKIMR_SERVER_COUNT 2)
+
+INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/local-kikimr/local-kikimr.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/endpoint/vhost-endpoint.inc)
 INCLUDE(${ARCADIA_ROOT}/cloud/blockstore/tests/recipes/qemu.inc)
 


### PR DESCRIPTION
### Notes
Makes the attached disks notice size changes without need to reattach.
Referenced the unmerged vhost changes until they are merged.
Can also make endpoints refreshing happen in parallel if needed.
